### PR TITLE
ci(agent): add label-triggered Claude Code workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-spec.md
+++ b/.github/ISSUE_TEMPLATE/agent-spec.md
@@ -1,0 +1,36 @@
+---
+name: Agent spec
+about: Spec for a task that an AI agent will execute. Add the `agent:ready` label when ready to dispatch.
+title: ""
+labels: []
+assignees: []
+---
+
+## Goal
+<one sentence, concrete>
+
+## Context / Why
+<what prompted this, links to prior work, related issues/PRs>
+
+## Constraints
+-
+
+## Acceptance criteria
+- [ ]
+
+## Files likely touched
+-
+
+## Out of scope
+-
+
+## Verification
+Run before opening the PR:
+-
+
+<!--
+When this spec is ready, add the `agent:ready` label. The workflow at
+.github/workflows/agent.yml will pick it up and open a PR. Do not add the
+label until every section above is filled — the agent will not see any
+conversation outside this issue body.
+-->

--- a/.github/PROJECT_SETUP.md
+++ b/.github/PROJECT_SETUP.md
@@ -1,0 +1,65 @@
+# Project board setup (one-time)
+
+The agent workflow (`.github/workflows/agent.yml`) and the `/spec` slash command use three labels to drive a kanban board. This file documents the one-time manual setup.
+
+## 1. Labels
+
+Create these labels on the repo (Settings → Labels, or via `gh label create`):
+
+| Label | Color | Purpose |
+|---|---|---|
+| `agent:ready` | green | Spec is complete and ready for the agent to pick up. |
+| `agent:running` | yellow | Agent workflow is currently executing. Applied by the workflow. |
+| `agent:failed` | red | Agent workflow errored. Applied by the workflow; needs human triage. |
+
+```bash
+gh label create agent:ready   --color 0e8a16 --description "Ready for the agent to pick up"
+gh label create agent:running --color fbca04 --description "Agent workflow is executing"
+gh label create agent:failed  --color b60205 --description "Agent workflow errored — human triage needed"
+```
+
+## 2. Project v2 board
+
+Create a Project and link it to this repo:
+
+1. Create a Project named **vcad agent queue** (user or org scope).
+2. Add a **Status** field with columns: **Backlog**, **Ready**, **In Progress**, **Review**, **Done**.
+3. Link the repo so new issues auto-add to the Project.
+
+## 3. Project automations
+
+All configurable in the Project's "Workflows" UI — no code required.
+
+| Trigger | Effect |
+|---|---|
+| Item added (any issue) | Status → **Backlog** |
+| Label `agent:ready` added | Status → **Ready** |
+| Label `agent:running` added | Status → **In Progress** |
+| Linked PR opened | Status → **Review** |
+| Issue closed | Status → **Done** |
+| Label `agent:failed` added | Status → **Backlog** (so it re-surfaces for triage) |
+
+The workflow only toggles labels; the Project board handles column moves.
+
+## 4. Secrets
+
+Add to repo secrets (Settings → Secrets and variables → Actions):
+
+- `ANTHROPIC_API_KEY` — required by `claude-code-action`.
+
+`GITHUB_TOKEN` is provided automatically by Actions and has enough scope for the label/PR operations the workflow performs.
+
+### Scope note for local `gh` usage
+
+`gh project` commands require the `project` scope, which is not part of the default `gh auth login` set. If `gh project list` returns an empty result or fails, run:
+
+```bash
+gh auth refresh -s project,read:project
+```
+
+## 5. Smoke test
+
+1. From a chat, run `/spec` on a trivial task and approve the draft.
+2. Confirm the issue exists with `agent:ready` and the board card is in **Ready**.
+3. Watch the **Agent** workflow run. Card should move to **In Progress** when `agent:running` is applied.
+4. Once the PR opens, card moves to **Review**. Merging moves it to **Done**.

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,0 +1,116 @@
+name: Agent
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agent-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  run:
+    if: github.event.label.name == 'agent:ready'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Flip agent:ready → agent:running
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label agent:ready \
+            --add-label agent:running
+
+      - uses: actions/checkout@v4
+
+      # Sibling path-dep workspaces — mirrors ci.yml so the agent can build.
+      - name: Clone sibling repos
+        run: |
+          git clone --depth 1 https://github.com/ecto/tang.git ../tang
+          git clone --depth 1 https://github.com/ecto/phyz.git ../phyz
+          git clone --depth 1 https://github.com/ecto/loon.git ../loon
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install apt deps
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
+
+      - run: npm ci
+
+      - name: Configure git
+        run: |
+          git config user.name  "vcad-agent[bot]"
+          git config user.email "vcad-agent@users.noreply.github.com"
+
+      - name: Run agent
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            You are executing GitHub issue #${{ github.event.issue.number }}:
+            "${{ github.event.issue.title }}"
+
+            Read CLAUDE.md first. It defines the coordinate system (Z-up),
+            workspace layout, and the commands CI runs. Follow those
+            conventions.
+
+            The full spec is below. Treat it as the complete contract — do
+            not infer requirements that aren't written here.
+
+            --- BEGIN SPEC ---
+            ${{ github.event.issue.body }}
+            --- END SPEC ---
+
+            Execute the spec:
+            1. Create a branch: `agent/issue-${{ github.event.issue.number }}`.
+            2. Implement the changes. Keep the diff minimal — don't refactor
+               surrounding code that wasn't asked for.
+            3. Run every command in the spec's "Verification" section. All
+               must pass. If a command fails, fix the root cause and re-run
+               — never use --no-verify or bypass checks.
+            4. Commit with a clear message. Push the branch.
+            5. Open a PR with `gh pr create` that includes
+               `Closes #${{ github.event.issue.number }}` in the body. Keep
+               the PR body short; the spec lives in the issue.
+
+            If the spec is ambiguous or acceptance criteria conflict, stop
+            and post a comment on the issue describing the conflict instead
+            of guessing.
+          claude_args: |
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cargo:*),Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(rustup:*)"
+
+      - name: Mark failed on error
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label agent:running \
+            --add-label agent:failed
+          gh issue comment ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --body "Agent run failed. See workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/crates/vcad-cli/src/app.rs
+++ b/crates/vcad-cli/src/app.rs
@@ -1392,10 +1392,8 @@ fn run_loop(
         // Handle input with 16ms poll
         if event::poll(Duration::from_millis(16))? {
             match event::read()? {
-                Event::Key(key) => {
-                    if !crate::input::handle_key(app, key)? {
-                        app.running = false;
-                    }
+                Event::Key(key) if !crate::input::handle_key(app, key)? => {
+                    app.running = false;
                 }
                 Event::Mouse(mouse) => {
                     let cell_dims = match protocol {

--- a/crates/vcad-cli/src/input.rs
+++ b/crates/vcad-cli/src/input.rs
@@ -575,10 +575,8 @@ fn handle_tool_input_key(app: &mut App, key: KeyEvent) -> anyhow::Result<bool> {
                 app.process_command(&cmd)?;
             }
         }
-        KeyCode::Backspace => {
-            if ti.editing || ti.text_mode {
-                ti.edit_buf.pop();
-            }
+        KeyCode::Backspace if ti.editing || ti.text_mode => {
+            ti.edit_buf.pop();
         }
         KeyCode::Left => {
             if ti.text_mode {
@@ -711,15 +709,13 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> anyhow::Result<bool> {
     // Welcome overlay intercepts all keys when visible
     if app.show_welcome {
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if app.welcome_selected > 0 {
-                    app.welcome_selected -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if app.welcome_selected > 0 => {
+                app.welcome_selected -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if app.welcome_selected + 1 < crate::ui::welcome::ITEM_COUNT {
-                    app.welcome_selected += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j')
+                if app.welcome_selected + 1 < crate::ui::welcome::ITEM_COUNT =>
+            {
+                app.welcome_selected += 1;
             }
             KeyCode::Enter => {
                 let action = match app.welcome_selected {
@@ -793,10 +789,8 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> anyhow::Result<bool> {
                 app.command_input.pop();
                 app.command_selected_index = 0;
             }
-            KeyCode::Up => {
-                if app.command_selected_index > 0 {
-                    app.command_selected_index -= 1;
-                }
+            KeyCode::Up if app.command_selected_index > 0 => {
+                app.command_selected_index -= 1;
             }
             KeyCode::Down => {
                 let items = crate::ui::command::build_command_items(&app.command_input);
@@ -815,11 +809,9 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> anyhow::Result<bool> {
                 app.mode = TuiMode::Normal;
                 app.set_status("Exited sketch mode");
             }
-            KeyCode::Char(c) => {
-                if state.handle_key(c) {
-                    let name = state.tool_name().to_string();
-                    app.set_status(format!("Sketch tool: {}", name));
-                }
+            KeyCode::Char(c) if state.handle_key(c) => {
+                let name = state.tool_name().to_string();
+                app.set_status(format!("Sketch tool: {}", name));
             }
             _ => {}
         },

--- a/crates/vcad-cli/src/ui/buffer.rs
+++ b/crates/vcad-cli/src/ui/buffer.rs
@@ -282,12 +282,10 @@ pub fn set_char_underline(buf: &mut CellBuffer, x: u16, y: u16, ch: char, fg: Co
 
 /// Helper: write a string horizontally starting at (x, y).
 pub fn set_string(buf: &mut CellBuffer, x: u16, y: u16, s: &str, fg: Color, bg: Color) {
-    let mut cx = x;
-    for ch in s.chars() {
+    for (cx, ch) in (x..).zip(s.chars()) {
         if cx >= buf.width {
             break;
         }
         set_char(buf, cx, y, ch, fg, bg);
-        cx += 1;
     }
 }

--- a/crates/vcad-cli/src/ui/viewport.rs
+++ b/crates/vcad-cli/src/ui/viewport.rs
@@ -85,14 +85,13 @@ pub fn render_viewport_braille(buf: &mut CellBuffer, render_buffer: &RenderBuffe
             }
 
             let ch = char::from_u32(0x2800 + dots as u32).unwrap_or(' ');
-            let color = if count > 0 {
-                Color::rgb(
-                    (total_r / count) as u8,
-                    (total_g / count) as u8,
-                    (total_b / count) as u8,
-                )
-            } else {
-                theme::BG()
+            let color = match (
+                total_r.checked_div(count),
+                total_g.checked_div(count),
+                total_b.checked_div(count),
+            ) {
+                (Some(r), Some(g), Some(b)) => Color::rgb(r as u8, g as u8, b as u8),
+                _ => theme::BG(),
             };
 
             if let Some(cell) = buf.cell_mut(area.x + col, area.y + row) {

--- a/crates/vcad-embroidery-wasm/src/lib.rs
+++ b/crates/vcad-embroidery-wasm/src/lib.rs
@@ -98,14 +98,12 @@ impl WasmEmbPattern {
                         }
                         points.push([*x, *y]);
                     }
-                    StitchCommand::Trim | StitchCommand::End => {
-                        if !points.is_empty() {
-                            paths.push(StitchPathInfo {
-                                thread_index: group.thread_index,
-                                color: thread.color,
-                                points: std::mem::take(&mut points),
-                            });
-                        }
+                    StitchCommand::Trim | StitchCommand::End if !points.is_empty() => {
+                        paths.push(StitchPathInfo {
+                            thread_index: group.thread_index,
+                            color: thread.color,
+                            points: std::mem::take(&mut points),
+                        });
                     }
                     _ => {}
                 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -5215,14 +5215,12 @@ mod embroidery_wasm {
                         }
                         points.push([*x, *y]);
                     }
-                    StitchCommand::Trim | StitchCommand::End => {
-                        if !points.is_empty() {
-                            paths.push(StitchPathInfo {
-                                thread_index: group.thread_index,
-                                color: thread.color,
-                                points: std::mem::take(&mut points),
-                            });
-                        }
+                    StitchCommand::Trim | StitchCommand::End if !points.is_empty() => {
+                        paths.push(StitchPathInfo {
+                            thread_index: group.thread_index,
+                            color: thread.color,
+                            points: std::mem::take(&mut points),
+                        });
                     }
                     _ => {}
                 }

--- a/plugins/claude-code/commands/spec.md
+++ b/plugins/claude-code/commands/spec.md
@@ -1,0 +1,64 @@
+---
+name: spec
+description: Turn the current chat thread into a GitHub issue spec for an agent to execute
+---
+
+You are turning the current conversation into a tight, executable spec and filing it as a GitHub issue. The issue will be picked up by `.github/workflows/agent.yml` when labeled `agent:ready`, so the spec must be self-contained — the agent will not see this conversation.
+
+## Process
+
+1. **Draft.** Read back over the conversation so far and render a spec using the template below. Pull the Goal, Context, Constraints, and Acceptance Criteria from what has actually been discussed — do not invent requirements.
+
+2. **Gate on missing sections.** Every section except "Out of scope" is required. If any required section cannot be filled from the conversation, stop and ask the user to clarify before drafting. Do not pad a section with "TBD" or guesses.
+
+3. **Show the draft to the user in full.** Include the title (under 70 chars) and the complete body. Do not call `gh` yet.
+
+4. **Require explicit approval.** Ask the user to confirm with "send it" or equivalent. If they say anything else, treat it as a revision request. Never file the issue without an explicit go — mirrors the email-approval rule in the user's global CLAUDE.md.
+
+5. **File it.** Once approved, run:
+   ```bash
+   gh issue create \
+     --title "<title>" \
+     --label "agent:ready" \
+     --body-file -
+   ```
+   piping the rendered body on stdin. Print the returned issue URL.
+
+6. **Do not comment further.** The agent workflow takes over from here.
+
+## Spec template
+
+```markdown
+## Goal
+<one sentence, concrete>
+
+## Context / Why
+<what prompted this, links to prior work, related issues/PRs>
+
+## Constraints
+- <non-negotiables: perf, API stability, coord system (Z-up), etc.>
+- <each constraint on its own line>
+
+## Acceptance criteria
+- [ ] <testable bullet>
+- [ ] <testable bullet>
+
+## Files likely touched
+- `path/to/file.rs`
+- `path/to/other.ts`
+
+## Out of scope
+- <explicit non-goals, if any>
+
+## Verification
+Run before opening the PR:
+- `cargo test -p <crate>` / `cargo clippy --workspace -- -D warnings`
+- `npm run build -w @vcad/<package>` / `npm test -w @vcad/<package>`
+- <any manual verification the agent cannot run>
+```
+
+## Notes
+
+- Keep the spec shorter than 60 lines. If it's longer, the task is too big — suggest splitting it into separate issues.
+- Acceptance criteria must be testable. "Works correctly" is not acceptance; "`cargo test -p vcad-cli` passes with a new test for `--version`" is.
+- The `Verification` section should reuse commands already in `CLAUDE.md` or `ci.yml` where possible — the agent builds on the same CI toolchain.


### PR DESCRIPTION
## Summary
- `/spec` slash command turns the active Claude chat into a structured GitHub issue (gated on explicit user approval before `gh issue create`)
- `.github/workflows/agent.yml` triggers on `agent:ready` label, flips to `agent:running`, runs `anthropics/claude-code-action@v1` against the issue body, opens a PR with `Closes #N`
- `.github/ISSUE_TEMPLATE/agent-spec.md` mirrors the spec shape so humans can also file specs directly
- `.github/PROJECT_SETUP.md` documents the one-time Project v2 board + automations + `ANTHROPIC_API_KEY` secret

Design rationale: PR review is a worse medium than chat for design conversations, so the loop shifts design work left — the chat with Claude produces a tight issue, and the agent executes against it. PR review becomes a rubber-stamp + smoke test.

Labels already created on the repo: `agent:ready`, `agent:running`, `agent:failed`.

## Follow-ups (human required — cannot be done by CLI with current token scopes)
- [x] `gh auth refresh -s project,read:project` then create the Project v2 board per `PROJECT_SETUP.md`
- [x] Configure Project workflows (auto-add, close → Done, etc.) in the Projects UI
- [x] Add `ANTHROPIC_API_KEY` repo secret: `gh secret set ANTHROPIC_API_KEY --repo ecto/vcad`
- [x] Verify Actions → Settings → General → Workflow permissions = Read and write

## Test plan
- [ ] Merge this PR
- [ ] In a fresh Claude chat, describe a trivial task (e.g. "add `--version` flag to `vcad-cli`")
- [ ] Run `/spec`, approve the draft
- [ ] Verify the issue gets `agent:ready` label and a card appears in the Project
- [ ] Watch the Agent workflow run; verify label flips to `agent:running`
- [ ] Verify the agent opens a PR with `Closes #N`
- [ ] Merge the agent's PR; confirm issue auto-closes and card moves to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)