### PR TITLE
ci(desktop): add release pipeline for mac/win/linux bundles

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,152 @@
+name: Desktop Release
+
+# Phase 5 of the desktop plan. Builds vcad-desktop for macOS (universal),
+# Windows, and Linux, and (when triggered by a tag) publishes the
+# installers as a draft GitHub release. Signing/notarization only kicks
+# in when the relevant secrets are set — unsigned builds still succeed,
+# they just show OS warnings on first launch.
+#
+# Triggers
+#   - workflow_dispatch: ad-hoc matrix build; artifacts only, no release.
+#   - push of a `v*` tag: matrix build + draft release with installers.
+#
+# Adding a platform is a one-line change in the matrix.
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # needed to create the draft release
+
+concurrency:
+  group: desktop-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: macOS (universal)
+            platform: macos-latest
+            rust-target: aarch64-apple-darwin,x86_64-apple-darwin
+            tauri-args: --target universal-apple-darwin
+          - label: Windows (x64)
+            platform: windows-latest
+            rust-target: ''
+            tauri-args: ''
+          - label: Linux (x64)
+            platform: ubuntu-22.04
+            rust-target: ''
+            tauri-args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Path-dep sibling workspaces (mirrors ci.yml / agent.yml).
+      - name: Clone sibling repos
+        shell: bash
+        run: |
+          git clone --depth 1 https://github.com/ecto/tang.git ../tang
+          git clone --depth 1 https://github.com/ecto/phyz.git ../phyz
+          git clone --depth 1 https://github.com/ecto/loon.git ../loon
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: ${{ matrix.rust-target != '' && format('{0},wasm32-unknown-unknown', matrix.rust-target) || 'wasm32-unknown-unknown' }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Keep the desktop crate's cache keyed per-platform so macOS and
+          # Linux builds don't stomp on each other.
+          key: ${{ matrix.platform }}
+          cache-workspace-crates: true
+
+      - name: Install Linux system deps
+        if: startsWith(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            librsvg2-dev \
+            libsoup-3.0-dev \
+            libatk1.0-dev \
+            libayatana-appindicator3-dev \
+            libcairo2-dev \
+            libjpeg-dev \
+            libpango1.0-dev \
+            libgif-dev \
+            rpm
+
+      - name: Install wasm-pack
+        shell: bash
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Install npm deps
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      # Warm up @vcad/app's workspace dependencies via turbo so tauri-action's
+      # subsequent beforeBuildCommand (which only runs the app's own build)
+      # finds @vcad/{core,engine,ir,auth,kernel-wasm} already built.
+      - name: Build @vcad/app
+        run: npm run build -- --filter=@vcad/app
+
+      - name: Build and publish desktop bundles
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Tauri updater signing — optional; tauri-action skips signing
+          # when the key is absent.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # macOS code signing + notarization — all optional. Unsigned .dmg
+          # still builds; users will see a Gatekeeper warning.
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          projectPath: crates/vcad-desktop
+          # Only create a release when triggered by a tag push.
+          tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
+          releaseName: 'vcad ${{ github.ref_name }}'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.tauri-args }}
+
+      # For workflow_dispatch runs (no tag), preserve the installers as
+      # workflow artifacts so a maintainer can inspect them without
+      # cutting a release.
+      - name: Upload artifacts (non-release runs)
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: vcad-desktop-${{ matrix.platform }}
+          if-no-files-found: warn
+          path: |
+            target/release/bundle/**/*.dmg
+            target/release/bundle/**/*.app
+            target/release/bundle/**/*.msi
+            target/release/bundle/**/*.exe
+            target/release/bundle/**/*.AppImage
+            target/release/bundle/**/*.deb
+            target/release/bundle/**/*.rpm
+            target/universal-apple-darwin/release/bundle/**/*.dmg
+            target/universal-apple-darwin/release/bundle/**/*.app


### PR DESCRIPTION
## Summary

Phase 5 of the desktop plan — build and (optionally) publish installers for the Tauri shell across all three desktop platforms. No code changes, only CI.

- Matrix via [`tauri-apps/tauri-action`](https://github.com/tauri-apps/tauri-action):
  - **macOS universal** — `--target universal-apple-darwin` produces a single .dmg that works on Apple Silicon + Intel
  - **Windows x64** — .msi + NSIS .exe
  - **Linux x64** (on `ubuntu-22.04` for wider glibc compat) — .deb, .rpm, .AppImage
- Triggers:
  - `push` of a `v*` tag → matrix build + **draft** GitHub release with installers attached
  - `workflow_dispatch` → matrix build, installers as workflow artifacts (no release)
- Signing/notarization envs (`TAURI_SIGNING_*`, `APPLE_*`) are wired but optional — unsigned builds still succeed; users just see a Gatekeeper / SmartScreen warning on first launch. Populate the secrets in repo settings when ready.
- Mirrors `ci.yml` for sibling-repo clones (`tang`/`phyz`/`loon`) and `wasm-pack` install, then seeds `@vcad/app`'s workspace deps via `npm run build -- --filter=@vcad/app` so `tauri-action`'s `beforeBuildCommand` finds them already built.
- `Swatinem/rust-cache` keyed per-platform so macOS and Linux runs don't stomp caches.

## Test plan

- [ ] Manual: run the workflow from the Actions tab (`workflow_dispatch`) and confirm all three matrix legs finish green
- [ ] Download each per-platform artifact and smoke-test install/launch on a clean VM
- [ ] Tag `v0.8.1-rc1` (or similar) on this branch; confirm a draft release appears with `.dmg`, `.msi`, `.AppImage`, `.deb`, `.rpm` attached

## Follow-ups (intentionally out of scope)

- Tauri updater plugin + hosted update manifest (needs `TAURI_SIGNING_PRIVATE_KEY` and a public endpoint)
- macOS code signing / notarization paperwork (Apple Developer account)
- Windows EV code signing
- PR smoke-test job that runs `cargo check -p vcad-desktop` on Linux — currently `ci.yml` excludes the crate, so breakage only surfaces in this release workflow. Add to `ci.yml` in a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)