### PR TITLE
ci: speed up TypeScript job (7m → ~2m warm)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,16 @@ jobs:
       # --dev skips wasm-opt (~2m) and uses cargo's dev profile (faster
       # compile, larger/slower wasm — fine for CI tests, never shipped).
       # Production wasm is built by Vercel, not this workflow.
+      #
+      # `no-builtin-font` drops the include_bytes!() of
+      # node_modules/next/.../noto-sans.ttf, which doesn't exist here
+      # (this job doesn't run `npm ci`). Matches the Rust CI job.
       - name: Build wasm (dev)
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: |
-          wasm-pack build crates/vcad-kernel-wasm --dev --target web --out-dir ../../packages/kernel-wasm/pkg
+          wasm-pack build crates/vcad-kernel-wasm --dev --target web \
+            --out-dir ../../packages/kernel-wasm/pkg \
+            --features no-builtin-font
           cp packages/kernel-wasm/pkg/vcad_kernel_wasm* packages/kernel-wasm/
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,15 +150,17 @@ jobs:
       # (~23s) and the native compile step.
       - run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts
       - run: npm run version:check
-      # Filter out vcad-kernel-wasm: the `wasm` job already produced
-      # its outputs and the download-artifact step put them in place,
-      # so running the task would just rebuild them. Downstream tasks
-      # (@vcad/engine etc.) read those files directly and don't need
-      # turbo to have "built" them.
+      # VCAD_WASM_SKIP short-circuits vcad-kernel-wasm's build script
+      # (the `wasm` job already produced pkg/ via the artifact above).
+      # turbo's task graph still includes vcad-kernel-wasm#build as a
+      # dep of @vcad/engine#build, so we can't just filter it out —
+      # the script itself has to become a noop.
       #
       # @vcad/docs is excluded: it's a Next.js static-site build (~44s,
       # 303 pages) that deploys via its own Vercel project, not via CI
       # artifacts. Building it in the PR job adds latency without
       # exercising anything other code paths don't already cover.
-      - run: npm run build -- --filter=!@vcad/docs --filter=!vcad-kernel-wasm
+      - run: npm run build -- --filter=!@vcad/docs
+        env:
+          VCAD_WASM_SKIP: '1'
       - run: npm test --workspaces --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,11 @@ jobs:
       - run: cargo build --workspace --exclude vcad-desktop --examples --features vcad-kernel-text/no-builtin-font
       - run: cargo doc --workspace --exclude vcad-desktop --no-deps --features vcad-kernel-text/no-builtin-font
 
-  typescript:
-    name: TypeScript
+  # wasm-pack dominates the TS critical path (~3m23s of a 7m job), so it
+  # runs as its own job. The TS job starts in parallel and downloads the
+  # built pkg/ via artifact — no Rust toolchain needed there.
+  wasm:
+    name: WASM build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,50 +56,103 @@ jobs:
           git clone --depth 1 https://github.com/ecto/tang.git ../tang
           git clone --depth 1 https://github.com/ecto/phyz.git ../phyz
           git clone --depth 1 https://github.com/ecto/loon.git ../loon
-      - uses: actions/setup-node@v4
+      # Include sibling repo commits in the cache key so updates to
+      # tang/phyz/loon invalidate prebuilt wasm.
+      - name: Record sibling SHAs
+        run: |
+          mkdir -p .sibling-sha
+          git -C ../tang rev-parse HEAD > .sibling-sha/tang
+          git -C ../phyz rev-parse HEAD > .sibling-sha/phyz
+          git -C ../loon rev-parse HEAD > .sibling-sha/loon
+      # Cache the produced pkg/ directly, keyed on every source input that
+      # could change the wasm bytes. A hit skips the whole Rust build.
+      - name: Restore wasm pkg cache
+        id: wasm-cache
+        uses: actions/cache@v4
         with:
-          node-version: 22
-          cache: npm
-      # @vcad/kernel-wasm builds via wasm-pack, which needs the Rust
-      # toolchain + the wasm32-unknown-unknown target + wasm-pack itself.
+          path: |
+            packages/kernel-wasm/pkg
+            packages/kernel-wasm/vcad_kernel_wasm.js
+            packages/kernel-wasm/vcad_kernel_wasm.d.ts
+            packages/kernel-wasm/vcad_kernel_wasm_bg.wasm
+            packages/kernel-wasm/vcad_kernel_wasm_bg.wasm.d.ts
+          key: wasm-pkg-${{ runner.os }}-${{ hashFiles('crates/**/src/**', 'crates/**/Cargo.toml', 'Cargo.lock', 'Cargo.toml', '.sibling-sha/*') }}
+          restore-keys: |
+            wasm-pkg-${{ runner.os }}-
       - uses: dtolnay/rust-toolchain@master
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
         with:
-          # wasm-pack compiles vcad workspace crates into the wasm32
-          # target, so workspace-crate incremental artifacts are worth
-          # caching for PR re-runs that only touch TS.
           cache-workspace-crates: true
-      # Turbo local cache. Preserves per-task outputs (dist/, pkg/, wasm
-      # artifacts) across runs. Key bumps on any Rust or TS source change
-      # so we don't serve stale artifacts; a miss still falls back to a
-      # full rebuild.
+      - name: Install wasm-pack
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      # --dev skips wasm-opt (~2m) and uses cargo's dev profile (faster
+      # compile, larger/slower wasm — fine for CI tests, never shipped).
+      # Production wasm is built by Vercel, not this workflow.
+      - name: Build wasm (dev)
+        if: steps.wasm-cache.outputs.cache-hit != 'true'
+        run: |
+          wasm-pack build crates/vcad-kernel-wasm --dev --target web --out-dir ../../packages/kernel-wasm/pkg
+          cp packages/kernel-wasm/pkg/vcad_kernel_wasm* packages/kernel-wasm/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: |
+            packages/kernel-wasm/pkg
+            packages/kernel-wasm/vcad_kernel_wasm.js
+            packages/kernel-wasm/vcad_kernel_wasm.d.ts
+            packages/kernel-wasm/vcad_kernel_wasm_bg.wasm
+            packages/kernel-wasm/vcad_kernel_wasm_bg.wasm.d.ts
+          retention-days: 1
+          if-no-files-found: error
+
+  typescript:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    needs: wasm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      # Pull the wasm pkg built by the `wasm` job. Unpacks into
+      # packages/kernel-wasm/ (both pkg/ and the root-level copies).
+      - uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: packages/kernel-wasm
+      # Turbo local cache. Primary key is the commit SHA (always unique,
+      # so we always save); restore-keys fall back to the most recent
+      # entry for the branch/OS. Turbo's own per-task hash determines
+      # what's reused vs rebuilt — no need to encode inputs in the key.
       - name: Restore turbo cache
         uses: actions/cache@v4
         with:
           path: node_modules/.cache/turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'package-lock.json', 'turbo.json') }}-${{ hashFiles('crates/**/src/**', 'crates/**/Cargo.toml', 'packages/**/src/**', 'packages/**/package.json', 'packages/**/tsconfig.json') }}
+          key: turbo-${{ runner.os }}-${{ github.sha }}
           restore-keys: |
-            turbo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', 'package-lock.json', 'turbo.json') }}-
             turbo-${{ runner.os }}-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libjpeg-dev libpango1.0-dev libgif-dev librsvg2-dev
-      # --prefer-offline hits the npm module cache (restored by setup-node)
-      # before the network; --no-audit / --no-fund skip two network round-
-      # trips that have no effect on CI correctness.
-      - run: npm ci --prefer-offline --no-audit --no-fund
+      # --ignore-scripts skips the canvas native build (hf-space only).
+      # hf-space has no `build` or `test` task so CI never touches canvas
+      # at runtime, which lets us drop libcairo/libpango/librsvg apt deps
+      # (~23s) and the native compile step.
+      - run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts
       - run: npm run version:check
-      # Use turbo (npm run build) instead of `--workspaces --if-present` so
-      # workspace deps build before their consumers. The latter runs in
-      # alphabetical order (app < auth < core …) which fails on a clean
-      # checkout because @vcad/app builds before @vcad/{ir,engine,core}.
+      # Filter out vcad-kernel-wasm: the `wasm` job already produced
+      # its outputs and the download-artifact step put them in place,
+      # so running the task would just rebuild them. Downstream tasks
+      # (@vcad/engine etc.) read those files directly and don't need
+      # turbo to have "built" them.
       #
       # @vcad/docs is excluded: it's a Next.js static-site build (~44s,
       # 303 pages) that deploys via its own Vercel project, not via CI
       # artifacts. Building it in the PR job adds latency without
       # exercising anything other code paths don't already cover.
-      - run: npm run build -- --filter=!@vcad/docs
+      - run: npm run build -- --filter=!@vcad/docs --filter=!vcad-kernel-wasm
       - run: npm test --workspaces --if-present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
             packages/kernel-wasm/vcad_kernel_wasm.d.ts
             packages/kernel-wasm/vcad_kernel_wasm_bg.wasm
             packages/kernel-wasm/vcad_kernel_wasm_bg.wasm.d.ts
-          key: wasm-pkg-${{ runner.os }}-${{ hashFiles('crates/**/src/**', 'crates/**/Cargo.toml', 'Cargo.lock', 'Cargo.toml', '.sibling-sha/*') }}
+          # v2 in the key prefix forces eviction of --dev-profile entries
+          # from before we switched to --profiling.
+          key: wasm-pkg-v2-${{ runner.os }}-${{ hashFiles('crates/**/src/**', 'crates/**/Cargo.toml', 'Cargo.lock', 'Cargo.toml', '.sibling-sha/*') }}
           restore-keys: |
-            wasm-pkg-${{ runner.os }}-
+            wasm-pkg-v2-${{ runner.os }}-
       - uses: dtolnay/rust-toolchain@master
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         with:
@@ -91,17 +93,19 @@ jobs:
       - name: Install wasm-pack
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      # --dev skips wasm-opt (~2m) and uses cargo's dev profile (faster
-      # compile, larger/slower wasm — fine for CI tests, never shipped).
-      # Production wasm is built by Vercel, not this workflow.
+      # --profiling uses cargo release + light `-O` wasm-opt (configured
+      # in vcad-kernel-wasm/Cargo.toml). Saves ~2m vs default release
+      # (which runs full wasm-opt). We can't use --dev because the PWA
+      # plugin in @vcad/app caps precachable assets at 10 MB and
+      # dev-profile wasm is ~29 MB.
       #
       # `no-builtin-font` drops the include_bytes!() of
       # node_modules/next/.../noto-sans.ttf, which doesn't exist here
       # (this job doesn't run `npm ci`). Matches the Rust CI job.
-      - name: Build wasm (dev)
+      - name: Build wasm (profiling)
         if: steps.wasm-cache.outputs.cache-hit != 'true'
         run: |
-          wasm-pack build crates/vcad-kernel-wasm --dev --target web \
+          wasm-pack build crates/vcad-kernel-wasm --profiling --target web \
             --out-dir ../../packages/kernel-wasm/pkg \
             --features no-builtin-font
           cp packages/kernel-wasm/pkg/vcad_kernel_wasm* packages/kernel-wasm/

--- a/crates/vcad-kernel-wasm/Cargo.toml
+++ b/crates/vcad-kernel-wasm/Cargo.toml
@@ -37,6 +37,10 @@ ts-rs = { version = "10", optional = true }
 # intentionally shipping a slimmer build, and update the wasm-pack
 # invocation alongside.
 default = ["console_error_panic_hook", "physics", "slicer", "cam", "gpu", "raytrace", "cpu-raytrace", "ecad", "embroidery"]
+# Skip the include_bytes!() compile-time font embed in vcad-kernel-text.
+# The font file lives under node_modules/next/..., so CI jobs that run
+# wasm-pack before `npm ci` can't see it. Shipping wasm keeps the font.
+no-builtin-font = ["vcad-kernel/no-builtin-font"]
 console_error_panic_hook = ["dep:console_error_panic_hook"]
 gpu = ["dep:vcad-kernel-gpu"]
 raytrace = ["dep:vcad-kernel-raytrace", "dep:vcad-kernel-topo", "dep:vcad-kernel-geom", "dep:vcad-kernel-math", "dep:wgpu", "gpu", "vcad-kernel-raytrace/gpu"]

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -20,3 +20,9 @@ vcad-kernel-shell = { path = "../vcad-kernel-shell" }
 vcad-kernel-step = { path = "../vcad-kernel-step" }
 vcad-kernel-constraints = { path = "../vcad-kernel-constraints" }
 vcad-kernel-text = { path = "../vcad-kernel-text" }
+
+[features]
+# Forwards the `no-builtin-font` flag from vcad-kernel-text so downstream
+# crates (e.g. vcad-kernel-wasm) can disable the compile-time font embed
+# without reaching into a transitive dependency.
+no-builtin-font = ["vcad-kernel-text/no-builtin-font"]

--- a/packages/kernel-wasm/package.json
+++ b/packages/kernel-wasm/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/ecto/vcad"
   },
   "scripts": {
-    "build": "wasm-pack build ../../crates/vcad-kernel-wasm --target web --out-dir ../../packages/kernel-wasm/pkg && cp pkg/vcad_kernel_wasm* ."
+    "build": "if [ -n \"$VCAD_WASM_SKIP\" ]; then echo \"wasm build skipped (VCAD_WASM_SKIP set, assuming pkg/ is already populated)\"; else wasm-pack build ../../crates/vcad-kernel-wasm --target web --out-dir ../../packages/kernel-wasm/pkg && cp pkg/vcad_kernel_wasm* .; fi"
   },
   "files": [
     "vcad_kernel_wasm_bg.wasm",

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,8 @@
         "../../Cargo.toml",
         "../../Cargo.lock"
       ],
-      "outputs": ["pkg/**", "*.wasm", "*.js", "*.d.ts"]
+      "outputs": ["pkg/**", "*.wasm", "*.js", "*.d.ts"],
+      "env": ["VCAD_WASM_SKIP"]
     },
     "@vcad/engine#build": {
       "dependsOn": ["vcad-kernel-wasm#build", "^build"],


### PR DESCRIPTION
## Summary

TypeScript CI was **7m3s** with wasm-pack (3m23s) on the critical path. Five targeted changes bring the warm case to **~2m** (TS-only PRs, which are the common case).

### Measured on this branch

| Scenario | Before | After |
|----------|-------:|------:|
| **Warm** (wasm cache hit, TS-only PR) | 7m3s | **2m4s** (WASM 10s + TS 1m54s) |
| **Cold** (wasm source changed) | 7m3s | ~6m37s (WASM 4m25s + TS 2m12s) |

### Changes

1. **Split `wasm` into its own job** — runs in parallel with Rust jobs; TS job downloads `packages/kernel-wasm/pkg/` via artifact, no Rust toolchain in the TS path.
2. **Cache wasm pkg/ output** keyed on `crates/** + Cargo.lock + sibling repo HEADs`. TS-only PRs skip wasm-pack entirely (10s restore vs 3m23s rebuild).
3. **`wasm-pack --profiling`** uses release compile + light `-O` wasm-opt instead of the default heavy `-O2`. Saves ~2m per miss; output fits under the 10MB PWA workbox limit. (Tried `--dev` first — produced 29MB wasm that tripped the PWA plugin.)
4. **Fix turbo cache key** — was `hashFiles('crates/**/src/**', 'packages/**/src/**', …)` which changes on every PR (near-zero hit rate). New primary is `github.sha` with a broad restore-keys fallback; turbo's own per-task hash decides what's actually reused.
5. **Drop `libcairo/libpango/librsvg` apt install** (~23s) by using `npm ci --ignore-scripts`. Those deps existed only to compile `canvas` in `packages/hf-space`, which has no `build` or `test` task in CI.

### Supporting changes

- `vcad-kernel-wasm` and `vcad-kernel` get a `no-builtin-font` feature that forwards to `vcad-kernel-text/no-builtin-font`, so the wasm job (which has no `node_modules/next/...`) can skip the font `include_bytes!`. Matches what the Rust CI job already does.
- `packages/kernel-wasm` build script short-circuits when `VCAD_WASM_SKIP=1` is set. Turbo's task graph still walks `vcad-kernel-wasm#build` as a `dependsOn` of `@vcad/engine#build`, so filtering it out wasn't enough — the script itself has to become a noop.
- `turbo.json` adds `VCAD_WASM_SKIP` to the task's `env` allowlist (turbo v2 scrubs env vars by default).

Rust stable/nightly jobs untouched.

## Test plan

- [x] CI passes (run 24789234485 — cold, all green)
- [x] Warm cache run confirms wasm cache hit (run 24789582591 — WASM 10s, TS 1m54s)
- [x] Rust stable and nightly jobs still green
- [x] `npm test --workspaces --if-present` still passes in TS job (profiling-profile wasm works for tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)