### PR TITLE
docs: fix tauri:dev script and document worktree bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,22 @@ git clone git@github.com:ecto/tang.git ../tang
 Cargo paths in the workspace (`tang`, `tang-la`, `tang-expr`) all point at
 `../tang/crates/*`.
 
+**Fresh worktrees** (`.claude/worktrees/*`) start with no `node_modules` — run `npm ci`
+before any npm/tauri command. Tauri needs the `cargo-tauri` binary (installed globally
+via `cargo install tauri-cli`); the npm scripts invoke it as `cargo tauri`, so no local
+`tauri` on PATH is required.
+
+After `npm ci`, the app imports from `@vcad/core`, `@vcad/engine`, `@vcad/ir`, `@vcad/mcp`
+which all resolve to `dist/index.js` — so workspace packages must be built before
+`npm run dev` or `tauri:dev` will start. Fastest path:
+
+```bash
+VCAD_WASM_SKIP=1 npm run build --workspaces --if-present
+```
+
+`VCAD_WASM_SKIP=1` skips the wasm-pack rebuild when `packages/kernel-wasm/vcad_kernel_wasm*`
+artifacts are already checked in; drop it if you need a fresh kernel WASM.
+
 ## Commands
 
 ```bash
@@ -35,7 +51,8 @@ npm run build --workspaces         # build all TS packages
 npm test --workspaces --if-present # run tests
 
 # App
-npm run dev -w @vcad/app           # run web app locally
+npm run dev -w @vcad/app           # run web app locally (browser)
+npm run tauri:dev -w @vcad/app     # run desktop app (Tauri shell + Vite)
 
 # Supabase (database)
 supabase db push --dry-run         # preview migration changes

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "tauri:dev": "cd ../../crates/vcad-desktop && tauri dev",
-    "tauri:build": "cd ../../crates/vcad-desktop && tauri build"
+    "tauri:dev": "cd ../../crates/vcad-desktop && cargo tauri dev",
+    "tauri:build": "cd ../../crates/vcad-desktop && cargo tauri build"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## Summary
- Fix `tauri:dev` / `tauri:build` in [packages/app/package.json](packages/app/package.json) to invoke `cargo tauri` instead of `tauri` — previous scripts failed when only the globally-installed `cargo-tauri` binary was on PATH.
- Document two bootstrap gotchas in CLAUDE.md that tripped up a fresh worktree setup:
  - `.claude/worktrees/*` start with no `node_modules` — must `npm ci` first.
  - App imports from `@vcad/core`/`engine`/`ir`/`mcp` resolve to `dist/index.js`, so `npm run build --workspaces --if-present` must run before `dev` or `tauri:dev`. `VCAD_WASM_SKIP=1` skips the slow wasm-pack rebuild when the kernel artifacts are already checked in.

## Why
Starting the Tauri desktop app from a clean worktree failed at three different layers (missing `tauri` binary, missing `node_modules`, missing workspace `dist/`). Each failure was silent enough that the root cause wasn't obvious. These changes make the happy path work out of the box and document the remaining manual step.

## Test plan
- [x] `npm run tauri:dev -w @vcad/app` starts the desktop app cleanly in a fresh worktree after `npm ci && VCAD_WASM_SKIP=1 npm run build --workspaces --if-present`.
- [ ] Verify `npm run tauri:build -w @vcad/app` still produces a release bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)