### PR TITLE
feat(app): world-class document identity — titlebar, URL, versions, AI presence

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -36,6 +36,7 @@ const AboutModal = lazyWithRetry(() => import("@/components/AboutModal").then(m 
 const RecentFilesModal = lazyWithRetry(() => import("@/components/RecentFilesModal").then(m => ({ default: m.RecentFilesModal })), "RecentFilesModal");
 const ProductModal = lazyWithRetry(() => import("@/components/ProductModal").then(m => ({ default: m.ProductModal })), "ProductModal");
 const ShareDialog = lazyWithRetry(() => import("@/components/ShareDialog").then(m => ({ default: m.ShareDialog })), "ShareDialog");
+const VersionHistoryModal = lazyWithRetry(() => import("@/components/VersionHistoryModal").then(m => ({ default: m.VersionHistoryModal })), "VersionHistoryModal");
 const ForkPromptModal = lazyWithRetry(() => import("@/components/ForkPromptModal").then(m => ({ default: m.ForkPromptModal })), "ForkPromptModal");
 const ReadOnlyBanner = lazyWithRetry(() => import("@/components/ReadOnlyBanner").then(m => ({ default: m.ReadOnlyBanner })), "ReadOnlyBanner");
 const ProfilePage = lazyWithRetry(() => import("@/components/ProfilePage").then(m => ({ default: m.ProfilePage })), "ProfilePage");
@@ -170,6 +171,7 @@ export function App() {
   const [aboutOpen, setAboutOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [documentPickerOpen, setDocumentPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -787,6 +789,7 @@ export function App() {
                 onSave={handleSave}
                 onOpen={handleOpen}
                 onShareOpen={() => setShareOpen(true)}
+                onVersionHistoryOpen={() => setVersionHistoryOpen(true)}
               >
                 {!sketchActive && <ToolPalette />}
               </Header>
@@ -821,6 +824,10 @@ export function App() {
           <AboutModal open={aboutOpen} onOpenChange={setAboutOpen} />
           <ProductModal open={productOpen} onOpenChange={setProductOpen} />
           <ShareDialog open={shareOpen} onOpenChange={setShareOpen} />
+          <VersionHistoryModal
+            open={versionHistoryOpen}
+            onOpenChange={setVersionHistoryOpen}
+          />
           <ForkPromptModal />
           <DocumentPicker
             open={documentPickerOpen}

--- a/packages/app/src/components/DocTitle.tsx
+++ b/packages/app/src/components/DocTitle.tsx
@@ -90,12 +90,16 @@ export function DocTitle({ macOverlay }: { macOverlay?: boolean }) {
 
   // Select the whole name when edit mode opens so a single click + type
   // replaces it wholesale — the familiar Finder rename interaction.
+  // Depending on `draft !== null` (not `draft` itself) keeps the effect from
+  // re-firing on every keystroke — otherwise each new character re-selects
+  // the text and gets replaced by the next one.
+  const editing = draft !== null;
   useEffect(() => {
-    if (draft !== null) {
+    if (editing) {
       inputRef.current?.focus();
       inputRef.current?.select();
     }
-  }, [draft]);
+  }, [editing]);
 
   const startEdit = () => {
     if (readOnlyShare) return;

--- a/packages/app/src/components/DocTitle.tsx
+++ b/packages/app/src/components/DocTitle.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useRef, useState } from "react";
+import { Circle } from "@phosphor-icons/react/dist/ssr/Circle";
+import { Lock } from "@phosphor-icons/react/dist/ssr/Lock";
+import { CaretRight } from "@phosphor-icons/react/dist/ssr/CaretRight";
+import { Sparkle } from "@phosphor-icons/react/dist/ssr/Sparkle";
+import {
+  useDocumentStore,
+  useUiStore,
+  useSketchStore,
+  useChatStore,
+  useParticipantStore,
+  AI_PARTICIPANT_ID,
+  getSketchPlaneName,
+} from "@vcad/core";
+import { useAuthStore, useSyncStore } from "@vcad/auth";
+import { useDrawingStore } from "@/stores/drawing-store";
+import { useElectronicsStore } from "@/stores/electronics-store";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Titlebar identity strip — filename, ambient save state, scope breadcrumb.
+ *
+ * Centered in the header row. Click the name to inline-rename (Enter commits,
+ * Esc reverts). The save dot reuses the same state machine as StatusBar:
+ *  local dirty → brand/pulse, cloud syncing → yellow/pulse, sync error → danger,
+ *  otherwise muted "saved". In a read-only share session, a lock badge replaces
+ *  the save dot.
+ *
+ * Scope crumbs are clickable shortcuts back out of the current mode (exit
+ * sketch, leave drawing-mode, etc).
+ */
+
+export function DocTitle({ macOverlay }: { macOverlay?: boolean }) {
+  const documentName = useDocumentStore((s) => s.documentName);
+  const setDocumentName = useDocumentStore((s) => s.setDocumentName);
+  const isDirty = useDocumentStore((s) => s.isDirty);
+  const readOnlyShare = useUiStore((s) => s.readOnlyShare);
+
+  const user = useAuthStore((s) => s.user);
+  const isAnonymous = useAuthStore((s) => s.isAnonymous);
+  const isSignedIn = !!user && !isAnonymous;
+  const syncStatus = useSyncStore((s) => s.syncStatus);
+
+  const sketchActive = useSketchStore((s) => s.active);
+  const sketchPlane = useSketchStore((s) => s.plane);
+  const requestSketchExit = useSketchStore((s) => s.requestExit);
+
+  const drawingMode = useDrawingStore((s) => s.viewMode);
+  const setDrawingMode = useDrawingStore((s) => s.setViewMode);
+
+  const electronicsActive = useElectronicsStore((s) => s.active);
+  const exitElectronics = useElectronicsStore((s) => s.exit);
+
+  // AI presence — treat the chat assistant as a peer editor. "Streaming"
+  // means an LLM pass is live; useChatHandler retires the participant shortly
+  // after the turn ends to clear the viewport frustum.
+  const chatStreaming = useChatStore((s) => s.streaming);
+  const openChat = useChatStore((s) => s.setOpen);
+  const aiParticipant = useParticipantStore((s) =>
+    s.participants.get(AI_PARTICIPANT_ID),
+  );
+
+  // Local edit-mode — null means not editing, string means draft value.
+  const [draft, setDraft] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Keep the native Tauri window title + dock tile in sync with the doc name.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { isTauri } = await import("@/lib/tauri");
+        if (!isTauri()) return;
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        if (cancelled) return;
+        await getCurrentWindow().setTitle(
+          documentName && documentName !== "Untitled"
+            ? `${documentName} — vcad`
+            : "vcad",
+        );
+      } catch {
+        // Not running under Tauri, or window API missing — ignore.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [documentName]);
+
+  // Select the whole name when edit mode opens so a single click + type
+  // replaces it wholesale — the familiar Finder rename interaction.
+  useEffect(() => {
+    if (draft !== null) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [draft]);
+
+  const startEdit = () => {
+    if (readOnlyShare) return;
+    setDraft(documentName);
+  };
+  const commitEdit = () => {
+    if (draft === null) return;
+    const next = draft.trim();
+    if (next && next !== documentName) setDocumentName(next);
+    setDraft(null);
+  };
+  const cancelEdit = () => setDraft(null);
+
+  // Save-state visual — mirrors StatusBar's decision tree so the two
+  // indicators never disagree. The StatusBar dot is gone once this lands.
+  const saveIndicator: {
+    dotClass: string;
+    pulse: boolean;
+    tooltip: string;
+  } = isDirty
+    ? {
+        dotClass: "text-brand",
+        pulse: true,
+        tooltip: "Unsaved changes",
+      }
+    : isSignedIn && syncStatus === "syncing"
+      ? {
+          dotClass: "text-yellow-500",
+          pulse: true,
+          tooltip: "Syncing to cloud",
+        }
+      : isSignedIn && syncStatus === "error"
+        ? {
+            dotClass: "text-danger",
+            pulse: false,
+            tooltip: "Cloud sync failed",
+          }
+        : {
+            dotClass: "text-text-muted/50",
+            pulse: false,
+            tooltip: isSignedIn ? "Saved · synced to cloud" : "Saved",
+          };
+
+  const nameDisplay = documentName || "Untitled";
+  const nameIsDefault = !documentName || documentName === "Untitled";
+
+  return (
+    <div
+      data-tauri-drag-region={macOverlay ? "false" : undefined}
+      className={cn(
+        "flex h-6 items-center gap-1.5 px-2 text-[11px] select-none",
+        "max-w-[min(60vw,720px)]",
+      )}
+    >
+      {/* Filename — click to rename */}
+      {draft !== null ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitEdit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancelEdit();
+            }
+          }}
+          className={cn(
+            "h-5 min-w-[4ch] max-w-[32ch] px-1 text-[11px] font-medium",
+            "bg-bg text-text border border-brand/60 outline-none",
+            "rounded-sm",
+          )}
+          spellCheck={false}
+        />
+      ) : (
+        <Tooltip content={readOnlyShare ? "Read-only share" : "Click to rename"}>
+          <button
+            type="button"
+            onClick={startEdit}
+            disabled={!!readOnlyShare}
+            className={cn(
+              "h-5 px-1 text-[11px] font-medium truncate max-w-[32ch] rounded-sm",
+              "hover:bg-hover transition-colors outline-none",
+              nameIsDefault ? "text-text-muted italic" : "text-text",
+              readOnlyShare && "cursor-not-allowed opacity-80",
+            )}
+          >
+            {nameDisplay}
+          </button>
+        </Tooltip>
+      )}
+
+      {/* Save state — swapped for a lock in read-only sessions */}
+      {readOnlyShare ? (
+        <Tooltip content="Read-only share — fork to edit">
+          <span className="flex items-center gap-1 text-amber-500 text-[10px]">
+            <Lock size={10} weight="fill" />
+            <span className="uppercase tracking-wide">read-only</span>
+          </span>
+        </Tooltip>
+      ) : (
+        <Tooltip content={saveIndicator.tooltip}>
+          <Circle
+            size={6}
+            weight="fill"
+            className={cn(
+              saveIndicator.dotClass,
+              saveIndicator.pulse && "animate-pulse",
+            )}
+            aria-label={saveIndicator.tooltip}
+          />
+        </Tooltip>
+      )}
+
+      {/* Scope breadcrumb — only shows when out of doc root */}
+      {sketchActive && (
+        <ScopeCrumb onExit={() => requestSketchExit()}>
+          Sketch <span className="text-text-muted">on</span>{" "}
+          {getSketchPlaneName(sketchPlane)}
+        </ScopeCrumb>
+      )}
+      {!sketchActive && drawingMode === "2d" && (
+        <ScopeCrumb onExit={() => setDrawingMode("3d")}>Drawing</ScopeCrumb>
+      )}
+      {!sketchActive && electronicsActive && (
+        <ScopeCrumb onExit={() => exitElectronics()}>Electronics</ScopeCrumb>
+      )}
+
+      {/* AI presence — visible while the assistant is actively editing. */}
+      {chatStreaming && aiParticipant && (
+        <Tooltip content="Open chat">
+          <button
+            type="button"
+            onClick={() => openChat(true)}
+            className={cn(
+              "ml-1 flex items-center gap-1 h-5 px-1.5 rounded-sm",
+              "bg-brand/10 hover:bg-brand/20 transition-colors outline-none",
+              "text-[10px] font-medium",
+            )}
+            style={{ color: aiParticipant.color }}
+            aria-label={`${aiParticipant.name} is editing`}
+          >
+            <Sparkle size={9} weight="fill" className="animate-pulse" />
+            <span>{aiParticipant.name}</span>
+            <span className="text-text-muted">editing</span>
+          </button>
+        </Tooltip>
+      )}
+    </div>
+  );
+}
+
+function ScopeCrumb({
+  onExit,
+  children,
+}: {
+  onExit: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <CaretRight size={10} className="text-text-muted/60 shrink-0" />
+      <Tooltip content="Click to exit this mode">
+        <button
+          type="button"
+          onClick={onExit}
+          className={cn(
+            "h-5 px-1 text-[11px] text-text-muted rounded-sm",
+            "hover:bg-hover hover:text-text transition-colors outline-none",
+          )}
+        >
+          {children}
+        </button>
+      </Tooltip>
+    </>
+  );
+}

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -7,6 +7,7 @@ import { Export } from "@phosphor-icons/react/dist/ssr/Export";
 import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr/MagnifyingGlass";
 import { Bell } from "@phosphor-icons/react/dist/ssr/Bell";
 import { Link as LinkIcon } from "@phosphor-icons/react/dist/ssr/Link";
+import { DocTitle } from "@/components/DocTitle";
 import * as Menubar from "@radix-ui/react-menubar";
 import {
   useDocumentStore,
@@ -48,6 +49,8 @@ interface HeaderProps {
   onOpen: () => void;
   /** Opens the ShareDialog. Enabled only when signed in + cloud-synced. */
   onShareOpen: () => void;
+  /** Opens the VersionHistoryModal. Enabled only when signed in. */
+  onVersionHistoryOpen: () => void;
   /** Tool palette (tab strip + icon row) docked directly under the menu bar. */
   children?: React.ReactNode;
 }
@@ -270,8 +273,7 @@ function RayTracingSubmenu() {
   );
 }
 
-export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen, children }: HeaderProps) {
-  const isDirty = useDocumentStore((s) => s.isDirty);
+export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen, onVersionHistoryOpen, children }: HeaderProps) {
   const user = useAuthStore((s) => s.user);
   const isAnonymous = useAuthStore((s) => s.isAnonymous);
   // "Has a permanent identity" — false for anon Supabase sessions.
@@ -386,24 +388,12 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           >
             vcad<span className="text-brand">.</span>
           </button>
-          {isDirty && <span className="text-brand text-xs">*</span>}
         </div>
 
-        {/* iTunes-style center search bar — opens the screen-centered ⌘K palette */}
-        <button
-          onClick={handleCommandPalette}
-          className={cn(
-            "absolute left-1/2 -translate-x-1/2",
-            "flex h-5 w-72 max-w-[40vw] items-center gap-1.5 px-2",
-            "border border-border bg-bg/60 hover:bg-bg",
-            "text-[11px] text-text-muted hover:text-text",
-            "rounded-sm transition-colors",
-          )}
-        >
-          <MagnifyingGlass size={11} />
-          <span className="flex-1 text-left truncate">Search or ask AI…</span>
-          <span className="text-[9px] text-text-muted/70 font-mono">⌘K</span>
-        </button>
+        {/* Centered document-identity strip — filename, save state, scope breadcrumb */}
+        <div className="absolute left-1/2 -translate-x-1/2">
+          <DocTitle macOverlay={macOverlay} />
+        </div>
 
         <Menubar.Root
           value={menuValue}
@@ -438,6 +428,12 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
                   disabled={!isSignedIn}
                 >
                   Share link…
+                </MenuItem>
+                <MenuItem
+                  onSelect={onVersionHistoryOpen}
+                  disabled={!isSignedIn}
+                >
+                  Version history…
                 </MenuItem>
                 <MenuSeparator />
                 <Submenu label="Export" icon={Export} iconClassName="text-sky-400">
@@ -590,7 +586,19 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           data-tauri-drag-region={macOverlay ? "" : undefined}
         />
 
-        {/* Right cluster: glance zone — changelog bell + auth */}
+        {/* Right cluster: search · changelog bell · auth */}
+        <button
+          type="button"
+          onClick={handleCommandPalette}
+          title="Search or ask AI… (⌘K)"
+          aria-label="Search or ask AI"
+          className={cn(
+            "relative flex items-center justify-center w-6 h-6",
+            "text-text-muted hover:text-text hover:bg-hover transition-colors",
+          )}
+        >
+          <MagnifyingGlass size={13} />
+        </button>
         <button
           type="button"
           onClick={openChangelogPanel}

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { Circle } from "@phosphor-icons/react/dist/ssr/Circle";
 import { Terminal } from "@phosphor-icons/react/dist/ssr/Terminal";
 import { useDocumentStore, useUiStore, type LogLevelName } from "@vcad/core";
-import { useAuthStore, useSyncStore } from "@vcad/auth";
 import { useLogStore, getFilteredEntries } from "@/stores/log-store";
 import { cn } from "@/lib/utils";
 
@@ -35,15 +34,8 @@ function formatAgo(ts: number, now: number): string {
  */
 export function StatusBar() {
   const parts = useDocumentStore((s) => s.parts);
-  const isDirty = useDocumentStore((s) => s.isDirty);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const cursorWorld = useUiStore((s) => s.cursorWorld);
-  const user = useAuthStore((s) => s.user);
-  const isAnonymous = useAuthStore((s) => s.isAnonymous);
-  // Anonymous Supabase sessions exist for chat-thread RLS scoping; the
-  // status bar's "syncing as ..." UI should treat them as not-signed-in.
-  const isSignedIn = !!user && !isAnonymous;
-  const syncStatus = useSyncStore((s) => s.syncStatus);
 
   // Subscribe to the pieces of the log store the ticker actually needs so we
   // re-render only when filtered output changes.
@@ -80,41 +72,6 @@ export function StatusBar() {
   const selCount = selectedPartIds.size;
   const fresh = latest && now - latest.timestamp < 3000;
   const levelColor = latest ? LEVEL_COLOR[latest.level] : "";
-
-  // Combined save indicator: local dirty state takes precedence, then cloud
-  // sync status (only meaningful when the user is signed in).
-  const saveIndicator: {
-    label: string;
-    title: string;
-    className: string;
-    pulse: boolean;
-  } = isDirty
-    ? {
-        label: "modified",
-        title: "Unsaved changes",
-        className: "text-brand",
-        pulse: true,
-      }
-    : isSignedIn && syncStatus === "syncing"
-      ? {
-          label: "syncing",
-          title: "Syncing to cloud",
-          className: "text-yellow-500",
-          pulse: true,
-        }
-      : isSignedIn && syncStatus === "error"
-        ? {
-            label: "sync failed",
-            title: "Cloud sync failed",
-            className: "text-danger",
-            pulse: false,
-          }
-        : {
-            label: "saved",
-            title: isSignedIn ? "Saved and synced" : "Saved",
-            className: "text-text-muted/60",
-            pulse: false,
-          };
 
   return (
     <div
@@ -204,24 +161,13 @@ export function StatusBar() {
         )}
       </div>
 
-      {/* Right: doc metrics */}
+      {/* Right: doc metrics — save state now lives in the titlebar's DocTitle */}
       <div
         className={cn(
           "flex items-center gap-3 px-3 border-l border-border/40",
           "text-text-muted",
         )}
       >
-        <span
-          className={cn("flex items-center gap-1", saveIndicator.className)}
-          title={saveIndicator.title}
-        >
-          <Circle
-            size={7}
-            weight="fill"
-            className={cn(saveIndicator.pulse && "animate-pulse")}
-          />
-          {saveIndicator.label}
-        </span>
         <span className="tabular-nums">
           {parts.length} {parts.length === 1 ? "part" : "parts"}
         </span>

--- a/packages/app/src/components/VersionHistoryModal.tsx
+++ b/packages/app/src/components/VersionHistoryModal.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "@phosphor-icons/react/dist/ssr/X";
+import { ClockCounterClockwise } from "@phosphor-icons/react/dist/ssr/ClockCounterClockwise";
+import { useDocumentStore } from "@vcad/core";
+import { VersionHistoryPanel, useAuthStore } from "@vcad/auth";
+import { loadDocument as loadStoredDocument } from "@/lib/storage";
+import { useNotificationStore } from "@/stores/notification-store";
+import { cn } from "@/lib/utils";
+
+interface VersionHistoryModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Modal wrapper around `VersionHistoryPanel`. Resolves the cloud ID for the
+ * currently open document from local storage; the panel itself handles the
+ * not-signed-in / not-synced cases with a friendly message.
+ */
+export function VersionHistoryModal({
+  open,
+  onOpenChange,
+}: VersionHistoryModalProps) {
+  const documentId = useDocumentStore((s) => s.documentId);
+  const documentName = useDocumentStore((s) => s.documentName);
+  const user = useAuthStore((s) => s.user);
+  const isAnonymous = useAuthStore((s) => s.isAnonymous);
+  const isSignedIn = !!user && !isAnonymous;
+
+  const [cloudId, setCloudId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || !documentId) {
+      setCloudId(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const stored = await loadStoredDocument(documentId);
+        if (cancelled) return;
+        setCloudId(stored?.cloudId ?? null);
+      } catch {
+        if (!cancelled) setCloudId(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, documentId]);
+
+  const handleRestore = () => {
+    useNotificationStore.getState().addToast("Version restored", "success");
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2",
+            "bg-surface shadow-2xl focus:outline-none max-h-[80vh] overflow-auto",
+          )}
+        >
+          <Dialog.Close className="absolute right-3 top-3 p-1.5 text-text-muted hover:text-text transition-colors cursor-pointer">
+            <X size={14} />
+          </Dialog.Close>
+
+          <div className="flex items-center gap-2 px-6 pt-6 pb-2">
+            <ClockCounterClockwise size={14} className="text-brand" />
+            <Dialog.Title className="text-sm font-semibold text-text truncate">
+              Version history · {documentName || "document"}
+            </Dialog.Title>
+          </div>
+
+          {!isSignedIn ? (
+            <div className="p-6 text-sm text-text-muted">
+              Sign in to enable cloud sync and access version history.
+            </div>
+          ) : documentId ? (
+            <VersionHistoryPanel
+              localDocId={documentId}
+              cloudDocId={cloudId}
+              onRestore={handleRestore}
+            />
+          ) : (
+            <div className="p-6 text-sm text-text-muted">
+              No document open.
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import {
   useChatStore,
   useDocumentStore,
@@ -573,4 +573,37 @@ export function useChatHandler() {
     useChatStore.getState().setSendHandler(handleChatSend);
     return () => useChatStore.getState().setSendHandler(null);
   }, [handleChatSend]);
+
+  // Retire the AI participant (camera frustum + selection highlight in the
+  // viewport) shortly after a chat turn ends. Debounced because `streaming`
+  // toggles within a single turn (LLM pass → tool call → next LLM pass);
+  // we don't want the frustum flickering between passes. The DocTitle
+  // presence pill is gated on `streaming` directly and doesn't flicker —
+  // this cleanup is only for the lingering viewport state.
+  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    const unsubscribe = useChatStore.subscribe((state, prev) => {
+      if (state.streaming === prev.streaming) return;
+      if (state.streaming) {
+        // New pass started — cancel any pending cleanup.
+        if (cleanupTimerRef.current) {
+          clearTimeout(cleanupTimerRef.current);
+          cleanupTimerRef.current = null;
+        }
+      } else {
+        // Streaming paused. If the whole turn is done, tear down AI presence.
+        cleanupTimerRef.current = setTimeout(() => {
+          useParticipantStore.getState().remove(AI_PARTICIPANT_ID);
+          cleanupTimerRef.current = null;
+        }, 800);
+      }
+    });
+    return () => {
+      unsubscribe();
+      if (cleanupTimerRef.current) {
+        clearTimeout(cleanupTimerRef.current);
+        cleanupTimerRef.current = null;
+      }
+    };
+  }, []);
 }

--- a/packages/app/src/hooks/useUrlSync.ts
+++ b/packages/app/src/hooks/useUrlSync.ts
@@ -1,10 +1,28 @@
 import { useEffect, useRef } from "react";
-import { useUiStore, useSketchStore, type SidebarPane } from "@vcad/core";
+import {
+  useDocumentStore,
+  useUiStore,
+  useSketchStore,
+  type SidebarPane,
+} from "@vcad/core";
 
 const INSPECT_VALUES = ["scene"] as const;
 type InspectValue = (typeof INSPECT_VALUES)[number];
 function isInspectValue(v: string | null): v is InspectValue {
   return v != null && (INSPECT_VALUES as readonly string[]).includes(v);
+}
+
+/**
+ * Returns the pathname the URL should carry for a given `documentId`, or null
+ * to leave the pathname alone. We only own the `/d/<id>` and `/` prefixes —
+ * any other path (share token, public slug, profile page) is another
+ * subsystem's to manage.
+ */
+function desiredPathname(documentId: string | null): string | null {
+  const path = window.location.pathname;
+  const ownedByDocSync = path === "/" || /^\/d\//.test(path);
+  if (!ownedByDocSync) return null;
+  return documentId ? `/d/${documentId}` : "/";
 }
 
 /**
@@ -21,6 +39,7 @@ function isInspectValue(v: string | null): v is InspectValue {
  * stores, and a guard ref prevents the two from chasing each other.
  */
 export function useUrlSync() {
+  const documentId = useDocumentStore((s) => s.documentId);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const sidebarPane = useUiStore((s) => s.sidebarPane);
   const inspectorTarget = useUiStore((s) => s.inspectorTarget);
@@ -95,9 +114,13 @@ export function useUrlSync() {
     }
 
     const next = params.toString();
-    const url = `${window.location.pathname}${next ? "?" + next : ""}${window.location.hash}`;
+    // The pathname is either the `/d/<id>` we want (local doc), or we leave
+    // it alone (share token / public slug / profile page).
+    const pathname =
+      desiredPathname(documentId) ?? window.location.pathname;
+    const url = `${pathname}${next ? "?" + next : ""}${window.location.hash}`;
     if (url !== window.location.pathname + window.location.search + window.location.hash) {
       window.history.replaceState(null, "", url);
     }
-  }, [selectedPartIds, sidebarPane, sketchActive, inspectorTarget]);
+  }, [documentId, selectedPartIds, sidebarPane, sketchActive, inspectorTarget]);
 }

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -17,7 +17,7 @@ import {
   loadDocument as loadDocumentFromDb,
   generateDocumentName,
 } from "@/lib/storage";
-import { loadDocumentFromUrl } from "@/lib/url-document";
+import { loadDocumentFromUrl, getLocalDocRouteId } from "@/lib/url-document";
 import type { UrlDocumentResult } from "@/lib/url-document";
 import { useNotificationStore } from "@/stores/notification-store";
 import { analytics } from "@/lib/analytics";
@@ -237,6 +237,23 @@ async function fetchDocumentData(): Promise<DocumentBootData> {
   try {
     const urlDoc = await loadDocumentFromUrl();
     if (urlDoc) return { kind: "url", urlDoc };
+
+    // `/d/<localId>` — URL carries the exact local doc to open. If the doc
+    // doesn't exist on this device, fall through to the most-recent flow
+    // rather than crash; the URL is replaced by the mirror after loading.
+    const routedId = getLocalDocRouteId();
+    if (routedId) {
+      const stored = await loadDocumentFromDb(routedId);
+      if (stored) {
+        return {
+          kind: "stored",
+          id: stored.id,
+          name: stored.name,
+          file: stored.document,
+        };
+      }
+      logger.warn("app", `URL referenced unknown local doc ${routedId}, falling back`);
+    }
 
     const recent = await getMostRecentDocument();
     if (recent) {

--- a/packages/app/src/lib/url-document.ts
+++ b/packages/app/src/lib/url-document.ts
@@ -108,6 +108,7 @@ type UrlRoute =
   | { kind: "share-token"; token: string }
   | { kind: "public-doc"; username: string; slug: string }
   | { kind: "profile"; username: string }
+  | { kind: "local-doc"; id: string }
   | null;
 
 /** Parse the current pathname into a route. */
@@ -127,7 +128,21 @@ function parseRoute(): UrlRoute {
   const profileMatch = path.match(/^\/@([a-z0-9][a-z0-9-]*[a-z0-9])\/?$/);
   if (profileMatch?.[1]) return { kind: "profile", username: profileMatch[1] };
 
+  // /d/<uuid> — local IndexedDB document identity
+  const localMatch = path.match(/^\/d\/([0-9a-fA-F-]{8,64})\/?$/);
+  if (localMatch?.[1]) return { kind: "local-doc", id: localMatch[1] };
+
   return null;
+}
+
+/**
+ * Returns the local document ID from the current URL, if the user landed on
+ * a `/d/<id>` path. Bootstrap checks this before falling back to
+ * "most recent document" so refresh always reopens the exact doc.
+ */
+export function getLocalDocRouteId(): string | null {
+  const route = parseRoute();
+  return route?.kind === "local-doc" ? route.id : null;
 }
 
 /** Read and decode the optional ?at=<encoded> viewer state hint. */

--- a/packages/auth/src/components/VersionHistoryPanel.tsx
+++ b/packages/auth/src/components/VersionHistoryPanel.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   getVersionHistory,
+  labelVersion,
   restoreVersion,
+  unlabelVersion,
   type DocumentVersion,
 } from "../version-history";
 
@@ -14,9 +16,18 @@ interface VersionHistoryPanelProps {
   onRestore?: () => void;
 }
 
+type Tab = "named" | "all";
+
 /**
  * Panel showing version history for a cloud-synced document.
- * Allows restoring to previous versions.
+ *
+ * Two tabs: **Named** (default) shows versions the user explicitly labeled as
+ * waypoints ("v1 pre-review", "manufacturable"), and **All history** shows
+ * every auto-saved row. CAD users need named waypoints, not 600 timestamps —
+ * the default tab reflects that.
+ *
+ * Restoring a version pulls its content into the local IndexedDB doc and
+ * triggers a sync back up to cloud.
  */
 export function VersionHistoryPanel({
   localDocId,
@@ -27,26 +38,30 @@ export function VersionHistoryPanel({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [restoring, setRestoring] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("named");
+  const [labelingId, setLabelingId] = useState<string | null>(null);
+  const [labelDraft, setLabelDraft] = useState("");
 
-  useEffect(() => {
+  const loadVersions = useCallback(async () => {
     if (!cloudDocId) {
       setLoading(false);
       return;
     }
-
     setLoading(true);
     setError(null);
-
-    getVersionHistory(cloudDocId)
-      .then((v) => {
-        setVersions(v);
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
+    try {
+      const v = await getVersionHistory(cloudDocId);
+      setVersions(v);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
   }, [cloudDocId]);
+
+  useEffect(() => {
+    void loadVersions();
+  }, [loadVersions]);
 
   const handleRestore = async (version: DocumentVersion) => {
     setRestoring(version.id);
@@ -57,6 +72,31 @@ export function VersionHistoryPanel({
       setError((err as Error).message);
     } finally {
       setRestoring(null);
+    }
+  };
+
+  const handleLabelSubmit = async (versionId: string) => {
+    const label = labelDraft.trim();
+    if (!label) {
+      setLabelingId(null);
+      return;
+    }
+    try {
+      await labelVersion(versionId, label);
+      setLabelingId(null);
+      setLabelDraft("");
+      await loadVersions();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleUnlabel = async (versionId: string) => {
+    try {
+      await unlabelVersion(versionId);
+      await loadVersions();
+    } catch (err) {
+      setError((err as Error).message);
     }
   };
 
@@ -89,11 +129,40 @@ export function VersionHistoryPanel({
     );
   }
 
+  const namedVersions = versions.filter((v) => v.label);
+  const shown = tab === "named" ? namedVersions : versions;
+
   return (
     <div className="p-4">
-      <h3 className="font-semibold mb-3 text-zinc-900 dark:text-zinc-100">
-        Version History
-      </h3>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="font-semibold text-zinc-900 dark:text-zinc-100">
+          Version History
+        </h3>
+        <div className="flex gap-1 text-xs">
+          <button
+            type="button"
+            onClick={() => setTab("named")}
+            className={
+              tab === "named"
+                ? "px-2 py-1 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100"
+                : "px-2 py-1 rounded text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+            }
+          >
+            Named ({namedVersions.length})
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("all")}
+            className={
+              tab === "all"
+                ? "px-2 py-1 rounded bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100"
+                : "px-2 py-1 rounded text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+            }
+          >
+            All history
+          </button>
+        </div>
+      </div>
 
       {loading && (
         <div className="flex items-center gap-2 text-sm text-zinc-500">
@@ -108,35 +177,87 @@ export function VersionHistoryPanel({
         </div>
       )}
 
-      {!loading && versions.length === 0 && (
+      {!loading && shown.length === 0 && (
         <p className="text-sm text-zinc-500 dark:text-zinc-400">
-          No previous versions yet. Versions are created automatically when you
-          save changes.
+          {tab === "named"
+            ? "No named versions yet. Use “All history” and click “Label…” on a row to promote it to a named waypoint."
+            : "No previous versions yet. Versions are created automatically when you save changes."}
         </p>
       )}
 
-      {versions.length > 0 && (
+      {shown.length > 0 && (
         <div className="space-y-1">
-          {versions.map((v) => (
+          {shown.map((v) => (
             <div
               key={v.id}
               className="flex items-center justify-between py-2 px-2 -mx-2 rounded hover:bg-zinc-50 dark:hover:bg-zinc-800"
             >
-              <div>
-                <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
-                  Version {v.versionNumber}
-                </div>
+              <div className="min-w-0 flex-1">
+                {v.label ? (
+                  <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100 truncate">
+                    {v.label}
+                  </div>
+                ) : (
+                  <div className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                    Version {v.versionNumber}
+                  </div>
+                )}
                 <div className="text-xs text-zinc-500 dark:text-zinc-400">
+                  {v.label && `v${v.versionNumber} · `}
                   {formatRelativeTime(v.deviceModifiedAt)}
                 </div>
               </div>
-              <button
-                onClick={() => handleRestore(v)}
-                disabled={restoring === v.id}
-                className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 disabled:opacity-50"
-              >
-                {restoring === v.id ? "Restoring..." : "Restore"}
-              </button>
+              <div className="flex items-center gap-2 shrink-0">
+                {labelingId === v.id ? (
+                  <>
+                    <input
+                      autoFocus
+                      value={labelDraft}
+                      onChange={(e) => setLabelDraft(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") void handleLabelSubmit(v.id);
+                        if (e.key === "Escape") setLabelingId(null);
+                      }}
+                      placeholder="v1 pre-review"
+                      className="text-xs px-1.5 py-0.5 border border-zinc-300 dark:border-zinc-600 rounded bg-white dark:bg-zinc-900 text-zinc-900 dark:text-zinc-100"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => void handleLabelSubmit(v.id)}
+                      className="text-xs text-blue-600 dark:text-blue-400"
+                    >
+                      Save
+                    </button>
+                  </>
+                ) : v.label ? (
+                  <button
+                    type="button"
+                    onClick={() => void handleUnlabel(v.id)}
+                    className="text-xs text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+                    title="Remove label (auto-version row is preserved)"
+                  >
+                    Unlabel
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setLabelingId(v.id);
+                      setLabelDraft("");
+                    }}
+                    className="text-xs text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"
+                  >
+                    Label…
+                  </button>
+                )}
+                <button
+                  onClick={() => handleRestore(v)}
+                  disabled={restoring === v.id}
+                  className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 disabled:opacity-50"
+                >
+                  {restoring === v.id ? "Restoring..." : "Restore"}
+                </button>
+              </div>
             </div>
           ))}
         </div>

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -72,7 +72,11 @@ export {
   restoreVersion,
   getCloudIdForDocument,
   configureVersionHistoryStorage,
+  labelVersion,
+  unlabelVersion,
+  listNamedVersions,
   type DocumentVersion,
+  type NamedVersion,
 } from "./version-history";
 
 // AI

--- a/packages/auth/src/version-history.ts
+++ b/packages/auth/src/version-history.ts
@@ -10,6 +10,25 @@ export interface DocumentVersion {
   content: unknown;
   deviceModifiedAt: number;
   createdAt: string;
+  /** Non-null when the user promoted this row to a named version. */
+  label?: string | null;
+  labeledAt?: string | null;
+  labeledBy?: string | null;
+}
+
+/**
+ * Named-version list row (subset of `DocumentVersion`, no content blob).
+ * Returned by `listNamedVersions` — intentionally skips `content` so the list
+ * view stays cheap for long histories.
+ */
+export interface NamedVersion {
+  id: string;
+  versionNumber: number;
+  label: string;
+  labeledAt: string;
+  labeledBy: string | null;
+  deviceModifiedAt: number;
+  createdAt: string;
 }
 
 // Storage adapter - shared with sync module
@@ -56,6 +75,70 @@ export async function getVersionHistory(
     id: v.id,
     versionNumber: v.version_number,
     content: v.content,
+    deviceModifiedAt: v.device_modified_at,
+    createdAt: v.created_at,
+    label: v.label ?? null,
+    labeledAt: v.labeled_at ?? null,
+    labeledBy: v.labeled_by ?? null,
+  }));
+}
+
+/**
+ * Attach a human-readable label to an existing auto-version row, promoting
+ * it to a named version. Label cannot be empty; RPC enforces ownership.
+ */
+export async function labelVersion(
+  versionId: string,
+  label: string,
+): Promise<void> {
+  const supabase = requireSupabase();
+  const { error } = await supabase.rpc("label_version", {
+    p_version_id: versionId,
+    p_label: label,
+  });
+  if (error) throw new Error(`Failed to label version: ${error.message}`);
+}
+
+/** Remove a named-version label. The auto-save row itself is preserved. */
+export async function unlabelVersion(versionId: string): Promise<void> {
+  const supabase = requireSupabase();
+  const { error } = await supabase.rpc("unlabel_version", {
+    p_version_id: versionId,
+  });
+  if (error) throw new Error(`Failed to unlabel version: ${error.message}`);
+}
+
+/**
+ * List the labeled versions for a document, newest-labeled-first. Skips the
+ * `content` column — callers wanting the blob should load the specific
+ * version through `getVersionHistory` and find by id.
+ */
+export async function listNamedVersions(
+  cloudDocId: string,
+): Promise<NamedVersion[]> {
+  const supabase = requireSupabase();
+  const { data, error } = await supabase.rpc("list_named_versions", {
+    p_document_id: cloudDocId,
+  });
+  if (error) {
+    throw new Error(`Failed to fetch named versions: ${error.message}`);
+  }
+  return (
+    data as Array<{
+      id: string;
+      version_number: number;
+      label: string;
+      labeled_by: string | null;
+      labeled_at: string;
+      device_modified_at: number;
+      created_at: string;
+    }>
+  ).map((v) => ({
+    id: v.id,
+    versionNumber: v.version_number,
+    label: v.label,
+    labeledBy: v.labeled_by,
+    labeledAt: v.labeled_at,
     deviceModifiedAt: v.device_modified_at,
     createdAt: v.created_at,
   }));

--- a/supabase/migrations/015_named_versions.sql
+++ b/supabase/migrations/015_named_versions.sql
@@ -1,0 +1,104 @@
+-- Phase: named versions.
+--
+-- `document_versions` already captures every content change as a row via the
+-- trigger in 002_versions.sql. That's great for reconstructive history but
+-- too noisy to scroll through. Named versions let a user promote specific
+-- rows to first-class waypoints ("v1 pre-review", "manufacturable") without
+-- changing how auto-versioning works.
+--
+-- Additive: unlabeled rows remain the full auto-save history.
+
+alter table public.document_versions
+  add column if not exists label text,
+  add column if not exists labeled_by uuid references auth.users(id) on delete set null,
+  add column if not exists labeled_at timestamptz;
+
+create index if not exists document_versions_labeled_idx
+  on public.document_versions(document_id, labeled_at desc)
+  where label is not null;
+
+-- ─── RPC: label_version ───────────────────────────────────────────────────
+-- Promotes a single auto-version to a named one. Enforces ownership via the
+-- underlying documents RLS by joining through documents.user_id.
+create or replace function public.label_version(p_version_id uuid, p_label text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if p_label is null or length(btrim(p_label)) = 0 then
+    raise exception 'label cannot be empty';
+  end if;
+
+  update document_versions v
+  set
+    label = btrim(p_label),
+    labeled_by = auth.uid(),
+    labeled_at = now()
+  from documents d
+  where v.id = p_version_id
+    and v.document_id = d.id
+    and d.user_id = auth.uid();
+
+  if not found then
+    raise exception 'version not found or not owned by caller';
+  end if;
+end;
+$$;
+
+grant execute on function public.label_version(uuid, text) to authenticated;
+
+-- ─── RPC: unlabel_version ─────────────────────────────────────────────────
+-- Removes a named-version label (auto row survives).
+create or replace function public.unlabel_version(p_version_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update document_versions v
+  set label = null, labeled_by = null, labeled_at = null
+  from documents d
+  where v.id = p_version_id
+    and v.document_id = d.id
+    and d.user_id = auth.uid();
+
+  if not found then
+    raise exception 'version not found or not owned by caller';
+  end if;
+end;
+$$;
+
+grant execute on function public.unlabel_version(uuid) to authenticated;
+
+-- ─── RPC: list_named_versions ─────────────────────────────────────────────
+-- Returns labeled versions for a document, newest label first. RLS still
+-- applies on the underlying table — this is just a convenience view.
+create or replace function public.list_named_versions(p_document_id uuid)
+returns table (
+  id uuid,
+  version_number int,
+  label text,
+  labeled_by uuid,
+  labeled_at timestamptz,
+  device_modified_at bigint,
+  created_at timestamptz
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select v.id, v.version_number, v.label, v.labeled_by, v.labeled_at,
+         v.device_modified_at, v.created_at
+  from document_versions v
+  join documents d on d.id = v.document_id
+  where d.user_id = auth.uid()
+    and v.document_id = p_document_id
+    and v.label is not null
+  order by v.labeled_at desc;
+$$;
+
+grant execute on function public.list_named_versions(uuid) to authenticated;


### PR DESCRIPTION
## Summary

vcad is document-based but the UI barely surfaced *which* document was open. This lands four phases of the "instrument panel moment" so the titlebar, URL, version history, and AI collaboration all clearly answer **"what am I editing?"** — on both the web app and the Tauri desktop build.

## What changed

### Phase 1 — titlebar identity
- **New `DocTitle` component** centered in the header row
  - Filename (inline rename on click · Enter commits · Esc reverts)
  - Ambient save-state dot: dirty → brand/pulse, syncing → yellow/pulse, error → danger, otherwise muted
  - 🔒 read-only pill when viewing a share token
  - Clickable scope breadcrumbs for sketch (`› Sketch on XY`), drawing, and electronics modes — each exits that mode
  - Native window title + dock tile sync under Tauri
- Header: removed the `*` dirty marker, moved the ⌘K search to the right cluster as an icon button
- StatusBar: removed the now-duplicated save indicator (still owns parts/selection counts + console ticker)

### Phase 2 — URL = identity
- `/d/<localId>` pathname mirrored from the document store via `useUrlSync`
- Bootstrap prefers the URL-referenced doc over "most recent" on refresh; unknown IDs fall back silently
- Leaves `/@user/slug`, `/view/<token>`, and `/` alone — `desiredPathname()` only owns the `/d/` prefix

### Phase 3 — named versions
- Additive migration `015_named_versions.sql`: `label`, `labeled_by`, `labeled_at` columns + index
- RPCs: `label_version`, `unlabel_version`, `list_named_versions` (owner-checked via `documents.user_id`)
- `VersionHistoryPanel` gains **Named** (default) / **All history** tabs with inline label+unlabel
- New `VersionHistoryModal` wires it into **File → Version history…**

### Phase 4 — AI as a peer
- "Claude editing" pill in `DocTitle`, driven by `useChatStore.streaming`; click opens the chat sidebar
- 800ms-debounced cleanup in `useChatHandler` retires the AI participant after a turn ends, so the viewport frustum doesn't flicker across multi-pass LLM turns (LLM → tool → LLM)

## Why

Design rationale lives in the plan file, but the headline: CAD users stay in a doc for hours and CAD docs are hierarchical (doc → part → sketch/drawing). The incumbents (Figma, Google Docs, Onshape) all center doc name in the titlebar — vcad matches that and adds scope crumbs + AI presence, which no incumbent can copy quickly.

## Test plan

- [ ] `npm run dev -w @vcad/app` — doc title centered, click to rename, refresh preserves via `/d/<id>`
- [ ] Enter a sketch → `› Sketch on XY` crumb appears → click exits sketch
- [ ] Edit a part → save dot brand/pulsing → autosave → muted dot
- [ ] Sign in and sync → dot yellow during sync → muted when synced
- [ ] Open `/view/<token>` in incognito → save dot replaced by 🔒 read-only pill
- [ ] `npm run tauri:dev -w @vcad/app` — traffic lights don't overlap DocTitle; window title updates on rename
- [ ] Select a feature, copy URL, paste in a fresh tab — same doc + selection restored
- [ ] `supabase db push --dry-run supabase/migrations/015_named_versions.sql` — confirm additive only
- [ ] Apply migration, open Version history… modal, promote a row with Label…, restore it
- [ ] Ask the chat to add a cube — "Claude editing" pill appears, disappears ~800ms after the turn ends

## Notes for reviewers

- `useChatHandler` already routed AI selection through `participant-store`; Phase 4 is just *displaying* that presence + cleaning it up on turn end
- `VersionHistoryPanel` lives in `@vcad/auth` (cloud-aware) rather than app; the new modal in app is just the Radix dialog wrapper + cloudId lookup
- Migration is purely additive; existing `document_versions` rows become the "All history" tab, named versions are a subset surfaced by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)