### PR TITLE
Persist chat sidebar open/closed state to localStorage

### DIFF
--- a/packages/app/src/components/mobile/MobileShell.tsx
+++ b/packages/app/src/components/mobile/MobileShell.tsx
@@ -72,13 +72,15 @@ export function MobileShell({ onAboutOpen, onSave, onOpen, children }: MobileShe
   // Chat opens only on explicit action — dock button, ⌘K / F6 event, or
   // code that dispatches `vcad:open-chat`. Never mirrors the store's default
   // `open: true` (which is right for desktop sidebars, wrong for mobile sheets).
+  // We use setState directly (bypassing setOpen) so these mobile-only
+  // transitions don't overwrite the persisted desktop preference.
   const handleChatSheetChange = (next: boolean) => {
     setChatSheetOpen(next);
-    useChatStore.getState().setOpen(next);
+    useChatStore.setState({ open: next });
   };
   useEffect(() => {
     // Force the store closed on mount so the mobile shell starts with no sheet.
-    if (useChatStore.getState().open) useChatStore.getState().setOpen(false);
+    if (useChatStore.getState().open) useChatStore.setState({ open: false });
     const handleOpen = () => setChatSheetOpen(true);
     window.addEventListener("vcad:open-chat", handleOpen);
     return () => window.removeEventListener("vcad:open-chat", handleOpen);

--- a/packages/core/src/stores/chat-store.ts
+++ b/packages/core/src/stores/chat-store.ts
@@ -38,6 +38,32 @@ function persistAnonUsage(used: number): void {
 }
 
 // ---------------------------------------------------------------------------
+// Sidebar open/closed persistence
+// ---------------------------------------------------------------------------
+
+const OPEN_KEY = "vcad:chat:open";
+
+function loadOpen(): boolean {
+  if (typeof localStorage === "undefined") return true;
+  try {
+    const raw = localStorage.getItem(OPEN_KEY);
+    if (raw === null) return true;
+    return raw === "true";
+  } catch {
+    return true;
+  }
+}
+
+function persistOpen(open: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(OPEN_KEY, open ? "true" : "false");
+  } catch {
+    /* localStorage quota/privacy — non-fatal */
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -261,7 +287,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   threadId: null,
   hydrating: false,
   messages: [WELCOME_MESSAGE],
-  open: true,
+  open: loadOpen(),
   streaming: false,
   error: null,
   cancelRequested: false,
@@ -272,9 +298,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
   _abortController: null,
   locallyStreamingIds: new Set(),
 
-  setOpen: (open) => set({ open }),
+  setOpen: (open) => {
+    persistOpen(open);
+    set({ open });
+  },
 
-  toggleOpen: () => set((s) => ({ open: !s.open })),
+  toggleOpen: () =>
+    set((s) => {
+      const open = !s.open;
+      persistOpen(open);
+      return { open };
+    }),
 
   setThreadId: (id) => set({ threadId: id }),
 


### PR DESCRIPTION
## Summary
This PR adds persistence of the chat sidebar's open/closed state to localStorage, so the user's preference is maintained across page reloads and sessions.

## Key Changes
- **Chat Store**: Added `loadOpen()` and `persistOpen()` functions to manage localStorage persistence of the sidebar state
  - Initialize the `open` state from localStorage instead of defaulting to `true`
  - Persist state changes whenever `setOpen()` or `toggleOpen()` are called
  - Gracefully handle cases where localStorage is unavailable (SSR, private browsing, quota exceeded)

- **Mobile Shell**: Updated to bypass persistence when managing mobile-specific sheet transitions
  - Changed from `setOpen()` to direct `setState()` calls to prevent mobile sheet state from overwriting the persisted desktop preference
  - Ensures mobile and desktop have independent state management for the sidebar/sheet

## Implementation Details
- Uses the existing `vcad:chat:open` localStorage key pattern
- Defaults to `true` if localStorage is unavailable or uninitialized (preserves current behavior for first-time users)
- Mobile transitions use `setState()` directly to avoid persisting temporary mobile-only state changes
- All localStorage operations are wrapped in try-catch blocks to handle quota and privacy errors gracefully

https://claude.ai/code/session_0126yNhCwsmakQNkaY6xck79