### PR TITLE
Add Discord webhook notifications for key user activities

### DIFF
--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -8,3 +8,9 @@ VITE_SUPABASE_ANON_KEY=eyJ...
 
 # API URL (optional - defaults to same origin for /api/* routes)
 VITE_API_URL=
+
+# Discord activity notifications (optional)
+# Single webhook URL for all events (billing, signups via DB triggers, etc).
+# Leave unset to disable. Per-kind overrides: DISCORD_WEBHOOK_URL_BILLING,
+# DISCORD_WEBHOOK_URL_SIGNUP, DISCORD_WEBHOOK_URL_DOCUMENT, DISCORD_WEBHOOK_URL_CHAT.
+DISCORD_WEBHOOK_URL=

--- a/packages/app/api/_lib/discord.ts
+++ b/packages/app/api/_lib/discord.ts
@@ -1,0 +1,74 @@
+// Discord webhook helper. Fire-and-forget activity notifications for events
+// we want visibility into (new signups, new docs, new chat threads, billing).
+//
+// Env:
+//   DISCORD_WEBHOOK_URL — default webhook for all event types.
+//   DISCORD_WEBHOOK_URL_<KIND> — optional per-kind override (e.g.
+//   DISCORD_WEBHOOK_URL_BILLING). Falls back to DISCORD_WEBHOOK_URL.
+//
+// Failures are logged but never thrown — Discord being down must never break
+// a user-facing request.
+
+const BRAND_COLOR = 0xf92672; // vcad pink
+
+type EventKind = "signup" | "document" | "chat" | "billing";
+
+const KIND_META: Record<EventKind, { emoji: string; color: number }> = {
+  signup: { emoji: "👋", color: 0x66d9ef },
+  document: { emoji: "📐", color: BRAND_COLOR },
+  chat: { emoji: "💬", color: 0xa6e22e },
+  billing: { emoji: "💳", color: 0xfd971f },
+};
+
+interface NotifyOpts {
+  kind: EventKind;
+  title: string;
+  description?: string;
+  fields?: Array<{ name: string; value: string; inline?: boolean }>;
+  url?: string;
+}
+
+function resolveWebhook(kind: EventKind): string | null {
+  const specific = process.env[`DISCORD_WEBHOOK_URL_${kind.toUpperCase()}`];
+  if (specific && specific.length > 0) return specific;
+  const fallback = process.env.DISCORD_WEBHOOK_URL;
+  return fallback && fallback.length > 0 ? fallback : null;
+}
+
+export async function notifyDiscord(opts: NotifyOpts): Promise<void> {
+  const webhook = resolveWebhook(opts.kind);
+  if (!webhook) return;
+
+  const meta = KIND_META[opts.kind];
+  const embed: Record<string, unknown> = {
+    title: `${meta.emoji} ${opts.title}`,
+    color: meta.color,
+    timestamp: new Date().toISOString(),
+  };
+  if (opts.description) embed.description = opts.description;
+  if (opts.url) embed.url = opts.url;
+  if (opts.fields && opts.fields.length > 0) embed.fields = opts.fields;
+
+  try {
+    const res = await fetch(webhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ embeds: [embed] }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error("[discord] webhook error:", res.status, body.slice(0, 200));
+    }
+  } catch (err) {
+    console.error("[discord] webhook failed:", err);
+  }
+}
+
+/** Safe email masking: "alex@example.com" → "a***@example.com". */
+export function maskEmail(email: string | null | undefined): string {
+  if (!email) return "unknown";
+  const [local, domain] = email.split("@");
+  if (!local || !domain) return "unknown";
+  const head = local.slice(0, 1);
+  return `${head}${"*".repeat(Math.max(1, local.length - 1))}@${domain}`;
+}

--- a/packages/app/api/billing/webhook.ts
+++ b/packages/app/api/billing/webhook.ts
@@ -15,6 +15,7 @@ import { tierFromStripeLookupKey, type TierId } from "@vcad/core";
 import { getSupabaseAdmin } from "../_lib/supabase.js";
 import { getStripe } from "../_lib/stripe.js";
 import { sendEmail, upgradeWelcomeEmail } from "../_lib/email.js";
+import { maskEmail, notifyDiscord } from "../_lib/discord.js";
 
 export const config = {
   api: {
@@ -106,6 +107,7 @@ async function markSubscriptionCanceled(
 ): Promise<void> {
   const userId = await resolveUserId(admin, sub);
   if (!userId) return;
+  const priorTier = tierFromSubscription(sub);
   const { error } = await admin
     .from("subscriptions")
     .update({
@@ -116,7 +118,25 @@ async function markSubscriptionCanceled(
       cancel_at_period_end: false,
     })
     .eq("user_id", userId);
-  if (error) console.error("[webhook] cancel update failed:", error);
+  if (error) {
+    console.error("[webhook] cancel update failed:", error);
+    return;
+  }
+  void (async () => {
+    try {
+      const { data: authUser } = await admin.auth.admin.getUserById(userId);
+      await notifyDiscord({
+        kind: "billing",
+        title: "Subscription canceled",
+        fields: [
+          { name: "was", value: priorTier, inline: true },
+          { name: "email", value: maskEmail(authUser?.user?.email), inline: true },
+        ],
+      });
+    } catch (err) {
+      console.error("[webhook] cancel notify failed:", err);
+    }
+  })();
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -186,6 +206,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                   })();
                   const msg = upgradeWelcomeEmail({ firstName, tier });
                   await sendEmail({ to: email, ...msg });
+                  void notifyDiscord({
+                    kind: "billing",
+                    title: `New ${tier} subscriber`,
+                    fields: [
+                      { name: "tier", value: tier, inline: true },
+                      { name: "email", value: maskEmail(email), inline: true },
+                    ],
+                  });
                 } catch (err) {
                   console.error("[webhook] welcome email failed:", err);
                 }

--- a/supabase/migrations/021_discord_notifications.sql
+++ b/supabase/migrations/021_discord_notifications.sql
@@ -1,0 +1,173 @@
+-- Discord activity notifications.
+--
+-- Fires webhooks to Discord on three events that happen client-direct-to-DB
+-- (so they can't be trivially caught by a server-side API handler):
+--
+--   * auth.users INSERT        → new user signup
+--   * documents INSERT         → new cloud document
+--   * chat_threads INSERT      → first message in a new chat thread
+--
+-- Uses the pg_net extension to POST asynchronously so nothing about the
+-- user's request depends on Discord being reachable. The webhook URL lives
+-- in vault.decrypted_secrets under name 'discord_webhook_url'. Set it with:
+--
+--   select vault.create_secret(
+--     'https://discord.com/api/webhooks/...', 'discord_webhook_url');
+--
+-- When the secret isn't set, the helper function returns without calling
+-- Discord — so this migration is safe to apply before the webhook is wired.
+-- Subscription events (upgrades/cancels) are handled in the billing webhook
+-- handler directly (packages/app/api/billing/webhook.ts), not here.
+
+create extension if not exists pg_net;
+
+-- ─── notify_discord() — shared helper ────────────────────────────────────
+
+create or replace function notify_discord(embed jsonb)
+returns void
+language plpgsql
+security definer
+set search_path = public, vault
+as $$
+declare
+  webhook_url text;
+begin
+  select decrypted_secret
+    into webhook_url
+    from vault.decrypted_secrets
+    where name = 'discord_webhook_url'
+    limit 1;
+
+  if webhook_url is null or webhook_url = '' then
+    return;
+  end if;
+
+  perform net.http_post(
+    url := webhook_url,
+    headers := jsonb_build_object('Content-Type', 'application/json'),
+    body := jsonb_build_object('embeds', jsonb_build_array(embed))
+  );
+exception when others then
+  -- Never let a Discord failure roll back a user-facing write.
+  raise warning 'notify_discord failed: %', sqlerrm;
+end;
+$$;
+
+-- ─── new user signup ─────────────────────────────────────────────────────
+
+create or replace function notify_discord_on_user_signup()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  masked_email text;
+  provider text;
+begin
+  -- Skip anonymous Supabase sessions — users bounce in and out of those
+  -- constantly; we only care about real signups.
+  if coalesce(new.is_anonymous, false) then
+    return new;
+  end if;
+
+  -- "a***@example.com"
+  if new.email is not null and position('@' in new.email) > 0 then
+    masked_email := substr(new.email, 1, 1)
+      || repeat('*', greatest(1, position('@' in new.email) - 2))
+      || substr(new.email, position('@' in new.email));
+  else
+    masked_email := 'unknown';
+  end if;
+
+  provider := coalesce(
+    new.raw_app_meta_data ->> 'provider',
+    'email'
+  );
+
+  perform notify_discord(jsonb_build_object(
+    'title', '👋 New user signup',
+    'color', 6750207, -- #66d9ef
+    'timestamp', new.created_at,
+    'fields', jsonb_build_array(
+      jsonb_build_object('name', 'email',    'value', masked_email, 'inline', true),
+      jsonb_build_object('name', 'provider', 'value', provider,     'inline', true)
+    )
+  ));
+
+  return new;
+end;
+$$;
+
+drop trigger if exists discord_notify_user_signup on auth.users;
+create trigger discord_notify_user_signup
+  after insert on auth.users
+  for each row execute function notify_discord_on_user_signup();
+
+-- ─── new cloud document ──────────────────────────────────────────────────
+
+create or replace function notify_discord_on_document_create()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  owner_username text;
+  owner_label text;
+begin
+  select username into owner_username from profiles where id = new.user_id;
+  owner_label := coalesce(owner_username, 'user:' || substr(new.user_id::text, 1, 8));
+
+  perform notify_discord(jsonb_build_object(
+    'title', '📐 New document',
+    'color', 16328818, -- #f92672
+    'timestamp', new.created_at,
+    'fields', jsonb_build_array(
+      jsonb_build_object('name', 'name',  'value', coalesce(new.name, 'untitled'), 'inline', true),
+      jsonb_build_object('name', 'owner', 'value', owner_label,                    'inline', true)
+    )
+  ));
+
+  return new;
+end;
+$$;
+
+drop trigger if exists discord_notify_document_create on public.documents;
+create trigger discord_notify_document_create
+  after insert on public.documents
+  for each row execute function notify_discord_on_document_create();
+
+-- ─── new chat thread (first message) ─────────────────────────────────────
+
+create or replace function notify_discord_on_chat_thread_create()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  owner_username text;
+  owner_label text;
+begin
+  select username into owner_username from profiles where id = new.user_id;
+  owner_label := coalesce(owner_username, 'user:' || substr(new.user_id::text, 1, 8));
+
+  perform notify_discord(jsonb_build_object(
+    'title', '💬 New chat thread',
+    'color', 10937650, -- #a6e22e
+    'timestamp', new.created_at,
+    'fields', jsonb_build_array(
+      jsonb_build_object('name', 'user',     'value', owner_label,     'inline', true),
+      jsonb_build_object('name', 'document', 'value', new.document_id, 'inline', true)
+    )
+  ));
+
+  return new;
+end;
+$$;
+
+drop trigger if exists discord_notify_chat_thread_create on public.chat_threads;
+create trigger discord_notify_chat_thread_create
+  after insert on public.chat_threads
+  for each row execute function notify_discord_on_chat_thread_create();


### PR DESCRIPTION
## Summary
Adds Discord webhook integration to send real-time notifications for key user activities and billing events. Implements both database-level triggers (for events that bypass the API) and application-level handlers (for billing webhooks).

## Key Changes

- **Database triggers** (`supabase/migrations/021_discord_notifications.sql`):
  - New `notify_discord()` helper function that safely retrieves webhook URL from Supabase vault and posts embeds asynchronously via `pg_net` extension
  - Trigger on `auth.users` INSERT to notify on new user signups (with email masking)
  - Trigger on `documents` INSERT to notify on new cloud documents
  - Trigger on `chat_threads` INSERT to notify on new chat threads
  - All triggers gracefully handle missing webhook configuration and never fail user-facing requests

- **Application-level Discord helper** (`packages/app/api/_lib/discord.ts`):
  - New `notifyDiscord()` function for server-side event notifications
  - Support for per-event-kind webhook URL overrides via environment variables
  - `maskEmail()` utility for privacy-preserving email display ("a***@example.com")
  - Consistent embed formatting with emoji, color coding, and metadata fields
  - Fire-and-forget error handling that logs but never throws

- **Billing webhook integration** (`packages/app/api/billing/webhook.ts`):
  - Notify Discord on new subscription upgrades with tier and masked email
  - Notify Discord on subscription cancellations with prior tier information
  - Async notification dispatch to avoid blocking webhook response

- **Configuration** (`packages/app/.env.example`):
  - Added `DISCORD_WEBHOOK_URL` for default webhook
  - Documented per-kind overrides: `DISCORD_WEBHOOK_URL_BILLING`, `DISCORD_WEBHOOK_URL_SIGNUP`, `DISCORD_WEBHOOK_URL_DOCUMENT`, `DISCORD_WEBHOOK_URL_CHAT`

## Implementation Details

- Database triggers use `security definer` to safely access vault secrets
- All Discord operations are non-blocking and failures are logged but never propagated
- Email masking preserves domain while obscuring local part for privacy
- Color-coded embeds by event type for visual organization in Discord
- Webhook URL resolution falls back from specific kind overrides to default URL

https://claude.ai/code/session_01XUpnJ3mwZqRJ4TpWtpfopy