### PR TITLE
Fix screenshot capture color rendering with postprocessing

### DIFF
--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useMemo, useState, useCallback, Suspense } from "react";
-import { Spherical, Vector3, Box3, Plane, Raycaster, Vector2, Quaternion, Matrix4, Color, TOUCH, PerspectiveCamera, WebGLRenderTarget, SRGBColorSpace } from "three";
+import { Spherical, Vector3, Box3, Plane, Raycaster, Vector2, Quaternion, Matrix4, Color, TOUCH, PerspectiveCamera, WebGLRenderTarget, SRGBColorSpace, ACESFilmicToneMapping } from "three";
 
 const isCoarsePointer =
   typeof window !== "undefined" &&
@@ -970,14 +970,30 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
       tempCam.lookAt(tx, ty, tz);
       tempCam.updateMatrixWorld();
 
-      const rt = new WebGLRenderTarget(w, h, { samples: 4 });
-      rt.texture.colorSpace = SRGBColorSpace;
+      const rt = new WebGLRenderTarget(w, h, {
+        samples: 4,
+        colorSpace: SRGBColorSpace,
+      });
 
+      // EffectComposer/postprocessing passes mutate renderer state (tone
+      // mapping, output colorspace) while compositing. If the capture lands
+      // between those passes, the scene is rendered linearly but the 2D canvas
+      // interprets the bytes as sRGB, producing a green-tinted image. Pin the
+      // relevant state to known values here and restore after.
       const prevTarget = gl.getRenderTarget();
+      const prevToneMapping = gl.toneMapping;
+      const prevToneMappingExposure = gl.toneMappingExposure;
+      const prevOutputColorSpace = gl.outputColorSpace;
+      gl.toneMapping = ACESFilmicToneMapping;
+      gl.toneMappingExposure = 1.0;
+      gl.outputColorSpace = SRGBColorSpace;
       gl.setRenderTarget(rt);
       gl.clear();
       gl.render(r3fScene, tempCam);
       gl.setRenderTarget(prevTarget);
+      gl.toneMapping = prevToneMapping;
+      gl.toneMappingExposure = prevToneMappingExposure;
+      gl.outputColorSpace = prevOutputColorSpace;
 
       const buffer = new Uint8Array(w * h * 4);
       gl.readRenderTargetPixels(rt, 0, 0, w, h, buffer);


### PR DESCRIPTION
## Summary
Fixed an issue where screenshots captured during postprocessing passes were rendered with incorrect colors (green-tinted) due to mismatched tone mapping and color space state between the capture and the renderer.

## Changes
- Added `ACESFilmicToneMapping` import from three.js
- Refactored `WebGLRenderTarget` initialization to include `colorSpace` in options object
- Implemented state preservation and restoration for renderer properties during screenshot capture:
  - Save and restore `toneMapping`, `toneMappingExposure`, and `outputColorSpace`
  - Pin these values to known states (`ACESFilmicToneMapping`, `1.0`, and `SRGBColorSpace`) during the render-to-texture operation
- Added detailed comment explaining the root cause: EffectComposer/postprocessing passes mutate renderer state, and if capture occurs between passes, the scene renders linearly but the canvas interprets bytes as sRGB

## Implementation Details
The fix ensures that screenshot captures are rendered with consistent tone mapping and color space settings, preventing the green-tinted artifacts that occurred when the capture happened during postprocessing composition. The renderer state is properly restored after the capture to maintain the intended postprocessing pipeline behavior.

https://claude.ai/code/session_01Rc88LwwCT9bcvxrZAJkSRX