### PR TITLE
Add high-level geometry tools for AI chat (tube, place, inspect)

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,16 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-23-ai-chat-higher-level-tools",
+      "version": "0.8.0",
+      "date": "2026-04-23",
+      "category": "feat",
+      "title": "Higher-level tools for the AI chat",
+      "summary": "Added tube, polyline_tube, inspect_part, and place tools plus a pivot option on rotate (defaults to the part's bbox center) and a quad option on screenshot_viewport. Captures now suppress selection highlights and draw an XYZ axes gnomon so material colors and orientation read cleanly.",
+      "features": ["chat", "ai", "viewport"],
+      "mcpTools": ["tube", "polyline_tube", "inspect_part", "place"]
+    },
+    {
       "id": "2026-04-16-ai-as-participant",
       "version": "0.8.0",
       "date": "2026-04-16",

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -365,6 +365,11 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Disable raycasting during orbit for performance
   const isOrbiting = useUiStore((s) => s.isOrbiting);
+  // During AI screenshot capture, suppress emissive tint so user-selected
+  // parts don't glow in the shot — the AI is verifying geometry/materials,
+  // not watching the user's cursor.
+  const captureMode = useUiStore((s) => s.captureMode);
+  const effectiveSelected = selected && !captureMode;
 
   // Use selectionId if provided, otherwise fall back to partInfo.id
   const effectiveSelectionId = selectionId ?? partInfo.id;
@@ -477,14 +482,14 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Compute emissive state: selected > hovered > none (face highlight uses overlay)
   const emissiveColor = useMemo(() => {
-    if (selected) return materialColor.clone().multiplyScalar(0.3);
-    if (isHovered && !faceSelectionMode) return HOVER_EMISSIVE;
+    if (effectiveSelected) return materialColor.clone().multiplyScalar(0.3);
+    if (isHovered && !faceSelectionMode && !captureMode) return HOVER_EMISSIVE;
     return undefined;
-  }, [selected, isHovered, faceSelectionMode, materialColor]);
+  }, [effectiveSelected, isHovered, faceSelectionMode, captureMode, materialColor]);
 
-  const emissiveIntensity = selected
+  const emissiveIntensity = effectiveSelected
     ? 0.2
-    : isHovered && !faceSelectionMode
+    : isHovered && !faceSelectionMode && !captureMode
     ? 0.08
     : 0;
 
@@ -494,17 +499,17 @@ export const SceneMesh = memo(function SceneMesh({
     const uniforms = shaderMaterial.uniforms;
     if (!uniforms["uEmissive"] || !uniforms["uEmissiveIntensity"]) return;
 
-    if (selected) {
+    if (effectiveSelected) {
       uniforms["uEmissive"].value = materialColor.clone().multiplyScalar(0.3);
       uniforms["uEmissiveIntensity"].value = 0.2;
-    } else if (isHovered && !faceSelectionMode) {
+    } else if (isHovered && !faceSelectionMode && !captureMode) {
       uniforms["uEmissive"].value = HOVER_EMISSIVE;
       uniforms["uEmissiveIntensity"].value = 0.08;
     } else {
       uniforms["uEmissive"].value = new THREE.Color(0, 0, 0);
       uniforms["uEmissiveIntensity"].value = 0;
     }
-  }, [shaderMaterial, selected, isHovered, faceSelectionMode, materialColor]);
+  }, [shaderMaterial, effectiveSelected, isHovered, faceSelectionMode, captureMode, materialColor]);
 
   useEffect(() => {
     setDraftName(partInfo.name);

--- a/packages/app/src/components/SelectionOverlay.tsx
+++ b/packages/app/src/components/SelectionOverlay.tsx
@@ -175,9 +175,48 @@ function ParticipantSelection({ ids, color }: { ids: Set<string>; color: string 
   return <BoundingBoxLines box={box} color={color} opacity={0.7} />;
 }
 
+/** Labeled axis gnomon at the world origin, only visible during
+ *  ai-screenshot.ts's capture window. Gives the AI an unambiguous reference
+ *  for "which way is +X / +Y / +Z" in the captured image, so it doesn't have
+ *  to guess from scene context whether the bike is laid out along X or Y.
+ *  The scene is kernel Z-up but gets wrapped in a -90° X rotation by the
+ *  viewport geometry group; this axes helper lives inside the same group so
+ *  the labels match the kernel frame (X red, Y green, Z blue). */
+function CaptureAxesGnomon() {
+  const scene = useEngineStore((s) => s.scene);
+  // Scale the gnomon with the scene so it's readable regardless of zoom.
+  const size = useMemo(() => {
+    let maxDim = 100;
+    if (scene?.parts) {
+      for (const p of scene.parts) {
+        const pos = p.mesh.positions;
+        for (let i = 0; i < pos.length; i += 3) {
+          maxDim = Math.max(maxDim, Math.abs(pos[i]!), Math.abs(pos[i + 1]!), Math.abs(pos[i + 2]!));
+        }
+      }
+    }
+    return maxDim * 0.25;
+  }, [scene]);
+
+  return (
+    <group>
+      <Line points={[[0, 0, 0], [size, 0, 0]]} color="#ff3b30" lineWidth={3} />
+      <Line points={[[0, 0, 0], [0, size, 0]]} color="#34c759" lineWidth={3} />
+      <Line points={[[0, 0, 0], [0, 0, size]]} color="#0a84ff" lineWidth={3} />
+    </group>
+  );
+}
+
 export function SelectionOverlay() {
   const isDraggingGizmo = useUiStore((s) => s.isDraggingGizmo);
   const isOrbiting = useUiStore((s) => s.isOrbiting);
+  const captureMode = useUiStore((s) => s.captureMode);
+
+  // During an AI screenshot, swap the usual selection/attention overlays
+  // for a clean axes gnomon. This is the single feedback channel the model
+  // uses to verify work, so it should show material colors — not participant
+  // bbox rings that happen to dominate the frame.
+  if (captureMode) return <CaptureAxesGnomon />;
 
   // Skip rendering during orbit for performance.
   if (isOrbiting || isDraggingGizmo) return null;

--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -8,6 +8,7 @@ import {
   AI_PARTICIPANT_ID,
   commandRegistry,
   executeCrud,
+  HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX,
 } from "@vcad/core";
 import type { SelectionContext, ToolCallInfo, MessagePart, ExecutionResult, ChatUsageError, ChatAttachment, ChatMessage } from "@vcad/core";
 import { persistToolResult, useAuthStore } from "@vcad/auth";
@@ -172,6 +173,7 @@ function runTurn(
     const tools = [...commandRegistry.toAnthropicTools(), SCREENSHOT_VIEWPORT_TOOL];
     const systemPrompt =
       commandRegistry.buildSystemPrompt(getDocumentParts(), context) +
+      HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX +
       SCREENSHOT_SYSTEM_PROMPT_APPENDIX +
       AI_CAMERA_SYSTEM_PROMPT_APPENDIX;
 

--- a/packages/app/src/lib/ai-screenshot.ts
+++ b/packages/app/src/lib/ai-screenshot.ts
@@ -4,11 +4,15 @@ import {
   frameBbox,
   isSnapView,
   useParticipantStore,
+  useUiStore,
 } from "@vcad/core";
 import type { AnthropicTool, CameraGoal, SnapView } from "@vcad/core";
 import { computeSceneBbox, setAiCamera } from "@/lib/ai-camera-tools";
 
-/** Named camera presets the screenshot tool can target. Subset of SnapView. */
+/** Named camera presets the screenshot tool can target. Subset of SnapView,
+ *  plus a `quad` pseudo-view that composes iso + front + right + top into a
+ *  single 2×2 image. Quad mode is the fastest way for the AI to verify a
+ *  multi-part assembly — one tool call instead of four. */
 export const SCREENSHOT_VIEW_NAMES = [
   "front",
   "back",
@@ -18,13 +22,19 @@ export const SCREENSHOT_VIEW_NAMES = [
   "bottom",
   "iso",
   "hero",
+  "quad",
 ] as const;
 export type ScreenshotView = (typeof SCREENSHOT_VIEW_NAMES)[number];
+
+/** The four views composed into a quad screenshot. Chosen so the AI sees an
+ *  orthographic top-down plus two side elevations plus an isometric — enough
+ *  to disambiguate most positional errors at a glance. */
+const QUAD_VIEWS: SnapView[] = ["iso", "front", "right", "top"];
 
 export const SCREENSHOT_VIEWPORT_TOOL: AnthropicTool = {
   name: "screenshot_viewport",
   description:
-    "Capture a screenshot from YOUR camera (not the user's) so you can visually verify your work. The user's viewport is not disturbed — they see this angle as your wireframe frustum if they're watching. Pass an optional `view` (front/back/left/right/top/bottom/iso/hero) to reframe your camera first; omit it to shoot from wherever you last aimed your camera with set_view / frame_all / focus_part. Each screenshot costs tokens, so don't spam — one iso shot after a multi-step task is usually enough.",
+    "Capture a screenshot from YOUR camera (not the user's) so you can visually verify your work. The user's viewport is not disturbed — they see this angle as your wireframe frustum if they're watching. Pass an optional `view` (front/back/left/right/top/bottom/iso/hero) to reframe your camera first; omit it to shoot from wherever you last aimed your camera with set_view / frame_all / focus_part. Use `quad` to capture iso+front+right+top as a single 2×2 image — the fastest way to verify a multi-part assembly from one tool call. Each screenshot costs tokens, so don't spam — one iso or quad shot after a multi-step task is usually enough. Material colors will show correctly in the shot (no selection highlights), and a small XYZ gnomon at the origin marks the axes (X red, Y green, Z blue).",
   input_schema: {
     type: "object",
     properties: {
@@ -32,7 +42,7 @@ export const SCREENSHOT_VIEWPORT_TOOL: AnthropicTool = {
         type: "string",
         enum: [...SCREENSHOT_VIEW_NAMES],
         description:
-          "Optional named camera angle. If provided, your camera is reframed to this angle (fitted to the scene) before the shot. If omitted, your camera stays where set_view / frame_all / focus_part left it.",
+          "Optional named camera angle. If provided, your camera is reframed to this angle (fitted to the scene) before the shot. Pass `quad` for a 2×2 iso+front+right+top composite. If omitted, your camera stays where set_view / frame_all / focus_part left it.",
       },
     },
   },
@@ -182,6 +192,45 @@ function getCaptureFn(): CaptureFn | null {
   return win.__vcadCaptureAiCamera ?? null;
 }
 
+/** Render a single snap view at full viewport resolution. Returns the raw
+ *  canvas ready for composition or encoding. Caller is responsible for
+ *  toggling capture mode around the call. */
+function captureSnapView(view: SnapView, capture: CaptureFn): HTMLCanvasElement | null {
+  const bbox = computeSceneBbox();
+  const goal = bbox ? frameBbox(bbox, { view }) : defaultCameraGoal();
+  return capture(goal);
+}
+
+/** Compose a 2×2 grid of canvases into a single labeled canvas. Used for
+ *  the `view: "quad"` screenshot mode — one tool call, four angles. */
+function composeQuad(
+  shots: Array<{ canvas: HTMLCanvasElement; label: string }>,
+): HTMLCanvasElement {
+  const tileW = shots[0]!.canvas.width;
+  const tileH = shots[0]!.canvas.height;
+  const out = document.createElement("canvas");
+  out.width = tileW * 2;
+  out.height = tileH * 2;
+  const ctx = out.getContext("2d");
+  if (!ctx) throw new Error("2D context unavailable");
+  ctx.fillStyle = "#1a1a1a";
+  ctx.fillRect(0, 0, out.width, out.height);
+  for (let i = 0; i < shots.length; i++) {
+    const col = i % 2;
+    const row = Math.floor(i / 2);
+    const x = col * tileW;
+    const y = row * tileH;
+    ctx.drawImage(shots[i]!.canvas, x, y);
+    // Label in the top-left of each tile so the AI can match tile to view.
+    ctx.fillStyle = "rgba(0, 0, 0, 0.6)";
+    ctx.fillRect(x + 8, y + 8, 80, 28);
+    ctx.fillStyle = "#ffffff";
+    ctx.font = "bold 16px -apple-system, system-ui, sans-serif";
+    ctx.fillText(shots[i]!.label, x + 16, y + 28);
+  }
+  return out;
+}
+
 export async function executeScreenshotViewport(
   args: Record<string, unknown>,
 ): Promise<ScreenshotExecutionResult> {
@@ -208,7 +257,55 @@ export async function executeScreenshotViewport(
     };
   }
 
+  // Toggle capture mode so the SelectionOverlay skips selection / participant
+  // rings and draws a labeled XYZ gnomon instead. Materials then show up
+  // faithfully in the shot rather than being washed out by highlight bboxes.
+  const uiStore = useUiStore.getState();
+  const prevCaptureMode = uiStore.captureMode;
+  uiStore.setCaptureMode(true);
+
   try {
+    // A couple of frames for the capture-mode change to propagate into the
+    // R3F scene graph (overlay removal + gnomon mount).
+    await nextFrame();
+    await nextFrame();
+
+    if (viewArg === "quad") {
+      const shots: Array<{ canvas: HTMLCanvasElement; label: string }> = [];
+      for (const v of QUAD_VIEWS) {
+        const rendered = captureSnapView(v, capture);
+        if (!rendered) {
+          return {
+            status: "error",
+            result: `screenshot_viewport: quad capture failed at ${v}`,
+            toolResultContent: null,
+            imageDataUrl: null,
+            duration: performance.now() - t0,
+          };
+        }
+        shots.push({ canvas: rendered, label: v.toUpperCase() });
+        await nextFrame();
+      }
+      const composed = composeQuad(shots);
+      const { base64, mediaType, dataUrl, width, height } = encodeCanvasAsJpeg(composed);
+      return {
+        status: "success",
+        result: `Captured quad view (${width}×${height}, ${QUAD_VIEWS.join(" / ")})`,
+        toolResultContent: [
+          {
+            type: "image",
+            source: { type: "base64", media_type: mediaType, data: base64 },
+          },
+          {
+            type: "text",
+            text: `Quad screenshot — 2×2 grid of iso / front / right / top. Top-left = ISO, top-right = FRONT (looking down -Y), bottom-left = RIGHT (looking down -X), bottom-right = TOP (looking down -Z). The small red/green/blue axes at the origin mark +X / +Y / +Z in the kernel Z-up frame.`,
+          },
+        ],
+        imageDataUrl: dataUrl,
+        duration: performance.now() - t0,
+      };
+    }
+
     const goal = resolveGoal(viewArg as ScreenshotView | undefined);
 
     // Small settle window so the user's frustum overlay starts moving before
@@ -243,7 +340,7 @@ export async function executeScreenshotViewport(
         },
         {
           type: "text",
-          text: `Screenshot from your camera (${viewLabel}). This is YOUR view; the user's viewport is unchanged but they see this angle as your frustum overlay. Use this to verify the document state and then continue.`,
+          text: `Screenshot from your camera (${viewLabel}). The small red/green/blue axes at the origin mark +X / +Y / +Z. Material colors are faithful — selection highlights are suppressed during capture.`,
         },
       ],
       imageDataUrl: dataUrl,
@@ -257,5 +354,7 @@ export async function executeScreenshotViewport(
       imageDataUrl: null,
       duration: performance.now() - t0,
     };
+  } finally {
+    useUiStore.getState().setCaptureMode(prevCaptureMode);
   }
 }

--- a/packages/core/src/__tests__/command-registry.test.ts
+++ b/packages/core/src/__tests__/command-registry.test.ts
@@ -184,6 +184,10 @@ describe("CommandRegistry", () => {
         "focus_part",
         "frame_all",
         "set_view",
+        "tube",
+        "polyline_tube",
+        "inspect_part",
+        "place",
       ]);
     });
 
@@ -307,7 +311,7 @@ describe("CommandRegistry", () => {
       fresh.loadSchemas("[]");
       const tools = fresh.toAnthropicTools();
       // 5 CRUD/material + 3 AI camera tools.
-      expect(tools).toHaveLength(8);
+      expect(tools).toHaveLength(12);
       const create = tools[0]!;
       const typeEnum = (create.input_schema.properties as Record<string, Record<string, unknown>>)
         .type.enum as string[];

--- a/packages/core/src/commands/executors.ts
+++ b/packages/core/src/commands/executors.ts
@@ -2,11 +2,134 @@ import type { ExecutionResult, ExecutionDisplay, SummarySegment } from "./types.
 import type { PlannedResponse, ToolOutcome } from "./registry.js";
 import { commandRegistry } from "./registry.js";
 import { useDocumentStore } from "../stores/document-store.js";
+import { useEngineStore } from "../stores/engine-store.js";
 import { useUiStore } from "../stores/ui-store.js";
 import { vec3Cross, vec3Normalize } from "@vcad/ir";
+import type { Vec3, PathCurve } from "@vcad/ir";
+import { expandBboxFromPositions, type Bbox } from "../camera-framing.js";
 
 type DocStore = ReturnType<typeof useDocumentStore.getState>;
 type UiStore = ReturnType<typeof useUiStore.getState>;
+
+// ---------------------------------------------------------------------------
+// Geometry helpers used by tube / place / rotate-with-pivot / inspect_part.
+// ---------------------------------------------------------------------------
+
+/** Read a part's current world-space AABB from the evaluated scene. Returns
+ *  null when the scene hasn't been evaluated yet or when the part isn't in
+ *  the scene (e.g. it was just created this tick and is still cooking). */
+function computePartWorldBbox(partId: string, docStore: DocStore): Bbox | null {
+  const scene = useEngineStore.getState().scene;
+  if (!scene) return null;
+  const idx = docStore.parts.findIndex((p) => p.id === partId);
+  if (idx >= 0) {
+    const evalPart = scene.parts[idx];
+    if (evalPart) return expandBboxFromPositions(null, evalPart.mesh.positions);
+  }
+  if (scene.instances) {
+    for (const inst of scene.instances) {
+      const id =
+        (inst as { id?: string; instanceId?: string; partDefId?: string }).id ??
+        (inst as { id?: string; instanceId?: string; partDefId?: string }).instanceId ??
+        (inst as { id?: string; instanceId?: string; partDefId?: string }).partDefId;
+      if (id === partId) return expandBboxFromPositions(null, inst.mesh.positions);
+    }
+  }
+  return null;
+}
+
+function bboxCenter(b: Bbox): Vec3 {
+  return {
+    x: (b.min[0] + b.max[0]) / 2,
+    y: (b.min[1] + b.max[1]) / 2,
+    z: (b.min[2] + b.max[2]) / 2,
+  };
+}
+
+function bboxSize(b: Bbox): Vec3 {
+  return {
+    x: b.max[0] - b.min[0],
+    y: b.max[1] - b.min[1],
+    z: b.max[2] - b.min[2],
+  };
+}
+
+/** Read the current Translate.offset wrapping a part, or (0,0,0) if missing. */
+function getCurrentOffset(partId: string, docStore: DocStore): Vec3 {
+  const part = docStore.partIndex.get(partId);
+  const p = part as { translateNodeId?: number | string } | undefined;
+  if (!p?.translateNodeId) return { x: 0, y: 0, z: 0 };
+  const node = docStore.document.nodes[String(p.translateNodeId)];
+  const op = node?.op as { type?: string; offset?: Vec3 } | undefined;
+  if (op?.type !== "Translate" || !op.offset) return { x: 0, y: 0, z: 0 };
+  return { x: op.offset.x, y: op.offset.y, z: op.offset.z };
+}
+
+/** Read the current Rotate.angles (Euler XYZ degrees), or zeros if missing. */
+function getCurrentAngles(partId: string, docStore: DocStore): Vec3 {
+  const part = docStore.partIndex.get(partId);
+  const p = part as { rotateNodeId?: number | string } | undefined;
+  if (!p?.rotateNodeId) return { x: 0, y: 0, z: 0 };
+  const node = docStore.document.nodes[String(p.rotateNodeId)];
+  const op = node?.op as { type?: string; angles?: Vec3 } | undefined;
+  if (op?.type !== "Rotate" || !op.angles) return { x: 0, y: 0, z: 0 };
+  return { x: op.angles.x, y: op.angles.y, z: op.angles.z };
+}
+
+/** Apply an Euler-XYZ rotation (degrees, applied X then Y then Z, the same
+ *  convention vcad-kernel uses) to a point. */
+function rotateVec3(p: Vec3, eulerDeg: Vec3): Vec3 {
+  const rad = (d: number) => (d * Math.PI) / 180;
+  const cx = Math.cos(rad(eulerDeg.x)), sx = Math.sin(rad(eulerDeg.x));
+  const cy = Math.cos(rad(eulerDeg.y)), sy = Math.sin(rad(eulerDeg.y));
+  const cz = Math.cos(rad(eulerDeg.z)), sz = Math.sin(rad(eulerDeg.z));
+  // Rx
+  let x = p.x, y = p.y * cx - p.z * sx, z = p.y * sx + p.z * cx;
+  // Ry
+  let x2 = x * cy + z * sy, y2 = y, z2 = -x * sy + z * cy;
+  x = x2; y = y2; z = z2;
+  // Rz
+  x2 = x * cz - y * sz; y2 = x * sz + y * cz; z2 = z;
+  return { x: x2, y: y2, z: z2 };
+}
+
+/** Invert an Euler-XYZ rotation by negating and reversing order. Sufficient
+ *  for our purposes because rotateVec3 + inverseRotateVec3 round-trip. */
+function inverseRotateVec3(p: Vec3, eulerDeg: Vec3): Vec3 {
+  const rad = (d: number) => (d * Math.PI) / 180;
+  const cx = Math.cos(rad(eulerDeg.x)), sx = Math.sin(rad(eulerDeg.x));
+  const cy = Math.cos(rad(eulerDeg.y)), sy = Math.sin(rad(eulerDeg.y));
+  const cz = Math.cos(rad(eulerDeg.z)), sz = Math.sin(rad(eulerDeg.z));
+  // Inverse order: Rz^-1, Ry^-1, Rx^-1
+  let x = p.x * cz + p.y * sz, y = -p.x * sz + p.y * cz, z = p.z;
+  let x2 = x * cy - z * sy, y2 = y, z2 = x * sy + z * cy;
+  x = x2; y = y2; z = z2;
+  x2 = x; y2 = y * cx + z * sx; z2 = -y * sx + z * cx;
+  return { x: x2, y: y2, z: z2 };
+}
+
+/** Build a closed-loop circular sketch profile in the plane (x_dir, y_dir)
+ *  centered on origin. Two semicircle arcs — matches the convention in the
+ *  system prompt (sketches must be closed and have ≥2 segments). */
+function circleProfileSegments(radius: number): unknown[] {
+  return [
+    { type: "Arc", start: { x: radius, y: 0 }, end: { x: -radius, y: 0 }, center: { x: 0, y: 0 }, ccw: false },
+    { type: "Arc", start: { x: -radius, y: 0 }, end: { x: radius, y: 0 }, center: { x: 0, y: 0 }, ccw: false },
+  ];
+}
+
+/** Derive two unit vectors perpendicular to `dir` to form a sketch plane.
+ *  `dir` need not be unit-length. Returns null if `dir` is zero. */
+function perpendicularBasis(dir: Vec3): { xDir: Vec3; yDir: Vec3 } | null {
+  const len = Math.hypot(dir.x, dir.y, dir.z);
+  if (len < 1e-9) return null;
+  const d = { x: dir.x / len, y: dir.y / len, z: dir.z / len };
+  // Pick a reference axis that's not near-parallel to d.
+  const ref: Vec3 = Math.abs(d.z) < 0.9 ? { x: 0, y: 0, z: 1 } : { x: 1, y: 0, z: 0 };
+  const yDir = vec3Normalize(vec3Cross(d, ref));
+  const xDir = vec3Normalize(vec3Cross(yDir, d));
+  return { xDir, yDir };
+}
 
 /** Validate that a part ID exists in the document. */
 function validatePartId(partId: string, docStore: DocStore, label: string): ExecutionResult | null {
@@ -216,9 +339,201 @@ function executeCrudInner(
       return executeDelete(args.part_id as string, docStore, uiStore);
     case "set_material":
       return executeSetMaterial(args.part_id as string, args.material as string, docStore);
+    case "inspect_part":
+      return executeInspectPart(args.part_id as string, docStore);
+    case "place":
+      return executePlace(args, docStore);
+    case "tube":
+      return executeCreateWithName(
+        tool,
+        args as Record<string, unknown>,
+        undefined,
+        args.name as string | undefined,
+        docStore,
+        uiStore,
+      );
+    case "polyline_tube":
+      // polyline_tube names each segment individually inside executeCreate,
+      // so don't let executeCreateWithName rename the last segment on top.
+      return executeCreateWithName(
+        tool,
+        args as Record<string, unknown>,
+        undefined,
+        undefined,
+        docStore,
+        uiStore,
+      );
     default:
       return { status: "error", result: `Unknown tool: ${tool}` };
   }
+}
+
+// ---------------------------------------------------------------------------
+// inspect_part — world-frame bbox + size + material + material-mass. Gives
+// the AI a way to verify geometry between tool calls without spending tokens
+// on a screenshot. Return shape is JSON in `result` so the model can parse it.
+// ---------------------------------------------------------------------------
+function executeInspectPart(partId: string, docStore: DocStore): ExecutionResult {
+  if (!partId) return { status: "error", result: "inspect_part requires part_id" };
+  const part = docStore.partIndex.get(partId);
+  if (!part) {
+    const err = validatePartId(partId, docStore, "inspect_part part_id");
+    return err ?? { status: "error", result: `Part ${partId} not found` };
+  }
+  const bbox = computePartWorldBbox(partId, docStore);
+  const offset = getCurrentOffset(partId, docStore);
+  const angles = getCurrentAngles(partId, docStore);
+  const kind = part.kind;
+  const name = part.name;
+
+  // Material: read from the document's material assignments if present.
+  const doc = docStore.document as unknown as { materials?: Record<string, unknown>; partMaterials?: Record<string, string> };
+  const material = doc.partMaterials?.[partId] ?? null;
+
+  const out: Record<string, unknown> = {
+    id: partId,
+    name,
+    kind,
+    translate: offset,
+    rotate: angles,
+    material,
+  };
+  if (bbox) {
+    const center = bboxCenter(bbox);
+    const size = bboxSize(bbox);
+    out.bbox = {
+      min: { x: bbox.min[0], y: bbox.min[1], z: bbox.min[2] },
+      max: { x: bbox.max[0], y: bbox.max[1], z: bbox.max[2] },
+      center,
+      size,
+    };
+    // Anchors: canonical named points on the part's world-space AABB that
+    // `place` can target. Keeps both tools in sync on what a name resolves to.
+    out.anchors = {
+      center,
+      min: { x: bbox.min[0], y: bbox.min[1], z: bbox.min[2] },
+      max: { x: bbox.max[0], y: bbox.max[1], z: bbox.max[2] },
+      top:    { x: center.x,   y: center.y,   z: bbox.max[2] },
+      bottom: { x: center.x,   y: center.y,   z: bbox.min[2] },
+      front:  { x: center.x,   y: bbox.min[1], z: center.z   },
+      back:   { x: center.x,   y: bbox.max[1], z: center.z   },
+      left:   { x: bbox.min[0], y: center.y,   z: center.z   },
+      right:  { x: bbox.max[0], y: center.y,   z: center.z   },
+    };
+  } else {
+    out.bbox = null;
+    out.bbox_note = "scene not yet evaluated — try again after a microtask, or after creating/updating this part";
+  }
+  return {
+    status: "success",
+    result: JSON.stringify(out),
+    partId,
+    display: {
+      summary: [text("⌕ Inspect "), link(partId, docStore)],
+      affectedPartIds: [partId],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// place — anchor-based positioning. Translates a part so that its `from`
+// anchor lands on the world-space `to` point (or another part's anchor).
+// Optional `align` rotates the part so an axis on it matches a world-space
+// direction. This is the high-level alternative to computing translate+rotate
+// by hand; the AI can say "place handlebar's center on stem's top".
+// ---------------------------------------------------------------------------
+
+type AnchorName =
+  | "center" | "min" | "max"
+  | "top" | "bottom" | "front" | "back" | "left" | "right";
+
+type AnchorRef =
+  | AnchorName
+  | Vec3
+  | { part: string; anchor: AnchorName };
+
+function resolveAnchorOnPart(
+  partId: string,
+  anchor: AnchorName,
+  docStore: DocStore,
+): Vec3 | null {
+  const bbox = computePartWorldBbox(partId, docStore);
+  if (!bbox) return null;
+  const c = bboxCenter(bbox);
+  switch (anchor) {
+    case "center": return c;
+    case "min": return { x: bbox.min[0], y: bbox.min[1], z: bbox.min[2] };
+    case "max": return { x: bbox.max[0], y: bbox.max[1], z: bbox.max[2] };
+    case "top":    return { x: c.x, y: c.y, z: bbox.max[2] };
+    case "bottom": return { x: c.x, y: c.y, z: bbox.min[2] };
+    case "front":  return { x: c.x, y: bbox.min[1], z: c.z };
+    case "back":   return { x: c.x, y: bbox.max[1], z: c.z };
+    case "left":   return { x: bbox.min[0], y: c.y, z: c.z };
+    case "right":  return { x: bbox.max[0], y: c.y, z: c.z };
+  }
+}
+
+function resolveAnchor(
+  ref: AnchorRef | undefined,
+  selfPartId: string,
+  docStore: DocStore,
+): Vec3 | null {
+  if (!ref) return null;
+  if (typeof ref === "string") {
+    return resolveAnchorOnPart(selfPartId, ref as AnchorName, docStore);
+  }
+  if ("x" in ref && "y" in ref && "z" in ref) {
+    return { x: (ref as Vec3).x, y: (ref as Vec3).y, z: (ref as Vec3).z };
+  }
+  if ("part" in ref && "anchor" in ref) {
+    return resolveAnchorOnPart((ref as { part: string }).part, (ref as { anchor: AnchorName }).anchor, docStore);
+  }
+  return null;
+}
+
+function executePlace(
+  args: Record<string, unknown>,
+  docStore: DocStore,
+): ExecutionResult {
+  const partId = args.part_id as string;
+  if (!partId) return { status: "error", result: "place requires part_id" };
+  const err = validatePartId(partId, docStore, "place part_id");
+  if (err) return err;
+
+  const from = (args.from as AnchorRef | undefined) ?? ("center" as AnchorName);
+  const to = args.to as AnchorRef | undefined;
+  if (!to) return { status: "error", result: "place requires a `to` anchor (Vec3, named anchor, or {part,anchor})" };
+
+  const fromWorld = resolveAnchor(from, partId, docStore);
+  if (!fromWorld) return { status: "error", result: "place: could not resolve `from` anchor — the scene may not be evaluated yet" };
+  const toWorld = resolveAnchor(to, partId, docStore);
+  if (!toWorld) return { status: "error", result: "place: could not resolve `to` anchor" };
+
+  const currentOffset = getCurrentOffset(partId, docStore);
+  const newOffset = {
+    x: currentOffset.x + (toWorld.x - fromWorld.x),
+    y: currentOffset.y + (toWorld.y - fromWorld.y),
+    z: currentOffset.z + (toWorld.z - fromWorld.z),
+  };
+  docStore.setTranslation(partId, newOffset);
+
+  return {
+    status: "success",
+    result: `Placed ${partId} so that ${JSON.stringify(from)} → (${toWorld.x.toFixed(1)}, ${toWorld.y.toFixed(1)}, ${toWorld.z.toFixed(1)})`,
+    partId,
+    display: {
+      summary: [
+        text("◎ Place "),
+        link(partId, docStore),
+        text(` at (${toWorld.x.toFixed(1)}, ${toWorld.y.toFixed(1)}, ${toWorld.z.toFixed(1)})`),
+      ],
+      fields: [
+        { label: "from", value: typeof from === "string" ? from : JSON.stringify(from) },
+        { label: "to", value: typeof to === "string" ? to : JSON.stringify(to) },
+      ],
+      affectedPartIds: [partId],
+    },
+  };
 }
 
 function executeSetMaterial(
@@ -357,6 +672,120 @@ function executeCreate(
       case "cone":
         return { status: "error", result: "Cone primitive not yet supported via addPrimitive" };
 
+      case "tube": {
+        // High-level primitive: a cylindrical pipe between two world-space
+        // points. Desugars to a sweep of a circular sketch along a straight
+        // segment. Gives the AI a one-call "draw me a pipe from A to B with
+        // radius r" — no perpendicular-basis math, no tube-length
+        // calculation. Caller supplies `start`, `end`, optional `radius`
+        // (default 5mm) and optional `arc_segments` (default 16).
+        const start = params.start as Vec3 | undefined;
+        const end = params.end as Vec3 | undefined;
+        if (!start || !end) return { status: "error", result: "tube requires start and end points" };
+        const radius = (params.radius as number | undefined) ?? 5;
+        if (radius <= 0) return { status: "error", result: "tube radius must be positive" };
+        const arcSegments = (params.arc_segments as number | undefined) ?? 16;
+        const dir = { x: end.x - start.x, y: end.y - start.y, z: end.z - start.z };
+        const length = Math.hypot(dir.x, dir.y, dir.z);
+        if (length < 1e-6) return { status: "error", result: "tube start and end are coincident" };
+        const basis = perpendicularBasis(dir);
+        if (!basis) return { status: "error", result: "tube direction is degenerate" };
+        const normal = vec3Normalize(vec3Cross(basis.xDir, basis.yDir));
+        const plane = { type: "face" as const, origin: start, xDir: basis.xDir, yDir: basis.yDir, normal };
+        const path: PathCurve = { type: "Line", start, end };
+        const partId = docStore.addSweep(
+          plane,
+          start,
+          circleProfileSegments(radius) as never[],
+          path,
+          {},
+        );
+        if (!partId) return { status: "error", result: "tube creation failed" };
+        // Bump arc count by updating the sweep op's arc_segments param. Best-effort.
+        const info = docStore.partIndex.get(partId) as { sweepNodeId?: number | string } | undefined;
+        if (info?.sweepNodeId !== undefined) {
+          try {
+            docStore.setFeatureParam(partId, "arc_segments", { F64: arcSegments } as never);
+          } catch {
+            // non-fatal
+          }
+        }
+        uiStore.select(partId);
+        return {
+          status: "success",
+          result: `Created tube with id: ${partId}`,
+          partId,
+          display: {
+            summary: [
+              text(`∥ Tube r=${radius}mm, L=${length.toFixed(1)}mm → `),
+              link(partId, docStore),
+            ],
+            fields: [
+              { label: "start", value: `(${start.x}, ${start.y}, ${start.z})` },
+              { label: "end", value: `(${end.x}, ${end.y}, ${end.z})` },
+              { label: "radius", value: `${radius} mm` },
+              { label: "length", value: `${length.toFixed(2)} mm` },
+            ],
+            affectedPartIds: [partId],
+          },
+        };
+      }
+
+      case "polyline_tube": {
+        // Chain of tubes through a sequence of points. Each segment gets its
+        // own part (kept separate so later edits target individual segments).
+        // Typical use: bike frames, piping, cable runs — cases where authors
+        // want to specify joints as points instead of computing each tube's
+        // direction vector and length by hand.
+        const points = params.points as Vec3[] | undefined;
+        if (!points || points.length < 2) {
+          return { status: "error", result: "polyline_tube requires points[] with at least 2 entries" };
+        }
+        const radius = (params.radius as number | undefined) ?? 5;
+        const nameBase = (params.name as string | undefined) ?? "Tube";
+        const createdIds: string[] = [];
+        for (let i = 0; i < points.length - 1; i++) {
+          const segRes = executeCreate(
+            "tube",
+            { start: points[i], end: points[i + 1], radius, arc_segments: params.arc_segments },
+            undefined,
+            docStore,
+            uiStore,
+          );
+          if (segRes.status !== "success" || !segRes.partId) {
+            // Roll back: delete anything we already created to keep the doc clean.
+            for (const id of createdIds) {
+              try { docStore.removePart(id); } catch { /* ignore */ }
+            }
+            return { status: "error", result: `polyline_tube: segment ${i} failed — ${segRes.result}` };
+          }
+          createdIds.push(segRes.partId);
+          if (nameBase && typeof docStore.renamePart === "function") {
+            try {
+              docStore.renamePart(segRes.partId, `${nameBase} ${i + 1}`);
+            } catch {
+              // non-fatal
+            }
+          }
+        }
+        return {
+          status: "success",
+          result: `Created ${createdIds.length} tube segments: ${createdIds.join(", ")}`,
+          partId: createdIds[createdIds.length - 1]!,
+          display: {
+            summary: [
+              text(`∥∥ Polyline tube (${createdIds.length} segs, r=${radius}mm)`),
+            ],
+            fields: [
+              { label: "segments", value: `${createdIds.length}` },
+              { label: "points", value: `${points.length}` },
+              { label: "radius", value: `${radius} mm` },
+            ],
+            affectedPartIds: createdIds,
+          },
+        };
+      }
+
       case "translate": {
         const child = params.child as string;
         const offset = params.offset as { x: number; y: number; z: number };
@@ -385,7 +814,57 @@ function executeCreate(
         if (!child || !angles) return { status: "error", result: "rotate requires child and angles" };
         const err = validatePartId(child, docStore, "rotate child");
         if (err) return err;
-        docStore.setRotation(child, angles);
+
+        // Pivot semantics:
+        //   omitted / "center"  → rotate around the part's current world bbox center
+        //   "origin"            → rotate around world origin (legacy behavior)
+        //   {x,y,z}             → rotate around the given world-space point
+        // The underlying CRDT engine rotates child geometry around the origin
+        // of the part's local frame, then applies the outer Translate. To
+        // simulate rotating around an arbitrary world pivot P we compute a
+        // compensating translation:
+        //     T_new = P - R_new · (R_old⁻¹ · (P - T_old))
+        // which lands the world point `P` at the same place after the
+        // rotation swap. This makes "rotate in place" Just Work for primitives,
+        // extrudes, sweeps, booleans, etc. without touching Rust.
+        const rawPivot = params.pivot as Vec3 | "center" | "origin" | undefined;
+        let pivot: Vec3 | null = null;
+        if (rawPivot === "origin") {
+          pivot = null;
+        } else if (rawPivot && typeof rawPivot === "object" && "x" in rawPivot && "y" in rawPivot && "z" in rawPivot) {
+          pivot = { x: (rawPivot as Vec3).x, y: (rawPivot as Vec3).y, z: (rawPivot as Vec3).z };
+        } else {
+          // Default ("center"): use the part's current world bbox center.
+          const bbox = computePartWorldBbox(child, docStore);
+          if (bbox) pivot = bboxCenter(bbox);
+        }
+
+        if (pivot) {
+          const tOld = getCurrentOffset(child, docStore);
+          const rOld = getCurrentAngles(child, docStore);
+          // Local-frame vector from the part's origin to the pivot, at the
+          // moment we captured it. Undoing R_old takes world → local-before-R.
+          const pivotLocal = inverseRotateVec3(
+            { x: pivot.x - tOld.x, y: pivot.y - tOld.y, z: pivot.z - tOld.z },
+            rOld,
+          );
+          const pivotAfter = rotateVec3(pivotLocal, angles);
+          const tNew = {
+            x: pivot.x - pivotAfter.x,
+            y: pivot.y - pivotAfter.y,
+            z: pivot.z - pivotAfter.z,
+          };
+          docStore.setRotation(child, angles);
+          docStore.setTranslation(child, tNew);
+        } else {
+          docStore.setRotation(child, angles);
+        }
+        const pivotLabel =
+          rawPivot === "origin"
+            ? " around origin"
+            : pivot
+              ? ` around (${pivot.x.toFixed(1)}, ${pivot.y.toFixed(1)}, ${pivot.z.toFixed(1)})`
+              : "";
         return {
           status: "success",
           result: `Rotated ${child}`,
@@ -394,9 +873,14 @@ function executeCreate(
             summary: [
               text("↻ Rotate "),
               link(child, docStore),
-              text(` by (${angles.x}°, ${angles.y}°, ${angles.z}°)`),
+              text(` by (${angles.x}°, ${angles.y}°, ${angles.z}°)${pivotLabel}`),
             ],
-            fields: [{ label: "angles", value: `(${angles.x}°, ${angles.y}°, ${angles.z}°)` }],
+            fields: [
+              { label: "angles", value: `(${angles.x}°, ${angles.y}°, ${angles.z}°)` },
+              ...(pivot
+                ? [{ label: "pivot", value: `(${pivot.x.toFixed(1)}, ${pivot.y.toFixed(1)}, ${pivot.z.toFixed(1)})` }]
+                : [{ label: "pivot", value: "origin" }]),
+            ],
             affectedPartIds: [child],
           },
         };
@@ -616,6 +1100,45 @@ function executeCreate(
         const path = params.path as Record<string, unknown>;
         const normal = vec3Normalize(vec3Cross(s.x_dir, s.y_dir));
         const plane = { type: "face" as const, origin: s.origin, xDir: s.x_dir, yDir: s.y_dir, normal };
+
+        // Polyline paths are a vcad-TS convenience: the Rust kernel only
+        // understands Line/Helix, so we desugar {type:"Polyline", points:[]}
+        // into N separate Line sweeps sharing the same profile. Keeping them
+        // as distinct parts (instead of unioning) avoids the cost and
+        // robustness risk of N-1 boolean operations for common cases like
+        // pipe runs and frame-tube-chains where the separation doesn't
+        // matter visually.
+        if (path && (path as { type?: string }).type === "Polyline") {
+          const points = (path as { points?: Vec3[] }).points;
+          if (!points || points.length < 2) {
+            return { status: "error", result: "sweep Polyline requires points[] with ≥2 entries" };
+          }
+          const ids: string[] = [];
+          for (let i = 0; i < points.length - 1; i++) {
+            const segPath: PathCurve = { type: "Line", start: points[i]!, end: points[i + 1]! };
+            const id = docStore.addSweep(plane, s.origin, s.segments as never[], segPath, {
+              twist_angle: params.twist_angle as number | undefined,
+              scale_start: params.scale_start as number | undefined,
+              scale_end: params.scale_end as number | undefined,
+            });
+            if (!id) {
+              for (const x of ids) { try { docStore.removePart(x); } catch { /* ignore */ } }
+              return { status: "error", result: `sweep Polyline segment ${i} failed` };
+            }
+            ids.push(id);
+          }
+          return {
+            status: "success",
+            result: `Swept polyline (${ids.length} segments): ${ids.join(", ")}`,
+            partId: ids[ids.length - 1]!,
+            display: {
+              summary: [text(`〰 Polyline sweep (${ids.length} segs)`)],
+              fields: [{ label: "segments", value: `${ids.length}` }],
+              affectedPartIds: ids,
+            },
+          };
+        }
+
         const partId = docStore.addSweep(plane, s.origin, s.segments as never[], path as never, {
           twist_angle: params.twist_angle as number | undefined,
           scale_start: params.scale_start as number | undefined,

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,3 +1,4 @@
 export { CommandRegistry, commandRegistry } from "./registry.js";
 export { executeCrud } from "./executors.js";
+export { HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX } from "./prompt-appendix.js";
 export type { ToolSchemaEntry, ExecutionResult, ExecutionDisplay, SummarySegment, AnthropicTool } from "./types.js";

--- a/packages/core/src/commands/prompt-appendix.ts
+++ b/packages/core/src/commands/prompt-appendix.ts
@@ -1,0 +1,75 @@
+/** Teaching prompt for the high-level chat tools that desugar to existing
+ *  primitives. These tools (`tube`, `polyline_tube`, `place`, `inspect_part`,
+ *  the `pivot` option on rotate, and the `quad` option on screenshot_viewport)
+ *  exist specifically to cut the amount of math the model has to do by hand —
+ *  most frame/pipe/assembly work can be expressed as a few `tube` + `place`
+ *  calls instead of dozens of extrude-with-perpendicular-basis invocations.
+ *  The model won't use them unless we explicitly tell it they're the
+ *  preferred path; hence this appendix. */
+export const HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX = `
+
+## High-level geometry tools — PREFER THESE
+
+These tools are shorthand for common patterns. Use them whenever they apply —
+they're much less error-prone than the long form.
+
+- **tube(start, end, radius)** — a cylindrical pipe between two world points.
+  One call. No trigonometry, no perpendicular-basis vectors, no length math.
+  This is the RIGHT tool for: bicycle frame tubes, pipes, handlebars, axles,
+  drive shafts, spindles, struts, spokes. Do NOT build these as extrudes with
+  hand-computed x_dir / y_dir — use tube.
+
+- **polyline_tube(points, radius)** — a chain of tubes through N points. Each
+  segment becomes its own part. Perfect for bike frames (rear dropouts → BB →
+  seat tube top), routed pipes, cable runs. One call replaces N-1 individual
+  tube calls.
+
+- **place(part_id, from, to)** — position a part by anchor. \`from\` is an
+  anchor on this part; \`to\` is either a world point {x,y,z}, a named anchor
+  (resolved on this part), or {part, anchor} on another part. Named anchors:
+  center, min, max, top, bottom, front, back, left, right. Example: after
+  creating a seat post, \`place(seatPost, from: "bottom", to: {part:
+  "seatTubeTop", anchor: "top"})\` — no manual translate math.
+
+- **inspect_part(part_id)** — return JSON with world-space bbox, size, center,
+  translate, rotate, material, and the anchor table. Use this INSTEAD of
+  screenshot_viewport when you just need numeric verification; it's much
+  cheaper in tokens. Especially useful after creating a tube or extrude to
+  confirm it landed where intended.
+
+## rotate: in-place by default
+
+\`rotate(child, angles)\` rotates around the part's current bbox center by
+default — so "rotate 90° around X" rotates the part in place, not around the
+world origin. This is almost always what you want. To override, pass an
+explicit \`pivot\`:
+- \`pivot: "center"\` (default) — rotate around the part's bbox center
+- \`pivot: "origin"\` — legacy, rotate around world origin
+- \`pivot: {x, y, z}\` — rotate around a specific world-space point
+
+If you want a part to rotate around another part's anchor (e.g. a door hinge
+at a frame's edge), first call inspect_part on the frame to get the anchor
+coordinates, then pass those coordinates as the pivot.
+
+## screenshot_viewport: prefer \`view: "quad"\` for assemblies
+
+For any assembly with more than ~3 parts, capture a \`quad\` screenshot — it
+gives you iso + front + right + top in a single 2×2 image. One tool call, the
+most spatial information per token. Material colors are faithful during
+capture (no selection highlights), and the origin has a small XYZ gnomon
+(X red, Y green, Z blue).
+
+## Recipe: building a bicycle frame
+
+Instead of extruding each tube with perpendicular-basis math, do this:
+
+1. \`polyline_tube({ points: [rearDropout, bb, seatTubeTop, topTubeJoint, headTubeTop, bb], radius: 14, name: "Frame" })\`
+2. \`tube({ start: headTubeTop, end: headTubeBottom, radius: 16, name: "Head Tube" })\`
+3. \`tube({ start: headTubeBottom, end: frontHub, radius: 12, name: "Fork" })\`
+4. \`cylinder\` for wheels, \`place\` each to its hub.
+5. \`tube\` for handlebar, seat post, crank arm.
+6. \`set_material\` on each part.
+7. \`screenshot_viewport({ view: "quad" })\` to verify.
+
+This pattern generalizes: whenever you'd be tempted to compute perpendicular
+vectors or tube lengths by hand, stop and use tube / polyline_tube instead.`;

--- a/packages/core/src/commands/registry.ts
+++ b/packages/core/src/commands/registry.ts
@@ -272,6 +272,88 @@ export class CommandRegistry {
           required: ["name"],
         },
       },
+      {
+        name: "tube",
+        description:
+          "Create a cylindrical pipe/tube between two world-space points. One call, no trigonometry: pass start and end and radius, and the tube is created with correct orientation, length, and cross-section. Strongly preferred over manually building an extrude with perpendicular-basis vectors — this is the right tool for frame tubes, pipes, handlebars, axles, spindles, and similar segments.",
+        input_schema: {
+          type: "object",
+          properties: {
+            start: {
+              type: "object",
+              properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } },
+              description: "World-space start point of the tube centerline.",
+              required: ["x", "y", "z"],
+            },
+            end: {
+              type: "object",
+              properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } },
+              description: "World-space end point of the tube centerline.",
+              required: ["x", "y", "z"],
+            },
+            radius: { type: "number", description: "Tube radius in mm (default 5)." },
+            arc_segments: { type: "integer", description: "Circumferential resolution (default 16)." },
+            name: { type: "string", description: "Short descriptive name for the tube." },
+          },
+          required: ["start", "end"],
+        },
+      },
+      {
+        name: "polyline_tube",
+        description:
+          "Create a chain of tubes through a sequence of world-space points. Each consecutive pair of points becomes one tube segment (a separate part — not unioned). Perfect for bike frames, piping, cable runs, and any multi-segment pipe run where the joints are points rather than vectors.",
+        input_schema: {
+          type: "object",
+          properties: {
+            points: {
+              type: "array",
+              description: "Ordered list of world-space points the tube passes through. Must have ≥2 entries.",
+              items: {
+                type: "object",
+                properties: { x: { type: "number" }, y: { type: "number" }, z: { type: "number" } },
+                required: ["x", "y", "z"],
+              },
+            },
+            radius: { type: "number", description: "Tube radius in mm (default 5)." },
+            arc_segments: { type: "integer", description: "Circumferential resolution (default 16)." },
+            name: { type: "string", description: "Base name (segments named 'Base 1', 'Base 2', ...)." },
+          },
+          required: ["points"],
+        },
+      },
+      {
+        name: "inspect_part",
+        description:
+          "Read a part's current world-space geometry: bounding box, size, center, translate, rotation, material, and the set of named anchors (center/min/max/top/bottom/front/back/left/right) you can pass to `place`. Use this to verify what the scene looks like after a tool call without spending tokens on a screenshot — it's much cheaper than screenshot_viewport. Result is JSON.",
+        input_schema: {
+          type: "object",
+          properties: {
+            part_id: {
+              type: "string",
+              description: "The part ID to inspect.",
+            },
+          },
+          required: ["part_id"],
+        },
+      },
+      {
+        name: "place",
+        description:
+          "Position a part by anchor: moves the part so that its `from` anchor lands on the `to` anchor. Both anchors can be either a named anchor on this or another part (center/min/max/top/bottom/front/back/left/right), or an explicit world-space {x,y,z} point. Prefer this over manual translate/rotate when you're aligning to another part — it remains correct when upstream dimensions change.",
+        input_schema: {
+          type: "object",
+          properties: {
+            part_id: { type: "string", description: "The part to move." },
+            from: {
+              description: "The anchor on this part to place. Either a named anchor string, a {x,y,z} point, or {part, anchor}. Defaults to 'center'.",
+            },
+            to: {
+              description: "The destination. Either a named anchor string (resolved on this part), a {x,y,z} world point, or {part, anchor}.",
+            },
+          },
+          required: ["part_id", "to"],
+        },
+      },
     ];
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -182,7 +182,7 @@ export {
 } from "./keybindings/index.js";
 
 // AI Tool Registry (CRUD)
-export { commandRegistry, executeCrud } from "./commands/index.js";
+export { commandRegistry, executeCrud, HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX } from "./commands/index.js";
 export type { ToolSchemaEntry, ExecutionResult, ExecutionDisplay, SummarySegment, AnthropicTool } from "./commands/index.js";
 
 // Part labels

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -41,6 +41,13 @@ export interface UiState {
   theme: Theme;
   isDraggingGizmo: boolean;
   isOrbiting: boolean;
+  /** True while ai-screenshot.ts is capturing an off-screen frame from the
+   *  AI's camera. Overlays (selection highlights, participant attention
+   *  rings) should suppress themselves when this is set so the screenshot
+   *  reflects material colors rather than UI chrome. An axes gnomon is
+   *  rendered in this mode so the AI can orient itself without guessing
+   *  which direction is "right" or "front". Always false in normal use. */
+  captureMode: boolean;
   showWireframe: boolean;
   gridSnap: boolean;
   pointSnap: boolean;
@@ -97,6 +104,7 @@ export interface UiState {
   setSnapIncrement: (value: number) => void;
   setDraggingGizmo: (dragging: boolean) => void;
   setOrbiting: (orbiting: boolean) => void;
+  setCaptureMode: (on: boolean) => void;
   copyToClipboard: (partIds: string[]) => void;
   showDeleteConfirm: (partIds: string[]) => void;
   hideDeleteConfirm: () => void;
@@ -170,6 +178,7 @@ export const useUiStore = create<UiState>((set) => ({
   theme: "system",
   isDraggingGizmo: false,
   isOrbiting: false,
+  captureMode: false,
   showWireframe: false,
   gridSnap: true,
   pointSnap: true,
@@ -253,6 +262,8 @@ export const useUiStore = create<UiState>((set) => ({
   setDraggingGizmo: (dragging) => set({ isDraggingGizmo: dragging }),
 
   setOrbiting: (orbiting) => set({ isOrbiting: orbiting }),
+
+  setCaptureMode: (on) => set({ captureMode: on }),
 
   copyToClipboard: (partIds) => set({ clipboard: partIds }),
 


### PR DESCRIPTION
## Summary

This PR adds a suite of high-level geometry tools designed to reduce the amount of mathematical computation the AI model needs to perform when building assemblies. Instead of manually computing perpendicular basis vectors and rotation matrices, the AI can now use intuitive commands like `tube()` for pipes, `place()` for anchor-based positioning, and `inspect_part()` for geometry verification.

## Key Changes

### New Tools in Command Registry
- **`tube(start, end, radius)`** — Create a cylindrical pipe between two world-space points in a single call. Automatically computes orientation, length, and cross-section without requiring perpendicular-basis math.
- **`polyline_tube(points, radius)`** — Chain multiple tube segments through a sequence of points. Each segment becomes a separate part, ideal for bike frames and piping runs.
- **`inspect_part(part_id)`** — Return JSON with world-space bounding box, size, center, translation, rotation, material, and named anchors (center/min/max/top/bottom/front/back/left/right). Allows the AI to verify geometry without taking screenshots.
- **`place(part_id, from, to)`** — Position a part by anchor-based alignment. Moves a part so its `from` anchor lands on the `to` anchor (which can be a named anchor, explicit point, or another part's anchor).

### Enhanced Existing Tools
- **`rotate()`** — Added optional `pivot` parameter (defaults to part's bbox center). Supports `"center"` (default), `"origin"` (legacy), or explicit `{x,y,z}` world-space point. Implements in-place rotation via compensating translation math.
- **`screenshot_viewport()`** — Added `view: "quad"` option to capture iso+front+right+top as a single 2×2 labeled image in one tool call.

### Geometry Helper Functions
- `computePartWorldBbox()` — Read a part's current world-space AABB from the evaluated scene
- `bboxCenter()` / `bboxSize()` — Utility functions for bounding box operations
- `getCurrentOffset()` / `getCurrentAngles()` — Read current Translate/Rotate parameters from the document
- `rotateVec3()` / `inverseRotateVec3()` — Euler-XYZ rotation math (degrees, X→Y→Z order)
- `perpendicularBasis()` — Derive two perpendicular unit vectors from a direction
- `circleProfileSegments()` — Generate a closed-loop circular sketch profile for sweep operations
- `resolveAnchor()` / `resolveAnchorOnPart()` — Resolve anchor references to world-space points

### UI/Rendering Changes
- Added `captureMode` flag to `UiStore` to suppress selection highlights during AI screenshot capture
- Implemented `CaptureAxesGnomon` component — renders labeled XYZ axes at the world origin during capture so the AI can orient itself without guessing direction
- Modified `SceneMesh` to suppress emissive tint (selection glow) when `captureMode` is active, ensuring material colors show faithfully in screenshots
- Updated `SelectionOverlay` to render only the axes gnomon during capture mode

### Polyline Path Support
- Added desugaring of `{type: "Polyline", points: []}` paths in sweep operations into N separate Line sweeps, avoiding expensive boolean operations for common pipe/frame patterns

### Documentation
- Created `prompt-appendix.ts` with `HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX` — teaching prompt explaining when and how to use the new tools, with a bicycle frame example recipe
- Updated tool descriptions in registry to guide the AI toward these higher-level abstractions

## Implementation Details

- **Anchor resolution** is bidirectional: `inspect_part` returns the anchor table so `place` can reference it, keeping both tools in sync
- **In-place rotation** uses the formula `T_new = P - R_new · (R_old⁻¹ · (P - T_old))` to compute compensating translation, allowing rotation around arbitrary pivots without modifying the underlying geometry
- **

https://claude.ai/code/session_01CTa9eYKncxSwi5MHqyksSG