### PR TITLE
Improve camera zoom-to-fit using bounding sphere and FOV

### DIFF
--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -387,11 +387,12 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     box.getCenter(kernelCenter);
     const size = new Vector3();
     box.getSize(size);
-    const maxDim = Math.max(size.x, size.y, size.z);
+    // Bounding-sphere radius — independent of orbit angle, safe for any view.
+    const radius = Math.max(size.length() * 0.5, 1e-3);
     // Transform kernel Z-up center to Three.js Y-up world space
     // Rotation -90° around X: (x, y, z) → (x, z, -y)
     const center = new Vector3(kernelCenter.x, kernelCenter.z, -kernelCenter.y);
-    return { center, maxDim };
+    return { center, radius };
   }, [selectedPartIds, scene, parts, isPartSelected]);
 
   // Animate orbit target to selection center and zoom to fit
@@ -399,15 +400,25 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   useEffect(() => {
     if (selectionInfo && !isDraggingGizmo) {
       targetGoalRef.current.copy(selectionInfo.center);
-      // Distance = 2.5x the max dimension, clamped to reasonable range
-      distanceGoalRef.current = Math.max(
-        30,
-        Math.min(300, selectionInfo.maxDim * 2.5),
-      );
+      // Fit the selection's bounding sphere to the viewport using the
+      // camera's actual FOV + aspect, so tiny features don't vanish and
+      // huge ones don't get clipped. Uses the more restrictive of the
+      // vertical/horizontal FOVs so the sphere fits in both directions.
+      const padding = 1.2;
+      if (camera instanceof PerspectiveCamera) {
+        const vFov = (camera.fov * Math.PI) / 180;
+        const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
+        const fitFov = Math.min(vFov, hFov);
+        const distance =
+          (selectionInfo.radius / Math.sin(fitFov / 2)) * padding;
+        distanceGoalRef.current = Math.max(camera.near * 2, distance);
+      } else {
+        distanceGoalRef.current = selectionInfo.radius * 3 * padding;
+      }
       isAnimatingTargetRef.current = true;
       setIsCameraMoving(true);
     }
-  }, [selectionInfo, isDraggingGizmo]);
+  }, [selectionInfo, isDraggingGizmo, camera]);
 
   // Smooth target and distance animation
   useFrame(() => {


### PR DESCRIPTION
## Summary
Improved the camera zoom-to-fit behavior when selecting parts by replacing a simple max-dimension approach with a mathematically precise bounding sphere calculation that accounts for the camera's field of view and aspect ratio.

## Key Changes
- **Bounding sphere calculation**: Changed from using the max dimension of the bounding box to calculating the radius of the bounding sphere (`size.length() * 0.5`), which is independent of orbit angle and safe for any viewing direction
- **FOV-aware distance calculation**: Replaced the hardcoded `2.5x` multiplier with a proper calculation that:
  - Extracts both vertical and horizontal fields of view from the camera
  - Uses the more restrictive FOV to ensure the sphere fits in both directions
  - Calculates the required distance using trigonometry: `radius / sin(fov/2)`
- **Camera type handling**: Added explicit handling for `PerspectiveCamera` vs other camera types (e.g., `OrthographicCamera`)
- **Safety bounds**: Ensures the calculated distance respects the camera's near plane (`camera.near * 2`) and includes a padding factor (1.2x) for visual breathing room
- **Dependency update**: Added `camera` to the effect dependency array to recalculate when the camera changes

## Implementation Details
The new approach uses the formula for fitting a sphere in a camera's view: `distance = radius / sin(fov/2)`. This ensures that tiny features remain visible and large objects don't get clipped, regardless of the selection's orientation or the viewport's aspect ratio.

https://claude.ai/code/session_01EvDizH9wKoJx1n5nYeNFsd