### PR TITLE
Add login notifications for returning users

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -31,6 +31,7 @@ const GuidedFlowOverlay = lazyWithRetry(() => import("@/components/GuidedFlowOve
 const GhostPromptController = lazyWithRetry(() => import("@/components/GhostPromptController").then(m => ({ default: m.GhostPromptController })), "GhostPromptController");
 const CelebrationOverlay = lazyWithRetry(() => import("@/components/CelebrationOverlay").then(m => ({ default: m.CelebrationOverlay })), "CelebrationOverlay");
 const SignInDelight = lazyWithRetry(() => import("@/components/SignInDelight").then(m => ({ default: m.SignInDelight })), "SignInDelight");
+const LoginNotifications = lazyWithRetry(() => import("@/components/LoginNotifications").then(m => ({ default: m.LoginNotifications })), "LoginNotifications");
 const UpgradeDelight = lazyWithRetry(() => import("@/components/UpgradeDelight").then(m => ({ default: m.UpgradeDelight })), "UpgradeDelight");
 const AboutModal = lazyWithRetry(() => import("@/components/AboutModal").then(m => ({ default: m.AboutModal })), "AboutModal");
 const RecentFilesModal = lazyWithRetry(() => import("@/components/RecentFilesModal").then(m => ({ default: m.RecentFilesModal })), "RecentFilesModal");
@@ -721,6 +722,7 @@ export function App() {
         <GhostPromptController />
         <CelebrationOverlay />
         <SignInDelight />
+        <LoginNotifications />
         <UpgradeDelight />
       </Suspense>
 

--- a/packages/app/src/components/LoginNotifications.tsx
+++ b/packages/app/src/components/LoginNotifications.tsx
@@ -1,0 +1,75 @@
+import { useEffect } from "react";
+import { useNotificationStore } from "@/stores/notification-store";
+import { notify } from "@/lib/native-notify";
+
+interface SignInSuccessDetail {
+  firstName: string;
+  email?: string;
+  provider?: string;
+}
+
+interface SignInAttemptDetail {
+  email: string;
+}
+
+interface SignInAttemptFailedDetail {
+  email: string;
+  message: string;
+}
+
+/**
+ * Surfaces login and login-attempt events as in-app toasts and OS
+ * notifications. The AuthProvider and AuthModal dispatch window CustomEvents
+ * — this component listens and routes them to the notification store.
+ */
+export function LoginNotifications() {
+  const toast = useNotificationStore((s) => s.toast);
+
+  useEffect(() => {
+    const handleSignInSuccess = (e: CustomEvent<SignInSuccessDetail>) => {
+      const { firstName, provider } = e.detail;
+      const providerLabel = provider && provider !== "email" ? ` via ${provider}` : "";
+      toast.success(`Signed in as ${firstName}${providerLabel}`);
+      void notify({
+        title: "vcad — Signed in",
+        body: `Welcome back, ${firstName}.`,
+      });
+    };
+
+    const handleSignOut = () => {
+      toast.info("Signed out");
+    };
+
+    const handleAttempt = (e: CustomEvent<SignInAttemptDetail>) => {
+      toast.info(`Sending sign-in link to ${e.detail.email}…`, { duration: 2500 });
+    };
+
+    const handleAttemptSent = (e: CustomEvent<SignInAttemptDetail>) => {
+      toast.success(`Magic link sent to ${e.detail.email}. Check your inbox.`);
+    };
+
+    const handleAttemptFailed = (e: CustomEvent<SignInAttemptFailedDetail>) => {
+      toast.error(`Sign-in failed: ${e.detail.message}`);
+      void notify({
+        title: "vcad — Sign-in failed",
+        body: e.detail.message,
+      });
+    };
+
+    window.addEventListener("vcad:sign-in-success", handleSignInSuccess as EventListener);
+    window.addEventListener("vcad:sign-out", handleSignOut as EventListener);
+    window.addEventListener("vcad:sign-in-attempt", handleAttempt as EventListener);
+    window.addEventListener("vcad:sign-in-attempt-sent", handleAttemptSent as EventListener);
+    window.addEventListener("vcad:sign-in-attempt-failed", handleAttemptFailed as EventListener);
+
+    return () => {
+      window.removeEventListener("vcad:sign-in-success", handleSignInSuccess as EventListener);
+      window.removeEventListener("vcad:sign-out", handleSignOut as EventListener);
+      window.removeEventListener("vcad:sign-in-attempt", handleAttempt as EventListener);
+      window.removeEventListener("vcad:sign-in-attempt-sent", handleAttemptSent as EventListener);
+      window.removeEventListener("vcad:sign-in-attempt-failed", handleAttemptFailed as EventListener);
+    };
+  }, [toast]);
+
+  return null;
+}

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -38,6 +38,10 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
     setLoading(true);
     setError(null);
 
+    window.dispatchEvent(
+      new CustomEvent("vcad:sign-in-attempt", { detail: { email } }),
+    );
+
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
@@ -47,8 +51,16 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
 
     if (error) {
       setError(error.message);
+      window.dispatchEvent(
+        new CustomEvent("vcad:sign-in-attempt-failed", {
+          detail: { email, message: error.message },
+        }),
+      );
     } else {
       setSent(true);
+      window.dispatchEvent(
+        new CustomEvent("vcad:sign-in-attempt-sent", { detail: { email } }),
+      );
     }
     setLoading(false);
   };

--- a/packages/auth/src/components/AuthProvider.tsx
+++ b/packages/auth/src/components/AuthProvider.tsx
@@ -152,10 +152,14 @@ export function AuthProvider({
           });
         }
 
-        // Check if this is a first-time sign-in celebration
-        if (!hasSeenCelebration && isNewUser(session.user.created_at)) {
+        const firstName = getFirstName(session.user);
+        const provider = session.user.app_metadata?.provider;
+        const isFirstTime = !hasSeenCelebration && isNewUser(session.user.created_at);
+
+        // Check if this is a first-time sign-in celebration. First-time users
+        // get the welcome toast instead of the generic "Signed in" toast.
+        if (isFirstTime) {
           markCelebrationSeen();
-          const firstName = getFirstName(session.user);
           // Dispatch celebration event for CelebrationOverlay
           window.dispatchEvent(new CustomEvent("vcad:celebrate-sign-in"));
           // Dispatch welcome event with user's name for toast
@@ -163,6 +167,19 @@ export function AuthProvider({
             new CustomEvent("vcad:welcome-sign-in", { detail: { firstName } })
           );
           onFirstSignIn?.(firstName);
+        } else {
+          // Notify listeners that a returning user has signed in. The app
+          // surfaces this as an in-app toast and (when backgrounded) an OS
+          // notification so users know when an account sign-in happens.
+          window.dispatchEvent(
+            new CustomEvent("vcad:sign-in-success", {
+              detail: {
+                firstName,
+                email: session.user.email,
+                provider,
+              },
+            }),
+          );
         }
 
         onSignIn?.();
@@ -171,6 +188,7 @@ export function AuthProvider({
         if (typeof posthog !== "undefined") {
           posthog.reset();
         }
+        window.dispatchEvent(new CustomEvent("vcad:sign-out"));
         onSignOut?.();
       }
     });


### PR DESCRIPTION
## Summary
This PR adds in-app toast and OS notifications for authentication events, particularly for returning users signing in. A new `LoginNotifications` component listens to custom events dispatched by the auth system and surfaces them as user-facing notifications.

## Key Changes
- **New `LoginNotifications` component** (`packages/app/src/components/LoginNotifications.tsx`): Listens to five authentication-related custom events and routes them to the notification store and native OS notifications:
  - `vcad:sign-in-success` — Returning user sign-in (shows toast + OS notification)
  - `vcad:sign-out` — User sign-out (shows info toast)
  - `vcad:sign-in-attempt` — Sign-in link request initiated (shows brief info toast)
  - `vcad:sign-in-attempt-sent` — Magic link successfully sent (shows success toast)
  - `vcad:sign-in-attempt-failed` — Sign-in failed (shows error toast + OS notification)

- **Updated `AuthProvider`** (`packages/auth/src/components/AuthProvider.tsx`):
  - Dispatches `vcad:sign-in-success` event for returning users (first-time users continue to get the existing celebration flow)
  - Dispatches `vcad:sign-out` event on sign-out
  - Extracts user's first name and provider info to include in success event details

- **Updated `AuthModal`** (`packages/auth/src/components/AuthModal.tsx`):
  - Dispatches `vcad:sign-in-attempt` when user submits email
  - Dispatches `vcad:sign-in-attempt-sent` on successful magic link send
  - Dispatches `vcad:sign-in-attempt-failed` on error with error message

- **Updated `App.tsx`**: Registers the new `LoginNotifications` component in the app root

## Implementation Details
- The component uses a custom event system to decouple auth logic from notification UI, allowing the auth package to remain independent
- OS notifications are only sent for critical events (sign-in success and failure) to avoid notification spam
- Returning users get a generic "Signed in" notification instead of the celebration overlay, which is reserved for first-time users
- All event listeners are properly cleaned up on component unmount

https://claude.ai/code/session_01Kh2RAsWxdf1ng83VuRzy6K