### PR TITLE
Fix signed-in users seeing "Free chat limit reached" banner

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,15 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-23-fix-chat-free-limit-when-signed-in",
+      "version": "0.8.0",
+      "date": "2026-04-23",
+      "category": "fix",
+      "title": "Stop showing 'Free chat limit reached' to signed-in users",
+      "summary": "Signed-in users with credits no longer see the anon free-tier banner when their access token momentarily fails to validate — the chat client now refreshes the Supabase session and retries, and the banner is gated to truly anonymous sessions.",
+      "features": ["chat", "auth"]
+    },
+    {
       "id": "2026-04-23-ai-chat-higher-level-tools",
       "version": "0.8.0",
       "date": "2026-04-23",

--- a/packages/app/api/_lib/supabase.ts
+++ b/packages/app/api/_lib/supabase.ts
@@ -47,26 +47,51 @@ export async function getUserIdFromAuth(
   }
 }
 
-/** Extract both the uid and whether the session is anonymous. Use this
- *  when you need to differentiate between "no session", "anon session",
- *  and "permanent session" — for example, the chat endpoint stores rows
- *  under the anon uid but applies the anonymous rate-limit tier. */
+/** Result of resolving the Bearer token on a request.
+ *
+ *  `tokenStatus` lets callers distinguish three cases that are otherwise
+ *  collapsed into "userId is null":
+ *    * `"missing"` — no Authorization header (a true anonymous caller — e.g.
+ *      the marketing site, a CLI without `vcad login`, the `/api/chat` flow
+ *      that explicitly supports anonymous use).
+ *    * `"valid"`   — a token was sent and Supabase accepted it. `userId` is
+ *      populated with the resolved auth.uid().
+ *    * `"invalid"` — a token was sent but Supabase rejected it (expired,
+ *      malformed, revoked, network blip on getUser). The caller should
+ *      respond with 401 so the client can refresh its session and retry,
+ *      rather than silently downgrading the request to the anonymous tier
+ *      and producing a misleading "free chat limit reached" error. */
+export interface AuthDetail {
+  userId: string | null;
+  isAnonymous: boolean;
+  tokenStatus: "missing" | "valid" | "invalid";
+}
+
+/** Extract the uid, anonymity flag, and token-validation status from a
+ *  request's Bearer token. See `AuthDetail` for the three-way distinction
+ *  callers need when a logged-in user's token is rejected. */
 export async function getAuthDetail(
   req: VercelRequest,
   admin: SupabaseClient | null,
-): Promise<{ userId: string | null; isAnonymous: boolean }> {
-  if (!admin) return { userId: null, isAnonymous: false };
+): Promise<AuthDetail> {
+  if (!admin) return { userId: null, isAnonymous: false, tokenStatus: "missing" };
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return { userId: null, isAnonymous: false };
+    return { userId: null, isAnonymous: false, tokenStatus: "missing" };
   }
   const token = authHeader.slice(7);
   try {
     const { data, error } = await admin.auth.getUser(token);
-    if (error || !data.user) return { userId: null, isAnonymous: false };
-    return { userId: data.user.id, isAnonymous: !!data.user.is_anonymous };
+    if (error || !data.user) {
+      return { userId: null, isAnonymous: false, tokenStatus: "invalid" };
+    }
+    return {
+      userId: data.user.id,
+      isAnonymous: !!data.user.is_anonymous,
+      tokenStatus: "valid",
+    };
   } catch {
-    return { userId: null, isAnonymous: false };
+    return { userId: null, isAnonymous: false, tokenStatus: "invalid" };
   }
 }
 

--- a/packages/app/api/chat.ts
+++ b/packages/app/api/chat.ts
@@ -607,6 +607,23 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // auth.uid() (including anon) — used for chat_threads ownership so anon
   // users still get their conversation persisted under a stable id.
   const auth = await getAuthDetail(req, admin);
+
+  // If the client sent a Bearer token but Supabase rejected it (typical
+  // cause: an access token that expired between auto-refreshes, or a
+  // transient `getUser` blip), don't silently treat the caller as
+  // anonymous — that path applies the IP-based 3-msg/day cap and
+  // surfaces a misleading "Free chat limit reached" banner to a user
+  // who is, in fact, signed in with credits. Return 401 instead so the
+  // client can refresh the session and retry the same request.
+  if (auth.tokenStatus === "invalid") {
+    console.warn("[chat] rejected request with invalid bearer token");
+    res.status(401).json({
+      error: "auth_invalid",
+      message: "Your sign-in session expired. Refreshing and retrying...",
+    });
+    return;
+  }
+
   const userId = auth.isAnonymous ? null : auth.userId;
   const persistUserId = auth.userId;
   const ip = getClientIp(req);

--- a/packages/app/src/components/ChatSidebar.tsx
+++ b/packages/app/src/components/ChatSidebar.tsx
@@ -426,7 +426,7 @@ export function ChatSidebar() {
   const anonUsage = useChatStore((s) => s.anonUsage);
   const usageError = useChatStore((s) => s.usageError);
   const setUsageError = useChatStore((s) => s.setUsageError);
-  const { user } = useAuth();
+  const { user, isAuthenticated } = useAuth();
 
   // Derive a short display name for the IRC-style role prefix. Prefer the
   // user's first name, then the email prefix, then fall back to "you" for
@@ -463,14 +463,17 @@ export function ChatSidebar() {
   }, []);
 
   // Route each kind of usage error to the right modal: anon → sign in,
-  // monthly → upgrade plan.
+  // monthly → upgrade plan. Guard the anon path against authenticated users
+  // — receiving `anon_limit` while signed-in means the request was treated
+  // as anonymous on the server (typically a stale token), and popping the
+  // sign-in modal at that point would be both confusing and useless.
   useEffect(() => {
-    if (usageError?.kind === "anon_limit") {
+    if (usageError?.kind === "anon_limit" && !isAuthenticated) {
       setShowAuthModal(true);
     } else if (usageError?.kind === "monthly_limit") {
       setShowUpgradeModal(true);
     }
-  }, [usageError]);
+  }, [usageError, isAuthenticated]);
 
   const sendMessage = useCallback(
     (content: string, attachments?: ChatAttachment[]) => {
@@ -610,13 +613,19 @@ export function ChatSidebar() {
             <ConversationScrollButton />
           </Conversation>
 
-          {/* Signed-in: live usage meter drives the "approaching limit" UX. */}
-          {user && (
+          {/* Signed-in (permanent identity): live usage meter drives the
+              "approaching limit" UX. ChatUsageMeter itself bails out for
+              anonymous Supabase sessions, but we also gate it here so the
+              footer doesn't reserve layout space for them. */}
+          {isAuthenticated && (
             <ChatUsageMeter onUpgradeClick={() => setShowUpgradeModal(true)} />
           )}
 
-          {/* Anon: unchanged — sign-in banner since they have no meter. */}
-          {usageError?.kind === "anon_limit" && (
+          {/* Anon-only sign-in banner. The `!isAuthenticated` guard is what
+              keeps a signed-in user from seeing "Free chat limit reached"
+              if a stale-token request gets routed to the anon rate limit
+              before the auto-refresh kicks in. */}
+          {usageError?.kind === "anon_limit" && !isAuthenticated && (
             <div className="shrink-0 bg-brand/10 px-4 py-2 text-[10px] text-text">
               <div className="mb-0.5 font-semibold text-brand">Free chat limit reached</div>
               <div className="text-text-muted">{usageError.message}</div>
@@ -628,7 +637,7 @@ export function ChatSidebar() {
               </button>
             </div>
           )}
-          {!user && anonUsage.used > 0 && !usageError && (
+          {!isAuthenticated && anonUsage.used > 0 && !usageError && (
             <div className="shrink-0 px-4 py-1 text-center text-[9px] text-text-muted">
               {Math.min(anonUsage.used, anonUsage.limit)}/{anonUsage.limit} free chat messages used
             </div>

--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -27,30 +27,39 @@ import {
 
 /**
  * Parse a rate-limit error body emitted by streamChat with LIMIT_ERROR_PREFIX.
- * Returns null if the string isn't a rate-limit error.
+ * Returns null if the string isn't a rate-limit error or if the embedded
+ * `error` field isn't a known kind. Unknown kinds previously fell through
+ * to "anon_limit" and were rendered as "Free chat limit reached", which
+ * masked auth/server errors as a sign-in problem.
  */
 function parseLimitError(err: string): ChatUsageError | null {
   if (!err.startsWith(LIMIT_ERROR_PREFIX)) return null;
   const json = err.slice(LIMIT_ERROR_PREFIX.length);
+  let parsed: {
+    error?: string;
+    message?: string;
+    usage?: number;
+    limit?: number;
+    resets_at?: string;
+  };
   try {
-    const parsed = JSON.parse(json) as {
-      error?: string;
-      message?: string;
-      usage?: number;
-      limit?: number;
-      resets_at?: string;
-    };
-    const kind = parsed.error === "monthly_limit" ? "monthly_limit" : "anon_limit";
-    return {
-      kind,
-      message: parsed.message ?? (kind === "monthly_limit" ? "Monthly limit reached." : "Free limit reached."),
-      usage: parsed.usage,
-      limit: parsed.limit,
-      resetsAt: parsed.resets_at,
-    };
+    parsed = JSON.parse(json);
   } catch {
     return null;
   }
+  if (parsed.error !== "monthly_limit" && parsed.error !== "anon_limit") {
+    return null;
+  }
+  const kind = parsed.error;
+  return {
+    kind,
+    message:
+      parsed.message ??
+      (kind === "monthly_limit" ? "Monthly limit reached." : "Free limit reached."),
+    usage: parsed.usage,
+    limit: parsed.limit,
+    resetsAt: parsed.resets_at,
+  };
 }
 
 /**
@@ -406,6 +415,20 @@ export function useChatHandler() {
             // usageError state (which the sidebar turns into a banner / modal
             // trigger) instead of showing a generic error message.
             const limit = parseLimitError(error);
+            // Defense-in-depth: an `anon_limit` reply for a permanently
+            // signed-in user means the request was treated as anonymous on
+            // the server (almost always a stale token or transient auth
+            // blip). The misleading "Free chat limit reached / Sign in"
+            // banner is the wrong UX for an authed user — surface it as a
+            // generic error so they retry instead.
+            if (limit && limit.kind === "anon_limit" && !isAnon) {
+              const msg = "Authentication issue — please retry in a moment.";
+              parts.push({ type: "text", text: `Error: ${msg}` });
+              fullText += `\n\nError: ${msg}`;
+              useChatStore.getState().setError(msg);
+              updateUI();
+              break;
+            }
             if (limit) {
               useChatStore.getState().setUsageError(limit);
               // Don't pollute the chat with an Error: line — the banner shows.

--- a/packages/app/src/lib/chat-api.ts
+++ b/packages/app/src/lib/chat-api.ts
@@ -1,5 +1,5 @@
 import type { SelectionContext, AnthropicTool } from "@vcad/core";
-import { useAuthStore } from "@vcad/auth";
+import { getSupabase, useAuthStore } from "@vcad/auth";
 
 /**
  * Prefix used to signal a rate-limit error payload to the chat handler.
@@ -7,6 +7,36 @@ import { useAuthStore } from "@vcad/auth";
  * of showing a generic error.
  */
 export const LIMIT_ERROR_PREFIX = "LIMIT:";
+
+/**
+ * Ask Supabase to refresh the current session so we get a new access token.
+ * The auth-state-change listener in AuthProvider picks up the new session
+ * and writes it into useAuthStore — so a subsequent read of
+ * `useAuthStore.getState().session.access_token` returns the fresh token.
+ *
+ * Returns the new access token, or null if no Supabase client is configured
+ * or the refresh failed (no active refresh token, network error, etc).
+ */
+async function refreshAccessToken(): Promise<string | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  try {
+    const { data, error } = await supabase.auth.refreshSession();
+    if (error || !data.session) return null;
+    return data.session.access_token;
+  } catch {
+    return null;
+  }
+}
+
+/** Build the Authorization header from the current store session. Returns
+ *  an empty record when there's no session — callers are anonymous in that
+ *  case and the server applies the anon-tier rate limits. */
+function authHeaders(): Record<string, string> {
+  const session = useAuthStore.getState().session;
+  if (!session?.access_token) return {};
+  return { Authorization: `Bearer ${session.access_token}` };
+}
 
 export interface ChatRequestMessage {
   role: "user" | "assistant";
@@ -58,32 +88,56 @@ export async function streamChat(
   }));
 
   try {
+    const { apiUrl } = await import("@/lib/api-origin");
+    const url = apiUrl("/api/chat");
+    const requestBody = JSON.stringify({
+      messages,
+      context: { selectedParts },
+      tools: options?.tools,
+      systemPrompt: options?.systemPrompt,
+      thread_id: options?.threadId ?? null,
+      document_id: options?.documentId ?? null,
+      user_message_id: options?.userMessageId ?? null,
+      parent_message_id: options?.parentMessageId ?? null,
+      assistant_message_id: options?.assistantMessageId ?? null,
+    });
+
     // Attach the Supabase access token if the user is signed in (including
     // anonymous sessions), so the backend can scope persistence rows to
     // their auth.uid() and apply the right rate-limit tier.
-    const session = useAuthStore.getState().session;
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (session?.access_token) {
-      headers.Authorization = `Bearer ${session.access_token}`;
+    const post = (extraHeaders: Record<string, string>) =>
+      fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...extraHeaders,
+        },
+        body: requestBody,
+        signal: options?.signal,
+      });
+
+    let response = await post(authHeaders());
+
+    // The server returns 401 with `error: "auth_invalid"` when a Bearer
+    // token was sent but Supabase rejected it (typically: the access token
+    // expired between the auto-refresh and this send). Refresh the session
+    // once and retry the same request — without this, the user would see a
+    // misleading "Free chat limit reached" banner because the server would
+    // have routed the orphaned request through the anon IP rate limit.
+    if (response.status === 401 && useAuthStore.getState().session) {
+      const newToken = await refreshAccessToken();
+      if (newToken) {
+        response = await post({ Authorization: `Bearer ${newToken}` });
+      }
     }
 
-    const { apiUrl } = await import("@/lib/api-origin");
-    const response = await fetch(apiUrl("/api/chat"), {
-      method: "POST",
-      headers,
-      body: JSON.stringify({
-        messages,
-        context: { selectedParts },
-        tools: options?.tools,
-        systemPrompt: options?.systemPrompt,
-        thread_id: options?.threadId ?? null,
-        document_id: options?.documentId ?? null,
-        user_message_id: options?.userMessageId ?? null,
-        parent_message_id: options?.parentMessageId ?? null,
-        assistant_message_id: options?.assistantMessageId ?? null,
-      }),
-      signal: options?.signal,
-    });
+    if (response.status === 401) {
+      callbacks.onError(
+        "Sign-in session expired. Please sign in again to continue.",
+      );
+      callbacks.onFinish();
+      return;
+    }
 
     if (response.status === 429) {
       // Rate limit hit — pass the full JSON body through with a prefix so


### PR DESCRIPTION
## Summary
This PR fixes a UX issue where signed-in users with valid credits would see the "Free chat limit reached" banner when their access token momentarily failed to validate. The fix implements token refresh-and-retry logic on the client side and proper 401 error handling on the server side to distinguish between truly anonymous requests and authenticated requests with invalid tokens.

## Key Changes

**Client-side (`chat-api.ts`)**
- Added `refreshAccessToken()` function to refresh the Supabase session when a token becomes invalid
- Added `authHeaders()` helper to build Authorization headers from the current auth store
- Implemented retry logic: when the server returns 401 with an authenticated user, the client now refreshes the session and retries the request instead of treating it as anonymous
- Added explicit 401 error handling to show a session-expired message to the user

**Server-side (`api/chat.ts`)**
- Enhanced `getAuthDetail()` to return a three-way `tokenStatus` ("missing" | "valid" | "invalid") instead of just a boolean
- Added 401 response when a Bearer token is sent but Supabase rejects it, allowing the client to refresh and retry rather than silently downgrading to anonymous tier

**Client-side error handling (`useChatHandler.ts`)**
- Updated `parseLimitError()` to validate that the error kind is a known type, preventing unknown errors from being misclassified as rate limits
- Added defense-in-depth check: if an authenticated user receives an `anon_limit` error, it's treated as a generic authentication error instead of showing the misleading "Free chat limit reached" banner

**UI (`ChatSidebar.tsx`)**
- Updated usage error modal logic to only show the sign-in prompt for truly anonymous users (`!isAuthenticated`)
- Guarded the free-tier usage meter and banner to only show for anonymous sessions, preventing authenticated users from seeing conflicting UX

## Implementation Details
- The fix uses the existing auth-state-change listener in AuthProvider to automatically update the auth store when the session is refreshed
- The 401 response includes `error: "auth_invalid"` to allow the client to distinguish this case from other 401 scenarios
- All changes maintain backward compatibility with existing anonymous user flows

https://claude.ai/code/session_01B8Um2h8TbKLWYfvPKhpBUv