### PR TITLE
Implement Follow mode camera tracking for AI participant

### DIFF
--- a/packages/app/src/components/FollowModeToggle.tsx
+++ b/packages/app/src/components/FollowModeToggle.tsx
@@ -14,9 +14,11 @@ import { cn } from "@/lib/utils";
  * user's camera relates to the AI's.
  *
  *  - Free   : hide AI frustum + attention highlights; ignore AI camera.
- *  - Follow : show the AI camera as a frustum in-scene, user view
- *             untouched.
- *  - Lock   : lerp the user camera onto the AI's each frame.
+ *  - Follow : render the AI camera as a frustum in-scene and aim the
+ *             user's view at it. User stays put, but rotates to track
+ *             the frustum wireframe as it moves.
+ *  - Lock   : user camera matches the AI's exactly, in realtime —
+ *             "see through their eyes".
  *
  * Hidden entirely when no non-local participant has joined the document
  * yet — there's nothing to follow.
@@ -78,8 +80,8 @@ export function FollowModeToggle() {
       <div className="h-3 w-px bg-border/40" aria-hidden />
       <div className="flex items-center gap-0.5" role="group" aria-label="AI camera follow mode">
         {btn("free", "Free", "Free: ignore the AI camera")}
-        {btn("follow", "Follow", "Follow: show AI camera as a frustum in-scene")}
-        {btn("lock", "Lock", "Lock: see through the AI's camera")}
+        {btn("follow", "Follow", "Follow: aim your view at the AI's camera frustum")}
+        {btn("lock", "Lock", "Lock: see through the AI's camera in realtime")}
       </div>
     </div>
   );

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -65,14 +65,16 @@ const INITIAL_POSITION_V = new Vector3(50, 50, 50);
 const INITIAL_TARGET_V = new Vector3(0, 0, 0);
 const INITIAL_DISTANCE_V = INITIAL_POSITION_V.distanceTo(INITIAL_TARGET_V);
 
-// Reused per-frame in the Lock-mode lerp hook.
-const _lockGoalPos = new Vector3();
-const _lockGoalTarget = new Vector3();
+// Reused per-frame in the participant-sync hook (Lock + Follow).
+const _syncGoalPos = new Vector3();
+const _syncGoalTarget = new Vector3();
 
 /**
  * Flip Lock mode back to Free when the user grabs the camera themselves.
- * Cheap to call on every orbit start / pointer down / wheel tick — noop
- * unless we're actually locked.
+ * Follow mode is intentionally *not* broken here — the user is supposed to
+ * be able to orbit around the followed participant's camera while still
+ * tracking it. Cheap to call on every orbit start / pointer down / wheel
+ * tick — noop unless we're actually locked.
  */
 function breakLockOnUserInput(): void {
   const ui = useUiStore.getState();
@@ -481,13 +483,15 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   });
 
   // Demand rendering never kicks a frame on its own when the AI moves
-  // its camera while we're in Lock (we skip drawing the AI's frustum in
-  // that mode, so there's no other subscriber to invalidate for us).
-  // Subscribe to both stores and invalidate whenever a lock-relevant
-  // change lands — the useFrame below self-sustains after the first fire.
+  // its camera while we're in Follow/Lock (in Lock we skip drawing the
+  // AI's frustum, so there's no other subscriber to invalidate for us;
+  // in Follow the frustum overlay kicks itself but we still need a frame
+  // to re-aim the user camera). Subscribe to both stores and invalidate
+  // whenever a mode-relevant change lands — the useFrame below
+  // self-sustains after the first fire.
   useEffect(() => {
     const kick = () => {
-      if (useUiStore.getState().followMode === "lock") invalidate();
+      if (useUiStore.getState().followMode !== "free") invalidate();
     };
     const unsubUi = useUiStore.subscribe(kick);
     const unsubPart = useParticipantStore.subscribe(kick);
@@ -497,40 +501,56 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     };
   }, [invalidate]);
 
-  // Lock mode: each frame, lerp the user's camera onto the followed
-  // participant's camera (kernel Z-up → display Y-up). Skip when the
-  // existing animation system is already driving the camera so we don't
-  // fight over it. Also skips when no participant is followed or the
-  // target participant has no camera opinion yet.
+  // Per-frame participant-camera sync (Follow + Lock).
+  //
+  //  - Lock   : hard-copy the followed participant's camera every frame
+  //             (kernel Z-up → display Y-up). No interpolation — the user
+  //             sees exactly what the AI sees. Preempts any in-flight
+  //             focus/snap animation so lock stays authoritative.
+  //  - Follow : keep the user's eye position; lerp the orbit target
+  //             toward the AI's eye position so the user's view rotates
+  //             to frame the AI's frustum wireframe. User keeps orbit +
+  //             zoom, but always rotates around / looks at the AI.
   useFrame(() => {
     const { followMode, followingParticipantId } = useUiStore.getState();
-    if (followMode !== "lock" || !followingParticipantId) return;
-    if (isAnimatingTargetRef.current) return;
+    if (followMode === "free" || !followingParticipantId) return;
     const participant =
       useParticipantStore.getState().participants.get(followingParticipantId);
     if (!participant?.camera) return;
 
     const [px, py, pz] = kernelToDisplay(participant.camera.position);
-    const [tx, ty, tz] = kernelToDisplay(participant.camera.target);
-    const goalPos = _lockGoalPos.set(px, py, pz);
-    const goalTarget = _lockGoalTarget.set(tx, ty, tz);
-    const lerp = 0.15;
-    camera.position.lerp(goalPos, lerp);
-    if (orbitRef.current) {
-      orbitRef.current.target.lerp(goalTarget, lerp);
-      orbitRef.current.update();
-    } else {
-      camera.lookAt(goalTarget);
+    const goalPos = _syncGoalPos.set(px, py, pz);
+
+    if (followMode === "lock") {
+      // Lock overrides any in-flight focus/snap animation.
+      if (isAnimatingTargetRef.current) cancelCameraAnimation();
+      const [tx, ty, tz] = kernelToDisplay(participant.camera.target);
+      const goalTarget = _syncGoalTarget.set(tx, ty, tz);
+      camera.position.copy(goalPos);
+      if (orbitRef.current) {
+        orbitRef.current.target.copy(goalTarget);
+        orbitRef.current.update();
+      } else {
+        camera.lookAt(goalTarget);
+      }
+      invalidate();
+      return;
     }
-    // Only keep the demand loop alive while we're still converging.
-    // Once we're within a tight tolerance of the goal, stop asking for
-    // frames — the store subscription above will kick us again the
-    // next time the AI moves its camera.
-    const posDelta = camera.position.distanceToSquared(goalPos);
-    const targetDelta = orbitRef.current
-      ? orbitRef.current.target.distanceToSquared(goalTarget)
-      : 0;
-    if (posDelta > 1e-4 || targetDelta > 1e-4) invalidate();
+
+    // Follow: aim the user's look-at at the AI's eye (frustum apex).
+    // Don't fight an in-flight focus animation the user explicitly
+    // triggered — let it finish, then follow resumes next frame.
+    if (isAnimatingTargetRef.current) return;
+    const lerp = 0.15;
+    if (orbitRef.current) {
+      orbitRef.current.target.lerp(goalPos, lerp);
+      orbitRef.current.update();
+      const targetDelta =
+        orbitRef.current.target.distanceToSquared(goalPos);
+      if (targetDelta > 1e-4) invalidate();
+    } else {
+      camera.lookAt(goalPos);
+    }
   });
 
   // Wheel handler with configurable control schemes

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -16,11 +16,13 @@ export type SidebarPane = "tree" | "inspector";
 
 /**
  * How the local user's camera relates to another participant's camera.
- * - "free": independent. The local camera is only moved by user input.
- * - "follow": user camera stays put, but the other participant's camera
- *             is rendered in-scene (frustum + attention highlight).
- * - "lock":  user camera lerps to match the followed participant's camera
- *             every frame — "see through their eyes".
+ * - "free":   independent. The local camera is only moved by user input.
+ * - "follow": other participant's camera is rendered in-scene (frustum +
+ *             attention highlight); the user's eye stays put but their
+ *             look-at target tracks the other participant's eye so the
+ *             frustum stays framed in the user's view.
+ * - "lock":   user camera matches the followed participant's camera
+ *             exactly every frame — "see through their eyes".
  */
 export type FollowMode = "free" | "follow" | "lock";
 


### PR DESCRIPTION
## Summary
This PR implements a new "Follow" mode for camera synchronization with AI participants, distinct from the existing "Lock" mode. While Lock mode hard-copies the AI's camera view, Follow mode keeps the user's eye position fixed but rotates their view to track the AI's camera frustum in the scene.

## Key Changes

- **Refactored participant-sync logic**: Consolidated Lock and Follow mode camera updates into a single `useFrame` hook that handles both modes with different behaviors
  - Lock mode: hard-copies the AI's camera position and target every frame, preempting any in-flight animations
  - Follow mode: keeps user eye position static, lerps the orbit target toward the AI's eye position so the view rotates to frame the frustum

- **Updated demand rendering**: Changed the frame invalidation condition from `followMode === "lock"` to `followMode !== "free"` to support rendering updates in both Lock and Follow modes

- **Improved variable naming**: Renamed `_lockGoalPos`/`_lockGoalTarget` to `_syncGoalPos`/`_syncGoalTarget` to reflect their use across both modes

- **Enhanced documentation**: Updated comments and docstrings throughout to clarify the distinction between Follow and Lock modes:
  - Follow mode allows user orbit/zoom control while tracking the AI's camera
  - Lock mode provides a "see through their eyes" experience with no user camera control
  - Updated UI tooltips and type documentation to reflect the new behavior

## Implementation Details

- Follow mode respects in-flight focus/snap animations triggered by the user, resuming tracking after they complete
- Lock mode overrides any animations to maintain authoritative synchronization
- Both modes use the same coordinate transformation (kernel Z-up → display Y-up)
- Frame invalidation in Follow mode only continues while the orbit target is converging toward the goal position

https://claude.ai/code/session_01FLQ9bveCAZBFMfqw5bwUjX