### PR TITLE
Enrich Discord notification for new chat threads

### DIFF
--- a/supabase/migrations/022_chat_thread_notification_enrich.sql
+++ b/supabase/migrations/022_chat_thread_notification_enrich.sql
@@ -1,0 +1,48 @@
+-- Enrich the "💬 New chat thread" Discord notification.
+--
+-- Privacy stance: we intentionally do NOT include message content, email, or
+-- full user/document UUIDs. The document name is the only new human-readable
+-- field, and it is already broadcast by the document-create trigger in 021.
+
+create or replace function notify_discord_on_chat_thread_create()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  owner_username text;
+  owner_label text;
+  doc_name text;
+  doc_owner_id uuid;
+  doc_label text;
+  fields jsonb;
+begin
+  select username into owner_username from profiles where id = new.user_id;
+  owner_label := coalesce(owner_username, 'user:' || substr(new.user_id::text, 1, 8));
+
+  select name, user_id into doc_name, doc_owner_id from documents where id = new.document_id;
+  doc_label := coalesce(nullif(doc_name, ''), 'doc:' || substr(new.document_id, 1, 8));
+
+  fields := jsonb_build_array(
+    jsonb_build_object('name', 'user',     'value', owner_label,                        'inline', true),
+    jsonb_build_object('name', 'document', 'value', doc_label,                          'inline', true),
+    jsonb_build_object('name', 'thread',   'value', substr(new.id::text, 1, 8),         'inline', true)
+  );
+
+  if doc_owner_id is not null and doc_owner_id <> new.user_id then
+    fields := fields || jsonb_build_array(
+      jsonb_build_object('name', 'context', 'value', 'shared doc', 'inline', true)
+    );
+  end if;
+
+  perform notify_discord(jsonb_build_object(
+    'title', '💬 New chat thread',
+    'color', 10937650, -- #a6e22e
+    'timestamp', new.created_at,
+    'fields', fields
+  ));
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Summary
This migration adds a new PostgreSQL function to enrich the Discord notification sent when a new chat thread is created. The notification now includes contextual information about the thread creator, associated document, and thread ID.

## Key Changes
- Created `notify_discord_on_chat_thread_create()` trigger function that:
  - Retrieves the username of the thread creator (with fallback to shortened user ID)
  - Fetches the document name and owner information (with fallback to shortened document ID)
  - Constructs a Discord embed with user, document, and thread fields
  - Adds a "shared doc" context indicator when the thread is created on a document owned by a different user
  - Sends the enriched notification via the existing `notify_discord()` function

## Implementation Details
- **Privacy-conscious**: Intentionally excludes message content, email addresses, and full UUIDs to maintain user privacy
- **Graceful fallbacks**: Uses shortened IDs (first 8 characters) when human-readable names are unavailable
- **Context awareness**: Detects and flags when a thread is created on a shared document (document owner differs from thread creator)
- **Consistent styling**: Uses the same green color (#a6e22e) and timestamp format as other notifications
- **Security**: Function uses `security definer` with restricted `search_path` to safely access user and document data

https://claude.ai/code/session_01ED52eMhnLFJJ9aghiNAddw