### PR TITLE
feat: launch prep — Apache 2.0, legal pages, ToS gate

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,15 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-23-launch-prep-legal",
+      "version": "0.8.0",
+      "date": "2026-04-23",
+      "category": "feat",
+      "title": "Privacy, terms, and a proper license",
+      "summary": "Privacy policy, terms of service, and security pages are live at /privacy, /terms, and /security, linked from the account menu. New users see a brief acceptance prompt on first load. vcad is now licensed under Apache 2.0 with Municipal Robotics Corporation as the copyright holder.",
+      "features": ["legal", "onboarding", "licensing"]
+    },
+    {
       "id": "2026-04-23-fix-chat-free-limit-when-signed-in",
       "version": "0.8.0",
       "date": "2026-04-23",

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Municipal Robotics, Inc.
+   Copyright 2026 Municipal Robotics Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,201 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 Cam Pedersen
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Municipal Robotics, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,8 +1,8 @@
 vcad
-Copyright 2025-2026 Municipal Robotics, Inc.
+Copyright 2025-2026 Municipal Robotics Corporation
 Portions Copyright 2025 Cam Pedersen
 
-This product includes software developed by Municipal Robotics, Inc.
+This product includes software developed by Municipal Robotics Corporation
 and its contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,5 @@
 vcad
-Copyright 2025-2026 Municipal Robotics Corporation
-Portions Copyright 2025 Cam Pedersen
+Copyright 2026 Municipal Robotics Corporation
 
 This product includes software developed by Municipal Robotics Corporation
 and its contributors.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+vcad
+Copyright 2025-2026 Municipal Robotics, Inc.
+Portions Copyright 2025 Cam Pedersen
+
+This product includes software developed by Municipal Robotics, Inc.
+and its contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run tauri:build        # produces a signed/unsigned installer
 
 ## License
 
-Copyright © 2025–2026 Municipal Robotics, Inc.
+Copyright © 2025–2026 Municipal Robotics Corporation
 
 Licensed under the [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for
 attributions. Contributions are accepted under the same license per the

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run tauri:build        # produces a signed/unsigned installer
 
 ## License
 
-Copyright © 2025–2026 Municipal Robotics Corporation
+Copyright © 2026 Municipal Robotics Corporation
 
 Licensed under the [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for
 attributions. Contributions are accepted under the same license per the

--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ vcad/
 
 ## Development
 
+> **Heads up:** vcad depends on the `tang` math workspace at a **sibling path**
+> (`../tang`). Clone it next to vcad before any `cargo` command, or the
+> workspace will fail to resolve:
+>
+> ```bash
+> git clone git@github.com:ecto/tang.git ../tang
+> ```
+
 ```bash
 # Rust
 cargo test --workspace
@@ -99,4 +107,8 @@ npm run tauri:build        # produces a signed/unsigned installer
 
 ## License
 
-[MIT](LICENSE)
+Copyright © 2025–2026 Municipal Robotics, Inc.
+
+Licensed under the [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for
+attributions. Contributions are accepted under the same license per the
+[Apache 2.0 Section 5](LICENSE) inbound-equals-outbound rule.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -41,6 +41,8 @@ const VersionHistoryModal = lazyWithRetry(() => import("@/components/VersionHist
 const ForkPromptModal = lazyWithRetry(() => import("@/components/ForkPromptModal").then(m => ({ default: m.ForkPromptModal })), "ForkPromptModal");
 const ReadOnlyBanner = lazyWithRetry(() => import("@/components/ReadOnlyBanner").then(m => ({ default: m.ReadOnlyBanner })), "ReadOnlyBanner");
 const ProfilePage = lazyWithRetry(() => import("@/components/ProfilePage").then(m => ({ default: m.ProfilePage })), "ProfilePage");
+const LegalPage = lazyWithRetry(() => import("@/components/LegalPage").then(m => ({ default: m.LegalPage })), "LegalPage");
+const TermsGate = lazyWithRetry(() => import("@/components/TermsGate").then(m => ({ default: m.TermsGate })), "TermsGate");
 // UsernamePickerModal is lazy-loaded inside ShareDialog, not here.
 const CommandPalette = lazyWithRetry(() => import("@/components/CommandPalette").then(m => ({ default: m.CommandPalette })), "CommandPalette");
 const SketchToolbar = lazyWithRetry(() => import("@/components/SketchToolbar").then(m => ({ default: m.SketchToolbar })), "SketchToolbar");
@@ -85,7 +87,7 @@ import { bootstrap } from "@/lib/bootstrap";
 import { useBootStore } from "@/stores/boot-store";
 import { Splash } from "@/components/Splash";
 import { ErrorScreen } from "@/components/ErrorScreen";
-import { getProfileRouteUsername } from "@/lib/url-document";
+import { getProfileRouteUsername, getLegalRouteSlug } from "@/lib/url-document";
 import {
   mergeMeshes,
 } from "@vcad/engine";
@@ -693,6 +695,23 @@ export function App() {
     );
   }
 
+  // /privacy, /terms, /security — render static legal content.
+  const legalSlug = getLegalRouteSlug();
+  if (legalSlug) {
+    return (
+      <AsyncBoundary
+        region="legal-page"
+        fallback={
+          <div className="flex h-screen items-center justify-center bg-bg text-text-muted text-sm">
+            Loading…
+          </div>
+        }
+      >
+        <LegalPage slug={legalSlug} />
+      </AsyncBoundary>
+    );
+  }
+
   const viewportStack = (
     <>
       <Viewport />
@@ -773,6 +792,9 @@ export function App() {
   return (
     <ErrorBoundary>
       <TooltipProvider>
+        <Suspense fallback={null}>
+          <TermsGate />
+        </Suspense>
         <div
           className="contents"
           onDragOver={handleDragOver}

--- a/packages/app/src/components/AboutModal.tsx
+++ b/packages/app/src/components/AboutModal.tsx
@@ -143,7 +143,7 @@ export function AboutModal({
           {/* Footer links */}
           <div className="flex items-center justify-center gap-6 text-xs">
             <a
-              href="https://github.com/nicholaschuayunzhi/vcad"
+              href="https://github.com/ecto/vcad"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-1.5 text-text-muted hover:text-text transition-colors"
@@ -179,6 +179,13 @@ export function AboutModal({
             >
               v{__APP_VERSION__}
             </button>
+          </div>
+
+          {/* Legal */}
+          <div className="mt-4 flex items-center justify-center gap-4 text-[11px] text-text-muted/60">
+            <a href="/privacy" className="hover:text-text-muted transition-colors">Privacy</a>
+            <a href="/terms" className="hover:text-text-muted transition-colors">Terms</a>
+            <a href="/security" className="hover:text-text-muted transition-colors">Security</a>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/app/src/components/LegalPage.tsx
+++ b/packages/app/src/components/LegalPage.tsx
@@ -8,7 +8,7 @@ interface LegalContent {
 }
 
 const CONTACT_EMAIL = "info@muni.works";
-const COMPANY = "Municipal Robotics, Inc.";
+const COMPANY = "Municipal Robotics Corporation";
 const LAST_UPDATED = "April 23, 2026";
 
 const PRIVACY: LegalContent = {

--- a/packages/app/src/components/LegalPage.tsx
+++ b/packages/app/src/components/LegalPage.tsx
@@ -7,7 +7,7 @@ interface LegalContent {
   sections: { heading: string; body: string[] }[];
 }
 
-const CONTACT_EMAIL = "legal@municipalrobotics.com";
+const CONTACT_EMAIL = "info@muni.works";
 const COMPANY = "Municipal Robotics, Inc.";
 const LAST_UPDATED = "April 23, 2026";
 

--- a/packages/app/src/components/LegalPage.tsx
+++ b/packages/app/src/components/LegalPage.tsx
@@ -1,0 +1,239 @@
+import { useEffect } from "react";
+import type { LegalSlug } from "@/lib/url-document";
+
+interface LegalContent {
+  title: string;
+  updated: string;
+  sections: { heading: string; body: string[] }[];
+}
+
+const CONTACT_EMAIL = "legal@municipalrobotics.com";
+const COMPANY = "Municipal Robotics, Inc.";
+const LAST_UPDATED = "April 23, 2026";
+
+const PRIVACY: LegalContent = {
+  title: "Privacy Policy",
+  updated: LAST_UPDATED,
+  sections: [
+    {
+      heading: "Who we are",
+      body: [
+        `vcad is operated by ${COMPANY} ("we", "us"). This policy describes what data we collect when you use vcad.io, the vcad desktop app, the vcad CLI, and the vcad MCP server, and what we do with it.`,
+      ],
+    },
+    {
+      heading: "What we collect",
+      body: [
+        "Account data: email address, display name, and avatar URL from Google or GitHub OAuth. We do not receive your OAuth password.",
+        "Document data: the .vcad files you choose to sync to the cloud, plus their version history. Local-only files are never transmitted.",
+        "Usage data: feature events (e.g., which export formats are used, how often AI generation is invoked), anonymized error reports, and coarse performance metrics.",
+        "Billing data: if you subscribe to a paid plan, Stripe handles your payment method. We receive a customer ID, plan tier, and subscription status — never your full card number.",
+      ],
+    },
+    {
+      heading: "How we use it",
+      body: [
+        "To provide the product: authenticating you, syncing your documents, enforcing plan limits, and rendering AI responses.",
+        "To improve the product: aggregated analytics on which features succeed or fail.",
+        "To support you: responding when you contact us for help.",
+        "We do not sell personal data. We do not use your CAD files to train models without your explicit, opt-in consent.",
+      ],
+    },
+    {
+      heading: "Third-party services",
+      body: [
+        "Supabase (database + auth), Stripe (billing), Google and GitHub (OAuth), and our AI inference providers receive the minimum data needed to perform their function.",
+      ],
+    },
+    {
+      heading: "Your rights",
+      body: [
+        "You may export, correct, or delete your data at any time from your profile settings, or by emailing " + CONTACT_EMAIL + ". Deleting your account removes your documents and version history within 30 days.",
+      ],
+    },
+    {
+      heading: "Children",
+      body: [
+        "vcad is not directed to children under 13. We do not knowingly collect data from children under 13.",
+      ],
+    },
+    {
+      heading: "Changes",
+      body: [
+        "We'll post any material changes to this policy on this page and update the date above.",
+      ],
+    },
+    {
+      heading: "Contact",
+      body: [`Questions: ${CONTACT_EMAIL}`],
+    },
+  ],
+};
+
+const TERMS: LegalContent = {
+  title: "Terms of Service",
+  updated: LAST_UPDATED,
+  sections: [
+    {
+      heading: "Acceptance",
+      body: [
+        `By using vcad you agree to these terms. vcad is operated by ${COMPANY}.`,
+      ],
+    },
+    {
+      heading: "Your account",
+      body: [
+        "You are responsible for activity under your account. Keep your credentials safe. Notify us immediately if you suspect unauthorized access.",
+        "One human per account. You may not share credentials.",
+      ],
+    },
+    {
+      heading: "Your content",
+      body: [
+        "You retain ownership of the CAD files and other content you create in vcad. You grant us the narrow license needed to host, sync, render, and back up that content so we can provide the service.",
+        "You are responsible for making sure you have the right to upload any content you import (STEP files, meshes, images, etc.).",
+      ],
+    },
+    {
+      heading: "Acceptable use",
+      body: [
+        "Don't use vcad to break the law, infringe others' rights, transmit malware, or attempt to access accounts or data that aren't yours. Don't abuse our AI features to generate content that would violate our providers' policies.",
+        "We may suspend accounts that violate these terms.",
+      ],
+    },
+    {
+      heading: "Paid plans",
+      body: [
+        "Paid plans renew automatically at the interval you select until cancelled. You can cancel from your profile; cancellations take effect at the end of the current billing period. Fees are non-refundable except where required by law.",
+        "We may adjust pricing with at least 30 days' notice; existing paid subscribers keep their current price until their next renewal after the change.",
+      ],
+    },
+    {
+      heading: "Open source components",
+      body: [
+        "The vcad source is available under the Apache License 2.0. This service-level agreement governs the hosted service at vcad.io and related binaries; the Apache license governs the source code itself.",
+      ],
+    },
+    {
+      heading: "Warranty disclaimer",
+      body: [
+        `THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND. DO NOT RELY ON vcad AS THE SOLE AUTHORITY FOR SAFETY-CRITICAL ENGINEERING DECISIONS — always verify exports with independent review before manufacturing.`,
+      ],
+    },
+    {
+      heading: "Limitation of liability",
+      body: [
+        `To the maximum extent permitted by law, ${COMPANY} is not liable for indirect, incidental, or consequential damages. Our total liability is capped at the greater of $100 or the fees you paid us in the 12 months before the claim.`,
+      ],
+    },
+    {
+      heading: "Termination",
+      body: [
+        "Either of us may terminate at any time. Upon termination, your right to use the hosted service ends; you may export your documents for at least 30 days after termination.",
+      ],
+    },
+    {
+      heading: "Governing law",
+      body: [
+        "These terms are governed by the laws of the State of Delaware, USA, without regard to conflict-of-law principles.",
+      ],
+    },
+    {
+      heading: "Contact",
+      body: [`Questions: ${CONTACT_EMAIL}`],
+    },
+  ],
+};
+
+const SECURITY: LegalContent = {
+  title: "Security",
+  updated: LAST_UPDATED,
+  sections: [
+    {
+      heading: "Our approach",
+      body: [
+        "We take a defense-in-depth approach: encryption in transit (TLS 1.2+) and at rest, row-level security on user data, least-privilege access for engineers, and automated dependency and secret scanning on every commit.",
+      ],
+    },
+    {
+      heading: "Authentication",
+      body: [
+        "Sign-in uses Google or GitHub OAuth through Supabase Auth. We never see your OAuth password. Session tokens are scoped per device and can be revoked from your profile.",
+      ],
+    },
+    {
+      heading: "Data isolation",
+      body: [
+        "Your documents are isolated per user via Postgres row-level security. A user can only read or write rows they own unless they have explicitly shared a document.",
+      ],
+    },
+    {
+      heading: "Reporting a vulnerability",
+      body: [
+        `If you believe you've found a security vulnerability, please email ${CONTACT_EMAIL} with details. Please do not file a public GitHub issue for security reports.`,
+        "We aim to acknowledge reports within 2 business days and triage within 5 business days. We commit not to pursue legal action against researchers who report in good faith and follow responsible disclosure.",
+      ],
+    },
+    {
+      heading: "Scope",
+      body: [
+        "In scope: vcad.io, its API endpoints, the published desktop binaries, and the @vcad/mcp npm package.",
+        "Out of scope: third-party services (Supabase, Stripe, Google, GitHub) — please report those to the respective vendors.",
+      ],
+    },
+  ],
+};
+
+const CONTENT: Record<LegalSlug, LegalContent> = {
+  privacy: PRIVACY,
+  terms: TERMS,
+  security: SECURITY,
+};
+
+export function LegalPage({ slug }: { slug: LegalSlug }) {
+  const content = CONTENT[slug];
+
+  useEffect(() => {
+    const prev = document.title;
+    document.title = `${content.title} · vcad`;
+    return () => {
+      document.title = prev;
+    };
+  }, [content.title]);
+
+  return (
+    <div className="min-h-screen bg-bg text-text">
+      <div className="mx-auto max-w-2xl px-6 py-16">
+        <a
+          href="/"
+          className="text-xs uppercase tracking-wider text-text-muted hover:text-text transition-colors"
+        >
+          ← vcad
+        </a>
+        <h1 className="mt-6 text-3xl font-bold tracking-tight">{content.title}</h1>
+        <p className="mt-2 text-xs text-text-muted">Last updated {content.updated}</p>
+
+        <div className="mt-10 space-y-8">
+          {content.sections.map((section) => (
+            <section key={section.heading}>
+              <h2 className="text-sm font-semibold uppercase tracking-wider text-text-muted">
+                {section.heading}
+              </h2>
+              <div className="mt-3 space-y-3 text-sm leading-relaxed">
+                {section.body.map((para, i) => (
+                  <p key={i}>{para}</p>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+
+        <footer className="mt-16 flex gap-6 border-t border-border pt-6 text-xs text-text-muted">
+          <a href="/privacy" className="hover:text-text transition-colors">Privacy</a>
+          <a href="/terms" className="hover:text-text transition-colors">Terms</a>
+          <a href="/security" className="hover:text-text transition-colors">Security</a>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/TermsGate.tsx
+++ b/packages/app/src/components/TermsGate.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { useTermsStore } from "@/stores/terms-store";
+
+/**
+ * Blocking overlay shown until the user accepts the Terms of Service and
+ * acknowledges the Privacy Policy. Rendered as a fixed full-viewport modal
+ * on top of the app so the editor behind it is inert.
+ *
+ * Not rendered on the /privacy, /terms, /security legal pages themselves —
+ * users must be able to read the documents before agreeing.
+ */
+export function TermsGate() {
+  const accepted = useTermsStore((s) => s.accepted);
+  const accept = useTermsStore((s) => s.accept);
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    if (accepted) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [accepted]);
+
+  if (accepted) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tos-gate-title"
+    >
+      <div className="w-full max-w-md bg-surface border border-border p-8 shadow-2xl">
+        <h2
+          id="tos-gate-title"
+          className="text-xl font-semibold tracking-tight text-text"
+        >
+          Welcome to vcad
+        </h2>
+        <p className="mt-3 text-sm text-text-muted leading-relaxed">
+          Before you start modeling, please review and accept our terms.
+        </p>
+
+        <label className="mt-6 flex items-start gap-3 text-sm text-text cursor-pointer">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={(e) => setChecked(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span>
+            I agree to the{" "}
+            <a
+              href="/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand hover:underline"
+            >
+              Terms of Service
+            </a>{" "}
+            and acknowledge the{" "}
+            <a
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand hover:underline"
+            >
+              Privacy Policy
+            </a>
+            .
+          </span>
+        </label>
+
+        <button
+          type="button"
+          disabled={!checked}
+          onClick={accept}
+          className="mt-6 w-full bg-brand px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          Continue to vcad
+        </button>
+
+        <p className="mt-4 text-[11px] text-text-muted/70">
+          You can review these documents at any time from the account menu.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/lib/url-document.ts
+++ b/packages/app/src/lib/url-document.ts
@@ -111,18 +111,26 @@ export interface UrlDocumentResult {
   ownerUsername?: string;
 }
 
+/** Legal page slugs served from the SPA. */
+export type LegalSlug = "privacy" | "terms" | "security";
+
 /** Route type detected from the current pathname. */
 type UrlRoute =
   | { kind: "share-token"; token: string }
   | { kind: "public-doc"; username: string; slug: string }
   | { kind: "profile"; username: string }
   | { kind: "local-doc"; id: string }
+  | { kind: "legal"; slug: LegalSlug }
   | null;
 
 /** Parse the current pathname into a route. */
 function parseRoute(): UrlRoute {
   if (typeof window === "undefined") return null;
   const path = window.location.pathname;
+
+  // /privacy, /terms, /security
+  const legalMatch = path.match(/^\/(privacy|terms|security)\/?$/);
+  if (legalMatch?.[1]) return { kind: "legal", slug: legalMatch[1] as LegalSlug };
 
   // /view/<uuid-token>
   const shareMatch = path.match(/^\/view\/([0-9a-fA-F-]{8,64})\/?$/);
@@ -274,4 +282,13 @@ export function hasUrlDocument(): boolean {
 export function getProfileRouteUsername(): string | null {
   const route = parseRoute();
   return route?.kind === "profile" ? route.username : null;
+}
+
+/**
+ * Check if the current URL is a legal page (/privacy, /terms, /security).
+ * The app renders a LegalPage instead of the normal editor in this case.
+ */
+export function getLegalRouteSlug(): LegalSlug | null {
+  const route = parseRoute();
+  return route?.kind === "legal" ? route.slug : null;
 }

--- a/packages/app/src/stores/terms-store.ts
+++ b/packages/app/src/stores/terms-store.ts
@@ -1,0 +1,34 @@
+import { create } from "zustand";
+
+export const TERMS_VERSION = "2026-04-23";
+const STORAGE_KEY = `vcad.tos.accepted.${TERMS_VERSION}`;
+
+interface TermsState {
+  accepted: boolean;
+  accept: () => void;
+}
+
+function readAccepted(): boolean {
+  if (typeof window === "undefined") return true;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export const useTermsStore = create<TermsState>((set) => ({
+  accepted: readAccepted(),
+  accept: () => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, "1");
+      window.localStorage.setItem(
+        `${STORAGE_KEY}.at`,
+        new Date().toISOString(),
+      );
+    } catch {
+      // ignore — in-memory acceptance still lets the session proceed
+    }
+    set({ accepted: true });
+  },
+}));

--- a/packages/auth/src/components/UserMenu.tsx
+++ b/packages/auth/src/components/UserMenu.tsx
@@ -253,6 +253,12 @@ export function UserMenu({
             </span>
           </label>
 
+          <div className="border-t border-border px-3 py-2 flex gap-3 text-[10px] text-text-muted">
+            <a href="/privacy" className="hover:text-text transition-colors">Privacy</a>
+            <a href="/terms" className="hover:text-text transition-colors">Terms</a>
+            <a href="/security" className="hover:text-text transition-colors">Security</a>
+          </div>
+
           <button
             onClick={handleSignOut}
             className="w-full px-3 py-2 text-left text-xs text-danger hover:bg-border/50 border-t border-border"


### PR DESCRIPTION
## Summary

Launch-prep paperwork: relicense vcad under Apache 2.0, ship public legal pages, and gate first-time users on a Terms of Service acceptance.

### Licensing
- **Relicense MIT → Apache 2.0** under **Municipal Robotics Corporation** (copyright 2026).
- Apache 2.0 adds an explicit contributor patent grant and a patent-retaliation clause — the teeth MIT lacks.
- New `NOTICE` file carries contributor attribution per Apache 2.0 §4(d).
- `README.md` license section rewritten; tang sibling-clone prerequisite now called out up front.

### Legal pages (`/privacy`, `/terms`, `/security`)
- Single `LegalPage` component renders all three documents; routed via a new `legal` arm in `url-document.parseRoute`.
- Contact email: `info@muni.works`.
- Linked from the `UserMenu` dropdown and the `AboutModal` footer.
- Drive-by: fixed `AboutModal` GitHub link that pointed at a personal fork (`nicholaschuayunzhi/vcad` → `ecto/vcad`).

### ToS acceptance gate
- `TermsGate` is a full-viewport blocking overlay shown until the user checks the agreement box.
- Acceptance is versioned in `terms-store` via a localStorage key (`vcad.tos.accepted.2026-04-23`) — bumping `TERMS_VERSION` forces re-acceptance on future revisions.
- Legal pages themselves bypass the gate, so users can read documents before agreeing.

## P1 follow-ups filed separately (not in this PR)

- #76 — AI generation can't be cancelled with Escape
- #77 — CLI help advertises unimplemented Shift+D duplicate
- #78 — Silently failing topology tests in `@vcad/engine`
- #79 — Loon export silently drops unsupported IR variants

## Test plan

- [x] `VCAD_WASM_SKIP=1 npm run build -w @vcad/app` passes after rebase on latest `main`
- [x] Merge conflicts with `main` resolved (CHANGELOG entry coexistence, `UrlRoute` type picking up the new `local-doc` variant alongside `legal`)
- [ ] Smoke-test first-load: incognito → editor blocked by ToS modal → check agreement → "Continue" dismisses → localStorage key set → reload goes straight to editor
- [ ] `/privacy`, `/terms`, `/security` render correctly in `npm run dev -w @vcad/app`; inter-page nav and "← vcad" back link work
- [ ] Account menu (avatar → dropdown) shows the Privacy / Terms / Security row with working links
- [ ] AboutModal footer shows the same legal row; GitHub link resolves to `github.com/ecto/vcad`
- [ ] **Have counsel review the privacy / terms / security copy before launch** — current text is thoughtful boilerplate, not a substitute for legal review
- [ ] Confirm **Delaware** is the intended governing-law jurisdiction in the ToS (currently assumed)