### PR TITLE
Refactor app update detection to use GitHub releases manifest

### DIFF
--- a/packages/app/src/hooks/useAppUpdate.ts
+++ b/packages/app/src/hooks/useAppUpdate.ts
@@ -1,23 +1,75 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { isTauri } from "@/lib/tauri";
+
+// Piggyback on the desktop updater manifest: `.github/workflows/desktop-release.yml`
+// only publishes this file on `v*` tag pushes, so gating the banner on it keeps
+// ad-hoc main-branch deploys from surfacing as "Update Available" to web users.
+const LATEST_JSON_URL =
+  "https://github.com/ecto/vcad/releases/latest/download/latest.json";
+const CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+function isNewerVersion(remote: string, local: string): boolean {
+  const parse = (s: string): number[] =>
+    s
+      .replace(/^v/, "")
+      .split(/[.+-]/)
+      .map((p) => parseInt(p, 10) || 0);
+  const r = parse(remote);
+  const l = parse(local);
+  const len = Math.max(r.length, l.length);
+  for (let i = 0; i < len; i++) {
+    const a = r[i] ?? 0;
+    const b = l[i] ?? 0;
+    if (a > b) return true;
+    if (a < b) return false;
+  }
+  return false;
+}
 
 export function useAppUpdate() {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [latestTagVersion, setLatestTagVersion] = useState<string | null>(null);
+  const [dismissedVersion, setDismissedVersion] = useState<string | null>(null);
 
   const {
-    needRefresh: [updateAvailable, setUpdateAvailable],
     offlineReady: [offlineReady, setOfflineReady],
     updateServiceWorker,
   } = useRegisterSW({
     onRegisteredSW(_, r) {
-      // Check for updates hourly
       if (!r) return;
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
-      intervalRef.current = setInterval(() => r.update(), 60 * 60 * 1000);
+      intervalRef.current = setInterval(() => r.update(), CHECK_INTERVAL_MS);
     },
   });
+
+  useEffect(() => {
+    // Tauri has its own signed updater (see native-updater.ts) that hits the
+    // same manifest — skip the web path inside the desktop shell.
+    if (isTauri()) return;
+
+    let cancelled = false;
+    const check = async () => {
+      try {
+        const res = await fetch(LATEST_JSON_URL, { cache: "no-store" });
+        if (!res.ok) return;
+        const data = (await res.json()) as { version?: string };
+        if (!cancelled && typeof data.version === "string") {
+          setLatestTagVersion(data.version);
+        }
+      } catch {
+        // Offline, rate-limited, CORS hiccup — retry on next interval.
+      }
+    };
+    void check();
+    const id = setInterval(check, CHECK_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -28,6 +80,11 @@ export function useAppUpdate() {
     };
   }, []);
 
+  const updateAvailable =
+    latestTagVersion !== null &&
+    latestTagVersion !== dismissedVersion &&
+    isNewerVersion(latestTagVersion, __APP_VERSION__);
+
   return {
     updateAvailable,
     offlineReady,
@@ -36,8 +93,8 @@ export function useAppUpdate() {
       [updateServiceWorker]
     ),
     dismissUpdate: useCallback(
-      () => setUpdateAvailable(false),
-      [setUpdateAvailable]
+      () => setDismissedVersion(latestTagVersion),
+      [latestTagVersion]
     ),
     dismissOfflineReady: useCallback(
       () => setOfflineReady(false),
@@ -45,5 +102,6 @@ export function useAppUpdate() {
     ),
     version: __APP_VERSION__,
     buildTime: __BUILD_TIME__,
+    latestTagVersion,
   };
 }


### PR DESCRIPTION
## Summary
Refactored the app update detection mechanism to fetch version information from the GitHub releases manifest (`latest.json`) instead of relying solely on the PWA service worker's `needRefresh` signal. This provides more reliable update detection for web users while maintaining compatibility with Tauri's native updater.

## Key Changes
- **Version comparison logic**: Added `isNewerVersion()` function to parse and compare semantic versions, supporting formats like `v1.2.3`, `1.2.3-beta`, etc.
- **Manifest-based detection**: Implemented periodic fetching of `latest.json` from GitHub releases (hourly interval) to check for newer versions
- **Tauri compatibility**: Added check to skip web-based update detection when running in Tauri, deferring to the native updater
- **Dismissal tracking**: Changed from boolean state to version-based dismissal, allowing users to dismiss a specific version without blocking future updates
- **State management**: Replaced `needRefresh` from PWA registration with explicit `latestTagVersion` and `dismissedVersion` state
- **Exposed version info**: Added `latestTagVersion` to the hook's return value for UI consumption

## Implementation Details
- The manifest URL is gated to only publish on `v*` tag pushes, preventing ad-hoc main-branch deploys from showing as available updates to web users
- Version comparison handles edge cases like missing segments and non-numeric parts
- Fetch errors (offline, rate-limiting, CORS) are silently caught and retried on the next interval
- Proper cleanup of intervals and cancellation flags to prevent memory leaks

https://claude.ai/code/session_01MHn8pJWPjtF78bdrXaNQhd