### PR TITLE
Local-doc URLs: short nanoid IDs at /~<id>, with SPA rewrite

### DIFF
--- a/packages/app/src/components/DocumentPicker.tsx
+++ b/packages/app/src/components/DocumentPicker.tsx
@@ -29,6 +29,7 @@ import {
   getStorageUsage,
   isDocumentLocked,
 } from "@/lib/storage";
+import { newDocId } from "@/lib/doc-id";
 
 function formatDate(timestamp: number): string {
   const date = new Date(timestamp);
@@ -305,7 +306,7 @@ export function DocumentPicker({
 
   const handleNewDocument = useCallback(async () => {
     const name = await generateDocumentName();
-    const id = crypto.randomUUID();
+    const id = newDocId();
     useDocumentStore.getState().newDocument(id, name);
     onOpenChange(false);
     useNotificationStore.getState().addToast(`Created "${name}"`, "success");

--- a/packages/app/src/hooks/useAppCommands.ts
+++ b/packages/app/src/hooks/useAppCommands.ts
@@ -18,6 +18,7 @@ import { useSlicerStore } from "@/stores/slicer-store";
 import { useCamStore } from "@/stores/cam-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { downloadBlob } from "@/lib/download";
+import { newDocId } from "@/lib/doc-id";
 import { analytics } from "@/lib/analytics";
 
 export type CommandSurface = "palette" | "mobile-menu" | "desktop-menu";
@@ -124,7 +125,7 @@ export function useAppCommands({
         ) {
           return;
         }
-        useDocumentStore.getState().newDocument(crypto.randomUUID(), "Untitled");
+        useDocumentStore.getState().newDocument(newDocId(), "Untitled");
         onDismiss();
       },
       openFromCloud: () => {

--- a/packages/app/src/hooks/useUrlSync.ts
+++ b/packages/app/src/hooks/useUrlSync.ts
@@ -14,15 +14,16 @@ function isInspectValue(v: string | null): v is InspectValue {
 
 /**
  * Returns the pathname the URL should carry for a given `documentId`, or null
- * to leave the pathname alone. We only own the `/d/<id>` and `/` prefixes —
- * any other path (share token, public slug, profile page) is another
- * subsystem's to manage.
+ * to leave the pathname alone. We only own the `/~<id>` (and legacy `/d/<id>`)
+ * and `/` prefixes — any other path (share token, public slug, profile page)
+ * is another subsystem's to manage.
  */
 function desiredPathname(documentId: string | null): string | null {
   const path = window.location.pathname;
-  const ownedByDocSync = path === "/" || /^\/d\//.test(path);
+  const ownedByDocSync =
+    path === "/" || path.startsWith("/~") || /^\/d\//.test(path);
   if (!ownedByDocSync) return null;
-  return documentId ? `/d/${documentId}` : "/";
+  return documentId ? `/~${documentId}` : "/";
 }
 
 /**
@@ -114,7 +115,7 @@ export function useUrlSync() {
     }
 
     const next = params.toString();
-    // The pathname is either the `/d/<id>` we want (local doc), or we leave
+    // The pathname is either the `/~<id>` we want (local doc), or we leave
     // it alone (share token / public slug / profile page).
     const pathname =
       desiredPathname(documentId) ?? window.location.pathname;

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/storage";
 import { loadDocumentFromUrl, getLocalDocRouteId } from "@/lib/url-document";
 import type { UrlDocumentResult } from "@/lib/url-document";
+import { newDocId } from "@/lib/doc-id";
 import { useNotificationStore } from "@/stores/notification-store";
 import { analytics } from "@/lib/analytics";
 
@@ -293,10 +294,10 @@ async function fetchDocumentData(): Promise<DocumentBootData> {
     }
 
     const name = await generateDocumentName();
-    return { kind: "new", id: crypto.randomUUID(), name };
+    return { kind: "new", id: newDocId(), name };
   } catch (err) {
     logger.warn("app", `Failed to resolve initial document: ${err}`);
-    return { kind: "new", id: crypto.randomUUID(), name: "Untitled" };
+    return { kind: "new", id: newDocId(), name: "Untitled" };
   }
 }
 
@@ -316,7 +317,7 @@ function applyDocumentData(data: DocumentBootData): void {
 
   // kind === "url"
   const { urlDoc } = data;
-  const id = crypto.randomUUID();
+  const id = newDocId();
   docStore.loadDocument(urlDoc.file);
   docStore.setDocumentMeta(id, urlDoc.name);
 

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -263,7 +263,7 @@ async function fetchDocumentData(): Promise<DocumentBootData> {
     const urlDoc = await loadDocumentFromUrl();
     if (urlDoc) return { kind: "url", urlDoc };
 
-    // `/d/<localId>` — URL carries the exact local doc to open. If the doc
+    // `/~<localId>` — URL carries the exact local doc to open. If the doc
     // doesn't exist on this device, fall through to the most-recent flow
     // rather than crash; the URL is replaced by the mirror after loading.
     const routedId = getLocalDocRouteId();

--- a/packages/app/src/lib/doc-id.ts
+++ b/packages/app/src/lib/doc-id.ts
@@ -1,0 +1,13 @@
+import { customAlphabet } from "nanoid";
+
+// 12 chars from a base62 alphabet — ~71 bits of entropy, far more than
+// enough for per-user local document IDs, and much shorter/prettier than
+// UUIDs in URLs like /d/aB3kZ9pQwR2z.
+const generate = customAlphabet(
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
+  12,
+);
+
+export function newDocId(): string {
+  return generate();
+}

--- a/packages/app/src/lib/doc-id.ts
+++ b/packages/app/src/lib/doc-id.ts
@@ -2,7 +2,7 @@ import { customAlphabet } from "nanoid";
 
 // 12 chars from a base62 alphabet — ~71 bits of entropy, far more than
 // enough for per-user local document IDs, and much shorter/prettier than
-// UUIDs in URLs like /d/aB3kZ9pQwR2z.
+// UUIDs in URLs like /~aB3kZ9pQwR2z.
 const generate = customAlphabet(
   "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
   12,

--- a/packages/app/src/lib/url-document.ts
+++ b/packages/app/src/lib/url-document.ts
@@ -144,8 +144,9 @@ function parseRoute(): UrlRoute {
   const profileMatch = path.match(/^\/@([a-z0-9][a-z0-9-]*[a-z0-9])\/?$/);
   if (profileMatch?.[1]) return { kind: "profile", username: profileMatch[1] };
 
-  // /d/<uuid> — local IndexedDB document identity
-  const localMatch = path.match(/^\/d\/([0-9a-fA-F-]{8,64})\/?$/);
+  // /d/<id> — local IndexedDB document identity. Accepts both legacy UUIDs
+  // (hex + dashes) and short base62 nanoids minted by newDocId().
+  const localMatch = path.match(/^\/d\/([A-Za-z0-9_-]{8,64})\/?$/);
   if (localMatch?.[1]) return { kind: "local-doc", id: localMatch[1] };
 
   return null;

--- a/packages/app/src/lib/url-document.ts
+++ b/packages/app/src/lib/url-document.ts
@@ -144,9 +144,11 @@ function parseRoute(): UrlRoute {
   const profileMatch = path.match(/^\/@([a-z0-9][a-z0-9-]*[a-z0-9])\/?$/);
   if (profileMatch?.[1]) return { kind: "profile", username: profileMatch[1] };
 
-  // /d/<id> — local IndexedDB document identity. Accepts both legacy UUIDs
-  // (hex + dashes) and short base62 nanoids minted by newDocId().
-  const localMatch = path.match(/^\/d\/([A-Za-z0-9_-]{8,64})\/?$/);
+  // /~<id> — local IndexedDB document identity (canonical). The legacy
+  // /d/<id> form is still accepted so existing bookmarks keep working.
+  // Accepts both legacy UUIDs (hex + dashes) and short base62 nanoids
+  // minted by newDocId().
+  const localMatch = path.match(/^\/(?:~|d\/)([A-Za-z0-9_-]{8,64})\/?$/);
   if (localMatch?.[1]) return { kind: "local-doc", id: localMatch[1] };
 
   return null;
@@ -154,7 +156,7 @@ function parseRoute(): UrlRoute {
 
 /**
  * Returns the local document ID from the current URL, if the user landed on
- * a `/d/<id>` path. Bootstrap checks this before falling back to
+ * a `/~<id>` (or legacy `/d/<id>`) path. Bootstrap checks this before falling back to
  * "most recent document" so refresh always reopens the exact doc.
  */
 export function getLocalDocRouteId(): string | null {

--- a/vercel.json
+++ b/vercel.json
@@ -7,7 +7,8 @@
     { "source": "/~(.*)", "destination": "/" },
     { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },
-    { "source": "/@:path*", "destination": "/" }
+    { "source": "/@:path*", "destination": "/" },
+    { "source": "/(privacy|terms|security)", "destination": "/" }
   ],
   "headers": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "buildCommand": "npm run build -w @vcad/ir && npm run build -w @vcad/engine && npm run build -w @vcad/core && npm run build -w @vcad/mcp && npm run build -w @vcad/app",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/~(.*)", "destination": "/" },
     { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },
     { "source": "/@:path*", "destination": "/" }

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "buildCommand": "npm run build -w @vcad/ir && npm run build -w @vcad/engine && npm run build -w @vcad/core && npm run build -w @vcad/mcp && npm run build -w @vcad/app",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },
     { "source": "/@:path*", "destination": "/" }
   ],


### PR DESCRIPTION
## Summary

- Local-document URLs move from `/d/<uuid>` to **`/~<id>`** with a 12-char base62 nanoid.
- The `~` sigil joins `@` in the social URL family:
  - `/@cam` — a person
  - `/@cam/bracket-v2` — a person's named work
  - `/~aB3kZ9pQ` — an anonymous draft (just an id, no owner yet)
- Adds Vercel SPA rewrites for both `/~(.*)` and the legacy `/d/(.*)` so hard-refresh no longer 404s.
- Legacy `/d/<id>` paths continue to parse so existing bookmarks keep working; new URLs all emit `/~<id>`.

## Why

@cam reported that `vcad.io` redirected to `/d/<uuid>` but a refresh 404'd — there was no SPA rewrite for that prefix. Fixing that opened the door to also (a) shorten the IDs (UUIDs are noisy in URLs) and (b) reshape the sigil to fit alongside the upcoming `/@username` social routes.

Cloud sync is unaffected — `documents.local_id` is `text` in Postgres, so any string ID drops in.

## Test plan

- [x] Bootstrap mints 12-char base62 IDs; URL becomes `/~<nanoid>`.
- [x] `getLocalDocRouteId()` parses both `/~<nanoid>` and legacy `/d/<uuid>`; rejects too-short/invalid-char inputs.
- [x] App boots cleanly on `/~<id>` in dev (verified via preview).
- [ ] After deploy, hard-refresh on `vcad.io/~<id>` should serve the SPA (not 404).
- [ ] Existing bookmarks of the form `vcad.io/d/<uuid>` should still open the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)