### PR TITLE
Fix LegalPage layout to enable scrolling on smaller screens

### DIFF
--- a/packages/app/src/components/LegalPage.tsx
+++ b/packages/app/src/components/LegalPage.tsx
@@ -202,7 +202,7 @@ export function LegalPage({ slug }: { slug: LegalSlug }) {
   }, [content.title]);
 
   return (
-    <div className="min-h-screen bg-bg text-text">
+    <div className="h-screen overflow-y-auto bg-bg text-text">
       <div className="mx-auto max-w-2xl px-6 py-16">
         <a
           href="/"


### PR DESCRIPTION
## Summary
Updated the LegalPage component's container styling to properly handle content overflow on smaller viewports by enabling vertical scrolling.

## Changes
- Changed the container from `min-h-screen` to `h-screen overflow-y-auto`
  - `h-screen`: Sets a fixed height equal to the viewport height
  - `overflow-y-auto`: Allows vertical scrolling when content exceeds the viewport height
  - Removes `min-h-screen` which could cause content to extend beyond the viewport without scrolling capability

## Details
This change ensures that on smaller screens or when the legal page content is lengthy, users can scroll through the content instead of having it overflow outside the visible area. The fixed height combined with overflow handling provides a better user experience across different device sizes.

https://claude.ai/code/session_01D4hD694AvQAwr7AyZW1kzJ