### PR TITLE
Auto-fit sketch viewport when opening populated sketches

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,15 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-23-auto-zoom-sketch-viewport",
+      "version": "0.9.0",
+      "date": "2026-04-23",
+      "category": "feat",
+      "title": "Auto-zoom viewport to fit populated sketches on open",
+      "summary": "Opening a document that lands in sketch mode with existing segments now frames the sketch automatically instead of defaulting to a fixed 60 mm distance. Skipped when a share URL carries a ?at= viewer-state hint.",
+      "features": ["sketch", "viewport", "camera"]
+    },
+    {
       "id": "2026-04-23-v0-9-0",
       "version": "0.9.0",
       "date": "2026-04-23",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -82,6 +82,7 @@ import { useCollabSync } from "@/hooks/useCollabSync";
 import { useChatHandler } from "@/hooks/useChatHandler";
 import { useChatHydration } from "@/hooks/useChatHydration";
 import { useUrlSync } from "@/hooks/useUrlSync";
+import { useSketchAutoFit } from "@/hooks/useSketchAutoFit";
 import { saveDocument } from "@/lib/save-load";
 import { bootstrap } from "@/lib/bootstrap";
 import { useBootStore } from "@/stores/boot-store";
@@ -169,6 +170,7 @@ export function App() {
   useChatHandler();
   useChatHydration();
   useUrlSync();
+  useSketchAutoFit();
 
   const [aboutOpen, setAboutOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -1038,6 +1038,79 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
       );
   }, []);
 
+  // Fit-sketch view: position the camera perpendicular to the sketch plane at
+  // a distance that frames the sketch's U/V bounds in the current viewport.
+  const viewportAspect = useThree((s) => s.size.width / Math.max(1, s.size.height));
+  useEffect(() => {
+    const handleFitSketch = (
+      e: CustomEvent<{
+        // Kernel Z-up space (caller converts from sketch plane basis)
+        planeNormal: { x: number; y: number; z: number };
+        planeCenter: { x: number; y: number; z: number };
+        // Sketch-local bounds width (U) and height (V) in mm
+        width: number;
+        height: number;
+      }>,
+    ) => {
+      const { planeNormal, planeCenter, width, height } = e.detail;
+
+      // Kernel Z-up → display Y-up: (x, y, z) → (x, z, -y)
+      const [cx, cy, cz] = kernelToDisplay([
+        planeCenter.x,
+        planeCenter.y,
+        planeCenter.z,
+      ]);
+      const [nx, ny, nz] = kernelToDisplay([
+        planeNormal.x,
+        planeNormal.y,
+        planeNormal.z,
+      ]);
+      // Re-normalize to guard against any accumulated drift in the source basis.
+      const nLen = Math.hypot(nx, ny, nz) || 1;
+      const wNormal = new Vector3(nx / nLen, ny / nLen, nz / nLen);
+
+      // Fit distance for a Three.js perspective camera (vertical FOV). We
+      // check both the vertical and horizontal extent and pick whichever is
+      // tight; a 20% padding keeps the sketch off the viewport edges.
+      const perspective = camera as PerspectiveCamera;
+      const fovRad = (perspective.isPerspectiveCamera ? perspective.fov : 50) * (Math.PI / 180);
+      const aspect = perspective.isPerspectiveCamera
+        ? perspective.aspect
+        : viewportAspect;
+      const padding = 1.2;
+      const safeWidth = Math.max(width, 1);
+      const safeHeight = Math.max(height, 1);
+      const distV = (safeHeight / 2) / Math.tan(fovRad / 2);
+      const distH = (safeWidth / 2) / (aspect * Math.tan(fovRad / 2));
+      const viewDistance = Math.max(distV, distH, 10) * padding;
+
+      targetGoalRef.current.set(cx, cy, cz);
+      const cameraPos = new Vector3(
+        cx + wNormal.x * viewDistance,
+        cy + wNormal.y * viewDistance,
+        cz + wNormal.z * viewDistance,
+      );
+      cameraPositionGoalRef.current = cameraPos;
+      distanceGoalRef.current = viewDistance;
+
+      computeLevelQuaternion(cameraPos, targetGoalRef.current, goalQuatRef.current);
+
+      if (orbitRef.current) orbitRef.current.enabled = false;
+      isAnimatingTargetRef.current = true;
+      setIsCameraMoving(true);
+    };
+
+    window.addEventListener(
+      "vcad:fit-sketch",
+      handleFitSketch as EventListener,
+    );
+    return () =>
+      window.removeEventListener(
+        "vcad:fit-sketch",
+        handleFitSketch as EventListener,
+      );
+  }, [camera, viewportAspect]);
+
   // Offscreen render from the AI's camera goal. The AI's `screenshot_viewport`
   // tool calls `window.__vcadCaptureAiCamera(goal)` to grab a frame from the
   // AI's point of view WITHOUT disturbing the user's OrbitControls state.

--- a/packages/app/src/hooks/useSketchAutoFit.ts
+++ b/packages/app/src/hooks/useSketchAutoFit.ts
@@ -1,0 +1,87 @@
+import { useEffect, useRef } from "react";
+import {
+  useSketchStore,
+  getPlaneBasis,
+  computeSketchBounds,
+} from "@vcad/core";
+
+/**
+ * Auto-fit the viewport camera to the active sketch the first time the
+ * sketch has segments to show. Fires `vcad:fit-sketch` — see the handler
+ * in ViewportContent for the camera math. Skips when a share URL supplied
+ * a `?at=` viewer-state hint, since that hint owns the camera.
+ *
+ * Only fires once per sketch-active session: entering an empty sketch and
+ * then drawing into it should not yank the camera, but opening a doc that
+ * already has a populated sketch should frame it.
+ */
+export function useSketchAutoFit(): void {
+  const active = useSketchStore((s) => s.active);
+  const firedRef = useRef(false);
+
+  // Reset the one-shot guard when the user leaves sketch mode so the next
+  // session gets its own auto-fit.
+  useEffect(() => {
+    if (!active) firedRef.current = false;
+  }, [active]);
+
+  useEffect(() => {
+    if (!active || firedRef.current) return;
+
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      if (params.has("at")) return;
+    }
+
+    const { segments, plane, origin } = useSketchStore.getState();
+    if (segments.length === 0) return;
+
+    const bounds = computeSketchBounds(segments);
+    if (!bounds) return;
+
+    const basis = getPlaneBasis(plane);
+    // Sketch-plane origin is stored on the sketch store (it's optional on
+    // axis-aligned `"XY" | "XZ" | "YZ"` planes); prefer the store value so
+    // face-derived sketches with a non-zero origin still fit correctly.
+    const planeWithOrigin =
+      typeof plane === "string"
+        ? { ...basis, origin }
+        : basis;
+
+    const centerU = (bounds.minU + bounds.maxU) / 2;
+    const centerV = (bounds.minV + bounds.maxV) / 2;
+    const width = bounds.maxU - bounds.minU;
+    const height = bounds.maxV - bounds.minV;
+
+    // Project the 2D center back through the plane basis to get a kernel-
+    // space world point. Done inline because `sketchToWorld` from
+    // sketch-math.ts ignores the dynamic origin carried on the store for
+    // axis-aligned planes.
+    const planeCenter = {
+      x:
+        planeWithOrigin.origin.x +
+        centerU * planeWithOrigin.xDir.x +
+        centerV * planeWithOrigin.yDir.x,
+      y:
+        planeWithOrigin.origin.y +
+        centerU * planeWithOrigin.xDir.y +
+        centerV * planeWithOrigin.yDir.y,
+      z:
+        planeWithOrigin.origin.z +
+        centerU * planeWithOrigin.xDir.z +
+        centerV * planeWithOrigin.yDir.z,
+    };
+
+    firedRef.current = true;
+    window.dispatchEvent(
+      new CustomEvent("vcad:fit-sketch", {
+        detail: {
+          planeNormal: planeWithOrigin.normal,
+          planeCenter,
+          width,
+          height,
+        },
+      }),
+    );
+  }, [active]);
+}

--- a/packages/core/src/__tests__/sketch-bounds.test.ts
+++ b/packages/core/src/__tests__/sketch-bounds.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import type { SketchSegment2D } from "@vcad/ir";
+import { computeSketchBounds } from "../sketch-math.js";
+
+describe("computeSketchBounds", () => {
+  it("returns null for empty segment list", () => {
+    expect(computeSketchBounds([])).toBeNull();
+  });
+
+  it("computes bounds for line segments", () => {
+    const segs: SketchSegment2D[] = [
+      { type: "Line", start: { x: 0, y: 0 }, end: { x: 10, y: 0 } },
+      { type: "Line", start: { x: 10, y: 0 }, end: { x: 10, y: 5 } },
+      { type: "Line", start: { x: 10, y: 5 }, end: { x: -2, y: 5 } },
+      { type: "Line", start: { x: -2, y: 5 }, end: { x: 0, y: 0 } },
+    ];
+    expect(computeSketchBounds(segs)).toEqual({
+      minU: -2,
+      maxU: 10,
+      minV: 0,
+      maxV: 5,
+    });
+  });
+
+  it("includes the full enclosing circle for a closed loop of arcs", () => {
+    // Full circle radius 7 around (3, 4), split into 4 quarter arcs.
+    const cx = 3;
+    const cy = 4;
+    const r = 7;
+    const segs: SketchSegment2D[] = [
+      {
+        type: "Arc",
+        start: { x: cx + r, y: cy },
+        end: { x: cx, y: cy + r },
+        center: { x: cx, y: cy },
+        ccw: true,
+      },
+      {
+        type: "Arc",
+        start: { x: cx, y: cy + r },
+        end: { x: cx - r, y: cy },
+        center: { x: cx, y: cy },
+        ccw: true,
+      },
+      {
+        type: "Arc",
+        start: { x: cx - r, y: cy },
+        end: { x: cx, y: cy - r },
+        center: { x: cx, y: cy },
+        ccw: true,
+      },
+      {
+        type: "Arc",
+        start: { x: cx, y: cy - r },
+        end: { x: cx + r, y: cy },
+        center: { x: cx, y: cy },
+        ccw: true,
+      },
+    ];
+    const b = computeSketchBounds(segs)!;
+    expect(b.minU).toBeCloseTo(cx - r);
+    expect(b.maxU).toBeCloseTo(cx + r);
+    expect(b.minV).toBeCloseTo(cy - r);
+    expect(b.maxV).toBeCloseTo(cy + r);
+  });
+
+  it("only extends to cardinals the arc actually sweeps through", () => {
+    // Quarter arc from (+r, 0) CCW to (0, +r), centered at origin, r=5.
+    // It crosses the +V cardinal (90°) but not -U, -V, or +U (start).
+    const segs: SketchSegment2D[] = [
+      {
+        type: "Arc",
+        start: { x: 5, y: 0 },
+        end: { x: 0, y: 5 },
+        center: { x: 0, y: 0 },
+        ccw: true,
+      },
+    ];
+    const b = computeSketchBounds(segs)!;
+    expect(b.minU).toBeCloseTo(0);
+    expect(b.maxU).toBeCloseTo(5);
+    expect(b.minV).toBeCloseTo(0);
+    expect(b.maxV).toBeCloseTo(5);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -226,8 +226,9 @@ export {
   hitTestSegments,
   buildRectangle,
   buildCircle,
+  computeSketchBounds,
 } from "./sketch-math.js";
-export type { PlaneBasis, SnapOptions, SnapResult } from "./sketch-math.js";
+export type { PlaneBasis, SnapOptions, SnapResult, SketchBounds2D } from "./sketch-math.js";
 
 // Camera framing math (kernel Z-up)
 export {

--- a/packages/core/src/sketch-math.ts
+++ b/packages/core/src/sketch-math.ts
@@ -387,6 +387,92 @@ export function buildRectangle(p1: Vec2, p2: Vec2): SketchSegment2D[] {
   ];
 }
 
+// ---------------------------------------------------------------------------
+// Bounds
+// ---------------------------------------------------------------------------
+
+/** 2D axis-aligned bounds in sketch-local (U/V) coordinates. */
+export interface SketchBounds2D {
+  minU: number;
+  maxU: number;
+  minV: number;
+  maxV: number;
+}
+
+/**
+ * Tight 2D bounds of a sketch in its plane-local coordinates. Line endpoints
+ * are included as-is; arcs also contribute any of the cardinal extremes
+ * (+/-U, +/-V relative to center) that the swept angle actually covers, so a
+ * quarter-arc doesn't get bounded by the full enclosing circle.
+ *
+ * Returns `null` for an empty segment list — callers should fall back to a
+ * default extent rather than fitting to nothing.
+ */
+export function computeSketchBounds(
+  segments: SketchSegment2D[],
+): SketchBounds2D | null {
+  if (segments.length === 0) return null;
+
+  let minU = Infinity;
+  let maxU = -Infinity;
+  let minV = Infinity;
+  let maxV = -Infinity;
+
+  const expand = (x: number, y: number) => {
+    if (x < minU) minU = x;
+    if (x > maxU) maxU = x;
+    if (y < minV) minV = y;
+    if (y > maxV) maxV = y;
+  };
+
+  for (const seg of segments) {
+    expand(seg.start.x, seg.start.y);
+    expand(seg.end.x, seg.end.y);
+
+    if (seg.type === "Arc") {
+      const r = Math.hypot(seg.start.x - seg.center.x, seg.start.y - seg.center.y);
+      const a0 = Math.atan2(seg.start.y - seg.center.y, seg.start.x - seg.center.x);
+      const a1 = Math.atan2(seg.end.y - seg.center.y, seg.end.x - seg.center.x);
+
+      // Resolve signed sweep for the direction flag, then check which of the
+      // four cardinal angles (0, π/2, π, -π/2) fall inside it.
+      let sweep = a1 - a0;
+      if (seg.ccw && sweep < 0) sweep += 2 * Math.PI;
+      if (!seg.ccw && sweep > 0) sweep -= 2 * Math.PI;
+
+      const cardinals = [0, Math.PI / 2, Math.PI, -Math.PI / 2];
+      for (const c of cardinals) {
+        // Distance from the start angle to this cardinal, in sweep direction.
+        let d = c - a0;
+        if (seg.ccw) {
+          while (d < 0) d += 2 * Math.PI;
+          while (d > 2 * Math.PI) d -= 2 * Math.PI;
+          if (d <= sweep) {
+            expand(
+              seg.center.x + r * Math.cos(c),
+              seg.center.y + r * Math.sin(c),
+            );
+          }
+        } else {
+          while (d > 0) d -= 2 * Math.PI;
+          while (d < -2 * Math.PI) d += 2 * Math.PI;
+          if (d >= sweep) {
+            expand(
+              seg.center.x + r * Math.cos(c),
+              seg.center.y + r * Math.sin(c),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  if (!isFinite(minU) || !isFinite(maxU) || !isFinite(minV) || !isFinite(maxV)) {
+    return null;
+  }
+  return { minU, maxU, minV, maxV };
+}
+
 /** Build an N-sided polygonal approximation of a circle as arc segments. */
 export function buildCircle(
   center: Vec2,


### PR DESCRIPTION
## Summary
Adds automatic viewport framing when entering sketch mode with existing segments. The camera now positions itself perpendicular to the sketch plane at a distance that fits all sketch geometry, rather than defaulting to a fixed 60 mm distance. This behavior is skipped when a share URL provides a `?at=` viewer-state hint, allowing explicit camera positioning to take precedence.

## Key Changes

- **New `useSketchAutoFit` hook** (`packages/app/src/hooks/useSketchAutoFit.ts`): 
  - Fires once per sketch-active session when segments are first available
  - Computes sketch bounds and dispatches a `vcad:fit-sketch` custom event
  - Respects the `?at=` URL parameter to avoid overriding shared viewer states
  - Resets the one-shot guard when exiting sketch mode

- **New `computeSketchBounds` function** (`packages/core/src/sketch-math.ts`):
  - Calculates tight 2D axis-aligned bounds in sketch-local (U/V) coordinates
  - Handles line segments directly and includes cardinal extremes for arcs
  - Returns `null` for empty segment lists to allow fallback behavior
  - Properly accounts for arc sweep direction (CCW vs CW) when determining which cardinal points to include

- **Viewport camera handler** (`packages/app/src/components/ViewportContent.tsx`):
  - Listens for `vcad:fit-sketch` events and animates the camera to frame the sketch
  - Converts sketch plane basis (kernel Z-up) to display coordinates (Y-up)
  - Calculates fit distance accounting for viewport aspect ratio and camera FOV
  - Applies 20% padding to keep sketch off viewport edges
  - Disables orbit controls during the animation

- **Test coverage** (`packages/core/src/__tests__/sketch-bounds.test.ts`):
  - Tests empty segment lists, line segments, full circles, and partial arcs
  - Verifies that only cardinal extremes within the arc sweep are included

- **Exports and integration**:
  - Exports `computeSketchBounds` and `SketchBounds2D` from core package
  - Integrates `useSketchAutoFit` hook into the main App component
  - Adds changelog entry documenting the feature

## Implementation Details

The bounds computation for arcs uses angle arithmetic to determine which of the four cardinal directions (0°, 90°, 180°, 270°) fall within the swept angle, accounting for both CCW and CW directions. The camera positioning uses Three.js perspective camera math to calculate the distance needed to frame both the vertical and horizontal extents of the sketch with proper padding.

https://claude.ai/code/session_01VgQrr54LfzjSkdUSN6GyrH