### PR TITLE
Add image drop support to chat sidebar and viewport

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,15 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-24-chat-image-drop",
+      "version": "0.9.0",
+      "date": "2026-04-24",
+      "category": "feat",
+      "title": "Drop images into the AI chat",
+      "summary": "Dragging an image onto the chat sidebar attaches it to the composer, and dropping an image on the viewport now opens the chat and attaches it there instead of failing. Ask the AI to build CAD from the picture.",
+      "features": ["chat", "ai"]
+    },
+    {
       "id": "2026-04-23-auto-zoom-sketch-viewport",
       "version": "0.9.0",
       "date": "2026-04-23",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -301,6 +301,18 @@ export function App() {
   const processFile = useCallback(async (file: File) => {
     const ext = file.name.split(".").pop()?.toLowerCase();
 
+    // Images dropped onto the viewport go to the AI chat as attachments —
+    // the user can then ask it to build something from the image. The bridge
+    // inside ChatSidebar's PromptInput drains pendingAttachments on mount
+    // (handles the case where the sidebar was closed and is lazy-loaded by
+    // setOpen), and also picks up subsequent queued pushes.
+    if (file.type.startsWith("image/")) {
+      useChatStore.getState().queuePendingAttachments([file]);
+      useChatStore.getState().setOpen(true);
+      window.dispatchEvent(new Event("vcad:focus-chat-input"));
+      return;
+    }
+
     // Handle STEP files
     if (ext === "step" || ext === "stp") {
       try {

--- a/packages/app/src/components/ChatSidebar.tsx
+++ b/packages/app/src/components/ChatSidebar.tsx
@@ -77,6 +77,31 @@ function AttachViewportButton() {
   );
 }
 
+// Bridge that lets callers outside the PromptInput (the chat sidebar's
+// whole-pane drop zone, or an image dropped on the 3D viewport) push files
+// into the PromptInput's attachment list. Drains chat-store.pendingAttachments
+// on mount (covers the viewport case, where the sidebar is lazy-mounted after
+// the drop) and subscribes for subsequent pushes.
+// Must render inside a <PromptInput> to access the local attachments context.
+function ChatAttachmentBridge() {
+  const attachments = usePromptInputAttachments();
+  useEffect(() => {
+    // Drain anything queued before this component mounted.
+    const queued = useChatStore.getState().consumePendingAttachments();
+    if (queued.length > 0) attachments.add(queued);
+
+    // Then stay subscribed for any future queued files while the sidebar is open.
+    const unsub = useChatStore.subscribe((s, prev) => {
+      if (s.pendingAttachments !== prev.pendingAttachments && s.pendingAttachments.length > 0) {
+        const files = useChatStore.getState().consumePendingAttachments();
+        if (files.length > 0) attachments.add(files);
+      }
+    });
+    return unsub;
+  }, [attachments]);
+  return null;
+}
+
 // Render the current attachment list as a thumbnail strip above the textarea.
 // Users can click a thumbnail to remove it.
 function AttachmentPreviewStrip() {
@@ -443,7 +468,54 @@ export function ChatSidebar() {
   const [selectionContext, removeContextPart] = useSelectionContext();
   const [showAuthModal, setShowAuthModal] = useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = useState(false);
+  const [isDraggingImage, setIsDraggingImage] = useState(false);
+  const dragDepthRef = useRef(0);
   const inputWrapRef = useRef<HTMLDivElement>(null);
+
+  // Whole-pane image drop. PromptInput already handles drops on its own form,
+  // so we forward only drops that land outside the input wrap (messages area,
+  // header, etc.) by pushing them onto chat-store.pendingAttachments, which
+  // the ChatAttachmentBridge inside the PromptInput subscribes to.
+  const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (!e.dataTransfer?.types?.includes("Files")) return;
+    dragDepthRef.current += 1;
+    setIsDraggingImage(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setIsDraggingImage(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    if (e.dataTransfer?.types?.includes("Files")) {
+      e.preventDefault();
+    }
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    dragDepthRef.current = 0;
+    setIsDraggingImage(false);
+
+    // Drops on the PromptInput form are handled by the form's own native
+    // listener — don't double-add. Still stop propagation so App's
+    // viewport-level drop handler doesn't try to parse the image as a .vcad.
+    const target = e.target as Node | null;
+    if (target && inputWrapRef.current?.contains(target)) {
+      e.stopPropagation();
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const files = [...(e.dataTransfer?.files ?? [])].filter((f) =>
+      f.type.startsWith("image/"),
+    );
+    if (files.length === 0) return;
+
+    useChatStore.getState().queuePendingAttachments(files);
+  }, []);
 
   // External callers (e.g. the welcome overlay's "Build with AI" action)
   // can dispatch `vcad:focus-chat-input` to jump cursor to the textarea.
@@ -541,10 +613,21 @@ export function ChatSidebar() {
   return (
     <div
       className={cn(
-        "flex h-full w-full flex-col",
+        "relative flex h-full w-full flex-col",
         "bg-surface",
       )}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
     >
+      {isDraggingImage && (
+        <div className="pointer-events-none absolute inset-2 z-20 flex items-center justify-center rounded-lg border-2 border-dashed border-brand/60 bg-brand/10">
+          <div className="text-[11px] font-semibold text-brand">
+            Drop image to attach
+          </div>
+        </div>
+      )}
       {/* Header with tabs */}
       <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border/40 shrink-0">
         <button
@@ -653,6 +736,7 @@ export function ChatSidebar() {
 
             <div ref={inputWrapRef}>
               <PromptInput onSubmit={handlePromptSubmit} accept="image/*">
+                <ChatAttachmentBridge />
                 {selectionContext.length > 0 && (
                   <PromptInputHeader>
                     {selectionContext.map((ctx) => (

--- a/packages/core/src/stores/chat-store.ts
+++ b/packages/core/src/stores/chat-store.ts
@@ -190,6 +190,11 @@ export interface ChatState {
    * Realtime updates for these ids are ignored by useChatHydration so the
    * local SSE-driven render isn't overwritten by the slower DB roundtrip. */
   locallyStreamingIds: Set<string>;
+  /** Files queued to be dropped into the chat composer's attachment list as
+   * soon as the ChatSidebar (lazy-loaded, gated on `open`) mounts. Used by
+   * the viewport image-drop flow, where the sender doesn't have direct
+   * access to the PromptInput's attachment context. */
+  pendingAttachments: File[];
 
   // Visibility
   setOpen: (open: boolean) => void;
@@ -254,6 +259,10 @@ export interface ChatState {
   markLocallyStreaming: (id: string) => void;
   unmarkLocallyStreaming: (id: string) => void;
 
+  // Pending composer attachments (see field comment).
+  queuePendingAttachments: (files: File[]) => void;
+  consumePendingAttachments: () => File[];
+
   // Usage tracking
   incAnonUsage: () => void;
   setUsageError: (err: ChatUsageError | null) => void;
@@ -297,6 +306,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   _hydrateHandler: null,
   _abortController: null,
   locallyStreamingIds: new Set(),
+  pendingAttachments: [],
 
   setOpen: (open) => {
     persistOpen(open);
@@ -428,6 +438,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return { locallyStreamingIds: next };
     }),
 
+  queuePendingAttachments: (files) =>
+    set((s) => ({ pendingAttachments: [...s.pendingAttachments, ...files] })),
+  consumePendingAttachments: () => {
+    const files = get().pendingAttachments;
+    if (files.length > 0) set({ pendingAttachments: [] });
+    return files;
+  },
+
   incAnonUsage: () => set((s) => {
     const used = s.anonUsage.used + 1;
     persistAnonUsage(used);
@@ -451,5 +469,6 @@ export const useChatStore = create<ChatState>((set, get) => ({
     error: null,
     cancelRequested: false,
     usageError: null,
+    pendingAttachments: [],
   }),
 }));


### PR DESCRIPTION
## Summary
This PR enables users to attach images to the AI chat composer by dragging and dropping them onto the chat sidebar or the 3D viewport. Images dropped on the viewport now open the chat and attach the image, allowing users to ask the AI to build CAD from the picture.

## Key Changes

- **ChatAttachmentBridge component**: New bridge component that syncs files from `chat-store.pendingAttachments` into the PromptInput's attachment list. Handles both initial drain on mount (for viewport drops when sidebar is lazy-loaded) and ongoing subscriptions for future queued files.

- **Chat sidebar drop zone**: Added drag-and-drop handlers (`handleDragEnter`, `handleDragLeave`, `handleDragOver`, `handleDrop`) to the ChatSidebar root element to accept image files dropped anywhere in the sidebar (outside the PromptInput form itself). Shows a visual drop indicator when dragging images over the sidebar.

- **Viewport image handling**: Modified `App.tsx` to intercept image files dropped on the viewport and queue them via `useChatStore.queuePendingAttachments()`, then open the chat sidebar and focus the input.

- **Chat store extensions**: Added `pendingAttachments` state array and two new methods:
  - `queuePendingAttachments(files)`: Adds files to the pending queue
  - `consumePendingAttachments()`: Returns and clears the pending queue

## Implementation Details

- Uses a `dragDepthRef` counter to properly handle nested drag events and avoid flickering the drop indicator
- Filters drops to only accept image files (`image/*` MIME type)
- Prevents double-processing by checking if the drop target is within the PromptInput form (which handles its own drops)
- The ChatAttachmentBridge uses Zustand's `subscribe` method to reactively listen for store changes while the sidebar is open

https://claude.ai/code/session_01AdKFxKgswFtmnt1aHm1iHT