### PR TITLE
Add batch operations, patterns, and scene introspection tools

### DIFF
--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback, useRef } from "react";
 import {
   useChatStore,
   useDocumentStore,
+  useEngineStore,
   useUiStore,
   useParticipantStore,
   ensureAiParticipant,
@@ -164,6 +165,61 @@ function getDocumentParts(): Array<{ id: string; name: string; kind: string }> {
 }
 
 /**
+ * Build a compact human-readable scene snapshot for the AI: each part with
+ * its world position, size, and material. Cheap to emit, very high value
+ * — the alternative is the AI calling `inspect_part` repeatedly to learn
+ * where things ended up. Capped at 60 parts to bound token cost; beyond
+ * that the AI is told to use describe_scene/inspect_part for detail.
+ */
+function buildSceneSnapshot(): string {
+  const docStore = useDocumentStore.getState();
+  const scene = useEngineStore.getState().scene;
+  const doc = docStore.document as unknown as {
+    partMaterials?: Record<string, string>;
+  };
+  const parts = docStore.parts;
+  if (parts.length === 0) return "";
+  const MAX = 60;
+  const lines: string[] = [];
+  const visible = parts.slice(0, MAX);
+  for (let i = 0; i < visible.length; i++) {
+    const p = visible[i]!;
+    let bboxStr = "";
+    let centerStr = "";
+    if (scene) {
+      const ep = scene.parts[i];
+      if (ep) {
+        const positions = ep.mesh.positions;
+        if (positions && positions.length >= 3) {
+          let minX = Infinity, minY = Infinity, minZ = Infinity;
+          let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+          for (let j = 0; j < positions.length; j += 3) {
+            const x = positions[j]!;
+            const y = positions[j + 1]!;
+            const z = positions[j + 2]!;
+            if (x < minX) minX = x; if (x > maxX) maxX = x;
+            if (y < minY) minY = y; if (y > maxY) maxY = y;
+            if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+          }
+          const cx = (minX + maxX) / 2;
+          const cy = (minY + maxY) / 2;
+          const cz = (minZ + maxZ) / 2;
+          centerStr = ` @(${cx.toFixed(0)},${cy.toFixed(0)},${cz.toFixed(0)})`;
+          bboxStr = ` ${(maxX - minX).toFixed(0)}×${(maxY - minY).toFixed(0)}×${(maxZ - minZ).toFixed(0)}mm`;
+        }
+      }
+    }
+    const material = doc.partMaterials?.[p.id];
+    const matStr = material ? ` [${material}]` : "";
+    lines.push(`- ${p.id} "${p.name}" (${p.kind})${centerStr}${bboxStr}${matStr}`);
+  }
+  if (parts.length > MAX) {
+    lines.push(`- … ${parts.length - MAX} more parts (use inspect_part or describe_scene for detail)`);
+  }
+  return `\n\n## Scene snapshot (world coordinates, mm)\n\n${lines.join("\n")}\n`;
+}
+
+/**
  * Run a streaming chat turn. Returns the text content and any tool calls.
  * Tool calls are returned but NOT executed — caller decides when.
  */
@@ -197,7 +253,8 @@ function runTurn(
       HIGH_LEVEL_TOOLS_SYSTEM_PROMPT_APPENDIX +
       SCREENSHOT_SYSTEM_PROMPT_APPENDIX +
       AI_CAMERA_SYSTEM_PROMPT_APPENDIX +
-      AI_DOCUMENT_SYSTEM_PROMPT_APPENDIX;
+      AI_DOCUMENT_SYSTEM_PROMPT_APPENDIX +
+      buildSceneSnapshot();
 
     streamChat(history, context, {
       onText: (t) => { text = t; onStreamText(t); },
@@ -361,6 +418,14 @@ export function useChatHandler() {
       // those as user messages (results live on chat_tool_calls rows).
       let nextUserMessageId = firstUserMessageId;
       let nextAssistantMessageId: string = firstAssistantMessageId;
+
+      // Mark the document store as being in a transient-eval batch for the
+      // duration of the AI turn. useEngine reads this flag and skips clash
+      // detection (O(n²) pairwise boolean intersections) while the flag is
+      // set, then runs a single refinement pass ~100ms after it flips back
+      // to false. Without this, a 53-part bike build blocks the viewport
+      // for ~9s per tool call waiting on clash.
+      useDocumentStore.getState().setTransientEval(true);
 
       try {
         while (true) {
@@ -608,6 +673,9 @@ export function useChatHandler() {
         // future Realtime updates (e.g. server marking it interrupted via
         // a sweep) actually take effect.
         useChatStore.getState().unmarkLocallyStreaming(nextAssistantMessageId);
+        // Flip the transient-eval flag off; useEngine will schedule a
+        // refinement pass with full clash detection ~100ms later.
+        useDocumentStore.getState().setTransientEval(false);
       }
     },
     [],

--- a/packages/app/src/hooks/useEngine.ts
+++ b/packages/app/src/hooks/useEngine.ts
@@ -25,9 +25,42 @@ export function useEngine() {
       const engine = useEngineStore.getState().engine;
       if (!engine) return;
 
+      const docChanged = state.document !== prevState?.document;
+      const transientEnded =
+        !!prevState?.isTransientEval && !state.isTransientEval;
+      const dragEnded =
+        !!prevState?.isParameterDragging && !state.isParameterDragging;
+
+      // Handle "transient batch just ended without another doc change" by
+      // scheduling a refinement pass with full clash detection. This is
+      // how the viewport's clash highlights catch up after the AI stops
+      // calling tools, or after the user releases a drag whose final
+      // position equals the last LOD eval.
+      if (!docChanged && (transientEnded || dragEnded)) {
+        if (refinementTimeout) {
+          clearTimeout(refinementTimeout);
+        }
+        refinementTimeout = setTimeout(() => {
+          const refGen = ++evalGeneration;
+          const doc = useDocumentStore.getState().document;
+          engine
+            .evaluateAsync(doc, { skipClashDetection: false })
+            .then((refinedScene) => {
+              if (refGen !== evalGeneration) return;
+              useEngineStore.getState().setScene(refinedScene);
+            })
+            .catch((e) => {
+              if (refGen !== evalGeneration) return;
+              useEngineStore.getState().setError(String(e));
+            });
+          refinementTimeout = null;
+        }, 100);
+        return;
+      }
+
       // Only re-evaluate if the actual document content changed
       // Skip metadata-only changes (isDirty, lastSavedAt, etc.)
-      if (state.document === prevState?.document) {
+      if (!docChanged) {
         return;
       }
 
@@ -55,8 +88,16 @@ export function useEngine() {
           }
         }
 
-        // During parameter dragging: skip clash detection for faster updates
-        const isDragging = state.isParameterDragging;
+        // Skip clash detection for transient updates (user drag, AI tool
+        // call batches). Clash is O(n²) pairwise boolean intersections and
+        // dominates large-scene eval cost (~9s on a 53-part bike). Painting
+        // the viewport within one animation frame is worth deferring the
+        // overlap highlights until the batch quiesces.
+        const isTransient =
+          state.isParameterDragging || state.isTransientEval;
+        const wasTransient =
+          (prevState?.isParameterDragging ?? false) ||
+          (prevState?.isTransientEval ?? false);
 
         const dirtyNodes = state.clearDirtyNodes();
         if (dirtyNodes.size > 0) {
@@ -65,7 +106,7 @@ export function useEngine() {
 
         const gen = ++evalGeneration;
         engine
-          .evaluateAsync(state.document, { skipClashDetection: isDragging })
+          .evaluateAsync(state.document, { skipClashDetection: isTransient })
           .then((scene) => {
             if (gen !== evalGeneration) return;
             useEngineStore.getState().setScene(scene);
@@ -75,8 +116,9 @@ export function useEngine() {
             useEngineStore.getState().setError(String(e));
           });
 
-        // If dragging just ended, schedule a refinement pass with clash detection
-        if (prevState?.isParameterDragging && !isDragging) {
+        // If the transient batch just ended, schedule a refinement pass with
+        // full clash detection.
+        if (wasTransient && !isTransient) {
           if (refinementTimeout) {
             clearTimeout(refinementTimeout);
           }

--- a/packages/core/src/__tests__/command-registry.test.ts
+++ b/packages/core/src/__tests__/command-registry.test.ts
@@ -188,6 +188,7 @@ describe("CommandRegistry", () => {
         "polyline_tube",
         "inspect_part",
         "place",
+        "describe_scene",
       ]);
     });
 
@@ -206,13 +207,17 @@ describe("CommandRegistry", () => {
       }
     });
 
-    it("set_material tool has part_id and material params", () => {
+    it("set_material tool supports single-part, batch, and selector inputs", () => {
       const tools = registry.toAnthropicTools();
       const setMaterial = tools.find((t) => t.name === "set_material")!;
       const props = setMaterial.input_schema.properties as Record<string, unknown>;
       expect(props.part_id).toBeDefined();
+      expect(props.part_ids).toBeDefined();
+      expect(props.selector).toBeDefined();
       expect(props.material).toBeDefined();
-      expect((setMaterial.input_schema.required as string[])).toEqual(["part_id", "material"]);
+      // Only `material` is required now — the target is chosen between
+      // part_id / part_ids / selector at execution time.
+      expect((setMaterial.input_schema.required as string[])).toEqual(["material"]);
     });
   });
 
@@ -310,8 +315,9 @@ describe("CommandRegistry", () => {
       const fresh = new CommandRegistry();
       fresh.loadSchemas("[]");
       const tools = fresh.toAnthropicTools();
-      // 5 CRUD/material + 3 AI camera tools.
-      expect(tools).toHaveLength(12);
+      // 5 CRUD/material + 3 AI camera tools + 4 high-level tools
+      // (tube, polyline_tube, inspect_part, place) + describe_scene.
+      expect(tools).toHaveLength(13);
       const create = tools[0]!;
       const typeEnum = (create.input_schema.properties as Record<string, Record<string, unknown>>)
         .type.enum as string[];

--- a/packages/core/src/commands/executors.ts
+++ b/packages/core/src/commands/executors.ts
@@ -38,6 +38,95 @@ function computePartWorldBbox(partId: string, docStore: DocStore): Bbox | null {
   return null;
 }
 
+/** Try to read a part's world AABB; if the scene is stale (the part was
+ *  just created and the RAF-debounced eval hasn't fired yet), force a
+ *  synchronous evaluation of the current document and retry once. This
+ *  removes the most common cause of the cryptic "scene may not be evaluated
+ *  yet" error from the AI's path: it lets the AI chain `tube` → `place`
+ *  in the same turn without waiting for the next animation frame.
+ *
+ *  Force-eval is bounded — it skips clash detection (the O(n²) cost) and
+ *  reads the existing scene cache when possible, so the worst case on a
+ *  large scene is a single tessellation pass on the dirty subgraph. */
+function computePartWorldBboxForceEval(
+  partId: string,
+  docStore: DocStore,
+): Bbox | null {
+  const first = computePartWorldBbox(partId, docStore);
+  if (first) return first;
+  const engineStore = useEngineStore.getState();
+  const engine = engineStore.engine;
+  if (!engine || typeof engine.evaluate !== "function") return null;
+  try {
+    const scene = engine.evaluate(docStore.document, { skipClashDetection: true });
+    engineStore.setScene(scene);
+  } catch {
+    return null;
+  }
+  return computePartWorldBbox(partId, docStore);
+}
+
+/** Build a structured-error JSON string the AI can act on. Keeping it as
+ *  a single line keeps it cheap to emit from any executor while still
+ *  giving the model enough handles to recover (a code, hints about what
+ *  was looked up, and an explicit suggestion). */
+function structuredError(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+): string {
+  return JSON.stringify({ ok: false, code, message, ...(details ?? {}) });
+}
+
+/** Build a compact JSON summary for successful CRUD operations. Gives the
+ *  model enough information to decide what to do next (bbox for placing,
+ *  resulting transform for chaining, material for bulk ops) without a
+ *  follow-up `inspect_part` round-trip. Force-evaluates if the scene is
+ *  stale so fresh parts report real coordinates, not zeros. */
+function buildPartSnapshot(
+  partId: string,
+  docStore: DocStore,
+  extra?: Record<string, unknown>,
+): Record<string, unknown> {
+  const part = docStore.partIndex.get(partId);
+  const translate = getCurrentOffset(partId, docStore);
+  const rotate = getCurrentAngles(partId, docStore);
+  const doc = docStore.document as unknown as {
+    partMaterials?: Record<string, string>;
+  };
+  const material = doc.partMaterials?.[partId] ?? null;
+  const snapshot: Record<string, unknown> = {
+    ok: true,
+    part_id: partId,
+    name: part?.name ?? null,
+    kind: part?.kind ?? null,
+    translate,
+    rotate,
+    material,
+    ...(extra ?? {}),
+  };
+  const bbox = computePartWorldBboxForceEval(partId, docStore);
+  if (bbox) {
+    const center = bboxCenter(bbox);
+    const size = bboxSize(bbox);
+    snapshot.bbox = {
+      min: { x: bbox.min[0], y: bbox.min[1], z: bbox.min[2] },
+      max: { x: bbox.max[0], y: bbox.max[1], z: bbox.max[2] },
+      center,
+      size,
+    };
+  }
+  return snapshot;
+}
+
+function snapshotJson(
+  partId: string,
+  docStore: DocStore,
+  extra?: Record<string, unknown>,
+): string {
+  return JSON.stringify(buildPartSnapshot(partId, docStore, extra));
+}
+
 function bboxCenter(b: Bbox): Vec3 {
   return {
     x: (b.min[0] + b.max[0]) / 2,
@@ -241,6 +330,32 @@ function tryExecuteViaWasm(
   // mutation, and the planner would just return a no-outcome
   // PlannedResponse we'd still have to translate.
   if (tool === "read") return null;
+  // Skip set_material when bulk inputs are present — the Rust planner only
+  // knows the single-part shape and would reject `part_ids` / `selector`
+  // with an error before TS got a chance.
+  if (
+    tool === "set_material" &&
+    (args.selector !== undefined || Array.isArray(args.part_ids))
+  ) {
+    return null;
+  }
+  // Skip tools the Rust planner doesn't know about. Without this, an AI
+  // call like `circular_pattern(...)` short-circuits with the planner's
+  // "unknown tool" error before the TS dispatch can route it. Keep this
+  // list in sync with the top-level tools handled in `executeCrudInner`
+  // that aren't in the Rust planner's match.
+  const TS_ONLY_TOOLS = new Set([
+    "tube",
+    "polyline_tube",
+    "linear_pattern",
+    "circular_pattern",
+    "mirror",
+    "inspect_part",
+    "place",
+    "describe_scene",
+    "batch",
+  ]);
+  if (TS_ONLY_TOOLS.has(tool)) return null;
 
   const docJson = JSON.stringify(docStore.document);
   const planned: PlannedResponse | null = commandRegistry.planCrud(
@@ -338,11 +453,13 @@ function executeCrudInner(
     case "delete":
       return executeDelete(args.part_id as string, docStore, uiStore);
     case "set_material":
-      return executeSetMaterial(args.part_id as string, args.material as string, docStore);
+      return executeSetMaterial(args, docStore);
     case "inspect_part":
       return executeInspectPart(args.part_id as string, docStore);
     case "place":
       return executePlace(args, docStore);
+    case "describe_scene":
+      return executeDescribeScene(args, docStore);
     case "tube":
       return executeCreateWithName(
         tool,
@@ -363,6 +480,22 @@ function executeCrudInner(
         docStore,
         uiStore,
       );
+    case "linear_pattern":
+    case "circular_pattern":
+      // Pattern primitives are advertised as top-level tools in
+      // static-schemas.ts; route them through executeCreate so the AI can
+      // call either `circular_pattern(...)` or `create(type:"circular_pattern",
+      // params:...)` and get the same result. Without this case, the AI
+      // gets `Unknown tool: circular_pattern` and falls back to manually
+      // unrolling the pattern (e.g. 16 separate spoke tubes).
+      return executeCreateWithName(
+        tool,
+        args as Record<string, unknown>,
+        undefined,
+        args.name as string | undefined,
+        docStore,
+        uiStore,
+      );
     default:
       return { status: "error", result: `Unknown tool: ${tool}` };
   }
@@ -380,7 +513,11 @@ function executeInspectPart(partId: string, docStore: DocStore): ExecutionResult
     const err = validatePartId(partId, docStore, "inspect_part part_id");
     return err ?? { status: "error", result: `Part ${partId} not found` };
   }
-  const bbox = computePartWorldBbox(partId, docStore);
+  // Force-eval if the scene is stale (e.g. this part was just created
+  // within the same AI turn). This was the #1 source of failed `inspect`
+  // calls: the AI would create a tube, then immediately ask to inspect it,
+  // and the RAF-debounced eval hadn't fired yet.
+  const bbox = computePartWorldBboxForceEval(partId, docStore);
   const offset = getCurrentOffset(partId, docStore);
   const angles = getCurrentAngles(partId, docStore);
   const kind = part.kind;
@@ -436,6 +573,59 @@ function executeInspectPart(partId: string, docStore: DocStore): ExecutionResult
 }
 
 // ---------------------------------------------------------------------------
+// describe_scene — one-call snapshot of every part's position, bbox, and
+// material. Replaces the AI's habit of calling `inspect_part` 8× in a row
+// while debugging coordinate drift. Accepts optional `part_ids` to scope
+// the response, and `limit` to cap output. Force-evaluates the scene once
+// at the start so positions are fresh.
+// ---------------------------------------------------------------------------
+function executeDescribeScene(
+  args: Record<string, unknown>,
+  docStore: DocStore,
+): ExecutionResult {
+  const requestedIds = args.part_ids as string[] | undefined;
+  const limit = (args.limit as number | undefined) ?? 100;
+  // Force one eval up front so every snapshot below can reuse the fresh
+  // scene cache without N separate force-eval calls.
+  const engineStore = useEngineStore.getState();
+  const engine = engineStore.engine;
+  if (engine && (!engineStore.scene || docStore.parts.length > 0)) {
+    try {
+      const scene = engine.evaluate(docStore.document, { skipClashDetection: true });
+      engineStore.setScene(scene);
+    } catch {
+      // If eval fails, fall through — we'll emit whatever we have.
+    }
+  }
+  const ids = requestedIds && requestedIds.length > 0
+    ? requestedIds
+    : docStore.parts.map((p) => p.id).slice(0, limit);
+  const missing: string[] = [];
+  const parts: Array<Record<string, unknown>> = [];
+  for (const id of ids) {
+    const part = docStore.partIndex.get(id);
+    if (!part) {
+      missing.push(id);
+      continue;
+    }
+    parts.push(buildPartSnapshot(id, docStore));
+  }
+  return {
+    status: "success",
+    result: JSON.stringify({
+      ok: true,
+      part_count: parts.length,
+      parts,
+      missing: missing.length > 0 ? missing : undefined,
+    }),
+    display: {
+      summary: [text(`⌕ Describe scene (${parts.length} parts)`)],
+      affectedPartIds: [],
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
 // place — anchor-based positioning. Translates a part so that its `from`
 // anchor lands on the world-space `to` point (or another part's anchor).
 // Optional `align` rotates the part so an axis on it matches a world-space
@@ -457,7 +647,7 @@ function resolveAnchorOnPart(
   anchor: AnchorName,
   docStore: DocStore,
 ): Vec3 | null {
-  const bbox = computePartWorldBbox(partId, docStore);
+  const bbox = computePartWorldBboxForceEval(partId, docStore);
   if (!bbox) return null;
   const c = bboxCenter(bbox);
   switch (anchor) {
@@ -472,6 +662,10 @@ function resolveAnchorOnPart(
     case "right":  return { x: bbox.max[0], y: c.y, z: c.z };
   }
 }
+
+const ANCHOR_NAMES: AnchorName[] = [
+  "center", "min", "max", "top", "bottom", "front", "back", "left", "right",
+];
 
 function resolveAnchor(
   ref: AnchorRef | undefined,
@@ -505,9 +699,38 @@ function executePlace(
   if (!to) return { status: "error", result: "place requires a `to` anchor (Vec3, named anchor, or {part,anchor})" };
 
   const fromWorld = resolveAnchor(from, partId, docStore);
-  if (!fromWorld) return { status: "error", result: "place: could not resolve `from` anchor — the scene may not be evaluated yet" };
+  if (!fromWorld) {
+    return {
+      status: "error",
+      result: structuredError(
+        "ANCHOR_UNRESOLVED",
+        "place: could not resolve `from` anchor",
+        {
+          part_id: partId,
+          from,
+          available_anchors: ANCHOR_NAMES,
+          suggestion:
+            "If you just created this part, the scene is still evaluating. Try `inspect_part` first, or pass `from` as an explicit Vec3 (e.g. {x,y,z}).",
+        },
+      ),
+    };
+  }
   const toWorld = resolveAnchor(to, partId, docStore);
-  if (!toWorld) return { status: "error", result: "place: could not resolve `to` anchor" };
+  if (!toWorld) {
+    return {
+      status: "error",
+      result: structuredError(
+        "ANCHOR_UNRESOLVED",
+        "place: could not resolve `to` anchor",
+        {
+          to,
+          available_anchors: ANCHOR_NAMES,
+          suggestion:
+            "If `to` references another part, that part may not exist or may not yet be evaluated. Try `inspect_part` on it first, or pass `to` as an explicit Vec3.",
+        },
+      ),
+    };
+  }
 
   const currentOffset = getCurrentOffset(partId, docStore);
   const newOffset = {
@@ -519,7 +742,11 @@ function executePlace(
 
   return {
     status: "success",
-    result: `Placed ${partId} so that ${JSON.stringify(from)} → (${toWorld.x.toFixed(1)}, ${toWorld.y.toFixed(1)}, ${toWorld.z.toFixed(1)})`,
+    result: snapshotJson(partId, docStore, {
+      applied: "place",
+      from_world: fromWorld,
+      to_world: toWorld,
+    }),
     partId,
     display: {
       summary: [
@@ -536,34 +763,113 @@ function executePlace(
   };
 }
 
+/** Resolve a part-id selector to a concrete list of ids. Selectors let the
+ *  AI assign a material to many parts in one call (e.g. all spokes, all
+ *  parts whose name starts with "Frame") instead of issuing N separate
+ *  `set_material` calls — which is what produced the 18-call material run
+ *  in the bicycle transcript. */
+function resolveSelector(
+  selector: unknown,
+  docStore: DocStore,
+): string[] {
+  if (!selector || typeof selector !== "object") return [];
+  const sel = selector as { by?: string; value?: string };
+  if (!sel.by || sel.value == null) return [];
+  const value = String(sel.value).toLowerCase();
+  const ids: string[] = [];
+  for (const p of docStore.parts) {
+    let match = false;
+    switch (sel.by) {
+      case "kind":
+        match = p.kind?.toLowerCase() === value;
+        break;
+      case "name_prefix":
+        match = !!p.name && p.name.toLowerCase().startsWith(value);
+        break;
+      case "name_contains":
+        match = !!p.name && p.name.toLowerCase().includes(value);
+        break;
+      case "name_equals":
+        match = !!p.name && p.name.toLowerCase() === value;
+        break;
+    }
+    if (match) ids.push(p.id);
+  }
+  return ids;
+}
+
 function executeSetMaterial(
-  partId: string,
-  materialKey: string,
+  args: Record<string, unknown>,
   docStore: DocStore,
 ): ExecutionResult {
-  if (!partId) return { status: "error", result: "set_material requires part_id" };
+  const materialKey = args.material as string | undefined;
   if (!materialKey) return { status: "error", result: "set_material requires material key" };
-  const err = validatePartId(partId, docStore, "set_material part_id");
-  if (err) return err;
-  try {
-    docStore.setPartMaterial(partId, materialKey);
-    return {
-      status: "success",
-      result: `Set ${partId} material to ${materialKey}`,
-      partId,
-      display: {
-        summary: [
-          text("⬤ Material "),
-          link(partId, docStore),
-          text(` = ${materialKey}`),
-        ],
-        fields: [{ label: "material", value: materialKey }],
-        affectedPartIds: [partId],
-      },
-    };
-  } catch (e) {
-    return { status: "error", result: e instanceof Error ? e.message : "set_material failed" };
+
+  // Resolve the target list. Three input shapes are accepted:
+  //   { part_id: "p1", material: "..." }              — one part
+  //   { part_ids: ["p1","p2","p3"], material: "..." } — explicit batch
+  //   { selector: { by, value }, material: "..." }    — match by kind/name
+  // Falling back to single-part keeps the old call sites working.
+  let targetIds: string[] = [];
+  const partIds = args.part_ids as string[] | undefined;
+  const partId = args.part_id as string | undefined;
+  const selector = args.selector;
+  if (Array.isArray(partIds) && partIds.length > 0) {
+    targetIds = partIds.slice();
+  } else if (partId) {
+    targetIds = [partId];
+  } else if (selector) {
+    targetIds = resolveSelector(selector, docStore);
+    if (targetIds.length === 0) {
+      return {
+        status: "error",
+        result: structuredError(
+          "SELECTOR_EMPTY",
+          "set_material: selector matched zero parts",
+          { selector, suggestion: "Inspect the scene snapshot to confirm the selector value (case-insensitive)." },
+        ),
+      };
+    }
+  } else {
+    return { status: "error", result: "set_material requires one of: part_id, part_ids[], or selector{by,value}" };
   }
+
+  const succeeded: string[] = [];
+  const failed: Array<{ id: string; reason: string }> = [];
+  for (const id of targetIds) {
+    const err = validatePartId(id, docStore, "set_material part_id");
+    if (err) {
+      failed.push({ id, reason: typeof err.result === "string" ? err.result : "invalid id" });
+      continue;
+    }
+    try {
+      docStore.setPartMaterial(id, materialKey);
+      succeeded.push(id);
+    } catch (e) {
+      failed.push({ id, reason: e instanceof Error ? e.message : "set_material failed" });
+    }
+  }
+
+  return {
+    status: failed.length > 0 && succeeded.length === 0 ? "error" : "success",
+    result: JSON.stringify({
+      ok: failed.length === 0,
+      applied: "set_material",
+      material: materialKey,
+      part_ids: succeeded,
+      failed: failed.length > 0 ? failed : undefined,
+    }),
+    partId: succeeded[0],
+    display: {
+      summary: [
+        text("⬤ Material"),
+        ...(targetIds.length === 1 ? [text(" "), link(targetIds[0]!, docStore)] : [text(` ×${succeeded.length}`)]),
+        text(` = ${materialKey}`),
+      ],
+      fields: [{ label: "material", value: materialKey }],
+      affectedPartIds: succeeded,
+    },
+  };
 }
 
 /** Apply a user-provided name to a freshly created part, if any. */
@@ -659,7 +965,7 @@ function executeCreate(
 
         return {
           status: "success",
-          result: `Created ${type} with id: ${partId}`,
+          result: snapshotJson(partId, docStore, { created: type }),
           partId,
           display: {
             summary: [text(`+ ${capitalized}${sizeSuffix} `), link(partId, docStore)],
@@ -713,7 +1019,11 @@ function executeCreate(
         uiStore.select(partId);
         return {
           status: "success",
-          result: `Created tube with id: ${partId}`,
+          result: snapshotJson(partId, docStore, {
+            created: "tube",
+            radius,
+            length,
+          }),
           partId,
           display: {
             summary: [
@@ -786,6 +1096,131 @@ function executeCreate(
         };
       }
 
+      case "linear_pattern": {
+        // Repeat a child part along a direction. Vastly preferable to the AI
+        // manually creating N copies because the kernel evaluates the pattern
+        // as one node (cheap re-eval) and edits to the source propagate to
+        // every instance.
+        const child = params.child as string;
+        const direction = params.direction as Vec3 | undefined;
+        const count = params.count as number | undefined;
+        const spacing = params.spacing as number | undefined;
+        if (!child) return { status: "error", result: "linear_pattern requires child part_id" };
+        if (!direction) return { status: "error", result: "linear_pattern requires direction (Vec3)" };
+        if (!count || count < 1) return { status: "error", result: "linear_pattern requires count ≥ 1" };
+        if (spacing == null) return { status: "error", result: "linear_pattern requires spacing" };
+        const err = validatePartId(child, docStore, "linear_pattern child");
+        if (err) return err;
+        const partId = docStore.addLinearPattern(child, direction, count, spacing);
+        if (!partId) return { status: "error", result: "linear_pattern failed" };
+        uiStore.select(partId);
+        return {
+          status: "success",
+          result: snapshotJson(partId, docStore, {
+            created: "linear_pattern",
+            child,
+            count,
+            spacing,
+            direction,
+          }),
+          partId,
+          display: {
+            summary: [
+              text(`▦ Linear pattern ×${count} → `),
+              link(partId, docStore),
+            ],
+            fields: [
+              { label: "child", value: child },
+              { label: "direction", value: `(${direction.x}, ${direction.y}, ${direction.z})` },
+              { label: "count", value: `${count}` },
+              { label: "spacing", value: `${spacing} mm` },
+            ],
+            affectedPartIds: [partId],
+          },
+        };
+      }
+
+      case "circular_pattern": {
+        // Repeat a child part around an axis. Use this for spokes, bolt
+        // circles, fan blades — any radial array. One node, one eval cost,
+        // identical instances.
+        const child = params.child as string;
+        const axisOrigin = params.axis_origin as Vec3 | undefined;
+        const axisDir = params.axis_dir as Vec3 | undefined;
+        const count = params.count as number | undefined;
+        const angleDeg = params.angle_deg as number | undefined;
+        if (!child) return { status: "error", result: "circular_pattern requires child part_id" };
+        if (!axisOrigin) return { status: "error", result: "circular_pattern requires axis_origin (Vec3)" };
+        if (!axisDir) return { status: "error", result: "circular_pattern requires axis_dir (Vec3)" };
+        if (!count || count < 1) return { status: "error", result: "circular_pattern requires count ≥ 1" };
+        if (angleDeg == null) return { status: "error", result: "circular_pattern requires angle_deg" };
+        const err = validatePartId(child, docStore, "circular_pattern child");
+        if (err) return err;
+        const partId = docStore.addCircularPattern(child, axisOrigin, axisDir, count, angleDeg);
+        if (!partId) return { status: "error", result: "circular_pattern failed" };
+        uiStore.select(partId);
+        return {
+          status: "success",
+          result: snapshotJson(partId, docStore, {
+            created: "circular_pattern",
+            child,
+            count,
+            angle_deg: angleDeg,
+            axis_origin: axisOrigin,
+            axis_dir: axisDir,
+          }),
+          partId,
+          display: {
+            summary: [
+              text(`◯ Circular pattern ×${count} → `),
+              link(partId, docStore),
+            ],
+            fields: [
+              { label: "child", value: child },
+              { label: "axis_origin", value: `(${axisOrigin.x}, ${axisOrigin.y}, ${axisOrigin.z})` },
+              { label: "axis_dir", value: `(${axisDir.x}, ${axisDir.y}, ${axisDir.z})` },
+              { label: "count", value: `${count}` },
+              { label: "angle_deg", value: `${angleDeg}°` },
+            ],
+            affectedPartIds: [partId],
+          },
+        };
+      }
+
+      case "mirror": {
+        const child = params.child as string;
+        const plane = params.plane as "XY" | "XZ" | "YZ" | undefined;
+        if (!child) return { status: "error", result: "mirror requires child part_id" };
+        if (plane !== "XY" && plane !== "XZ" && plane !== "YZ") {
+          return { status: "error", result: "mirror requires plane: 'XY' | 'XZ' | 'YZ'" };
+        }
+        const err = validatePartId(child, docStore, "mirror child");
+        if (err) return err;
+        const partId = docStore.addMirror(child, plane);
+        if (!partId) return { status: "error", result: "mirror failed" };
+        uiStore.select(partId);
+        return {
+          status: "success",
+          result: snapshotJson(partId, docStore, {
+            created: "mirror",
+            child,
+            plane,
+          }),
+          partId,
+          display: {
+            summary: [
+              text(`⇋ Mirror ${plane} → `),
+              link(partId, docStore),
+            ],
+            fields: [
+              { label: "child", value: child },
+              { label: "plane", value: plane },
+            ],
+            affectedPartIds: [partId],
+          },
+        };
+      }
+
       case "translate": {
         const child = params.child as string;
         const offset = params.offset as { x: number; y: number; z: number };
@@ -795,7 +1230,10 @@ function executeCreate(
         docStore.setTranslation(child, offset);
         return {
           status: "success",
-          result: `Translated ${child} by (${offset.x}, ${offset.y}, ${offset.z})`,
+          result: snapshotJson(child, docStore, {
+            applied: "translate",
+            offset,
+          }),
           partId: child,
           display: {
             summary: [
@@ -867,7 +1305,11 @@ function executeCreate(
               : "";
         return {
           status: "success",
-          result: `Rotated ${child}`,
+          result: snapshotJson(child, docStore, {
+            applied: "rotate",
+            angles,
+            pivot: pivot ?? "origin",
+          }),
           partId: child,
           display: {
             summary: [
@@ -894,7 +1336,10 @@ function executeCreate(
         docStore.setScale(child, factor);
         return {
           status: "success",
-          result: `Scaled ${child}`,
+          result: snapshotJson(child, docStore, {
+            applied: "scale",
+            factor,
+          }),
           partId: child,
           display: {
             summary: [

--- a/packages/core/src/commands/prompt-appendix.ts
+++ b/packages/core/src/commands/prompt-appendix.ts
@@ -37,6 +37,21 @@ they're much less error-prone than the long form.
   cheaper in tokens. Especially useful after creating a tube or extrude to
   confirm it landed where intended.
 
+- **circular_pattern(child, axis_origin, axis_dir, count, angle_deg)** —
+  repeat a part around an axis. ALWAYS use this for spokes, bolt circles,
+  fan blades, gear teeth, anything radial. Do NOT manually create N copies.
+  Example for 16 spokes on a wheel centered at the front hub (axis along Y):
+  \`circular_pattern({ child: spokeId, axis_origin: {x:720, y:0, z:350},
+  axis_dir: {x:0, y:1, z:0}, count: 16, angle_deg: 360 })\` — one call,
+  one part, one eval cost. Edits to the source spoke propagate to all 16.
+
+- **linear_pattern(child, direction, count, spacing)** — repeat a part along
+  a direction. Use for stair treads, fence posts, louver fins, anything in
+  a row. Same one-call principle.
+
+- **mirror(child, plane)** — mirror a part across "XY", "XZ", or "YZ".
+  Use for left/right handed pairs (crank arms, fork blades, chainstays).
+
 ## rotate: in-place by default
 
 \`rotate(child, angles)\` rotates around the part's current bbox center by
@@ -67,9 +82,13 @@ Instead of extruding each tube with perpendicular-basis math, do this:
 2. \`tube({ start: headTubeTop, end: headTubeBottom, radius: 16, name: "Head Tube" })\`
 3. \`tube({ start: headTubeBottom, end: frontHub, radius: 12, name: "Fork" })\`
 4. \`cylinder\` for wheels, \`place\` each to its hub.
-5. \`tube\` for handlebar, seat post, crank arm.
-6. \`set_material\` on each part.
-7. \`screenshot_viewport({ view: "quad" })\` to verify.
+5. For spokes: \`tube\` ONE spoke, then
+   \`circular_pattern({ child: spokeId, axis_origin: hub, axis_dir: {x:0,y:1,z:0}, count: 16, angle_deg: 360 })\`.
+   NEVER create N spokes by hand.
+6. \`tube\` for handlebar, seat post; \`mirror\` for crank arms.
+7. Bulk-color: \`set_material({ selector: { by: "tag", value: "frame" } }, "abs-red")\` etc.
+8. \`screenshot_viewport({ view: "quad" })\` to verify.
 
 This pattern generalizes: whenever you'd be tempted to compute perpendicular
-vectors or tube lengths by hand, stop and use tube / polyline_tube instead.`;
+vectors or tube lengths by hand, stop and use tube / polyline_tube instead.
+Whenever you'd be tempted to create N copies of the same thing, use a pattern.`;

--- a/packages/core/src/commands/registry.ts
+++ b/packages/core/src/commands/registry.ts
@@ -216,20 +216,43 @@ export class CommandRegistry {
       },
       {
         name: "set_material",
-        description: "Set the material/color of a part. Use one of the preset material keys listed in the system prompt.",
+        description:
+          "Set the material/color of one OR MANY parts in a single call. " +
+          "Provide ONE of: `part_id` (single), `part_ids` (explicit array), or " +
+          "`selector` (match by kind/name). Prefer the bulk forms — assigning " +
+          "the same material to 18 parts via 18 calls is wasteful when one " +
+          "selector call would do it.",
         input_schema: {
           type: "object",
           properties: {
             part_id: {
               type: "string",
-              description: "The part ID to set the material on.",
+              description: "Single part ID to set the material on.",
+            },
+            part_ids: {
+              type: "array",
+              items: { type: "string" },
+              description: "Array of part IDs — applies the material to each.",
+            },
+            selector: {
+              type: "object",
+              description:
+                "Match many parts at once. `by` is one of: 'kind' | 'name_prefix' | 'name_contains' | 'name_equals'. `value` is matched case-insensitively. Example: { by: 'name_prefix', value: 'Spoke' }.",
+              properties: {
+                by: {
+                  type: "string",
+                  enum: ["kind", "name_prefix", "name_contains", "name_equals"],
+                },
+                value: { type: "string" },
+              },
+              required: ["by", "value"],
             },
             material: {
               type: "string",
               description: "Material preset key (e.g. 'aluminum', 'gold', 'oak', 'abs-red').",
             },
           },
-          required: ["part_id", "material"],
+          required: ["material"],
         },
       },
       {
@@ -352,6 +375,25 @@ export class CommandRegistry {
             },
           },
           required: ["part_id", "to"],
+        },
+      },
+      {
+        name: "describe_scene",
+        description:
+          "One-call snapshot of the whole scene (or a subset of parts): each part's world-space bbox, center, translate, rotate, and material as JSON. Use this INSTEAD of a chain of `inspect_part` calls when you need positions for several parts at once — one turn, no round-trips. Also use it after a batch of edits to verify where everything ended up.",
+        input_schema: {
+          type: "object",
+          properties: {
+            part_ids: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional list of part IDs to describe. Omit to describe every part.",
+            },
+            limit: {
+              type: "integer",
+              description: "Cap the number of parts returned when no part_ids are provided (default 100).",
+            },
+          },
         },
       },
     ];

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -184,6 +184,13 @@ export interface DocumentState {
   /** Whether a parametric drag is in progress (enables LOD mode) */
   isParameterDragging: boolean;
 
+  /** Whether a transient batch of mutations is in progress (e.g. an AI is
+   *  streaming a sequence of tool calls). When true, evals skip clash
+   *  detection so the viewport paints in ~30ms instead of waiting for the
+   *  O(n²) clash loop. A refinement pass with full clash runs ~100ms after
+   *  this flips back to false. */
+  isTransientEval: boolean;
+
   /** Loon source code — non-null when document was loaded from loon format. */
   loonSource: string | null;
 
@@ -382,6 +389,7 @@ export interface DocumentState {
   // Incremental evaluation actions (no-ops — CRDT replaces document wholesale)
   clearDirtyNodes: () => Set<NodeId>;
   setParameterDragging: (dragging: boolean) => void;
+  setTransientEval: (active: boolean) => void;
   // Visibility toggle
   setPartVisible: (partId: string, visible: boolean) => void;
   // Reorder parts in tree
@@ -731,6 +739,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
   documentName: "Untitled",
   lastSavedAt: null,
   isParameterDragging: false,
+  isTransientEval: false,
   loonSource: null,
 
   // CRDT bridge state
@@ -1653,6 +1662,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
         documentName: name,
         lastSavedAt: null,
         isParameterDragging: false,
+        isTransientEval: false,
         loonSource: null,
         _crdtEngine: engine,
       });
@@ -1668,6 +1678,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
         documentName: name,
         lastSavedAt: null,
         isParameterDragging: false,
+        isTransientEval: false,
         loonSource: null,
       });
     }
@@ -1680,6 +1691,10 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
 
   setParameterDragging: (dragging) => {
     set({ isParameterDragging: dragging });
+  },
+
+  setTransientEval: (active) => {
+    set({ isTransientEval: active });
   },
 
   setPartVisible: (partId, visible) => {


### PR DESCRIPTION
## Summary

This PR significantly enhances the AI's ability to perform bulk operations and understand scene state by adding batch material assignment, pattern creation tools (linear/circular patterns and mirrors), a scene description endpoint, and improved error handling with structured JSON responses.

## Key Changes

### New Tools & Operations
- **Batch `set_material`**: Extended to support three input modes:
  - Single part via `part_id` (backward compatible)
  - Explicit batch via `part_ids` array
  - Selector-based matching via `selector` object (by kind, name prefix/contains/equals)
  - Resolves the inefficiency of 18 separate material calls in a single operation

- **Pattern creation tools**: Added three new primitives that create single nodes instead of N copies:
  - `linear_pattern(child, direction, count, spacing)` — repeat along a direction
  - `circular_pattern(child, axis_origin, axis_dir, count, angle_deg)` — repeat around an axis
  - `mirror(child, plane)` — mirror across XY/XZ/YZ planes
  - All route through the same `executeCreate` path as other primitives

- **`describe_scene` tool**: One-call snapshot of all parts (or a subset) with world-space bbox, center, translate, rotate, and material. Replaces the AI's habit of calling `inspect_part` repeatedly for coordinate debugging.

### Scene Evaluation & Caching
- **Force-eval on stale scenes**: New `computePartWorldBboxForceEval()` function detects when the scene cache is stale (e.g., a part was just created) and synchronously evaluates the document with `skipClashDetection: true` to get fresh coordinates. Removes the "scene may not be evaluated yet" error that was the #1 source of failed `inspect_part` calls.

- **Transient batch mode**: Added `isTransientEval` flag to document store. When true (during AI tool call sequences), evals skip the O(n²) clash detection loop, allowing the viewport to paint in ~30ms. A refinement pass with full clash detection runs ~100ms after the batch ends. This prevents 53-part bike builds from blocking the viewport for ~9s per tool call.

- **Scene snapshot in chat context**: `buildSceneSnapshot()` in `useChatHandler` emits a compact human-readable summary of all parts (capped at 60) with positions, sizes, and materials directly in the system prompt, reducing the need for the AI to call `inspect_part` for basic orientation.

### Response Format Improvements
- **Structured error JSON**: New `structuredError()` helper returns JSON with `ok: false`, `code`, `message`, and contextual details (e.g., available anchors, suggestions). Gives the AI actionable recovery hints instead of cryptic strings.

- **Rich operation snapshots**: `buildPartSnapshot()` and `snapshotJson()` return JSON with part metadata, transform, material, and bbox (center/size/min/max). All CRUD operations now return these snapshots instead of plain text, so the AI can chain operations without round-trips (e.g., `tube` → `place` in the same turn).

- **Batch operation results**: `set_material` returns JSON with succeeded/failed arrays, allowing the AI to see which parts were updated and which failed.

### Planner Integration
- **TS-only tools list**: Added explicit check in `tryExecuteViaWasm()` to skip tools the Rust planner doesn't know about (`tube`, `polyline_tube`, `linear_pattern`, `circular_pattern`, `mirror`, `inspect_part`, `place`, `describe_scene`, `batch`). Prevents "unknown tool" errors from short-circuiting the TypeScript dispatch.

- **Bulk input filtering**: Skip `set_material` to Rust planner when `selector` or `part_ids` are present, since the planner only knows the single-part shape.

### Documentation & Schema
- Updated `CommandRegistry` schema for `set_material` to document all three input modes and emphasize bulk operations.
- Added `describe_scene` to the tool registry with full schema.
- Extended `prompt-appendix.ts` with examples of `circular_pattern`, `

https://claude.ai/code/session_01QmhLPWVa9hHPH92uJbkTFN