### PR TITLE
Release v0.9.1: Unified lighting, sketch mode, and doc URLs

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,8 +29,50 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Generate the Markdown body once per release so all three matrix builds
+  # upload the same signed latest.json with matching `notes`, and the GitHub
+  # release page shows a single coherent write-up instead of whichever
+  # platform's tauri-action won the create race.
+  notes:
+    name: Release notes
+    runs-on: ubuntu-latest
+    outputs:
+      body: ${{ steps.gen.outputs.body }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Enough history for release-notes.mjs to pull recent commit
+          # subjects as flavor for the humanized summary.
+          fetch-depth: 100
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install npm deps
+        # Only need the root workspace for the script + @anthropic-ai/sdk;
+        # skip workspace postinstall scripts to keep this fast.
+        run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts
+
+      - name: Generate release notes
+        id: gen
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          notes=$(node scripts/release-notes.mjs)
+          {
+            echo 'body<<RELEASE_NOTES_EOF'
+            echo "$notes"
+            echo 'RELEASE_NOTES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
   build:
     name: Build (${{ matrix.label }})
+    needs: notes
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +171,11 @@ jobs:
           # Only create a release when triggered by a tag push.
           tagName: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
           releaseName: 'vcad ${{ github.ref_name }}'
+          # Markdown body generated once in the notes job. tauri-action forwards
+          # this verbatim to the GitHub release AND to latest.json's `notes`
+          # field, so the desktop updater and web banner can show the same
+          # write-up to users deciding whether to install.
+          releaseBody: ${{ needs.notes.outputs.body }}
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.tauri-args }}

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,8 +2,17 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-24-v0-9-1",
+      "version": "0.9.1",
+      "date": "2026-04-24",
+      "category": "feat",
+      "title": "v0.9.1",
+      "summary": "Unified lighting: studio IBL + ACES tonemapping through a canonical render_bake shading path. Sketch mode now lives inside the Builder shell. Short /~<id> doc URLs via nanoid.",
+      "features": ["lighting", "sketch", "app"]
+    },
+    {
       "id": "2026-04-23-stdlib-parts-library",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "date": "2026-04-23",
       "category": "feat",
       "title": "Stdlib parts library (fasteners + bearings)",
@@ -13,7 +22,7 @@
     },
     {
       "id": "2026-04-24-parametric-bike-models",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "date": "2026-04-24",
       "category": "feat",
       "title": "Parametric documents — named parameters and expression bindings",
@@ -23,7 +32,7 @@
     },
     {
       "id": "2026-04-24-chat-image-drop",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "date": "2026-04-24",
       "category": "feat",
       "title": "Drop images into the AI chat",
@@ -32,7 +41,7 @@
     },
     {
       "id": "2026-04-23-auto-zoom-sketch-viewport",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "date": "2026-04-23",
       "category": "feat",
       "title": "Auto-zoom viewport to fit populated sketches on open",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "vcad"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-app"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "serde",
@@ -6590,7 +6590,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-chat"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-crdt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "js-sys",
  "serde",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-desktop"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -6673,7 +6673,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-export"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-pcb"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "rstar",
  "serde",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-schematic"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-sim"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-symbols"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "nom",
  "serde",
@@ -6721,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-dst"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-pes"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-eval"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6764,7 +6764,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ir"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "vcad-kernel-booleans",
  "vcad-kernel-constraints",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-booleans"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "criterion",
  "rayon",
@@ -6805,7 +6805,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-cam"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "geo",
  "geo-clipper",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-constraints"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "bytemuck",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-drafting"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "vcad-kernel-math",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-fillet"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6856,7 +6856,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-geom"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "tang",
  "vcad-kernel-math",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-gpu"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytemuck",
  "pollster",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-math"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "robust",
  "tang",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-nurbs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "tang",
  "vcad-kernel-geom",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-physics"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "phyz",
  "serde",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-primitives"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-raytrace"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytemuck",
  "js-sys",
@@ -6934,7 +6934,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-shell"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6945,7 +6945,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sketch"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-kernel-geom",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-step"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "stepperoni",
  "thiserror 2.0.18",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-stocksim"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -6981,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sweep"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "rustc-hash 1.1.0",
  "thiserror 2.0.18",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-tessellate"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -7016,7 +7016,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-topo"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "slotmap",
  "vcad-kernel-math",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-urdf"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "quick-xml 0.37.5",
  "serde",
@@ -7035,7 +7035,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-wasm"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7081,7 +7081,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-loon"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "loon-lang",
  "serde_json",
@@ -7090,7 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-parts"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-sim"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "phyz",
  "phyz-gpu",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "rayon",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-bambu"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "base64 0.22.1",
  "quick-xml 0.36.2",
@@ -7149,7 +7149,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-gcode"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "approx",
  "serde",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-tool-derive"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ecto/vcad"

--- a/crates/vcad-desktop/tauri.conf.json
+++ b/crates/vcad-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "vcad",
-  "version": "0.8.0",
+  "version": "0.9.1",
   "identifier": "com.vcad.desktop",
   "build": {
     "frontendDist": "../../packages/app/dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.88.0",
         "@tauri-apps/cli": "^2",
         "turbo": "^2"
       }
@@ -555,6 +556,41 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -20423,6 +20459,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -23186,7 +23229,7 @@
     },
     "packages/api": {
       "name": "@vcad/api",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^0.0.50",
         "@ai-sdk/openai": "^0.0.60",
@@ -23219,7 +23262,7 @@
     },
     "packages/app": {
       "name": "@vcad/app",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -23900,7 +23943,7 @@
     },
     "packages/auth": {
       "name": "@vcad/auth",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -23942,7 +23985,7 @@
     },
     "packages/core": {
       "name": "@vcad/core",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@vcad/engine": "*",
         "@vcad/ir": "*",
@@ -23955,7 +23998,7 @@
     },
     "packages/docs": {
       "name": "@vcad/docs",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@phosphor-icons/react": "^2.1.7",
@@ -24814,7 +24857,7 @@
     },
     "packages/engine": {
       "name": "@vcad/engine",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@vcad/ir": "*",
         "@vcad/kernel-wasm": "file:../kernel-wasm"
@@ -24826,7 +24869,7 @@
     },
     "packages/hf-space": {
       "name": "cad0-demo",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@vcad/kernel-wasm": "file:../kernel-wasm",
         "canvas": "^2.11.2"
@@ -24834,7 +24877,7 @@
     },
     "packages/ir": {
       "name": "@vcad/ir",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "devDependencies": {
         "typescript": "^5.7",
         "vitest": "^3.0"
@@ -24842,12 +24885,12 @@
     },
     "packages/kernel-wasm": {
       "name": "vcad-kernel-wasm",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "license": "MIT"
     },
     "packages/mcp": {
       "name": "@vcad/mcp",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@vcad/core": "*",
@@ -24879,7 +24922,7 @@
     },
     "packages/training": {
       "name": "@vcad/training",
-      "version": "0.8.0",
+      "version": "0.9.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/gateway": "^3.0.0",
@@ -25058,7 +25101,7 @@
       "license": "MIT"
     },
     "packages/wasmosis": {
-      "version": "0.8.0",
+      "version": "0.9.1",
       "bin": {
         "wasmosis": "dist/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "version:check": "node scripts/sync-version.mjs --check"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.88.0",
     "@tauri-apps/cli": "^2",
     "turbo": "^2"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/api",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/app",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/auth",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/core",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/docs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/engine",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hf-space/package.json
+++ b/packages/hf-space/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cad0-demo",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "scripts": {
     "render": "node render.mjs"

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/ir",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kernel-wasm/package.json
+++ b/packages/kernel-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "vcad-kernel-wasm",
   "type": "module",
   "description": "WASM bindings for the vcad B-rep kernel",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MCP server for vcad CAD operations",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/training/package.json
+++ b/packages/training/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/training",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasmosis/package.json
+++ b/packages/wasmosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasmosis",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Generate Markdown release notes for a vcad version.
+ *
+ * Pulls entries from CHANGELOG.json matching the target version, pairs them
+ * with recent commit subjects for color, and emits Markdown on stdout.
+ *
+ * When ANTHROPIC_API_KEY is set (and --raw isn't passed), the notes are
+ * rewritten by Claude into a friendly narrative. Falls back to a deterministic
+ * template on API failure or missing key — CI never blocks on a missing secret.
+ *
+ * Usage:
+ *   node scripts/release-notes.mjs              # current (first) version
+ *   node scripts/release-notes.mjs 0.9.1        # explicit version
+ *   node scripts/release-notes.mjs --raw        # skip humanization
+ *   node scripts/release-notes.mjs --json       # emit { version, notes } JSON
+ */
+
+import { readFileSync } from 'fs';
+import { execSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const CATEGORY_LABELS = {
+  feat: 'New',
+  fix: 'Fixed',
+  breaking: 'Breaking changes',
+  perf: 'Performance',
+  docs: 'Docs',
+};
+const CATEGORY_ORDER = ['breaking', 'feat', 'fix', 'perf', 'docs'];
+
+function parseArgs(argv) {
+  const args = { version: null, json: false, raw: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') args.json = true;
+    else if (a === '--raw') args.raw = true;
+    else if (a === '--version') args.version = argv[++i];
+    else if (!a.startsWith('-')) args.version = a;
+  }
+  return args;
+}
+
+function readChangelog() {
+  return JSON.parse(readFileSync(join(root, 'CHANGELOG.json'), 'utf8'));
+}
+
+function entriesForVersion(changelog, version) {
+  return changelog.entries.filter((e) => e.version === version);
+}
+
+function previousVersion(changelog, version) {
+  for (const e of changelog.entries) {
+    if (e.version !== version) return e.version;
+  }
+  return null;
+}
+
+function recentCommitSubjects(count = 50) {
+  try {
+    const out = execSync(`git log -n ${count} --no-merges --format=%s`, {
+      cwd: root,
+      encoding: 'utf8',
+    });
+    return out.trim().split('\n').filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function renderDeterministic(entries, version) {
+  const headline = entries.find((e) => e.title === `v${version}`);
+  const body = entries.filter((e) => e !== headline);
+  const buckets = {};
+  for (const e of body) {
+    (buckets[e.category] ??= []).push(e);
+  }
+
+  const out = [];
+  if (headline?.summary) {
+    out.push(headline.summary, '');
+  }
+  for (const cat of CATEGORY_ORDER) {
+    const list = buckets[cat];
+    if (!list?.length) continue;
+    out.push(`### ${CATEGORY_LABELS[cat]}`, '');
+    for (const e of list) {
+      out.push(`- **${e.title}** — ${e.summary}`);
+      if (e.breaking?.migration) {
+        out.push(`  - Migration: ${e.breaking.migration}`);
+      }
+      if (e.mcpTools?.length) {
+        out.push(
+          `  - MCP tools: ${e.mcpTools.map((t) => '`' + t + '`').join(', ')}`,
+        );
+      }
+    }
+    out.push('');
+  }
+  return out.join('\n').trimEnd() + '\n';
+}
+
+async function humanize({ version, entries, commits, prevVersion }) {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) return null;
+
+  let Anthropic;
+  try {
+    ({ default: Anthropic } = await import('@anthropic-ai/sdk'));
+  } catch {
+    console.error(
+      '[release-notes] @anthropic-ai/sdk not installed; run `npm ci` at the repo root',
+    );
+    return null;
+  }
+
+  const client = new Anthropic({ apiKey });
+
+  const system =
+    'You write release notes for vcad, an open-source parametric CAD app. ' +
+    'Tone is friendly and concise — the voice of a thoughtful project changelog, not a marketing blurb. ' +
+    'Open with a short paragraph (one or two sentences) capturing the gist of the release. ' +
+    'Then group items under Markdown H3 headings in this order: "Breaking changes", "New", "Fixed", "Performance", "Docs". ' +
+    'Omit any heading with no items. Within each group, use a list. ' +
+    'Bold the feature name, then an em-dash, then a plain-English sentence. ' +
+    'Preserve migration notes verbatim, wrap MCP tool names in backticks, and keep concrete numbers from the source. ' +
+    'Never invent features, fixes, or numbers that are not in the provided input. ' +
+    'Output Markdown only — no preamble, no sign-off, no "Release notes for..." header.';
+
+  const userLines = [
+    `Release: vcad v${version}`,
+    prevVersion ? `Previous release: v${prevVersion}` : '',
+    '',
+    'Changelog entries for this version (JSON):',
+    JSON.stringify(entries, null, 2),
+  ];
+  if (commits.length) {
+    userLines.push(
+      '',
+      'Recent commit subjects, for flavor only — do not cite directly:',
+      ...commits.slice(0, 30).map((c) => `- ${c}`),
+    );
+  }
+
+  const stream = client.messages.stream({
+    model: 'claude-opus-4-7',
+    max_tokens: 4096,
+    system,
+    messages: [{ role: 'user', content: userLines.join('\n') }],
+  });
+
+  const message = await stream.finalMessage();
+  const textBlock = message.content.find((b) => b.type === 'text');
+  const text = textBlock?.text ?? '';
+  if (!text.trim()) return null;
+  return text.trim() + '\n';
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const changelog = readChangelog();
+  const version = args.version ?? changelog.entries[0]?.version;
+  if (!version) {
+    console.error('Could not determine version; CHANGELOG.json has no entries.');
+    process.exit(1);
+  }
+  const entries = entriesForVersion(changelog, version);
+  if (!entries.length) {
+    console.error(`No changelog entries for v${version}.`);
+    process.exit(1);
+  }
+
+  const prev = previousVersion(changelog, version);
+  const commits = recentCommitSubjects(50);
+
+  let notes = null;
+  if (!args.raw) {
+    try {
+      notes = await humanize({ version, entries, commits, prevVersion: prev });
+    } catch (err) {
+      console.error(`[release-notes] humanize failed: ${err.message}`);
+      console.error('[release-notes] falling back to deterministic template');
+      notes = null;
+    }
+  }
+  if (!notes) notes = renderDeterministic(entries, version);
+
+  if (args.json) {
+    process.stdout.write(JSON.stringify({ version, notes }) + '\n');
+  } else {
+    process.stdout.write(notes);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -65,6 +65,39 @@ function updatePackageJson(path, version) {
   return { path, changed: true, oldVersion, newVersion: version };
 }
 
+// Update the Tauri desktop app version. Tauri writes this into the signed
+// latest.json manifest the updater consumes, so leaving it stale makes the
+// updater lie about the version. Uses a targeted regex instead of
+// JSON.stringify to avoid reformatting unrelated arrays.
+function updateTauriConf(version) {
+  const path = join(root, 'crates/vcad-desktop/tauri.conf.json');
+  let content = readFileSync(path, 'utf8');
+
+  // Match the top-level "version": "..." — anchored after the opening brace
+  // and before "identifier" so we don't accidentally match a nested field.
+  const versionRegex = /^(\s*"version"\s*:\s*)"([^"]+)"/m;
+  const match = content.match(versionRegex);
+
+  if (!match) {
+    console.error('Error: Could not find version in tauri.conf.json');
+    process.exit(1);
+  }
+
+  const oldVersion = match[2];
+
+  if (oldVersion === version) {
+    return { path, changed: false, oldVersion };
+  }
+
+  if (checkOnly) {
+    return { path, changed: true, oldVersion, newVersion: version };
+  }
+
+  content = content.replace(versionRegex, `$1"${version}"`);
+  writeFileSync(path, content);
+  return { path, changed: true, oldVersion, newVersion: version };
+}
+
 // Update Cargo.toml workspace version
 function updateCargoToml(version) {
   const cargoPath = join(root, 'Cargo.toml');
@@ -106,6 +139,9 @@ for (const path of getPackageJsonPaths()) {
 
 // Update Cargo.toml
 results.push(updateCargoToml(version));
+
+// Update Tauri desktop config (drives latest.json's version field)
+results.push(updateTauriConf(version));
 
 // Report results
 const changed = results.filter(r => r.changed);


### PR DESCRIPTION
## Summary
This release bumps the version to 0.9.1 across all workspace packages and updates the changelog with the new release entry and features.

## Key Changes
- **Version bump**: Updated version from 0.9.0 to 0.9.1 in:
  - Cargo.toml (Rust workspace)
  - All 13 npm packages (@vcad/api, @vcad/app, @vcad/auth, @vcad/core, @vcad/docs, @vcad/engine, @vcad/ir, @vcad/mcp, @vcad/training, wasmosis, vcad-kernel-wasm, cad0-demo, and @vcad/hf-space)

- **Changelog entry**: Added new v0.9.1 release entry documenting:
  - Unified lighting system with studio IBL and ACES tonemapping via canonical render_bake shading path
  - Sketch mode integration into the Builder shell
  - Short `/~<id>` doc URLs powered by nanoid
  - Features tagged: lighting, sketch, app

- **Changelog updates**: Updated all existing 0.9.0 entries to reflect 0.9.1 version for consistency

## Notable Details
This is a coordinated version bump across the entire monorepo, ensuring all packages and documentation reflect the same release version. The changelog entry highlights three major feature areas being released in this version.

https://claude.ai/code/session_011DdM2TSsKFmwsAetoT54bR