### PR TITLE
Fix desktop release pipeline for Windows and macOS

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -154,18 +154,50 @@ jobs:
       # should not be able to lift the signing/notarization keys into its
       # build output. Dependabot (see .github/dependabot.yml) pins
       # tauri-apps/tauri-action to a commit SHA on its first update.
+      #
+      # Apple codesign env vars are gated on APPLE_CERTIFICATE actually being
+      # set (not just "we're on a tag") because `env:` can't distinguish an
+      # unset secret from an empty-string secret — any non-null value lands
+      # as "" in the action, which then pipes an empty blob into
+      # `security import` and fails with SecKeychainItemImport. We set the
+      # vars here via $GITHUB_ENV only when the cert secret is non-empty;
+      # absent that, tauri-action builds unsigned bundles. Users get a
+      # Gatekeeper warning on first open but install works; when the Apple
+      # secrets are added to the repo, signing lights up automatically.
+      - name: Configure Apple code signing
+        if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        env:
+          CERT: ${{ secrets.APPLE_CERTIFICATE }}
+          CERT_PW: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID_IN: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD_IN: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID_IN: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -z "$CERT" ]; then
+            echo "APPLE_CERTIFICATE secret not set; building macOS bundles unsigned."
+            exit 0
+          fi
+          {
+            echo "APPLE_CERTIFICATE=$CERT"
+            echo "APPLE_CERTIFICATE_PASSWORD=$CERT_PW"
+            echo "APPLE_SIGNING_IDENTITY=$IDENTITY"
+            echo "APPLE_ID=$APPLE_ID_IN"
+            echo "APPLE_PASSWORD=$APPLE_PASSWORD_IN"
+            echo "APPLE_TEAM_ID=$APPLE_TEAM_ID_IN"
+          } >> "$GITHUB_ENV"
+          echo "Apple codesign env configured from repo secrets."
+
       - name: Build and publish desktop bundles
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY || '' }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD || '' }}
-          APPLE_CERTIFICATE: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ startsWith(github.ref, 'refs/tags/') && secrets.APPLE_TEAM_ID || '' }}
+          # APPLE_* env vars are set by the preceding "Configure Apple code
+          # signing" step (only when APPLE_CERTIFICATE is truly populated), so
+          # no placeholder empty strings leak into tauri-action here.
         with:
           projectPath: crates/vcad-desktop
           # Only create a release when triggered by a tag push.

--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,15 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-24-v0-9-2-desktop-release-fixes",
+      "version": "0.9.2",
+      "date": "2026-04-24",
+      "category": "fix",
+      "title": "Desktop release pipeline fixes (Windows + macOS)",
+      "summary": "Cross-platform Node wrapper for @vcad/kernel-wasm build so Windows no longer chokes on bash-only script syntax. macOS codesign step now skips cleanly when Apple secrets aren't configured instead of piping empty data into `security import`.",
+      "features": ["desktop", "ci"]
+    },
+    {
       "id": "2026-04-24-v0-9-1",
       "version": "0.9.1",
       "date": "2026-04-24",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6560,7 +6560,7 @@ dependencies = [
 
 [[package]]
 name = "vcad"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6576,7 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-app"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -6590,7 +6590,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-chat"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6607,7 +6607,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-cli"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -6643,7 +6643,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-crdt"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "js-sys",
  "serde",
@@ -6652,7 +6652,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-desktop"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -6673,7 +6673,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-export"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6681,7 +6681,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-pcb"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "rstar",
  "serde",
@@ -6692,7 +6692,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-schematic"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6702,7 +6702,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-sim"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6710,7 +6710,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-symbols"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "nom",
  "serde",
@@ -6721,7 +6721,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6729,7 +6729,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-dst"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6738,7 +6738,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-pes"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6747,7 +6747,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-eval"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6764,7 +6764,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ir"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6773,7 +6773,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "vcad-kernel-booleans",
  "vcad-kernel-constraints",
@@ -6792,7 +6792,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-booleans"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "criterion",
  "rayon",
@@ -6805,7 +6805,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-cam"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "geo",
  "geo-clipper",
@@ -6817,7 +6817,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-constraints"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "approx",
  "bytemuck",
@@ -6835,7 +6835,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-drafting"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "vcad-kernel-math",
@@ -6844,7 +6844,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-fillet"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6856,7 +6856,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-geom"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "tang",
  "vcad-kernel-math",
@@ -6864,7 +6864,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-gpu"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytemuck",
  "pollster",
@@ -6876,7 +6876,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-math"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "robust",
  "tang",
@@ -6884,7 +6884,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-nurbs"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "tang",
  "vcad-kernel-geom",
@@ -6893,7 +6893,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-physics"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "phyz",
  "serde",
@@ -6905,7 +6905,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-primitives"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6914,7 +6914,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-raytrace"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytemuck",
  "js-sys",
@@ -6934,7 +6934,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-shell"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6945,7 +6945,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sketch"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-kernel-geom",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-step"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "stepperoni",
  "thiserror 2.0.18",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-stocksim"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -6981,7 +6981,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sweep"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "rustc-hash 1.1.0",
  "thiserror 2.0.18",
@@ -6995,7 +6995,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-tessellate"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -7016,7 +7016,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-topo"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "slotmap",
  "vcad-kernel-math",
@@ -7024,7 +7024,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-urdf"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "quick-xml 0.37.5",
  "serde",
@@ -7035,7 +7035,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-wasm"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7081,7 +7081,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-loon"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "loon-lang",
  "serde_json",
@@ -7090,7 +7090,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-parts"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-sim"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "phyz",
  "phyz-gpu",
@@ -7113,7 +7113,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "approx",
  "rayon",
@@ -7128,7 +7128,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-bambu"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "base64 0.22.1",
  "quick-xml 0.36.2",
@@ -7149,7 +7149,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-gcode"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "approx",
  "serde",
@@ -7160,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-tool-derive"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ecto/vcad"

--- a/crates/vcad-desktop/tauri.conf.json
+++ b/crates/vcad-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "vcad",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "identifier": "com.vcad.desktop",
   "build": {
     "frontendDist": "../../packages/app/dist",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/api",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/app",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/auth",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/core",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/docs",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/engine",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hf-space/package.json
+++ b/packages/hf-space/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cad0-demo",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "scripts": {
     "render": "node render.mjs"

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/ir",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kernel-wasm/package.json
+++ b/packages/kernel-wasm/package.json
@@ -2,14 +2,14 @@
   "name": "vcad-kernel-wasm",
   "type": "module",
   "description": "WASM bindings for the vcad B-rep kernel",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ecto/vcad"
   },
   "scripts": {
-    "build": "if [ -n \"$VCAD_WASM_SKIP\" ]; then echo \"wasm build skipped (VCAD_WASM_SKIP set, assuming pkg/ is already populated)\"; else wasm-pack build ../../crates/vcad-kernel-wasm --target web --out-dir ../../packages/kernel-wasm/pkg && cp pkg/vcad_kernel_wasm* .; fi"
+    "build": "node scripts/build.mjs"
   },
   "files": [
     "vcad_kernel_wasm_bg.wasm",

--- a/packages/kernel-wasm/scripts/build.mjs
+++ b/packages/kernel-wasm/scripts/build.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+/**
+ * Cross-platform build for @vcad/kernel-wasm.
+ *
+ * Replaces the previous bash-only inline script so `npm run build` works on
+ * Windows runners (cmd.exe can't parse `if [ -n "$VCAD_WASM_SKIP" ]; then ...`
+ * or expand `cp pkg/vcad_kernel_wasm*`).
+ *
+ * Honors VCAD_WASM_SKIP=1 to short-circuit the wasm-pack rebuild when the
+ * checked-in artifacts in packages/kernel-wasm/ are already current. Otherwise
+ * runs wasm-pack against crates/vcad-kernel-wasm and copies the generated
+ * vcad_kernel_wasm* files into the package root so the package.json `files`
+ * array picks them up.
+ */
+
+import { spawnSync } from 'child_process';
+import { copyFileSync, readdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, '..');
+const cratePath = join(pkgRoot, '..', '..', 'crates', 'vcad-kernel-wasm');
+const outDir = join(pkgRoot, 'pkg');
+
+if (process.env.VCAD_WASM_SKIP) {
+  console.log(
+    '[kernel-wasm] VCAD_WASM_SKIP set — using checked-in artifacts',
+  );
+  process.exit(0);
+}
+
+const result = spawnSync(
+  'wasm-pack',
+  ['build', cratePath, '--target', 'web', '--out-dir', outDir],
+  { stdio: 'inherit', shell: process.platform === 'win32' },
+);
+
+if (result.error || result.status !== 0) {
+  console.error(
+    `[kernel-wasm] wasm-pack failed (${result.error ?? `exit ${result.status}`})`,
+  );
+  process.exit(result.status ?? 1);
+}
+
+for (const file of readdirSync(outDir)) {
+  if (file.startsWith('vcad_kernel_wasm')) {
+    copyFileSync(join(outDir, file), join(pkgRoot, file));
+  }
+}
+console.log('[kernel-wasm] build complete');

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "MCP server for vcad CAD operations",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/training/package.json
+++ b/packages/training/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/training",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasmosis/package.json
+++ b/packages/wasmosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasmosis",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
This PR fixes critical issues in the desktop release pipeline that prevent successful builds on Windows and macOS by replacing bash-specific syntax with cross-platform Node.js tooling and improving Apple codesign secret handling.

## Key Changes

- **Cross-platform WASM build script**: Replaced bash-only inline script in `packages/kernel-wasm/package.json` with a new Node.js build script (`scripts/build.mjs`) that works on Windows, macOS, and Linux. The previous script used bash conditionals and glob expansion that cmd.exe cannot parse.

- **Improved Apple codesign configuration**: Refactored the macOS codesign step in the desktop release workflow to explicitly check if the `APPLE_CERTIFICATE` secret is populated before setting environment variables. This prevents empty strings from being passed to `security import`, which was causing failures. When secrets aren't configured, the build now gracefully produces unsigned bundles instead of failing.

- **Version bump to 0.9.2**: Updated all package versions and workspace version to reflect these fixes.

## Implementation Details

The new `scripts/build.mjs`:
- Respects the existing `VCAD_WASM_SKIP` environment variable to skip rebuilds when checked-in artifacts are current
- Uses `spawnSync` with `shell: true` on Windows to properly invoke `wasm-pack`
- Copies generated `vcad_kernel_wasm*` files from the build output directory to the package root for inclusion in the published package
- Provides clear console logging for debugging

The GitHub Actions workflow now:
- Runs a dedicated "Configure Apple code signing" step that only executes on macOS tag builds
- Conditionally populates `GITHUB_ENV` only when the certificate secret is non-empty
- Removes placeholder empty-string environment variables that were leaking into tauri-action

https://claude.ai/code/session_011DdM2TSsKFmwsAetoT54bR