### PR TITLE
Support Claude Code on the web preview environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SessionStart hook for vcad
+#
+# In a fresh Claude Code on the web sandbox the sibling `tang` workspace is
+# missing, `node_modules` is empty, and workspace package `dist/` outputs are
+# absent. `cargo build` and `npm run dev -w @vcad/app` both fail under those
+# conditions. This hook provisions everything the preview / test / lint
+# commands need so the session is immediately useful.
+#
+# Local runs (no CLAUDE_CODE_REMOTE) exit fast so contributors don't have their
+# environment rewritten.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+log() { printf '[session-start] %s\n' "$*"; }
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR"
+
+# Pin tang to a known-good commit so cloud preview builds are reproducible.
+# Bump this when vcad needs newer tang APIs; running the hook again will
+# fetch and check out the new SHA in place.
+TANG_REV="289b4a8871933f6500f150bee4dc0a2c81031607"
+TANG_DIR="$(cd "$PROJECT_DIR/.." && pwd)/tang"
+if [ ! -d "$TANG_DIR/.git" ]; then
+  log "cloning tang into $TANG_DIR"
+  git clone https://github.com/ecto/tang.git "$TANG_DIR"
+fi
+if [ "$(git -C "$TANG_DIR" rev-parse HEAD)" != "$TANG_REV" ]; then
+  log "checking out tang @ $TANG_REV"
+  git -C "$TANG_DIR" fetch --quiet origin "$TANG_REV"
+  git -C "$TANG_DIR" checkout --quiet "$TANG_REV"
+else
+  log "tang already at pinned rev $TANG_REV"
+fi
+
+if [ ! -d "$PROJECT_DIR/node_modules" ]; then
+  log "installing npm dependencies (npm ci)"
+  npm ci --no-audit --no-fund
+else
+  log "node_modules present, running npm install to reconcile"
+  npm install --no-audit --no-fund
+fi
+
+log "building workspace packages via turbo (wasm skipped, checked-in artifacts reused)"
+# turbo respects the package dependency graph so @vcad/core/engine/ir build
+# before consumers. Skip @vcad/app — its dist isn't consumed by the dev
+# server (vite serves source directly) and the tsc pass is multi-minute.
+VCAD_WASM_SKIP=1 npx --no-install turbo run build --filter='!@vcad/app'
+
+log "ready"

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,7 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": [
         "-c",
-        "if [ -f .env ]; then set -a && source .env && set +a; fi && TAURI_DEV=1 npm run dev -w @vcad/app"
+        "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0"
       ],
       "port": 5173
     }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-start.sh",
+            "timeout": 600000
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23229,7 +23229,7 @@
     },
     "packages/api": {
       "name": "@vcad/api",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^0.0.50",
         "@ai-sdk/openai": "^0.0.60",
@@ -23262,7 +23262,7 @@
     },
     "packages/app": {
       "name": "@vcad/app",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -23943,7 +23943,7 @@
     },
     "packages/auth": {
       "name": "@vcad/auth",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -23985,7 +23985,7 @@
     },
     "packages/core": {
       "name": "@vcad/core",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@vcad/engine": "*",
         "@vcad/ir": "*",
@@ -23998,7 +23998,7 @@
     },
     "packages/docs": {
       "name": "@vcad/docs",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@phosphor-icons/react": "^2.1.7",
@@ -24857,7 +24857,7 @@
     },
     "packages/engine": {
       "name": "@vcad/engine",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@vcad/ir": "*",
         "@vcad/kernel-wasm": "file:../kernel-wasm"
@@ -24869,7 +24869,7 @@
     },
     "packages/hf-space": {
       "name": "cad0-demo",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@vcad/kernel-wasm": "file:../kernel-wasm",
         "canvas": "^2.11.2"
@@ -24877,7 +24877,7 @@
     },
     "packages/ir": {
       "name": "@vcad/ir",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "devDependencies": {
         "typescript": "^5.7",
         "vitest": "^3.0"
@@ -24885,12 +24885,12 @@
     },
     "packages/kernel-wasm": {
       "name": "vcad-kernel-wasm",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT"
     },
     "packages/mcp": {
       "name": "@vcad/mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@vcad/core": "*",
@@ -24922,7 +24922,7 @@
     },
     "packages/training": {
       "name": "@vcad/training",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/gateway": "^3.0.0",
@@ -25101,7 +25101,7 @@
       "license": "MIT"
     },
     "packages/wasmosis": {
-      "version": "0.9.1",
+      "version": "0.9.2",
       "bin": {
         "wasmosis": "dist/cli.js"
       },

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -285,7 +285,10 @@ export default defineConfig(({ mode }) => {
 
   return {
     server: {
-      allowedHosts: ["mew"],
+      // CLAUDE_PREVIEW: served behind a cloud reverse proxy (Claude Code on
+      // the web) — bind all hostnames since the inbound Host header is
+      // generated per-session. Local dev keeps the existing "mew" entry.
+      allowedHosts: process.env.CLAUDE_PREVIEW === "1" ? true : ["mew"],
     },
     envDir: "../../",
     define: {
@@ -293,7 +296,10 @@ export default defineConfig(({ mode }) => {
       __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
     },
     plugins: [
-      !process.env.TAURI_DEV && basicSsl(),
+      // basicSsl produces a self-signed cert for local HTTPS dev. Skip it under
+      // TAURI_DEV (Tauri provides its own webview) and CLAUDE_PREVIEW (cloud
+      // proxy terminates TLS upstream and rejects self-signed certs).
+      !process.env.TAURI_DEV && process.env.CLAUDE_PREVIEW !== "1" && basicSsl(),
       devApiPlugin(env),
       preloadKernelWasmPlugin(),
       react(),


### PR DESCRIPTION
This PR adds support for running the vcad preview in Claude Code on the web by configuring the development environment for cloud-hosted sessions.

## Summary
Added infrastructure to automatically provision and configure the vcad workspace when running in Claude Code on the web, while maintaining compatibility with local development workflows.

## Key Changes

- **Session initialization hook** (`.claude/hooks/session-start.sh`): New bash script that runs automatically in cloud sessions to:
  - Clone and pin the `tang` dependency to a known-good commit for reproducible builds
  - Install npm dependencies via `npm ci`
  - Build workspace packages using turbo (skipping `@vcad/app` since Vite serves source directly)
  - Exits immediately on local runs to avoid rewriting contributor environments

- **Claude settings configuration** (`.claude/settings.json`): Registered the session-start hook with a 10-minute timeout to allow sufficient time for dependency installation and builds

- **Vite configuration** (`packages/app/vite.config.ts`): 
  - Made `allowedHosts` dynamic: accepts all hostnames when `CLAUDE_PREVIEW=1` (cloud reverse proxy generates per-session Host headers), preserves "mew" restriction for local dev
  - Conditionally disabled `basicSsl()` plugin in cloud preview since the upstream proxy terminates TLS and rejects self-signed certificates

- **Launch configuration** (`.claude/launch.json`): Updated dev server invocation to set `CLAUDE_PREVIEW=1` and bind to `0.0.0.0` for cloud accessibility

## Implementation Details

The hook uses environment detection (`CLAUDE_CODE_REMOTE=true`) to distinguish cloud sessions from local development, ensuring local contributors aren't affected. The tang dependency is pinned to enable reproducible cloud builds while remaining easy to update when vcad requires newer APIs.

https://claude.ai/code/session_01TyNeJSb7uggSaxKF2JHZ8b