### PR TITLE
Add desktop magic-link auth via deep-link bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ Open-source parametric CAD for the AI era.
 
 Visit [vcad.io](https://vcad.io) — no install required.
 
+### Desktop App
+
+Download the installer for your platform from the [latest release](https://github.com/ecto/vcad/releases/latest):
+
+- **macOS** — universal `.dmg` (Intel + Apple Silicon)
+- **Windows** — `.msi` installer
+- **Linux** — `.AppImage`, `.deb`, or `.rpm`
+
+#### First launch on macOS
+
+Releases are not yet notarized with Apple, so on first launch macOS shows
+*"Apple could not verify 'vcad.app' is free of malware"*. To open it:
+
+- **macOS 15+** — open **System Settings → Privacy & Security**, scroll to the
+  "vcad was blocked" notice, click **Open Anyway**, then re-launch vcad.
+- **Earlier macOS** — right-click `vcad.app` in `/Applications` and choose
+  **Open**, then **Open** in the confirmation dialog.
+- **From Terminal** — `xattr -d com.apple.quarantine /Applications/vcad.app`
+  removes the quarantine flag so the app launches normally.
+
+You only need to do this once per install. We'll remove this step once
+Apple Developer signing is set up.
+
 ### CLI
 
 ```bash

--- a/packages/app/src/lib/deep-links.ts
+++ b/packages/app/src/lib/deep-links.ts
@@ -8,11 +8,36 @@
  * Example URLs:
  *   vcad://open/<file-id>        — open a shared document
  *   vcad://model/<slug>          — jump to a catalog model
+ *   vcad://auth/callback?...     — completes a desktop magic-link sign-in
+ *
+ * Auth callbacks are handled inline (the @vcad/auth package owns the
+ * Supabase exchange) before the event fan-out, since the rest of the
+ * app should never see auth tokens floating past as generic deep links.
  */
+
+import { handleAuthDeepLink, isAuthDeepLink } from "@vcad/auth";
 
 import { isTauri } from "@/lib/tauri";
 
 let installed = false;
+
+async function dispatchDeepLink(url: string): Promise<void> {
+  if (isAuthDeepLink(url)) {
+    const result = await handleAuthDeepLink(url);
+    if (!result.ok) {
+      console.warn("[deep-link] auth callback failed:", result.error);
+      window.dispatchEvent(
+        new CustomEvent("vcad:auth-callback-failed", {
+          detail: { error: result.error },
+        }),
+      );
+    }
+    return;
+  }
+  window.dispatchEvent(
+    new CustomEvent("vcad:deep-link", { detail: { url } }),
+  );
+}
 
 export async function installDeepLinkListener(): Promise<void> {
   if (installed) return;
@@ -22,9 +47,7 @@ export async function installDeepLinkListener(): Promise<void> {
     const { onOpenUrl } = await import("@tauri-apps/plugin-deep-link");
     await onOpenUrl((urls) => {
       for (const url of urls) {
-        window.dispatchEvent(
-          new CustomEvent("vcad:deep-link", { detail: { url } }),
-        );
+        void dispatchDeepLink(url);
       }
     });
   } catch (err) {

--- a/packages/auth/src/auth-deep-link.ts
+++ b/packages/auth/src/auth-deep-link.ts
@@ -1,0 +1,129 @@
+/**
+ * Desktop auth deep-link bridge.
+ *
+ * The desktop app cannot complete a magic-link sign-in by itself —
+ * Supabase emails a URL the user clicks in their external browser, and
+ * that browser has no path back into the Tauri window. We solve this
+ * with a static bridge page on vcad.io (`/auth/desktop`) that forwards
+ * the click to the `vcad://auth/callback` custom scheme, which the OS
+ * routes to a running (or freshly-launched) vcad desktop instance via
+ * the Tauri deep-link plugin.
+ *
+ * `handleAuthDeepLink` parses whatever Supabase put on the URL (query
+ * `?code=...` for PKCE, query `?token_hash=...&type=...` for the OTP
+ * magic-link, or hash `#access_token=...&refresh_token=...` for the
+ * implicit flow) and turns it into an active Supabase session. The
+ * bridge page deliberately does not load supabase-js so the one-shot
+ * token isn't burned in the browser before reaching the desktop.
+ */
+
+import { getSupabase } from "./client";
+
+export interface AuthDeepLinkResult {
+  /** True when the URL produced an active session. */
+  ok: boolean;
+  /** Populated on failure; safe to surface to the user. */
+  error?: string;
+}
+
+/**
+ * Returns true when `url` is the deep-link vcad emits for a completed
+ * sign-in (e.g. `vcad://auth/callback?...`). The caller should check
+ * this before invoking `handleAuthDeepLink` to avoid swallowing other
+ * `vcad://` URLs (shared documents, catalog jumps, etc.).
+ */
+export function isAuthDeepLink(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "vcad:") return false;
+    // `vcad://auth/callback` parses as host=auth, pathname=/callback.
+    // Accept either shape so the bridge page can use whichever feels
+    // cleaner without breaking the desktop.
+    const path = `${parsed.host}${parsed.pathname}`.replace(/\/+$/, "");
+    return path === "auth/callback" || path === "auth";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Materialize a Supabase session from a `vcad://auth/callback` URL.
+ * Returns `{ ok: true }` when a session was established; `AuthProvider`
+ * will pick it up via its `onAuthStateChange` subscription.
+ */
+export async function handleAuthDeepLink(
+  url: string,
+): Promise<AuthDeepLinkResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { ok: false, error: "Auth is not configured" };
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, error: "Malformed callback URL" };
+  }
+
+  // Implicit-flow tokens land in the fragment. Supabase exposes
+  // `setSession` as the canonical way to install them on the client.
+  const hash = parsed.hash.startsWith("#") ? parsed.hash.slice(1) : parsed.hash;
+  if (hash) {
+    const fragment = new URLSearchParams(hash);
+    const accessToken = fragment.get("access_token");
+    const refreshToken = fragment.get("refresh_token");
+    if (accessToken && refreshToken) {
+      const { error } = await supabase.auth.setSession({
+        access_token: accessToken,
+        refresh_token: refreshToken,
+      });
+      if (error) return { ok: false, error: error.message };
+      return { ok: true };
+    }
+  }
+
+  const query = parsed.searchParams;
+
+  // PKCE / OAuth code exchange. Note this only succeeds when the
+  // desktop is the same client that initiated the sign-in (the code
+  // verifier lives in the app's localStorage).
+  const code = query.get("code");
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  }
+
+  // Magic-link OTP: token_hash is single-use and verified server-side,
+  // so it works even though the click happened in the user's browser.
+  // `signInWithOtp` always emits one of the email OTP types (magiclink
+  // by default, or `email` when shouldCreateUser is false). The
+  // `EmailOtpType` union is not exported, so we narrow with a cast on
+  // the verified-against-the-server set.
+  const tokenHash = query.get("token_hash");
+  const otpType = query.get("type") as
+    | "signup"
+    | "invite"
+    | "magiclink"
+    | "recovery"
+    | "email_change"
+    | "email"
+    | null;
+  if (tokenHash && otpType) {
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type: otpType,
+    });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true };
+  }
+
+  const errDescription =
+    query.get("error_description") ?? query.get("error") ?? null;
+  if (errDescription) {
+    return { ok: false, error: errDescription };
+  }
+
+  return { ok: false, error: "Callback URL had no auth parameters" };
+}

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,3 +1,34 @@
+/**
+ * True when running inside the Tauri desktop shell. Detected via the
+ * runtime global the @tauri-apps/api `isTauri()` helper checks for, so
+ * we don't need to take a hard dep on tauri from the auth package
+ * (which is also consumed by the pure-web bundle).
+ */
+export function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  return "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Where Supabase should redirect the magic-link click. On web this is
+ * the current origin (Supabase strips its tokens out of the URL via
+ * `detectSessionInUrl`). On desktop the magic-link arrives in the
+ * user's external browser, which can't hand tokens back to the Tauri
+ * window directly — so we route through a static bridge page on
+ * vcad.io that JS-redirects to the `vcad://auth/callback` deep link.
+ *
+ * The bridge page does NOT load supabase-js (which would auto-verify
+ * the one-shot token_hash and prevent the desktop from completing the
+ * sign-in). It only forwards the URL's query + fragment unchanged, so
+ * the desktop can call `verifyOtp` / `setSession` itself.
+ */
+export function getAuthRedirectUrl(): string {
+  if (isTauriRuntime()) {
+    return "https://vcad.io/auth/desktop";
+  }
+  return typeof window !== "undefined" ? window.location.origin : "";
+}
+
 import {
   createClient,
   type Session as SupabaseSession,

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, EnvelopeSimple } from "@phosphor-icons/react";
-import { getSupabase } from "../client";
+import { getAuthRedirectUrl, getSupabase } from "../client";
 import type { GatedFeature } from "../hooks/useRequireAuth";
 
 interface AuthModalProps {
@@ -45,7 +45,7 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
     const { error } = await supabase.auth.signInWithOtp({
       email,
       options: {
-        emailRedirectTo: window.location.origin,
+        emailRedirectTo: getAuthRedirectUrl(),
       },
     });
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,19 @@
 // Client
-export { ensureSession, getSupabase, isAuthEnabled, requireSupabase } from "./client";
+export {
+  ensureSession,
+  getAuthRedirectUrl,
+  getSupabase,
+  isAuthEnabled,
+  isTauriRuntime,
+  requireSupabase,
+} from "./client";
+
+// Desktop deep-link auth bridge
+export {
+  handleAuthDeepLink,
+  isAuthDeepLink,
+  type AuthDeepLinkResult,
+} from "./auth-deep-link";
 
 // Stores
 export { useAuthStore } from "./stores/auth-store";

--- a/scripts/release-notes.mjs
+++ b/scripts/release-notes.mjs
@@ -34,6 +34,22 @@ const CATEGORY_LABELS = {
 };
 const CATEGORY_ORDER = ['breaking', 'feat', 'fix', 'perf', 'docs'];
 
+// Until the macOS build is notarized with an Apple Developer ID, the
+// downloaded .app is unsigned and Gatekeeper blocks first launch with
+// "Apple could not verify 'vcad.app' is free of malware". Append the
+// bypass to every release page so users hitting that dialog don't have
+// to dig through the README. Drop this once Apple signing is wired up.
+const MACOS_FIRST_LAUNCH_FOOTER = `### Installing on macOS
+
+This build is not yet Apple-notarized, so first launch shows
+*"Apple could not verify 'vcad.app' is free of malware"*. To open it:
+
+- **macOS 15+** — System Settings → Privacy & Security → "Open Anyway".
+- **Earlier macOS** — right-click \`vcad.app\` in /Applications → Open.
+- **Terminal** — \`xattr -d com.apple.quarantine /Applications/vcad.app\`.
+
+You only need to do this once per install.`;
+
 function parseArgs(argv) {
   const args = { version: null, json: false, raw: false };
   for (let i = 0; i < argv.length; i++) {
@@ -189,6 +205,8 @@ async function main() {
     }
   }
   if (!notes) notes = renderDeterministic(entries, version);
+
+  notes = notes.trimEnd() + '\n\n' + MACOS_FIRST_LAUNCH_FOOTER + '\n';
 
   if (args.json) {
     process.stdout.write(JSON.stringify({ version, notes }) + '\n');


### PR DESCRIPTION
## Summary

Implements desktop magic-link authentication by routing Supabase's email clicks through a static bridge page (`vcad.io/auth/desktop`) that redirects to the `vcad://auth/callback` deep-link scheme. This allows the desktop app to complete sign-ins without burning one-shot tokens in the browser.

## Key Changes

- **New `auth-deep-link.ts` module** — Provides `isAuthDeepLink()` and `handleAuthDeepLink()` to parse and materialize Supabase sessions from deep-link URLs. Handles three auth flows:
  - Implicit flow (hash-based `access_token` + `refresh_token`)
  - PKCE code exchange (query `?code=...`)
  - Magic-link OTP verification (query `?token_hash=...&type=...`)

- **Updated `client.ts`** — Added `isTauriRuntime()` to detect desktop environment and `getAuthRedirectUrl()` to return the appropriate redirect target:
  - Desktop: `https://vcad.io/auth/desktop` (bridge page)
  - Web: current origin (standard Supabase flow)

- **Updated `AuthModal.tsx`** — Uses `getAuthRedirectUrl()` instead of hardcoded `window.location.origin` for magic-link redirects

- **Updated `deep-links.ts`** — Integrated auth deep-link handling into the dispatcher; auth callbacks are processed inline before generic deep-link events to prevent tokens from leaking as regular events

- **Documentation updates** — Added desktop app installation instructions to README and release notes, including macOS Gatekeeper bypass steps for unsigned builds

## Implementation Details

- The bridge page deliberately does not load supabase-js to preserve the one-shot `token_hash` for the desktop to verify
- Auth deep-links are intercepted before the generic `vcad:deep-link` event to prevent token exposure
- Errors from auth callbacks emit a separate `vcad:auth-callback-failed` event for UI handling
- Supports both `vcad://auth/callback` and `vcad://auth` URL shapes for flexibility

https://claude.ai/code/session_01LhvNGybJe6z1bZzrdRw6Dh