### PR TITLE
feat(auth): vcad.io bridge page + Supabase redirect allow-list

### DIFF
--- a/packages/app/public/auth/desktop.html
+++ b/packages/app/public/auth/desktop.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in to vcad — Desktop</title>
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      :root { color-scheme: light dark; }
+      html, body {
+        margin: 0;
+        height: 100%;
+        font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Roboto, system-ui, sans-serif;
+        background: #fafaf9;
+        color: #1c1917;
+      }
+      @media (prefers-color-scheme: dark) {
+        html, body { background: #0c0a09; color: #f5f5f4; }
+      }
+      main {
+        max-width: 28rem;
+        margin: 0 auto;
+        padding: 4rem 1.5rem;
+        text-align: center;
+      }
+      h1 { font-size: 1.5rem; font-weight: 700; margin: 0 0 0.5rem; letter-spacing: -0.02em; }
+      h1 span { color: #f97316; }
+      p { color: #57534e; margin: 0.5rem 0; }
+      @media (prefers-color-scheme: dark) {
+        p { color: #a8a29e; }
+      }
+      .actions { margin-top: 2rem; display: flex; flex-direction: column; gap: 0.5rem; align-items: center; }
+      a { color: inherit; }
+      button, .btn {
+        padding: 0.625rem 1rem;
+        border: 1px solid currentColor;
+        background: transparent;
+        color: inherit;
+        font: inherit;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-block;
+        min-width: 12rem;
+      }
+      button:hover, .btn:hover { background: rgba(127, 127, 127, 0.1); }
+      .hide { display: none; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>vcad<span>.</span></h1>
+      <p id="status">Opening the desktop app…</p>
+      <div class="actions">
+        <button id="retry" class="hide" type="button">Open vcad</button>
+        <a id="web" class="btn hide" href="https://vcad.io/">Continue in browser</a>
+      </div>
+      <noscript>
+        <p>Enable JavaScript to complete sign-in, or open this link on the
+          device where vcad is installed.</p>
+      </noscript>
+    </main>
+    <script src="/auth/desktop.js"></script>
+  </body>
+</html>

--- a/packages/app/public/auth/desktop.js
+++ b/packages/app/public/auth/desktop.js
@@ -1,0 +1,46 @@
+// Desktop auth bridge.
+//
+// Supabase emails the user a magic-link that points here. We forward the
+// click to vcad://auth/callback with the URL's query and fragment intact,
+// so the Tauri deep-link plugin can hand the tokens to the desktop app.
+//
+// We deliberately do NOT load supabase-js on this page — `detectSessionInUrl`
+// would burn the one-shot token_hash in the browser before the desktop ever
+// got a chance to verify it.
+(function () {
+  var search = window.location.search || "";
+  var hash = window.location.hash || "";
+  var target = "vcad://auth/callback" + search + hash;
+
+  var status = document.getElementById("status");
+  var retryBtn = document.getElementById("retry");
+  var webLink = document.getElementById("web");
+
+  function go() {
+    // location.replace keeps the magic-link URL out of the history stack
+    // so the user can't accidentally re-click it after it has been used.
+    window.location.replace(target);
+  }
+
+  function showFallback() {
+    if (status) {
+      status.textContent =
+        "If vcad didn't open automatically, click below to try again. " +
+        "If you don't have vcad installed, you can sign in on the web.";
+    }
+    if (retryBtn) {
+      retryBtn.classList.remove("hide");
+      retryBtn.addEventListener("click", go);
+    }
+    if (webLink) webLink.classList.remove("hide");
+  }
+
+  // Browsers don't fire a reliable event when a custom-scheme handler
+  // succeeds or fails. Wait long enough that a registered handler would
+  // have moved the user off this page; if we're still here, surface the
+  // manual recovery affordances. The exact threshold is forgiving — most
+  // OSes hand the URL off in well under a second.
+  setTimeout(showFallback, 1500);
+
+  go();
+})();

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -4,6 +4,7 @@
   "buildCommand": "cd ../.. && npm run build -w @vcad/ir && npm run build -w @vcad/engine && npm run build -w @vcad/core && npm run build -w @vcad/mcp && npm run build -w @vcad/app",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/auth/desktop", "destination": "/auth/desktop.html" },
     { "source": "/~(.*)", "destination": "/" },
     { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -9,6 +9,30 @@ port = 5432
 # Enable/disable email auth
 enabled = true
 
+# Where Supabase sends users after auth. The site URL is the canonical
+# web home; additional_redirect_urls is the allow-list of every other
+# URL that the magic-link / OAuth flows are allowed to redirect to.
+#
+# - https://vcad.io/auth/desktop is the static bridge page that forwards
+#   a completed magic-link to the vcad:// custom scheme so the Tauri
+#   desktop app can complete sign-in. See
+#   packages/auth/src/auth-deep-link.ts and
+#   packages/app/public/auth/desktop.html.
+# - http://localhost:5173 lets `npm run dev -w @vcad/app` complete a
+#   sign-in against the production Supabase project during local
+#   development.
+#
+# Apply with `supabase config push` (the linked project's allow-list
+# is the source of truth at runtime; this file just keeps the desired
+# state in source control).
+site_url = "https://vcad.io"
+additional_redirect_urls = [
+  "https://vcad.io/**",
+  "https://vcad.io/auth/desktop",
+  "http://localhost:5173",
+  "http://localhost:5173/**",
+]
+
 # OAuth providers (configured in Supabase dashboard)
 # [auth.external.google]
 # enabled = true


### PR DESCRIPTION
## Summary

Completes the desktop magic-link sign-in flow added in #99. That PR taught
the desktop app to redirect sign-in through `https://vcad.io/auth/desktop`
and to materialize a Supabase session from a `vcad://auth/callback` deep
link, but the bridge page itself didn't exist yet and Supabase's redirect
allow-list wasn't tracked in source control.

- **`packages/app/public/auth/desktop.{html,js}`** — minimal static bridge.
  Forwards `window.location.search` and `window.location.hash` unchanged to
  `vcad://auth/callback`. Deliberately does *not* load supabase-js, since
  `detectSessionInUrl` would burn the one-shot magic-link token in the
  browser before the desktop ever gets to verify it. The JS lives in a
  separate file because the production CSP (`script-src 'self'`) blocks
  inline scripts. After 1.5s, surfaces a "vcad didn't open" fallback so
  users without the desktop app installed can drop back to web sign-in.
- **`packages/app/vercel.json`** — rewrite `/auth/desktop` →
  `/auth/desktop.html` so the URL Supabase emails stays extension-free.
- **`supabase/config.toml`** — adds `site_url` and
  `additional_redirect_urls` so the allow-list is reviewable in source
  control. The runtime source of truth is still the linked project's
  settings; apply with `supabase config push` (or paste into the dashboard
  at Auth → URL Configuration → Redirect URLs).

## Manual step required after merge

Supabase enforces the redirect allow-list from the linked project, not from
this file. Run `supabase config push`, or add the four entries from
`supabase/config.toml` to the dashboard:

- `https://vcad.io/**`
- `https://vcad.io/auth/desktop`
- `http://localhost:5173`
- `http://localhost:5173/**`

Without this step, magic-link clicks will be rejected with "Invalid Redirect
URL" before they ever reach the bridge page.

## Test plan

- [ ] App build picks up the new files: `dist/auth/desktop.html` and
  `dist/auth/desktop.js` exist after `npm run build -w @vcad/app`.
- [ ] Vercel preview serves the bridge at `/auth/desktop` (rewrite),
  `/auth/desktop.html` (direct), and that the JS runs (CSP allows it).
- [ ] After `supabase config push`: desktop sign-in end-to-end —
  magic-link email arrives, click on a machine with vcad installed opens
  the desktop app and lands the user signed in; click on a machine
  *without* vcad shows the fallback UI with a "Continue in browser" link.
- [ ] Web sign-in on `https://vcad.io` still works (no regression to the
  default redirect path).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhvNGybJe6z1bZzrdRw6Dh)_