### PR TITLE
fix(supabase): pin live auth settings so `config push` can't drift them

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -33,6 +33,13 @@ additional_redirect_urls = [
   "http://localhost:5173/**",
 ]
 
+# Anonymous sign-ins are required by the app: client.ts/ensureSession
+# creates an anon session for every visitor so RLS predicates of the
+# form `auth.uid() = user_id` hold uniformly across logged-in and
+# logged-out users. Pinning this here so `supabase config push` can't
+# silently revert the project to the CLI default of `false`.
+enable_anonymous_sign_ins = true
+
 # OAuth providers (configured in Supabase dashboard)
 # [auth.external.google]
 # enabled = true
@@ -44,8 +51,19 @@ additional_redirect_urls = [
 # client_id = "env(GITHUB_CLIENT_ID)"
 # secret = "env(GITHUB_CLIENT_SECRET)"
 
+# Match the production project's hardened email settings so a future
+# `supabase config push` doesn't drift them back to CLI defaults.
 [auth.email]
-# Enable magic link sign in
 enable_signup = true
 double_confirm_changes = true
 enable_confirmations = true
+# 1-minute rate limit on magic-link / OTP emails (CLI default is 1s).
+max_frequency = "1m0s"
+# 8-digit OTP (CLI default is 6).
+otp_length = 8
+
+# Production has TOTP MFA enrollment + verification on. Don't let a
+# config push flip it off.
+[auth.mfa.totp]
+enroll_enabled = true
+verify_enabled = true


### PR DESCRIPTION
## Summary

The first `supabase config push` against the linked project (after #100
merged) revealed five auth fields that are live in production with
non-default values — but `config.toml` didn't track them, so the CLI was
about to overwrite them with its own defaults. Caught the diff, pinned the
live values here so future pushes are no-ops on these fields.

| Field | Live value | CLI default | Why it matters |
| :--- | :---: | :---: | :--- |
| `auth.enable_anonymous_sign_ins` | `true` | `false` | `client.ts:120` calls `signInAnonymously()` for every visitor; RLS predicates `auth.uid() = user_id` rely on it. Disabling would break sign-in for anyone without an account. |
| `auth.email.max_frequency` | `"1m0s"` | `"1s"` | Rate limit on magic-link / OTP emails. Going to 1s lets attackers blast 60× the requests. |
| `auth.email.otp_length` | `8` | `6` | OTP entropy — 6-digit codes are 100× weaker. |
| `auth.mfa.totp.enroll_enabled` | `true` | `false` | TOTP MFA enrollment. |
| `auth.mfa.totp.verify_enabled` | `true` | `false` | TOTP MFA verification. |

After this lands, re-running `supabase config push` should produce a diff
of *only* the `additional_redirect_urls` line that #100 added, which is
the actual allow-list change we want to ship to enable desktop sign-in.

## Test plan

- [ ] `npx supabase config push` shows only the `additional_redirect_urls`
  diff (the four allow-list entries from #100). No surprises in
  `enable_anonymous_sign_ins`, `email.max_frequency`, `email.otp_length`,
  or `mfa.totp.*`.
- [ ] Anonymous sessions still get created on `vcad.io` for logged-out
  visitors after the push (i.e. `client.ts:120` `signInAnonymously()`
  succeeds).
- [ ] Magic-link email rate limit still hits at ~1/minute, not 1/second.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhvNGybJe6z1bZzrdRw6Dh)_