### PR TITLE
chore: release v0.9.3 — desktop sign-in + macOS first-launch docs

### DIFF
--- a/CHANGELOG.json
+++ b/CHANGELOG.json
@@ -2,6 +2,24 @@
   "$schema": "./changelog.schema.json",
   "entries": [
     {
+      "id": "2026-04-25-desktop-magic-link-signin",
+      "version": "0.9.3",
+      "date": "2026-04-25",
+      "category": "feat",
+      "title": "Desktop magic-link sign-in",
+      "summary": "Sign in to vcad from the Tauri desktop app. Magic-link clicks now route through https://vcad.io/auth/desktop and back to the app via the vcad:// custom scheme, completing the Supabase session in-process. Password-recovery and email-change links use the same bridge.",
+      "features": ["auth", "desktop"]
+    },
+    {
+      "id": "2026-04-25-macos-first-launch-docs",
+      "version": "0.9.3",
+      "date": "2026-04-25",
+      "category": "docs",
+      "title": "macOS first-launch bypass instructions",
+      "summary": "Until releases are Apple-notarized, opening the macOS .dmg trips a Gatekeeper warning. README and every GitHub release page now spell out the three ways past it: System Settings → Privacy & Security → Open Anyway, right-click → Open, or `xattr -d com.apple.quarantine /Applications/vcad.app`.",
+      "features": ["desktop", "docs"]
+    },
+    {
       "id": "2026-04-24-spanish-ui-translation",
       "version": "0.9.2",
       "date": "2026-04-24",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ecto/vcad"

--- a/crates/vcad-desktop/tauri.conf.json
+++ b/crates/vcad-desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "vcad",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "identifier": "com.vcad.desktop",
   "build": {
     "frontendDist": "../../packages/app/dist",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/api",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/app",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/auth",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/core",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/docs",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/engine",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/hf-space/package.json
+++ b/packages/hf-space/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cad0-demo",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "scripts": {
     "render": "node render.mjs"

--- a/packages/ir/package.json
+++ b/packages/ir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/ir",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/kernel-wasm/package.json
+++ b/packages/kernel-wasm/package.json
@@ -2,7 +2,7 @@
   "name": "vcad-kernel-wasm",
   "type": "module",
   "description": "WASM bindings for the vcad B-rep kernel",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/mcp",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "MCP server for vcad CAD operations",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/training/package.json
+++ b/packages/training/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcad/training",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasmosis/package.json
+++ b/packages/wasmosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wasmosis",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release commit for vcad **v0.9.3**. Two user-facing items since 0.9.2:

- **feat: Desktop magic-link sign-in** (#99, #100, #101). The Tauri app now
  redirects sign-in through `https://vcad.io/auth/desktop`, returns through
  the `vcad://` custom scheme, and `handleAuthDeepLink` completes the
  Supabase session in-process. Password-recovery and email-change flows
  use the same bridge.
- **docs: macOS first-launch bypass instructions**. Until releases are
  Apple-notarized, the .dmg trips a Gatekeeper warning. README and every
  generated GitHub release body now spell out the three ways past it.

Bumps every `package.json`, `Cargo.toml`, and `tauri.conf.json` to `0.9.3`
via `npm run version:sync`.

## Releasing

After this lands on main:

```bash
git fetch origin main
git tag v0.9.3 origin/main
git push origin v0.9.3
```

That kicks off `.github/workflows/desktop-release.yml`, which builds the
universal-mac, Windows, and Linux bundles and drafts a GitHub release.

## Test plan

- [ ] `npm run version:check` is clean.
- [ ] `node scripts/release-notes.mjs --raw` renders the two entries plus
  the macOS first-launch footer.
- [ ] Desktop build succeeds locally: `npm run tauri:build -w @vcad/app`
  (or rely on the release matrix).
- [ ] After tag push: the three release-matrix jobs go green and a draft
  release is created with the .dmg / .msi / .AppImage attached.
- [ ] Smoke-test desktop sign-in against the production Supabase project
  using the freshly-signed (or unsigned) bundle.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhvNGybJe6z1bZzrdRw6Dh)_