### PR TITLE
chore: sync package-lock.json to v0.9.3 (unblocks tag build)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23229,7 +23229,7 @@
     },
     "packages/api": {
       "name": "@vcad/api",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^0.0.50",
         "@ai-sdk/openai": "^0.0.60",
@@ -23262,7 +23262,7 @@
     },
     "packages/app": {
       "name": "@vcad/app",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -23943,7 +23943,7 @@
     },
     "packages/auth": {
       "name": "@vcad/auth",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -23985,7 +23985,7 @@
     },
     "packages/core": {
       "name": "@vcad/core",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@vcad/engine": "*",
         "@vcad/ir": "*",
@@ -23998,7 +23998,7 @@
     },
     "packages/docs": {
       "name": "@vcad/docs",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@phosphor-icons/react": "^2.1.7",
@@ -24857,7 +24857,7 @@
     },
     "packages/engine": {
       "name": "@vcad/engine",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@vcad/ir": "*",
         "@vcad/kernel-wasm": "file:../kernel-wasm"
@@ -24869,7 +24869,7 @@
     },
     "packages/hf-space": {
       "name": "cad0-demo",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@vcad/kernel-wasm": "file:../kernel-wasm",
         "canvas": "^2.11.2"
@@ -24877,7 +24877,7 @@
     },
     "packages/ir": {
       "name": "@vcad/ir",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "devDependencies": {
         "typescript": "^5.7",
         "vitest": "^3.0"
@@ -24885,12 +24885,12 @@
     },
     "packages/kernel-wasm": {
       "name": "vcad-kernel-wasm",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT"
     },
     "packages/mcp": {
       "name": "@vcad/mcp",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@vcad/core": "*",
@@ -24922,7 +24922,7 @@
     },
     "packages/training": {
       "name": "@vcad/training",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/gateway": "^3.0.0",
@@ -25101,7 +25101,7 @@
       "license": "MIT"
     },
     "packages/wasmosis": {
-      "version": "0.9.2",
+      "version": "0.9.3",
       "bin": {
         "wasmosis": "dist/cli.js"
       },


### PR DESCRIPTION
## Summary

Follow-up to #102. The v0.9.3 release commit ran `npm run version:sync`,
which only updates `package.json` files — it doesn't regenerate the
lockfile. So every `packages/*` block in `package-lock.json` on main
still pins `0.9.2`, while the matching `package.json` says `0.9.3`.
`npm ci` enforces lockfile coherence and will fail with
`EUSAGE - Invalid: lock file's @vcad/app@0.9.3 does not satisfy
@vcad/app@0.9.2` before installing anything.

This blocks **CI on main, Vercel previews, and — most importantly — the
`v0.9.3` desktop-release matrix that's about to be tagged**, because
`tauri-action` runs `npm ci` as its first step.

Fix: re-run `npm install` (no dependency changes — just updates the
twelve `version` fields the sync script missed) and commit the result.

## Merge order

This needs to land **before** `git push origin v0.9.3`. Otherwise the
matrix kicks off, npm ci fails on every platform, and we have to retag.

## Test plan

- [ ] `npm ci` succeeds locally on this branch from a clean checkout.
- [ ] CI on this PR is green (Rust, audits, WASM build).
- [ ] After merge: `npm ci` on main is green before tagging v0.9.3.
- [ ] Add a `version:sync` follow-up to also run `npm install --package-lock-only`
  so this can't recur (out of scope for this PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhvNGybJe6z1bZzrdRw6Dh)_