### PR TITLE
Hide axis lines when document has parts or not orbiting

### DIFF
--- a/packages/app/src/components/GridPlane.tsx
+++ b/packages/app/src/components/GridPlane.tsx
@@ -1,9 +1,13 @@
 import { useMemo } from "react";
 import { Grid, Line } from "@react-three/drei";
 import { useTheme } from "@/hooks/useTheme";
+import { useDocumentStore, useUiStore } from "@vcad/core";
 
 export function GridPlane() {
   const { isDark } = useTheme();
+  const isOrbiting = useUiStore((s) => s.isOrbiting);
+  const hasParts = useDocumentStore((s) => s.parts.length > 0);
+  const showAxes = isOrbiting || !hasParts;
 
   // Axis lines at origin - RGB convention (X=red, Y=green, Z=blue)
   // Grid is outside the Z-up rotation group, so we draw in Three.js Y-up space
@@ -51,39 +55,40 @@ export function GridPlane() {
         fadeStrength={1}
         infiniteGrid
       />
-      {/* X axis - red */}
-      <Line
-        points={xAxisPoints}
-        color={isDark ? "#e06c75" : "#c94f4f"}
-        lineWidth={1.5}
-        transparent
-        opacity={0.7}
-        depthWrite={false}
-        depthTest={false}
-        renderOrder={1}
-      />
-      {/* Y axis - green */}
-      <Line
-        points={yAxisPoints}
-        color={isDark ? "#98c379" : "#5a9a4a"}
-        lineWidth={1.5}
-        transparent
-        opacity={0.7}
-        depthWrite={false}
-        depthTest={false}
-        renderOrder={1}
-      />
-      {/* Z axis - blue */}
-      <Line
-        points={zAxisPoints}
-        color={isDark ? "#61afef" : "#4a7dc9"}
-        lineWidth={1.5}
-        transparent
-        opacity={0.7}
-        depthWrite={false}
-        depthTest={false}
-        renderOrder={1}
-      />
+      {showAxes && (
+        <>
+          {/* X axis - red */}
+          <Line
+            points={xAxisPoints}
+            color={isDark ? "#e06c75" : "#c94f4f"}
+            lineWidth={1.5}
+            transparent
+            opacity={0.7}
+            depthWrite={false}
+            renderOrder={-1}
+          />
+          {/* Y axis - green */}
+          <Line
+            points={yAxisPoints}
+            color={isDark ? "#98c379" : "#5a9a4a"}
+            lineWidth={1.5}
+            transparent
+            opacity={0.7}
+            depthWrite={false}
+            renderOrder={-1}
+          />
+          {/* Z axis - blue */}
+          <Line
+            points={zAxisPoints}
+            color={isDark ? "#61afef" : "#4a7dc9"}
+            lineWidth={1.5}
+            transparent
+            opacity={0.7}
+            depthWrite={false}
+            renderOrder={-1}
+          />
+        </>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary
Updated the GridPlane component to conditionally render the X, Y, and Z axis lines based on the application state. The axes are now only displayed when the user is orbiting the view or when there are no parts in the document.

## Key Changes
- Added imports for `useDocumentStore` and `useUiStore` from `@vcad/core`
- Introduced `showAxes` computed state that evaluates to `true` when either orbiting or the document has no parts
- Wrapped all three axis Line components in a conditional fragment that only renders when `showAxes` is `true`
- Removed `depthTest={false}` property from axis lines (now only using `depthWrite={false}`)
- Changed `renderOrder` from `1` to `-1` for all axis lines to adjust rendering priority

## Implementation Details
The axes visibility logic follows this pattern:
- Show axes during orbit interactions (camera manipulation mode)
- Show axes when the document is empty (no parts loaded)
- Hide axes once parts exist and the user is not actively orbiting

This improves the UI by reducing visual clutter once the user has started building their model.

https://claude.ai/code/session_01KfwPtPEtEvBqG4Kdhz8Pp5