### PR TITLE
Add feedback button to header with modal dialog

### DIFF
--- a/changelog/entries/2026-04-25-feedback-button.json
+++ b/changelog/entries/2026-04-25-feedback-button.json
@@ -1,0 +1,12 @@
+{
+  "id": "2026-04-25-feedback-button",
+  "version": "0.9.3",
+  "date": "2026-04-25",
+  "category": "feat",
+  "title": "Header feedback button",
+  "summary": "A megaphone button in the header's top-right opens a quick feedback dialog. Submitting opens a prefilled GitHub issue so you can tell us what's working and what isn't.",
+  "features": [
+    "header",
+    "feedback"
+  ]
+}

--- a/packages/app/src/components/FeedbackModal.tsx
+++ b/packages/app/src/components/FeedbackModal.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "@phosphor-icons/react/dist/ssr/X";
+import { Megaphone } from "@phosphor-icons/react/dist/ssr/Megaphone";
+import { cn } from "@/lib/utils";
+
+const ISSUE_URL = "https://github.com/ecto/vcad/issues/new";
+
+export function FeedbackModal({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [text, setText] = useState("");
+
+  function submit() {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    const body = `${trimmed}\n\n---\n_Sent from vcad ${__APP_VERSION__} · ${navigator.userAgent}_`;
+    const url = `${ISSUE_URL}?body=${encodeURIComponent(body)}`;
+    window.open(url, "_blank", "noopener,noreferrer");
+    setText("");
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
+            "bg-surface p-6 shadow-2xl",
+            "focus:outline-none",
+          )}
+        >
+          <Dialog.Close className="absolute right-3 top-3 p-1.5 text-text-muted hover:text-text transition-colors cursor-pointer">
+            <X size={14} />
+          </Dialog.Close>
+
+          <div className="flex items-center gap-2 mb-1">
+            <Megaphone size={16} className="text-brand" />
+            <Dialog.Title className="text-sm font-medium text-text">
+              Send feedback
+            </Dialog.Title>
+          </div>
+          <Dialog.Description className="text-xs text-text-muted mb-3">
+            Bug, idea, or wish? Opens a GitHub issue with your message
+            prefilled.
+          </Dialog.Description>
+
+          <textarea
+            autoFocus
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            placeholder="What's on your mind?"
+            rows={6}
+            className={cn(
+              "w-full resize-none bg-bg p-3 text-xs text-text",
+              "placeholder:text-text-muted/60 focus:outline-none",
+              "border border-border focus:border-brand/50 transition-colors",
+            )}
+          />
+
+          <div className="mt-3 flex items-center justify-between gap-2">
+            <span className="text-[10px] text-text-muted/60">
+              ⌘↵ to submit
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className={cn(
+                  "h-7 px-3 text-xs text-text-muted hover:text-text",
+                  "hover:bg-hover transition-colors",
+                )}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={submit}
+                disabled={!text.trim()}
+                className={cn(
+                  "h-7 px-3 text-xs font-medium",
+                  "bg-brand text-white hover:bg-brand/90 transition-colors",
+                  "disabled:opacity-40 disabled:cursor-not-allowed",
+                )}
+              >
+                Send
+              </button>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { CaretRight } from "@phosphor-icons/react/dist/ssr/CaretRight";
 import { Export } from "@phosphor-icons/react/dist/ssr/Export";
 import { MagnifyingGlass } from "@phosphor-icons/react/dist/ssr/MagnifyingGlass";
 import { Bell } from "@phosphor-icons/react/dist/ssr/Bell";
+import { Megaphone } from "@phosphor-icons/react/dist/ssr/Megaphone";
 import { Link as LinkIcon } from "@phosphor-icons/react/dist/ssr/Link";
 import { DocTitle } from "@/components/DocTitle";
 import * as Menubar from "@radix-ui/react-menubar";
@@ -41,6 +42,10 @@ const InputPreferencesDialog = lazy(() =>
   import("./InputPreferencesDialog").then((m) => ({
     default: m.InputPreferencesDialog,
   })),
+);
+
+const FeedbackModal = lazy(() =>
+  import("./FeedbackModal").then((m) => ({ default: m.FeedbackModal })),
 );
 
 interface HeaderProps {
@@ -299,6 +304,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
   const billingTier = useBillingStore((s) => s.snapshot?.tier ?? null);
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const [inputPrefsOpen, setInputPrefsOpen] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [menuValue, setMenuValue] = useState("");
   const unreadChangelog = useChangelogStore((s) => s.getUnreadCount());
   const openChangelogPanel = useChangelogStore((s) => s.openPanel);
@@ -649,6 +655,18 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
             />
           )}
         </button>
+        <button
+          type="button"
+          onClick={() => setFeedbackOpen(true)}
+          title="Send feedback"
+          aria-label="Send feedback"
+          className={cn(
+            "relative flex items-center justify-center w-6 h-6",
+            "text-text-muted hover:text-text hover:bg-hover transition-colors",
+          )}
+        >
+          <Megaphone size={13} />
+        </button>
         <SignInButton
           variant="icon-text"
           className={cn(
@@ -683,6 +701,11 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           open={inputPrefsOpen}
           onOpenChange={setInputPrefsOpen}
         />
+      </Suspense>
+      <Suspense fallback={null}>
+        {feedbackOpen && (
+          <FeedbackModal open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+        )}
       </Suspense>
 
       {/* ─────────────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary
This PR adds a feedback mechanism to the application by introducing a new feedback button in the header that opens a modal dialog for users to submit bug reports, feature ideas, and general feedback directly to GitHub issues.

## Key Changes
- **New FeedbackModal component** (`packages/app/src/components/FeedbackModal.tsx`): A reusable modal dialog that allows users to compose and submit feedback. The modal:
  - Uses Radix UI Dialog for accessible modal behavior
  - Provides a textarea for users to type their feedback
  - Supports keyboard shortcut (Cmd/Ctrl + Enter) for quick submission
  - Automatically opens a prefilled GitHub issue with the user's message, app version, and user agent
  - Clears the input and closes after submission

- **Header integration** (`packages/app/src/components/Header.tsx`):
  - Added a megaphone icon button in the top-right of the header
  - Lazy-loads the FeedbackModal component for better code splitting
  - Manages feedback modal open/close state

- **Changelog entry**: Documents the new feature for version 0.9.3

## Implementation Details
- The feedback submission constructs a GitHub issue URL with the user's message and system information (app version and user agent) as the issue body
- The modal uses the existing design system tokens (colors, spacing, typography) for consistency
- The submit button is disabled when the textarea is empty to prevent blank submissions
- The modal is lazy-loaded and only rendered when opened to minimize initial bundle size

https://claude.ai/code/session_011o3bCg5sZ3RFAYUyBpNffb