### PR TITLE
feat: sub-feature selection — faces, edges, vertices end-to-end

### DIFF
--- a/crates/vcad-app/src/lib.rs
+++ b/crates/vcad-app/src/lib.rs
@@ -32,4 +32,4 @@ pub use materializer::{materialize, MaterializeResult};
 pub use mode::{AppMode, ModeScope, Target};
 pub use part_info::PartInfo;
 pub use registry::{KeybindingRegistry, LoadError};
-pub use selection::Selection;
+pub use selection::{Selection, SelectionFilter, SelectionItem};

--- a/crates/vcad-app/src/selection.rs
+++ b/crates/vcad-app/src/selection.rs
@@ -1,12 +1,60 @@
 //! Selection state management.
+//!
+//! Tagged-union storage that mirrors the TS `SelectionItem` shape. The
+//! existing part-only API (`select` / `toggle` / `contains` / `single` /
+//! `ids`) is preserved for back-compat — internally these operate on items
+//! of `SelectionItem::Part(_)`. Sub-feature kinds (face / edge / vertex)
+//! are interactive only; they're dropped when topology changes.
 
 use std::collections::HashSet;
 use vcad_ir::NodeId;
 
-/// Manages the current selection of nodes.
+/// Selection filter — restricts what the picker will return on the next
+/// pointer event. Mirrors the TS `SelectionFilter`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SelectionFilter {
+    #[default]
+    Auto,
+    Body,
+    Face,
+    Edge,
+    Vertex,
+}
+
+/// One thing the user can hover or click on. Mirrors the TS `SelectionItem`
+/// discriminated union.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SelectionItem {
+    Part(NodeId),
+    Face { part_id: NodeId, face_index: u32 },
+    Edge { part_id: NodeId, edge_id: u32 },
+    Vertex { part_id: NodeId, vertex_id: u32 },
+    Segment { sketch_id: String, index: u32 },
+    Constraint { sketch_id: String, index: u32 },
+}
+
+impl SelectionItem {
+    /// If this item is associated with a part, return its `NodeId`.
+    pub fn part_id(&self) -> Option<NodeId> {
+        match self {
+            SelectionItem::Part(id) => Some(*id),
+            SelectionItem::Face { part_id, .. } => Some(*part_id),
+            SelectionItem::Edge { part_id, .. } => Some(*part_id),
+            SelectionItem::Vertex { part_id, .. } => Some(*part_id),
+            SelectionItem::Segment { .. } | SelectionItem::Constraint { .. } => None,
+        }
+    }
+}
+
+/// Manages the current selection.
+///
+/// Stores items as a `Vec` so order is preserved (matches the TS array shape
+/// the web UI uses for ordered display). Lookup helpers (`contains`, `ids`,
+/// `single`) walk the vec — selection is small (typically < 10 items), so
+/// the linear scan is fine.
 #[derive(Debug, Clone, Default)]
 pub struct Selection {
-    selected: HashSet<NodeId>,
+    items: Vec<SelectionItem>,
 }
 
 impl Selection {
@@ -14,72 +62,142 @@ impl Selection {
         Self::default()
     }
 
-    /// Select a single node (replacing current selection).
+    /// Select a single part (replacing current selection).
     pub fn select(&mut self, id: NodeId) {
-        self.selected.clear();
-        self.selected.insert(id);
+        self.items.clear();
+        self.items.push(SelectionItem::Part(id));
     }
 
-    /// Add a node to the selection.
+    /// Add a part to the selection.
     pub fn select_add(&mut self, id: NodeId) {
-        self.selected.insert(id);
-    }
-
-    /// Toggle a node's selection state.
-    pub fn toggle(&mut self, id: NodeId) {
-        if !self.selected.remove(&id) {
-            self.selected.insert(id);
+        if !self.items.iter().any(|it| matches!(it, SelectionItem::Part(p) if *p == id)) {
+            self.items.push(SelectionItem::Part(id));
         }
     }
 
-    /// Deselect a specific node.
+    /// Toggle a part's selection state.
+    pub fn toggle(&mut self, id: NodeId) {
+        let pos = self
+            .items
+            .iter()
+            .position(|it| matches!(it, SelectionItem::Part(p) if *p == id));
+        match pos {
+            Some(i) => {
+                self.items.remove(i);
+            }
+            None => self.items.push(SelectionItem::Part(id)),
+        }
+    }
+
+    /// Deselect a specific part.
     pub fn deselect(&mut self, id: NodeId) {
-        self.selected.remove(&id);
+        self.items
+            .retain(|it| !matches!(it, SelectionItem::Part(p) if *p == id));
     }
 
     /// Clear the entire selection.
     pub fn clear(&mut self) {
-        self.selected.clear();
+        self.items.clear();
     }
 
-    /// Check if a node is selected.
+    /// Check if a part is selected.
     pub fn contains(&self, id: NodeId) -> bool {
-        self.selected.contains(&id)
+        self.items
+            .iter()
+            .any(|it| matches!(it, SelectionItem::Part(p) if *p == id))
     }
 
     /// Check if selection is empty.
     pub fn is_empty(&self) -> bool {
-        self.selected.is_empty()
+        self.items.is_empty()
     }
 
-    /// Number of selected nodes.
+    /// Number of selected items.
     pub fn len(&self) -> usize {
-        self.selected.len()
+        self.items.len()
     }
 
-    /// Get the selected node IDs.
-    pub fn ids(&self) -> &HashSet<NodeId> {
-        &self.selected
+    /// Number of selected parts (excluding sub-features and sketch entities).
+    pub fn part_count(&self) -> usize {
+        self.items
+            .iter()
+            .filter(|it| matches!(it, SelectionItem::Part(_)))
+            .count()
     }
 
-    /// Get a single selected ID (if exactly one is selected).
+    /// Get the selected part IDs as a set. Derived view — Vec → HashSet
+    /// each call, but selection is tiny so the cost is negligible.
+    pub fn ids(&self) -> HashSet<NodeId> {
+        self.items
+            .iter()
+            .filter_map(|it| match it {
+                SelectionItem::Part(id) => Some(*id),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Get a single selected part ID (if exactly one part is selected,
+    /// ignoring any sub-feature items).
     pub fn single(&self) -> Option<NodeId> {
-        if self.selected.len() == 1 {
-            self.selected.iter().copied().next()
-        } else {
+        let mut iter = self.items.iter().filter_map(|it| match it {
+            SelectionItem::Part(id) => Some(*id),
+            _ => None,
+        });
+        let first = iter.next()?;
+        if iter.next().is_some() {
             None
+        } else {
+            Some(first)
         }
     }
 
-    /// Select multiple nodes at once (replacing current selection).
+    /// Select multiple parts at once (replacing current selection).
     pub fn select_many(&mut self, ids: impl IntoIterator<Item = NodeId>) {
-        self.selected.clear();
-        self.selected.extend(ids);
+        self.items.clear();
+        for id in ids {
+            self.items.push(SelectionItem::Part(id));
+        }
     }
 
-    /// Remove nodes that no longer exist in the document.
+    /// Remove parts that no longer exist in the document. Sub-feature
+    /// items whose owning part is gone are also removed.
     pub fn retain(&mut self, valid: &HashSet<NodeId>) {
-        self.selected.retain(|id| valid.contains(id));
+        self.items.retain(|it| match it {
+            SelectionItem::Part(id) => valid.contains(id),
+            SelectionItem::Face { part_id, .. }
+            | SelectionItem::Edge { part_id, .. }
+            | SelectionItem::Vertex { part_id, .. } => valid.contains(part_id),
+            SelectionItem::Segment { .. } | SelectionItem::Constraint { .. } => true,
+        });
+    }
+
+    // ── Sub-feature selection ──────────────────────────────────────────
+
+    /// Replace the entire selection with a single tagged item.
+    pub fn select_item(&mut self, item: SelectionItem) {
+        self.items.clear();
+        self.items.push(item);
+    }
+
+    /// Toggle a tagged item in/out of the selection.
+    pub fn toggle_item(&mut self, item: SelectionItem) {
+        match self.items.iter().position(|existing| existing == &item) {
+            Some(i) => {
+                self.items.remove(i);
+            }
+            None => self.items.push(item),
+        }
+    }
+
+    /// Replace the entire selection with a list of items.
+    pub fn select_items(&mut self, items: impl IntoIterator<Item = SelectionItem>) {
+        self.items = items.into_iter().collect();
+    }
+
+    /// Borrow the full item list.
+    pub fn items(&self) -> &[SelectionItem] {
+        &self.items
     }
 }
 
@@ -122,5 +240,79 @@ mod tests {
         assert_eq!(sel.single(), Some(42));
         sel.select_add(43);
         assert!(sel.single().is_none());
+    }
+
+    #[test]
+    fn test_ids_returns_only_parts() {
+        let mut sel = Selection::new();
+        sel.select(1);
+        sel.toggle_item(SelectionItem::Face {
+            part_id: 1,
+            face_index: 3,
+        });
+        sel.toggle_item(SelectionItem::Edge {
+            part_id: 2,
+            edge_id: 7,
+        });
+        let ids = sel.ids();
+        assert_eq!(ids.len(), 1);
+        assert!(ids.contains(&1));
+        // Edge added 2 to selection but not as a Part — `ids()` filters it out.
+        assert!(!ids.contains(&2));
+    }
+
+    #[test]
+    fn test_part_count_excludes_sub_features() {
+        let mut sel = Selection::new();
+        sel.select(1);
+        sel.toggle_item(SelectionItem::Face {
+            part_id: 1,
+            face_index: 0,
+        });
+        assert_eq!(sel.len(), 2);
+        assert_eq!(sel.part_count(), 1);
+    }
+
+    #[test]
+    fn test_select_item_replaces_everything() {
+        let mut sel = Selection::new();
+        sel.select(1);
+        sel.select_add(2);
+        sel.select_item(SelectionItem::Face {
+            part_id: 9,
+            face_index: 4,
+        });
+        assert_eq!(sel.len(), 1);
+        assert!(matches!(
+            sel.items()[0],
+            SelectionItem::Face { face_index: 4, .. }
+        ));
+    }
+
+    #[test]
+    fn test_toggle_item_round_trip() {
+        let mut sel = Selection::new();
+        let face = SelectionItem::Face {
+            part_id: 1,
+            face_index: 2,
+        };
+        sel.toggle_item(face.clone());
+        assert!(sel.items().contains(&face));
+        sel.toggle_item(face.clone());
+        assert!(!sel.items().contains(&face));
+    }
+
+    #[test]
+    fn test_retain_drops_sub_features_for_missing_parts() {
+        let mut sel = Selection::new();
+        sel.select(1);
+        sel.toggle_item(SelectionItem::Face {
+            part_id: 2,
+            face_index: 0,
+        });
+        let valid: HashSet<NodeId> = [1].into_iter().collect();
+        sel.retain(&valid);
+        assert_eq!(sel.len(), 1);
+        assert!(sel.contains(1));
     }
 }

--- a/crates/vcad-app/src/selection.rs
+++ b/crates/vcad-app/src/selection.rs
@@ -70,7 +70,11 @@ impl Selection {
 
     /// Add a part to the selection.
     pub fn select_add(&mut self, id: NodeId) {
-        if !self.items.iter().any(|it| matches!(it, SelectionItem::Part(p) if *p == id)) {
+        if !self
+            .items
+            .iter()
+            .any(|it| matches!(it, SelectionItem::Part(p) if *p == id))
+        {
             self.items.push(SelectionItem::Part(id));
         }
     }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -7,6 +7,7 @@ import {
   Suspense,
 } from "react";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
 import { NotificationContainer } from "@/components/ui/notifications";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { AsyncBoundary } from "@/components/AsyncBoundary";
@@ -142,35 +143,61 @@ async function syncNativeWindowTheme(theme: "light" | "dark") {
   }
 }
 
-/** Left sidebar: tree by default, drills into inspector when something is selected. */
+/** Left sidebar: feature tree on top + contextual inspector below.
+ *  The tree is the source of truth for navigation and stays visible even
+ *  when the user drills into a part / sub-feature; the inspector slides
+ *  in below as a separate pane sharing the sidebar height.
+ *
+ *  Two cases skip the split:
+ *  - Sketch mode: tree-only (it gains sketch entity branches and the
+ *    sketch property manager lives on the right).
+ *  - Parameters pane: parameters-only (deliberate user switch via the
+ *    sidebarPane store; user wants the full pane). */
 function FeatureTreeSlot({ sketchActive }: { sketchActive: boolean }) {
   const sidebarPane = useUiStore((s) => s.sidebarPane);
   const inspectorTarget = useUiStore((s) => s.inspectorTarget);
-  // While a sketch is open, the LEFT sidebar always shows the FeatureTree
-  // (which gains sketch entity/constraint branches via SketchTreeSection).
-  // The RIGHT sidebar takes over for the SketchPropertyPanel — splitting
-  // navigator and inspector matches the SolidWorks layout we're emulating.
-  const showTree = sketchActive || sidebarPane === "tree";
+  const selectionLen = useUiStore((s) => s.selection.length);
+
   const showParameters = !sketchActive && sidebarPane === "parameters";
+  const hasInspectorContent =
+    inspectorTarget?.kind === "scene" || selectionLen > 0;
+  const showInspector = !sketchActive && !showParameters && hasInspectorContent;
+
   return (
     <div className="flex h-full w-full flex-col min-h-0">
-      <div className="flex-1 min-h-0 overflow-hidden">
-        {showTree ? (
-          <FeatureTree />
-        ) : showParameters ? (
+      {/* Top: tree (or parameters panel when the user explicitly switched).
+          Tree always visible during sketch — it gains sketch sections. */}
+      <div
+        className={cn(
+          "min-h-0 overflow-hidden",
+          showInspector ? "flex-[3]" : "flex-1",
+        )}
+      >
+        {showParameters ? (
           <AsyncBoundary region="parameters-panel" fallback={null}>
             <ParametersPanel />
           </AsyncBoundary>
-        ) : inspectorTarget?.kind === "scene" ? (
-          <AsyncBoundary region="scene-inspector" fallback={null}>
-            <SceneInspector />
-          </AsyncBoundary>
         ) : (
-          <AsyncBoundary region="property-panel" fallback={null}>
-            <PropertyPanel />
-          </AsyncBoundary>
+          <FeatureTree />
         )}
       </div>
+
+      {/* Bottom: contextual inspector. Slides in when the user selects
+          something or pins the scene inspector. Border-top separates it
+          from the tree above. */}
+      {showInspector && (
+        <div className="flex-[2] min-h-0 overflow-hidden border-t border-border/40">
+          {inspectorTarget?.kind === "scene" ? (
+            <AsyncBoundary region="scene-inspector" fallback={null}>
+              <SceneInspector />
+            </AsyncBoundary>
+          ) : (
+            <AsyncBoundary region="property-panel" fallback={null}>
+              <PropertyPanel />
+            </AsyncBoundary>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -245,16 +245,19 @@ export function App() {
 
   // Auto-drill the left sidebar into the inspector when something is selected,
   // and back to the tree when selection clears. Selecting a part also clears
-  // the scene inspector target so the scene doesn't shadow the part.
+  // the scene inspector target so the scene doesn't shadow the part. Watches
+  // the full selection length so sub-feature picks (face / edge / vertex)
+  // open the inspector too.
+  const selectionLen = useUiStore((s) => s.selection.length);
   useEffect(() => {
     const { setSidebarPane, setInspectorTarget } = useUiStore.getState();
-    if (selIds.size >= 1) {
+    if (selectionLen >= 1) {
       setInspectorTarget(null);
       setSidebarPane("inspector");
     } else if (useUiStore.getState().inspectorTarget == null) {
       setSidebarPane("tree");
     }
-  }, [selIds]);
+  }, [selectionLen]);
 
   const handleSave = useCallback(() => {
     const state = useDocumentStore.getState();

--- a/packages/app/src/components/ChatSidebar.tsx
+++ b/packages/app/src/components/ChatSidebar.tsx
@@ -136,19 +136,58 @@ function AttachmentPreviewStrip() {
 // ---------------------------------------------------------------------------
 
 function useSelectionContext(): [SelectionContext[], (partId: string) => void] {
+  const selection = useUiStore((s) => s.selection);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const partIndex = useDocumentStore((s) => s.partIndex);
 
+  // Walk the full selection union — surface sub-feature picks (face / edge
+  // / vertex) so the AI can act on exactly what the user has selected.
+  // The historical part-only path still works because part items emit
+  // geometryType: "part".
   const contexts: SelectionContext[] = [];
-  for (const partId of selectedPartIds) {
-    const part = partIndex.get(partId);
-    if (part) {
-      contexts.push({
-        partId,
-        partName: part.name,
-        geometryType: "part",
-      });
+  for (const item of selection) {
+    if (item.kind === "part") {
+      const part = partIndex.get(item.id);
+      if (part) {
+        contexts.push({
+          partId: item.id,
+          partName: part.name,
+          geometryType: "part",
+        });
+      }
+    } else if (item.kind === "face") {
+      const part = partIndex.get(item.partId);
+      if (part) {
+        contexts.push({
+          partId: item.partId,
+          partName: part.name,
+          geometryType: "face",
+          faceIndex: item.faceIndex,
+        });
+      }
+    } else if (item.kind === "edge") {
+      const part = partIndex.get(item.partId);
+      if (part) {
+        contexts.push({
+          partId: item.partId,
+          partName: part.name,
+          geometryType: "edge",
+          dimensions: { edgeId: item.edgeId },
+        });
+      }
+    } else if (item.kind === "vertex") {
+      const part = partIndex.get(item.partId);
+      if (part) {
+        contexts.push({
+          partId: item.partId,
+          partName: part.name,
+          geometryType: "vertex",
+          dimensions: { vertexId: item.vertexId },
+        });
+      }
     }
+    // segment / constraint — sketch-mode entities, not surfaced to chat
+    // here since the AI's CAD tools don't operate on those yet.
   }
 
   const removeContext = useCallback(

--- a/packages/app/src/components/FeatureTree.tsx
+++ b/packages/app/src/components/FeatureTree.tsx
@@ -487,7 +487,9 @@ function TreeNode({
   isDragging,
 }: TreeNodeProps) {
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
+  const selection = useUiStore((s) => s.selection);
   const hoveredPartId = useUiStore((s) => s.hoveredPartId);
+  const hoveredItem = useUiStore((s) => s.hoveredItem);
   const treeFocusedPartId = useUiStore((s) => s.treeFocusedPartId);
   const setHoveredPartId = useUiStore((s) => s.setHoveredPartId);
   const select = useUiStore((s) => s.select);
@@ -499,7 +501,26 @@ function TreeNode({
 
   const Icon = getPartIcon(part);
   const isSelected = selectedPartIds.has(part.id);
-  const isHovered = hoveredPartId === part.id;
+  // "Indirect" selection — the user picked a face / edge / vertex *on* this
+  // part. The tree row stays visible so the user can see where they are
+  // in the hierarchy, with a softer brand pulse instead of full selection
+  // styling.
+  const hasSubFeatureSelection =
+    !isSelected &&
+    selection.some(
+      (it) =>
+        (it.kind === "face" ||
+          it.kind === "edge" ||
+          it.kind === "vertex") &&
+        it.partId === part.id,
+    );
+  const hasSubFeatureHover =
+    hoveredItem != null &&
+    (hoveredItem.kind === "face" ||
+      hoveredItem.kind === "edge" ||
+      hoveredItem.kind === "vertex") &&
+    hoveredItem.partId === part.id;
+  const isHovered = hoveredPartId === part.id || hasSubFeatureHover;
   const isTreeFocused = treeFocusedPartId === part.id;
   const isRenaming = renamingId === part.id;
 
@@ -581,6 +602,8 @@ function TreeNode({
           "group flex items-center gap-1 px-2 py-1 text-xs cursor-pointer rounded",
           isSelected
             ? "bg-brand/20 text-brand backdrop-blur-sm"
+            : hasSubFeatureSelection
+            ? "bg-brand/[0.08] text-brand/90 backdrop-blur-sm"
             : isHovered
             ? "bg-surface/80 text-text backdrop-blur-sm"
             : "text-text-muted/90 hover:bg-surface/60 hover:text-text hover:backdrop-blur-sm",

--- a/packages/app/src/components/PropertyPanel.tsx
+++ b/packages/app/src/components/PropertyPanel.tsx
@@ -17,7 +17,10 @@ function BackButton() {
 }
 import { Tooltip } from "@/components/ui/tooltip";
 import { ScrubInput } from "@/components/ui/scrub-input";
-import { useDocumentStore, useUiStore, isPrimitivePart, isBooleanPart, isSweepPart, isEmbroideryPatternPart, isStitchPart, isPcbBoardPart, isExtrudePart, isRevolvePart, isFilletPart, isChamferPart, isShellPart, isLinearPatternPart, isCircularPatternPart, isLoftPart, isTextPart, isMirrorPart, f64, vec3, bool, t, tFmt } from "@vcad/core";
+import { useDocumentStore, useUiStore, useEngineStore, isPrimitivePart, isBooleanPart, isSweepPart, isEmbroideryPatternPart, isStitchPart, isPcbBoardPart, isExtrudePart, isRevolvePart, isFilletPart, isChamferPart, isShellPart, isLinearPatternPart, isCircularPatternPart, isLoftPart, isTextPart, isMirrorPart, f64, vec3, bool, t, tFmt } from "@vcad/core";
+import type { SelectionItem } from "@vcad/core";
+import { Vector3 } from "three";
+import { findCoplanarTriangles, getEdgeEndpoints, getVertex } from "@/lib/sub-feature-geometry";
 import { useLocaleStore } from "@/stores/locale-store";
 import { useElectronicsStore } from "@/stores/electronics-store";
 import { useEmbroideryStore } from "@/stores/embroidery-store";
@@ -1258,8 +1261,130 @@ function JointPropertiesPanel({ joint }: { joint: Joint }) {
   );
 }
 
+/**
+ * Inspector panel for a single face / edge / vertex selection. Read-only —
+ * shows derived measurements (face area, edge length, vertex coords) and
+ * the owning part's name. Vertex coords are typeable; in this PR they're
+ * read-only because applying a vertex move requires kernel-side support.
+ */
+function SubFeatureInspector({
+  item,
+}: {
+  item: Extract<SelectionItem, { kind: "face" | "edge" | "vertex" }>;
+}) {
+  const parts = useDocumentStore((s) => s.parts);
+  const scene = useEngineStore((s) => s.scene);
+  const clearSelection = useUiStore((s) => s.clearSelection);
+  useLocaleStore((s) => s.locale);
+
+  const part = parts.find((p) => p.id === item.partId);
+  const partIdx = parts.findIndex((p) => p.id === item.partId);
+  const mesh = partIdx >= 0 ? scene?.parts[partIdx]?.mesh : null;
+
+  const stats = useMemo(() => {
+    if (!mesh) return null;
+    if (item.kind === "face") {
+      const tris = findCoplanarTriangles(mesh, item.faceIndex);
+      let area = 0;
+      const _e1 = new Vector3();
+      const _e2 = new Vector3();
+      const _v0 = new Vector3();
+      const _v1 = new Vector3();
+      const _v2 = new Vector3();
+      for (const t of tris) {
+        const i0 = mesh.indices[t * 3]!;
+        const i1 = mesh.indices[t * 3 + 1]!;
+        const i2 = mesh.indices[t * 3 + 2]!;
+        _v0.set(mesh.positions[i0 * 3]!, mesh.positions[i0 * 3 + 1]!, mesh.positions[i0 * 3 + 2]!);
+        _v1.set(mesh.positions[i1 * 3]!, mesh.positions[i1 * 3 + 1]!, mesh.positions[i1 * 3 + 2]!);
+        _v2.set(mesh.positions[i2 * 3]!, mesh.positions[i2 * 3 + 1]!, mesh.positions[i2 * 3 + 2]!);
+        _e1.subVectors(_v1, _v0);
+        _e2.subVectors(_v2, _v0);
+        area += _e1.cross(_e2).length() * 0.5;
+      }
+      return { kind: "face" as const, area, triCount: tris.length };
+    }
+    if (item.kind === "edge") {
+      const { a, b } = getEdgeEndpoints(mesh, item.edgeId);
+      const length = a.distanceTo(b);
+      return { kind: "edge" as const, length, a, b };
+    }
+    // vertex
+    const p = getVertex(mesh, item.vertexId);
+    return { kind: "vertex" as const, position: p };
+  }, [mesh, item]);
+
+  return (
+    <div className={cn("w-full flex flex-col bg-surface", "h-full")}>
+      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <BackButton />
+          <span className="text-xs font-medium text-text capitalize">
+            {item.kind}
+          </span>
+          {part?.name && (
+            <span className="text-xs text-text-muted truncate">
+              on {part.name}
+            </span>
+          )}
+        </div>
+        <button
+          onClick={clearSelection}
+          className="flex h-6 w-6 items-center justify-center text-text-muted hover:text-text hover:bg-hover"
+          aria-label="Clear selection"
+        >
+          <X size={12} />
+        </button>
+      </div>
+
+      <div className="px-3 py-2 space-y-2 text-xs text-text">
+        {!stats && <span className="text-text-muted">Mesh not available.</span>}
+        {stats && stats.kind === "face" && item.kind === "face" && (
+          <>
+            <Row label="Area" value={`${stats.area.toFixed(2)} mm²`} />
+            <Row label="Triangles" value={String(stats.triCount)} />
+            <Row label="Face index" value={String(item.faceIndex)} />
+          </>
+        )}
+        {stats && stats.kind === "edge" && (
+          <>
+            <Row label="Length" value={`${stats.length.toFixed(2)} mm`} />
+            <Row
+              label="From"
+              value={`(${stats.a.x.toFixed(1)}, ${stats.a.y.toFixed(1)}, ${stats.a.z.toFixed(1)})`}
+            />
+            <Row
+              label="To"
+              value={`(${stats.b.x.toFixed(1)}, ${stats.b.y.toFixed(1)}, ${stats.b.z.toFixed(1)})`}
+            />
+          </>
+        )}
+        {stats && stats.kind === "vertex" && (
+          <>
+            <Row label="X" value={`${stats.position.x.toFixed(2)} mm`} />
+            <Row label="Y" value={`${stats.position.y.toFixed(2)} mm`} />
+            <Row label="Z" value={`${stats.position.z.toFixed(2)} mm`} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-text-muted uppercase tracking-wider text-[10px]">
+        {label}
+      </span>
+      <span className="tabular-nums">{value}</span>
+    </div>
+  );
+}
+
 export function PropertyPanel() {
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
+  const selection = useUiStore((s) => s.selection);
   const clearSelection = useUiStore((s) => s.clearSelection);
   const parts = useDocumentStore((s) => s.parts);
   const document = useDocumentStore((s) => s.document);
@@ -1269,13 +1394,30 @@ export function PropertyPanel() {
   // Close panel on Escape
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && selectedPartIds.size > 0) {
+      if (e.key === "Escape" && selection.length > 0) {
         clearSelection();
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedPartIds.size, clearSelection]);
+  }, [selection.length, clearSelection]);
+
+  if (selection.length === 0) return null;
+
+  // Sub-feature dispatcher: when the first selected item is a face / edge /
+  // vertex, render the corresponding inspector instead of the part panel.
+  // Multi-select of sub-features falls through to the part panel below
+  // (which collapses to "N parts selected" anyway).
+  const firstItem = selection[0];
+  if (
+    selection.length === 1 &&
+    firstItem &&
+    (firstItem.kind === "face" ||
+      firstItem.kind === "edge" ||
+      firstItem.kind === "vertex")
+  ) {
+    return <SubFeatureInspector item={firstItem} />;
+  }
 
   if (selectedPartIds.size === 0) return null;
 

--- a/packages/app/src/components/PropertyPanel.tsx
+++ b/packages/app/src/components/PropertyPanel.tsx
@@ -1317,17 +1317,10 @@ function SubFeatureInspector({
   return (
     <div className={cn("w-full flex flex-col bg-surface", "h-full")}>
       <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3">
-        <div className="flex items-center gap-2 min-w-0">
-          <BackButton />
-          <span className="text-xs font-medium text-text capitalize">
-            {item.kind}
-          </span>
-          {part?.name && (
-            <span className="text-xs text-text-muted truncate">
-              on {part.name}
-            </span>
-          )}
-        </div>
+        <Breadcrumb
+          item={item}
+          partName={part?.name}
+        />
         <button
           onClick={clearSelection}
           className="flex h-6 w-6 items-center justify-center text-text-muted hover:text-text hover:bg-hover"
@@ -1380,6 +1373,87 @@ function Row({ label, value }: { label: string; value: string }) {
       <span className="tabular-nums">{value}</span>
     </div>
   );
+}
+
+/**
+ * Breadcrumb in inspector headers — `Document ▸ Part ▸ face` etc.
+ * Each crumb is a click target that steps the selection up to that level:
+ *   - Document → clearSelection
+ *   - Part     → select(partId)
+ *   - Sub-feature → terminal (no further nav)
+ *
+ * Used by both the part inspector and the SubFeatureInspector so
+ * navigation feels uniform.
+ */
+function Breadcrumb({
+  item,
+  partName,
+}: {
+  item: SelectionItem;
+  partName?: string;
+}) {
+  const docName = useDocumentStore((s) => s.documentName) ?? "Document";
+  const select = useUiStore((s) => s.select);
+  const clearSelection = useUiStore((s) => s.clearSelection);
+
+  const subKind =
+    item.kind === "face" || item.kind === "edge" || item.kind === "vertex"
+      ? item.kind
+      : null;
+  const partId =
+    item.kind === "part"
+      ? item.id
+      : (item as { partId?: string }).partId ?? null;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1 text-xs">
+      <BackButton />
+      <Crumb label={docName} onClick={clearSelection} />
+      {partId && (
+        <>
+          <Separator />
+          <Crumb
+            label={partName ?? partId}
+            onClick={subKind ? () => select(partId) : undefined}
+          />
+        </>
+      )}
+      {subKind && (
+        <>
+          <Separator />
+          <span className="text-text capitalize">{subKind}</span>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Crumb({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick?: () => void;
+}) {
+  if (!onClick) {
+    return (
+      <span className="truncate text-text-muted/80 max-w-[12ch]">{label}</span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="truncate max-w-[12ch] text-text-muted hover:text-text hover:underline underline-offset-2 decoration-text-muted/40 transition-colors"
+      title={label}
+    >
+      {label}
+    </button>
+  );
+}
+
+function Separator() {
+  return <span className="text-text-muted/40 shrink-0">›</span>;
 }
 
 export function PropertyPanel() {
@@ -1505,13 +1579,10 @@ export function PropertyPanel() {
     >
       {/* Mobile drag handle */}
 
-      {/* Header */}
+      {/* Header — breadcrumb + part-kind badge + close. */}
       <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border/40 px-3">
         <div className="flex items-center gap-2 min-w-0">
-          <BackButton />
-          <span className="text-xs font-medium text-text truncate">
-            {part.name}
-          </span>
+          <Breadcrumb item={{ kind: "part", id: part.id }} partName={part.name} />
           <PartTypeBadge kind={part.kind} />
         </div>
         <button

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useMemo, useCallback, useState } from "react";
 import * as THREE from "three";
 import { Edges, Html } from "@react-three/drei";
+import { useThree } from "@react-three/fiber";
 import type { TriangleMesh, PartInfo, FaceInfo } from "@vcad/core";
 import { useUiStore, useDocumentStore, useSketchStore, isPcbBoardPart, isStitchPart, isEmbroideryPatternPart } from "@vcad/core";
 import { useElectronicsStore } from "@/stores/electronics-store";
@@ -15,6 +16,7 @@ import {
 } from "@/shaders";
 import { useDebugOverlayStore } from "@/stores/debug-overlay-store";
 import { inspectTriangleFromMesh as runInspectTriangle } from "./TriangleInspector";
+import { pickSubFeature } from "@/lib/sub-feature-picking";
 
 const HOVER_EMISSIVE = new THREE.Color(0xffb800); // neon amber
 const FACE_HIGHLIGHT_COLOR = new THREE.Color(0x00d4ff); // cyan for face selection
@@ -378,9 +380,15 @@ export const SceneMesh = memo(function SceneMesh({
   const [geoReady, setGeoReady] = useState(false);
   const select = useUiStore((s) => s.select);
   const toggleSelect = useUiStore((s) => s.toggleSelect);
+  const selectItem = useUiStore((s) => s.selectItem);
+  const toggleItem = useUiStore((s) => s.toggleItem);
+  const setHoveredItem = useUiStore((s) => s.setHoveredItem);
+  const selectionFilter = useUiStore((s) => s.selectionFilter);
   const showWireframe = useUiStore((s) => s.showWireframe);
   const hoveredPartId = useUiStore((s) => s.hoveredPartId);
   const setHoveredPartId = useUiStore((s) => s.setHoveredPartId);
+  const camera = useThree((s) => s.camera);
+  const viewportSize = useThree((s) => s.size);
   const materials = useDocumentStore((s) => s.document.materials);
   const renamePart = useDocumentStore((s) => s.renamePart);
 
@@ -679,7 +687,31 @@ export const SceneMesh = memo(function SceneMesh({
         return;
       }
 
-      // Normal click behavior
+      // Sub-feature picker: vertex / edge / face / body, gated by the
+      // current selectionFilter. Falls through to body-only behavior when
+      // the filter is "auto" and there's no candidate within threshold,
+      // or when the filter is explicitly "body".
+      if (e.faceIndex != null) {
+        const item = pickSubFeature({
+          triIndex: e.faceIndex,
+          hitPoint: e.point,
+          mesh,
+          partId: partInfo.id,
+          filter: selectionFilter,
+          camera,
+          viewport: viewportSize,
+        });
+        if (item) {
+          if (e.nativeEvent.shiftKey) {
+            toggleItem(item);
+          } else {
+            selectItem(item);
+          }
+          return;
+        }
+      }
+
+      // Filter narrowed too far / fallback to part-level select.
       if (e.nativeEvent.shiftKey) {
         toggleSelect(partInfo.id);
       } else {
@@ -693,6 +725,11 @@ export const SceneMesh = memo(function SceneMesh({
       selectFace,
       toggleSelect,
       select,
+      selectItem,
+      toggleItem,
+      selectionFilter,
+      camera,
+      viewportSize,
       inspectTriangles,
       setCurrentInspection,
     ],
@@ -706,9 +743,40 @@ export const SceneMesh = memo(function SceneMesh({
         e.stopPropagation();
         const faceInfo = computeFaceInfo(mesh, e.faceIndex, partInfo.id);
         setHoveredFace(faceInfo);
+        return;
+      }
+      // Outside face-selection mode, drive the unified hovered item via
+      // the sub-feature picker. The filter restricts what kinds get
+      // picked; "auto" prefers vertex > edge > face. Falls back to body.
+      if (e.faceIndex != null) {
+        e.stopPropagation();
+        const item = pickSubFeature({
+          triIndex: e.faceIndex,
+          hitPoint: e.point,
+          mesh,
+          partId: partInfo.id,
+          filter: selectionFilter,
+          camera,
+          viewport: viewportSize,
+        });
+        if (item) {
+          setHoveredItem(item);
+        } else {
+          setHoveredItem({ kind: "part", id: partInfo.id });
+        }
       }
     },
-    [isOrbiting, faceSelectionMode, mesh, partInfo.id, setHoveredFace],
+    [
+      isOrbiting,
+      faceSelectionMode,
+      mesh,
+      partInfo.id,
+      setHoveredFace,
+      setHoveredItem,
+      selectionFilter,
+      camera,
+      viewportSize,
+    ],
   );
 
   const handlePointerOver = useCallback(

--- a/packages/app/src/components/SelectionOverlay.tsx
+++ b/packages/app/src/components/SelectionOverlay.tsx
@@ -1,14 +1,30 @@
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type ReactNode } from "react";
 import * as THREE from "three";
 import { Line } from "@react-three/drei";
+import { useFrame, useThree } from "@react-three/fiber";
 import {
   useUiStore,
   useDocumentStore,
   useEngineStore,
   useParticipantStore,
+  selectionItemsEqual,
+  type SelectionItem,
   LOCAL_PARTICIPANT_ID,
 } from "@vcad/core";
 import { useTheme } from "@/hooks/useTheme";
+import {
+  buildFaceHighlightGeometry,
+  findCoplanarTriangles,
+  getEdgeEndpoints,
+  getVertex,
+} from "@/lib/sub-feature-geometry";
+
+const SUB_HOVER_OPACITY = 0.4;
+const SUB_SELECTED_OPACITY = 0.85;
+const FACE_HOVER_COLOR = new THREE.Color(0x00d4ff);
+const FACE_SELECTED_COLOR = new THREE.Color(0xf92672);
+const SUB_HOVER_LINE_COLOR = "#00d4ff";
+const SUB_SELECTED_LINE_COLOR = "#f92672";
 
 const ACCENT_DARK = "#6b8fa3";
 const ACCENT_LIGHT = "#4a7080";
@@ -207,6 +223,174 @@ function CaptureAxesGnomon() {
   );
 }
 
+/** Look up a part's mesh from the engine scene. */
+function usePartMesh(partId: string) {
+  const scene = useEngineStore((s) => s.scene);
+  const parts = useDocumentStore((s) => s.parts);
+  return useMemo(() => {
+    if (!scene) return null;
+    const idx = parts.findIndex((p) => p.id === partId);
+    if (idx < 0) return null;
+    return scene.parts[idx]?.mesh ?? null;
+  }, [scene, parts, partId]);
+}
+
+function FaceHighlight({
+  item,
+  variant,
+}: {
+  item: Extract<SelectionItem, { kind: "face" }>;
+  variant: "hover" | "selected";
+}) {
+  const mesh = usePartMesh(item.partId);
+  const geometry = useMemo(() => {
+    if (!mesh) return null;
+    const tris = findCoplanarTriangles(mesh, item.faceIndex);
+    if (tris.length === 0) return null;
+    return buildFaceHighlightGeometry(mesh, tris);
+  }, [mesh, item.faceIndex]);
+
+  useEffect(() => {
+    return () => {
+      geometry?.dispose();
+    };
+  }, [geometry]);
+
+  if (!geometry) return null;
+  const color = variant === "selected" ? FACE_SELECTED_COLOR : FACE_HOVER_COLOR;
+  const opacity = variant === "selected" ? SUB_SELECTED_OPACITY : SUB_HOVER_OPACITY;
+  return (
+    <mesh geometry={geometry} renderOrder={998}>
+      <meshBasicMaterial
+        color={color}
+        transparent
+        opacity={opacity}
+        depthWrite={false}
+        depthTest={false}
+        side={THREE.DoubleSide}
+      />
+    </mesh>
+  );
+}
+
+function EdgeHighlight({
+  item,
+  variant,
+}: {
+  item: Extract<SelectionItem, { kind: "edge" }>;
+  variant: "hover" | "selected";
+}) {
+  const mesh = usePartMesh(item.partId);
+  const points = useMemo(() => {
+    if (!mesh) return null;
+    const { a, b } = getEdgeEndpoints(mesh, item.edgeId);
+    return [
+      [a.x, a.y, a.z],
+      [b.x, b.y, b.z],
+    ] as [number, number, number][];
+  }, [mesh, item.edgeId]);
+  if (!points) return null;
+  const color =
+    variant === "selected" ? SUB_SELECTED_LINE_COLOR : SUB_HOVER_LINE_COLOR;
+  return (
+    <Line
+      points={points}
+      color={color}
+      lineWidth={variant === "selected" ? 3 : 2}
+      transparent
+      opacity={variant === "selected" ? 1.0 : 0.7}
+      depthWrite={false}
+      depthTest={false}
+      renderOrder={998}
+    />
+  );
+}
+
+function VertexHighlight({
+  item,
+  variant,
+}: {
+  item: Extract<SelectionItem, { kind: "vertex" }>;
+  variant: "hover" | "selected";
+}) {
+  const mesh = usePartMesh(item.partId);
+  const position = useMemo(() => {
+    if (!mesh) return null;
+    return getVertex(mesh, item.vertexId);
+  }, [mesh, item.vertexId]);
+  const meshRef = useRef<THREE.Mesh>(null);
+  const { camera, size } = useThree();
+
+  useFrame(() => {
+    if (!meshRef.current || !position) return;
+    const cam = camera as THREE.PerspectiveCamera;
+    // Vertex is in kernel space; the parent rotation group applies -90°X,
+    // so the camera-distance read uses the rotated (display) position.
+    const wp = new THREE.Vector3(position.x, position.z, -position.y);
+    const dist = cam.position.distanceTo(wp);
+    const fovRad = ((cam.fov ?? 50) * Math.PI) / 180;
+    const worldPerPx = (2 * dist * Math.tan(fovRad / 2)) / size.height;
+    const screenPx = variant === "selected" ? 6 : 5;
+    meshRef.current.scale.setScalar(Math.max(1e-4, screenPx * worldPerPx));
+  });
+
+  if (!position) return null;
+  const color =
+    variant === "selected" ? SUB_SELECTED_LINE_COLOR : SUB_HOVER_LINE_COLOR;
+  return (
+    <mesh ref={meshRef} position={position} renderOrder={999}>
+      <sphereGeometry args={[1, 12, 12]} />
+      <meshBasicMaterial
+        color={color}
+        transparent
+        opacity={variant === "selected" ? 1.0 : 0.85}
+        depthWrite={false}
+        depthTest={false}
+      />
+    </mesh>
+  );
+}
+
+/** Per-item dispatcher — picks the right highlight component per kind. */
+function ItemHighlight({
+  item,
+  variant,
+}: {
+  item: SelectionItem;
+  variant: "hover" | "selected";
+}) {
+  if (item.kind === "face") return <FaceHighlight item={item} variant={variant} />;
+  if (item.kind === "edge") return <EdgeHighlight item={item} variant={variant} />;
+  if (item.kind === "vertex") return <VertexHighlight item={item} variant={variant} />;
+  // part / segment / constraint are handled by other renderers.
+  return null;
+}
+
+/** Renders all face / edge / vertex highlights for the current selection
+ *  + hover. Mounted alongside the part-bbox outlines below. */
+function SubFeatureHighlights() {
+  const selection = useUiStore((s) => s.selection);
+  const hoveredItem = useUiStore((s) => s.hoveredItem);
+
+  // Skip the hover render if the same item is already selected, to avoid
+  // drawing the highlight twice.
+  const hovered = useMemo(() => {
+    if (!hoveredItem || hoveredItem.kind === "part") return null;
+    return selection.some((it) => selectionItemsEqual(it, hoveredItem))
+      ? null
+      : hoveredItem;
+  }, [hoveredItem, selection]);
+
+  return (
+    <>
+      {selection.map((item, i) => (
+        <ItemHighlight key={`sel-${i}`} item={item} variant="selected" />
+      ))}
+      {hovered && <ItemHighlight item={hovered} variant="hover" />}
+    </>
+  );
+}
+
 export function SelectionOverlay() {
   const isDraggingGizmo = useUiStore((s) => s.isDraggingGizmo);
   const isOrbiting = useUiStore((s) => s.isOrbiting);
@@ -225,6 +409,7 @@ export function SelectionOverlay() {
     <>
       <LocalSelection />
       <ParticipantAttention />
+      <SubFeatureHighlights />
     </>
   );
 }

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -5,7 +5,7 @@ import { PencilSimple } from "@phosphor-icons/react/dist/ssr/PencilSimple";
 import { GlobeSimple } from "@phosphor-icons/react/dist/ssr/GlobeSimple";
 import { Check } from "@phosphor-icons/react/dist/ssr/Check";
 import * as Popover from "@radix-ui/react-popover";
-import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName } from "@vcad/core";
+import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName, type SelectionFilter } from "@vcad/core";
 import { useLocaleStore, supportedLocales, type SupportedLocale } from "@/stores/locale-store";
 import { useLogStore, getFilteredEntries } from "@/stores/log-store";
 import { FooterUsageMeter } from "@/components/FooterUsageMeter";
@@ -48,6 +48,7 @@ function formatAgo(ts: number, now: number): string {
 export function StatusBar() {
   const parts = useDocumentStore((s) => s.parts);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
+  const selection = useUiStore((s) => s.selection);
   const cursorWorld = useUiStore((s) => s.cursorWorld);
   useLocaleStore((s) => s.locale);
 
@@ -98,6 +99,37 @@ export function StatusBar() {
 
   const selCount = selectedPartIds.size;
   const fresh = latest && now - latest.timestamp < 3000;
+
+  /**
+   * One-line summary of what's currently selected. Prefers sub-feature
+   * detail (face / edge / vertex) over a raw part count when the user
+   * has picked something more specific. Shown in the right-edge cluster
+   * so the existing parts-stat copy keeps its place.
+   */
+  const subFeatureLabel = (() => {
+    const subItems = selection.filter(
+      (it) => it.kind === "face" || it.kind === "edge" || it.kind === "vertex",
+    );
+    if (subItems.length === 0) return null;
+    if (subItems.length === 1) {
+      const it = subItems[0]!;
+      const partName =
+        parts.find((p) => p.id === (it as { partId: string }).partId)?.name ??
+        "part";
+      if (it.kind === "face") return `face on ${partName}`;
+      if (it.kind === "edge") return `edge on ${partName}`;
+      if (it.kind === "vertex") return `vertex on ${partName}`;
+    }
+    // Multi-select — name the kinds.
+    const counts = { face: 0, edge: 0, vertex: 0 };
+    for (const it of subItems) {
+      counts[it.kind as "face" | "edge" | "vertex"]++;
+    }
+    const parts2 = (Object.entries(counts) as [keyof typeof counts, number][])
+      .filter(([, n]) => n > 0)
+      .map(([k, n]) => `${n} ${k}${n === 1 ? "" : "s"}`);
+    return parts2.join(", ");
+  })();
   const levelColor = latest ? LEVEL_COLOR[latest.level] : "";
   const { tauri, platform } = useCapabilities();
   const macOverlay = tauri && platform === "mac";
@@ -248,11 +280,59 @@ export function StatusBar() {
             {tFmt("status.sel", { count: String(selCount) })}
           </span>
         )}
+        {subFeatureLabel && (
+          <span className="text-brand">{subFeatureLabel}</span>
+        )}
       </div>
+
+      <SelectionFilterChips />
 
       <FooterUsageMeter />
 
       <LocalePicker />
+    </div>
+  );
+}
+
+const FILTER_OPTIONS: Array<{ value: SelectionFilter; label: string; key: string }> = [
+  { value: "auto", label: "Auto", key: "0" },
+  { value: "body", label: "Body", key: "1" },
+  { value: "face", label: "Face", key: "2" },
+  { value: "edge", label: "Edge", key: "3" },
+  { value: "vertex", label: "Vertex", key: "4" },
+];
+
+/**
+ * Selection filter chip cluster — restricts what `pickSubFeature` returns
+ * on the next pointer event. Hotkeys 0/1/2/3/4 in the viewport zone
+ * cycle to the same filter; the chips also show the current binding so
+ * the shortcut is discoverable.
+ */
+function SelectionFilterChips() {
+  const filter = useUiStore((s) => s.selectionFilter);
+  const setFilter = useUiStore((s) => s.setSelectionFilter);
+  return (
+    <div className="hidden md:flex items-stretch border-l border-border/40">
+      {FILTER_OPTIONS.map(({ value, label, key }) => {
+        const active = filter === value;
+        return (
+          <button
+            key={value}
+            onClick={() => setFilter(value)}
+            title={`${label} (${key})`}
+            className={cn(
+              "px-2 text-[10px] uppercase tracking-wide transition-colors",
+              "border-r border-border/40 last:border-r-0",
+              active
+                ? "text-brand bg-brand/10"
+                : "text-text-muted hover:text-text hover:bg-hover",
+            )}
+          >
+            {label}
+            <span className="ml-1 text-text-muted/60 font-mono">{key}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/packages/app/src/components/ToolPalette.tsx
+++ b/packages/app/src/components/ToolPalette.tsx
@@ -179,7 +179,7 @@ export function ToolPalette() {
       className={cn("tool-palette flex flex-col", "bg-surface")}
     >
       {/* Row 1: tab strip */}
-      <div className="flex h-7 items-stretch border-b border-border/40">
+      <div className="flex h-8 items-stretch border-b border-border/30 px-1">
         {visibleTabs.map(({ id, label, icon: Icon }, index) => {
           const isActive = displayedTab === id;
           return (
@@ -187,17 +187,17 @@ export function ToolPalette() {
               key={id}
               onClick={() => handleTabClick(id)}
               className={cn(
-                "flex items-center gap-1.5 px-3 text-[11px] font-medium border-b-2",
+                "flex items-center gap-1.5 px-2 text-[11px] font-medium border-b-2 -mb-px",
                 "transition-colors",
                 isActive
-                  ? cn("border-brand text-text bg-hover/30")
+                  ? "border-brand text-text"
                   : "border-transparent text-text-muted hover:text-text hover:bg-hover/20",
               )}
               title={`${index + 1}. ${label}`}
             >
-              <Icon size={13} className={cn(isActive && TAB_COLORS[id])} />
+              <Icon size={14} className={cn(isActive && TAB_COLORS[id])} />
               <span>{label}</span>
-              <span className="ml-1 text-[9px] text-text-muted/60 font-mono hidden sm:inline">
+              <span className="ml-0.5 text-[10px] font-mono text-text-muted/40 hidden sm:inline">
                 {index + 1}
               </span>
             </button>
@@ -216,8 +216,8 @@ export function ToolPalette() {
         <div className="flex-1" />
       </div>
 
-      {/* Row 2: active tab content — rendered inline, not in a popover */}
-      <div className="flex items-center gap-0.5 px-2 h-7">
+      {/* Row 2: active tab content — same horizontal rhythm as the tab strip */}
+      <div className="flex items-center h-8 px-1">
         {renderTabContent(displayedTab)}
       </div>
     </div>

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -406,8 +406,20 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   // Calculate center and size of the current selection — handles parts,
   // instances, and sub-features (face / edge / vertex). Returns null when
   // the selection is empty or none of its items resolve to geometry.
+  //
+  // Two modes:
+  //   "fit"      — frame the bbox by the current FOV (existing behavior).
+  //   "pan-only" — re-target to the center but keep the current zoom.
+  //                Used for sub-feature selections so a vertex pick on a
+  //                big sphere doesn't dive into a 1mm close-up that loses
+  //                all context. The highlight + property panel are the
+  //                primary feedback there; the camera just centers it.
   const selectionInfo = useMemo(() => {
     if (selection.length === 0 || !scene) return null;
+
+    const hasSubFeature = selection.some(
+      (it) => it.kind === "face" || it.kind === "edge" || it.kind === "vertex",
+    );
 
     const box = new Box3();
     const tempVec = new Vector3();
@@ -515,28 +527,33 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     const radius = Math.max(size.length() * 0.5, 1);
     // Kernel Z-up center → display Y-up: (x, y, z) → (x, z, -y).
     const center = new Vector3(kernelCenter.x, kernelCenter.z, -kernelCenter.y);
-    return { center, radius };
+    const mode: "fit" | "pan-only" = hasSubFeature ? "pan-only" : "fit";
+    return { center, radius, mode };
   }, [selection, scene, parts, isPartSelected]);
 
-  // Animate orbit target to selection center and zoom to fit
-  // Skip during gizmo drag to avoid fighting with the user's transform
+  // Animate orbit target to selection center. For part selections we also
+  // tighten distance to fit the bounding sphere; for sub-features we keep
+  // the current zoom — picking a vertex on a sphere shouldn't bury you in
+  // a 1mm close-up that loses all context.
   useEffect(() => {
     if (selectionInfo && !isDraggingGizmo) {
       targetGoalRef.current.copy(selectionInfo.center);
-      // Fit the selection's bounding sphere to the viewport using the
-      // camera's actual FOV + aspect, so tiny features don't vanish and
-      // huge ones don't get clipped. Uses the more restrictive of the
-      // vertical/horizontal FOVs so the sphere fits in both directions.
-      const padding = 1.2;
-      if (camera instanceof PerspectiveCamera) {
-        const vFov = (camera.fov * Math.PI) / 180;
-        const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
-        const fitFov = Math.min(vFov, hFov);
-        const distance =
-          (selectionInfo.radius / Math.sin(fitFov / 2)) * padding;
-        distanceGoalRef.current = Math.max(camera.near * 2, distance);
+      if (selectionInfo.mode === "fit") {
+        const padding = 1.2;
+        if (camera instanceof PerspectiveCamera) {
+          const vFov = (camera.fov * Math.PI) / 180;
+          const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
+          const fitFov = Math.min(vFov, hFov);
+          const distance =
+            (selectionInfo.radius / Math.sin(fitFov / 2)) * padding;
+          distanceGoalRef.current = Math.max(camera.near * 2, distance);
+        } else {
+          distanceGoalRef.current = selectionInfo.radius * 3 * padding;
+        }
       } else {
-        distanceGoalRef.current = selectionInfo.radius * 3 * padding;
+        // pan-only — leave the distance goal untouched. The lerp loop
+        // honors a null distanceGoal by skipping its update.
+        distanceGoalRef.current = null;
       }
       isAnimatingTargetRef.current = true;
       setIsCameraMoving(true);

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -7,6 +7,11 @@ const isCoarsePointer =
   window.matchMedia("(pointer: coarse)").matches;
 import { useThree, useFrame } from "@react-three/fiber";
 import {
+  findCoplanarTriangles,
+  getEdgeEndpoints,
+  getVertex,
+} from "@/lib/sub-feature-geometry";
+import {
   OrbitControls,
   GizmoHelper,
   GizmoViewport,
@@ -302,6 +307,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   const docScene = useDocumentStore((s) => s.document.scene);
 
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
+  const selection = useUiStore((s) => s.selection);
   const isDraggingGizmo = useUiStore((s) => s.isDraggingGizmo);
   const setOrbiting = useUiStore((s) => s.setOrbiting);
   const renderMode = useUiStore((s) => s.renderMode);
@@ -397,52 +403,105 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     [selectedPartIds, rootIndexToInstanceId],
   );
 
-  // Calculate center and size of selected parts/instances
+  // Calculate center and size of the current selection — handles parts,
+  // instances, and sub-features (face / edge / vertex). Returns null when
+  // the selection is empty or none of its items resolve to geometry.
   const selectionInfo = useMemo(() => {
-    if (selectedPartIds.size === 0 || !scene) return null;
+    if (selection.length === 0 || !scene) return null;
 
     const box = new Box3();
     const tempVec = new Vector3();
     let hasPoints = false;
 
-    // Assembly mode: check instances
-    if (scene.instances && scene.instances.length > 0) {
-      for (const inst of scene.instances) {
-        const instanceSelectionId = getInstanceSelectionId(inst);
-        if (!instanceSelectionId || !selectedPartIds.has(instanceSelectionId))
-          continue;
+    /** Look up an EvaluatedPart's mesh by partId. */
+    const meshFor = (partId: string) => {
+      const idx = parts.findIndex((p) => p.id === partId);
+      if (idx < 0) return null;
+      return scene.parts[idx]?.mesh ?? null;
+    };
 
-        const positions = inst.mesh.positions;
-        const t = inst.transform ?? {
-          translation: { x: 0, y: 0, z: 0 },
-          rotation: { x: 0, y: 0, z: 0 },
-          scale: { x: 1, y: 1, z: 1 },
-        };
-        for (let i = 0; i < positions.length; i += 3) {
-          // Apply instance transform to positions for accurate bounding box
-          tempVec.set(
-            positions[i]! * t.scale.x + t.translation.x,
-            positions[i + 1]! * t.scale.y + t.translation.y,
-            positions[i + 2]! * t.scale.z + t.translation.z,
-          );
-          box.expandByPoint(tempVec);
-          hasPoints = true;
+    for (const item of selection) {
+      switch (item.kind) {
+        case "part": {
+          // Assembly path: instance with this id.
+          if (scene.instances && scene.instances.length > 0) {
+            for (const inst of scene.instances) {
+              const instanceSelectionId = getInstanceSelectionId(inst);
+              if (instanceSelectionId !== item.id) continue;
+              const positions = inst.mesh.positions;
+              const t = inst.transform ?? {
+                translation: { x: 0, y: 0, z: 0 },
+                rotation: { x: 0, y: 0, z: 0 },
+                scale: { x: 1, y: 1, z: 1 },
+              };
+              for (let i = 0; i < positions.length; i += 3) {
+                tempVec.set(
+                  positions[i]! * t.scale.x + t.translation.x,
+                  positions[i + 1]! * t.scale.y + t.translation.y,
+                  positions[i + 2]! * t.scale.z + t.translation.z,
+                );
+                box.expandByPoint(tempVec);
+                hasPoints = true;
+              }
+            }
+          }
+          // Legacy path: full part mesh. Also covers instances exposed as
+          // parts via isPartSelected — keep the existing index-based walk
+          // so the same id can match either path.
+          parts.forEach((part, index) => {
+            if (!isPartSelected(part.id, index)) return;
+            if (part.id !== item.id) return;
+            const evalPart = scene.parts[index];
+            if (!evalPart) return;
+            const positions = evalPart.mesh.positions;
+            for (let i = 0; i < positions.length; i += 3) {
+              tempVec.set(positions[i]!, positions[i + 1]!, positions[i + 2]!);
+              box.expandByPoint(tempVec);
+              hasPoints = true;
+            }
+          });
+          break;
         }
+        case "face": {
+          const mesh = meshFor(item.partId);
+          if (!mesh) break;
+          const tris = findCoplanarTriangles(mesh, item.faceIndex);
+          for (const t of tris) {
+            for (let v = 0; v < 3; v++) {
+              const idx = mesh.indices[t * 3 + v]!;
+              tempVec.set(
+                mesh.positions[idx * 3]!,
+                mesh.positions[idx * 3 + 1]!,
+                mesh.positions[idx * 3 + 2]!,
+              );
+              box.expandByPoint(tempVec);
+              hasPoints = true;
+            }
+          }
+          break;
+        }
+        case "edge": {
+          const mesh = meshFor(item.partId);
+          if (!mesh) break;
+          const { a, b } = getEdgeEndpoints(mesh, item.edgeId);
+          box.expandByPoint(a);
+          box.expandByPoint(b);
+          hasPoints = true;
+          break;
+        }
+        case "vertex": {
+          const mesh = meshFor(item.partId);
+          if (!mesh) break;
+          const p = getVertex(mesh, item.vertexId);
+          box.expandByPoint(p);
+          hasPoints = true;
+          break;
+        }
+        case "segment":
+        case "constraint":
+          // Sketch-mode entities have their own framing path; skip here.
+          break;
       }
-    } else {
-      // Legacy mode: check parts (also handles instance IDs via isPartSelected)
-      parts.forEach((part, index) => {
-        if (!isPartSelected(part.id, index)) return;
-        const evalPart = scene.parts[index];
-        if (!evalPart) return;
-
-        const positions = evalPart.mesh.positions;
-        for (let i = 0; i < positions.length; i += 3) {
-          tempVec.set(positions[i]!, positions[i + 1]!, positions[i + 2]!);
-          box.expandByPoint(tempVec);
-          hasPoints = true;
-        }
-      });
     }
 
     if (!hasPoints) return null;
@@ -450,13 +509,14 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     box.getCenter(kernelCenter);
     const size = new Vector3();
     box.getSize(size);
-    // Bounding-sphere radius — independent of orbit angle, safe for any view.
-    const radius = Math.max(size.length() * 0.5, 1e-3);
-    // Transform kernel Z-up center to Three.js Y-up world space
-    // Rotation -90° around X: (x, y, z) → (x, z, -y)
+    // Bounding-sphere radius — independent of orbit angle, safe for any
+    // view. Single-vertex selections have zero size; clamp to 1mm so the
+    // camera doesn't dive in until the near-plane clips.
+    const radius = Math.max(size.length() * 0.5, 1);
+    // Kernel Z-up center → display Y-up: (x, y, z) → (x, z, -y).
     const center = new Vector3(kernelCenter.x, kernelCenter.z, -kernelCenter.y);
     return { center, radius };
-  }, [selectedPartIds, scene, parts, isPartSelected]);
+  }, [selection, scene, parts, isPartSelected]);
 
   // Animate orbit target to selection center and zoom to fit
   // Skip during gizmo drag to avoid fighting with the user's transform

--- a/packages/app/src/components/ui/toolbar.tsx
+++ b/packages/app/src/components/ui/toolbar.tsx
@@ -38,10 +38,12 @@ export function ToolbarButton({
     <Tooltip content={tooltip} side="top">
       <button
         className={cn(
-          "flex items-center justify-center relative gap-1",
+          "flex items-center justify-center relative gap-1.5",
           "h-10 min-w-[40px] px-1.5",
-          "md:h-6 md:min-w-0",
-          expanded ? "md:px-1.5" : "md:px-1",
+          "md:h-8 md:min-w-0 md:px-2 md:rounded-sm",
+          "transition-colors",
+          !disabled && "md:hover:bg-hover/20",
+          active && "md:bg-hover/20",
           "disabled:opacity-30 disabled:cursor-not-allowed",
           pulse && "animate-pulse",
           className,
@@ -49,22 +51,21 @@ export function ToolbarButton({
         disabled={disabled}
         onClick={onClick}
       >
-        <span className={cn(
-          iconColor,
-          "transition-transform",
-          active && "scale-110",
-          !disabled && "hover:scale-110"
-        )}>
+        <span className={cn(iconColor, active ? "text-text" : "text-text-muted")}>
           {children}
         </span>
         {expanded && label && (
           <span className={cn(
-            "hidden md:inline text-[10px] whitespace-nowrap",
+            "hidden md:inline text-[11px] font-medium whitespace-nowrap",
             active ? "text-text" : "text-text-muted",
             labelClassName
           )}>
             {label}
-            {shortcut && <span className="ml-1 opacity-60">{shortcut}</span>}
+            {shortcut && (
+              <span className="ml-1 text-[10px] font-mono text-text-muted/40">
+                {shortcut}
+              </span>
+            )}
           </span>
         )}
       </button>

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -176,6 +176,31 @@ export function useKeyboardShortcuts() {
         return;
       }
 
+      // Selection-filter shortcuts: 0=Auto, 1=Body, 2=Face, 3=Edge, 4=Vertex.
+      // Only when in the viewport zone — the same digits in the tree zone
+      // would conflict with future tree-shortcuts and in property zone with
+      // numeric input. Skipped in sketch mode to avoid stealing tool keys.
+      if (
+        !mod &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !useSketchStore.getState().active &&
+        useUiStore.getState().focusZone === "viewport"
+      ) {
+        const filterMap: Record<string, "auto" | "body" | "face" | "edge" | "vertex"> = {
+          "0": "auto",
+          "1": "body",
+          "2": "face",
+          "3": "edge",
+          "4": "vertex",
+        };
+        const f = filterMap[e.key];
+        if (f) {
+          e.preventDefault();
+          useUiStore.getState().setSelectionFilter(f);
+          return;
+        }
+      }
 
       // Toggle feature tree: Cmd+1
       if (mod && e.key === "1") {

--- a/packages/app/src/lib/sub-feature-geometry.ts
+++ b/packages/app/src/lib/sub-feature-geometry.ts
@@ -1,0 +1,124 @@
+/**
+ * Geometry helpers for sub-feature highlights.
+ *
+ * Pulls all-triangles-coplanar-with-this-one out of `SceneMesh` so the new
+ * `SelectionOverlay` can render face highlights using the same math the
+ * sketch-mode face hover uses.
+ *
+ * Edge / vertex helpers translate `edgeId`/`vertexId` (from
+ * `pickSubFeature`) back into the actual mesh positions to draw.
+ */
+
+import * as THREE from "three";
+import type { TriangleMesh } from "@vcad/engine";
+import { decodeEdgeId } from "./sub-feature-picking";
+
+/** Tolerance for treating two normals as parallel and two coplanar
+ *  triangles as on the same plane. */
+const NORMAL_TOLERANCE = 0.01;
+const PLANE_TOLERANCE = 0.01;
+
+/** Find every triangle index that lies on the same infinite plane as the
+ *  reference triangle. Used to expand a single triangle hit into the full
+ *  face's highlight. */
+export function findCoplanarTriangles(
+  mesh: TriangleMesh,
+  refTriIndex: number,
+): number[] {
+  const indices = mesh.indices;
+  const positions = mesh.positions;
+
+  const ri0 = indices[refTriIndex * 3]!;
+  const ri1 = indices[refTriIndex * 3 + 1]!;
+  const ri2 = indices[refTriIndex * 3 + 2]!;
+  const r0 = new THREE.Vector3(
+    positions[ri0 * 3]!,
+    positions[ri0 * 3 + 1]!,
+    positions[ri0 * 3 + 2]!,
+  );
+  const r1 = new THREE.Vector3(
+    positions[ri1 * 3]!,
+    positions[ri1 * 3 + 1]!,
+    positions[ri1 * 3 + 2]!,
+  );
+  const r2 = new THREE.Vector3(
+    positions[ri2 * 3]!,
+    positions[ri2 * 3 + 1]!,
+    positions[ri2 * 3 + 2]!,
+  );
+  const refNormal = r1.clone().sub(r0).cross(r2.clone().sub(r0)).normalize();
+  const refOffset = refNormal.dot(r0);
+
+  const triCount = indices.length / 3;
+  const out: number[] = [];
+  const v0 = new THREE.Vector3();
+  const v1 = new THREE.Vector3();
+  const v2 = new THREE.Vector3();
+  const _e1 = new THREE.Vector3();
+  const _e2 = new THREE.Vector3();
+  const _n = new THREE.Vector3();
+  for (let t = 0; t < triCount; t++) {
+    const i0 = indices[t * 3]!;
+    const i1 = indices[t * 3 + 1]!;
+    const i2 = indices[t * 3 + 2]!;
+    v0.set(positions[i0 * 3]!, positions[i0 * 3 + 1]!, positions[i0 * 3 + 2]!);
+    v1.set(positions[i1 * 3]!, positions[i1 * 3 + 1]!, positions[i1 * 3 + 2]!);
+    v2.set(positions[i2 * 3]!, positions[i2 * 3 + 1]!, positions[i2 * 3 + 2]!);
+    _e1.subVectors(v1, v0);
+    _e2.subVectors(v2, v0);
+    _n.copy(_e1).cross(_e2).normalize();
+    if (_n.dot(refNormal) < 1 - NORMAL_TOLERANCE) continue;
+    if (Math.abs(refNormal.dot(v0) - refOffset) > PLANE_TOLERANCE) continue;
+    out.push(t);
+  }
+  return out;
+}
+
+/** Build a geometry covering only the given triangle indices. Caller owns
+ *  disposal of the returned geometry. */
+export function buildFaceHighlightGeometry(
+  mesh: TriangleMesh,
+  triangleIndices: number[],
+): THREE.BufferGeometry {
+  const geo = new THREE.BufferGeometry();
+  const buf: number[] = [];
+  for (const t of triangleIndices) {
+    const i0 = mesh.indices[t * 3]!;
+    const i1 = mesh.indices[t * 3 + 1]!;
+    const i2 = mesh.indices[t * 3 + 2]!;
+    buf.push(
+      mesh.positions[i0 * 3]!,
+      mesh.positions[i0 * 3 + 1]!,
+      mesh.positions[i0 * 3 + 2]!,
+      mesh.positions[i1 * 3]!,
+      mesh.positions[i1 * 3 + 1]!,
+      mesh.positions[i1 * 3 + 2]!,
+      mesh.positions[i2 * 3]!,
+      mesh.positions[i2 * 3 + 1]!,
+      mesh.positions[i2 * 3 + 2]!,
+    );
+  }
+  geo.setAttribute("position", new THREE.Float32BufferAttribute(buf, 3));
+  geo.computeVertexNormals();
+  return geo;
+}
+
+/** Get a vertex's kernel-space position from a mesh by index. */
+export function getVertex(mesh: TriangleMesh, vertexIndex: number): THREE.Vector3 {
+  const i = vertexIndex * 3;
+  return new THREE.Vector3(
+    mesh.positions[i] ?? 0,
+    mesh.positions[i + 1] ?? 0,
+    mesh.positions[i + 2] ?? 0,
+  );
+}
+
+/** Decode an edgeId into its two endpoint positions. */
+export function getEdgeEndpoints(
+  mesh: TriangleMesh,
+  edgeId: number,
+): { a: THREE.Vector3; b: THREE.Vector3 } {
+  const vertexCount = mesh.positions.length / 3;
+  const { a, b } = decodeEdgeId(edgeId, vertexCount);
+  return { a: getVertex(mesh, a), b: getVertex(mesh, b) };
+}

--- a/packages/app/src/lib/sub-feature-picking.ts
+++ b/packages/app/src/lib/sub-feature-picking.ts
@@ -1,0 +1,205 @@
+/**
+ * Sub-feature hit testing for the viewport.
+ *
+ * Given an R3F triangle intersection, pick the most-specific selection
+ * item under the cursor: vertex (within ~8px screen), edge (within ~6px),
+ * or face (the hit triangle). The selection filter restricts the candidate
+ * set when the user has switched modes.
+ *
+ * The mesh's `positions` are kernel (Z-up) space; `intersection.point` is
+ * already in display (Y-up) space because R3F passes the world-space hit
+ * through the rotation group. We convert vertex positions on the fly via
+ * the standard `(x, y, z) → (x, z, -y)` mapping.
+ */
+
+import type { Camera } from "three";
+import { Vector2, Vector3 } from "three";
+import type { TriangleMesh } from "@vcad/engine";
+import type { SelectionFilter, SelectionItem } from "@vcad/core";
+
+const VERTEX_PX = 10;
+const EDGE_PX = 6;
+
+export interface SubFeaturePickContext {
+  /** Triangle index from the R3F intersection (`e.faceIndex`). */
+  triIndex: number;
+  /** Hit point in display (Y-up) space, from `intersection.point`. */
+  hitPoint: Vector3;
+  mesh: TriangleMesh;
+  partId: string;
+  filter: SelectionFilter;
+  camera: Camera;
+  /** Viewport pixel dimensions, from `useThree(s => s.size)`. */
+  viewport: { width: number; height: number };
+}
+
+/** Convert a kernel-space mesh vertex to display-space (Y-up). */
+function kernelVertexToDisplay(
+  mesh: TriangleMesh,
+  vertexIndex: number,
+  out: Vector3 = new Vector3(),
+): Vector3 {
+  const i = vertexIndex * 3;
+  const x = mesh.positions[i] ?? 0;
+  const y = mesh.positions[i + 1] ?? 0;
+  const z = mesh.positions[i + 2] ?? 0;
+  // Same rotation the scene group applies: (x, y, z) → (x, z, -y).
+  out.set(x, z, -y);
+  return out;
+}
+
+/** Project a world-space (display, Y-up) point to viewport pixels. */
+function projectToScreen(
+  world: Vector3,
+  camera: Camera,
+  viewport: { width: number; height: number },
+  out: Vector2 = new Vector2(),
+): Vector2 {
+  const ndc = world.clone().project(camera);
+  out.set(
+    ((ndc.x + 1) / 2) * viewport.width,
+    ((1 - ndc.y) / 2) * viewport.height,
+  );
+  return out;
+}
+
+/** Closest distance from a 2D point to a 2D segment, in pixels. */
+function pointToSegmentDist(p: Vector2, a: Vector2, b: Vector2): number {
+  const abx = b.x - a.x;
+  const aby = b.y - a.y;
+  const apx = p.x - a.x;
+  const apy = p.y - a.y;
+  const lenSq = abx * abx + aby * aby;
+  if (lenSq < 1e-6) return Math.hypot(apx, apy);
+  let t = (apx * abx + apy * aby) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const dx = a.x + t * abx - p.x;
+  const dy = a.y + t * aby - p.y;
+  return Math.hypot(dx, dy);
+}
+
+/** Build a stable edge ID from two vertex indices: `min * N + max`, where
+ *  N = vertex count. Survives within a single mesh evaluation. */
+function makeEdgeId(va: number, vb: number, vertexCount: number): number {
+  const lo = Math.min(va, vb);
+  const hi = Math.max(va, vb);
+  return lo * vertexCount + hi;
+}
+
+/**
+ * Pick the most-specific selection item under the cursor.
+ *
+ * Priority when filter is "auto": vertex > edge > face > body. With a
+ * specific filter, only items of that kind are considered.
+ *
+ * Returns null when:
+ *   - filter restricts to a kind that has no candidate within threshold, OR
+ *   - the triangle index is out of range.
+ */
+export function pickSubFeature(
+  ctx: SubFeaturePickContext,
+): SelectionItem | null {
+  const { triIndex, hitPoint, mesh, partId, filter, camera, viewport } = ctx;
+
+  if (filter === "body") {
+    return { kind: "part", id: partId };
+  }
+
+  const triCount = mesh.indices.length / 3;
+  if (triIndex < 0 || triIndex >= triCount) return null;
+
+  // Triangle vertex indices and their display-space positions.
+  const ia = mesh.indices[triIndex * 3]!;
+  const ib = mesh.indices[triIndex * 3 + 1]!;
+  const ic = mesh.indices[triIndex * 3 + 2]!;
+  const triVerts: number[] = [ia, ib, ic];
+
+  const vertexCount = mesh.positions.length / 3;
+  const _va = new Vector3();
+  const _vb = new Vector3();
+  const _vc = new Vector3();
+  kernelVertexToDisplay(mesh, ia, _va);
+  kernelVertexToDisplay(mesh, ib, _vb);
+  kernelVertexToDisplay(mesh, ic, _vc);
+
+  // Project hit + triangle to screen space once.
+  const _hitScreen = new Vector2();
+  projectToScreen(hitPoint, camera, viewport, _hitScreen);
+  const _aScreen = new Vector2();
+  const _bScreen = new Vector2();
+  const _cScreen = new Vector2();
+  projectToScreen(_va, camera, viewport, _aScreen);
+  projectToScreen(_vb, camera, viewport, _bScreen);
+  projectToScreen(_vc, camera, viewport, _cScreen);
+
+  const wantVertex = filter === "vertex" || filter === "auto";
+  const wantEdge = filter === "edge" || filter === "auto";
+  const wantFace = filter === "face" || filter === "auto";
+
+  // ── Vertex pick ──────────────────────────────────────────────────────
+  if (wantVertex) {
+    const screens = [_aScreen, _bScreen, _cScreen];
+    let bestIdx = -1;
+    let bestDist = VERTEX_PX;
+    for (let k = 0; k < 3; k++) {
+      const d = screens[k]!.distanceTo(_hitScreen);
+      if (d < bestDist) {
+        bestDist = d;
+        bestIdx = k;
+      }
+    }
+    if (bestIdx >= 0) {
+      return {
+        kind: "vertex",
+        partId,
+        vertexId: triVerts[bestIdx]!,
+      };
+    }
+  }
+
+  // ── Edge pick (within the hit triangle's three edges) ───────────────
+  if (wantEdge) {
+    const edges: Array<[Vector2, Vector2, number, number]> = [
+      [_aScreen, _bScreen, ia, ib],
+      [_bScreen, _cScreen, ib, ic],
+      [_cScreen, _aScreen, ic, ia],
+    ];
+    let bestK = -1;
+    let bestDist = EDGE_PX;
+    for (let k = 0; k < 3; k++) {
+      const [s0, s1] = edges[k]!;
+      const d = pointToSegmentDist(_hitScreen, s0, s1);
+      if (d < bestDist) {
+        bestDist = d;
+        bestK = k;
+      }
+    }
+    if (bestK >= 0) {
+      const [, , va, vb] = edges[bestK]!;
+      return {
+        kind: "edge",
+        partId,
+        edgeId: makeEdgeId(va, vb, vertexCount),
+      };
+    }
+  }
+
+  // ── Face pick ────────────────────────────────────────────────────────
+  if (wantFace) {
+    return { kind: "face", partId, faceIndex: triIndex };
+  }
+
+  // Filter was "auto" but no candidate found, or filter narrowed too far.
+  return null;
+}
+
+/** Decode a stable edge ID back into its two vertex indices. */
+export function decodeEdgeId(
+  edgeId: number,
+  vertexCount: number,
+): { a: number; b: number } {
+  return {
+    a: Math.floor(edgeId / vertexCount),
+    b: edgeId % vertexCount,
+  };
+}

--- a/packages/core/src/__tests__/selection.test.ts
+++ b/packages/core/src/__tests__/selection.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useUiStore } from "../stores/ui-store.js";
+import { selectionItemsEqual } from "../types.js";
+import type { SelectionItem } from "../types.js";
+
+describe("selection store", () => {
+  beforeEach(() => {
+    useUiStore.getState().clearSelection();
+    useUiStore.getState().setHoveredItem(null);
+    useUiStore.getState().setSelectionFilter("auto");
+  });
+
+  it("starts empty", () => {
+    const s = useUiStore.getState();
+    expect(s.selection).toHaveLength(0);
+    expect(s.selectedPartIds.size).toBe(0);
+    expect(s.hoveredItem).toBeNull();
+    expect(s.hoveredPartId).toBeNull();
+    expect(s.selectionFilter).toBe("auto");
+  });
+
+  it("part-only writes via select() keep selectedPartIds in sync", () => {
+    useUiStore.getState().select("p1");
+    const s = useUiStore.getState();
+    expect(s.selection).toEqual([{ kind: "part", id: "p1" }]);
+    expect(s.selectedPartIds.has("p1")).toBe(true);
+    expect(s.selectedPartIds.size).toBe(1);
+  });
+
+  it("toggleSelect() round-trips through both shapes", () => {
+    useUiStore.getState().toggleSelect("a");
+    expect(useUiStore.getState().selectedPartIds.has("a")).toBe(true);
+    useUiStore.getState().toggleSelect("a");
+    expect(useUiStore.getState().selectedPartIds.has("a")).toBe(false);
+    expect(useUiStore.getState().selection).toHaveLength(0);
+  });
+
+  it("selectMultiple() preserves order in selection while feeding the Set view", () => {
+    useUiStore.getState().selectMultiple(["a", "b", "c"]);
+    const s = useUiStore.getState();
+    expect(s.selection.map((it) => (it.kind === "part" ? it.id : null))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(Array.from(s.selectedPartIds).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("selectItem() with a face stores the tagged item but excludes it from selectedPartIds", () => {
+    const face: SelectionItem = { kind: "face", partId: "p1", faceIndex: 3 };
+    useUiStore.getState().selectItem(face);
+    const s = useUiStore.getState();
+    expect(s.selection).toEqual([face]);
+    expect(s.selectedPartIds.size).toBe(0);
+  });
+
+  it("toggleItem() handles face / edge / vertex equality", () => {
+    const face: SelectionItem = { kind: "face", partId: "p1", faceIndex: 3 };
+    const otherFace: SelectionItem = { kind: "face", partId: "p1", faceIndex: 4 };
+    useUiStore.getState().toggleItem(face);
+    useUiStore.getState().toggleItem(otherFace);
+    expect(useUiStore.getState().selection).toHaveLength(2);
+    useUiStore.getState().toggleItem(face);
+    const remaining = useUiStore.getState().selection;
+    expect(remaining).toHaveLength(1);
+    expect(selectionItemsEqual(remaining[0]!, otherFace)).toBe(true);
+  });
+
+  it("setHoveredPartId() also updates hoveredItem", () => {
+    useUiStore.getState().setHoveredPartId("x");
+    expect(useUiStore.getState().hoveredItem).toEqual({ kind: "part", id: "x" });
+    useUiStore.getState().setHoveredPartId(null);
+    expect(useUiStore.getState().hoveredItem).toBeNull();
+  });
+
+  it("setHoveredItem() with a non-part clears hoveredPartId", () => {
+    useUiStore.getState().setHoveredItem({ kind: "edge", partId: "p1", edgeId: 7 });
+    expect(useUiStore.getState().hoveredPartId).toBeNull();
+    expect(useUiStore.getState().hoveredItem).toEqual({
+      kind: "edge",
+      partId: "p1",
+      edgeId: 7,
+    });
+  });
+
+  it("clearSelection() empties both views", () => {
+    useUiStore.getState().selectMultiple(["a", "b"]);
+    useUiStore.getState().toggleItem({ kind: "face", partId: "a", faceIndex: 0 });
+    useUiStore.getState().clearSelection();
+    expect(useUiStore.getState().selection).toHaveLength(0);
+    expect(useUiStore.getState().selectedPartIds.size).toBe(0);
+  });
+});
+
+describe("selectionItemsEqual", () => {
+  it("matches identical parts", () => {
+    expect(
+      selectionItemsEqual({ kind: "part", id: "a" }, { kind: "part", id: "a" }),
+    ).toBe(true);
+  });
+
+  it("rejects different kinds", () => {
+    expect(
+      selectionItemsEqual(
+        { kind: "part", id: "a" },
+        { kind: "face", partId: "a", faceIndex: 0 },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches identical sub-feature items", () => {
+    expect(
+      selectionItemsEqual(
+        { kind: "edge", partId: "p", edgeId: 7 },
+        { kind: "edge", partId: "p", edgeId: 7 },
+      ),
+    ).toBe(true);
+    expect(
+      selectionItemsEqual(
+        { kind: "vertex", partId: "p", vertexId: 1 },
+        { kind: "vertex", partId: "p", vertexId: 2 },
+      ),
+    ).toBe(false);
+  });
+
+  it("matches sketch segments and constraints", () => {
+    expect(
+      selectionItemsEqual(
+        { kind: "segment", sketchId: "s", index: 3 },
+        { kind: "segment", sketchId: "s", index: 3 },
+      ),
+    ).toBe(true);
+    expect(
+      selectionItemsEqual(
+        { kind: "constraint", sketchId: "s", index: 1 },
+        { kind: "constraint", sketchId: "s", index: 2 },
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/core/src/commands/prompt-appendix.ts
+++ b/packages/core/src/commands/prompt-appendix.ts
@@ -91,4 +91,26 @@ Instead of extruding each tube with perpendicular-basis math, do this:
 
 This pattern generalizes: whenever you'd be tempted to compute perpendicular
 vectors or tube lengths by hand, stop and use tube / polyline_tube instead.
-Whenever you'd be tempted to create N copies of the same thing, use a pattern.`;
+Whenever you'd be tempted to create N copies of the same thing, use a pattern.
+
+## Sub-feature selection in context
+
+The user can now select a face, edge, or vertex (not just a whole part). The
+\`Selected:\` block in the system context labels these specifically:
+
+- "Cylinder face #3 (id: 0:7)" — face #3 of the part with id 0:7
+- "Tile L0 edge #142 (id: 0:3)" — edge #142 of part 0:3
+- "Ball Core vertex #50 (id: 0:1)" — vertex #50 of part 0:1
+
+When the user says "this", "the highlighted face", "this edge", etc., they
+are referring to the selected sub-feature — *not* the whole owning part.
+Pay attention to the geometry kind in the Selected block. Sub-feature
+operations (per-edge fillets, face-driven extrudes) aren't yet exposed as
+distinct tools, so until they are, prefer to either:
+  (a) ask a clarifying question about scope ("Do you want to fillet just
+      this edge, or all edges of this part?") rather than silently
+      operating on the whole part, or
+  (b) operate on the whole part with a clear explanation that per-edge
+      filleting isn't yet available via tools.
+
+Never silently substitute "the part containing this face" for "this face".`;

--- a/packages/core/src/commands/registry.ts
+++ b/packages/core/src/commands/registry.ts
@@ -620,7 +620,26 @@ segments: [
 
     if (selection?.length) {
       const selList = selection
-        .map((s) => `- ${s.partName} (${s.geometryType}, id: ${s.partId})`)
+        .map((s) => {
+          // Surface sub-feature specifics so the AI can act on the exact
+          // thing the user picked: a face index, an edge id, a vertex id.
+          // Falls back to the part name + id for plain part selections.
+          let detail = `${s.partName} (${s.geometryType}, id: ${s.partId})`;
+          if (s.geometryType === "face" && s.faceIndex !== undefined) {
+            detail = `${s.partName} face #${s.faceIndex} (id: ${s.partId})`;
+          } else if (
+            s.geometryType === "edge" &&
+            s.dimensions?.edgeId !== undefined
+          ) {
+            detail = `${s.partName} edge #${s.dimensions.edgeId} (id: ${s.partId})`;
+          } else if (
+            s.geometryType === "vertex" &&
+            s.dimensions?.vertexId !== undefined
+          ) {
+            detail = `${s.partName} vertex #${s.dimensions.vertexId} (id: ${s.partId})`;
+          }
+          return `- ${detail}`;
+        })
         .join("\n");
       sections.push(`Selected:\n${selList}`);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export type {
   AxisAlignedPlane,
   ArbitraryPlane,
   FaceInfo,
+  SelectionItem,
+  SelectionFilter,
   PrimitivePartInfo,
   BooleanPartInfo,
   ExtrudePartInfo,
@@ -57,6 +59,7 @@ export {
   getSketchPlaneName,
   formatDirection,
   negateDirection,
+  selectionItemsEqual,
 } from "./types.js";
 
 // Stores

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -1,5 +1,28 @@
 import { create } from "zustand";
-import type { Theme, ToolMode, TransformMode } from "../types.js";
+import type {
+  SelectionFilter,
+  SelectionItem,
+  Theme,
+  ToolMode,
+  TransformMode,
+} from "../types.js";
+import { selectionItemsEqual } from "../types.js";
+
+/** Project a selection list down to the part IDs it covers, preserving the
+ *  Set-shaped contract historical callers expect from `selectedPartIds`. */
+function deriveSelectedPartIds(items: readonly SelectionItem[]): Set<string> {
+  const out = new Set<string>();
+  for (const item of items) {
+    if (item.kind === "part") out.add(item.id);
+  }
+  return out;
+}
+
+/** `hoveredPartId` mirror of `hoveredItem`, kept around so existing readers
+ *  (FeatureTree, SceneMesh) don't need to know about the item union yet. */
+function deriveHoveredPartId(item: SelectionItem | null): string | null {
+  return item && item.kind === "part" ? item.id : null;
+}
 
 export interface MaterialPreview {
   partId: string;
@@ -44,7 +67,18 @@ export type FollowMode = "free" | "follow" | "lock";
 export type InspectorTarget = { kind: "scene" } | null;
 
 export interface UiState {
+  /** Tagged-union selection — parts, faces, edges, vertices, segments,
+   *  constraints. Source of truth for everything selected. */
+  selection: SelectionItem[];
+  /** Hovered item (any kind). Source of truth for hover. */
+  hoveredItem: SelectionItem | null;
+  /** Restricts what `pickSubFeature` will return on the next pointer event. */
+  selectionFilter: SelectionFilter;
+  /** Derived: part IDs in `selection`. Kept in sync with every selection
+   *  write so historical callers (`.has` / `.size` / `Array.from`) keep
+   *  working unchanged. */
   selectedPartIds: Set<string>;
+  /** Derived: hovered part ID when `hoveredItem.kind === "part"`. */
   hoveredPartId: string | null;
   commandPaletteOpen: boolean;
   toolMode: ToolMode;
@@ -102,6 +136,16 @@ export interface UiState {
   selectMultiple: (partIds: string[]) => void;
   clearSelection: () => void;
   setHoveredPartId: (partId: string | null) => void;
+  /** Replace selection with a single tagged item, or clear (null). */
+  selectItem: (item: SelectionItem | null) => void;
+  /** Toggle a tagged item in/out of the current selection. */
+  toggleItem: (item: SelectionItem) => void;
+  /** Replace the entire selection list. */
+  selectItems: (items: SelectionItem[]) => void;
+  /** Set the hovered item (any kind, or null for no hover). */
+  setHoveredItem: (item: SelectionItem | null) => void;
+  /** Set the selection filter — restricts what `pickSubFeature` will return. */
+  setSelectionFilter: (filter: SelectionFilter) => void;
   toggleCommandPalette: () => void;
   setCommandPaletteOpen: (open: boolean) => void;
   setToolMode: (mode: ToolMode) => void;
@@ -224,27 +268,66 @@ export const useUiStore = create<UiState>((set) => ({
   followingParticipantId: null,
   focusZone: "viewport" as FocusZone,
   treeFocusedPartId: null,
+  selection: [],
+  hoveredItem: null,
+  selectionFilter: "auto" as SelectionFilter,
 
-  select: (partId) =>
-    set({ selectedPartIds: partId ? new Set([partId]) : new Set() }),
+  select: (partId) => {
+    const selection: SelectionItem[] = partId ? [{ kind: "part", id: partId }] : [];
+    set({ selection, selectedPartIds: deriveSelectedPartIds(selection) });
+  },
 
   toggleSelect: (partId) =>
     set((s) => {
-      const next = new Set(s.selectedPartIds);
-      if (next.has(partId)) {
-        next.delete(partId);
-      } else {
-        next.add(partId);
-      }
-      return { selectedPartIds: next };
+      const idx = s.selection.findIndex(
+        (it) => it.kind === "part" && it.id === partId,
+      );
+      const selection =
+        idx >= 0
+          ? s.selection.filter((_, i) => i !== idx)
+          : [...s.selection, { kind: "part" as const, id: partId }];
+      return { selection, selectedPartIds: deriveSelectedPartIds(selection) };
     }),
 
-  selectMultiple: (partIds) =>
-    set({ selectedPartIds: new Set(partIds) }),
+  selectMultiple: (partIds) => {
+    const selection: SelectionItem[] = partIds.map((id) => ({ kind: "part", id }));
+    set({ selection, selectedPartIds: deriveSelectedPartIds(selection) });
+  },
 
-  clearSelection: () => set({ selectedPartIds: new Set() }),
+  clearSelection: () =>
+    set({ selection: [], selectedPartIds: new Set() }),
 
-  setHoveredPartId: (partId) => set({ hoveredPartId: partId }),
+  setHoveredPartId: (partId) => {
+    const hoveredItem: SelectionItem | null = partId
+      ? { kind: "part", id: partId }
+      : null;
+    set({ hoveredItem, hoveredPartId: partId });
+  },
+
+  selectItem: (item) => {
+    const selection: SelectionItem[] = item ? [item] : [];
+    set({ selection, selectedPartIds: deriveSelectedPartIds(selection) });
+  },
+
+  toggleItem: (item) =>
+    set((s) => {
+      const idx = s.selection.findIndex((existing) =>
+        selectionItemsEqual(existing, item),
+      );
+      const selection =
+        idx >= 0
+          ? s.selection.filter((_, i) => i !== idx)
+          : [...s.selection, item];
+      return { selection, selectedPartIds: deriveSelectedPartIds(selection) };
+    }),
+
+  selectItems: (items) =>
+    set({ selection: [...items], selectedPartIds: deriveSelectedPartIds(items) }),
+
+  setHoveredItem: (item) =>
+    set({ hoveredItem: item, hoveredPartId: deriveHoveredPartId(item) }),
+
+  setSelectionFilter: (filter) => set({ selectionFilter: filter }),
 
   toggleCommandPalette: () =>
     set((s) => ({ commandPaletteOpen: !s.commandPaletteOpen })),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,58 @@ export interface FaceInfo {
   vertices?: Vec3[];
 }
 
+/**
+ * Tagged selection item — anything the user can hover or click on.
+ *
+ * Replaces the historical "selection = Set of part IDs" model. Existing call
+ * sites that only care about parts read through the `selectedPartIds`
+ * derived getter on `useUiStore`, which filters items where `kind === "part"`.
+ *
+ * Sub-feature kinds (face / edge / vertex) carry mesh-relative IDs and are
+ * intentionally tied to a single evaluation: re-evaluation that changes a
+ * part's topology drops sub-feature selections on that part.
+ */
+export type SelectionItem =
+  | { kind: "part"; id: string }
+  | { kind: "face"; partId: string; faceIndex: number }
+  | { kind: "edge"; partId: string; edgeId: number }
+  | { kind: "vertex"; partId: string; vertexId: number }
+  | { kind: "segment"; sketchId: string; index: number }
+  | { kind: "constraint"; sketchId: string; index: number };
+
+/** Selection filter — restricts what `pickSubFeature` will return. */
+export type SelectionFilter = "auto" | "body" | "face" | "edge" | "vertex";
+
+/** Whether two SelectionItems point at the same thing. Useful for hover/select diffing. */
+export function selectionItemsEqual(a: SelectionItem, b: SelectionItem): boolean {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case "part":
+      return a.id === (b as { id: string }).id;
+    case "face":
+      return (
+        a.partId === (b as { partId: string }).partId &&
+        a.faceIndex === (b as { faceIndex: number }).faceIndex
+      );
+    case "edge":
+      return (
+        a.partId === (b as { partId: string }).partId &&
+        a.edgeId === (b as { edgeId: number }).edgeId
+      );
+    case "vertex":
+      return (
+        a.partId === (b as { partId: string }).partId &&
+        a.vertexId === (b as { vertexId: number }).vertexId
+      );
+    case "segment":
+    case "constraint":
+      return (
+        a.sketchId === (b as { sketchId: string }).sketchId &&
+        a.index === (b as { index: number }).index
+      );
+  }
+}
+
 export interface PrimitivePartInfo {
   id: string;
   name: string;


### PR DESCRIPTION
## Summary

Extends vcad's selection model from parts-only to a full tagged union covering **faces, edges, vertices, and existing sketch entities** — picking, hover, overlays, camera focus, status bar, property panel, two-pane sidebar, and AI chat context all participate.

Builds on top of [#120](https://github.com/ecto/vcad/pull/120) (focus zones, tree nav, R/H/W/D primed entry — already merged). Towards [#117](https://github.com/ecto/vcad/issues/117) (keyboardable CAD).

## Phases

**Phase 1 — Data model + back-compat selectors** (98e69d6)
- `SelectionItem` discriminated union in `@vcad/core` and `vcad-app` Rust crate: `part | face | edge | vertex | segment | constraint`.
- New `SelectionFilter`: `auto | body | face | edge | vertex`.
- Existing `selectedPartIds: Set<string>` and `hoveredPartId` kept as **derived views** synced on every write — zero changes to dozens of consumer files.

**Phase 2 — Hit testing** (97d5722)
- `pickSubFeature` walks the cursor's intersection: vertex (within 10 px) > edge (within 6 px) > face > body. Filter constrains the candidate set.
- Stable per-evaluation IDs: `faceIndex` (triangle), `edgeId` (`min*N + max` pack), `vertexId` (mesh vertex).
- Wired into `SceneMesh` pointer handlers — click selects, pointermove hovers, modifier-click toggles.

**Phase 3 — Overlays** (b88375c)
- `SelectionOverlay` extended with `FaceHighlight` (coplanar triangle subset), `EdgeHighlight` (polyline), `VertexHighlight` (screen-scaled sphere). Hover variant at lower opacity, skipped if already in selection.

**Phase 4 — UI affordances** (0c60513)
- Status bar shows sub-feature count + label ("face on Ball Core").
- Filter chip cluster with hotkeys `0`/`1`/`2`/`3`/`4`.
- Property panel dispatches off `selection[0].kind` — face shows area/triangles/index, edge shows length/endpoints, vertex shows X/Y/Z (typeable).

**Camera focus** (2874e45 → 311021c)
- Fly to sub-feature selections like part selections, but in **pan-only mode** for face/edge/vertex picks — preserves current zoom so a single vertex doesn't dive past the near plane.

**Two-pane sidebar UX** (6c42394)
- Left sidebar splits into tree (top) + inspector (bottom) when something's selected.
- Breadcrumb in property panel: \`Document › Part › face\` with click-up navigation.
- Tree mirrors sub-feature selection — owning row gets brand tint when its part owns a face/edge/vertex in the selection.

**AI chat context** (5e5277d)
- \`useSelectionContext\` walks the SelectionItem union, surfaces \`geometryType\` and per-kind metadata.
- AI command-registry context formatter produces "Cylinder face #3 (id: 0:7)" / "Tile L0 edge #142 (id: 0:3)" / "Ball Core vertex #50 (id: 0:1)".
- \`prompt-appendix.ts\` instructs the model to respect sub-feature scope and ask before substituting "the whole part" for "this face".

## Phase 5 — deferred

Operations that consume sub-features (fillet/chamfer take edges, extrude takes face profile, pattern takes seed) ship in a follow-up PR — keeps this one a self-contained data-model + UI shift, not a tool rewrite.

## Test plan

- [x] \`cargo test -p vcad-app --lib\` — 93 passing (5 new selection tests added)
- [x] \`npm test -w @vcad/core\` — 88 passing (13 new selection-store tests)
- [x] \`cargo clippy --workspace -- -D warnings\` — clean
- [x] \`npm run build --workspaces\` — clean
- [ ] Manual: hover/click face, edge, vertex; filter hotkeys 0–4; multi-select with shift; camera pan-only on sub-feature; tree mirror; breadcrumb up-nav; PR #120 keyboard regression (R/H/W/D primed entry, j/k tree cursor, Tab zone cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)