### PR TITLE
feat: footer chip system, header polish, native-app chrome

### DIFF
--- a/packages/app/api/_lib/discord.ts
+++ b/packages/app/api/_lib/discord.ts
@@ -6,6 +6,10 @@
 //   DISCORD_WEBHOOK_URL_<KIND> — optional per-kind override (e.g.
 //   DISCORD_WEBHOOK_URL_BILLING). Falls back to DISCORD_WEBHOOK_URL.
 //
+// Only fires from production deploys — VERCEL_ENV must be "production".
+// Preview deployments and local dev are silenced so test events don't spam
+// the channel. Set DISCORD_FORCE=1 to override (useful for debugging).
+//
 // Failures are logged but never thrown — Discord being down must never break
 // a user-facing request.
 
@@ -36,6 +40,7 @@ function resolveWebhook(kind: EventKind): string | null {
 }
 
 export async function notifyDiscord(opts: NotifyOpts): Promise<void> {
+  if (process.env.VERCEL_ENV !== "production" && process.env.DISCORD_FORCE !== "1") return;
   const webhook = resolveWebhook(opts.kind);
   if (!webhook) return;
 

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -77,6 +77,7 @@ import {
   parseVcadFile,
   parseStl,
   logger,
+  runJob,
 } from "@vcad/core";
 import { useEngine } from "@/hooks/useEngine";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -368,7 +369,10 @@ export function App() {
         logger.info("step", `Buffer size: ${buffer.byteLength}`);
 
         logger.info("step", "Calling engine.importStep...");
-        const rawMeshes = engine.importStep(buffer);
+        const rawMeshes = await runJob(
+          { verb: `Importing ${file.name}` },
+          () => engine.importStep(buffer),
+        );
         logger.info("step", `Got meshes: ${rawMeshes.length}`);
 
         if (rawMeshes.length === 0) {

--- a/packages/app/src/components/FooterUsageMeter.tsx
+++ b/packages/app/src/components/FooterUsageMeter.tsx
@@ -11,6 +11,7 @@ import {
 import { useAuth } from "@vcad/auth";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/shadcn/hover-card";
 import { UpgradeModal } from "@/components/UpgradeModal";
+import { FooterChipButton } from "@/components/footer/FooterChip";
 import { cn } from "@/lib/utils";
 import { refreshUsage } from "@/lib/billing-api";
 
@@ -83,15 +84,10 @@ export function FooterUsageMeter() {
     <>
       <HoverCard openDelay={120} closeDelay={80}>
         <HoverCardTrigger asChild>
-          <button
-            type="button"
+          <FooterChipButton
             onClick={() => setUpgradeOpen(true)}
             aria-label={`${tier.name} plan — ${formatTokens(used)} of ${formatTokens(snapshot.limit)} tokens used. Click to upgrade.`}
-            className={cn(
-              "group flex items-center gap-2 px-3 border-l border-border/40",
-              "text-text-muted hover:text-text hover:bg-hover transition-colors",
-              "focus:outline-none focus-visible:bg-hover",
-            )}
+            className="group"
           >
             <span
               className={cn(
@@ -121,14 +117,14 @@ export function FooterUsageMeter() {
             {statusLabel && (
               <span
                 className={cn(
-                  "uppercase tracking-wide hidden md:inline",
+                  "uppercase tracking-wide hidden xl:inline",
                   severity === "critical" ? "text-danger" : "text-amber-500",
                 )}
               >
                 {statusLabel}
               </span>
             )}
-          </button>
+          </FooterChipButton>
         </HoverCardTrigger>
         <HoverCardContent
           side="top"

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -21,6 +21,7 @@ import {
   TIERS,
   useBillingStore,
   t,
+  runJob,
   type Command,
 } from "@vcad/core";
 import { openCustomerPortal } from "@/lib/billing-api";
@@ -361,17 +362,20 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
     useUiStore.getState().setCommandPaletteOpen(true);
   };
 
-  const handleExport = (format: "stl" | "glb" | "step") => {
+  const handleExport = async (format: "stl" | "glb" | "step") => {
     const scene = useEngineStore.getState().scene;
     if (!scene) {
       useNotificationStore.getState().addToast("Nothing to export", "info");
       return;
     }
     try {
-      const blob =
-        format === "stl" ? exportStlBlob(scene)
-        : format === "glb" ? exportGltfBlob(scene)
-        : exportStepBlob(scene);
+      const blob = await runJob(
+        { verb: `Exporting ${format.toUpperCase()}` },
+        () =>
+          format === "stl" ? exportStlBlob(scene)
+          : format === "glb" ? exportGltfBlob(scene)
+          : exportStepBlob(scene),
+      );
       downloadBlob(blob, `model.${format}`);
     } catch (err) {
       useNotificationStore
@@ -430,7 +434,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           onValueChange={setMenuValue}
           loop
           className={cn(
-            "flex items-center gap-0",
+            "flex items-center gap-0 min-w-0 overflow-x-auto no-scrollbar",
             nativeMenu && "hidden",
           )}
         >
@@ -616,14 +620,15 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           data-tauri-drag-region={macOverlay ? "" : undefined}
         />
 
-        {/* Right cluster: search · changelog bell · auth */}
+        {/* Right cluster: search · changelog bell · auth. Search drops below
+            sm; bell drops below md. Auth/user always present. */}
         <button
           type="button"
           onClick={handleCommandPalette}
           title="Search or ask AI… (⌘K)"
           aria-label="Search or ask AI"
           className={cn(
-            "relative flex items-center justify-center w-6 h-6",
+            "relative shrink-0 hidden sm:flex items-center justify-center w-6 h-6",
             "text-text-muted hover:text-text hover:bg-hover transition-colors",
           )}
         >
@@ -643,7 +648,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
               : "What's new"
           }
           className={cn(
-            "relative flex items-center justify-center w-6 h-6",
+            "relative shrink-0 hidden md:flex items-center justify-center w-6 h-6",
             "text-text-muted hover:text-text hover:bg-hover transition-colors",
           )}
         >
@@ -670,7 +675,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
         <SignInButton
           variant="icon-text"
           className={cn(
-            "flex items-center justify-center gap-1.5 h-6 px-2 text-[10px] font-medium",
+            "shrink-0 flex items-center justify-center gap-1.5 h-6 px-2 text-[10px] font-medium",
             "text-text-muted hover:text-text hover:bg-hover",
           )}
         />

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -70,25 +70,28 @@ interface HeaderProps {
 // ---------------------------------------------------------------------------
 
 const TRIGGER_CLASS = cn(
-  "h-6 px-2 text-xs text-text outline-none cursor-default select-none",
-  "hover:bg-hover data-[state=open]:bg-hover transition-colors",
+  "h-6 px-2 text-[11px] font-medium text-text outline-none cursor-default select-none",
+  "hover:bg-hover data-[state=open]:bg-hover",
 );
 
 const CONTENT_CLASS =
-  "z-50 min-w-[180px] border border-border bg-surface shadow-lg py-1";
+  "z-50 min-w-[200px] border border-border/80 bg-surface py-1 shadow-md";
 
 const ITEM_CLASS = cn(
-  "flex w-full items-center gap-2 px-3 py-1 text-xs text-text outline-none cursor-default select-none",
+  "flex w-full items-center gap-2 px-2.5 py-1 text-[11px] text-text outline-none cursor-default select-none",
   "data-[highlighted]:bg-hover data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed",
 );
 
 /** Renders a top-level trigger label with the first letter underlined as a
  * typeahead hint — once the menubar has focus, pressing that letter jumps
- * to the corresponding menu. */
+ * to the corresponding menu. The underline is muted so it reads as a hint,
+ * not as emphasis. */
 function TriggerLabel({ label }: { label: string }) {
   return (
     <>
-      <span className="underline">{label[0]}</span>
+      <span className="underline decoration-text-muted/40 underline-offset-2">
+        {label[0]}
+      </span>
       {label.slice(1)}
     </>
   );
@@ -117,20 +120,24 @@ function MenuItem({
       onSelect={onSelect}
       className={ITEM_CLASS}
     >
-      {Icon && <Icon size={13} className={iconClassName ?? "text-text-muted"} />}
+      {Icon && <Icon size={12} className={iconClassName ?? "text-text-muted"} />}
       <span className="flex-1 text-left">{children}</span>
       {badge !== undefined && badge > 0 && (
-        <span className="min-w-[18px] rounded-full bg-brand px-1.5 py-0.5 text-center text-[10px] font-bold text-white">
+        <span className="min-w-[16px] rounded-sm bg-brand px-1 text-center text-[9px] font-bold text-white">
           {badge}
         </span>
       )}
-      {shortcut && <span className="text-text-muted text-[10px]">{shortcut}</span>}
+      {shortcut && (
+        <span className="ml-2 text-[10px] font-mono text-text-muted/40">
+          {shortcut}
+        </span>
+      )}
     </Menubar.Item>
   );
 }
 
 function MenuSeparator() {
-  return <Menubar.Separator className="my-1 border-t border-border/40" />;
+  return <Menubar.Separator className="my-1 border-t border-border/30" />;
 }
 
 /** A submenu that opens on hover/right-arrow. Menubar.Sub handles all the
@@ -153,17 +160,19 @@ function Submenu({
   return (
     <Menubar.Sub>
       <Menubar.SubTrigger className={ITEM_CLASS}>
-        {Icon && <Icon size={13} className={iconClassName ?? "text-text-muted"} />}
+        {Icon && <Icon size={12} className={iconClassName ?? "text-text-muted"} />}
         <span className="flex-1 text-left">{label}</span>
-        {hint && <span className="text-text-muted text-[10px]">{hint}</span>}
-        <CaretRight size={10} className="text-text-muted" />
+        {hint && (
+          <span className="ml-2 text-[10px] text-text-muted/60">{hint}</span>
+        )}
+        <CaretRight size={10} className="text-text-muted/60" />
       </Menubar.SubTrigger>
       <Menubar.Portal>
         <Menubar.SubContent
           sideOffset={0}
           alignOffset={-5}
           className={cn(
-            "z-50 min-w-[160px] border border-border bg-surface shadow-lg py-1",
+            "z-50 min-w-[180px] border border-border/80 bg-surface py-1 shadow-md",
             contentClassName,
           )}
         >
@@ -405,12 +414,12 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
       <div
         data-tauri-drag-region={macOverlay ? "" : undefined}
         className={cn(
-          "relative flex items-center gap-0 px-2 border-b border-border/40",
+          "relative flex items-center gap-0 px-1 border-b border-border/30",
           macOverlay ? "h-9 pl-[78px]" : "h-7",
         )}
       >
         <div
-          className="flex items-center gap-1 pr-3"
+          className="flex items-center pr-2 pl-1"
           data-tauri-drag-region={macOverlay ? "" : undefined}
         >
           <button
@@ -418,7 +427,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
             onClick={onAboutOpen}
             title="About vcad"
             aria-label="About vcad"
-            className="text-sm font-bold tracking-tighter text-text hover:text-brand transition-colors cursor-default outline-none"
+            className="text-[13px] font-semibold text-text hover:text-brand transition-colors cursor-default outline-none"
           >
             vcad<span className="text-brand">.</span>
           </button>
@@ -628,8 +637,8 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           title="Search or ask AI… (⌘K)"
           aria-label="Search or ask AI"
           className={cn(
-            "relative shrink-0 hidden sm:flex items-center justify-center w-6 h-6",
-            "text-text-muted hover:text-text hover:bg-hover transition-colors",
+            "relative shrink-0 hidden sm:flex items-center justify-center w-7 h-6",
+            "text-text-muted hover:text-text hover:bg-hover",
           )}
         >
           <MagnifyingGlass size={13} />
@@ -648,14 +657,14 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
               : "What's new"
           }
           className={cn(
-            "relative shrink-0 hidden md:flex items-center justify-center w-6 h-6",
-            "text-text-muted hover:text-text hover:bg-hover transition-colors",
+            "relative shrink-0 hidden md:flex items-center justify-center w-7 h-6",
+            "text-text-muted hover:text-text hover:bg-hover",
           )}
         >
           <Bell size={13} weight={unreadChangelog > 0 ? "fill" : "regular"} />
           {unreadChangelog > 0 && (
             <span
-              className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-brand"
+              className="absolute top-1 right-1.5 w-1.5 h-1.5 rounded-full bg-brand"
               aria-hidden="true"
             />
           )}
@@ -666,8 +675,8 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           title="Send feedback"
           aria-label="Send feedback"
           className={cn(
-            "relative flex items-center justify-center w-6 h-6",
-            "text-text-muted hover:text-text hover:bg-hover transition-colors",
+            "relative flex items-center justify-center w-7 h-6",
+            "text-text-muted hover:text-text hover:bg-hover",
           )}
         >
           <Megaphone size={13} />
@@ -675,7 +684,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
         <SignInButton
           variant="icon-text"
           className={cn(
-            "shrink-0 flex items-center justify-center gap-1.5 h-6 px-2 text-[10px] font-medium",
+            "shrink-0 flex items-center justify-center gap-1.5 h-6 px-2 text-[11px] font-medium",
             "text-text-muted hover:text-text hover:bg-hover",
           )}
         />

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -427,7 +427,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
             onClick={onAboutOpen}
             title="About vcad"
             aria-label="About vcad"
-            className="text-[13px] font-semibold text-text hover:text-brand transition-colors cursor-default outline-none"
+            className="font-mono text-[13px] font-semibold text-text hover:text-brand transition-colors cursor-default outline-none"
           >
             vcad<span className="text-brand">.</span>
           </button>

--- a/packages/app/src/components/SketchPlane3D.tsx
+++ b/packages/app/src/components/SketchPlane3D.tsx
@@ -1,6 +1,6 @@
-import { useRef, useMemo, useCallback } from "react";
+import { useRef, useMemo, useCallback, type ReactNode } from "react";
 import * as THREE from "three";
-import { useThree, ThreeEvent } from "@react-three/fiber";
+import { useThree, useFrame, ThreeEvent } from "@react-three/fiber";
 import { Line, Html } from "@react-three/drei";
 import {
   useSketchStore,
@@ -20,6 +20,47 @@ const POINT_SNAP_TOLERANCE = 5; // mm
 /** Convert a Vec3 to Three.js Vector3 */
 function toVec3(v: Vec3): THREE.Vector3 {
   return new THREE.Vector3(v.x, v.y, v.z);
+}
+
+/**
+ * Wraps children in a group that maintains a fixed pixel size as the camera
+ * moves. Pass `screenPx=1` and use unit-pixel-sized geometry — e.g.,
+ * `<ringGeometry args={[8, 10, 16]} />` will render as 8-10 pixels regardless
+ * of zoom.
+ *
+ * For perspective cameras: world-units per screen pixel is
+ *   (2 · distance · tan(fov / 2)) / viewport-height
+ * we apply that as the group's uniform scale every frame.
+ */
+function ScreenScaledGroup({
+  position,
+  screenPx = 1,
+  children,
+}: {
+  position: THREE.Vector3 | [number, number, number];
+  screenPx?: number;
+  children: ReactNode;
+}) {
+  const ref = useRef<THREE.Group>(null);
+  const { camera, size } = useThree();
+  const tmpV = useRef(new THREE.Vector3());
+
+  useFrame(() => {
+    const g = ref.current;
+    if (!g) return;
+    const p = Array.isArray(position) ? tmpV.current.fromArray(position) : position;
+    const cam = camera as THREE.PerspectiveCamera;
+    const dist = cam.position.distanceTo(p);
+    const fovRad = ((cam.fov ?? 50) * Math.PI) / 180;
+    const worldPerPx = (2 * dist * Math.tan(fovRad / 2)) / size.height;
+    g.scale.setScalar(Math.max(1e-4, screenPx * worldPerPx));
+  });
+
+  return (
+    <group ref={ref} position={position}>
+      {children}
+    </group>
+  );
 }
 
 /**
@@ -456,20 +497,24 @@ function SketchGeometry3D({
         />
       ))}
 
-      {/* Vertices */}
+      {/* Vertices — fixed 4px screen radius */}
       {vertices.map((v, i) => (
-        <mesh key={i} position={v}>
-          <sphereGeometry args={[0.8, 12, 12]} />
-          <meshBasicMaterial color={isDark ? "#00d4ff" : "#0891b2"} />
-        </mesh>
+        <ScreenScaledGroup key={i} position={v}>
+          <mesh>
+            <sphereGeometry args={[4, 12, 12]} />
+            <meshBasicMaterial color={isDark ? "#00d4ff" : "#0891b2"} />
+          </mesh>
+        </ScreenScaledGroup>
       ))}
 
-      {/* Pending points (during shape creation) */}
+      {/* Pending points (during shape creation) — fixed 5px screen radius */}
       {pendingPoints3D.map((pt, i) => (
-        <mesh key={`pending-${i}`} position={pt}>
-          <sphereGeometry args={[1.2, 12, 12]} />
-          <meshBasicMaterial color="#f59e0b" />
-        </mesh>
+        <ScreenScaledGroup key={`pending-${i}`} position={pt}>
+          <mesh>
+            <sphereGeometry args={[5, 12, 12]} />
+            <meshBasicMaterial color="#f59e0b" />
+          </mesh>
+        </ScreenScaledGroup>
       ))}
 
       {/* Constraint labels */}
@@ -517,34 +562,26 @@ function SketchCursor3D({
     () => (cursorWorldPos ? toVec3(cursorWorldPos) : null),
     [cursorWorldPos],
   );
-  const crosshairSize = 3;
+  // Crosshair points are expressed in local frame (centered at origin) and
+  // wrapped in a ScreenScaledGroup so they render at a fixed pixel size at
+  // any zoom. CROSSHAIR_PX is the half-length in pixels.
+  const CROSSHAIR_PX = 14;
 
-  // Crosshair lines
   const xCross = useMemo(() => {
-    if (!cursorPos) return null;
     const x = toVec3(xDir);
-    const start = cursorPos
-      .clone()
-      .sub(x.clone().multiplyScalar(crosshairSize));
-    const end = cursorPos.clone().add(x.clone().multiplyScalar(crosshairSize));
     return [
-      [start.x, start.y, start.z],
-      [end.x, end.y, end.z],
+      [-x.x * CROSSHAIR_PX, -x.y * CROSSHAIR_PX, -x.z * CROSSHAIR_PX],
+      [x.x * CROSSHAIR_PX, x.y * CROSSHAIR_PX, x.z * CROSSHAIR_PX],
     ] as [number, number, number][];
-  }, [cursorPos, xDir]);
+  }, [xDir]);
 
   const yCross = useMemo(() => {
-    if (!cursorPos) return null;
     const y = toVec3(yDir);
-    const start = cursorPos
-      .clone()
-      .sub(y.clone().multiplyScalar(crosshairSize));
-    const end = cursorPos.clone().add(y.clone().multiplyScalar(crosshairSize));
     return [
-      [start.x, start.y, start.z],
-      [end.x, end.y, end.z],
+      [-y.x * CROSSHAIR_PX, -y.y * CROSSHAIR_PX, -y.z * CROSSHAIR_PX],
+      [y.x * CROSSHAIR_PX, y.y * CROSSHAIR_PX, y.z * CROSSHAIR_PX],
     ] as [number, number, number][];
-  }, [cursorPos, yDir]);
+  }, [yDir]);
 
   // Preview line
   const previewLinePoints = useMemo(() => {
@@ -610,19 +647,22 @@ function SketchCursor3D({
 
   return (
     <group>
-      {/* Crosshair - cyan when grid snap active */}
-      <Line
-        points={xCross}
-        color={gridSnap && !snapTarget ? "#06b6d4" : "rgba(255,255,255,0.5)"}
-        lineWidth={gridSnap && !snapTarget ? 1.5 : 1}
-        depthWrite={false}
-      />
-      <Line
-        points={yCross}
-        color={gridSnap && !snapTarget ? "#06b6d4" : "rgba(255,255,255,0.5)"}
-        lineWidth={gridSnap && !snapTarget ? 1.5 : 1}
-        depthWrite={false}
-      />
+      {/* Crosshair - cyan when grid snap active. Pixel-sized so it stays
+          legible at any zoom level. */}
+      <ScreenScaledGroup position={cursorPos}>
+        <Line
+          points={xCross}
+          color={gridSnap && !snapTarget ? "#06b6d4" : "rgba(255,255,255,0.5)"}
+          lineWidth={gridSnap && !snapTarget ? 1.5 : 1}
+          depthWrite={false}
+        />
+        <Line
+          points={yCross}
+          color={gridSnap && !snapTarget ? "#06b6d4" : "rgba(255,255,255,0.5)"}
+          lineWidth={gridSnap && !snapTarget ? 1.5 : 1}
+          depthWrite={false}
+        />
+      </ScreenScaledGroup>
 
       {/* Preview line (dashed) */}
       {previewLinePoints && (
@@ -663,18 +703,18 @@ function SketchCursor3D({
         />
       )}
 
-      {/* Point snap indicator (green) */}
+      {/* Point snap indicator (green) — fixed pixel size at any zoom level */}
       {snapPos && (
-        <>
-          <mesh position={snapPos}>
-            <ringGeometry args={[2, 2.5, 16]} />
+        <ScreenScaledGroup position={snapPos}>
+          <mesh>
+            <ringGeometry args={[8, 10, 24]} />
             <meshBasicMaterial color="#22c55e" side={THREE.DoubleSide} />
           </mesh>
-          <mesh position={snapPos}>
-            <sphereGeometry args={[0.8, 12, 12]} />
+          <mesh>
+            <sphereGeometry args={[3, 12, 12]} />
             <meshBasicMaterial color="#22c55e" />
           </mesh>
-        </>
+        </ScreenScaledGroup>
       )}
 
       {/* Coordinate label */}

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -7,15 +7,34 @@ import { Check } from "@phosphor-icons/react/dist/ssr/Check";
 import * as Popover from "@radix-ui/react-popover";
 import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName, type SelectionFilter } from "@vcad/core";
 import { useLocaleStore, supportedLocales, type SupportedLocale } from "@/stores/locale-store";
+import { useDrawingStore } from "@/stores/drawing-store";
 import { useLogStore, getFilteredEntries } from "@/stores/log-store";
 import { FooterUsageMeter } from "@/components/FooterUsageMeter";
+import { FooterChip, FooterChipButton } from "@/components/footer/FooterChip";
+import { CursorCoordChip } from "@/components/footer/CursorCoordChip";
+import { KernelPulseChip } from "@/components/footer/KernelPulseChip";
+import { JobsChip } from "@/components/footer/JobsChip";
+import { KoanChip } from "@/components/footer/KoanChip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useCapabilities } from "@/lib/capabilities";
 
 const LOCALE_LABELS: Record<string, string> = {
+  cs: "Čeština",
+  de: "Deutsch",
   en: "English",
   es: "Español",
   fr: "Français",
+  it: "Italiano",
+  ja: "日本語",
+  ko: "한국어",
+  nl: "Nederlands",
+  pl: "Polski",
+  pt: "Português",
+  ru: "Русский",
+  tr: "Türkçe",
+  zh: "中文",
+  "zh-tw": "繁體中文",
 };
 
 const LEVEL_COLOR: Record<LogLevelName, string> = {
@@ -24,10 +43,6 @@ const LEVEL_COLOR: Record<LogLevelName, string> = {
   WARN: "text-yellow-400",
   ERROR: "text-red-400",
 };
-
-function formatCoord(n: number): string {
-  return n.toFixed(1).padStart(8, " ");
-}
 
 function formatAgo(ts: number, now: number): string {
   const diff = Math.max(0, now - ts);
@@ -40,23 +55,25 @@ function formatAgo(ts: number, now: number): string {
 /**
  * Ambient status bar.
  *
- * Left: live ticker of the most recent console log entry matching the current
- * filters. Slides in on change, click opens the full Console panel. Middle:
- * live cursor world position from the viewport raycast. Right: compact doc
- * metrics — dirty dot, part count, selection count.
+ * Composed from FooterChip primitives. Left → right:
+ * - Koan slot: selection summary, doc stats, or rotating idle koan.
+ * - Console ticker (expands to fill): latest log entry, click opens panel.
+ * - Sketch ribbon (when active): plane, cursor, snap, counts, solver state.
+ * - Cursor world coords (Z-up, with click-to-cycle unit and click-to-pan).
+ * - Active job (when running) → usage meter → locale picker.
+ * - Kernel pulse + frame-ms sparkline (rightmost, system telemetry).
  */
 export function StatusBar() {
   const parts = useDocumentStore((s) => s.parts);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const selection = useUiStore((s) => s.selection);
-  const cursorWorld = useUiStore((s) => s.cursorWorld);
   useLocaleStore((s) => s.locale);
 
-  // Sketch state — only rendered while sketch is active. Each subscription is
-  // cheap (primitives or shallow length), so the subscriber count overhead is
-  // a non-issue.
   const sketchActive = useSketchStore((s) => s.active);
   const sketchPlane = useSketchStore((s) => s.plane);
+  const drafting2d = useDrawingStore((s) => s.viewMode === "2d");
+  const renderMode = useUiStore((s) => s.renderMode);
+  const toolbarTab = useUiStore((s) => s.toolbarTab);
   const sketchCursor = useSketchStore((s) => s.cursorSketchPos);
   const sketchSnap = useSketchStore((s) => s.snapTarget);
   const sketchSegmentCount = useSketchStore((s) => s.segments.length);
@@ -65,16 +82,12 @@ export function StatusBar() {
   const gridSnap = useUiStore((s) => s.gridSnap);
   const pointSnap = useUiStore((s) => s.pointSnap);
 
-  // Subscribe to the pieces of the log store the ticker actually needs so we
-  // re-render only when filtered output changes.
   const entries = useLogStore((s) => s.entries);
   const minLevel = useLogStore((s) => s.minLevel);
   const enabledSources = useLogStore((s) => s.enabledSources);
   const togglePanel = useLogStore((s) => s.togglePanel);
 
   const latest = useMemo(() => {
-    // getFilteredEntries wants the whole state shape but only reads these
-    // four fields; the rest are never touched by the filter.
     const filtered = getFilteredEntries({
       entries,
       minLevel,
@@ -90,15 +103,14 @@ export function StatusBar() {
     return filtered.length > 0 ? filtered[filtered.length - 1] : null;
   }, [entries, minLevel, enabledSources]);
 
-  // Tick for "Ns ago" readout and to re-key the slide-in animation.
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, []);
 
-  const selCount = selectedPartIds.size;
   const fresh = latest && now - latest.timestamp < 3000;
+  const selCount = selectedPartIds.size;
 
   /**
    * One-line summary of what's currently selected. Prefers sub-feature
@@ -138,22 +150,76 @@ export function StatusBar() {
     <div
       data-tauri-drag-region={macOverlay ? "" : undefined}
       className={cn(
-        "flex h-6 items-stretch bg-surface text-[10px] font-mono select-none",
+        "vcad-footer flex h-6 items-stretch bg-surface select-none",
         "border-t border-border/40",
       )}
     >
-      {/* Left: console ticker — click to open the full console panel */}
-      <button
-        type="button"
-        onClick={togglePanel}
-        className={cn(
-          "flex items-center gap-2 px-3 min-w-0 flex-1",
-          "text-text-muted hover:bg-hover hover:text-text",
-          "focus:outline-none focus-visible:bg-hover",
-          "transition-colors",
-        )}
-        title={latest ? t("status.console_open") : t("status.console_empty_title")}
+      {/* Leftmost slot: sketch ribbon when sketching, koan / mode badge
+          otherwise. Both share the no-leading-divider position so the
+          chrome stays consistent regardless of mode. */}
+      {sketchActive ? (
+        <Tooltip
+          side="top"
+          content="Active sketch — plane, cursor, snap, entity / constraint counts, solver state"
+        >
+          <FooterChip
+            divider={false}
+            severity="warn"
+            className="tabular-nums"
+          >
+            <PencilSimple size={11} className="shrink-0" />
+            <span className="font-medium">SKETCH</span>
+            <span className="text-text-muted">
+              {typeof sketchPlane === "string" ? sketchPlane : "face"}
+            </span>
+            {sketchCursor && (
+              <span className="hidden md:inline text-text-muted">
+                ({sketchCursor.x.toFixed(1)}, {sketchCursor.y.toFixed(1)})
+              </span>
+            )}
+            <span className="hidden lg:inline text-text-muted">
+              snap: {sketchSnap ? "POINT" : gridSnap ? "GRID" : pointSnap ? "PT" : "OFF"}
+            </span>
+            <span className="text-text-muted">
+              {sketchSegmentCount} ent · {sketchConstraintCount} con
+            </span>
+            <span
+              className={cn(
+                "uppercase",
+                sketchStatus === "solved" && "text-emerald-400",
+                sketchStatus === "error" && "text-red-400",
+                sketchStatus === "over" && "text-orange-400",
+                sketchStatus === "under" && "text-yellow-400",
+              )}
+            >
+              [{sketchStatus}]
+            </span>
+          </FooterChip>
+        </Tooltip>
+      ) : (
+        <KoanChip
+          divider={false}
+          mode={
+            drafting2d
+              ? "drafting"
+              : renderMode === "raytrace"
+                ? "raytrace"
+                : toolbarTab === "assembly"
+                  ? "assembly"
+                  : null
+          }
+        />
+      )}
+
+      <Tooltip
+        side="top"
+        content={
+          latest
+            ? "Latest console message — click to open the panel"
+            : "Console is empty — click to open the panel"
+        }
       >
+      <FooterChipButton flex onClick={togglePanel}>
         <Terminal size={11} className="shrink-0 opacity-60" />
         {latest ? (
           <>
@@ -165,7 +231,7 @@ export function StatusBar() {
             >
               {latest.level}
             </span>
-            <span className="shrink-0 text-text-muted/70">
+            <span className="hidden md:inline shrink-0 text-text-muted/70">
               {latest.source}
             </span>
             <span
@@ -191,85 +257,14 @@ export function StatusBar() {
         ) : (
           <span className="text-text-muted/60">console empty</span>
         )}
-      </button>
+      </FooterChipButton>
+      </Tooltip>
 
-      {/* Sketch ribbon — only when active. Surfaces live cursor, snap state,
-          entity/constraint counts, and constraint solver status. */}
-      {sketchActive && (
-        <div
-          className={cn(
-            "flex items-center gap-2 px-3 border-l border-border/40",
-            "text-amber-400 tabular-nums whitespace-pre",
-          )}
-        >
-          <PencilSimple size={11} className="shrink-0" />
-          <span className="font-medium">SKETCH</span>
-          <span className="text-text-muted">
-            {typeof sketchPlane === "string" ? sketchPlane : "face"}
-          </span>
-          {sketchCursor && (
-            <span className="hidden md:inline text-text-muted">
-              ({sketchCursor.x.toFixed(1)}, {sketchCursor.y.toFixed(1)})
-            </span>
-          )}
-          <span className="hidden lg:inline text-text-muted">
-            snap: {sketchSnap ? "POINT" : gridSnap ? "GRID" : pointSnap ? "PT" : "OFF"}
-          </span>
-          <span className="text-text-muted">
-            {sketchSegmentCount} ent · {sketchConstraintCount} con
-          </span>
-          <span
-            className={cn(
-              "uppercase",
-              sketchStatus === "solved" && "text-emerald-400",
-              sketchStatus === "error" && "text-red-400",
-              sketchStatus === "over" && "text-orange-400",
-              sketchStatus === "under" && "text-yellow-400",
-            )}
-          >
-            [{sketchStatus}]
-          </span>
-        </div>
-      )}
+      <CursorCoordChip className={cn(sketchActive && "hidden lg:flex")} />
 
-      {/* Middle: live cursor world coords (Z-up, mm) */}
-      <div
-        className={cn(
-          "hidden sm:flex items-center gap-2 px-3 border-l border-border/40",
-          "text-text-muted tabular-nums whitespace-pre",
-          sketchActive && "hidden lg:flex",
-        )}
-        title={t("status.cursor_pos")}
-      >
-        {cursorWorld ? (
-          <>
-            <span>
-              <span className="text-brand">x</span>
-              {formatCoord(cursorWorld.x)}
-            </span>
-            <span>
-              <span className="text-brand">y</span>
-              {formatCoord(cursorWorld.y)}
-            </span>
-            <span>
-              <span className="text-brand">z</span>
-              {formatCoord(cursorWorld.z)}
-            </span>
-          </>
-        ) : (
-          <span className="opacity-40">
-            x       — y       — z       —
-          </span>
-        )}
-      </div>
+      <JobsChip />
 
-      {/* Right: doc metrics — save state now lives in the titlebar's DocTitle */}
-      <div
-        className={cn(
-          "flex items-center gap-3 px-3 border-l border-border/40",
-          "text-text-muted",
-        )}
-      >
+      <FooterChip className="gap-3">
         <span className="tabular-nums">
           {tFmt(parts.length === 1 ? "status.part" : "status.parts", {
             count: String(parts.length),
@@ -283,13 +278,15 @@ export function StatusBar() {
         {subFeatureLabel && (
           <span className="text-brand">{subFeatureLabel}</span>
         )}
-      </div>
+      </FooterChip>
 
       <SelectionFilterChips />
 
       <FooterUsageMeter />
 
       <LocalePicker />
+
+      <KernelPulseChip className="hidden md:flex" />
     </div>
   );
 }
@@ -344,48 +341,63 @@ function LocalePicker() {
 
   return (
     <Popover.Root>
-      <Popover.Trigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "flex items-center gap-1 px-2 border-l border-border/40",
-            "text-text-muted hover:text-text hover:bg-hover transition-colors",
-          )}
-          title={t("status.language")}
-        >
-          <GlobeSimple size={11} className="shrink-0" />
-          <span className="uppercase tracking-wide">{locale}</span>
-        </button>
-      </Popover.Trigger>
+      <Tooltip side="top" content="Display language — click to switch">
+        <Popover.Trigger asChild>
+          <FooterChipButton className="gap-1 px-2">
+            <GlobeSimple size={11} className="shrink-0" />
+            <span className="uppercase tracking-wide">{locale}</span>
+          </FooterChipButton>
+        </Popover.Trigger>
+      </Tooltip>
       <Popover.Portal>
         <Popover.Content
           side="top"
           align="end"
-          sideOffset={4}
+          sideOffset={6}
+          collisionPadding={8}
           className={cn(
-            "z-50 min-w-[140px] rounded-md border border-border bg-surface p-1 shadow-lg",
+            "z-50 w-[200px] max-h-[60vh] overflow-y-auto",
+            "rounded-md border border-border/60 bg-surface/95 backdrop-blur-md",
+            "p-1 shadow-xl",
             "animate-in fade-in slide-in-from-bottom-2 duration-150",
             "text-[11px] font-mono",
           )}
         >
-          {locales.map((loc) => (
-            <button
-              key={loc}
-              type="button"
-              onClick={() => setLoc(loc as SupportedLocale)}
-              className={cn(
-                "flex w-full items-center gap-2 rounded px-2 py-1",
-                "hover:bg-hover transition-colors",
-                loc === locale ? "text-text" : "text-text-muted",
-              )}
-            >
-              <span className="w-3">
-                {loc === locale && <Check size={10} weight="bold" className="text-brand" />}
-              </span>
-              <span className="uppercase tracking-wide w-5">{loc}</span>
-              <span className="text-text-muted">{LOCALE_LABELS[loc] ?? loc}</span>
-            </button>
-          ))}
+          <div className="px-2 pt-1 pb-1.5 text-text-muted/60 uppercase tracking-[0.15em] text-[9px]">
+            {t("status.language")}
+          </div>
+          {locales.map((loc) => {
+            const isActive = loc === locale;
+            return (
+              <button
+                key={loc}
+                type="button"
+                onClick={() => setLoc(loc as SupportedLocale)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5",
+                  "transition-colors",
+                  isActive
+                    ? "bg-brand/15 text-text"
+                    : "text-text-muted hover:bg-hover hover:text-text",
+                )}
+              >
+                <span
+                  className={cn(
+                    "shrink-0 w-7 text-[10px] uppercase tracking-wide tabular-nums",
+                    isActive ? "text-brand" : "text-text-muted/70",
+                  )}
+                >
+                  {loc}
+                </span>
+                <span className="flex-1 text-left whitespace-nowrap">
+                  {LOCALE_LABELS[loc] ?? loc}
+                </span>
+                {isActive && (
+                  <Check size={11} weight="bold" className="shrink-0 text-brand" />
+                )}
+              </button>
+            );
+          })}
         </Popover.Content>
       </Popover.Portal>
     </Popover.Root>

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -4,6 +4,7 @@ import { Terminal } from "@phosphor-icons/react/dist/ssr/Terminal";
 import { PencilSimple } from "@phosphor-icons/react/dist/ssr/PencilSimple";
 import { GlobeSimple } from "@phosphor-icons/react/dist/ssr/GlobeSimple";
 import { Check } from "@phosphor-icons/react/dist/ssr/Check";
+import { CrosshairSimple } from "@phosphor-icons/react/dist/ssr/CrosshairSimple";
 import * as Popover from "@radix-ui/react-popover";
 import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName, type SelectionFilter } from "@vcad/core";
 import { useLocaleStore, supportedLocales, type SupportedLocale } from "@/stores/locale-store";
@@ -291,46 +292,88 @@ export function StatusBar() {
   );
 }
 
-const FILTER_OPTIONS: Array<{ value: SelectionFilter; label: string; key: string }> = [
-  { value: "auto", label: "Auto", key: "0" },
-  { value: "body", label: "Body", key: "1" },
-  { value: "face", label: "Face", key: "2" },
-  { value: "edge", label: "Edge", key: "3" },
-  { value: "vertex", label: "Vertex", key: "4" },
+const FILTER_OPTIONS: Array<{ value: SelectionFilter; label: string; hint: string }> = [
+  { value: "auto", label: "Auto", hint: "Pick whatever's most specific under the cursor" },
+  { value: "body", label: "Body", hint: "Always select the whole part" },
+  { value: "face", label: "Face", hint: "Snap selection to the nearest face" },
+  { value: "edge", label: "Edge", hint: "Snap selection to the nearest edge" },
+  { value: "vertex", label: "Vertex", hint: "Snap selection to the nearest vertex" },
 ];
 
 /**
- * Selection filter chip cluster — restricts what `pickSubFeature` returns
- * on the next pointer event. Hotkeys 0/1/2/3/4 in the viewport zone
- * cycle to the same filter; the chips also show the current binding so
- * the shortcut is discoverable.
+ * Selection filter chip — single popover that shows the current pick mode
+ * (auto / body / face / edge / vertex) and lets you switch without taking
+ * over a digit hotkey. The toolbar tab strip owns 1–7, so we don't fight
+ * for them here.
  */
 function SelectionFilterChips() {
   const filter = useUiStore((s) => s.selectionFilter);
   const setFilter = useUiStore((s) => s.setSelectionFilter);
+  const current = FILTER_OPTIONS.find((o) => o.value === filter) ?? FILTER_OPTIONS[0]!;
   return (
-    <div className="hidden md:flex items-stretch border-l border-border/40">
-      {FILTER_OPTIONS.map(({ value, label, key }) => {
-        const active = filter === value;
-        return (
-          <button
-            key={value}
-            onClick={() => setFilter(value)}
-            title={`${label} (${key})`}
-            className={cn(
-              "px-2 text-[10px] uppercase tracking-wide transition-colors",
-              "border-r border-border/40 last:border-r-0",
-              active
-                ? "text-brand bg-brand/10"
-                : "text-text-muted hover:text-text hover:bg-hover",
-            )}
-          >
-            {label}
-            <span className="ml-1 text-text-muted/60 font-mono">{key}</span>
-          </button>
-        );
-      })}
-    </div>
+    <Popover.Root>
+      <Tooltip side="top" content="Pick mode — what hover and click target">
+        <Popover.Trigger asChild>
+          <FooterChipButton className="gap-1 px-2">
+            <CrosshairSimple size={11} className="shrink-0" />
+            <span className="uppercase tracking-wide">{current.label}</span>
+          </FooterChipButton>
+        </Popover.Trigger>
+      </Tooltip>
+      <Popover.Portal>
+        <Popover.Content
+          side="top"
+          align="end"
+          sideOffset={6}
+          collisionPadding={8}
+          className={cn(
+            "z-50 w-[260px]",
+            "rounded-md border border-border/60 bg-surface/95 backdrop-blur-md",
+            "p-1 shadow-xl",
+            "animate-in fade-in slide-in-from-bottom-2 duration-150",
+            "text-[11px]",
+          )}
+        >
+          <div className="px-2 pt-1 pb-1.5 text-text-muted/60 uppercase tracking-[0.15em] text-[9px]">
+            Pick mode
+          </div>
+          {FILTER_OPTIONS.map(({ value, label, hint }) => {
+            const active = filter === value;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setFilter(value)}
+                className={cn(
+                  "flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left",
+                  "transition-colors",
+                  active
+                    ? "bg-brand/15 text-text"
+                    : "text-text-muted hover:bg-hover hover:text-text",
+                )}
+              >
+                <span className="flex-1">
+                  <span
+                    className={cn(
+                      "block uppercase tracking-wide text-[10px]",
+                      active ? "text-brand" : "text-text",
+                    )}
+                  >
+                    {label}
+                  </span>
+                  <span className="block text-[10px] text-text-muted/70">
+                    {hint}
+                  </span>
+                </span>
+                {active && (
+                  <Check size={11} weight="bold" className="mt-0.5 shrink-0 text-brand" />
+                )}
+              </button>
+            );
+          })}
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }
 

--- a/packages/app/src/components/ToolPalette.tsx
+++ b/packages/app/src/components/ToolPalette.tsx
@@ -216,8 +216,15 @@ export function ToolPalette() {
         <div className="flex-1" />
       </div>
 
-      {/* Row 2: active tab content — same horizontal rhythm as the tab strip */}
-      <div className="flex items-center h-8 px-1">
+      {/* Row 2: active tab content — same horizontal rhythm as the tab strip,
+          with horizontal scroll + soft right-edge fade when tools overflow. */}
+      <div
+        className={cn(
+          "flex items-center h-8 px-1",
+          "overflow-x-auto no-scrollbar",
+          "[mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent_100%)]",
+        )}
+      >
         {renderTabContent(displayedTab)}
       </div>
     </div>

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -68,11 +68,6 @@ import { PcbScene } from "./electronics/pcb3d/PcbScene";
 import { usePcbCamera } from "./electronics/pcb3d/usePcbCamera";
 import { BG_DARK, BG_LIGHT } from "./Viewport";
 
-// Initial camera state for reset (module-scope so refs are stable)
-const INITIAL_POSITION_V = new Vector3(50, 50, 50);
-const INITIAL_TARGET_V = new Vector3(0, 0, 0);
-const INITIAL_DISTANCE_V = INITIAL_POSITION_V.distanceTo(INITIAL_TARGET_V);
-
 // Reused per-frame in the participant-sync hook (Lock + Follow).
 const _syncGoalPos = new Vector3();
 const _syncGoalTarget = new Vector3();
@@ -362,10 +357,6 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     if (orbitRef.current) orbitRef.current.enabled = true;
     setIsCameraMoving(false);
   }, []);
-
-  // Initial camera state for reset (stable refs across renders)
-  const INITIAL_TARGET = INITIAL_TARGET_V;
-  const INITIAL_DISTANCE = INITIAL_DISTANCE_V;
 
   // Build mapping from root index to instance ID (for assembly mode rendering with legacy parts)
   const rootIndexToInstanceId = useMemo(() => {
@@ -942,27 +933,25 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     };
   }, [setOrbiting, cancelCameraAnimation]);
 
-  // Double-click on empty canvas resets camera to initial position
+  // Double-click on empty canvas: fit camera to the scene (same handler as
+  // boot's auto-fit + the View → Fit menu). Was previously "reset to the
+  // hardcoded initial pose," which would hide the model whenever the
+  // geometry didn't live near (0, 0, 0).
   useEffect(() => {
     const controls = orbitRef.current;
     const domElement = controls?.domElement;
     if (!domElement) return;
 
     const handleDoubleClick = () => {
-      // Only reset when nothing is selected
+      // Only fit when nothing is selected — with selection, the existing
+      // selection-fit useEffect already does the right thing on the click.
       if (useUiStore.getState().selectedPartIds.size > 0) return;
-
-      // Animate to initial position
-      targetGoalRef.current.copy(INITIAL_TARGET);
-      distanceGoalRef.current = INITIAL_DISTANCE;
-      cameraPositionGoalRef.current = null; // Clear any position goal
-      isAnimatingTargetRef.current = true;
-      setIsCameraMoving(true);
+      window.dispatchEvent(new CustomEvent("vcad:camera-fit"));
     };
 
     domElement.addEventListener("dblclick", handleDoubleClick);
     return () => domElement.removeEventListener("dblclick", handleDoubleClick);
-  }, [INITIAL_DISTANCE, INITIAL_TARGET]);
+  }, []);
 
   // Publish cursor world position (Z-up) to UiStore for the status bar readout.
   // Raycasts pointer against the ground plane (kernel Z=0, display Y=0) via the
@@ -1021,37 +1010,75 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     };
   }, [camera]);
 
-  // Face selection: swing camera to view face flat
+  // Face selection: swing camera perpendicular to the face, framing its
+  // actual extent instead of a fixed-distance fallback.
   useEffect(() => {
     const handleFaceSelected = (
       e: CustomEvent<{
         normal: { x: number; y: number; z: number };
         centroid: { x: number; y: number; z: number };
+        vertices?: { x: number; y: number; z: number }[];
       }>,
     ) => {
-      const { normal, centroid } = e.detail;
+      const { normal, centroid, vertices } = e.detail;
 
-      // centroid is in world space (from Three.js e.point), but normal is in
-      // kernel Z-up space — transform normal: (nx, ny, nz) → (nx, nz, -ny)
-      const wNormal = new Vector3(normal.x, normal.z, -normal.y);
+      // Both centroid and normal arrive in kernel (Z-up) space. The camera
+      // and OrbitControls live in display (Y-up) space — convert both via
+      // the (x, y, z) → (x, z, -y) mapping that the scene's rotation group
+      // applies to geometry.
+      const wNormal = new Vector3(normal.x, normal.z, -normal.y).normalize();
+      const wCentroid = new Vector3(centroid.x, centroid.z, -centroid.y);
 
-      // Set target to face centroid (already world space)
-      targetGoalRef.current.set(centroid.x, centroid.y, centroid.z);
+      // Pick view distance from the face's actual U/V extent when we have
+      // vertices, using the camera FOV so the face fills the viewport with
+      // a 20% padding. Falls back to 60mm when vertices weren't supplied
+      // (e.g. axis-aligned plane gizmo entry).
+      let viewDistance = 60;
+      if (vertices && vertices.length >= 3) {
+        // Build an orthonormal U/V basis on the face.
+        const tmp = new Vector3(0, 1, 0);
+        if (Math.abs(wNormal.dot(tmp)) > 0.95) tmp.set(1, 0, 0);
+        const uDir = new Vector3().crossVectors(tmp, wNormal).normalize();
+        const vDir = new Vector3().crossVectors(wNormal, uDir).normalize();
+        let minU = Infinity, maxU = -Infinity;
+        let minV = Infinity, maxV = -Infinity;
+        const offset = new Vector3();
+        for (const k of vertices) {
+          const wp = new Vector3(k.x, k.z, -k.y);
+          offset.subVectors(wp, wCentroid);
+          const u = offset.dot(uDir);
+          const v = offset.dot(vDir);
+          if (u < minU) minU = u;
+          if (u > maxU) maxU = u;
+          if (v < minV) minV = v;
+          if (v > maxV) maxV = v;
+        }
+        const width = Math.max(1, maxU - minU);
+        const height = Math.max(1, maxV - minV);
+        const padding = 1.2;
+        if (camera instanceof PerspectiveCamera) {
+          const vFov = (camera.fov * Math.PI) / 180;
+          const hFov = 2 * Math.atan(Math.tan(vFov / 2) * camera.aspect);
+          const distV = (height / 2) / Math.tan(vFov / 2);
+          const distH = (width / 2) / Math.tan(hFov / 2);
+          viewDistance = Math.max(distV, distH, 10) * padding;
+        } else {
+          viewDistance = Math.max(width, height, 10) * padding;
+        }
+      }
 
-      // Camera should be positioned along the positive normal (in front of the face, looking at it)
-      // Distance of 60mm for a good view
-      const viewDistance = 60;
       const cameraPos = new Vector3(
-        centroid.x + wNormal.x * viewDistance,
-        centroid.y + wNormal.y * viewDistance,
-        centroid.z + wNormal.z * viewDistance,
+        wCentroid.x + wNormal.x * viewDistance,
+        wCentroid.y + wNormal.y * viewDistance,
+        wCentroid.z + wNormal.z * viewDistance,
       );
+
+      targetGoalRef.current.copy(wCentroid);
       cameraPositionGoalRef.current = cameraPos;
       distanceGoalRef.current = viewDistance;
 
       // Compute goal quaternion for smooth orientation interpolation (zero roll)
-      const targetVec = new Vector3(centroid.x, centroid.y, centroid.z);
-      computeLevelQuaternion(cameraPos, targetVec, goalQuatRef.current);
+      computeLevelQuaternion(cameraPos, wCentroid, goalQuatRef.current);
 
       // Disable OrbitControls during animation so it doesn't fight with our quaternion
       if (orbitRef.current) orbitRef.current.enabled = false;
@@ -1068,7 +1095,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         "vcad:face-selected",
         handleFaceSelected as EventListener,
       );
-  }, []);
+  }, [camera]);
 
   // Snap view: animate camera to predefined positions
   useEffect(() => {
@@ -1292,6 +1319,86 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
     window.addEventListener("vcad:hero-view", handleHeroView);
     return () => window.removeEventListener("vcad:hero-view", handleHeroView);
   }, []);
+
+  // Pan camera target to a kernel-space point. Triggered by the StatusBar
+  // cursor-coord chip when the user types a value and presses Enter. Keeps
+  // the camera position and zoom; only the look-at target moves.
+  useEffect(() => {
+    const handler = (
+      e: CustomEvent<{ x: number; y: number; z: number }>,
+    ) => {
+      const { x, y, z } = e.detail;
+      const [dx, dy, dz] = kernelToDisplay([x, y, z]);
+      targetGoalRef.current.set(dx, dy, dz);
+      cameraPositionGoalRef.current = null;
+      distanceGoalRef.current = null;
+      if (orbitRef.current) orbitRef.current.enabled = false;
+      isAnimatingTargetRef.current = true;
+      setIsCameraMoving(true);
+    };
+    window.addEventListener("vcad:focus-point", handler as EventListener);
+    return () =>
+      window.removeEventListener("vcad:focus-point", handler as EventListener);
+  }, []);
+
+  // Animated camera-fit. Boot's auto-fit takes the snap path inside
+  // useCameraControls so the user doesn't watch a sweep on every reload;
+  // this listener handles the user-driven dispatches (View → Fit menu,
+  // double-click on empty canvas) and flies the camera into place via the
+  // standard target+position+quaternion lerp.
+  useEffect(() => {
+    const handler = () => {
+      const scene = useEngineStore.getState().scene;
+      if (!scene || scene.parts.length === 0) return;
+
+      const box = new Box3();
+      const tmp = new Vector3();
+      let hasPoints = false;
+      for (const p of scene.parts) {
+        const pos = p.mesh.positions;
+        for (let i = 0; i < pos.length; i += 3) {
+          tmp.set(pos[i] ?? 0, pos[i + 1] ?? 0, pos[i + 2] ?? 0);
+          box.expandByPoint(tmp);
+          hasPoints = true;
+        }
+      }
+      if (!hasPoints) return;
+
+      const kernelCenter = new Vector3();
+      box.getCenter(kernelCenter);
+      const size = new Vector3();
+      box.getSize(size);
+      const dist = Math.max(size.x, size.y, size.z, 50) * 2;
+      // Kernel (Z-up) → display (Y-up).
+      const displayCenter = new Vector3(
+        kernelCenter.x,
+        kernelCenter.z,
+        -kernelCenter.y,
+      );
+
+      // Preserve the current view direction; fall back to isometric when
+      // camera and target coincide (shouldn't happen, but defensive).
+      const currentTarget =
+        orbitRef.current?.target ?? new Vector3();
+      const dir = new Vector3().copy(camera.position).sub(currentTarget);
+      if (dir.lengthSq() < 1e-6) dir.set(1, 1, 1);
+      dir.normalize();
+
+      const cameraPos = new Vector3()
+        .copy(displayCenter)
+        .addScaledVector(dir, dist);
+
+      targetGoalRef.current.copy(displayCenter);
+      cameraPositionGoalRef.current = cameraPos;
+      distanceGoalRef.current = dist;
+      computeLevelQuaternion(cameraPos, displayCenter, goalQuatRef.current);
+      if (orbitRef.current) orbitRef.current.enabled = false;
+      isAnimatingTargetRef.current = true;
+      setIsCameraMoving(true);
+    };
+    window.addEventListener("vcad:camera-fit", handler);
+    return () => window.removeEventListener("vcad:camera-fit", handler);
+  }, [camera]);
 
   // Get effective scene settings
   const sceneSettings = useMemo(

--- a/packages/app/src/components/footer/CursorCoordChip.tsx
+++ b/packages/app/src/components/footer/CursorCoordChip.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  formatLength,
+  toMm,
+  useUiStore,
+  UNIT_LABEL,
+  type LengthUnit,
+} from "@vcad/core";
+import { FooterChip } from "@/components/footer/FooterChip";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+type Axis = "x" | "y" | "z";
+
+const AXES: Axis[] = ["x", "y", "z"];
+
+/**
+ * Cursor world coordinates chip.
+ *
+ * Shows live mouse-on-ground-plane XYZ in the user's chosen length unit
+ * (Z-up, kernel space). Each axis is click-to-edit: focus opens an inline
+ * input populated with the current value; Enter dispatches a `vcad:focus-point`
+ * event that pans the camera to the typed point. Tab moves between axes.
+ * Escape cancels.
+ *
+ * The unit suffix is itself a click target — cycles mm → cm → in.
+ */
+export function CursorCoordChip({ className }: { className?: string }) {
+  const cursorWorld = useUiStore((s) => s.cursorWorld);
+  const lengthUnit = useUiStore((s) => s.lengthUnit);
+  const cycleLengthUnit = useUiStore((s) => s.cycleLengthUnit);
+
+  const [editing, setEditing] = useState<Axis | null>(null);
+  const [drafts, setDrafts] = useState<Record<Axis, string>>({ x: "", y: "", z: "" });
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Snapshot the cursor at edit-start so the user types against a fixed point
+  // rather than the wiggling live raycast.
+  const editAnchorRef = useRef<{ x: number; y: number; z: number } | null>(null);
+
+  const startEdit = useCallback(
+    (axis: Axis) => {
+      const anchor = cursorWorld ?? { x: 0, y: 0, z: 0 };
+      editAnchorRef.current = anchor;
+      setDrafts({
+        x: formatLength(anchor.x, lengthUnit),
+        y: formatLength(anchor.y, lengthUnit),
+        z: formatLength(anchor.z, lengthUnit),
+      });
+      setEditing(axis);
+    },
+    [cursorWorld, lengthUnit],
+  );
+
+  const commit = useCallback(
+    (focus: boolean) => {
+      const anchor = editAnchorRef.current ?? { x: 0, y: 0, z: 0 };
+      const parsed: Record<Axis, number> = {
+        x: parseFloat(drafts.x),
+        y: parseFloat(drafts.y),
+        z: parseFloat(drafts.z),
+      };
+      const target = {
+        x: Number.isFinite(parsed.x) ? toMm(parsed.x, lengthUnit) : anchor.x,
+        y: Number.isFinite(parsed.y) ? toMm(parsed.y, lengthUnit) : anchor.y,
+        z: Number.isFinite(parsed.z) ? toMm(parsed.z, lengthUnit) : anchor.z,
+      };
+      setEditing(null);
+      editAnchorRef.current = null;
+      if (focus) {
+        window.dispatchEvent(
+          new CustomEvent("vcad:focus-point", { detail: target }),
+        );
+      }
+    },
+    [drafts, lengthUnit],
+  );
+
+  const cancel = useCallback(() => {
+    setEditing(null);
+    editAnchorRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  // Per-axis visibility — Z drops first, then Y, then the whole chip is
+  // hidden by `className` from the parent at sm breakpoint. X is always
+  // visible while the chip is mounted.
+  const AXIS_VISIBILITY: Record<Axis, string> = {
+    x: "",
+    y: "hidden md:inline-flex",
+    z: "hidden xl:inline-flex",
+  };
+
+  return (
+    <Tooltip
+      side="top"
+      content="Cursor on the ground plane (Z-up). Click an axis to type a value and pan there."
+    >
+    <FooterChip
+      className={cn("hidden sm:flex tabular-nums gap-1.5", className)}
+    >
+      {AXES.map((axis) => (
+        <AxisField
+          key={axis}
+          axis={axis}
+          editing={editing === axis}
+          inputRef={editing === axis ? inputRef : undefined}
+          value={cursorWorld ? cursorWorld[axis] : null}
+          unit={lengthUnit}
+          draft={drafts[axis]}
+          onDraft={(v) => setDrafts((d) => ({ ...d, [axis]: v }))}
+          onStart={() => startEdit(axis)}
+          onCommit={() => commit(true)}
+          onCancel={cancel}
+          onTab={(shift) => {
+            const idx = AXES.indexOf(axis);
+            const nextIdx = shift ? (idx + 2) % 3 : (idx + 1) % 3;
+            setEditing(AXES[nextIdx] ?? axis);
+          }}
+          className={AXIS_VISIBILITY[axis]}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={cycleLengthUnit}
+        className={cn(
+          "uppercase tracking-wide text-text-muted/60",
+          "hover:text-text px-1 -mx-1 rounded transition-colors",
+        )}
+      >
+        {UNIT_LABEL[lengthUnit]}
+      </button>
+    </FooterChip>
+    </Tooltip>
+  );
+}
+
+interface AxisFieldProps {
+  axis: Axis;
+  editing: boolean;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  value: number | null;
+  unit: LengthUnit;
+  draft: string;
+  onDraft: (v: string) => void;
+  onStart: () => void;
+  onCommit: () => void;
+  onCancel: () => void;
+  onTab: (shift: boolean) => void;
+  className?: string;
+}
+
+function AxisField({
+  axis,
+  editing,
+  inputRef,
+  value,
+  unit,
+  draft,
+  onDraft,
+  onStart,
+  onCommit,
+  onCancel,
+  onTab,
+  className,
+}: AxisFieldProps) {
+  const display = value !== null ? formatLength(value, unit) : null;
+  return (
+    <span className={cn("inline-flex items-center", className)}>
+      <span className="text-brand">{axis}</span>
+      {editing ? (
+        <input
+          ref={inputRef}
+          type="text"
+          inputMode="decimal"
+          value={draft}
+          onChange={(e) => onDraft(e.target.value)}
+          onBlur={onCommit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onCommit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onCancel();
+            } else if (e.key === "Tab") {
+              e.preventDefault();
+              onTab(e.shiftKey);
+            }
+          }}
+          className={cn(
+            "w-12 bg-hover text-text outline-none",
+            "px-1 ml-0.5 tabular-nums",
+            "border border-brand/60 rounded-sm",
+          )}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={onStart}
+          className={cn(
+            "w-12 text-right tabular-nums",
+            "hover:text-text rounded-sm transition-colors",
+            display === null && "opacity-40",
+          )}
+        >
+          {display ?? "  —"}
+        </button>
+      )}
+    </span>
+  );
+}

--- a/packages/app/src/components/footer/FooterChip.tsx
+++ b/packages/app/src/components/footer/FooterChip.tsx
@@ -1,0 +1,122 @@
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+export type ChipSeverity = "muted" | "info" | "brand" | "warn" | "danger" | "success";
+
+const SEVERITY_TEXT: Record<ChipSeverity, string> = {
+  muted: "text-text-muted",
+  info: "text-text",
+  brand: "text-brand",
+  warn: "text-amber-400",
+  danger: "text-red-400",
+  success: "text-emerald-400",
+};
+
+interface ChipBase {
+  divider?: boolean;
+  flex?: boolean;
+  severity?: ChipSeverity;
+}
+
+function chipClass({
+  divider = true,
+  flex = false,
+  severity = "muted",
+  className,
+  interactive,
+}: ChipBase & { className?: string; interactive: boolean }): string {
+  return cn(
+    "flex items-center gap-2 px-3 whitespace-pre",
+    "text-[10px] font-mono",
+    SEVERITY_TEXT[severity],
+    divider && "border-l border-border/40",
+    flex && "flex-1 min-w-0",
+    interactive &&
+      "hover:bg-hover hover:text-text focus:outline-none focus-visible:bg-hover transition-colors",
+    className,
+  );
+}
+
+type FooterChipProps = ChipBase & HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Inert chip slot for the StatusBar footer.
+ *
+ * Shapes density and styling (divider, padding, severity color, font) so each
+ * footer section reads as one cell of the same grid. Render arbitrary content
+ * inside; the chip just controls the frame.
+ *
+ * - `divider`: left border separator. Default true; pass `false` for the
+ *   leading chip in a row.
+ * - `flex`: chip expands to fill available width (use for the ticker).
+ * - `severity`: text color cue.
+ *
+ * Uses `forwardRef` so this composes with Radix triggers via `asChild`.
+ */
+export const FooterChip = forwardRef<HTMLDivElement, FooterChipProps>(
+  function FooterChip({ divider, flex, severity, className, children, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={chipClass({ divider, flex, severity, className, interactive: false })}
+        {...rest}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+
+type FooterChipButtonProps = ChipBase & ButtonHTMLAttributes<HTMLButtonElement>;
+
+/**
+ * Interactive variant of FooterChip — same frame, plus hover/focus feedback
+ * and `cursor-pointer`. Renders a `<button>` so it works as a Radix
+ * Popover/HoverCard trigger via `asChild`.
+ */
+export const FooterChipButton = forwardRef<HTMLButtonElement, FooterChipButtonProps>(
+  function FooterChipButton(
+    { divider, flex, severity, className, type = "button", children, ...rest },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        className={chipClass({ divider, flex, severity, className, interactive: true })}
+        {...rest}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+interface ChipLabelProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/** Faint uppercase label for a chip's prefix (e.g., "PARTS", "FPS"). */
+export function ChipLabel({ children, className }: ChipLabelProps) {
+  return (
+    <span className={cn("uppercase tracking-wide text-text-muted/70", className)}>
+      {children}
+    </span>
+  );
+}
+
+interface ChipValueProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/** Tabular-nums numeric value, sized to align across chips. */
+export function ChipValue({ children, className }: ChipValueProps) {
+  return <span className={cn("tabular-nums", className)}>{children}</span>;
+}

--- a/packages/app/src/components/footer/JobsChip.tsx
+++ b/packages/app/src/components/footer/JobsChip.tsx
@@ -1,0 +1,90 @@
+import { X } from "@phosphor-icons/react/dist/ssr/X";
+import { useJobsStore } from "@vcad/core";
+import { FooterChip } from "@/components/footer/FooterChip";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+/**
+ * Active jobs surface in the footer.
+ *
+ * When at least one job is in flight, this chip slides in showing the most
+ * recent job's verb plus a thin progress bar (indeterminate when the job
+ * doesn't report progress). Cancellable jobs grow an X button.
+ *
+ * Multiple concurrent jobs collapse to a "+N more" suffix; the latest one
+ * drives the chip surface so the user always sees the most recent work.
+ */
+export function JobsChip({ className }: { className?: string }) {
+  const jobs = useJobsStore((s) => s.jobs);
+  const requestCancel = useJobsStore((s) => s.requestCancel);
+
+  if (jobs.length === 0) return null;
+
+  // Drive the chip from the most recent job.
+  const job = jobs[jobs.length - 1]!;
+  const others = jobs.length - 1;
+
+  const indeterminate = job.progress === null;
+  const pct = indeterminate ? 0 : Math.max(0, Math.min(100, job.progress! * 100));
+
+  return (
+    <Tooltip
+      side="top"
+      content={`Long-running operation in flight${others > 0 ? ` (+${others} more queued)` : ""} — verb: ${job.verb}`}
+    >
+    <FooterChip
+      severity="brand"
+      className={cn(
+        "animate-in fade-in slide-in-from-right-2 duration-200",
+        "gap-2",
+        className,
+      )}
+    >
+      <span className="uppercase tracking-wide text-text-muted">
+        {job.verb}
+      </span>
+
+      <div
+        className="h-1 w-16 overflow-hidden bg-border/40 rounded-sm"
+        aria-hidden
+      >
+        {indeterminate ? (
+          <div className="vcad-job-indeterminate h-full w-1/3 bg-brand" />
+        ) : (
+          <div
+            className="h-full bg-brand transition-all duration-150 ease-out"
+            style={{ width: `${pct}%` }}
+          />
+        )}
+      </div>
+
+      {!indeterminate && (
+        <span className="tabular-nums text-text-muted/70 w-8 text-right">
+          {pct.toFixed(0)}%
+        </span>
+      )}
+
+      {others > 0 && (
+        <span className="text-text-muted/60">+{others}</span>
+      )}
+
+      {job.cancellable && !job.cancelRequested && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            requestCancel(job.id);
+          }}
+          className="text-text-muted/70 hover:text-danger transition-colors"
+          aria-label={`Cancel ${job.verb}`}
+        >
+          <X size={10} weight="bold" />
+        </button>
+      )}
+      {job.cancelRequested && (
+        <span className="text-text-muted/60 italic">cancelling…</span>
+      )}
+    </FooterChip>
+    </Tooltip>
+  );
+}

--- a/packages/app/src/components/footer/KernelPulseChip.tsx
+++ b/packages/app/src/components/footer/KernelPulseChip.tsx
@@ -1,0 +1,207 @@
+import { useEngineStore, useDocumentStore } from "@vcad/core";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/shadcn/hover-card";
+import { FooterChip } from "@/components/footer/FooterChip";
+import { Sparkline } from "@/components/footer/Sparkline";
+import { usePerfMonitor } from "@/components/footer/usePerfMonitor";
+import { cn } from "@/lib/utils";
+
+/**
+ * Kernel pulse + frame-time sparkline.
+ *
+ * Surface (always visible):
+ *   • breathing dot — color + rate map to frame health
+ *   • current frame ms (numeric)
+ *   • inline frame-ms sparkline (32×8)
+ *
+ * Hover surfaces fps / frame / heap streams as larger sparklines plus the
+ * total triangle count, the most recent kernel evaluation time, JS heap
+ * usage, long-task count, and session uptime. Numbers are real — pulled from
+ * `performance.memory`, `PerformanceObserver` long-task entries, and the
+ * EvaluatedScene the engine produces.
+ */
+export function KernelPulseChip({
+  className,
+  divider,
+}: {
+  className?: string;
+  divider?: boolean;
+}) {
+  const perf = usePerfMonitor();
+  const engineLoading = useEngineStore((s) => s.loading);
+  const scene = useEngineStore((s) => s.scene);
+  const evalMs = scene?.timing?.total_ms ?? null;
+  const partCount = useDocumentStore((s) => s.parts.length);
+
+  const fps = perf.fps;
+  const ms = perf.frameMs;
+
+  const triangles = countSceneTriangles(scene);
+
+  // Pulse style — color + animation duration map to frame health.
+  let dotColor = "bg-emerald-400";
+  let pulseDur = 1.6;
+  if (engineLoading) {
+    dotColor = "bg-brand";
+    pulseDur = 0.5;
+  } else if (fps < 20) {
+    dotColor = "bg-red-400";
+    pulseDur = 0.5;
+  } else if (fps < 45) {
+    dotColor = "bg-amber-400";
+    pulseDur = 0.9;
+  }
+
+  const recentMaxMs = perf.frameMsSamples.length
+    ? Math.max(...perf.frameMsSamples.slice(-10))
+    : ms;
+  const sparkColor =
+    engineLoading || recentMaxMs > 50
+      ? "text-red-400"
+      : recentMaxMs > 22
+        ? "text-amber-400"
+        : "text-emerald-400/70";
+
+  return (
+    <HoverCard openDelay={150} closeDelay={80}>
+      <HoverCardTrigger asChild>
+        <FooterChip
+          divider={divider}
+          className={cn(
+            "opacity-70 hover:opacity-100 transition-opacity gap-2",
+            className,
+          )}
+        >
+          <span
+            className={cn("inline-block w-1.5 h-1.5 rounded-full", dotColor)}
+            style={{
+              animation: `vcad-pulse ${pulseDur.toFixed(2)}s cubic-bezier(0.4, 0, 0.6, 1) infinite`,
+            }}
+            aria-hidden
+          />
+          <span className="hidden xl:inline tabular-nums text-text-muted/80">
+            {ms.toFixed(1)}
+            <span className="text-text-muted/50">ms</span>
+          </span>
+          <Sparkline
+            samples={perf.frameMsSamples}
+            width={32}
+            height={8}
+            min={8}
+            max={33}
+            className={sparkColor}
+          />
+        </FooterChip>
+      </HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="end"
+        sideOffset={6}
+        className="w-72 p-0 font-mono text-[10px] border-border bg-surface"
+      >
+        <div className="px-3 py-2 border-b border-border/50 flex items-center justify-between text-text-muted">
+          <span className="uppercase tracking-[0.15em] text-text-muted/80">
+            kernel
+          </span>
+          <span className="tabular-nums">
+            {formatUptime(perf.uptimeSec)}
+          </span>
+        </div>
+
+        <div className="px-3 py-2 space-y-1.5">
+          <PerfRow label="fps" value={fps.toFixed(0)} samples={perf.fpsSamples} sparkColor="text-emerald-400/70" />
+          <PerfRow
+            label="frame"
+            value={`${ms.toFixed(1)} ms`}
+            samples={perf.frameMsSamples}
+            sparkColor={sparkColor}
+          />
+          {perf.heapMb !== null && (
+            <PerfRow
+              label="heap"
+              value={
+                perf.heapLimitMb !== null
+                  ? `${perf.heapMb.toFixed(0)}/${perf.heapLimitMb.toFixed(0)} MB`
+                  : `${perf.heapMb.toFixed(0)} MB`
+              }
+              samples={perf.heapSamples}
+              sparkColor="text-blue-400/70"
+            />
+          )}
+        </div>
+
+        <div className="px-3 py-2 border-t border-border/50 grid grid-cols-2 gap-x-3 gap-y-1 text-text-muted">
+          <Stat label="parts" value={partCount.toString()} />
+          <Stat label="tris" value={formatCount(triangles)} />
+          <Stat
+            label="eval"
+            value={evalMs !== null ? `${evalMs.toFixed(1)} ms` : "—"}
+          />
+          <Stat label="jank" value={perf.longTasks.toString()} />
+        </div>
+
+        {engineLoading && (
+          <div className="px-3 py-2 border-t border-border/50 text-brand uppercase tracking-[0.15em]">
+            kernel evaluating…
+          </div>
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  );
+}
+
+function PerfRow({
+  label,
+  value,
+  samples,
+  sparkColor,
+}: {
+  label: string;
+  value: string;
+  samples: number[];
+  sparkColor: string;
+}) {
+  return (
+    <div className="grid grid-cols-[2.75rem_1fr_4.5rem] items-center gap-2">
+      <span className="text-text-muted/70 uppercase tracking-[0.15em]">{label}</span>
+      <Sparkline samples={samples} width={104} height={12} className={sparkColor} />
+      <span className="tabular-nums text-text text-right">{value}</span>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-2">
+      <span className="text-text-muted/70 uppercase tracking-[0.15em]">{label}</span>
+      <span className="tabular-nums text-text">{value}</span>
+    </div>
+  );
+}
+
+function countSceneTriangles(
+  scene: ReturnType<typeof useEngineStore.getState>["scene"],
+): number {
+  if (!scene) return 0;
+  let total = 0;
+  for (const p of scene.parts) total += p.mesh.indices.length / 3;
+  if (scene.instances) {
+    for (const i of scene.instances) total += i.mesh.indices.length / 3;
+  }
+  return Math.round(total);
+}
+
+function formatCount(n: number): string {
+  if (n === 0) return "—";
+  if (n < 1000) return n.toString();
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}
+
+function formatUptime(sec: number): string {
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = Math.floor(sec % 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}

--- a/packages/app/src/components/footer/KoanChip.tsx
+++ b/packages/app/src/components/footer/KoanChip.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from "react";
+import { useDocumentStore, useUiStore, useEngineStore, tFmt } from "@vcad/core";
+import { FooterChip } from "@/components/footer/FooterChip";
+import { Tooltip } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+const KOANS = [
+  "kernel idle",
+  "shapes settling",
+  "blank page loaded",
+  "ready when you are",
+  "pencil sharpened",
+  "waiting for geometry",
+  "the void beckons",
+  "edges quiet, faces still",
+  "no parts in flight",
+  "begin anywhere",
+  "every shape starts as a thought",
+  "the kernel waits patiently",
+  "geometry begins with a point",
+  "BRep at rest",
+  "topology unbothered",
+  "z-up, ready",
+  "an empty canvas is potential",
+  "0 triangles, infinite possibilities",
+  "the manifold sleeps",
+  "draw something",
+];
+
+const ROTATE_MS = 18_000;
+
+export type FooterModeBadge = "drafting" | "raytrace" | "assembly";
+
+const MODE_META: Record<
+  FooterModeBadge,
+  { label: string; dot: string; text: string }
+> = {
+  drafting: {
+    label: "drafting",
+    dot: "bg-stone-300",
+    text: "text-stone-300",
+  },
+  raytrace: {
+    label: "ray-traced",
+    dot: "bg-violet-400",
+    text: "text-violet-400",
+  },
+  assembly: {
+    label: "assembly",
+    dot: "bg-cyan-400",
+    text: "text-cyan-400",
+  },
+};
+
+/**
+ * Idle-zone chip.
+ *
+ * Priority of what occupies the slot:
+ *   1. selection > 0 — selection summary (count + name when single).
+ *   2. mode badge — colored dot + label for the active app mode
+ *      (drafting / raytrace / assembly). Sketch is intentionally skipped
+ *      because the sketch ribbon already covers it.
+ *   3. parts > 0 — gentle stat about the document (parts · k tris).
+ *   4. empty doc — rotating koan, cycling every 18s.
+ */
+export function KoanChip({
+  className,
+  divider,
+  mode,
+}: {
+  className?: string;
+  divider?: boolean;
+  mode?: FooterModeBadge | null;
+}) {
+  const parts = useDocumentStore((s) => s.parts);
+  const selectedPartIds = useUiStore((s) => s.selectedPartIds);
+  const scene = useEngineStore((s) => s.scene);
+
+  const [koanIdx, setKoanIdx] = useState(() => Math.floor(Math.random() * KOANS.length));
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setKoanIdx((i) => (i + 1) % KOANS.length);
+    }, ROTATE_MS);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const selCount = selectedPartIds.size;
+
+  const triangles = useMemo(() => {
+    if (!scene) return 0;
+    let total = 0;
+    for (const p of scene.parts) total += p.mesh.indices.length / 3;
+    if (scene.instances) {
+      for (const i of scene.instances) total += i.mesh.indices.length / 3;
+    }
+    return Math.round(total);
+  }, [scene]);
+
+  let content: React.ReactNode;
+  let title: string;
+  if (selCount > 0) {
+    if (selCount === 1) {
+      const part = parts.find((p) => p.id === Array.from(selectedPartIds)[0]);
+      title = `Selected: ${part?.name ?? "1 part"}`;
+    } else {
+      title = `${selCount} parts selected`;
+    }
+  } else if (mode) {
+    const meta = MODE_META[mode];
+    title = `Mode: ${meta.label}`;
+  } else if (parts.length > 0) {
+    title = `${parts.length} ${parts.length === 1 ? "part" : "parts"}${
+      triangles > 0 ? ` · ${formatTris(triangles)} triangles` : ""
+    }`;
+  } else {
+    title = "Empty document";
+  }
+
+  if (selCount > 0) {
+    if (selCount === 1) {
+      const part = parts.find((p) => p.id === Array.from(selectedPartIds)[0]);
+      content = (
+        <span className="text-brand truncate max-w-[14rem]">
+          {part?.name ?? tFmt("status.sel", { count: "1" })}
+        </span>
+      );
+    } else {
+      content = (
+        <span className="text-brand tabular-nums">
+          {tFmt("status.sel", { count: String(selCount) })}
+        </span>
+      );
+    }
+  } else if (mode) {
+    const meta = MODE_META[mode];
+    content = (
+      <span
+        key={mode}
+        className={cn(
+          "inline-flex items-center gap-1.5 uppercase tracking-[0.15em] font-medium",
+          meta.text,
+          "animate-in fade-in duration-300",
+        )}
+      >
+        <span
+          className={cn("inline-block w-1.5 h-1.5 rounded-full", meta.dot)}
+          aria-hidden
+        />
+        {meta.label}
+      </span>
+    );
+  } else if (parts.length > 0) {
+    content = (
+      <span className="text-text-muted">
+        <span className="tabular-nums">{parts.length}</span>{" "}
+        {parts.length === 1 ? "part" : "parts"}
+        {triangles > 0 && (
+          <>
+            <span className="text-text-muted/40 mx-1.5">·</span>
+            <span className="tabular-nums">{formatTris(triangles)}</span> tris
+          </>
+        )}
+      </span>
+    );
+  } else {
+    content = (
+      <span
+        key={koanIdx}
+        className={cn(
+          "text-text-muted/60 italic",
+          "animate-in fade-in duration-500",
+        )}
+      >
+        {KOANS[koanIdx]}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip side="top" content={title}>
+      <FooterChip
+        divider={divider}
+        className={cn("hidden lg:flex", className)}
+      >
+        {content}
+      </FooterChip>
+    </Tooltip>
+  );
+}
+
+function formatTris(n: number): string {
+  if (n < 1000) return n.toString();
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`;
+  return `${(n / 1_000_000).toFixed(1)}M`;
+}

--- a/packages/app/src/components/footer/Sparkline.tsx
+++ b/packages/app/src/components/footer/Sparkline.tsx
@@ -1,0 +1,70 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+
+interface SparklineProps {
+  samples: number[];
+  width?: number;
+  height?: number;
+  /** Force a min/max for the y-axis instead of auto-scaling. */
+  min?: number;
+  max?: number;
+  className?: string;
+  strokeWidth?: number;
+}
+
+/**
+ * Inline SVG sparkline. Renders a polyline through `samples`, scaled to fill
+ * the box. Uses `currentColor` so the parent text color drives the stroke,
+ * which makes severity transitions free.
+ */
+export function Sparkline({
+  samples,
+  width = 28,
+  height = 8,
+  min,
+  max,
+  className,
+  strokeWidth = 1,
+}: SparklineProps) {
+  const points = useMemo(() => {
+    if (samples.length < 2) return null;
+    let lo = min ?? Infinity;
+    let hi = max ?? -Infinity;
+    if (min === undefined || max === undefined) {
+      for (const v of samples) {
+        if (min === undefined && v < lo) lo = v;
+        if (max === undefined && v > hi) hi = v;
+      }
+    }
+    const range = hi - lo || 1;
+    const stepX = width / (samples.length - 1);
+    const parts: string[] = [];
+    for (let i = 0; i < samples.length; i++) {
+      const x = i * stepX;
+      const v = samples[i] ?? 0;
+      const y = height - ((v - lo) / range) * height;
+      parts.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+    }
+    return parts.join(" ");
+  }, [samples, width, height, min, max]);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={cn("shrink-0 overflow-visible", className)}
+      aria-hidden
+    >
+      {points && (
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      )}
+    </svg>
+  );
+}

--- a/packages/app/src/components/footer/usePerfMonitor.ts
+++ b/packages/app/src/components/footer/usePerfMonitor.ts
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react";
+
+const SAMPLE_COUNT = 30;
+const UPDATE_HZ = 10;
+
+export interface PerfSnapshot {
+  /** Smoothed frames per second. */
+  fps: number;
+  /** Smoothed frame time in milliseconds (1000 / fps). */
+  frameMs: number;
+  /** JS heap usage in MB (Chrome only — null elsewhere). */
+  heapMb: number | null;
+  /** JS heap limit in MB (Chrome only). */
+  heapLimitMb: number | null;
+  /** Long-task count seen since hook mount (PerformanceObserver). */
+  longTasks: number;
+  /** Wall-clock seconds since the hook mounted (display: session uptime). */
+  uptimeSec: number;
+  fpsSamples: number[];
+  frameMsSamples: number[];
+  heapSamples: number[];
+}
+
+const EMPTY: PerfSnapshot = {
+  fps: 0,
+  frameMs: 0,
+  heapMb: null,
+  heapLimitMb: null,
+  longTasks: 0,
+  uptimeSec: 0,
+  fpsSamples: [],
+  frameMsSamples: [],
+  heapSamples: [],
+};
+
+interface ChromePerformance extends Performance {
+  memory?: { usedJSHeapSize: number; totalJSHeapSize: number; jsHeapSizeLimit: number };
+}
+
+/**
+ * Samples requestAnimationFrame deltas for FPS / frame-time, plus JS heap when
+ * available. Maintains a 30-sample ring buffer for sparkline rendering and
+ * exposes a smoothed current value.
+ *
+ * Update is throttled to UPDATE_HZ (10 Hz) so the consuming chip re-renders
+ * at most ten times per second regardless of frame rate.
+ */
+export function usePerfMonitor(): PerfSnapshot {
+  const [snap, setSnap] = useState<PerfSnapshot>(EMPTY);
+
+  useEffect(() => {
+    let raf = 0;
+    let cancelled = false;
+    const t0 = performance.now();
+    let lastFrame = t0;
+    let lastEmit = t0;
+    let smoothedFps = 60;
+    let smoothedMs = 16.67;
+    let longTasks = 0;
+    const fpsSamples: number[] = [];
+    const frameMsSamples: number[] = [];
+    const heapSamples: number[] = [];
+
+    // Long-task observer (Chrome / Edge). Each entry > 50ms on the main
+    // thread bumps the counter; surfaces "we paused this many times" without
+    // having to interpret the FPS dip.
+    let observer: PerformanceObserver | null = null;
+    if (typeof PerformanceObserver !== "undefined") {
+      try {
+        observer = new PerformanceObserver((list) => {
+          longTasks += list.getEntries().length;
+        });
+        observer.observe({ type: "longtask", buffered: false });
+      } catch {
+        observer = null;
+      }
+    }
+
+    const step = (now: number) => {
+      if (cancelled) return;
+      const dt = Math.max(0.001, now - lastFrame);
+      lastFrame = now;
+      const instFps = 1000 / dt;
+      // Exponential smoothing — long enough to reject single janky frames
+      // but quick enough to react to a sustained load.
+      smoothedFps = smoothedFps * 0.9 + instFps * 0.1;
+      smoothedMs = smoothedMs * 0.9 + dt * 0.1;
+
+      if (now - lastEmit >= 1000 / UPDATE_HZ) {
+        lastEmit = now;
+        fpsSamples.push(smoothedFps);
+        if (fpsSamples.length > SAMPLE_COUNT) fpsSamples.shift();
+        frameMsSamples.push(smoothedMs);
+        if (frameMsSamples.length > SAMPLE_COUNT) frameMsSamples.shift();
+
+        const mem = (performance as ChromePerformance).memory;
+        const heapMb = mem ? mem.usedJSHeapSize / (1024 * 1024) : null;
+        const heapLimitMb = mem ? mem.jsHeapSizeLimit / (1024 * 1024) : null;
+        if (heapMb !== null) {
+          heapSamples.push(heapMb);
+          if (heapSamples.length > SAMPLE_COUNT) heapSamples.shift();
+        }
+
+        setSnap({
+          fps: smoothedFps,
+          frameMs: smoothedMs,
+          heapMb,
+          heapLimitMb,
+          longTasks,
+          uptimeSec: (now - t0) / 1000,
+          fpsSamples: [...fpsSamples],
+          frameMsSamples: [...frameMsSamples],
+          heapSamples: [...heapSamples],
+        });
+      }
+      raf = requestAnimationFrame(step);
+    };
+
+    raf = requestAnimationFrame(step);
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf);
+      observer?.disconnect();
+    };
+  }, []);
+
+  return snap;
+}

--- a/packages/app/src/components/mobile/MobileToolPalette.tsx
+++ b/packages/app/src/components/mobile/MobileToolPalette.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { useSketchStore, useUiStore, type ToolbarTab } from "@vcad/core";
-import { BottomSheet } from "./BottomSheet";
+import { useEffect } from "react";
+import { useSketchStore, useUiStore } from "@vcad/core";
 import { TAB_COLORS } from "@/components/ui/toolbar-constants";
 import { cn } from "@/lib/utils";
 import {
@@ -10,18 +9,18 @@ import {
 } from "@/hooks/useToolDefinitions";
 
 /**
- * Mobile tool palette. A horizontally-scrolling tab bar across the bottom of
- * the screen — tapping a tab opens a bottom sheet whose grid mirrors the
- * desktop ToolPalette's active-tab content. Tool definitions come from
- * `useToolDefinitions`, the same hook that powers desktop, so the two stay
- * at parity automatically.
+ * Mobile tool palette. Two rows mirroring the desktop layout:
+ *   secondary tool row — horizontal-scroll list of the active tab's tools
+ *   tab bar            — primary categories (Create / Sketch / Transform / …)
+ *
+ * Tool definitions come from `useToolDefinitions`, the same hook that powers
+ * desktop, so the two stay at parity automatically.
  */
 export function MobileToolPalette() {
   const toolbarTab = useUiStore((s) => s.toolbarTab);
   const setToolbarTab = useUiStore((s) => s.setToolbarTab);
   const sketchActive = useSketchStore((s) => s.active);
   const { byTab, renderSimulateExtras } = useToolDefinitions();
-  const [sheetTab, setSheetTab] = useState<ToolbarTab | null>(null);
 
   // Sketch tab is permanent in ALL_TABS. Auto-select it whenever sketch
   // becomes active so the relevant tools are at hand.
@@ -29,40 +28,55 @@ export function MobileToolPalette() {
     if (sketchActive) setToolbarTab("sketch");
   }, [sketchActive, setToolbarTab]);
 
-  const handleTap = (tab: ToolbarTab) => {
-    setToolbarTab(tab);
-    setSheetTab(tab);
-  };
-
-  const activeTab = sheetTab;
-  const activeMeta = activeTab ? ALL_TABS.find((t) => t.id === activeTab) : null;
-  const activeDefs = activeTab ? byTab[activeTab] : [];
-  const effectiveActiveTab: ToolbarTab = toolbarTab;
+  const activeDefs = byTab[toolbarTab] ?? [];
 
   return (
     <>
+      {/* Secondary tool row — active tab's tools, scrollable horizontally. */}
       <div
         className={cn(
-          "flex h-14 shrink-0 items-stretch border-t border-border/40 bg-surface",
+          "flex h-12 shrink-0 items-stretch border-t border-border/40 bg-surface",
+          "overflow-x-auto no-scrollbar gap-1 px-2",
+        )}
+      >
+        {activeDefs.length === 0 ? (
+          <div className="flex items-center text-text-muted/60 text-xs px-2">
+            No tools on this tab yet.
+          </div>
+        ) : (
+          activeDefs.map((def) => <ToolTile key={def.id} def={def} />)
+        )}
+        {toolbarTab === "simulate" && (
+          <div className="flex items-center pl-2 border-l border-border/40 ml-1">
+            {renderSimulateExtras({ compact: true })}
+          </div>
+        )}
+      </div>
+
+      {/* Primary tab bar. */}
+      <div
+        className={cn(
+          "flex h-12 shrink-0 items-stretch border-t border-border/40 bg-surface",
           "overflow-x-auto no-scrollbar",
           "pb-[env(safe-area-inset-bottom)]",
         )}
       >
         {ALL_TABS.map(({ id, label, icon: Icon }) => {
-          const isActive = effectiveActiveTab === id;
+          const isActive = toolbarTab === id;
           return (
             <button
               key={id}
-              onClick={() => handleTap(id)}
+              onClick={() => setToolbarTab(id)}
               className={cn(
-                "flex min-w-[72px] flex-1 flex-col items-center justify-center gap-0.5 min-h-11 px-2",
+                "flex min-w-[64px] flex-1 flex-col items-center justify-center gap-0.5 min-h-11 px-2",
                 "text-text-muted active:bg-hover",
                 isActive && "text-text",
               )}
               aria-label={label}
+              aria-pressed={isActive}
             >
               <Icon
-                size={22}
+                size={18}
                 weight={isActive ? "fill" : "regular"}
                 className={cn(isActive && TAB_COLORS[id])}
               />
@@ -71,76 +85,27 @@ export function MobileToolPalette() {
           );
         })}
       </div>
-
-      <BottomSheet
-        open={sheetTab !== null}
-        onOpenChange={(open) => !open && setSheetTab(null)}
-        title={activeMeta?.label}
-      >
-        <div className="p-3">
-          <ToolGrid defs={activeDefs} onRun={() => setSheetTab(null)} />
-          {activeTab === "simulate" && (
-            <div className="mt-3 border-t border-border/40 pt-3">
-              {renderSimulateExtras({ compact: true })}
-            </div>
-          )}
-          {activeDefs.length === 0 && (
-            <div className="py-8 text-center text-sm text-text-muted">
-              No tools on this tab yet.
-            </div>
-          )}
-        </div>
-      </BottomSheet>
     </>
   );
 }
 
-function ToolGrid({
-  defs,
-  onRun,
-}: {
-  defs: ToolDef[];
-  onRun: () => void;
-}): ReactNode {
-  return (
-    <div className="grid grid-cols-3 gap-2">
-      {defs.map((def) => (
-        <ToolTile
-          key={def.id}
-          def={def}
-          onClick={() => {
-            def.onClick();
-            onRun();
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-function ToolTile({ def, onClick }: { def: ToolDef; onClick: () => void }) {
+function ToolTile({ def }: { def: ToolDef }) {
   const Icon = def.icon;
   return (
     <button
-      onClick={onClick}
+      onClick={def.onClick}
       disabled={!def.enabled}
+      title={def.label}
       className={cn(
-        "flex aspect-square flex-col items-center justify-center gap-1.5 rounded",
-        "border border-border bg-card active:bg-hover",
-        "disabled:opacity-30 disabled:active:bg-card",
-        def.active && "border-brand bg-brand/10",
+        "flex shrink-0 items-center gap-1.5 px-3 rounded",
+        "text-xs text-text active:bg-hover",
+        "disabled:opacity-30",
+        def.active && "bg-brand/10 text-brand",
         def.pulse && "animate-pulse",
       )}
     >
-      <Icon size={28} className={def.iconColor} />
-      <span className="text-[11px] text-text leading-none text-center px-1">
-        {def.label}
-      </span>
-      {def.shortcut && (
-        <span className="text-[9px] text-text-muted/60 font-mono leading-none">
-          {def.shortcut}
-        </span>
-      )}
+      <Icon size={16} className={def.iconColor} />
+      <span className="leading-none whitespace-nowrap">{def.label}</span>
     </button>
   );
 }

--- a/packages/app/src/hooks/useCameraControls.ts
+++ b/packages/app/src/hooks/useCameraControls.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useThree } from "@react-three/fiber";
 import * as THREE from "three";
 import { useEngineStore, useUiStore, useDocumentStore } from "@vcad/core";
@@ -8,6 +8,7 @@ export function useCameraControls() {
   const controls = useThree(
     (s) => s.controls as THREE.EventDispatcher & { target?: THREE.Vector3 } | null,
   );
+  const fittedForDocRef = useRef<string | null>(null);
 
   useEffect(() => {
     function handleFocusSelection() {
@@ -98,15 +99,25 @@ export function useCameraControls() {
 
     function handleCameraFit() {
       const box = getSceneBoundingBox();
-      const center = new THREE.Vector3();
+      const kernelCenter = new THREE.Vector3();
       let dist = 150;
 
       if (box) {
-        box.getCenter(center);
+        box.getCenter(kernelCenter);
         const size = new THREE.Vector3();
         box.getSize(size);
         dist = Math.max(size.x, size.y, size.z, 50) * 2;
       }
+
+      // The bounding box is in kernel (Z-up) space because the meshes are
+      // stored that way and rendered through the -90°X rotation group. The
+      // camera and OrbitControls live outside that rotation group, so we
+      // need the display-space (Y-up) center: (x, y, z) → (x, z, -y).
+      const displayCenter = new THREE.Vector3(
+        kernelCenter.x,
+        kernelCenter.z,
+        -kernelCenter.y,
+      );
 
       // Preserve current direction when there's already a meaningful target;
       // otherwise fall back to an isometric angle so pressing Fit on an empty
@@ -121,9 +132,9 @@ export function useCameraControls() {
       }
       dir.normalize();
 
-      camera.position.copy(center).addScaledVector(dir, dist);
+      camera.position.copy(displayCenter).addScaledVector(dir, dist);
       if (controls && "target" in controls && controls.target) {
-        controls.target.copy(center);
+        controls.target.copy(displayCenter);
       }
     }
 
@@ -186,18 +197,53 @@ export function useCameraControls() {
 
     window.addEventListener("vcad:focus-selection", handleFocusSelection);
     window.addEventListener("vcad:camera-isometric", handleCameraIsometric);
-    window.addEventListener("vcad:camera-fit", handleCameraFit);
+    // `vcad:camera-fit` is handled by ViewportContent's animated variant, so
+    // double-click / View → Fit fly into place. Boot's auto-fit (below) calls
+    // handleCameraFit() directly and stays as a snap so the user doesn't
+    // watch a sweep on every reload.
     window.addEventListener("vcad:camera-top", handleCameraTop);
     window.addEventListener("vcad:camera-front", handleCameraFront);
     window.addEventListener("vcad:camera-right", handleCameraRight);
 
+    // Auto-fit on document load: subscribe to (documentId, scene) inside R3F
+    // so camera + controls are guaranteed mounted by the time the fit runs.
+    // Keyed by documentId so opening a new doc refits but in-doc edits don't.
+    // Skipped when `?at=` is present (share URL with captured viewer state).
+    const tryAutoFit = () => {
+      // Wait until OrbitControls is actually mounted — `controls` arrives a
+      // tick after `camera` because the OrbitControls component mounts as a
+      // child of Canvas. Without it, the fit would land on the camera but
+      // OrbitControls would re-target to its old (default) target on the
+      // next frame, snapping the view back.
+      if (!controls || !("target" in controls) || !controls.target) return;
+      if (typeof window !== "undefined") {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has("at")) return;
+      }
+      const docId = useDocumentStore.getState().documentId;
+      const scene = useEngineStore.getState().scene;
+      if (!docId) return;
+      if (fittedForDocRef.current === docId) return;
+      const hasGeom =
+        !!scene &&
+        (scene.parts.some((p) => p.mesh.indices.length > 0) ||
+          (scene.instances?.some((i) => i.mesh.indices.length > 0) ?? false));
+      if (!hasGeom) return;
+      fittedForDocRef.current = docId;
+      handleCameraFit();
+    };
+    tryAutoFit();
+    const unsubDoc = useDocumentStore.subscribe(tryAutoFit);
+    const unsubEng = useEngineStore.subscribe(tryAutoFit);
+
     return () => {
       window.removeEventListener("vcad:focus-selection", handleFocusSelection);
       window.removeEventListener("vcad:camera-isometric", handleCameraIsometric);
-      window.removeEventListener("vcad:camera-fit", handleCameraFit);
       window.removeEventListener("vcad:camera-top", handleCameraTop);
       window.removeEventListener("vcad:camera-front", handleCameraFront);
       window.removeEventListener("vcad:camera-right", handleCameraRight);
+      unsubDoc();
+      unsubEng();
     };
   }, [camera, controls]);
 }

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -177,31 +177,6 @@ export function useKeyboardShortcuts() {
       }
 
       // Selection-filter shortcuts: 0=Auto, 1=Body, 2=Face, 3=Edge, 4=Vertex.
-      // Only when in the viewport zone — the same digits in the tree zone
-      // would conflict with future tree-shortcuts and in property zone with
-      // numeric input. Skipped in sketch mode to avoid stealing tool keys.
-      if (
-        !mod &&
-        !e.shiftKey &&
-        !e.altKey &&
-        !useSketchStore.getState().active &&
-        useUiStore.getState().focusZone === "viewport"
-      ) {
-        const filterMap: Record<string, "auto" | "body" | "face" | "edge" | "vertex"> = {
-          "0": "auto",
-          "1": "body",
-          "2": "face",
-          "3": "edge",
-          "4": "vertex",
-        };
-        const f = filterMap[e.key];
-        if (f) {
-          e.preventDefault();
-          useUiStore.getState().setSelectionFilter(f);
-          return;
-        }
-      }
-
       // Toggle feature tree: Cmd+1
       if (mod && e.key === "1") {
         e.preventDefault();

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -250,6 +250,55 @@ samp {
   }
 }
 
+/* Footer kernel-pulse — heartbeat dot whose duration is set inline by the
+   KernelPulseChip based on smoothed FPS and engine.loading. */
+@keyframes vcad-pulse {
+  0%, 100% {
+    opacity: 0.55;
+    transform: scale(0.85);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+/* Sliding indeterminate progress bar used by the JobsChip when a job has no
+   reportable progress. The 1/3-width inner bar slides full-width left→right. */
+@keyframes vcad-indeterminate {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(300%); }
+}
+.vcad-job-indeterminate {
+  animation: vcad-indeterminate 1.2s linear infinite;
+}
+
+/* ─── Footer chrome ──────────────────────────────────────────────────────
+   Boot sequence — chips fade up left→right when the footer first mounts.
+   Re-fires whenever a chip later mounts (sketch ribbon, jobs chip), which
+   is the right behavior — the new chip "introduces itself" the same way. */
+@keyframes vcad-chip-in {
+  from {
+    opacity: 0;
+    transform: translateY(3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.vcad-footer > * {
+  animation: vcad-chip-in 0.35s ease-out backwards;
+}
+.vcad-footer > *:nth-child(1) { animation-delay: 0.05s; }
+.vcad-footer > *:nth-child(2) { animation-delay: 0.10s; }
+.vcad-footer > *:nth-child(3) { animation-delay: 0.15s; }
+.vcad-footer > *:nth-child(4) { animation-delay: 0.20s; }
+.vcad-footer > *:nth-child(5) { animation-delay: 0.25s; }
+.vcad-footer > *:nth-child(6) { animation-delay: 0.30s; }
+.vcad-footer > *:nth-child(7) { animation-delay: 0.35s; }
+.vcad-footer > *:nth-child(8) { animation-delay: 0.40s; }
+
 /* Changelog tooltip */
 .changelog-tooltip {
   background: var(--surface);

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -77,18 +77,6 @@
   --color-input: var(--border);
   --color-ring: #F92672;
 
-  /* vcad design system: zero border radius. Override Tailwind's default radius
-     scale so every `rounded-*` utility resolves to 0. `rounded-full` is a
-     static utility (not token-driven), so it's flattened in @layer below. */
-  --radius: 0;
-  --radius-xs: 0;
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
-  --radius-xl: 0;
-  --radius-2xl: 0;
-  --radius-3xl: 0;
-  --radius-4xl: 0;
 }
 
 /* shadcn token aliases — these need to live in :root (not @theme) so they
@@ -185,14 +173,6 @@ body {
 :root.light body {
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
-}
-
-/* vcad design system: flatten Tailwind's static `rounded-full` utility.
-   The `--radius-*` tokens above handle the rest of the rounded-* scale. */
-@layer utilities {
-  .rounded-full {
-    border-radius: 0;
-  }
 }
 
 /* Global scrollbar styling */

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -145,18 +145,13 @@
   --hover: rgba(0, 0, 0, 0.05);
 }
 
-/* Body typography. Three deliberate calls here, in order of importance:
+/* Body typography. Two deliberate calls here, in order of importance:
  *
  *  1. `font-optical-sizing: auto` — engages Inter v4's `opsz` axis. Inter then
  *     uses tighter, more compact glyphs at small UI sizes and opens letters up
  *     at heading sizes, instead of one shape stretched to every size.
  *
- *  2. `letter-spacing: -0.011em` — modest negative tracking on the body. Inter
- *     ships slightly wide by default for a UI font; this shadcn-style nudge
- *     tightens labels and prose without making it feel cramped. Headings can
- *     go further (-0.02em / -0.025em) per-component if needed.
- *
- *  3. Font smoothing is theme-conditional, NOT a blanket `antialiased`:
+ *  2. Font smoothing is theme-conditional, NOT a blanket `antialiased`:
  *
  *       Dark mode  → `-webkit-font-smoothing: antialiased`
  *           Light text on a dark background renders thick under macOS's
@@ -170,12 +165,16 @@
  *
  *     `-moz-osx-font-smoothing: grayscale` only fires on Firefox/macOS and
  *     pairs with the dark-mode `antialiased` to keep both engines consistent.
+ *
+ *  We deliberately do NOT apply a global negative letter-spacing. Inter's
+ *  default tracking is correct at small UI sizes; shrinking it makes labels
+ *  feel cramped. Headings that genuinely want tighter tracking can opt in
+ *  per-component (e.g. `tracking-tight`).
  */
 body {
   margin: 0;
   font-family: var(--font-sans);
   font-optical-sizing: auto;
-  letter-spacing: -0.011em;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
@@ -186,18 +185,6 @@ body {
 :root.light body {
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
-}
-
-/* Mono surfaces (kbd, code, hex, coords, log lines) keep their own letter
- * spacing — Berkeley Mono is already designed for tabular alignment, and the
- * body's negative tracking would break the grid. Reset it everywhere mono
- * is applied. */
-.font-mono,
-kbd,
-code,
-pre,
-samp {
-  letter-spacing: 0;
 }
 
 /* vcad design system: flatten Tailwind's static `rounded-full` utility.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,15 @@ export type { CrdtDocumentState, CrdtValue } from "./stores/crdt-document-store.
 
 export { useUiStore } from "./stores/ui-store.js";
 export {
+  LENGTH_UNITS,
+  UNIT_LABEL,
+  fromMm,
+  toMm,
+  nextUnit,
+  formatLength,
+} from "./utils/length.js";
+export type { LengthUnit } from "./utils/length.js";
+export {
   useParametersStore,
   mergeParametersIntoDocument,
 } from "./stores/parameters-store.js";
@@ -95,6 +104,9 @@ export type { SketchStore, ProfileSnapshot, SketchExitStatus, PendingOperation }
 
 export { useEngineStore } from "./stores/engine-store.js";
 export type { EngineState } from "./stores/engine-store.js";
+
+export { useJobsStore, runJob } from "./stores/jobs-store.js";
+export type { Job, JobsState } from "./stores/jobs-store.js";
 
 export { useSimulationStore } from "./stores/simulation-store.js";
 export type {

--- a/packages/core/src/stores/jobs-store.ts
+++ b/packages/core/src/stores/jobs-store.ts
@@ -1,0 +1,97 @@
+import { create } from "zustand";
+
+/**
+ * Long-running operation surfaced in the footer.
+ *
+ * Jobs exist to give the user feedback during work that would otherwise look
+ * like a UI freeze (boolean ops, exports, STEP import) or to expose progress
+ * + cancel for genuinely async work (network jobs, future worker-backed
+ * solvers).
+ */
+export interface Job {
+  id: string;
+  /** Human-readable verb, e.g., "Importing STEP", "Exporting STL". */
+  verb: string;
+  /** 0..1 progress, or null for indeterminate. */
+  progress: number | null;
+  /** When false, the cancel button is hidden (default true). */
+  cancellable: boolean;
+  /** Set when the user clicked cancel. The job runner is expected to poll. */
+  cancelRequested: boolean;
+  startedAt: number;
+}
+
+export interface JobsState {
+  jobs: Job[];
+  startJob: (opts: {
+    id?: string;
+    verb: string;
+    progress?: number | null;
+    cancellable?: boolean;
+  }) => string;
+  updateJob: (id: string, patch: Partial<Pick<Job, "verb" | "progress">>) => void;
+  finishJob: (id: string) => void;
+  requestCancel: (id: string) => void;
+  isCancelRequested: (id: string) => boolean;
+}
+
+let nextJobId = 1;
+
+export const useJobsStore = create<JobsState>((set, get) => ({
+  jobs: [],
+
+  startJob: ({ id, verb, progress = null, cancellable = false }) => {
+    const jobId = id ?? `job-${nextJobId++}`;
+    const job: Job = {
+      id: jobId,
+      verb,
+      progress,
+      cancellable,
+      cancelRequested: false,
+      startedAt: performance.now(),
+    };
+    set((s) => ({ jobs: [...s.jobs.filter((j) => j.id !== jobId), job] }));
+    return jobId;
+  },
+
+  updateJob: (id, patch) =>
+    set((s) => ({
+      jobs: s.jobs.map((j) => (j.id === id ? { ...j, ...patch } : j)),
+    })),
+
+  finishJob: (id) =>
+    set((s) => ({ jobs: s.jobs.filter((j) => j.id !== id) })),
+
+  requestCancel: (id) =>
+    set((s) => ({
+      jobs: s.jobs.map((j) => (j.id === id ? { ...j, cancelRequested: true } : j)),
+    })),
+
+  isCancelRequested: (id) => get().jobs.find((j) => j.id === id)?.cancelRequested ?? false,
+}));
+
+/**
+ * Wrap a unit of work in a job. The job is registered before `fn` runs and
+ * unregistered when it resolves or throws. For synchronous heavy work, an
+ * rAF tick is awaited first so the chip can paint before the main thread is
+ * blocked.
+ */
+export async function runJob<T>(
+  opts: { verb: string; cancellable?: boolean; id?: string },
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const { startJob, finishJob } = useJobsStore.getState();
+  const id = startJob(opts);
+  try {
+    await new Promise<void>((resolve) => {
+      if (typeof requestAnimationFrame !== "undefined") {
+        requestAnimationFrame(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+    return await fn();
+  } finally {
+    finishJob(id);
+  }
+}

--- a/packages/core/src/stores/sketch-store.ts
+++ b/packages/core/src/stores/sketch-store.ts
@@ -308,11 +308,17 @@ export const useSketchStore = create<SketchStore>((set, get) => {
       future: [],
     });
 
-    // Dispatch event to trigger camera swing to face the plane
+    // Dispatch event to trigger camera swing to face the plane. Pass the
+    // face vertices along so the camera can fit the face's actual extent
+    // instead of a hardcoded distance.
     if (typeof window !== "undefined") {
       window.dispatchEvent(
         new CustomEvent("vcad:face-selected", {
-          detail: { normal: face.normal, centroid: face.centroid },
+          detail: {
+            normal: face.normal,
+            centroid: face.centroid,
+            vertices: face.vertices,
+          },
         })
       );
     }

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -7,9 +7,9 @@ import type {
   TransformMode,
 } from "../types.js";
 import { selectionItemsEqual } from "../types.js";
+import type { LengthUnit } from "../utils/length.js";
+import { LENGTH_UNITS, nextUnit } from "../utils/length.js";
 
-/** Project a selection list down to the part IDs it covers, preserving the
- *  Set-shaped contract historical callers expect from `selectedPartIds`. */
 function deriveSelectedPartIds(items: readonly SelectionItem[]): Set<string> {
   const out = new Set<string>();
   for (const item of items) {
@@ -18,8 +18,6 @@ function deriveSelectedPartIds(items: readonly SelectionItem[]): Set<string> {
   return out;
 }
 
-/** `hoveredPartId` mirror of `hoveredItem`, kept around so existing readers
- *  (FeatureTree, SceneMesh) don't need to know about the item union yet. */
 function deriveHoveredPartId(item: SelectionItem | null): string | null {
   return item && item.kind === "part" ? item.id : null;
 }
@@ -127,6 +125,10 @@ export interface UiState {
   followingParticipantId: string | null;
   // Live cursor position in world space (Z-up), null when pointer is off the viewport
   cursorWorld: { x: number; y: number; z: number } | null;
+  // Display unit for length-bearing values in the footer (and any other
+  // chrome that reads it). Kernel storage is always millimeters; this only
+  // affects how numbers are shown / typed.
+  lengthUnit: LengthUnit;
   // Read-only share session. When set, the app is viewing a public share link;
   // every persistent-state mutation is blocked and redirected to the fork prompt.
   readOnlyShare: { token: string; docName: string } | null;
@@ -195,6 +197,9 @@ export interface UiState {
   // Keyboard cursor in the feature tree (part id, or null for no cursor)
   treeFocusedPartId: string | null;
   setTreeFocusedPartId: (id: string | null) => void;
+  // Length unit (mm, cm, in)
+  setLengthUnit: (unit: LengthUnit) => void;
+  cycleLengthUnit: () => void;
 }
 
 // Load persisted material preferences from localStorage
@@ -227,8 +232,22 @@ function loadToolbarExpanded(): boolean {
   }
 }
 
+function loadLengthUnit(): LengthUnit {
+  if (typeof window === "undefined") return "mm";
+  try {
+    const stored = localStorage.getItem("vcad:lengthUnit");
+    if (stored && (LENGTH_UNITS as readonly string[]).includes(stored)) {
+      return stored as LengthUnit;
+    }
+  } catch {
+    // ignore
+  }
+  return "mm";
+}
+
 const persistedMaterials = loadPersistedMaterials();
 const persistedToolbarExpanded = loadToolbarExpanded();
+const persistedLengthUnit = loadLengthUnit();
 
 export const useUiStore = create<UiState>((set) => ({
   selectedPartIds: new Set(),
@@ -263,6 +282,7 @@ export const useUiStore = create<UiState>((set) => ({
   inspectorTarget: null as InspectorTarget,
   statusBarVisible: true,
   cursorWorld: null,
+  lengthUnit: persistedLengthUnit,
   readOnlyShare: null,
   followMode: "free",
   followingParticipantId: null,
@@ -463,4 +483,24 @@ export const useUiStore = create<UiState>((set) => ({
   setFocusZone: (zone) => set({ focusZone: zone }),
 
   setTreeFocusedPartId: (id) => set({ treeFocusedPartId: id }),
+
+  setLengthUnit: (unit) => {
+    try {
+      if (typeof window !== "undefined") localStorage.setItem("vcad:lengthUnit", unit);
+    } catch {
+      // ignore
+    }
+    set({ lengthUnit: unit });
+  },
+
+  cycleLengthUnit: () =>
+    set((s) => {
+      const next = nextUnit(s.lengthUnit);
+      try {
+        if (typeof window !== "undefined") localStorage.setItem("vcad:lengthUnit", next);
+      } catch {
+        // ignore
+      }
+      return { lengthUnit: next };
+    }),
 }));

--- a/packages/core/src/utils/length.ts
+++ b/packages/core/src/utils/length.ts
@@ -1,0 +1,52 @@
+/**
+ * Length unit conversion + formatting.
+ *
+ * The kernel works in millimeters everywhere. The UI lets the user view and
+ * type values in mm, cm, or inches. Conversion happens at the display
+ * boundary; nothing else in the codebase needs to know about units.
+ */
+
+export type LengthUnit = "mm" | "cm" | "in";
+
+export const LENGTH_UNITS: LengthUnit[] = ["mm", "cm", "in"];
+
+/** Display label rendered in chips and inputs. */
+export const UNIT_LABEL: Record<LengthUnit, string> = {
+  mm: "mm",
+  cm: "cm",
+  in: "in",
+};
+
+const MM_PER_UNIT: Record<LengthUnit, number> = {
+  mm: 1,
+  cm: 10,
+  in: 25.4,
+};
+
+/** Convert a kernel-space (mm) value to the chosen display unit. */
+export function fromMm(mm: number, unit: LengthUnit): number {
+  return mm / MM_PER_UNIT[unit];
+}
+
+/** Convert a typed display-unit value back to kernel-space mm. */
+export function toMm(value: number, unit: LengthUnit): number {
+  return value * MM_PER_UNIT[unit];
+}
+
+/**
+ * Step to the next unit in the cycle. Used by the click-to-cycle unit chip.
+ * Order matches LENGTH_UNITS.
+ */
+export function nextUnit(unit: LengthUnit): LengthUnit {
+  const i = LENGTH_UNITS.indexOf(unit);
+  return LENGTH_UNITS[(i + 1) % LENGTH_UNITS.length] ?? "mm";
+}
+
+/**
+ * Format a millimeter value for display. Inches need an extra decimal to feel
+ * legible at typical CAD scales; mm/cm look right at 1 decimal.
+ */
+export function formatLength(mm: number, unit: LengthUnit, opts?: { decimals?: number }): string {
+  const decimals = opts?.decimals ?? (unit === "in" ? 2 : 1);
+  return fromMm(mm, unit).toFixed(decimals);
+}


### PR DESCRIPTION
## Summary

Brings the local vibecode work forward and polishes the chrome to feel more like a native (Borland-era) application.

### Footer chip system
- New \`FooterChip\` / \`FooterChipButton\` primitives — uniform h-6 chrome, severity tints, divider control, flex variant.
- **Console ticker** (left, expands): latest log level / source / message + age, click to open the panel.
- **KoanChip**: boot fade-in + mode badge (drafting / raytrace / assembly) + shaving-style koan rotation.
- **CursorCoordChip**: live X/Y/Z (Z-up, mm) with click-to-cycle unit (mm / cm / in) + click-to-pan camera-to-cursor; persists unit in localStorage.
- **KernelPulseChip + Sparkline + usePerfMonitor**: rightmost telemetry chip — frame-ms sparkline, kernel eval pulse, tris/parts counts.
- **JobsChip**: backed by a tiny \`jobs-store\` for future long-running solver / boolean / mesh tasks.

### Pick mode chip
- Collapsed the five Auto/Body/Face/Edge/Vertex chips into a single crosshair-icon \`FooterChipButton\` showing the current mode (e.g. \"AUTO\"). Click opens a popover listing all five with one-line hints.
- Removed the digit hotkeys 0–4 — the toolbar tab strip owns 1–7, no more conflict.

### Camera + sketch
- Double-click on empty canvas now **fits to scene with a fly animation** (was a snap to origin).
- **Scale-aware sketch markers** — cursor/snap circles stay readable at every zoom by deriving size from screen pixels.
- Face-selected camera framing fix (correct centroid + orthogonal vector).

### ToolPalette polish
- Row 2 keeps the unified \`h-8\` typography from PR #122 and adds horizontal scroll + soft right-edge mask when tools overflow.
- Mobile tool palette gets the same overflow-with-fade treatment.

### Header — native crispy
- **Logo** \`vcad.\` rendered in **Berkeley Mono** so the brand has its own voice against the Inter menu bar.
- Menu triggers tightened to \`text-[11px] font-medium\`, transitions removed so hover flips instantly (more native).
- First-letter mnemonic underline muted to \`decoration-text-muted/40\` — reads as a hint, not as emphasis.
- Menu items, dropdowns, separators, and right-cluster icon hit areas all retuned for consistency with the toolbar below.

### Typography
- **Removed the global \`letter-spacing: -0.011em\`** on body. Inter's default tracking is correct at small UI sizes; the negative nudge made h-6/h-7 labels feel cramped.
- **Removed the global \`--radius-*: 0\` overrides** and the \`.rounded-full { border-radius: 0 }\` flattener. Tailwind's default radius scale is back, so \`rounded-sm\` / \`rounded-md\` / \`rounded-full\` utilities mean what they say across the app.

### API guard
- \`packages/app/api/_lib/discord.ts\` gates Discord webhook posts to production only.

## Test plan

- [x] \`npm test -w @vcad/core\` — 88/88 pass
- [x] App typechecks clean (\`tsc --noEmit -p packages/app/tsconfig.json\`)
- [x] Manual: dev server boots, disco-ball doc renders, all footer chips visible, pick-mode popover opens with five options + hint text, fly-on-double-click works, header reads as native chrome.

## Note on history

This is squashed from a long-running local \`vibecode\` branch (~25 commits) that diverged before PR #120/#122 merged. The squash resolves overlap with the \`StatusBar\` surface introduced in PR #122 and keeps the unified \`h-8\` toolbar typography from that PR. The original \`vibecode\` branch is preserved locally for reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)