### PR TITLE
Add OAuth authentication with Google and GitHub

### DIFF
--- a/crates/vcad-desktop/Cargo.toml
+++ b/crates/vcad-desktop/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-deep-link = "2"
+tauri-plugin-opener = "2"
 serde.workspace = true
 serde_json.workspace = true
 base64.workspace = true

--- a/crates/vcad-desktop/capabilities/default.json
+++ b/crates/vcad-desktop/capabilities/default.json
@@ -18,6 +18,7 @@
     "dialog:default",
     "fs:default",
     "updater:default",
-    "deep-link:default"
+    "deep-link:default",
+    "opener:default"
   ]
 }

--- a/crates/vcad-desktop/src/main.rs
+++ b/crates/vcad-desktop/src/main.rs
@@ -17,6 +17,7 @@ fn main() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_opener::init())
         .manage(bambu::BambuState::new())
         .setup(|app| {
             // macOS: activate the app so the window actually appears

--- a/package-lock.json
+++ b/package-lock.json
@@ -7750,6 +7750,15 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@tauri-apps/plugin-opener": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-opener/-/plugin-opener-2.5.3.tgz",
+      "integrity": "sha512-CCcUltXMOfUEArbf3db3kCE7Ggy1ExBEBl51Ko2ODJ6GDYHRp1nSNlQm5uNCFY5k7/ufaK5Ib3Du/Zir19IYQQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
     "node_modules/@tauri-apps/plugin-updater": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
@@ -23949,6 +23958,7 @@
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-dialog": "^1.1.4",
         "@supabase/supabase-js": "^2.45.0",
+        "@tauri-apps/plugin-opener": "^2",
         "zustand": "^5.0.0"
       },
       "devDependencies": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -18,6 +18,7 @@
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-dialog": "^1.1.4",
     "@supabase/supabase-js": "^2.45.0",
+    "@tauri-apps/plugin-opener": "^2",
     "zustand": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -6,7 +6,7 @@ import {
   GoogleLogo,
   GithubLogo,
 } from "@phosphor-icons/react";
-import { getAuthRedirectUrl, getSupabase } from "../client";
+import { getAuthRedirectUrl, getSupabase, isTauriRuntime } from "../client";
 import type { GatedFeature } from "../hooks/useRequireAuth";
 
 type OAuthProvider = "google" | "github";
@@ -48,23 +48,53 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       new CustomEvent("vcad:sign-in-attempt", { detail: { provider } }),
     );
 
-    const { error } = await supabase.auth.signInWithOAuth({
+    const tauri = isTauriRuntime();
+
+    const { data, error } = await supabase.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: getAuthRedirectUrl(),
+        // On desktop we hand the URL to the OS browser ourselves so
+        // Google/GitHub don't reject the embedded webview as "insecure".
+        skipBrowserRedirect: tauri,
       },
     });
 
-    if (error) {
-      setError(error.message);
+    const reportFailure = (message: string) => {
+      setError(message);
       window.dispatchEvent(
         new CustomEvent("vcad:sign-in-attempt-failed", {
-          detail: { provider, message: error.message },
+          detail: { provider, message },
         }),
       );
       setLoading(false);
+    };
+
+    if (error) {
+      reportFailure(error.message);
+      return;
     }
-    // On success Supabase navigates away; leave `loading` set so the
+
+    if (tauri) {
+      if (!data?.url) {
+        reportFailure("OAuth provider did not return a redirect URL");
+        return;
+      }
+      try {
+        const { openUrl } = await import("@tauri-apps/plugin-opener");
+        await openUrl(data.url);
+        // Browser is launched; auth completes via the deep-link handler
+        // and AuthProvider closes the modal. Re-enable the form so the
+        // user can retry if they cancel in the browser.
+        setLoading(false);
+      } catch (err) {
+        reportFailure(
+          err instanceof Error ? err.message : "Failed to open browser",
+        );
+      }
+      return;
+    }
+    // On web Supabase already navigated; leave `loading` set so the
     // form doesn't flash active mid-redirect.
   };
 

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -1,8 +1,15 @@
 import { useState, type FormEvent } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X, EnvelopeSimple } from "@phosphor-icons/react";
+import {
+  X,
+  EnvelopeSimple,
+  GoogleLogo,
+  GithubLogo,
+} from "@phosphor-icons/react";
 import { getAuthRedirectUrl, getSupabase } from "../client";
 import type { GatedFeature } from "../hooks/useRequireAuth";
+
+type OAuthProvider = "google" | "github";
 
 interface AuthModalProps {
   open: boolean;
@@ -21,7 +28,7 @@ const featureMessages: Record<GatedFeature, string> = {
 
 /**
  * Modal dialog for user authentication.
- * Supports magic link sign-in via email.
+ * Supports Google / GitHub OAuth and email magic link.
  */
 export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
   const [email, setEmail] = useState("");
@@ -30,6 +37,36 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
   const [error, setError] = useState<string | null>(null);
 
   const supabase = getSupabase();
+
+  const signInWithProvider = async (provider: OAuthProvider) => {
+    if (!supabase) return;
+
+    setLoading(true);
+    setError(null);
+
+    window.dispatchEvent(
+      new CustomEvent("vcad:sign-in-attempt", { detail: { provider } }),
+    );
+
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider,
+      options: {
+        redirectTo: getAuthRedirectUrl(),
+      },
+    });
+
+    if (error) {
+      setError(error.message);
+      window.dispatchEvent(
+        new CustomEvent("vcad:sign-in-attempt-failed", {
+          detail: { provider, message: error.message },
+        }),
+      );
+      setLoading(false);
+    }
+    // On success Supabase navigates away; leave `loading` set so the
+    // form doesn't flash active mid-redirect.
+  };
 
   const signInWithEmail = async (e: FormEvent) => {
     e.preventDefault();
@@ -120,8 +157,32 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
                 </button>
               </div>
             ) : (
-              <div className="w-64">
-                {/* Email form */}
+              <div className="w-64 flex flex-col gap-2">
+                <button
+                  type="button"
+                  onClick={() => signInWithProvider("google")}
+                  disabled={loading}
+                  className="w-full h-9 border border-border text-xs text-text hover:bg-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+                >
+                  <GoogleLogo size={14} weight="bold" />
+                  Continue with Google
+                </button>
+                <button
+                  type="button"
+                  onClick={() => signInWithProvider("github")}
+                  disabled={loading}
+                  className="w-full h-9 border border-border text-xs text-text hover:bg-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+                >
+                  <GithubLogo size={14} weight="fill" />
+                  Continue with GitHub
+                </button>
+
+                <div className="flex items-center gap-2 my-1">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-[10px] text-text-muted uppercase tracking-wider">or</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+
                 <form onSubmit={signInWithEmail} className="flex flex-col gap-2">
                   <input
                     type="email"
@@ -131,7 +192,6 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
                     className="w-full h-9 px-3 bg-transparent border border-border text-xs text-text placeholder-text-muted/50 focus:outline-none focus:border-brand transition-colors"
                     disabled={loading}
                     autoComplete="email"
-                    autoFocus
                   />
                   <button
                     type="submit"


### PR DESCRIPTION
## Summary
This PR adds OAuth authentication support to the AuthModal, allowing users to sign in with Google or GitHub in addition to the existing email magic link flow. Special handling is implemented for the Tauri desktop runtime to work around webview security restrictions.

## Key Changes
- **OAuth Provider Support**: Added `signInWithProvider` function to handle OAuth sign-in with Google and GitHub via Supabase
- **UI Updates**: 
  - Added OAuth buttons (Google and GitHub) above the email form
  - Added visual divider ("or") between OAuth and email authentication methods
  - Removed `autoFocus` from email input to allow OAuth buttons to be the primary interaction
- **Desktop Runtime Handling**: 
  - Detect Tauri runtime using `isTauriRuntime()` utility
  - On desktop, skip browser redirect and manually open the OAuth URL using the system browser via `@tauri-apps/plugin-opener`
  - This prevents OAuth providers from rejecting the embedded webview as insecure
- **Event Tracking**: Dispatch custom events (`vcad:sign-in-attempt` and `vcad:sign-in-attempt-failed`) for analytics/monitoring
- **Dependencies**: 
  - Added `@tauri-apps/plugin-opener` to auth package
  - Added `tauri-plugin-opener` to desktop Cargo dependencies
  - Registered `opener:default` capability in Tauri config

## Implementation Details
- OAuth flow gracefully handles both web and desktop environments with appropriate redirect strategies
- Error handling reports failures via both UI state and custom events
- Loading state is properly managed across async operations
- Desktop users can retry if they cancel the browser OAuth flow

https://claude.ai/code/session_01EFQEkrmz6VbN3end5K4h76