### PR TITLE
feat(chat): anon free trial = 10k token budget with progress bar

### DIFF
--- a/packages/app/api/chat.ts
+++ b/packages/app/api/chat.ts
@@ -30,7 +30,7 @@ import { sendEmail, usageAlertEmail } from "./_lib/email.js";
 const FALLBACK_SYSTEM_PROMPT =
   "You are vcad's AI assistant — a parametric CAD copilot. Coordinate system: Z-up (X right, Y forward, Z up). Units: millimeters. Be concise.";
 
-const ANON_DAILY_LIMIT = TIERS.anon.anonDailyMessageLimit ?? 3;
+const ANON_DAILY_TOKEN_LIMIT = TIERS.anon.anonDailyTokenLimit ?? 10_000;
 const ANTHROPIC_MODEL = "claude-opus-4-7";
 const ANTHROPIC_SAFETY_MODEL = "claude-haiku-4-5";
 const ANTHROPIC_MAX_TOKENS = 8192;
@@ -118,19 +118,23 @@ function hashIp(ip: string): string {
   return createHash("sha256").update(`${salt}:${ip}`).digest("hex");
 }
 
-async function countAnonMessages(admin: SupabaseClient, ipHash: string): Promise<number> {
+async function sumAnonTokens(admin: SupabaseClient, ipHash: string): Promise<number> {
   const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  const { count, error } = await admin
+  const { data, error } = await admin
     .from("inference_logs")
-    .select("id", { count: "exact", head: true })
+    .select("tokens")
     .eq("ip_hash", ipHash)
     .eq("kind", "chat")
     .gte("created_at", oneDayAgo);
   if (error) {
-    console.error("[chat] countAnonMessages error:", error);
+    console.error("[chat] sumAnonTokens error:", error);
     return 0;
   }
-  return count ?? 0;
+  let total = 0;
+  for (const row of (data ?? []) as Array<{ tokens: number | null }>) {
+    if (typeof row.tokens === "number") total += row.tokens;
+  }
+  return total;
 }
 
 // ---------------------------------------------------------------------------
@@ -638,6 +642,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Rate limit check — authed users go through entitlements, anon through the
   // IP-hash rolling daily counter.
   let entitlement: Entitlement | null = null;
+  // Track anon usage at the start of this turn so we can emit a `usage` SSE
+  // event with the post-turn cumulative total once Anthropic finishes.
+  let anonTokensUsedBefore = 0;
   if (admin) {
     if (userId) {
       entitlement = await getEntitlement(admin, userId);
@@ -654,13 +661,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         return;
       }
     } else {
-      const used = await countAnonMessages(admin, ipHash);
-      if (used >= ANON_DAILY_LIMIT) {
+      anonTokensUsedBefore = await sumAnonTokens(admin, ipHash);
+      if (anonTokensUsedBefore >= ANON_DAILY_TOKEN_LIMIT) {
         res.status(429).json({
           error: "anon_limit",
-          message: `You've used your ${ANON_DAILY_LIMIT} free chat messages. Sign in for more.`,
-          usage: used,
-          limit: ANON_DAILY_LIMIT,
+          message: `You've used your ${ANON_DAILY_TOKEN_LIMIT.toLocaleString()} free trial tokens. Sign in for more.`,
+          usage: anonTokensUsedBefore,
+          limit: ANON_DAILY_TOKEN_LIMIT,
         });
         return;
       }
@@ -878,6 +885,28 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       (chunk) => res.write(chunk),
       persistence,
     );
+
+    // Emit a usage event so the client can update its in-chat progress bar
+    // without polling. For anon users we report the rolling 24h total
+    // *including this turn*; authed users get nothing here (the FooterUsageMeter
+    // re-fetches /api/usage when streaming flips to false).
+    if (userId === null) {
+      const turnTokens = inputTokens + outputTokens;
+      const anonUsedAfter = anonTokensUsedBefore + turnTokens;
+      try {
+        res.write(
+          `data: ${JSON.stringify({
+            type: "usage",
+            input_tokens: inputTokens,
+            output_tokens: outputTokens,
+            anon_used: anonUsedAfter,
+            anon_limit: ANON_DAILY_TOKEN_LIMIT,
+          })}\n\n`,
+        );
+      } catch {
+        /* client may have disconnected — non-fatal */
+      }
+    }
     res.end();
 
     if (admin && persistedTurn) {

--- a/packages/app/src/components/ChatSidebar.tsx
+++ b/packages/app/src/components/ChatSidebar.tsx
@@ -10,6 +10,7 @@ import {
   useEngineStore,
   parseVcadFile,
   documentToLoon,
+  formatTokens,
 } from "@vcad/core";
 import type {
   SelectionContext,
@@ -360,10 +361,65 @@ function VcadMessage({ msg, userName }: { msg: ChatMessage; userName: string }) 
               <VcadToolCard key={call.id} call={call} />
             ))}
             {msg.content && <MessageResponse>{msg.content}</MessageResponse>}
+            {(isInterrupted || isErrored) && (
+              <p className="text-[9px] italic text-text-muted">
+                {isInterrupted
+                  ? "— interrupted before completing —"
+                  : "— turn errored out —"}
+              </p>
+            )}
           </>
         )}
       </MessageContent>
     </Message>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AnonTrialBar — token-budget progress bar shown above the composer for
+// signed-out users. Mirrors the FooterUsageMeter visual language so the
+// upgrade nudge feels consistent across the app.
+// ---------------------------------------------------------------------------
+
+function AnonTrialBar({ used, limit }: { used: number; limit: number }) {
+  const frac = limit > 0 ? Math.min(1, used / limit) : 0;
+  const pct = frac * 100;
+  const severity = frac >= 0.95 ? "critical" : frac >= 0.75 ? "warn" : "ok";
+  const barColor =
+    severity === "critical"
+      ? "bg-danger"
+      : severity === "warn"
+        ? "bg-amber-500"
+        : "bg-brand";
+  const labelColor =
+    severity === "critical"
+      ? "text-danger"
+      : severity === "warn"
+        ? "text-amber-500"
+        : "text-text-muted";
+  return (
+    <div
+      className="shrink-0 flex items-center gap-2 px-3 py-1.5 text-[9px]"
+      role="status"
+      aria-label={`Free trial: ${formatTokens(used)} of ${formatTokens(limit)} tokens used`}
+    >
+      <span className={cn("uppercase tracking-wider", labelColor)}>
+        free trial
+      </span>
+      <div
+        className="h-1 flex-1 overflow-hidden bg-border/40"
+        aria-hidden
+      >
+        <div
+          className={cn("h-full transition-all duration-500 ease-out", barColor)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="tabular-nums text-text-muted">
+        {formatTokens(Math.min(used, limit))}
+        <span className="text-text-muted/60">/{formatTokens(limit)}</span>
+      </span>
+    </div>
   );
 }
 
@@ -740,7 +796,7 @@ export function ChatSidebar() {
               before the auto-refresh kicks in. */}
           {usageError?.kind === "anon_limit" && !isAuthenticated && (
             <div className="shrink-0 bg-brand/10 px-4 py-2 text-[10px] text-text">
-              <div className="mb-0.5 font-semibold text-brand">Free chat limit reached</div>
+              <div className="mb-0.5 font-semibold text-brand">Free trial limit reached</div>
               <div className="text-text-muted">{usageError.message}</div>
               <button
                 onClick={() => setShowAuthModal(true)}
@@ -751,9 +807,7 @@ export function ChatSidebar() {
             </div>
           )}
           {!isAuthenticated && anonUsage.used > 0 && !usageError && (
-            <div className="shrink-0 px-4 py-1 text-center text-[9px] text-text-muted">
-              {Math.min(anonUsage.used, anonUsage.limit)}/{anonUsage.limit} free chat messages used
-            </div>
+            <AnonTrialBar used={anonUsage.used} limit={anonUsage.limit} />
           )}
 
           {/* Compose dock — suggestions + input grouped in one padded surface,

--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -262,6 +262,11 @@ function runTurn(
       onError: (err) => { error = err; },
       onFinish: () => { resolve({ text, toolCalls, error }); },
       onMeta,
+      onUsage: (u) => {
+        if (typeof u.anonUsed === "number") {
+          useChatStore.getState().setAnonUsage(u.anonUsed, u.anonLimit);
+        }
+      },
     }, {
       tools,
       systemPrompt,
@@ -318,7 +323,7 @@ export function useChatHandler() {
       if (isAnon && store.anonUsage.used >= store.anonUsage.limit) {
         store.setUsageError({
           kind: "anon_limit",
-          message: `You've used your ${store.anonUsage.limit} free chat messages. Sign in for more.`,
+          message: `You've used your ${store.anonUsage.limit.toLocaleString()} free trial tokens. Sign in for more.`,
           limit: store.anonUsage.limit,
           usage: store.anonUsage.used,
         });
@@ -393,11 +398,9 @@ export function useChatHandler() {
         uiState.setFollowingParticipant(AI_PARTICIPANT_ID);
       }
 
-      // Count the send against the local anon badge as soon as it leaves the
-      // client. The server is the source of truth; this is just the UX hint.
-      if (isAnon) {
-        store.incAnonUsage();
-      }
+      // Anon usage is now token-based and updated from the server's `usage`
+      // SSE event after each turn (see runTurn / onUsage). Nothing to do here
+      // pre-flight — the bar shows whatever was last reported.
 
       const accumulatedToolCalls: ToolCallInfo[] = [];
       const parts: MessagePart[] = [];
@@ -501,10 +504,10 @@ export function useChatHandler() {
             // generic error so they retry instead.
             if (limit && limit.kind === "anon_limit" && !isAnon) {
               const msg = "Authentication issue — please retry in a moment.";
-              parts.push({ type: "text", text: `Error: ${msg}` });
-              fullText += `\n\nError: ${msg}`;
               useChatStore.getState().setError(msg);
-              updateUI();
+              useChatStore
+                .getState()
+                .updateLastAssistant(fullText, accumulatedToolCalls, [...parts], "error");
               break;
             }
             if (limit) {
@@ -513,10 +516,10 @@ export function useChatHandler() {
               updateUI();
               break;
             }
-            parts.push({ type: "text", text: `Error: ${error}` });
-            fullText += `\n\nError: ${error}`;
             useChatStore.getState().setError(error);
-            updateUI();
+            useChatStore
+              .getState()
+              .updateLastAssistant(fullText, accumulatedToolCalls, [...parts], "error");
             break;
           }
 

--- a/packages/app/src/lib/chat-api.ts
+++ b/packages/app/src/lib/chat-api.ts
@@ -59,6 +59,15 @@ export interface ChatStreamCallbacks {
    * lazily server-side). The caller uses this to reconcile its in-memory
    * placeholder with the persisted row. */
   onMeta?: (meta: { threadId: string; assistantMessageId: string }) => void;
+  /** Emitted once per turn after Anthropic finishes. Carries the per-turn
+   * token split and (for anon users) the rolling 24h total + limit so the
+   * sidebar progress bar can update without polling. */
+  onUsage?: (usage: {
+    inputTokens: number;
+    outputTokens: number;
+    anonUsed?: number;
+    anonLimit?: number;
+  }) => void;
 }
 
 export async function streamChat(
@@ -217,6 +226,14 @@ export async function streamChat(
                 currentToolName = "";
                 currentToolJson = "";
               }
+              break;
+            case "usage":
+              callbacks.onUsage?.({
+                inputTokens: typeof event.input_tokens === "number" ? event.input_tokens : 0,
+                outputTokens: typeof event.output_tokens === "number" ? event.output_tokens : 0,
+                anonUsed: typeof event.anon_used === "number" ? event.anon_used : undefined,
+                anonLimit: typeof event.anon_limit === "number" ? event.anon_limit : undefined,
+              });
               break;
             case "done":
               break;

--- a/packages/core/src/__tests__/chat-store.test.ts
+++ b/packages/core/src/__tests__/chat-store.test.ts
@@ -174,17 +174,24 @@ describe("useChatStore", () => {
   });
 
   describe("anonUsage / usageError", () => {
-    it("initial anonUsage is zero with limit 3", () => {
+    it("initial anonUsage is zero with token-based limit", () => {
       const s = useChatStore.getState();
       expect(s.anonUsage.used).toBe(0);
-      expect(s.anonUsage.limit).toBe(3);
+      expect(s.anonUsage.limit).toBeGreaterThan(100);
     });
 
-    it("incAnonUsage bumps the counter", () => {
-      useChatStore.getState().incAnonUsage();
-      expect(useChatStore.getState().anonUsage.used).toBe(1);
-      useChatStore.getState().incAnonUsage();
-      expect(useChatStore.getState().anonUsage.used).toBe(2);
+    it("addAnonTokens accumulates the counter", () => {
+      useChatStore.getState().addAnonTokens(1500);
+      expect(useChatStore.getState().anonUsage.used).toBe(1500);
+      useChatStore.getState().addAnonTokens(2300);
+      expect(useChatStore.getState().anonUsage.used).toBe(3800);
+    });
+
+    it("setAnonUsage replaces the counter with an absolute value", () => {
+      useChatStore.getState().setAnonUsage(7000);
+      expect(useChatStore.getState().anonUsage.used).toBe(7000);
+      useChatStore.getState().setAnonUsage(2000);
+      expect(useChatStore.getState().anonUsage.used).toBe(2000);
     });
 
     it("setUsageError / clear on reset", () => {

--- a/packages/core/src/billing/tiers.ts
+++ b/packages/core/src/billing/tiers.ts
@@ -21,8 +21,8 @@ export interface Tier {
   priceMonthlyUsd: number | null;
   /** Monthly token budget (input + output summed). Zero for anon. */
   monthlyTokenLimit: number;
-  /** Anon tier only: max messages per rolling 24h window. */
-  anonDailyMessageLimit?: number;
+  /** Anon tier only: max chat tokens (input + output) per rolling 24h window. */
+  anonDailyTokenLimit?: number;
   /** Stripe price lookup_key — set manually in the Stripe dashboard. */
   stripeLookupKey?: string;
   /** Bullet-point feature list for the upgrade modal. */
@@ -36,8 +36,8 @@ export const TIERS: Record<TierId, Tier> = {
     tagline: "Try vcad without signing in.",
     priceMonthlyUsd: null,
     monthlyTokenLimit: 0,
-    anonDailyMessageLimit: 3,
-    perks: ["3 free chat messages per day", "No account required"],
+    anonDailyTokenLimit: 10_000,
+    perks: ["10,000 free chat tokens per day", "No account required"],
   },
   free: {
     id: "free",

--- a/packages/core/src/stores/chat-store.ts
+++ b/packages/core/src/stores/chat-store.ts
@@ -1,25 +1,29 @@
 import { create } from "zustand";
 import type { ExecutionDisplay } from "../commands/types.js";
+import { TIERS } from "../billing/tiers.js";
 
 // ---------------------------------------------------------------------------
 // Anon usage persistence
 // ---------------------------------------------------------------------------
 
-const ANON_USAGE_KEY = "vcad:chat-anon-usage";
-const ANON_FREE_LIMIT = 3;
+const ANON_USAGE_KEY = "vcad:chat-anon-tokens";
+const ANON_TOKEN_LIMIT = TIERS.anon.anonDailyTokenLimit ?? 10_000;
 
-/** Load anon message counter from localStorage. Resets if 24h have elapsed. */
+/** Load anon token counter from localStorage. Resets if 24h have elapsed.
+ * Counter is tokens (input + output) used in the rolling 24h window;
+ * the server is the source of truth, this is just the local mirror that
+ * drives the in-chat progress bar. */
 function loadAnonUsage(): { used: number; limit: number } {
-  if (typeof localStorage === "undefined") return { used: 0, limit: ANON_FREE_LIMIT };
+  if (typeof localStorage === "undefined") return { used: 0, limit: ANON_TOKEN_LIMIT };
   try {
     const raw = localStorage.getItem(ANON_USAGE_KEY);
-    if (!raw) return { used: 0, limit: ANON_FREE_LIMIT };
+    if (!raw) return { used: 0, limit: ANON_TOKEN_LIMIT };
     const parsed = JSON.parse(raw) as { used: number; firstAt: number };
     const age = Date.now() - (parsed.firstAt ?? 0);
-    if (age > 24 * 60 * 60 * 1000) return { used: 0, limit: ANON_FREE_LIMIT };
-    return { used: parsed.used ?? 0, limit: ANON_FREE_LIMIT };
+    if (age > 24 * 60 * 60 * 1000) return { used: 0, limit: ANON_TOKEN_LIMIT };
+    return { used: parsed.used ?? 0, limit: ANON_TOKEN_LIMIT };
   } catch {
-    return { used: 0, limit: ANON_FREE_LIMIT };
+    return { used: 0, limit: ANON_TOKEN_LIMIT };
   }
 }
 
@@ -174,7 +178,8 @@ export interface ChatState {
   error: string | null;
   /** True while the user has requested cancellation of the current response. */
   cancelRequested: boolean;
-  /** Anon message count (from localStorage) with rolling 24h window. */
+  /** Anon token usage (input + output, from localStorage) with rolling 24h
+   * window. Server is the source of truth; this drives the in-chat bar. */
   anonUsage: { used: number; limit: number };
   /** Server-rejected rate limit for the most recent send attempt. */
   usageError: ChatUsageError | null;
@@ -264,7 +269,11 @@ export interface ChatState {
   consumePendingAttachments: () => File[];
 
   // Usage tracking
-  incAnonUsage: () => void;
+  /** Add `tokens` (input + output for one turn) to the anon counter. */
+  addAnonTokens: (tokens: number) => void;
+  /** Set the anon counter to an absolute server-reported value. Used after
+   * each successful turn — the server's `usage` SSE event is authoritative. */
+  setAnonUsage: (used: number, limit?: number) => void;
   setUsageError: (err: ChatUsageError | null) => void;
 
   // Thread management
@@ -446,10 +455,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
     return files;
   },
 
-  incAnonUsage: () => set((s) => {
-    const used = s.anonUsage.used + 1;
+  addAnonTokens: (tokens) => set((s) => {
+    if (!Number.isFinite(tokens) || tokens <= 0) return s;
+    const used = s.anonUsage.used + Math.round(tokens);
     persistAnonUsage(used);
     return { anonUsage: { used, limit: s.anonUsage.limit } };
+  }),
+  setAnonUsage: (used, limit) => set((s) => {
+    const safeUsed = Number.isFinite(used) && used >= 0 ? Math.round(used) : s.anonUsage.used;
+    const safeLimit = limit && limit > 0 ? limit : s.anonUsage.limit;
+    persistAnonUsage(safeUsed);
+    return { anonUsage: { used: safeUsed, limit: safeLimit } };
   }),
   setUsageError: (err) => set({ usageError: err }),
 


### PR DESCRIPTION
## Summary

- Switch the anonymous-user free trial from **3 messages / 24h** to **10,000 tokens / 24h**, shown as a slim progress bar above the composer.
- Token budgets feel proportional to actual value delivered — one tool-using build (~5–7k tokens) lands the user at ~70-80% fill, so the upgrade nudge hits right after the first magic moment rather than punishing long single-turn use.
- Also hide raw backend errors from the chat: a generic backend failure now flips `msg.status` to `"error"` and renders a muted `— turn errored out —` footer instead of leaking `Error: HTTP 502 …` into the bubble.

## What changed

**Tier config** (single source of truth, tunable from one place):
- `packages/core/src/billing/tiers.ts`: `anonDailyMessageLimit: 3` → `anonDailyTokenLimit: 10_000`.

**Server** (`packages/app/api/chat.ts`):
- `countAnonMessages` → `sumAnonTokens` — sums the `tokens` column from `inference_logs` over the last 24h by `ip_hash`. Same data model, different aggregate; existing rows count toward the new budget.
- 429 `anon_limit` payload uses tokens (`usage` and `limit` are now token counts).
- Emits a new SSE event after each turn:
  ```
  data: { "type": "usage", "input_tokens": N, "output_tokens": N, "anon_used": N, "anon_limit": N }
  ```
  so the client bar updates without polling.

**Client store** (`packages/core/src/stores/chat-store.ts`):
- `anonUsage` semantics flipped from messages → tokens.
- New actions: `addAnonTokens(n)` and `setAnonUsage(used, limit?)` (the SSE event drives the latter — server is authoritative).
- localStorage key bumped to `vcad:chat-anon-tokens` (old key is orphaned and times out via the rolling 24h window).
- `incAnonUsage` removed.

**Client wiring**:
- `packages/app/src/lib/chat-api.ts`: parses the `usage` SSE event via a new `onUsage` callback.
- `packages/app/src/hooks/useChatHandler.ts`: wires `onUsage` → `setAnonUsage`. Pre-flight hard-block message updated to "free trial tokens".

**Client UI** (`packages/app/src/components/ChatSidebar.tsx`):
- New `AnonTrialBar` component above the composer (brand → amber @ 75% → danger @ 95%), mirrors `FooterUsageMeter` visual language for consistency.
- Banner copy: "Free trial limit reached" / "You've used your 10,000 free trial tokens. Sign in for more."
- Generic backend errors no longer push `Error: …` text into the assistant bubble — instead the message gets `status: "error"` and the existing muted `— turn errored out —` footer renders. Footer also shows in the legacy (no-parts) branch so a turn that errors before any text streams still shows it.

**Tests** (`packages/core/src/__tests__/chat-store.test.ts`):
- Renamed/updated to cover `addAnonTokens` and `setAnonUsage`. All 25 tests pass.

## Why 10,000

Picked so the bar fills around 70–80% on a typical first tool-using build (~5–7k tokens with vcad's full system prompt + tool defs + scene snapshot), and tips over on the second. Dial up/down in `tiers.ts` once we see real conversion data.

## Notes for reviewers

- Server-side rate limit is still the source of truth; the client bar is a UX hint driven by the SSE event.
- Existing `inference_logs` rows already record `tokens` per turn — no schema migration needed.
- `monthly_limit` (authed) path is untouched.

## Test plan

- [x] Anon: send a message → SSE `usage` event arrives → bar fills proportionally
- [x] Anon: bar transitions through brand → amber → danger as fill increases (verified at 45% and 95%)
- [x] Anon: 429 `anon_limit` triggers "Free trial limit reached" banner + auto-opens auth modal
- [x] Generic backend error (502/network) shows muted `— turn errored out —` footer with no raw error text
- [x] Rate-limit path still routes to banner (no inline error text)
- [x] No console errors
- [x] `npm test -w @vcad/core` (25/25 chat-store tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)