### PR TITLE
fix(chat): unstick the drop overlay + label image drops as AI

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -220,6 +220,7 @@ export function App() {
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [documentPickerOpen, setDocumentPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const [isDraggingImage, setIsDraggingImage] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const bootPhase = useBootStore((s) => s.phase);
@@ -578,22 +579,47 @@ export function App() {
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(true);
+    const items = e.dataTransfer?.items;
+    const hasImage = items
+      ? Array.from(items).some((it) => it.kind === "file" && it.type.startsWith("image/"))
+      : false;
+    setIsDraggingImage(hasImage);
   }, []);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     e.preventDefault();
     setIsDragging(false);
+    setIsDraggingImage(false);
   }, []);
 
   const handleDrop = useCallback(
     async (e: React.DragEvent) => {
       e.preventDefault();
       setIsDragging(false);
+      setIsDraggingImage(false);
       const file = e.dataTransfer.files[0];
       if (file) await processFile(file);
     },
     [processFile],
   );
+
+  // Window-level reset: any drop or drag cancel anywhere on the page always
+  // clears the overlay, even when a child handler called stopPropagation
+  // (e.g. ChatSidebar swallows image drops so App doesn't try to parse them
+  // as .vcad files — synthetic React propagation stops, but the native window
+  // event still fires).
+  useEffect(() => {
+    const reset = () => {
+      setIsDragging(false);
+      setIsDraggingImage(false);
+    };
+    window.addEventListener("drop", reset);
+    window.addEventListener("dragend", reset);
+    return () => {
+      window.removeEventListener("drop", reset);
+      window.removeEventListener("dragend", reset);
+    };
+  }, []);
 
   const handleOpenDocuments = useCallback(() => {
     setDocumentPickerOpen(true);
@@ -846,8 +872,14 @@ export function App() {
   const dragOverlay = isDragging && (
     <div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-brand/10 backdrop-blur-sm">
       <div className="rounded-lg border-2 border-dashed border-brand bg-bg/90 px-8 py-6 text-center">
-        <div className="text-lg font-medium text-text">Drop file to import</div>
-        <div className="mt-1 text-sm text-text-muted">.vcad, .loon, .stl, .step, .pes, .dst</div>
+        <div className="text-lg font-medium text-text">
+          {isDraggingImage ? "Drop image to send to AI" : "Drop file to import"}
+        </div>
+        <div className="mt-1 text-sm text-text-muted">
+          {isDraggingImage
+            ? "I'll attach it to chat — describe what you want me to build"
+            : ".vcad, .loon, .stl, .step, .pes, .dst"}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Window-level `drop`/`dragend` listener always resets `isDragging`, so the App-shell drag overlay no longer freezes after the ChatSidebar's image-drop handler calls `e.stopPropagation()`.
- Drag overlay now reads "Drop image to send to AI — I'll attach it to chat — describe what you want me to build" when the dragged item is an image, and the original "Drop file to import" copy otherwise.

## Why

The drop-image-to-chat path (PR #90 / commit 579896f) was fully wired end-to-end — `App.processFile` queues images to `chat-store.pendingAttachments`, the `ChatAttachmentBridge` inside `PromptInput` drains the queue, and `useChatHandler.buildUserMessageContent` already emits Anthropic `{type:"image", source:{type:"base64",...}}` blocks. Photos really were reaching the model.

Two things hid that from users:

1. **Stuck overlay.** ChatSidebar's whole-pane drop handler (correctly) calls `e.stopPropagation()` so App doesn't try to parse the photo as a `.vcad` document. But App's `onDrop` was the only place `setIsDragging(false)` ran, so the "Drop file to import" overlay got wedged on screen forever after a successful image attach. A native `window` `drop` listener fires regardless of React synthetic propagation, so adding one cleanly resets the state.

2. **Wrong copy.** The overlay said "Drop file to import" — even for photos, which actually go to AI chat. `dataTransfer.items[i].type` is exposed during `dragover` (you can read MIME types before drop, just not the file bytes), so we can branch the headline immediately.

## Test plan

- [x] Verified in browser (preview): image dragover shows "Drop image to send to AI"; window `drop` clears overlay (no freeze); window `dragend` clears overlay (Esc-cancel path); non-image dragover still shows "Drop file to import".
- [ ] Manual: drop a JPG from Finder onto the viewport — chat sidebar opens, attachment chip appears, overlay disappears, no freeze.
- [ ] Manual: drop a JPG onto the chat sidebar (panel itself, not the input) — same, no freeze.
- [ ] Manual: type "build this" with the photo attached and submit — model receives the image (sanity-check by asking it to describe the photo first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)