### PR TITLE
feat(picker): Fusion-style selection priority — hotkeys + right-click submenu

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,9 +6,10 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": [
         "-c",
-        "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0"
+        "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0 --port ${PORT}"
       ],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -6,7 +6,9 @@ import { Unite } from "@phosphor-icons/react/dist/ssr/Unite";
 import { Subtract } from "@phosphor-icons/react/dist/ssr/Subtract";
 import { Intersect } from "@phosphor-icons/react/dist/ssr/Intersect";
 import { Circuitry } from "@phosphor-icons/react/dist/ssr/Circuitry";
-import { useDocumentStore, useUiStore, useEngineStore } from "@vcad/core";
+import { CrosshairSimple } from "@phosphor-icons/react/dist/ssr/CrosshairSimple";
+import { Check } from "@phosphor-icons/react/dist/ssr/Check";
+import { useDocumentStore, useUiStore, useEngineStore, SELECTION_FILTER_OPTIONS } from "@vcad/core";
 import type { ReactNode } from "react";
 
 function MenuItem({
@@ -41,6 +43,8 @@ export function ContextMenu({ children }: { children: ReactNode }) {
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const clearSelection = useUiStore((s) => s.clearSelection);
   const select = useUiStore((s) => s.select);
+  const selectionFilter = useUiStore((s) => s.selectionFilter);
+  const setSelectionFilter = useUiStore((s) => s.setSelectionFilter);
   const removePart = useDocumentStore((s) => s.removePart);
   const duplicateParts = useDocumentStore((s) => s.duplicateParts);
   const applyBoolean = useDocumentStore((s) => s.applyBoolean);
@@ -96,6 +100,46 @@ export function ContextMenu({ children }: { children: ReactNode }) {
             disabled={!hasSelection}
             onClick={handleDelete}
           />
+
+          <RadixContextMenu.Separator className="my-1 h-px bg-border" />
+
+          <RadixContextMenu.Sub>
+            <RadixContextMenu.SubTrigger className="group flex items-center gap-2  px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-brand/20 data-[highlighted]:text-brand data-[state=open]:bg-brand/20 data-[state=open]:text-brand">
+              <CrosshairSimple size={14} className="shrink-0" />
+              <span className="flex-1">Selection priority</span>
+              <span className="ml-4 text-[10px] text-text-muted uppercase tracking-wide">
+                {SELECTION_FILTER_OPTIONS.find((o) => o.value === selectionFilter)?.label ?? "Auto"}
+              </span>
+            </RadixContextMenu.SubTrigger>
+            <RadixContextMenu.Portal>
+              <RadixContextMenu.SubContent
+                className="z-50 min-w-[200px] border border-border bg-card p-1 shadow-xl"
+                sideOffset={2}
+                alignOffset={-4}
+              >
+                {SELECTION_FILTER_OPTIONS.map(({ value, label, hotkey }) => {
+                  const active = selectionFilter === value;
+                  return (
+                    <RadixContextMenu.Item
+                      key={value}
+                      className="group flex items-center gap-2 px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-brand/20 data-[highlighted]:text-brand"
+                      onClick={() => setSelectionFilter(value)}
+                    >
+                      {active ? (
+                        <Check size={14} weight="bold" className="shrink-0 text-brand" />
+                      ) : (
+                        <span className="w-[14px] shrink-0" />
+                      )}
+                      <span className="flex-1">{label}</span>
+                      {hotkey && (
+                        <span className="ml-4 text-[10px] text-text-muted">{hotkey}</span>
+                      )}
+                    </RadixContextMenu.Item>
+                  );
+                })}
+              </RadixContextMenu.SubContent>
+            </RadixContextMenu.Portal>
+          </RadixContextMenu.Sub>
 
           <RadixContextMenu.Separator className="my-1 h-px bg-border" />
 

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -6,7 +6,7 @@ import { GlobeSimple } from "@phosphor-icons/react/dist/ssr/GlobeSimple";
 import { Check } from "@phosphor-icons/react/dist/ssr/Check";
 import { CrosshairSimple } from "@phosphor-icons/react/dist/ssr/CrosshairSimple";
 import * as Popover from "@radix-ui/react-popover";
-import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName, type SelectionFilter } from "@vcad/core";
+import { useDocumentStore, useUiStore, useSketchStore, t, tFmt, type LogLevelName, SELECTION_FILTER_OPTIONS } from "@vcad/core";
 import { useLocaleStore, supportedLocales, type SupportedLocale } from "@/stores/locale-store";
 import { useDrawingStore } from "@/stores/drawing-store";
 import { useLogStore, getFilteredEntries } from "@/stores/log-store";
@@ -292,24 +292,17 @@ export function StatusBar() {
   );
 }
 
-const FILTER_OPTIONS: Array<{ value: SelectionFilter; label: string; hint: string }> = [
-  { value: "auto", label: "Auto", hint: "Pick whatever's most specific under the cursor" },
-  { value: "body", label: "Body", hint: "Always select the whole part" },
-  { value: "face", label: "Face", hint: "Snap selection to the nearest face" },
-  { value: "edge", label: "Edge", hint: "Snap selection to the nearest edge" },
-  { value: "vertex", label: "Vertex", hint: "Snap selection to the nearest vertex" },
-];
-
 /**
  * Selection filter chip — single popover that shows the current pick mode
  * (auto / body / face / edge / vertex) and lets you switch without taking
  * over a digit hotkey. The toolbar tab strip owns 1–7, so we don't fight
- * for them here.
+ * for them here. Options come from `SELECTION_FILTER_OPTIONS` in core so the
+ * right-click context menu and any future surface stay in sync.
  */
 function SelectionFilterChips() {
   const filter = useUiStore((s) => s.selectionFilter);
   const setFilter = useUiStore((s) => s.setSelectionFilter);
-  const current = FILTER_OPTIONS.find((o) => o.value === filter) ?? FILTER_OPTIONS[0]!;
+  const current = SELECTION_FILTER_OPTIONS.find((o) => o.value === filter) ?? SELECTION_FILTER_OPTIONS[0]!;
   return (
     <Popover.Root>
       <Tooltip side="top" content="Pick mode — what hover and click target">
@@ -337,7 +330,7 @@ function SelectionFilterChips() {
           <div className="px-2 pt-1 pb-1.5 text-text-muted/60 uppercase tracking-[0.15em] text-[9px]">
             Pick mode
           </div>
-          {FILTER_OPTIONS.map(({ value, label, hint }) => {
+          {SELECTION_FILTER_OPTIONS.map(({ value, label, hint, hotkey }) => {
             const active = filter === value;
             return (
               <button
@@ -365,6 +358,17 @@ function SelectionFilterChips() {
                     {hint}
                   </span>
                 </span>
+                {hotkey && (
+                  <kbd
+                    className={cn(
+                      "mt-0.5 shrink-0 rounded-sm border border-border/60 bg-surface px-1 py-px",
+                      "font-mono text-[9px] uppercase tracking-wide",
+                      active ? "text-brand" : "text-text-muted/70",
+                    )}
+                  >
+                    {hotkey}
+                  </kbd>
+                )}
                 {active && (
                   <Check size={11} weight="bold" className="mt-0.5 shrink-0 text-brand" />
                 )}

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -176,7 +176,6 @@ export function useKeyboardShortcuts() {
         return;
       }
 
-      // Selection-filter shortcuts: 0=Auto, 1=Body, 2=Face, 3=Edge, 4=Vertex.
       // Toggle feature tree: Cmd+1
       if (mod && e.key === "1") {
         e.preventDefault();
@@ -359,6 +358,26 @@ export function useKeyboardShortcuts() {
           window.dispatchEvent(new CustomEvent("vcad:focus-selection"));
         }
         return;
+      }
+
+      // ── Selection priority (pick-mode) hotkeys ─────────────────────────
+      // A=Auto, B=Body, V=Vertex, E=Edge. Match Fusion 360: pressing the key
+      // for the active priority returns to Auto. Skip when sketching — the
+      // sketch-extrude binding above already handled E in that case.
+      if (!mod && !e.shiftKey && !e.altKey && !useSketchStore.getState().active) {
+        const key = e.key.toLowerCase();
+        let target: "auto" | "body" | "vertex" | "edge" | null = null;
+        if (key === "a") target = "auto";
+        else if (key === "b") target = "body";
+        else if (key === "v") target = "vertex";
+        else if (key === "e") target = "edge";
+        if (target) {
+          e.preventDefault();
+          const { selectionFilter, setSelectionFilter } = useUiStore.getState();
+          const next = selectionFilter === target && target !== "auto" ? "auto" : target;
+          setSelectionFilter(next);
+          return;
+        }
       }
 
       // Delete (Delete/Backspace) is now handled by the registry dispatcher

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
   FaceInfo,
   SelectionItem,
   SelectionFilter,
+  SelectionFilterOption,
   PrimitivePartInfo,
   BooleanPartInfo,
   ExtrudePartInfo,
@@ -60,6 +61,7 @@ export {
   formatDirection,
   negateDirection,
   selectionItemsEqual,
+  SELECTION_FILTER_OPTIONS,
 } from "./types.js";
 
 // Stores

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,6 +53,28 @@ export type SelectionItem =
 /** Selection filter — restricts what `pickSubFeature` will return. */
 export type SelectionFilter = "auto" | "body" | "face" | "edge" | "vertex";
 
+/**
+ * Display metadata for each selection priority. Single source of truth for
+ * the footer popover, the right-click submenu, and any future surfaces that
+ * need to render the priority list. `hotkey` is the single-letter shortcut
+ * (or null when none is bound — Face is intentionally unbound because `F`
+ * is reserved for focus-camera).
+ */
+export interface SelectionFilterOption {
+  value: SelectionFilter;
+  label: string;
+  hint: string;
+  hotkey: string | null;
+}
+
+export const SELECTION_FILTER_OPTIONS: readonly SelectionFilterOption[] = [
+  { value: "auto", label: "Auto", hint: "Pick whatever's most specific under the cursor", hotkey: "A" },
+  { value: "body", label: "Body", hint: "Always select the whole part", hotkey: "B" },
+  { value: "face", label: "Face", hint: "Snap selection to the nearest face", hotkey: null },
+  { value: "edge", label: "Edge", hint: "Snap selection to the nearest edge", hotkey: "E" },
+  { value: "vertex", label: "Vertex", hint: "Snap selection to the nearest vertex", hotkey: "V" },
+];
+
 /** Whether two SelectionItems point at the same thing. Useful for hover/select diffing. */
 export function selectionItemsEqual(a: SelectionItem, b: SelectionItem): boolean {
   if (a.kind !== b.kind) return false;


### PR DESCRIPTION
## Summary

Reworks the point/edge/vertex/body/auto picker to match Fusion 360's selection-priority model and adds the friction-relief paths that make body picking actually pleasant. Body picking was effectively unreachable in auto mode (face always wins the vertex→edge→face cascade since the hit triangle is always present), so users had to open the footer popover every time.

- **Hotkeys** with toggle-to-auto: `A`=Auto, `B`=Body, `V`=Vertex, `E`=Edge. `F` stays bound to focus-camera (auto already biases toward face). Press the active priority key again → back to Auto, mirroring Fusion's "click the active priority tool to clear it" behavior.
- **Right-click → Selection priority** submenu in the feature tree's existing context menu, sourced from the same `SELECTION_FILTER_OPTIONS` table that drives the footer popover.
- **Footer popover** now shows a `<kbd>` badge per row so the shortcuts are discoverable.
- Auto's vertex→edge→face cascade is unchanged — that's how Fusion works in no-priority mode and the right fix was making mode-switching faster, not changing default behavior.

## Files

- `packages/core/src/types.ts` — adds `SELECTION_FILTER_OPTIONS` (single source of truth: label, hint, hotkey).
- `packages/core/src/index.ts` — re-export.
- `packages/app/src/components/StatusBar.tsx` — consume shared options + render kbd badges.
- `packages/app/src/components/ContextMenu.tsx` — Radix sub-menu for Selection priority.
- `packages/app/src/hooks/useKeyboardShortcuts.ts` — A/B/V/E with toggle, sketch/modifier guards, drop a stale digit-shortcut comment.
- `.claude/launch.json` — `autoPort: true` + `${PORT}` so worktree dev runs don't collide on 5173.

## Out of scope (called out for follow-up)

- Modifier-click parity with Fusion (`Cmd/Ctrl=toggle`, `Shift=additive`) — vcad currently uses `Shift=toggle`; flipping shifts muscle memory app-wide.
- Drag-rect / window / crossing select.
- "Select Other" disambiguation for occluded geometry.
- Components priority (vcad has no Component concept distinct from Part yet).
- Viewport-level right-click menu — Viewport.tsx intentionally suppresses contextmenu for touch-gesture safety, so the priority submenu lives in the feature tree's right-click menu.

## Test plan

- [x] \`VCAD_WASM_SKIP=1 npm run build --workspaces --if-present\` clean
- [x] \`npm test -w @vcad/core\` — 88/88 pass (incl. 13 selection-store tests)
- [x] Preview (real keydown dispatches): footer chip flips Auto → Body on \`B\`, back to Auto on second \`B\`; \`V\` → Vertex; \`E\` → Edge; \`A\` always returns to Auto; \`F\` does **not** flip the filter (focus-camera path preserved); no console errors.
- [x] Right-click a part in the feature tree → "Selection priority — AUTO" submenu trigger appears between Delete and Union, with the current priority on the right.
- [ ] Sanity: in sketch mode with segments, \`E\` still triggers sketch-extrude (verified by code path: existing E handler returns first when \`sketchActive && segments.length > 0\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)