### PR TITLE
fix(docs): persist last-opened doc id so the right doc reopens on every launch

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -83,13 +83,14 @@ import { useEngine } from "@/hooks/useEngine";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useKeybindingDispatcher } from "@/hooks/useKeybindingDispatcher";
 import { useOperationPreview } from "@/hooks/useOperationPreview";
-import { useAutoSave } from "@/hooks/useAutoSave";
+import { useAutoSave, flushPendingSave } from "@/hooks/useAutoSave";
 import { useCollabSync } from "@/hooks/useCollabSync";
 import { useChatHandler } from "@/hooks/useChatHandler";
 import { useChatHydration } from "@/hooks/useChatHydration";
 import { useUrlSync } from "@/hooks/useUrlSync";
 import { useSketchAutoFit } from "@/hooks/useSketchAutoFit";
 import { saveDocument } from "@/lib/save-load";
+import { openLocalDocumentById } from "@/lib/open-document";
 import { bootstrap } from "@/lib/bootstrap";
 import { useBootStore } from "@/stores/boot-store";
 import { Splash } from "@/components/Splash";
@@ -238,6 +239,40 @@ export function App() {
     void import("@/lib/deep-links").then((m) =>
       m.installDeepLinkListener(),
     );
+
+    // When a sync conflict creates a fork, surface it as an actionable toast
+    // with a one-click "Open my version" button. Without this the fork sits
+    // silently in the document picker and the user has no way to find it.
+    let prevConflictCount = 0;
+    void import("@vcad/auth").then(({ useSyncStore }) => {
+      const initial = useSyncStore.getState().conflicts;
+      prevConflictCount = initial.length;
+      useSyncStore.subscribe((state) => {
+        const conflicts = state.conflicts;
+        if (conflicts.length <= prevConflictCount) {
+          prevConflictCount = conflicts.length;
+          return;
+        }
+        const fresh = conflicts.slice(prevConflictCount);
+        prevConflictCount = conflicts.length;
+        for (const c of fresh) {
+          useNotificationStore.getState().showActionResult({
+            type: "success",
+            title: "Cloud version was newer — your edits were saved as a fork",
+            description: c.forkName,
+            actions: [
+              {
+                label: "Open my version",
+                variant: "primary",
+                onClick: () => {
+                  void openLocalDocumentById(c.forkId);
+                },
+              },
+            ],
+          });
+        }
+      });
+    });
   }, []);
 
   const isMobile = useIsMobile();
@@ -402,6 +437,9 @@ export function App() {
         const finalIndices = mergedMesh.indices;
         const finalNormals: Float32Array | undefined = undefined;
 
+        // Persist any pending edit on the outgoing doc before swapping engines.
+        await flushPendingSave();
+
         // Add as a proper document part (not just a scene mesh)
         // This makes it selectable, deletable, and transformable
         useDocumentStore.getState().loadDocument({
@@ -457,6 +495,9 @@ export function App() {
         const buffer = await file.arrayBuffer();
         const mesh = parseStl(buffer);
         const triangleCount = mesh.indices.length / 3;
+
+        // Persist any pending edit on the outgoing doc before swapping engines.
+        await flushPendingSave();
 
         // Add as a proper document part (not just a scene mesh)
         // This makes it selectable, deletable, and exportable
@@ -553,6 +594,8 @@ export function App() {
           }
         : undefined;
       const vcadFile = parseVcadFile(text, evalLoon);
+      // Persist any pending edit on the outgoing doc before swapping engines.
+      await flushPendingSave();
       useDocumentStore.getState().loadDocument(vcadFile);
       useUiStore.getState().clearSelection();
     } catch (err) {
@@ -664,6 +707,8 @@ export function App() {
     ) => {
       try {
         const { exampleToVcadFile } = await import("./data/examples");
+        // Persist any pending edit on the outgoing doc before swapping engines.
+        await flushPendingSave();
         useDocumentStore.getState().loadDocument(exampleToVcadFile(e.detail.file));
         useUiStore.getState().clearSelection();
       } catch (err) {

--- a/packages/app/src/components/DocumentPicker.tsx
+++ b/packages/app/src/components/DocumentPicker.tsx
@@ -31,6 +31,8 @@ import {
   isDocumentLocked,
 } from "@/lib/storage";
 import { newDocId } from "@/lib/doc-id";
+import { flushPendingSave } from "@/hooks/useAutoSave";
+import { getLastOpenedDocId } from "@/lib/last-opened";
 
 function formatDate(timestamp: number): string {
   const date = new Date(timestamp);
@@ -85,6 +87,7 @@ interface DocumentRowProps {
   isSelected: boolean;
   isLocked: boolean;
   isDownloading: boolean;
+  isLastOpened: boolean;
   onSelect: () => void;
   onOpen: () => void;
   onDelete: () => void;
@@ -96,6 +99,7 @@ function DocumentRow({
   isSelected,
   isLocked,
   isDownloading,
+  isLastOpened,
   onSelect,
   onOpen,
   onDelete,
@@ -148,7 +152,17 @@ function DocumentRow({
             autoFocus
           />
         ) : (
-          <div className="text-sm text-text truncate">{doc.name}</div>
+          <div className="flex items-center gap-2 min-w-0">
+            <div className="text-sm text-text truncate">{doc.name}</div>
+            {isLastOpened && (
+              <span
+                className="shrink-0 text-[9px] uppercase tracking-wide font-medium text-brand bg-brand/10 px-1.5 py-0.5 rounded"
+                title="Will reopen on next launch"
+              >
+                Last opened
+              </span>
+            )}
+          </div>
         )}
         <div className="text-[10px] text-text-muted">
           {formatDate(doc.modifiedAt)}
@@ -234,6 +248,9 @@ export function DocumentPicker({
   // for chat-thread RLS scoping. Skip the cloud-list path for them.
   const isCloudUser = !!user && !isAnonymous;
   const currentDocId = useDocumentStore((s) => s.documentId);
+  // The doc that bootstrap will reopen on next launch. Read-once (re-read on
+  // open is fine — the slot updates synchronously when docs switch).
+  const lastOpenedId = open ? getLastOpenedDocId() : null;
 
   // Track online/offline status
   useEffect(() => {
@@ -308,6 +325,10 @@ export function DocumentPicker({
   }, [open, loadDocuments]);
 
   const handleNewDocument = useCallback(async () => {
+    // Persist any pending edit on the current doc BEFORE the engine swap.
+    // Without this, switching within the autosave debounce window dropped
+    // the user's most recent change.
+    await flushPendingSave();
     const name = await generateDocumentName();
     const id = newDocId();
     useDocumentStore.getState().newDocument(id, name);
@@ -320,6 +341,9 @@ export function DocumentPicker({
 
     const doc = documents.find((d) => d.id === selectedId);
     if (!doc) return;
+
+    // Persist any pending edit on the OUTGOING doc before we swap engines.
+    await flushPendingSave();
 
     // Cloud-only document - download first
     if (doc.syncStatus === "cloud-only" && doc.cloudId) {
@@ -515,6 +539,10 @@ export function DocumentPicker({
                     isSelected={selectedId === doc.id}
                     isLocked={lockedIds.has(doc.id)}
                     isDownloading={downloadingIds.has(doc.id)}
+                    isLastOpened={
+                      lastOpenedId !== null &&
+                      (doc.localId ?? doc.id) === lastOpenedId
+                    }
                     onSelect={() => setSelectedId(doc.id)}
                     onOpen={handleOpenDocument}
                     onDelete={() => handleDeleteDocument(doc.id)}

--- a/packages/app/src/hooks/useAutoSave.ts
+++ b/packages/app/src/hooks/useAutoSave.ts
@@ -13,6 +13,32 @@ import {
 const DEBOUNCE_MS = 1000;
 const LOCK_REFRESH_MS = 15000;
 
+/**
+ * Module-level pending-save registry.
+ *
+ * The autosave hook registers its current save closure here whenever a
+ * debounced save is queued. Doc-switch call sites await `flushPendingSave()`
+ * BEFORE swapping the engine, so the old doc's pending edit is persisted with
+ * its own documentId — without this, switching docs within DEBOUNCE_MS of an
+ * edit silently dropped that edit (the engine was replaced before the timer
+ * fired).
+ *
+ * `pendingSaveFn` is the actual save call; it captures the OLD documentId at
+ * dirty-tick time, so it remains valid after the store has moved on.
+ */
+let pendingSaveFn: (() => Promise<void>) | null = null;
+
+export async function flushPendingSave(): Promise<void> {
+  const fn = pendingSaveFn;
+  if (!fn) return;
+  pendingSaveFn = null;
+  try {
+    await fn();
+  } catch (err) {
+    console.error("flushPendingSave failed:", err);
+  }
+}
+
 export function useAutoSave() {
   const documentId = useDocumentStore((s) => s.documentId);
   const documentName = useDocumentStore((s) => s.documentName);
@@ -135,7 +161,14 @@ export function useAutoSave() {
       clearTimeout(debounceRef.current);
     }
 
+    // Register `save` as the pending flush. The closure captures the CURRENT
+    // documentId / documentName, so even if the store has switched docs by
+    // the time `flushPendingSave()` is awaited, the persisted row is the old
+    // doc — which is exactly what we want.
+    pendingSaveFn = save;
+
     debounceRef.current = setTimeout(() => {
+      pendingSaveFn = null;
       save();
     }, DEBOUNCE_MS);
 
@@ -144,6 +177,10 @@ export function useAutoSave() {
         clearTimeout(debounceRef.current);
         debounceRef.current = null;
       }
+      // Effect cleanup runs when documentId changes (or unmount). Clear our
+      // registration so a stale closure can't run later — the flush should
+      // have been awaited by whoever triggered the doc switch.
+      if (pendingSaveFn === save) pendingSaveFn = null;
     };
   }, [isDirty, documentId, save, hasLock, readOnlyShare]);
 

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -22,6 +22,10 @@ import {
 import { loadDocumentFromUrl, getLocalDocRouteId } from "@/lib/url-document";
 import type { UrlDocumentResult } from "@/lib/url-document";
 import { newDocId } from "@/lib/doc-id";
+import {
+  getLastOpenedDocId,
+  clearLastOpenedDocId,
+} from "@/lib/last-opened";
 import { useNotificationStore } from "@/stores/notification-store";
 import { analytics } from "@/lib/analytics";
 
@@ -287,6 +291,26 @@ async function fetchDocumentData(): Promise<DocumentBootData> {
       logger.warn("app", `URL referenced unknown local doc ${routedId}, falling back`);
     }
 
+    // The doc the user had open last session. This is the primary fallback for
+    // Tauri (where the webview always reloads `/`) and for web users who land
+    // back on `/`. We only fall through to "most recent by modifiedAt" when
+    // the slot is empty or its target was deleted, so a sync write that
+    // bumps another doc's modifiedAt can no longer steal startup.
+    const lastOpenedId = getLastOpenedDocId();
+    if (lastOpenedId) {
+      const stored = await loadDocumentFromDb(lastOpenedId);
+      if (stored) {
+        return {
+          kind: "stored",
+          id: stored.id,
+          name: stored.name,
+          file: stored.document,
+        };
+      }
+      logger.info("app", `last-opened doc ${lastOpenedId} no longer exists, clearing`);
+      clearLastOpenedDocId();
+    }
+
     const recent = await getMostRecentDocument();
     if (recent) {
       const stored = await loadDocumentFromDb(recent.id);
@@ -358,20 +382,27 @@ function applyDocumentData(data: DocumentBootData): void {
  * constraint exists because the Vite alias only maps a single resolution
  * from the app's import graph — going through core produces a second
  * WASM instance whose pointers don't match.
+ *
+ * If the engine class is missing or `_initCrdt` throws, we throw —
+ * `runBootstrap` surfaces it as a hard splash error. Previously this just
+ * logged a warning, and the subsequent `applyDocumentData` silently no-op'd
+ * the document load (the document store skips loadDocument when no engine
+ * class is registered) so the user saw the doc's title with empty content.
+ * That looked indistinguishable from "different doc opened" — much better
+ * to fail loudly with a Reload affordance.
  */
 function initCrdt(
   wasmModule: typeof import("@vcad/kernel-wasm"),
 ): void {
-  try {
-    const EngineClass = (wasmModule as Record<string, unknown>)
-      .WasmDocumentEngine as (new () => unknown) | undefined;
-    if (EngineClass) {
-      useDocumentStore.getState()._initCrdt(EngineClass as never);
-      logger.info("wasm", "CRDT document engine initialized");
-    }
-  } catch (e) {
-    logger.warn("wasm", `Failed to initialize CRDT engine: ${e}`);
+  const EngineClass = (wasmModule as Record<string, unknown>)
+    .WasmDocumentEngine as (new () => unknown) | undefined;
+  if (!EngineClass) {
+    throw new Error(
+      "CRDT engine class missing from kernel WASM — kernel build mismatch",
+    );
   }
+  useDocumentStore.getState()._initCrdt(EngineClass as never);
+  logger.info("wasm", "CRDT document engine initialized");
 }
 
 /**

--- a/packages/app/src/lib/last-opened.ts
+++ b/packages/app/src/lib/last-opened.ts
@@ -1,0 +1,69 @@
+/**
+ * Persistent "last-opened document id" slot.
+ *
+ * Bootstrap consults this AFTER URL routes but BEFORE most-recent-by-modifiedAt
+ * so that startup picks the doc the user actually had open last, not whichever
+ * row happens to have the highest `modifiedAt` after a background sync.
+ *
+ * localStorage is shared between web and Tauri webviews and survives reloads.
+ * A read-only share session must NOT poison the slot — the writer skips when
+ * `useUiStore.readOnlyShare` is set.
+ */
+
+import { useDocumentStore, useUiStore } from "@vcad/core";
+
+const STORAGE_KEY = "vcad:last-opened-doc-id";
+
+function safeStorage(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function getLastOpenedDocId(): string | null {
+  const storage = safeStorage();
+  if (!storage) return null;
+  try {
+    const v = storage.getItem(STORAGE_KEY);
+    return v && v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setLastOpenedDocId(id: string | null): void {
+  const storage = safeStorage();
+  if (!storage) return;
+  try {
+    if (id) {
+      storage.setItem(STORAGE_KEY, id);
+    } else {
+      storage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // Quota / disabled storage — non-fatal.
+  }
+}
+
+export function clearLastOpenedDocId(): void {
+  setLastOpenedDocId(null);
+}
+
+/**
+ * Subscribe to documentId changes and mirror them into the last-opened slot.
+ * Idempotent — safe to call once at app boot. Returns an unsubscribe fn for
+ * tests / hot-reload.
+ *
+ * Skips writes during read-only share sessions: a user landing on /view/<token>
+ * must not have their saved last-opened doc clobbered by the share id.
+ */
+export function installLastOpenedTracker(): () => void {
+  return useDocumentStore.subscribe((state, prev) => {
+    if (state.documentId === prev.documentId) return;
+    if (useUiStore.getState().readOnlyShare) return;
+    setLastOpenedDocId(state.documentId);
+  });
+}

--- a/packages/app/src/lib/open-document.ts
+++ b/packages/app/src/lib/open-document.ts
@@ -1,0 +1,31 @@
+/**
+ * Programmatic "open this local document" helper.
+ *
+ * Used by DocumentPicker, conflict-fork notifications, command palette etc.
+ * Centralizing the flow ensures every entry point flushes pending autosave
+ * BEFORE the engine swap, sets the document meta (so the URL and last-opened
+ * slot mirror correctly), and surfaces failures uniformly.
+ */
+
+import { useDocumentStore } from "@vcad/core";
+import { loadDocument as loadDocumentFromDb } from "@/lib/storage";
+import { flushPendingSave } from "@/hooks/useAutoSave";
+import { useNotificationStore } from "@/stores/notification-store";
+
+export async function openLocalDocumentById(id: string): Promise<boolean> {
+  await flushPendingSave();
+  try {
+    const stored = await loadDocumentFromDb(id);
+    if (!stored) {
+      useNotificationStore.getState().addToast("Document not found", "error");
+      return false;
+    }
+    useDocumentStore.getState().loadDocument(stored.document);
+    useDocumentStore.getState().setDocumentMeta(stored.id, stored.name);
+    return true;
+  } catch (err) {
+    console.error("openLocalDocumentById failed:", err);
+    useNotificationStore.getState().addToast("Failed to open document", "error");
+    return false;
+  }
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -31,6 +31,8 @@ import {
   saveCompleteDocument,
   updateDocument,
 } from "./lib/storage";
+import { installLastOpenedTracker } from "./lib/last-opened";
+import { useBootStore } from "./stores/boot-store";
 
 // Configure storage adapter for auth/sync
 const storageAdapter: StorageAdapter = {
@@ -84,6 +86,37 @@ const storageAdapter: StorageAdapter = {
 configureStorage(storageAdapter);
 configureVersionHistoryStorage(storageAdapter);
 initSyncListeners();
+installLastOpenedTracker();
+
+/**
+ * Defer the first sync until bootstrap finishes.
+ *
+ * On cold-start, AuthProvider's `ensureSession()` resolves quickly with the
+ * cached session and fires `onSignIn` while `bootstrap()` is still resolving
+ * the document. The original handler called `triggerSync()` immediately,
+ * which raced our IDB read in `fetchDocumentData()` — sync's downloads could
+ * land first and shift "most recent" out from under us. Gating the first
+ * sync on `phase === "ready"` removes that race entirely. Later sign-ins
+ * (user clicks "Sign in") happen long after boot, so they're unaffected.
+ */
+let firstSyncDone = false;
+function onSignInGated(): void {
+  if (firstSyncDone) {
+    void triggerSync();
+    return;
+  }
+  if (useBootStore.getState().phase === "ready") {
+    firstSyncDone = true;
+    void triggerSync();
+    return;
+  }
+  const unsub = useBootStore.subscribe((s) => {
+    if (s.phase !== "ready") return;
+    unsub();
+    firstSyncDone = true;
+    void triggerSync();
+  });
+}
 
 // Route: `/cli-auth` is the device-code browser flow completion page for
 // `vcad login`. Check the pathname at mount time and render the standalone
@@ -93,7 +126,7 @@ const isCliAuth = window.location.pathname === "/cli-auth";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AuthProvider onSignIn={() => triggerSync()}>
+    <AuthProvider onSignIn={onSignInGated}>
       {isCliAuth ? <CliAuth /> : <App />}
     </AuthProvider>
   </StrictMode>,

--- a/packages/app/src/test/last-opened.test.ts
+++ b/packages/app/src/test/last-opened.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getLastOpenedDocId,
+  setLastOpenedDocId,
+  clearLastOpenedDocId,
+} from "../lib/last-opened";
+
+describe("last-opened doc id slot", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(getLastOpenedDocId()).toBeNull();
+  });
+
+  it("round-trips a written value", () => {
+    setLastOpenedDocId("abc123");
+    expect(getLastOpenedDocId()).toBe("abc123");
+  });
+
+  it("clears the slot", () => {
+    setLastOpenedDocId("abc123");
+    clearLastOpenedDocId();
+    expect(getLastOpenedDocId()).toBeNull();
+  });
+
+  it("treats setLastOpenedDocId(null) as a clear", () => {
+    setLastOpenedDocId("abc123");
+    setLastOpenedDocId(null);
+    expect(getLastOpenedDocId()).toBeNull();
+  });
+
+  it("treats empty-string slot as null (so getMostRecent fallback fires)", () => {
+    window.localStorage.setItem("vcad:last-opened-doc-id", "");
+    expect(getLastOpenedDocId()).toBeNull();
+  });
+
+  it("does not throw if localStorage is unavailable", () => {
+    // Replace localStorage with one that throws on every method.
+    const original = window.localStorage;
+    const throwing = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("storage disabled");
+        },
+      },
+    ) as unknown as Storage;
+    Object.defineProperty(window, "localStorage", {
+      value: throwing,
+      configurable: true,
+    });
+    try {
+      expect(() => getLastOpenedDocId()).not.toThrow();
+      expect(() => setLastOpenedDocId("x")).not.toThrow();
+      expect(() => clearLastOpenedDocId()).not.toThrow();
+      expect(getLastOpenedDocId()).toBeNull();
+    } finally {
+      Object.defineProperty(window, "localStorage", {
+        value: original,
+        configurable: true,
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

vcad had no notion of *the doc the user had open last*. Tauri always cold-boots at `/` (the window-state plugin only restores window geometry), so startup fell straight through to `getMostRecentDocument()` — and because background sync rewrites local `modifiedAt` to the cloud's `device_modified_at` whenever another device edits a doc, "most recent" wasn't stable across launches. On web, landing on `/` (vs. a `/~<id>` deep link) hit the same path.

This PR adds a `vcad:last-opened-doc-id` localStorage slot that bootstrap consults **before** the most-recent fallback, plus several adjacent data-integrity fixes that turned up in the same audit.

## Changes

- **New `lib/last-opened.ts`** — owns the `vcad:last-opened-doc-id` slot and an `installLastOpenedTracker()` zustand subscriber that mirrors `documentId` on every change. Skips read-only share sessions so `/view/<token>` can't poison the slot.
- **`lib/bootstrap.ts`** — `fetchDocumentData()` resolution order is now `URL share → URL `/~<id>` → lastOpenedDocId → most recent → new`. Stale slot (target deleted) falls through cleanly.
- **`hooks/useAutoSave.ts`** — added module-level `flushPendingSave()`. The pending-save closure captures the OUTGOING documentId, so awaiting `flushPendingSave()` before an engine swap persists the old doc's edits even when the swap happens within the 1s autosave debounce. Fixes a silent data-loss bug — switching docs from the picker within ~1s of an edit dropped that edit.
- **Doc-switch call sites flush first** — `DocumentPicker` (open + new), STEP/STL imports, vcad/loon file load, example load (`App.tsx`).
- **First-sync race fix** — `main.tsx` now defers the cold-start `triggerSync()` until `useBootStore.phase === "ready"`. Previously, AuthProvider's `onSignIn` fired in parallel with bootstrap and could land cloud writes on top of the IDB read in `fetchDocumentData`. Later sign-ins (post-boot) still sync immediately.
- **CRDT init failure is now loud** — `initCrdt()` throws instead of warn-and-continue. The old path silently no-op'd `loadDocument` while still installing the doc id+name, leaving the user with the right title and empty content. Now surfaces as the splash error screen with a Reload button.
- **`DocumentPicker` "LAST OPENED" badge** — small UI badge on the row that startup will reopen, so users can tell at a glance.
- **Conflict-fork toast button** — when sync forks a doc due to a cloud-newer conflict, surface it as an actionable toast with a one-click "Open my version" button. Previously the fork sat silently in the picker.
- **New `lib/open-document.ts`** — shared `openLocalDocumentById()` helper that flushes autosave and loads/sets-meta uniformly.

## Test plan

- [x] `npm test -w @vcad/app` — 15/15 pass, including 6 new `last-opened.test.ts` cases (round-trip, clear, null-as-clear, empty-string-treated-as-null, throwing-localStorage no-throw).
- [x] `npm run build -w @vcad/app` — clean.
- [x] **Manual web** — created multiple docs, set `localStorage.vcad:last-opened-doc-id` to a doc that was NOT the highest `modifiedAt`, navigated to `/`, confirmed bootstrap loaded that doc and the picker showed the "LAST OPENED" badge on the correct row.
- [ ] **Manual Tauri** — same A/B/C scenario via `npm run tauri:dev -w @vcad/app`. Cmd-Q + relaunch should reopen the same doc the user had open. (Same code path as web — Tauri shares localStorage — but worth confirming end-to-end.)
- [ ] **CRDT init failure** — temporarily throw inside `initCrdt`. Splash error screen with Reload should render rather than a silently-empty doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)