### PR TITLE
Fix STEP export after boolean Difference operations

### DIFF
--- a/changelog/entries/2026-04-28-step-export-after-difference.json
+++ b/changelog/entries/2026-04-28-step-export-after-difference.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-04-28-step-export-after-difference",
+  "version": "0.9.3",
+  "date": "2026-04-28",
+  "category": "fix",
+  "title": "STEP export survives boolean Difference output",
+  "summary": "The writer used to error with `Invalid topology: half-edge has no parent edge` on every BRep that came out of a Difference (cube-minus-cylinder, plates with through-holes, stepped shafts) because boolean sewing leaves orphan half-edges where a curved face meets a polygonal hole. The writer now synthesizes a line edge for each orphan half-edge so the loop emits cleanly.",
+  "features": ["step", "kernel"]
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
@@ -349,17 +349,18 @@ impl RayTracePipeline {
             theme,
             refine_sample_count,
         );
-        let (pixels, accum, _ao) = self.render_with_render_state(
-            ctx,
-            scene,
-            camera,
-            width,
-            height,
-            accum_buffer,
-            None,
-            render_state,
-        )
-        .await?;
+        let (pixels, accum, _ao) = self
+            .render_with_render_state(
+                ctx,
+                scene,
+                camera,
+                width,
+                height,
+                accum_buffer,
+                None,
+                render_state,
+            )
+            .await?;
         Ok((pixels, accum))
     }
 

--- a/crates/vcad-kernel-step/Cargo.toml
+++ b/crates/vcad-kernel-step/Cargo.toml
@@ -16,3 +16,4 @@ stepperoni = { path = "../stepperoni" }
 thiserror.workspace = true
 
 [dev-dependencies]
+vcad-kernel-booleans = { path = "../vcad-kernel-booleans" }

--- a/crates/vcad-kernel-step/src/writer.rs
+++ b/crates/vcad-kernel-step/src/writer.rs
@@ -434,11 +434,7 @@ impl<'a> StepWriter<'a> {
         let loop_ids: Vec<LoopId> = self.solid.topology.loops.keys().collect();
 
         for loop_id in loop_ids {
-            let he_ids: Vec<HalfEdgeId> = self
-                .solid
-                .topology
-                .loop_half_edges(loop_id)
-                .collect();
+            let he_ids: Vec<HalfEdgeId> = self.solid.topology.loop_half_edges(loop_id).collect();
 
             let mut oriented_edge_ids = Vec::new();
 

--- a/crates/vcad-kernel-step/src/writer.rs
+++ b/crates/vcad-kernel-step/src/writer.rs
@@ -374,74 +374,96 @@ impl<'a> StepWriter<'a> {
             let he = &topo.half_edges[edge.half_edge];
             let start_vid = he.origin;
             let end_vid = topo.half_edge_dest(edge.half_edge);
-
-            let start_vertex = self.vertex_map[&start_vid];
-            let end_vertex = self.vertex_map[&end_vid];
-
-            // Write line geometry for the edge
-            let start_point = topo.vertices[start_vid].point;
-            let end_point = topo.vertices[end_vid].point;
-
-            let dir_vec = end_point - start_point;
-            let magnitude = dir_vec.norm();
-            let dir = if magnitude > 1e-15 {
-                Dir3::new_normalize(dir_vec)
-            } else {
-                Dir3::new_normalize(Vec3::x())
-            };
-
-            // Write point for line origin
-            let line_point_id = self.alloc_id();
-            self.emit(line_point_id, &write_cartesian_point(&start_point, ""));
-
-            // Write direction
-            let dir_id = self.alloc_id();
-            self.emit(dir_id, &write_direction(&dir, ""));
-
-            // Write vector
-            let vec_id = self.alloc_id();
-            self.emit(
-                vec_id,
-                &format!("VECTOR('', #{}, {:.15E})", dir_id, magnitude),
-            );
-
-            // Write line
-            let line_id = self.alloc_id();
-            self.emit(
-                line_id,
-                &format!("LINE('', #{}, #{})", line_point_id, vec_id),
-            );
-
-            // Write edge curve
-            let step_edge_id = self.alloc_id();
-            let entity = write_edge_curve("", start_vertex, end_vertex, line_id, true);
-            self.emit(step_edge_id, &entity);
+            let step_edge_id = self.write_line_edge_curve(start_vid, end_vid);
             self.edge_map.insert(edge_id, step_edge_id);
         }
 
         Ok(())
     }
 
-    fn write_loops(&mut self) -> Result<(), StepError> {
+    /// Emit a straight EDGE_CURVE between two vcad vertices and return its ID.
+    ///
+    /// Used by `write_edges` for proper edges and by `write_loops` to synthesize
+    /// edges for orphan half-edges (those whose `parent_edge` link was severed
+    /// by the boolean sewing pipeline — see crates/vcad-kernel-booleans/src/sew.rs).
+    /// The geometry is approximated as a line segment regardless of the
+    /// underlying surface's curvature; this matches `write_edges`'s existing
+    /// limitation and keeps the writer's contract simple.
+    fn write_line_edge_curve(&mut self, start_vid: VertexId, end_vid: VertexId) -> u64 {
         let topo = &self.solid.topology;
+        let start_vertex = self.vertex_map[&start_vid];
+        let end_vertex = self.vertex_map[&end_vid];
 
-        for (loop_id, _loop) in &topo.loops {
-            // Collect oriented edges for this loop
+        let start_point = topo.vertices[start_vid].point;
+        let end_point = topo.vertices[end_vid].point;
+
+        let dir_vec = end_point - start_point;
+        let magnitude = dir_vec.norm();
+        let dir = if magnitude > 1e-15 {
+            Dir3::new_normalize(dir_vec)
+        } else {
+            Dir3::new_normalize(Vec3::x())
+        };
+
+        let line_point_id = self.alloc_id();
+        self.emit(line_point_id, &write_cartesian_point(&start_point, ""));
+
+        let dir_id = self.alloc_id();
+        self.emit(dir_id, &write_direction(&dir, ""));
+
+        let vec_id = self.alloc_id();
+        self.emit(
+            vec_id,
+            &format!("VECTOR('', #{}, {:.15E})", dir_id, magnitude),
+        );
+
+        let line_id = self.alloc_id();
+        self.emit(
+            line_id,
+            &format!("LINE('', #{}, #{})", line_point_id, vec_id),
+        );
+
+        let step_edge_id = self.alloc_id();
+        let entity = write_edge_curve("", start_vertex, end_vertex, line_id, true);
+        self.emit(step_edge_id, &entity);
+        step_edge_id
+    }
+
+    fn write_loops(&mut self) -> Result<(), StepError> {
+        // Collect loops first so we can borrow self mutably inside.
+        let loop_ids: Vec<LoopId> = self.solid.topology.loops.keys().collect();
+
+        for loop_id in loop_ids {
+            let he_ids: Vec<HalfEdgeId> = self
+                .solid
+                .topology
+                .loop_half_edges(loop_id)
+                .collect();
+
             let mut oriented_edge_ids = Vec::new();
 
-            for he_id in topo.loop_half_edges(loop_id) {
-                let he = &topo.half_edges[he_id];
-                let edge_id = he.edge.ok_or_else(|| {
-                    StepError::InvalidTopology("half-edge has no parent edge".into())
-                })?;
+            for he_id in he_ids {
+                let he = &self.solid.topology.half_edges[he_id];
+                let (step_edge_id, orientation) = match he.edge {
+                    Some(edge_id) => {
+                        let step_edge_id = self.edge_map[&edge_id];
+                        let edge = &self.solid.topology.edges[edge_id];
+                        let orientation = edge.half_edge == he_id;
+                        (step_edge_id, orientation)
+                    }
+                    None => {
+                        // Orphan half-edge — boolean sewing leaves these when face
+                        // boundaries can't be paired (curved-vs-polygonal mismatch).
+                        // Synthesize a one-off line edge so the loop can still be
+                        // emitted; orientation is forward since this he is the
+                        // synthetic edge's only half-edge.
+                        let start_vid = he.origin;
+                        let end_vid = self.solid.topology.half_edge_dest(he_id);
+                        let step_edge_id = self.write_line_edge_curve(start_vid, end_vid);
+                        (step_edge_id, true)
+                    }
+                };
 
-                let step_edge_id = self.edge_map[&edge_id];
-
-                // Determine orientation: check if this half-edge is the "primary" one
-                let edge = &topo.edges[edge_id];
-                let orientation = edge.half_edge == he_id;
-
-                // Write oriented edge
                 let oe_id = self.alloc_id();
                 let entity = write_oriented_edge("", step_edge_id, orientation);
                 self.emit(oe_id, &entity);
@@ -450,7 +472,6 @@ impl<'a> StepWriter<'a> {
                 oriented_edge_ids.push(oe_id);
             }
 
-            // Write edge loop
             let el_id = self.alloc_id();
             let entity = write_edge_loop("", &oriented_edge_ids);
             self.emit(el_id, &entity);

--- a/crates/vcad-kernel-step/tests/boolean_roundtrip.rs
+++ b/crates/vcad-kernel-step/tests/boolean_roundtrip.rs
@@ -33,7 +33,10 @@ fn write_step_after_difference_round_trips() {
 
     let buffer = write_step_to_buffer(brep).expect("STEP write should succeed");
     let solids = read_step_from_buffer(&buffer).expect("STEP read should succeed");
-    assert!(!solids.is_empty(), "expected at least one solid round-tripped");
+    assert!(
+        !solids.is_empty(),
+        "expected at least one solid round-tripped"
+    );
 }
 
 #[test]

--- a/crates/vcad-kernel-step/tests/boolean_roundtrip.rs
+++ b/crates/vcad-kernel-step/tests/boolean_roundtrip.rs
@@ -1,0 +1,51 @@
+//! Regression: STEP writer must accept BReps produced by boolean operations.
+//!
+//! Before this test, the writer rejected every Difference result with
+//! `Invalid topology: half-edge has no parent edge`, because the sewing
+//! step left some half-edges without a parent edge link. Mecheval's
+//! step_roundtrip check failed on every cube-minus-cylinder shape it
+//! evaluated.
+
+use vcad_kernel_booleans::{boolean_op, BooleanOp};
+use vcad_kernel_primitives::{make_cube, make_cylinder};
+use vcad_kernel_step::{read_step_from_buffer, write_step_to_buffer};
+
+#[test]
+fn write_step_after_difference() {
+    let cube = make_cube(20.0, 20.0, 20.0);
+    let cyl = make_cylinder(5.0, 30.0, 32);
+    let result = boolean_op(&cube, &cyl, BooleanOp::Difference, 32);
+    let brep = result.as_brep().expect("Difference should yield BRep");
+
+    let buffer = write_step_to_buffer(brep).expect("STEP write should succeed");
+    assert!(!buffer.is_empty());
+}
+
+#[test]
+fn write_step_after_difference_round_trips() {
+    // The writer used to reject every Difference output with
+    // `InvalidTopology`; ensure not just that write succeeds but that the
+    // result parses back into at least one solid.
+    let cube = make_cube(20.0, 20.0, 20.0);
+    let cyl = make_cylinder(5.0, 30.0, 32);
+    let result = boolean_op(&cube, &cyl, BooleanOp::Difference, 32);
+    let brep = result.as_brep().expect("Difference should yield BRep");
+
+    let buffer = write_step_to_buffer(brep).expect("STEP write should succeed");
+    let solids = read_step_from_buffer(&buffer).expect("STEP read should succeed");
+    assert!(!solids.is_empty(), "expected at least one solid round-tripped");
+}
+
+#[test]
+fn write_step_after_union_overlap() {
+    let a = make_cube(20.0, 20.0, 20.0);
+    let mut b = make_cube(20.0, 20.0, 20.0);
+    for (_, v) in &mut b.topology.vertices {
+        v.point.x += 10.0;
+    }
+    let result = boolean_op(&a, &b, BooleanOp::Union, 32);
+    let brep = result.as_brep().expect("Union should yield BRep");
+
+    let buffer = write_step_to_buffer(brep).expect("STEP write should succeed");
+    assert!(!buffer.is_empty());
+}


### PR DESCRIPTION
## Summary
The STEP writer now successfully exports BReps produced by boolean operations, particularly `Difference`. Previously, the writer would fail with `Invalid topology: half-edge has no parent edge` because the boolean sewing pipeline leaves orphan half-edges (those whose `parent_edge` link was severed) when face boundaries can't be paired due to curved-vs-polygonal mismatches.

## Key Changes

- **Refactored edge writing logic**: Extracted the line edge curve generation into a new `write_line_edge_curve()` method that can be reused in multiple contexts. This method handles the full geometry pipeline (point, direction, vector, line, edge curve) and returns the allocated STEP ID.

- **Enhanced loop writing**: Modified `write_loops()` to handle orphan half-edges gracefully. When a half-edge lacks a parent edge, the writer now synthesizes a one-off line edge on-the-fly using `write_line_edge_curve()`, allowing the loop to be emitted cleanly.

- **Improved code organization**: Refactored `write_edges()` to use the new `write_line_edge_curve()` method, reducing duplication and making the geometry generation logic centralized.

- **Added regression tests**: Three new tests in `boolean_roundtrip.rs` verify that:
  - STEP write succeeds after a Difference operation
  - The written STEP file round-trips correctly (can be read back)
  - Union operations with overlapping geometry also work

## Implementation Details

The fix addresses a fundamental issue in the boolean sewing pipeline: when curved faces meet polygonal holes (or vice versa), the topology can't be fully paired, leaving some half-edges without a parent edge reference. Rather than treating this as an error, the writer now detects these orphan half-edges and synthesizes appropriate line-based edge geometry for them. This maintains the writer's contract while accommodating the reality of boolean operation outputs.

The geometry is approximated as a line segment regardless of underlying surface curvature, which matches the existing limitation in `write_edges()` and keeps the solution simple and maintainable.

https://claude.ai/code/session_01M4tyLhxqBx5J79jaPPD4Aj