### PR TITLE
feat(auth): redesign sign-in and terms-gate modals

### DIFF
--- a/packages/app/src/components/TermsGate.tsx
+++ b/packages/app/src/components/TermsGate.tsx
@@ -1,10 +1,15 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Sparkle, Check } from "@phosphor-icons/react";
 import { useTermsStore } from "@/stores/terms-store";
+
+const ACCEPT_DELAY_MS = 220;
 
 /**
  * Blocking overlay shown until the user accepts the Terms of Service and
- * acknowledges the Privacy Policy. Rendered as a fixed full-viewport modal
- * on top of the app so the editor behind it is inert.
+ * acknowledges the Privacy Policy. Rendered as a Radix Dialog so it inherits
+ * focus-trapping and screen-reader semantics; the dialog is non-dismissable
+ * (Esc and click-outside are intercepted) — the only exit is accepting.
  *
  * Not rendered on the /privacy, /terms, /security legal pages themselves —
  * users must be able to read the documents before agreeing.
@@ -13,79 +18,131 @@ export function TermsGate() {
   const accepted = useTermsStore((s) => s.accepted);
   const accept = useTermsStore((s) => s.accept);
   const [checked, setChecked] = useState(false);
-
-  useEffect(() => {
-    if (accepted) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [accepted]);
+  const [pressing, setPressing] = useState(false);
 
   if (accepted) return null;
 
+  const onContinue = () => {
+    if (!checked || pressing) return;
+    setPressing(true);
+    window.setTimeout(() => {
+      accept();
+    }, ACCEPT_DELAY_MS);
+  };
+
   return (
-    <div
-      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="tos-gate-title"
-    >
-      <div className="w-full max-w-md bg-surface border border-border p-8 shadow-2xl">
-        <h2
-          id="tos-gate-title"
-          className="text-xl font-semibold tracking-tight text-text"
+    <Dialog.Root open modal>
+      <Dialog.Portal>
+        <Dialog.Overlay className="auth-overlay fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-labelledby="tos-gate-title"
+          aria-describedby="tos-gate-desc"
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onInteractOutside={(e) => e.preventDefault()}
+          className="auth-content fixed left-1/2 top-1/2 z-[100] w-[440px] -translate-x-1/2 -translate-y-1/2 border border-border bg-card/85 backdrop-blur-xl shadow-[0_24px_60px_-12px_rgba(0,0,0,0.6)] focus:outline-none"
         >
-          Welcome to vcad
-        </h2>
-        <p className="mt-3 text-sm text-text-muted leading-relaxed">
-          Before you start modeling, please review and accept our terms.
-        </p>
-
-        <label className="mt-6 flex items-start gap-3 text-sm text-text cursor-pointer">
-          <input
-            type="checkbox"
-            checked={checked}
-            onChange={(e) => setChecked(e.target.checked)}
-            className="mt-0.5"
+          {/* Top brand edge highlight */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,var(--color-brand),transparent)] opacity-70"
           />
-          <span>
-            I agree to the{" "}
-            <a
-              href="/terms"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand hover:underline"
-            >
-              Terms of Service
-            </a>{" "}
-            and acknowledge the{" "}
-            <a
-              href="/privacy"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand hover:underline"
-            >
-              Privacy Policy
-            </a>
-            .
-          </span>
-        </label>
 
-        <button
-          type="button"
-          disabled={!checked}
-          onClick={accept}
-          className="mt-6 w-full bg-brand px-4 py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-        >
-          Continue to vcad
-        </button>
+          <div className="flex flex-col items-center px-8 pt-8 pb-7">
+            {/* Brand chip */}
+            <div className="flex h-10 w-10 items-center justify-center border border-brand/30 bg-brand/12">
+              <Sparkle size={22} weight="fill" className="text-brand" />
+            </div>
 
-        <p className="mt-4 text-[11px] text-text-muted/70">
-          You can review these documents at any time from the account menu.
-        </p>
-      </div>
-    </div>
+            <Dialog.Title
+              id="tos-gate-title"
+              className="mt-4 text-[22px] font-semibold tracking-tight text-text"
+            >
+              Welcome to vcad
+            </Dialog.Title>
+
+            <Dialog.Description
+              id="tos-gate-desc"
+              className="mt-2 text-center text-[13px] leading-relaxed text-text-muted"
+            >
+              A quick housekeeping note before we hand you the kernel.
+              <br />
+              <span className="text-text-muted/70">
+                We&rsquo;re open-source and don&rsquo;t sell your data — but
+                the lawyers want their moment.
+              </span>
+            </Dialog.Description>
+
+            {/* Custom checkbox row */}
+            <label className="mt-6 flex w-full cursor-pointer items-start gap-3 text-[13px] text-text">
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => setChecked(e.target.checked)}
+                className="peer sr-only"
+              />
+              <span
+                aria-hidden
+                data-checked={checked}
+                className="mt-0.5 flex h-4 w-4 flex-shrink-0 items-center justify-center border border-border bg-bg/40 transition-colors duration-150 hover:border-text-muted/60 data-[checked=true]:border-brand data-[checked=true]:bg-brand peer-focus-visible:ring-2 peer-focus-visible:ring-brand/60 peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-card"
+              >
+                <Check
+                  size={11}
+                  weight="bold"
+                  className="text-primary-foreground transition-[clip-path] duration-150"
+                  style={{
+                    clipPath: checked
+                      ? "inset(0 0 0 0)"
+                      : "inset(0 100% 0 0)",
+                  }}
+                />
+              </span>
+              <span className="leading-relaxed">
+                I agree to the{" "}
+                <a
+                  href="/terms"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-brand underline decoration-brand/40 underline-offset-4 transition-colors hover:text-brand-hover hover:decoration-brand"
+                >
+                  Terms of Service
+                </a>{" "}
+                and acknowledge the{" "}
+                <a
+                  href="/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-brand underline decoration-brand/40 underline-offset-4 transition-colors hover:text-brand-hover hover:decoration-brand"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </span>
+            </label>
+
+            {/* CTA */}
+            <button
+              type="button"
+              disabled={!checked || pressing}
+              onClick={onContinue}
+              className={
+                checked
+                  ? `upgrade-cta ${pressing ? "cta-press" : ""} mt-6 w-full border border-brand bg-brand px-4 py-3 text-[13px] font-medium text-primary-foreground transition-colors hover:bg-brand-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-card`
+                  : "mt-6 w-full cursor-not-allowed border border-border bg-bg/40 px-4 py-3 text-[13px] font-medium text-text-muted/50"
+              }
+            >
+              Continue to vcad
+            </button>
+
+            <div className="mt-6 h-px w-full bg-border/70" />
+
+            <p className="mt-3 text-[11px] text-text-muted/70">
+              You can review these documents at any time from the account
+              menu.
+            </p>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+/* Workspace packages whose JSX uses Tailwind classes need to be scanned
+   explicitly — Tailwind v4's auto-detection only walks the package that
+   owns this stylesheet. */
+@source "../../auth/src/**/*.{ts,tsx}";
+@source "../../core/src/**/*.{ts,tsx}";
+
 /* Inter Variable (v4) — UI body font. Self-hosted, full 100..900 weight axis
    plus the `opsz` axis (we engage it via `font-optical-sizing: auto` on body
    so glyphs visibly tighten at small sizes and open up in headings).
@@ -368,6 +374,53 @@ body {
 .upgrade-cta:hover::after {
   animation-play-state: paused;
   opacity: 0;
+}
+
+/* ------------------------------------------------------------------------
+ * Auth + Terms-gate modals
+ *
+ * Re-use the upgrade-modal keyframes so the sign-in and terms-acceptance
+ * surfaces feel like the same family as the upgrade flow. CSS-driven via
+ * Radix's data-state attribute — no JS animation lib needed.
+ * ------------------------------------------------------------------------ */
+.auth-overlay[data-state="open"] {
+  animation: upgrade-overlay-in 180ms ease-out;
+}
+.auth-overlay[data-state="closed"] {
+  animation: upgrade-overlay-out 140ms ease-in;
+}
+.auth-content[data-state="open"] {
+  animation: upgrade-content-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.auth-content[data-state="closed"] {
+  animation: upgrade-content-out 140ms ease-in;
+}
+
+/* Tiny press-celebration on the terms-gate Continue button — fires for
+   220ms before the modal exits, so accepting feels like a confirmation
+   gesture instead of an instant cut. */
+@keyframes vcad-cta-press {
+  0%   { transform: scale(1); }
+  35%  { transform: scale(0.97); }
+  100% { transform: scale(1.02); }
+}
+.cta-press {
+  animation: vcad-cta-press 220ms ease-out;
+}
+
+/* Magic-link success chip slides up + fades in. */
+@keyframes vcad-success-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.auth-success-in {
+  animation: vcad-success-in 360ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 /* Bottom toolbar: remove focus outlines in the bar and its menus */

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -1,10 +1,12 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import {
   X,
   EnvelopeSimple,
   GoogleLogo,
   GithubLogo,
+  ArrowRight,
+  CircleNotch,
 } from "@phosphor-icons/react";
 import { getAuthRedirectUrl, getSupabase, isTauriRuntime } from "../client";
 import type { GatedFeature } from "../hooks/useRequireAuth";
@@ -26,6 +28,10 @@ const featureMessages: Record<GatedFeature, string> = {
   "version-history": "to access history",
 };
 
+const RESEND_COOLDOWN_SECS = 30;
+
+const isValidEmail = (s: string) => /\S+@\S+\.\S+/.test(s.trim());
+
 /**
  * Modal dialog for user authentication.
  * Supports Google / GitHub OAuth and email magic link.
@@ -35,8 +41,15 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [resendIn, setResendIn] = useState(0);
 
   const supabase = getSupabase();
+
+  useEffect(() => {
+    if (resendIn <= 0) return;
+    const id = window.setTimeout(() => setResendIn((s) => s - 1), 1000);
+    return () => window.clearTimeout(id);
+  }, [resendIn]);
 
   const signInWithProvider = async (provider: OAuthProvider) => {
     if (!supabase) return;
@@ -54,8 +67,6 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       provider,
       options: {
         redirectTo: getAuthRedirectUrl(),
-        // On desktop we hand the URL to the OS browser ourselves so
-        // Google/GitHub don't reject the embedded webview as "insecure".
         skipBrowserRedirect: tauri,
       },
     });
@@ -83,9 +94,6 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       try {
         const { openUrl } = await import("@tauri-apps/plugin-opener");
         await openUrl(data.url);
-        // Browser is launched; auth completes via the deep-link handler
-        // and AuthProvider closes the modal. Re-enable the form so the
-        // user can retry if they cancel in the browser.
         setLoading(false);
       } catch (err) {
         reportFailure(
@@ -94,13 +102,10 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       }
       return;
     }
-    // On web Supabase already navigated; leave `loading` set so the
-    // form doesn't flash active mid-redirect.
   };
 
-  const signInWithEmail = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!supabase || !email) return;
+  const sendMagicLink = async () => {
+    if (!supabase || !isValidEmail(email)) return;
 
     setLoading(true);
     setError(null);
@@ -111,9 +116,7 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
 
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: {
-        emailRedirectTo: getAuthRedirectUrl(),
-      },
+      options: { emailRedirectTo: getAuthRedirectUrl() },
     });
 
     if (error) {
@@ -125,6 +128,7 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       );
     } else {
       setSent(true);
+      setResendIn(RESEND_COOLDOWN_SECS);
       window.dispatchEvent(
         new CustomEvent("vcad:sign-in-attempt-sent", { detail: { email } }),
       );
@@ -132,124 +136,272 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
     setLoading(false);
   };
 
+  const onEmailSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    sendMagicLink();
+  };
+
   const handleOpenChange = (open: boolean) => {
     onOpenChange(open);
     if (!open) {
-      // Reset state when modal closes
       setTimeout(() => {
         setEmail("");
         setSent(false);
         setError(null);
         setLoading(false);
+        setResendIn(0);
       }, 200);
     }
   };
 
+  const emailValid = isValidEmail(email);
+  const subtitle = feature
+    ? featureMessages[feature]
+    : "save your work, fork files, and use AI";
+
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 border border-border bg-card/95 backdrop-blur-sm shadow-lg focus:outline-none">
+        <Dialog.Overlay className="auth-overlay fixed inset-0 z-50 bg-black/65 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="auth-content fixed left-1/2 top-1/2 z-50 w-[340px] -translate-x-1/2 -translate-y-1/2 border border-border bg-card/85 backdrop-blur-xl shadow-[0_24px_60px_-12px_rgba(0,0,0,0.6)] focus:outline-none"
+        >
+          {/* Top brand edge highlight */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,var(--color-brand),transparent)] opacity-70"
+          />
+
           {/* Close button */}
-          <div className="absolute right-2 top-2 z-10">
-            <Dialog.Close className="p-1 text-text-muted hover:bg-border/50 hover:text-text cursor-pointer">
-              <X size={14} />
-            </Dialog.Close>
-          </div>
+          <Dialog.Close
+            aria-label="Close"
+            className="absolute right-2.5 top-2.5 z-10 p-1 text-text-muted/70 transition-colors hover:bg-hover hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+          >
+            <X size={12} />
+          </Dialog.Close>
 
           {/* Content */}
-          <div className="flex flex-col items-center px-6 py-5">
+          <div className="flex flex-col items-center px-7 pt-7 pb-6">
             {/* Header */}
-            <Dialog.Title className="text-2xl font-bold tracking-tighter text-text mb-5">
-              vcad<span className="text-brand">.</span>
+            <Dialog.Title className="text-3xl font-bold tracking-tighter text-text">
+              vcad
+              <span
+                className="text-brand"
+                style={{
+                  display: "inline-block",
+                  animation: "vcad-pulse 2.4s ease-in-out infinite",
+                }}
+              >
+                .
+              </span>
             </Dialog.Title>
+            <p className="mt-1 text-[11px] text-text-muted/80">
+              {subtitle}
+            </p>
 
             {error && (
-              <div className="w-full mb-4 p-2 bg-danger/10 border border-danger/30 text-xs text-danger text-center">
+              <div className="mt-4 w-full border border-danger/30 bg-danger/10 p-2 text-center text-xs text-danger">
                 {error}
               </div>
             )}
 
             {sent ? (
-              <div className="text-center">
-                <div className="w-10 h-10 mx-auto mb-3 flex items-center justify-center bg-brand/10">
-                  <EnvelopeSimple size={20} className="text-brand" />
-                </div>
-                <p className="text-sm text-text mb-1">Check your email</p>
-                <p className="text-xs text-text-muted mb-4">
-                  Link sent to <span className="text-text">{email}</span>
-                </p>
-                <button
-                  onClick={() => handleOpenChange(false)}
-                  className="text-[10px] text-text-muted hover:text-text"
-                >
-                  close
-                </button>
-              </div>
+              <SentState
+                email={email}
+                resendIn={resendIn}
+                loading={loading}
+                onResend={sendMagicLink}
+                onClose={() => handleOpenChange(false)}
+              />
             ) : (
-              <div className="w-64 flex flex-col gap-2">
-                <button
-                  type="button"
+              <div className="mt-5 flex w-full flex-col gap-2">
+                <ProviderButton
                   onClick={() => signInWithProvider("google")}
                   disabled={loading}
-                  className="w-full h-9 border border-border text-xs text-text hover:bg-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
-                >
-                  <GoogleLogo size={14} weight="bold" />
-                  Continue with Google
-                </button>
-                <button
-                  type="button"
+                  icon={<GoogleLogo size={16} weight="bold" />}
+                  label="Continue with Google"
+                />
+                <ProviderButton
                   onClick={() => signInWithProvider("github")}
                   disabled={loading}
-                  className="w-full h-9 border border-border text-xs text-text hover:bg-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
-                >
-                  <GithubLogo size={14} weight="fill" />
-                  Continue with GitHub
-                </button>
+                  icon={<GithubLogo size={16} weight="fill" />}
+                  label="Continue with GitHub"
+                />
 
-                <div className="flex items-center gap-2 my-1">
-                  <div className="flex-1 h-px bg-border" />
-                  <span className="text-[10px] text-text-muted uppercase tracking-wider">or</span>
-                  <div className="flex-1 h-px bg-border" />
+                <div className="my-3 flex items-center gap-2">
+                  <div className="h-px flex-1 bg-border/70" />
+                  <span className="text-[9.5px] uppercase tracking-[0.18em] text-text-muted">
+                    or
+                  </span>
+                  <div className="h-px flex-1 bg-border/70" />
                 </div>
 
-                <form onSubmit={signInWithEmail} className="flex flex-col gap-2">
+                <form
+                  onSubmit={onEmailSubmit}
+                  className="flex flex-col gap-2"
+                  noValidate
+                >
                   <input
                     type="email"
                     placeholder="Email address"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full h-9 px-3 bg-transparent border border-border text-xs text-text placeholder-text-muted/50 focus:outline-none focus:border-brand transition-colors"
+                    className="h-11 w-full border border-border bg-bg/60 px-3 text-[13px] text-text placeholder-text-muted/50 transition-colors focus:border-brand focus:bg-bg/80 focus:outline-none"
                     disabled={loading}
                     autoComplete="email"
                   />
-                  <button
-                    type="submit"
-                    disabled={loading || !email}
-                    className="w-full h-9 border border-border text-xs text-text hover:bg-border/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                  >
-                    {loading ? "Sending..." : "Continue with email"}
-                  </button>
+                  <EmailCta
+                    loading={loading}
+                    active={emailValid && !loading}
+                  />
                 </form>
               </div>
             )}
-
-            {/* Feature-context line (sits right above the legal footer) */}
-            <p className="text-[10px] text-text-muted mt-4">
-              {feature ? featureMessages[feature] : "sign in to save your work"}
-            </p>
           </div>
 
           {/* Footer */}
-          <div className="border-t border-border px-4 py-2.5 flex items-center justify-center">
+          <div className="flex items-center justify-center border-t border-border px-4 py-2.5">
             <p className="text-[10px] text-text-muted">
-              <a href="https://vcad.io/terms" className="hover:text-text" target="_blank" rel="noopener noreferrer">terms</a>
+              <a
+                href="https://vcad.io/terms"
+                className="hover:text-text"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                terms
+              </a>
               {" · "}
-              <a href="https://vcad.io/privacy" className="hover:text-text" target="_blank" rel="noopener noreferrer">privacy</a>
+              <a
+                href="https://vcad.io/privacy"
+                className="hover:text-text"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                privacy
+              </a>
+              {" · "}
+              <a
+                href="https://vcad.io/security"
+                className="hover:text-text"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                security
+              </a>
             </p>
           </div>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
+  );
+}
+
+function ProviderButton({
+  onClick,
+  disabled,
+  icon,
+  label,
+}: {
+  onClick: () => void;
+  disabled: boolean;
+  icon: React.ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="flex h-11 w-full items-center justify-center gap-2.5 border border-border text-[13px] text-text transition-colors duration-150 hover:border-text-muted/40 hover:bg-hover disabled:cursor-not-allowed disabled:opacity-30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function EmailCta({ loading, active }: { loading: boolean; active: boolean }) {
+  if (loading) {
+    return (
+      <button
+        type="submit"
+        disabled
+        className="flex h-11 w-full items-center justify-center gap-2 border border-border bg-transparent text-[13px] text-text-muted/70"
+      >
+        <CircleNotch size={12} className="animate-spin" />
+        Sending…
+      </button>
+    );
+  }
+
+  if (active) {
+    return (
+      <button
+        type="submit"
+        className="upgrade-cta group flex h-11 w-full items-center justify-center gap-2 border border-brand bg-brand text-[13px] font-medium text-primary-foreground transition-colors hover:bg-brand-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-card"
+      >
+        <span>Continue with email</span>
+        <ArrowRight
+          size={14}
+          weight="bold"
+          className="transition-transform duration-150 group-hover:translate-x-0.5"
+        />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="submit"
+      disabled
+      className="flex h-11 w-full items-center justify-center gap-2 border border-border bg-transparent text-[13px] text-text-muted/60"
+    >
+      Continue with email
+    </button>
+  );
+}
+
+function SentState({
+  email,
+  resendIn,
+  loading,
+  onResend,
+  onClose,
+}: {
+  email: string;
+  resendIn: number;
+  loading: boolean;
+  onResend: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="auth-success-in mt-5 flex w-full flex-col items-center text-center">
+      <div className="mb-3 flex h-11 w-11 items-center justify-center border border-brand/30 bg-brand/12">
+        <EnvelopeSimple size={22} className="text-brand" />
+      </div>
+      <p className="text-sm font-medium text-text">Check your email</p>
+      <p className="mt-1 text-[11px] text-text-muted">
+        We sent a sign-in link to{" "}
+        <span className="text-text">{email}</span>
+      </p>
+
+      <button
+        type="button"
+        onClick={onResend}
+        disabled={resendIn > 0 || loading}
+        className="mt-4 text-[11px] text-text-muted underline-offset-4 transition-colors hover:text-text hover:underline disabled:cursor-not-allowed disabled:opacity-50 disabled:no-underline"
+      >
+        {resendIn > 0 ? `Resend link in ${resendIn}s` : "Resend link"}
+      </button>
+
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-1 text-[10px] text-text-muted/70 hover:text-text"
+      >
+        close
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The two modals every new vcad user hits — **AuthModal** (sign-in) and **TermsGate** (ToS acceptance) — were functional but flat: no entrance animation, generic native checkbox, narrow 256px sign-in column, no shared visual signature. This brings both in line with the polished animation grammar already established by `UpgradeModal` so login → terms → app reads as one cinematic flow.

## What changed

**AuthModal** ([packages/auth/src/components/AuthModal.tsx](packages/auth/src/components/AuthModal.tsx))
- 340px glass card with backdrop-blur over a heavier overlay; brand top-edge gradient (a 1px Stripe/Linear-style edge highlight)
- Wordmark animates with a heartbeat on the pink dot — same `vcad-pulse` keyframe the kernel chip uses, linking auth chrome to the live app
- h-11 provider buttons with focus-visible brand rings
- Email CTA flips to brand-pink fill + sheen sweep + arrow nudge once the address is valid
- Polished sent-state: stacked envelope chip, 30-second resend countdown, ghost close
- Footer adds `security` next to `terms · privacy`

**TermsGate** ([packages/app/src/components/TermsGate.tsx](packages/app/src/components/TermsGate.tsx))
- Converted from raw `<div>` to **Radix Dialog** so it inherits focus-trap, scroll-lock, and screen-reader semantics; Esc and click-outside are intercepted (it stays a hard gate)
- Sparkle brand chip + warmer two-line copy ("A quick housekeeping note before we hand you the kernel.")
- Custom checkbox with a brand-pink tick that animates in via clip-path (no more native browser checkbox)
- CTA gets the upgrade-modal sheen sweep the moment the box is ticked, plus a 220ms press celebration before the modal unmounts

**[packages/app/src/index.css](packages/app/src/index.css)**
- New `.auth-overlay` / `.auth-content` classes that reuse the existing `upgrade-*` keyframes (no new animation library)
- Two small additions: `vcad-cta-press` for the accept celebration, `vcad-success-in` for the magic-link chip
- Added `@source` directives so Tailwind v4 scans the `@vcad/auth` and `@vcad/core` workspace packages — without these, arbitrary classes like `w-[340px]` in those packages don't generate

## Why this is safe

- Public API of `<AuthModal>` (`open`, `onOpenChange`, `feature`) and all `vcad:sign-in-attempt*` window events are unchanged — every existing call site keeps working.
- No new runtime dependencies. `motion/react` is already installed but we stick to CSS keyframes to match the existing UpgradeModal pattern.
- Tailwind v4 `@source` is purely additive (it makes more classes available; it doesn't remove any).

## Test plan

- [x] Dark + light mode for both modals (verified live; chrome inverts cleanly)
- [x] AuthModal: idle, focus-visible rings, brand sheen on the email CTA when address is valid
- [x] TermsGate: unchecked → checked tick animation, sheen on enabled CTA, Esc intercepted
- [x] `@vcad/auth` typecheck passes
- [x] `@vcad/app` typecheck passes
- [x] `@vcad/app` vitest: 15/15 passing
- [ ] (Reviewer) Spot-check the magic-link sent-state (requires Supabase env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)