### PR TITLE
feat(auth): popup OAuth on web so users keep their place

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -8,7 +8,8 @@
         "-c",
         "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0"
       ],
-      "port": 5173
+      "port": 5173,
+      "autoPort": true
     }
   ]
 }

--- a/packages/app/public/auth/popup.html
+++ b/packages/app/public/auth/popup.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in to vcad</title>
+    <meta name="robots" content="noindex" />
+    <link rel="icon" href="/favicon.ico" />
+    <style>
+      @font-face {
+        font-family: "Berkeley Mono";
+        font-weight: 400;
+        font-display: swap;
+        src: url("/fonts/BerkeleyMono-Regular.otf") format("opentype");
+      }
+      @font-face {
+        font-family: "Berkeley Mono";
+        font-weight: 700;
+        font-display: swap;
+        src: url("/fonts/BerkeleyMono-Bold.otf") format("opentype");
+      }
+
+      :root {
+        color-scheme: dark;
+        --bg: #222222;
+        --surface: #2a2a2a;
+        --border: #444444;
+        --text: #f8f8f2;
+        --text-muted: #75715e;
+        --hover: rgba(255, 255, 255, 0.1);
+        --brand: #f92672;
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          color-scheme: light;
+          --bg: #e8eaec;
+          --surface: #dde0e3;
+          --border: #c4c8cc;
+          --text: #1d1f23;
+          --text-muted: #6e7278;
+          --hover: rgba(0, 0, 0, 0.05);
+          --brand: #f92672;
+        }
+      }
+
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        font: 12px/1.5 "Berkeley Mono", ui-monospace, monospace;
+        background: var(--bg);
+        color: var(--text);
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      main {
+        min-height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        box-sizing: border-box;
+      }
+
+      .card {
+        width: 100%;
+        max-width: 24rem;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        padding: 1.5rem;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 1rem;
+      }
+      .logo {
+        font-size: 14px;
+        font-weight: 700;
+        letter-spacing: -0.05em;
+        color: var(--text);
+      }
+      .logo .dot {
+        color: var(--brand);
+      }
+      .label {
+        font-size: 12px;
+        color: var(--text-muted);
+      }
+
+      p {
+        margin: 0 0 0.75rem;
+        font-size: 12px;
+        color: var(--text);
+      }
+      p.muted {
+        color: var(--text-muted);
+      }
+
+      .actions {
+        margin-top: 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .btn {
+        height: 2rem;
+        padding: 0 0.75rem;
+        border: 1px solid var(--border);
+        background: var(--bg);
+        color: var(--text);
+        font: inherit;
+        font-size: 12px;
+        cursor: pointer;
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .btn:hover {
+        background: var(--hover);
+      }
+
+      .hide {
+        display: none;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="card">
+        <div class="header">
+          <span class="logo">vcad<span class="dot">.</span></span>
+          <span class="label">Sign-in</span>
+        </div>
+        <p id="status" class="muted">Completing sign-in…</p>
+        <div class="actions">
+          <a id="continue" class="btn hide" href="/">Continue to vcad</a>
+        </div>
+        <noscript>
+          <p class="muted">
+            Enable JavaScript to complete sign-in.
+          </p>
+        </noscript>
+      </div>
+    </main>
+    <script>
+      (function () {
+        var status = document.getElementById("status");
+        var continueLink = document.getElementById("continue");
+
+        try {
+          if (window.opener && !window.opener.closed) {
+            // Same-origin opener — postMessage the full URL so it can
+            // run the PKCE / OTP exchange against its own Supabase
+            // client (which holds the code verifier in localStorage).
+            window.opener.postMessage(
+              { type: "vcad:oauth-callback", url: window.location.href },
+              window.location.origin,
+            );
+            status.textContent = "Done. You can close this window.";
+            // Give the opener a tick to ack before closing — some
+            // browsers race the close against the message delivery.
+            setTimeout(function () {
+              try {
+                window.close();
+              } catch (_) {
+                /* user closes it manually */
+              }
+            }, 50);
+            return;
+          }
+        } catch (_) {
+          // Cross-origin or detached opener — fall through to the
+          // standalone path below.
+        }
+
+        // No opener (user pasted the URL into a fresh tab, or the
+        // browser killed the reference). Show a button back to the app.
+        status.textContent = "Sign-in complete.";
+        continueLink.classList.remove("hide");
+      })();
+    </script>
+  </body>
+</html>

--- a/packages/auth/src/auth-deep-link.ts
+++ b/packages/auth/src/auth-deep-link.ts
@@ -47,11 +47,18 @@ export function isAuthDeepLink(url: string): boolean {
 }
 
 /**
- * Materialize a Supabase session from a `vcad://auth/callback` URL.
+ * Materialize a Supabase session from any auth callback URL — used by
+ * both the desktop deep-link bridge and the web popup flow. Handles
+ * three shapes Supabase can return:
+ *
+ *   - `?code=…`            PKCE / OAuth code exchange
+ *   - `#access_token=…`    implicit-flow token pair
+ *   - `?token_hash=…&type` magic-link OTP
+ *
  * Returns `{ ok: true }` when a session was established; `AuthProvider`
  * will pick it up via its `onAuthStateChange` subscription.
  */
-export async function handleAuthDeepLink(
+export async function applyAuthCallback(
   url: string,
 ): Promise<AuthDeepLinkResult> {
   const supabase = getSupabase();
@@ -86,8 +93,8 @@ export async function handleAuthDeepLink(
   const query = parsed.searchParams;
 
   // PKCE / OAuth code exchange. Note this only succeeds when the
-  // desktop is the same client that initiated the sign-in (the code
-  // verifier lives in the app's localStorage).
+  // exchanging client is the same one that initiated the sign-in — the
+  // code verifier lives in the app's localStorage.
   const code = query.get("code");
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
@@ -126,4 +133,14 @@ export async function handleAuthDeepLink(
   }
 
   return { ok: false, error: "Callback URL had no auth parameters" };
+}
+
+/**
+ * Materialize a Supabase session from a `vcad://auth/callback` URL.
+ * Thin wrapper over `applyAuthCallback` retained for API stability.
+ */
+export async function handleAuthDeepLink(
+  url: string,
+): Promise<AuthDeepLinkResult> {
+  return applyAuthCallback(url);
 }

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -29,6 +29,23 @@ export function getAuthRedirectUrl(): string {
   return typeof window !== "undefined" ? window.location.origin : "";
 }
 
+/**
+ * Where Supabase should redirect a popup OAuth flow. This is a static
+ * page that postMessages the callback URL to its opener and closes
+ * itself, so the main window completes the PKCE exchange against the
+ * existing Supabase client without ever navigating away.
+ *
+ * Web only — Tauri keeps using `getAuthRedirectUrl()` so the OS browser
+ * routes back through the deep-link bridge.
+ */
+export function getPopupCallbackUrl(): string {
+  if (typeof window === "undefined") return "";
+  // `.html` extension keeps the URL pointing at the static file even
+  // on hosts that fall back to the SPA's index.html for unknown paths
+  // (Vite dev server, Cloudflare Pages, Vercel, etc.).
+  return `${window.location.origin}/auth/popup.html`;
+}
+
 import {
   createClient,
   type Session as SupabaseSession,

--- a/packages/auth/src/components/AuthModal.tsx
+++ b/packages/auth/src/components/AuthModal.tsx
@@ -7,6 +7,7 @@ import {
   GithubLogo,
 } from "@phosphor-icons/react";
 import { getAuthRedirectUrl, getSupabase, isTauriRuntime } from "../client";
+import { signInWithOAuthPopup } from "../oauth-popup";
 import type { GatedFeature } from "../hooks/useRequireAuth";
 
 type OAuthProvider = "google" | "github";
@@ -48,18 +49,6 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       new CustomEvent("vcad:sign-in-attempt", { detail: { provider } }),
     );
 
-    const tauri = isTauriRuntime();
-
-    const { data, error } = await supabase.auth.signInWithOAuth({
-      provider,
-      options: {
-        redirectTo: getAuthRedirectUrl(),
-        // On desktop we hand the URL to the OS browser ourselves so
-        // Google/GitHub don't reject the embedded webview as "insecure".
-        skipBrowserRedirect: tauri,
-      },
-    });
-
     const reportFailure = (message: string) => {
       setError(message);
       window.dispatchEvent(
@@ -70,12 +59,21 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       setLoading(false);
     };
 
-    if (error) {
-      reportFailure(error.message);
-      return;
-    }
-
-    if (tauri) {
+    if (isTauriRuntime()) {
+      // Desktop: open the OS browser and let the deep-link bridge
+      // complete the flow. Embedded webviews would be rejected by
+      // Google/GitHub as "insecure".
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          redirectTo: getAuthRedirectUrl(),
+          skipBrowserRedirect: true,
+        },
+      });
+      if (error) {
+        reportFailure(error.message);
+        return;
+      }
       if (!data?.url) {
         reportFailure("OAuth provider did not return a redirect URL");
         return;
@@ -94,8 +92,43 @@ export function AuthModal({ open, onOpenChange, feature }: AuthModalProps) {
       }
       return;
     }
-    // On web Supabase already navigated; leave `loading` set so the
-    // form doesn't flash active mid-redirect.
+
+    // Web: drive the OAuth dance inside a popup so the user keeps
+    // their place. `signInWithOAuthPopup` must run synchronously
+    // enough that the click gesture still authorizes window.open —
+    // it does (only state setters and the supabase call run before
+    // the popup is opened).
+    const result = await signInWithOAuthPopup(provider);
+
+    if (result.ok) {
+      // AuthProvider's onAuthStateChange handles the rest.
+      setLoading(false);
+      return;
+    }
+
+    if (result.cancelled) {
+      // User closed the popup; quietly reset the form.
+      setLoading(false);
+      return;
+    }
+
+    if (result.popupBlocked) {
+      // Fall back to today's full-page redirect so sign-in still
+      // completes, even if the user loses ephemeral state.
+      const { error: redirectError } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: { redirectTo: getAuthRedirectUrl() },
+      });
+      if (redirectError) {
+        reportFailure(redirectError.message);
+        return;
+      }
+      // Supabase has navigated the page; leave loading set so the
+      // form doesn't flash active mid-redirect.
+      return;
+    }
+
+    reportFailure(result.error ?? "Sign-in failed");
   };
 
   const signInWithEmail = async (e: FormEvent) => {

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -10,10 +10,18 @@ export {
 
 // Desktop deep-link auth bridge
 export {
+  applyAuthCallback,
   handleAuthDeepLink,
   isAuthDeepLink,
   type AuthDeepLinkResult,
 } from "./auth-deep-link";
+
+// Web popup OAuth flow
+export {
+  signInWithOAuthPopup,
+  type OAuthPopupProvider,
+  type OAuthPopupResult,
+} from "./oauth-popup";
 
 // Stores
 export { useAuthStore } from "./stores/auth-store";

--- a/packages/auth/src/oauth-popup.ts
+++ b/packages/auth/src/oauth-popup.ts
@@ -1,0 +1,157 @@
+/**
+ * Web popup-window OAuth flow.
+ *
+ * Opens a same-origin popup, drives the provider redirect inside it,
+ * and hands the resulting callback URL back to the main window via
+ * `postMessage`. The main window completes the PKCE exchange against
+ * the existing Supabase client (the code verifier is in shared
+ * `localStorage`) so `onAuthStateChange` fires in the original tab and
+ * the user keeps their place — no navigation, no state loss.
+ *
+ * Tauri uses a separate flow (external browser + deep-link bridge); the
+ * caller should branch on `isTauriRuntime()` before calling this.
+ */
+
+import { applyAuthCallback } from "./auth-deep-link";
+import { getPopupCallbackUrl, getSupabase } from "./client";
+
+export type OAuthPopupProvider = "google" | "github";
+
+export interface OAuthPopupResult {
+  ok: boolean;
+  /**
+   * True when the popup was blocked or unavailable and the caller should
+   * fall back to a full-page redirect. `error` is unset in this case.
+   */
+  popupBlocked?: boolean;
+  /** True when the user closed the popup before completing sign-in. */
+  cancelled?: boolean;
+  /** Populated on failure; safe to surface to the user. */
+  error?: string;
+}
+
+/**
+ * postMessage payload posted by `/auth/popup` once the OAuth provider
+ * has redirected to it. The main window is the only intended consumer.
+ */
+interface OAuthCallbackMessage {
+  type: "vcad:oauth-callback";
+  url: string;
+}
+
+function isCallbackMessage(data: unknown): data is OAuthCallbackMessage {
+  if (typeof data !== "object" || data === null) return false;
+  const msg = data as Record<string, unknown>;
+  return (
+    msg.type === "vcad:oauth-callback" && typeof msg.url === "string"
+  );
+}
+
+const POPUP_NAME = "vcad-oauth";
+const POPUP_FEATURES =
+  "popup=yes,width=500,height=700,menubar=no,toolbar=no,location=no,status=no";
+
+/**
+ * Sign in with an OAuth provider via a popup window. Must be called
+ * synchronously from a user-gesture handler (click) or the popup will
+ * be blocked. Returns `{ popupBlocked: true }` when the browser refused
+ * to open the popup so the caller can fall back to a full-page
+ * redirect.
+ */
+export async function signInWithOAuthPopup(
+  provider: OAuthPopupProvider,
+): Promise<OAuthPopupResult> {
+  if (typeof window === "undefined") {
+    return { ok: false, error: "Popup OAuth requires a browser" };
+  }
+
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { ok: false, error: "Auth is not configured" };
+  }
+
+  // Open synchronously inside the user gesture; assigning `location`
+  // after the async `signInWithOAuth` round-trip is fine.
+  const popup = window.open("about:blank", POPUP_NAME, POPUP_FEATURES);
+  if (!popup) {
+    return { ok: false, popupBlocked: true };
+  }
+
+  try {
+    popup.document.write(
+      '<!doctype html><meta charset="utf-8"><title>Connecting…</title>' +
+        '<body style="background:#222;color:#F8F8F2;font:12px ui-monospace,monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0">Connecting…</body>',
+    );
+  } catch {
+    // Some browsers throw on document.write into about:blank when
+    // tracking-protection rules apply. Harmless — the popup just
+    // stays blank until we navigate it below.
+  }
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider,
+    options: {
+      redirectTo: getPopupCallbackUrl(),
+      skipBrowserRedirect: true,
+    },
+  });
+
+  if (error || !data?.url) {
+    popup.close();
+    return {
+      ok: false,
+      error: error?.message ?? "OAuth provider did not return a redirect URL",
+    };
+  }
+
+  popup.location.href = data.url;
+
+  return new Promise<OAuthPopupResult>((resolve) => {
+    const expectedOrigin = window.location.origin;
+    let settled = false;
+
+    const cleanup = () => {
+      window.removeEventListener("message", onMessage);
+      if (pollHandle !== undefined) clearInterval(pollHandle);
+      try {
+        if (!popup.closed) popup.close();
+      } catch {
+        // Cross-origin access on `closed` can throw briefly while the
+        // provider page is loading; safe to ignore on cleanup.
+      }
+    };
+
+    const onMessage = async (event: MessageEvent) => {
+      if (event.origin !== expectedOrigin) return;
+      if (event.source !== popup) return;
+      if (!isCallbackMessage(event.data)) return;
+
+      if (settled) return;
+      settled = true;
+
+      const result = await applyAuthCallback(event.data.url);
+      cleanup();
+      if (result.ok) {
+        resolve({ ok: true });
+      } else {
+        resolve({ ok: false, error: result.error });
+      }
+    };
+
+    window.addEventListener("message", onMessage);
+
+    const pollHandle = window.setInterval(() => {
+      let closed = false;
+      try {
+        closed = popup.closed;
+      } catch {
+        // Ignore — see comment in cleanup().
+      }
+      if (closed && !settled) {
+        settled = true;
+        cleanup();
+        resolve({ ok: false, cancelled: true });
+      }
+    }, 500);
+  });
+}


### PR DESCRIPTION
## Summary

- Drive Google/GitHub OAuth inside a same-origin popup on web instead of navigating the main window away. Users keep their viewport, selection, sketch, route, and undo history through sign-in.
- New static `/auth/popup.html` page postMessages the callback URL back to its opener. The main window's existing Supabase client completes the PKCE exchange (code verifier is in shared `localStorage`), `onAuthStateChange` fires in the original tab, and `AuthProvider` lights up the session with no navigation.
- Falls back to today's full-page redirect when the popup is blocked. Tauri (external browser + `vcad://auth/callback` deep-link) and email magic-link flows are untouched.

## Why

The current web flow calls `supabase.auth.signInWithOAuth(...)` which navigates the page away and back. That nukes any ephemeral state the user had — in-flight unsaved edits, viewport camera, selection, URL/route, scroll position, undo/redo. Tauri already avoids this by handing the OAuth URL to the OS browser. Web should do the same in spirit via a popup.

## What changed

- `packages/auth/src/oauth-popup.ts` (new) — `signInWithOAuthPopup(provider)` opens a same-origin popup synchronously inside the click handler, drives `signInWithOAuth({ skipBrowserRedirect: true })`, and resolves on a `postMessage` from the callback page. Returns `{ popupBlocked: true }` for the redirect fallback and `{ cancelled: true }` when the user closes the popup.
- `packages/app/public/auth/popup.html` (new) — minimal static page that `postMessage`s the URL back to `window.opener` and closes itself. No `supabase-js` (don't want to burn the one-shot token before the opener sees it). Mirrors `desktop.html`.
- `packages/auth/src/auth-deep-link.ts` — extracted shared `applyAuthCallback(url)` util that handles all three callback shapes (PKCE `?code`, implicit-flow hash, magic-link `?token_hash`). `handleAuthDeepLink` is now a thin wrapper for API stability.
- `packages/auth/src/client.ts` — added `getPopupCallbackUrl()` returning `${origin}/auth/popup.html`.
- `packages/auth/src/components/AuthModal.tsx` — branches: Tauri keeps existing flow, web calls `signInWithOAuthPopup` and falls back to redirect on popup-blocked. Email magic-link path unchanged.
- `packages/auth/src/index.ts` — re-exports `signInWithOAuthPopup`, `applyAuthCallback`.
- `.claude/launch.json` — `autoPort: true` so the dev server doesn't fail when 5173 is taken by a sibling worktree.

## One-time dashboard step

Before merging, add the popup callback URL to the Supabase **Redirect URLs** allowlist:
- `https://vcad.io/auth/popup.html`
- `http://localhost:5173/auth/popup.html` (dev)

## Test plan

- [ ] Web: open the app, make a non-trivial change (extrude a sketch, rotate the camera). Click sign-in → "Continue with Google". Popup opens, completes OAuth, closes itself. Main tab still shows the same view, the sketch is intact, `useAuthStore.getState().session` is populated.
- [ ] Popup-blocked fallback: block popups in browser settings, retry sign-in, confirm it falls back to a full-page redirect and still completes successfully.
- [ ] Cancel: start sign-in, close the popup before completing → modal returns to idle, no console errors.
- [ ] Tauri regression: `npm run tauri:dev -w @vcad/app`, sign in, OS-browser + deep-link flow still works.
- [ ] Email magic-link regression: request a magic link, click it from email, sign-in still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)