### PR TITLE
fix(chat): persist assistant content_blocks before res.end()

### DIFF
--- a/packages/app/api/chat.ts
+++ b/packages/app/api/chat.ts
@@ -835,6 +835,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Capture into a const so the closure narrowing survives.
     const turnForPersistence = persistedTurn;
     const adminForPersistence = admin;
+    // In-stream writes (tool_call rows + per-block deltas) are queued without
+    // awaiting so they don't slow the SSE pipe, but we keep their promises so
+    // they can be drained before the function returns. On Vercel the Node
+    // function can be terminated as soon as the handler returns, which would
+    // strand truly fire-and-forget writes.
+    const pendingWrites: Promise<unknown>[] = [];
     const persistence: PersistenceHooks | undefined =
       turnForPersistence && adminForPersistence
         ? {
@@ -844,31 +850,37 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
                 block.id &&
                 block.name
               ) {
-                void persistToolCallStart(adminForPersistence, {
-                  toolUseId: block.id,
-                  messageId: turnForPersistence.assistantMessageId,
-                  threadId: turnForPersistence.threadId,
-                  name: block.name,
-                });
+                pendingWrites.push(
+                  persistToolCallStart(adminForPersistence, {
+                    toolUseId: block.id,
+                    messageId: turnForPersistence.assistantMessageId,
+                    threadId: turnForPersistence.threadId,
+                    name: block.name,
+                  }),
+                );
               } else if (
                 block.type === "__tool_args_finalized__" &&
                 block.id
               ) {
-                void persistToolCallArgs(
-                  adminForPersistence,
-                  block.id,
-                  (block.input ?? {}) as Record<string, unknown>,
+                pendingWrites.push(
+                  persistToolCallArgs(
+                    adminForPersistence,
+                    block.id,
+                    (block.input ?? {}) as Record<string, unknown>,
+                  ),
                 );
               }
             },
             onDelta: (deltaType, payload) => {
               const seq = deltaSequence++;
-              void persistDelta(adminForPersistence, {
-                messageId: turnForPersistence.assistantMessageId,
-                sequence: seq,
-                deltaType,
-                payload,
-              });
+              pendingWrites.push(
+                persistDelta(adminForPersistence, {
+                  messageId: turnForPersistence.assistantMessageId,
+                  sequence: seq,
+                  deltaType,
+                  payload,
+                }),
+              );
             },
           }
         : undefined;
@@ -907,15 +919,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         /* client may have disconnected — non-fatal */
       }
     }
-    res.end();
-
+    // Drain in-stream writes and the canonical finalize BEFORE res.end(). The
+    // streamed SSE body has already been flushed to the client; res.end() only
+    // sends the close signal. Awaiting here costs ~one Supabase round-trip
+    // but is essential for refresh-survival: if the Vercel function returns
+    // before these land, the assistant row stays at status='streaming' with
+    // empty content_blocks and the message is lost on hydration.
     if (admin && persistedTurn) {
       // Strip our internal sentinel that pipeAnthropicStream never adds to
       // the actual blocks list, but be defensive in case the shape evolves.
       const finalBlocks = contentBlocks.filter(
         (b) => b.type !== "__tool_args_finalized__",
       );
-      void finalizeAssistantMessage(admin, {
+      await Promise.allSettled(pendingWrites);
+      await finalizeAssistantMessage(admin, {
         messageId: persistedTurn.assistantMessageId,
         contentBlocks: finalBlocks,
         status: "complete",
@@ -923,12 +940,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         outputTokens,
         durationMs: Date.now() - startedAt,
       });
-      void updateThreadHead(
+      await updateThreadHead(
         admin,
         persistedTurn.threadId,
         persistedTurn.assistantMessageId,
       );
     }
+    res.end();
 
     if (cacheReadTokens > 0 || cacheCreationTokens > 0) {
       console.log(
@@ -992,14 +1010,21 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   } catch (err) {
     console.error("Chat API error:", err);
     if (admin && persistedTurn) {
-      void finalizeAssistantMessage(admin, {
-        messageId: persistedTurn.assistantMessageId,
-        contentBlocks: [],
-        status: "error",
-        inputTokens: 0,
-        outputTokens: 0,
-        durationMs: 0,
-      });
+      // Awaited so the row reflects the failure before the function exits;
+      // otherwise the client sees a stale 'streaming' row that only the
+      // sweep RPC eventually flips to 'interrupted'.
+      try {
+        await finalizeAssistantMessage(admin, {
+          messageId: persistedTurn.assistantMessageId,
+          contentBlocks: [],
+          status: "error",
+          inputTokens: 0,
+          outputTokens: 0,
+          durationMs: 0,
+        });
+      } catch (finalizeErr) {
+        console.error("Chat API finalize-on-error failed:", finalizeErr);
+      }
     }
     if (!res.headersSent) {
       res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## Summary

- Awaits `finalizeAssistantMessage` + `updateThreadHead` (and drains pending in-stream tool_call/delta writes) **before** `res.end()` in `packages/app/api/chat.ts`. Previously these were `void`-ed after `res.end()`, so Vercel could terminate the serverless function before the canonical write landed.
- Same treatment in the error path so a crashed turn records `status='error'` instead of leaving an orphan `streaming` row for the sweep RPC to clean up.

## Why

User-reported bug: "AI chat works great, but when I refresh, only about half the messages are saved." The architecture is correct (server-as-source-of-truth via `chat_threads` / `chat_messages` / `chat_tool_calls`, with `useChatHydration` projecting rows back on refresh). The bug was a fire-and-forget Supabase write racing function termination.

After-effect in the DB: assistant rows stuck at `status='streaming'` with `content_blocks=[]`. After 2 minutes `sweep_orphaned_streams` flipped them to `interrupted`, but the canonical content was permanently lost. `applyDeltasToMessage` is currently a no-op so deltas couldn't recover it either.

The streamed SSE body is already flushed before any of this awaiting happens — `res.end()` is just the close signal, so the user-facing latency cost is one Supabase round-trip. Acceptable.

## Test plan

- [x] `tsc --noEmit -p tsconfig.json` clean
- [x] `vitest run` — 15/15 pass
- [ ] Manual end-to-end (needs `vercel dev` + live Supabase + `ANTHROPIC_API_KEY`):
  1. Sign in, open a doc, send a multi-turn chat with a tool call (e.g. "make a 20mm cube and then double its size")
  2. Hard-refresh after the assistant finishes
  3. Confirm every assistant turn re-renders with full text + tool chips
- [ ] DB sanity:
  ```sql
  select id, role, status, jsonb_array_length(content_blocks) as block_count
  from chat_messages
  where thread_id = '<threadId>'
  order by created_at;
  ```
  Every assistant row should be `status='complete'` with `block_count > 0` immediately after the turn finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)