### PR TITLE
mecheval(leaderboard): clearer landing tagline + de-clutter "mecheval" branding

### DIFF
--- a/mecheval/leaderboard/src/build.ts
+++ b/mecheval/leaderboard/src/build.ts
@@ -660,7 +660,7 @@ function titleBlockHtml(tb: TitleBlock, generatedAt: string): string {
     <tr>
       <td><span class="k">date</span><br><span class="v">${escape(dateStr)}</span></td>
       <td><span class="k">drawn by</span><br><span class="v">muni</span></td>
-      <td><span class="k">project</span><br><span class="v">mecheval</span></td>
+      <td><span class="k">project</span><br><span class="v">${escape(tb.project ?? "—")}</span></td>
     </tr>
   </table></div>`;
 }
@@ -697,7 +697,7 @@ function pageShell(
 </head>
 <body><main class="sheet">
 <span class="corner-bl">└</span><span class="corner-br">┘</span>
-<div class="crumb">${crumbHtml}</div>
+${crumbHtml ? `<div class="crumb">${crumbHtml}</div>` : ""}
 ${bodyHtml}
 ${footerHtml()}
 ${titleBlockHtml(tb, generatedAt)}
@@ -1012,13 +1012,14 @@ function indexPage(
       Corpus: ${runs.length} run blobs across ${models.length} models, ${taskIds.length} tasks. Click any task, model, or run for full forensic detail.
     </p>`;
   return pageShell(
-    "mecheval — AI builds the mech",
-    `${escape(copy.brand)}`,
+    "mecheval — eval suite for AI mechanical design",
+    "",
     body,
     {
       drawing: copy.brand,
       sheet: "INDEX",
       scale: passKReady > 0 ? `pass^${k} · ${passKAchieved}/${passKReady}` : `pass^${k}`,
+      project: "leaderboard",
     },
   );
 }
@@ -1076,7 +1077,7 @@ function taskPage(
       `<a href="../index.html">← ${escape(copy.brand)}</a> / task / ${escape(taskId)}`,
       `<h1>${escape(taskId)}</h1>
        <div class="nodata">no task spec found at mecheval/tasks/${escape(taskId)}.json — OPERATOR can't find this one</div>`,
-      { drawing: copy.brand, sheet: `TASK · ${taskId}`, scale: "—" },
+      { drawing: copy.brand, sheet: `TASK · ${taskId}`, scale: "—", project: taskId },
     );
   }
   const checksHtml = spec.checks
@@ -1127,6 +1128,7 @@ function taskPage(
       drawing: copy.brand,
       sheet: `TASK · ${taskId}`,
       scale: `${runsForTask.length} runs`,
+      project: `${spec.suite} · ${spec.tier}`,
     },
   );
 }
@@ -1148,6 +1150,7 @@ function modelPage(modelId: string, runsForModel: RunMeta[]): string {
       drawing: copy.brand,
       sheet: `MODEL · ${modelId}`,
       scale: `${runsForModel.length} runs · ${taskCount} tasks`,
+      project: modelDisplayName(modelId),
     },
   );
 }
@@ -1255,6 +1258,7 @@ function runPage(blob: FullBlob, vcad: string | null, vcadSvg: string | null): s
       scale: blob.summary.passed
         ? "PASS"
         : `${blob.summary.checks_passed}/${blob.summary.checks_total}`,
+      project: `${taskId} · ${modelDisplayName(modelId)}`,
     },
   );
 }

--- a/mecheval/leaderboard/src/tokens.ts
+++ b/mecheval/leaderboard/src/tokens.ts
@@ -37,9 +37,9 @@ export const fontsHref =
 
 export const copy = {
   brand: "mecheval.",
-  tagline: "AI builds the mech. We measure how badly it fits.",
+  tagline: "The mechanical, physical, and CAD evaluation suite for AI models.",
   subtagline:
-    "mechanical, physical, and CAD evaluation suite for AI models",
+    "Every check is something the CAD kernel can compute exactly.",
   footerOwner: "Municipal Robotics",
   footerOwnerUrl: "https://muni.works",
   siblingProjectName: "vcad.",
@@ -53,4 +53,7 @@ export interface TitleBlock {
   sheet: string;
   /** Optional dimension callout shown in the corner — e.g. "PASS^5". */
   scale?: string;
+  /** Page-specific label for the bottom-right cell (e.g. "leaderboard",
+   *  task id, model id, run id). Defaults to "—" if omitted. */
+  project?: string;
 }


### PR DESCRIPTION
## Summary

- Replace the cute landing tagline (*"AI builds the mech. We measure how badly it fits."*) with the README's plain-prose line so first-time visitors immediately know what mecheval is.
- Replace the now-duplicate subtagline with the deterministic-grading note (*"Every check is something the CAD kernel can compute exactly."*).
- De-clutter the index page — drop the redundant top-left `mecheval.` crumb that sat 12px above the giant wordmark, and parameterize the title-block "project" cell so it shows page-specific context (`leaderboard` / `suite·tier` / model name / `task·model`) instead of parroting "mecheval" right next to the "drawing" cell.
- Tighten the index browser-tab title.

Visible "mecheval" instances on the landing index drop from 5 → 3 (wordmark, title-block drawing, footer). Inner pages keep their crumb as a useful back-link.

## Before / after

**Index hero, before:**
> mecheval.
> AI builds the mech. We measure how badly it fits.
> mechanical, physical, and CAD evaluation suite for AI models · pass⁵

**Index hero, after:**
> mecheval.
> The mechanical, physical, and CAD evaluation suite for AI models.
> Every check is something the CAD kernel can compute exactly. · pass⁵

## Test plan

- [x] `npm ci && npm run build -w @mecheval/harness && npm run build -w @mecheval/leaderboard` builds clean
- [x] Loaded `dist/index.html` in a browser preview — new tagline shows, no top-left crumb, title-block project cell reads `LEADERBOARD`
- [x] Loaded a task page (`task/a1-cube-01.html`) — back-link crumb intact, title-block project shows `A · A1`
- [x] Loaded a model page (`model/claude-direct-claude-opus-4-7.html`) — back-link crumb intact, title-block project shows `OPUS 4.7 (DIRECT)`
- [x] Browser tab title is `mecheval — eval suite for AI mechanical design`

🤖 Generated with [Claude Code](https://claude.com/claude-code)