### PR TITLE
fix(kernel): split sphere into two cap faces so Sphere ∩ Cube isn't empty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6030,7 +6030,7 @@ dependencies = [
 
 [[package]]
 name = "termview"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "base64 0.22.1",
  "image",
@@ -6641,7 +6641,7 @@ dependencies = [
 
 [[package]]
 name = "vcad"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -6657,7 +6657,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-app"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "serde",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-chat"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -6689,7 +6689,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-cli"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -6726,7 +6726,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-crdt"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "js-sys",
  "serde",
@@ -6735,7 +6735,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-desktop"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "base64 0.22.1",
  "reqwest 0.12.28",
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-export"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6766,7 +6766,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-pcb"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "rstar",
  "serde",
@@ -6777,7 +6777,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-schematic"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6787,7 +6787,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-sim"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
@@ -6795,7 +6795,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ecad-symbols"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "nom",
  "serde",
@@ -6806,7 +6806,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6814,7 +6814,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-dst"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6823,7 +6823,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-embroidery-pes"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -6832,7 +6832,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-eval"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6849,7 +6849,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-i18n"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6857,7 +6857,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-ir"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -6866,7 +6866,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "vcad-kernel-booleans",
  "vcad-kernel-constraints",
@@ -6885,7 +6885,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-booleans"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "criterion",
  "rayon",
@@ -6898,7 +6898,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-cam"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "geo",
  "geo-clipper",
@@ -6910,7 +6910,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-constraints"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "bytemuck",
@@ -6928,7 +6928,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-drafting"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "vcad-kernel-math",
@@ -6937,7 +6937,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-fillet"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -6949,7 +6949,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-geom"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "tang",
  "vcad-kernel-math",
@@ -6957,7 +6957,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-gpu"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bytemuck",
  "pollster",
@@ -6969,7 +6969,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-math"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "robust",
  "tang",
@@ -6977,7 +6977,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-nurbs"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "tang",
  "vcad-kernel-geom",
@@ -6986,7 +6986,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-physics"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "phyz",
  "serde",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-primitives"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -7007,7 +7007,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-raytrace"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "bytemuck",
  "js-sys",
@@ -7027,7 +7027,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-shell"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -7038,7 +7038,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sketch"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "thiserror 2.0.18",
  "vcad-kernel-geom",
@@ -7050,7 +7050,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-step"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "stepperoni",
  "thiserror 2.0.18",
@@ -7064,7 +7064,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-stocksim"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -7075,7 +7075,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-sweep"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "rustc-hash 1.1.0",
  "thiserror 2.0.18",
@@ -7089,7 +7089,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-tessellate"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "vcad-kernel-geom",
  "vcad-kernel-math",
@@ -7100,7 +7100,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-text"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "thiserror 2.0.18",
  "ttf-parser",
@@ -7110,7 +7110,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-topo"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "slotmap",
  "vcad-kernel-math",
@@ -7118,7 +7118,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-urdf"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "quick-xml 0.37.5",
  "serde",
@@ -7129,7 +7129,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-kernel-wasm"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7175,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-loon"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "loon-lang",
  "serde_json",
@@ -7184,7 +7184,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-parts"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -7202,7 +7202,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-sim"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "phyz",
  "phyz-gpu",
@@ -7216,7 +7216,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "rayon",
@@ -7231,7 +7231,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-bambu"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "base64 0.22.1",
  "md5",
@@ -7253,7 +7253,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-slicer-gcode"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "approx",
  "serde",
@@ -7264,7 +7264,7 @@ dependencies = [
 
 [[package]]
 name = "vcad-tool-derive"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "wasmosis"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "wasm-bindgen",
  "wasmosis-macro",
@@ -7448,7 +7448,7 @@ dependencies = [
 
 [[package]]
 name = "wasmosis-macro"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/changelog/entries/2026-04-29-sphere-intersection-cube.json
+++ b/changelog/entries/2026-04-29-sphere-intersection-cube.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-04-29-sphere-intersection-cube",
+  "version": "0.9.4",
+  "date": "2026-04-29",
+  "category": "fix",
+  "title": "Sphere ∩ Cube no longer returns an empty mesh",
+  "summary": "Boolean Intersection of a sphere with a cube/half-space (used for hemispheres, lenses, spherical caps) used to produce an empty mesh because the sphere was split into one face-with-hole plus a planar disk and the lone sphere face was always classified on the wrong side. The sphere now splits into two cap faces — each classified independently via the loop's solid-angle direction — so dome and lens constructions work.",
+  "features": ["kernel", "boolean"]
+}

--- a/crates/vcad-kernel-booleans/src/classify.rs
+++ b/crates/vcad-kernel-booleans/src/classify.rs
@@ -536,8 +536,27 @@ pub fn face_sample_point(brep: &BRepSolid, face_id: FaceId) -> Point3 {
                     return sph.center + sph.radius * ref_dir;
                 }
 
-                // For partial sphere faces with enough vertices, project centroid
-                // onto the sphere surface
+                // For cap faces produced by booleans, both caps share the
+                // same outer-loop centroid (the cutting circle's center),
+                // so the centroid-projection sample collapses to a single
+                // direction for both — selection then keeps or drops both
+                // together, which loses the operation. Use the loop's
+                // solid-angle integrand to pick each cap's own pole;
+                // it points to the bounded cap's interior by construction
+                // and disambiguates the two caps via their opposite loop
+                // windings.
+                let mut sa_normal = Vec3::zeros();
+                for i in 0..vertices.len() {
+                    let j = (i + 1) % vertices.len();
+                    let a = vertices[i] - sph.center;
+                    let b = vertices[j] - sph.center;
+                    sa_normal += a.cross(b);
+                }
+                let sa_len = sa_normal.norm();
+                if sa_len > 1e-12 {
+                    let cap_dir = sa_normal / sa_len;
+                    return sph.center + sph.radius * cap_dir;
+                }
                 let dir = centroid - sph.center;
                 let dir_len = dir.norm();
                 if dir_len > 1e-12 {

--- a/crates/vcad-kernel-booleans/src/lib.rs
+++ b/crates/vcad-kernel-booleans/src/lib.rs
@@ -1537,6 +1537,89 @@ mod tests {
         );
     }
 
+    /// Splitting a sphere into two cap faces along its equator should
+    /// yield a tessellation whose closed-surface volume matches the
+    /// original sphere. Catches winding inversions in the cap-tessellator
+    /// dispatch (the previous fix attempt's regression mode).
+    #[test]
+    fn test_split_sphere_volume_preservation() {
+        use vcad_kernel_geom::Circle3d;
+        use vcad_kernel_primitives::make_sphere;
+        use vcad_kernel_tessellate::tessellate_brep;
+
+        let radius = 10.0;
+        let mut brep = make_sphere(radius, 32);
+
+        // The full sphere has a single face. Split it along the equator
+        // (z = 0 circle) into two cap faces.
+        let face_id = brep
+            .topology
+            .faces
+            .iter()
+            .next()
+            .map(|(id, _)| id)
+            .expect("sphere should have a face");
+        let circle = Circle3d::new(Point3::new(0.0, 0.0, 0.0), radius);
+        let result = split::split_spherical_face_by_circle(&mut brep, face_id, &circle, 32);
+        assert_eq!(
+            result.sub_faces.len(),
+            2,
+            "split should produce exactly two cap faces"
+        );
+
+        let mesh = tessellate_brep(&brep, 32);
+        assert!(!mesh.indices.is_empty(), "tessellation should be non-empty");
+
+        let volume = compute_mesh_volume(&mesh);
+        let expected = 4.0 / 3.0 * std::f64::consts::PI * radius.powi(3);
+        let rel_err = (volume - expected).abs() / expected;
+        assert!(
+            rel_err < 0.05,
+            "split-sphere mesh volume {:.1} differs from sphere volume {:.1} by {:.1}%",
+            volume,
+            expected,
+            rel_err * 100.0
+        );
+    }
+
+    /// Reproduces issue #152: `Sphere ∩ HalfSpace` (cube clip) used to
+    /// return an empty mesh because the boolean classifier dropped the
+    /// only sphere face it had after the split (the planar disk + sphere
+    /// -with-hole arrangement). With two cap faces, the kept hemisphere
+    /// is a real spherical cap.
+    #[test]
+    fn test_sphere_intersection_cube_clip() {
+        use vcad_kernel_primitives::make_sphere;
+
+        let sphere = make_sphere(15.0, 32);
+        // Half-space cube (z >= 0): a 100x100x100 cube translated so its
+        // bottom face is at z = 0.
+        let mut cube = make_cube(100.0, 100.0, 100.0);
+        translate_brep(&mut cube, -50.0, -50.0, 0.0);
+
+        let result = boolean_op(&sphere, &cube, BooleanOp::Intersection, 32);
+        let mesh = result.to_mesh(32);
+        assert!(
+            !mesh.indices.is_empty(),
+            "sphere ∩ halfspace should produce a non-empty mesh"
+        );
+
+        let volume = compute_mesh_volume(&mesh);
+        let expected = 2.0 / 3.0 * std::f64::consts::PI * 15.0_f64.powi(3);
+        let rel_err = (volume - expected).abs() / expected;
+        assert!(
+            rel_err < 0.05,
+            "hemisphere mesh volume {:.1} differs from {:.1} by {:.1}%",
+            volume,
+            expected,
+            rel_err * 100.0
+        );
+
+        let (min, max) = compute_mesh_bbox(&mesh);
+        assert!(min[2] > -0.5, "hemisphere should not extend below z=0");
+        assert!(max[2] > 14.0, "hemisphere should reach near z=15");
+    }
+
     /// Test boolean difference with a Y-axis aligned (rotated) cylinder subtracted from a box.
     #[test]
     fn test_rotated_cylinder_subtract() {

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -1533,7 +1533,8 @@ pub fn split_spherical_face_by_circle(
 
     let tolerance = 1e-6;
 
-    // Generate circle vertices
+    // Generate the N shared circle vertices.
+    let n = segments as usize;
     let circle_verts: Vec<Point3> = (0..segments)
         .map(|i| {
             let theta = 2.0 * std::f64::consts::PI * (i as f64) / (segments as f64);
@@ -1543,100 +1544,56 @@ pub fn split_spherical_face_by_circle(
                     * (cos_t * circle.x_dir.into_inner() + sin_t * circle.y_dir.into_inner())
         })
         .collect();
-
-    // Create inner disk face on the plane of the circle.
-    // This face will be classified as inside/outside the other solid.
-    // First, find or create the planar surface for the disk.
-    let circle_normal = circle.x_dir.into_inner().cross(circle.y_dir.into_inner());
-    let disk_plane = vcad_kernel_geom::Plane::new(
-        circle.center,
-        circle.x_dir.into_inner(),
-        circle.y_dir.into_inner(),
-    );
-    let disk_surf_idx = brep.geometry.add_surface(Box::new(disk_plane));
-
-    let inner_verts: Vec<_> = circle_verts
+    let circle_vert_ids: Vec<_> = circle_verts
         .iter()
         .map(|p| find_or_create_vertex(brep, p, tolerance))
         .collect();
-    let inner_hes: Vec<_> = inner_verts
-        .iter()
-        .map(|&v| brep.topology.add_half_edge(v))
+
+    // Cap-A walks the circle in forward order: v[0], v[1], ..., v[N-1].
+    // Half-edge i has origin v[i] and points toward v[(i+1) mod N].
+    let he_a: Vec<_> = (0..n)
+        .map(|i| brep.topology.add_half_edge(circle_vert_ids[i]))
         .collect();
-    let inner_loop = brep.topology.add_loop(&inner_hes);
-    let inner_face = brep
-        .topology
-        .add_face(inner_loop, disk_surf_idx, orientation);
+    let loop_a = brep.topology.add_loop(&he_a);
 
-    // Add the circle as an inner loop (hole) on the sphere face.
-    // The hole winding must be opposite to the inner disk face's winding
-    // when viewed from outside the sphere.
-    // Determine winding: compute signed area of circle_verts projected along circle normal
-    let circle_signed_area = {
-        // Use the circle's own coordinate system
-        let pts_2d: Vec<(f64, f64)> = circle_verts
-            .iter()
-            .map(|p| {
-                let d = *p - circle.center;
-                (
-                    d.dot(circle.x_dir.into_inner()),
-                    d.dot(circle.y_dir.into_inner()),
-                )
-            })
-            .collect();
-        let mut a = 0.0;
-        for i in 0..pts_2d.len() {
-            let j = (i + 1) % pts_2d.len();
-            a += pts_2d[i].0 * pts_2d[j].1 - pts_2d[j].0 * pts_2d[i].1;
-        }
-        a / 2.0
-    };
-
-    // The sphere's outward direction at the circle center
-    let sphere_outward = (circle.center - sph.center).normalize();
-    // If circle_normal aligns with sphere_outward, the CCW vertices (as seen from outside)
-    // should be reversed for the hole
-    let normals_aligned = circle_normal.dot(sphere_outward) > 0.0;
-
-    // Inner loop on sphere should be CW when viewed from outside the sphere
-    // If circle area is positive and normals are aligned, the vertices are CCW from outside → reverse
-    let need_reverse = (circle_signed_area > 0.0) == normals_aligned;
-
-    let hole_verts: Vec<Point3> = if need_reverse {
-        circle_verts.iter().rev().cloned().collect()
-    } else {
-        circle_verts.clone()
-    };
-
-    let hole_vert_ids: Vec<_> = hole_verts
-        .iter()
-        .map(|p| find_or_create_vertex(brep, p, tolerance))
+    // Cap-B walks the circle in reverse: v[0], v[N-1], v[N-2], ..., v[1].
+    // Half-edge j has origin v[(N - j) mod N] (so j=0 → v[0], j=1 → v[N-1], ...).
+    // Cap-B's edge j spans {v[(N-j) mod N], v[(N-1-j) mod N]} — same physical
+    // edge as cap-A's edge i = N-1-j, traversed in reverse.
+    let he_b: Vec<_> = (0..n)
+        .map(|j| brep.topology.add_half_edge(circle_vert_ids[(n - j) % n]))
         .collect();
-    let hole_hes: Vec<_> = hole_vert_ids
-        .iter()
-        .map(|&v| brep.topology.add_half_edge(v))
-        .collect();
-    let hole_loop = brep.topology.add_loop(&hole_hes);
-    brep.topology.faces[face_id].inner_loops.push(hole_loop);
+    let loop_b = brep.topology.add_loop(&he_b);
 
-    // Add twin edges between inner disk and hole on sphere
-    for i in 0..segments as usize {
-        let inner_he = inner_hes[i];
-        let outer_he = hole_hes[(segments as usize - 1 - i) % segments as usize];
-        brep.topology.add_edge(inner_he, outer_he);
+    // Repurpose the original face as cap-A: clear holes, replace outer loop.
+    // Same surface, orientation, shell. The original 4-edge seam loop is
+    // now orphaned (no face references it) — benign because all kernel
+    // traversal goes from faces.
+    {
+        let f = &mut brep.topology.faces[face_id];
+        f.outer_loop = loop_a;
+        f.inner_loops.clear();
     }
 
-    // Add faces to shell
+    // Cap-B is a new face with the same surface and orientation.
+    let face_b = brep.topology.add_face(loop_b, surface_index, orientation);
+
+    // Twin-pair the two caps' half-edges along the shared circle.
+    for i in 0..n {
+        brep.topology.add_edge(he_a[i], he_b[n - 1 - i]);
+    }
+
+    // Add cap-B to the same shell as the original face.
     if let Some(shell_id) = brep.topology.faces[face_id].shell {
-        brep.topology.shells[shell_id].faces.push(inner_face);
-        brep.topology.faces[inner_face].shell = Some(shell_id);
+        brep.topology.shells[shell_id].faces.push(face_b);
+        brep.topology.faces[face_b].shell = Some(shell_id);
     }
 
-    // Add 3D curve
+    // Add the SSI circle as a 3D curve in the geometry store.
     brep.geometry.add_curve_3d(Box::new(circle.clone()));
 
     SplitResult {
-        sub_faces: vec![inner_face, face_id],
+        sub_faces: vec![face_id, face_b],
     }
 }
 

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -2531,6 +2531,7 @@ fn tessellate_spherical_cap(
         return mesh;
     }
 
+
     // Get sphere center and radius
     let (center, radius) = if let Some(sphere) = surface.as_any().downcast_ref::<SphereSurface>() {
         (sphere.center, sphere.radius)
@@ -2545,19 +2546,36 @@ fn tessellate_spherical_cap(
         (centroid, r)
     };
 
-    // Compute centroid of boundary vertices for cap center
-    let boundary_centroid: Point3 = loop_verts.iter().fold(Point3::origin(), |acc, p| {
-        Point3::new(acc.x + p.x, acc.y + p.y, acc.z + p.z)
-    });
-    let n = loop_verts.len() as f64;
-    let boundary_centroid = Point3::new(
-        boundary_centroid.x / n,
-        boundary_centroid.y / n,
-        boundary_centroid.z / n,
-    );
-
-    // Direction from sphere center to cap center
-    let cap_dir = (boundary_centroid - center).normalize();
+    // Direction to the cap pole, derived from the loop winding's
+    // solid-angle integrand. For a closed loop on a sphere, summing
+    // (p_i - c) × (p_{i+1} - c) over consecutive vertices yields a
+    // vector along the spherical cap's axis pointing toward the bounded
+    // cap's pole. This is robust to the two split caps sharing an
+    // identical boundary centroid (the previous `boundary_centroid -
+    // center` formulation collapsed both caps to the same direction).
+    let mut sa_normal = Vec3::zeros();
+    for i in 0..loop_verts.len() {
+        let j = (i + 1) % loop_verts.len();
+        let a = loop_verts[i] - center;
+        let b = loop_verts[j] - center;
+        sa_normal += a.cross(b);
+    }
+    let sa_len = sa_normal.norm();
+    let cap_dir = if sa_len > 1e-12 {
+        sa_normal / sa_len
+    } else {
+        // Degenerate: fall back to the boundary centroid direction.
+        let boundary_centroid: Point3 = loop_verts.iter().fold(Point3::origin(), |acc, p| {
+            Point3::new(acc.x + p.x, acc.y + p.y, acc.z + p.z)
+        });
+        let n = loop_verts.len() as f64;
+        let boundary_centroid = Point3::new(
+            boundary_centroid.x / n,
+            boundary_centroid.y / n,
+            boundary_centroid.z / n,
+        );
+        (boundary_centroid - center).normalize()
+    };
 
     // Compute angle from cap direction to each boundary vertex
     let boundary_angles: Vec<f64> = loop_verts
@@ -2574,12 +2592,40 @@ fn tessellate_spherical_cap(
         .fold(f64::INFINITY, f64::min);
     let avg_angle = boundary_angles.iter().sum::<f64>() / boundary_angles.len() as f64;
 
-    // Determine if this is a large cap (> ~90 degrees) or small cap
-    let is_large_cap = avg_angle > PI / 2.0;
+    // Use the small-cap path whenever the boundary stays clear of the
+    // antipode of the cap pole (phi < ~0.85·π, ≈153°). The small-cap
+    // slerp `(cap_dir·sin((1-t)·phi) + b_dir·sin(t·phi))/sin(phi)` is
+    // numerically robust through this range, including the hemispherical
+    // phi = π/2 case where the previous `> π/2` threshold flipped on
+    // floating-point noise. The large-cap path is reserved for caps
+    // that genuinely wrap toward the antipode (e.g. big-sphere minus
+    // small-bite from a Difference op).
+    let is_large_cap = avg_angle > 0.85 * PI;
 
     if is_large_cap {
-        tessellate_large_spherical_cap(loop_verts, center, radius, cap_dir, min_angle, reversed)
+        // `tessellate_large_spherical_cap` was written under the legacy
+        // convention where `cap_dir` points to the boundary side and
+        // `anti_pole = -cap_dir` is the cap interior pole. Our winding
+        // -derived `cap_dir` points to the cap interior, so flip it (and
+        // recompute the min angle in the flipped frame) for that path.
+        let flipped_cap_dir = -cap_dir;
+        let min_angle_flipped = loop_verts
+            .iter()
+            .map(|p| {
+                let v = (*p - center).normalize();
+                v.dot(flipped_cap_dir).clamp(-1.0, 1.0).acos()
+            })
+            .fold(f64::INFINITY, f64::min);
+        tessellate_large_spherical_cap(
+            loop_verts,
+            center,
+            radius,
+            flipped_cap_dir,
+            min_angle_flipped,
+            reversed,
+        )
     } else {
+        let _ = min_angle;
         tessellate_small_spherical_cap(loop_verts, center, radius, cap_dir, params, reversed)
     }
 }

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -2531,7 +2531,6 @@ fn tessellate_spherical_cap(
         return mesh;
     }
 
-
     // Get sphere center and radius
     let (center, radius) = if let Some(sphere) = surface.as_any().downcast_ref::<SphereSurface>() {
         (sphere.center, sphere.radius)


### PR DESCRIPTION
## Summary

Fixes [#152](https://github.com/ecto/vcad/issues/152). `Sphere ∩ Cube` (and any `Sphere ∩ HalfSpace` — domes, lenses, spherical caps) used to return an empty mesh because the boolean split produced one sphere-face-with-hole plus a planar disk, and the classifier could only ever keep or drop the entire sphere face — never just one hemisphere.

The split now produces **two cap faces** sharing the SSI circle, so each cap is classified independently. Each cap's sample point and tessellator pole come from the loop's solid-angle integrand (`Σ (p_i − c) × (p_{i+1} − c)`), which points to the bounded cap's pole and disambiguates the two caps via their opposite loop windings.

## Why the previous attempt regressed

The issue notes that an earlier session-scope branch made the same topology change but regressed `test_sphere_boolean_subtract`. The cause was the cap-tessellator dispatch: `is_large_cap = avg_angle > π/2` flips on floating-point noise at exactly π/2 (perfect hemispheres), sending one cap through the unstable large-cap path. This PR raises the threshold to `> 0.85π` so all hemispheres take the slerp path, and passes a flipped `cap_dir` to the genuine large-cap path to match its legacy convention.

## Files

- `crates/vcad-kernel-booleans/src/split.rs` — `split_spherical_face_by_circle` rewritten (2 cap faces, no planar disk)
- `crates/vcad-kernel-booleans/src/classify.rs` — sphere branch of `face_sample_point` uses the solid-angle integrand
- `crates/vcad-kernel-tessellate/src/lib.rs` — `tessellate_spherical_cap` derives `cap_dir` from loop winding; dispatch threshold raised; large-cap path receives flipped direction
- `crates/vcad-kernel-booleans/src/lib.rs` — two new regression tests
- `changelog/entries/2026-04-29-sphere-intersection-cube.json` — entry

## Test plan

- [x] `cargo test -p vcad-kernel-booleans` — 70/70 pass (was 69/70)
- [x] New `test_split_sphere_volume_preservation` — split sphere → tessellate → volume 4140 vs 4188.8 (98.83%)
- [x] New `test_sphere_intersection_cube_clip` — the issue's reproduction IR; volume 6987 vs 7068.6 (98.85%), bbox `(-15,-15,0)→(15,15,15)`
- [x] Existing `test_sphere_boolean_subtract` still passes (this was the regression risk)
- [x] All sibling kernel crates pass (tessellate, fillet, shell, primitives, geom, topo, math, sketch, nurbs, step)
- [x] Clippy clean on changed code (preexisting `needless_borrows_for_generic_args` warnings on lib.rs:704/882/914 are present on `main`)
- [ ] Re-run mecheval `a3-spherical-dome-block-01` after merge — should go from 0/5 → 5/5 across the lineup

🤖 Generated with [Claude Code](https://claude.com/claude-code)