### PR TITLE
mecheval A4 tier + kernel: trust face.orientation in planar tessellator

### DIFF
--- a/crates/vcad-kernel-booleans/src/lib.rs
+++ b/crates/vcad-kernel-booleans/src/lib.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn test_difference_hole_in_center() {
-        // Simpler test case: two axis-aligned cubes with partial overlap
+        // Two axis-aligned cubes with partial overlap.
         let big_cube = make_cube(10.0, 10.0, 10.0);
 
         let mut small_cube = make_cube(4.0, 20.0, 4.0);
@@ -99,16 +99,13 @@ mod tests {
 
         let volume = compute_mesh_volume(&mesh);
 
-        // Accept volume in range [600, 1100] as "working"
         // Expected: 10*10*10 - 4*10*4 = 1000 - 160 = 840
-        // The winding fix can affect volume calculation, so we use a wider tolerance.
         assert!(
-            volume > 600.0 && volume < 1100.0,
-            "Expected volume in [600,1100], got {}",
+            (volume - 840.0).abs() < 1.0,
+            "Expected volume ~840, got {}",
             volume
         );
 
-        // Check bounding box
         let (min, max) = compute_mesh_bbox(&mesh);
         assert!(
             min[0] >= -0.01 && min[1] >= -0.01 && min[2] >= -0.01,
@@ -124,6 +121,31 @@ mod tests {
         assert!(
             mesh.num_triangles() > 0,
             "Result mesh should have triangles"
+        );
+    }
+
+    /// Regression for the planar-tessellator winding-flip heuristic that
+    /// previously over-counted cavity-wall contributions. Cube-minus-cube
+    /// hollow tube: outer 40×40×80 minus inner 28×28×80, both axis-aligned
+    /// and centred in XY. Cavity walls are reversed-orientation planar
+    /// faces; the volume integrator must respect the orientation flag, not
+    /// override it from loop winding.
+    #[test]
+    fn test_difference_hollow_tube_volume() {
+        let mut outer = make_cube(40.0, 40.0, 80.0);
+        translate_brep(&mut outer, -20.0, -20.0, 0.0);
+        let mut inner = make_cube(28.0, 28.0, 84.0);
+        translate_brep(&mut inner, -14.0, -14.0, -2.0);
+
+        let result = boolean_op(&outer, &inner, BooleanOp::Difference, 32);
+        let mesh = result.to_mesh(32);
+        let volume = compute_mesh_volume(&mesh);
+
+        // Expected: (40² − 28²) × 80 = 65280 mm³.
+        assert!(
+            (volume - 65280.0).abs() < 1.0,
+            "Expected hollow-tube volume ~65280, got {}",
+            volume
         );
     }
 

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -791,12 +791,10 @@ fn tessellate_face(
     }
 }
 
-/// Tessellate a planar face with geometry-aware winding detection.
-///
-/// This function detects when the loop vertex winding doesn't match the expected
-/// face normal (surface normal * orientation), which can happen after boolean
-/// operations that split faces. When mismatch is detected, the reversed flag
-/// is flipped to ensure correct triangle orientation.
+/// Tessellate a planar face. Producers (primitives + booleans) wind the
+/// loop consistent with the surface's stored normal; `Orientation::Reversed`
+/// flips the effective face normal without touching loop ordering — so the
+/// volume integrator and renderer see the normal the topology intends.
 fn tessellate_planar_face_with_geom(
     topo: &Topology,
     geom: &GeometryStore,
@@ -805,16 +803,7 @@ fn tessellate_planar_face_with_geom(
 ) -> TriangleMesh {
     let face = &topo.faces[face_id];
     let surface = &geom.surfaces[face.surface_index];
-
-    // Get the surface normal direction (at parameter origin)
     let surface_normal = surface.normal(Point2::new(0.0, 0.0));
-
-    // Effective face normal accounts for orientation
-    let expected_normal = if reversed {
-        -surface_normal
-    } else {
-        surface_normal
-    };
 
     let outer_verts: Vec<_> = topo
         .loop_half_edges(face.outer_loop)
@@ -825,33 +814,13 @@ fn tessellate_planar_face_with_geom(
         return TriangleMesh::new();
     }
 
-    // Compute geometric winding normal from loop vertices using Newell's method.
-    // This is robust for non-convex polygons and any orientation.
-    let mut geom_normal = Vec3::zeros();
-    for i in 0..outer_verts.len() {
-        let curr = outer_verts[i];
-        let next = outer_verts[(i + 1) % outer_verts.len()];
-        geom_normal.x += (curr.y - next.y) * (curr.z + next.z);
-        geom_normal.y += (curr.z - next.z) * (curr.x + next.x);
-        geom_normal.z += (curr.x - next.x) * (curr.y + next.y);
-    }
-
-    // Check if geometric winding matches expected face normal
-    let dot = geom_normal.dot(expected_normal);
-    let winding_matches = dot > 0.0;
-
-    // If winding doesn't match, flip the reversed flag
-    let effective_reversed = if winding_matches { reversed } else { !reversed };
-
-    // Check if face has inner loops (holes)
     let mut mesh = if !face.inner_loops.is_empty() {
-        tessellate_planar_face_with_holes(topo, face_id, effective_reversed)
+        tessellate_planar_face_with_holes(topo, face_id, reversed)
     } else {
-        tessellate_planar_face_core(&outer_verts, effective_reversed)
+        tessellate_planar_face_core(&outer_verts, reversed)
     };
 
-    // Add constant analytical normal for all vertices (planar face has uniform normal)
-    let face_normal = if effective_reversed {
+    let face_normal = if reversed {
         -surface_normal
     } else {
         surface_normal

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120403Z-84d3",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6505.61132
+      }
+    ],
+    "tokens": {
+      "input": 749,
+      "output": 1543,
+      "total": 2292
+    },
+    "wallclock_sec": 6.50561132
+  },
+  "output": {
+    "vcad_path": "20260429T120403Z-84d3.vcad",
+    "vcad_sha256": "2522c6c64c396896398d27ba88e88d17a52fb506b46a57aef40f8eea37a08bae",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:03.044Z",
+    "ended_at": "2026-04-29T12:04:09.559Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": []
@@ -123,51 +123,51 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -191,7 +191,7 @@
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -232,7 +232,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120403Z-84d3.vcad
@@ -1,0 +1,184 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "main_cyl": {
+      "id": "main_cyl",
+      "name": "Main cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 50,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "central_bore": {
+      "id": "central_bore",
+      "name": "Central bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 20,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1": {
+      "id": "bolt_hole_1",
+      "name": "Bolt hole 1 at 0 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_cyl": {
+      "id": "bolt_hole_cyl",
+      "name": "Bolt hole cylinder template",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2": {
+      "id": "bolt_hole_2",
+      "name": "Bolt hole 2 at 60 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 18.75,
+          "y": 32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_3": {
+      "id": "bolt_hole_3",
+      "name": "Bolt hole 3 at 120 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -18.75,
+          "y": 32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_4": {
+      "id": "bolt_hole_4",
+      "name": "Bolt hole 4 at 180 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_5": {
+      "id": "bolt_hole_5",
+      "name": "Bolt hole 5 at 240 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -18.75,
+          "y": -32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_6": {
+      "id": "bolt_hole_6",
+      "name": "Bolt hole 6 at 300 degrees",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 18.75,
+          "y": -32.476,
+          "z": 0
+        }
+      }
+    },
+    "with_central_bore": {
+      "id": "with_central_bore",
+      "name": "Flange minus central bore",
+      "op": {
+        "type": "Difference",
+        "left": "main_cyl",
+        "right": "central_bore"
+      }
+    },
+    "with_bolt_hole_1": {
+      "id": "with_bolt_hole_1",
+      "name": "Minus bolt hole 1",
+      "op": {
+        "type": "Difference",
+        "left": "with_central_bore",
+        "right": "bolt_hole_1"
+      }
+    },
+    "with_bolt_hole_2": {
+      "id": "with_bolt_hole_2",
+      "name": "Minus bolt hole 2",
+      "op": {
+        "type": "Difference",
+        "left": "with_bolt_hole_1",
+        "right": "bolt_hole_2"
+      }
+    },
+    "with_bolt_hole_3": {
+      "id": "with_bolt_hole_3",
+      "name": "Minus bolt hole 3",
+      "op": {
+        "type": "Difference",
+        "left": "with_bolt_hole_2",
+        "right": "bolt_hole_3"
+      }
+    },
+    "with_bolt_hole_4": {
+      "id": "with_bolt_hole_4",
+      "name": "Minus bolt hole 4",
+      "op": {
+        "type": "Difference",
+        "left": "with_bolt_hole_3",
+        "right": "bolt_hole_4"
+      }
+    },
+    "with_bolt_hole_5": {
+      "id": "with_bolt_hole_5",
+      "name": "Minus bolt hole 5",
+      "op": {
+        "type": "Difference",
+        "left": "with_bolt_hole_4",
+        "right": "bolt_hole_5"
+      }
+    },
+    "final_flange": {
+      "id": "final_flange",
+      "name": "Final flange with all holes",
+      "op": {
+        "type": "Difference",
+        "left": "with_bolt_hole_5",
+        "right": "bolt_hole_6"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_flange",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120409Z-c889",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5692.274183
+      }
+    ],
+    "tokens": {
+      "input": 749,
+      "output": 1439,
+      "total": 2188
+    },
+    "wallclock_sec": 5.692274183
+  },
+  "output": {
+    "vcad_path": "20260429T120409Z-c889.vcad",
+    "vcad_sha256": "fe8af847105e64751d2249c01a8789bc94f2e5b119b418f6d2b76e1caf5b8302",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:09.656Z",
+    "ended_at": "2026-04-29T12:04:15.359Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": []
@@ -123,51 +123,51 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -191,7 +191,7 @@
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -232,7 +232,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120409Z-c889.vcad
@@ -1,0 +1,204 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cylinder": {
+      "id": 0,
+      "name": "base_cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 50,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "center_bore": {
+      "id": 1,
+      "name": "center_bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 20,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "after_center_bore": {
+      "id": 2,
+      "name": "after_center_bore",
+      "op": {
+        "type": "Difference",
+        "left": 0,
+        "right": 1
+      }
+    },
+    "bolt_hole_0": {
+      "id": 3,
+      "name": "bolt_hole_0",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": 37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_1": {
+      "id": 4,
+      "name": "bolt_hole_1",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": 18.75,
+          "y": 32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_2": {
+      "id": 5,
+      "name": "bolt_hole_2",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": -18.75,
+          "y": 32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_3": {
+      "id": 6,
+      "name": "bolt_hole_3",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": -37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_4": {
+      "id": 7,
+      "name": "bolt_hole_4",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": -18.75,
+          "y": -32.476,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_5": {
+      "id": 8,
+      "name": "bolt_hole_5",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {
+          "x": 18.75,
+          "y": -32.476,
+          "z": 0
+        }
+      }
+    },
+    "after_bolt_0": {
+      "id": 9,
+      "name": "after_bolt_0",
+      "op": {
+        "type": "Difference",
+        "left": 2,
+        "right": 3
+      }
+    },
+    "after_bolt_1": {
+      "id": 10,
+      "name": "after_bolt_1",
+      "op": {
+        "type": "Difference",
+        "left": 9,
+        "right": 4
+      }
+    },
+    "after_bolt_2": {
+      "id": 11,
+      "name": "after_bolt_2",
+      "op": {
+        "type": "Difference",
+        "left": 10,
+        "right": 5
+      }
+    },
+    "after_bolt_3": {
+      "id": 12,
+      "name": "after_bolt_3",
+      "op": {
+        "type": "Difference",
+        "left": 11,
+        "right": 6
+      }
+    },
+    "after_bolt_4": {
+      "id": 13,
+      "name": "after_bolt_4",
+      "op": {
+        "type": "Difference",
+        "left": 12,
+        "right": 7
+      }
+    },
+    "final_flange": {
+      "id": 14,
+      "name": "final_flange",
+      "op": {
+        "type": "Difference",
+        "left": 13,
+        "right": 8
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 14,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120415Z-c1ce",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6338.290138
+      }
+    ],
+    "tokens": {
+      "input": 749,
+      "output": 1469,
+      "total": 2218
+    },
+    "wallclock_sec": 6.3382901380000005
+  },
+  "output": {
+    "vcad_path": "20260429T120415Z-c1ce.vcad",
+    "vcad_sha256": "5ebd96dc36742b511c4c2a26794d5ea386b3c821aef7213ae51ce52ca105b906",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:15.456Z",
+    "ended_at": "2026-04-29T12:04:21.804Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": []
@@ -123,51 +123,51 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -191,7 +191,7 @@
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -232,7 +232,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120415Z-c1ce.vcad
@@ -1,0 +1,184 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "cylinder_main": {
+      "id": "cylinder_main",
+      "name": "Main cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 50,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "central_bore": {
+      "id": "central_bore",
+      "name": "Central bore cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 20,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1": {
+      "id": "bolt_hole_1",
+      "name": "Bolt hole 1",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_cyl": {
+      "id": "bolt_hole_cyl",
+      "name": "Bolt hole cylinder template",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2": {
+      "id": "bolt_hole_2",
+      "name": "Bolt hole 2",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 18.75,
+          "y": 32.475,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_3": {
+      "id": "bolt_hole_3",
+      "name": "Bolt hole 3",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -18.75,
+          "y": 32.475,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_4": {
+      "id": "bolt_hole_4",
+      "name": "Bolt hole 4",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -37.5,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_5": {
+      "id": "bolt_hole_5",
+      "name": "Bolt hole 5",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": -18.75,
+          "y": -32.475,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_6": {
+      "id": "bolt_hole_6",
+      "name": "Bolt hole 6",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_cyl",
+        "offset": {
+          "x": 18.75,
+          "y": -32.475,
+          "z": 0
+        }
+      }
+    },
+    "with_central_bore": {
+      "id": "with_central_bore",
+      "name": "Main cylinder with central bore",
+      "op": {
+        "type": "Difference",
+        "left": "cylinder_main",
+        "right": "central_bore"
+      }
+    },
+    "with_hole_1": {
+      "id": "with_hole_1",
+      "name": "With bolt hole 1",
+      "op": {
+        "type": "Difference",
+        "left": "with_central_bore",
+        "right": "bolt_hole_1"
+      }
+    },
+    "with_hole_2": {
+      "id": "with_hole_2",
+      "name": "With bolt hole 2",
+      "op": {
+        "type": "Difference",
+        "left": "with_hole_1",
+        "right": "bolt_hole_2"
+      }
+    },
+    "with_hole_3": {
+      "id": "with_hole_3",
+      "name": "With bolt hole 3",
+      "op": {
+        "type": "Difference",
+        "left": "with_hole_2",
+        "right": "bolt_hole_3"
+      }
+    },
+    "with_hole_4": {
+      "id": "with_hole_4",
+      "name": "With bolt hole 4",
+      "op": {
+        "type": "Difference",
+        "left": "with_hole_3",
+        "right": "bolt_hole_4"
+      }
+    },
+    "with_hole_5": {
+      "id": "with_hole_5",
+      "name": "With bolt hole 5",
+      "op": {
+        "type": "Difference",
+        "left": "with_hole_4",
+        "right": "bolt_hole_5"
+      }
+    },
+    "final_flange": {
+      "id": "final_flange",
+      "name": "Final flange with all holes",
+      "op": {
+        "type": "Difference",
+        "left": "with_hole_5",
+        "right": "bolt_hole_6"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_flange",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": []
@@ -123,51 +123,51 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -191,7 +191,7 @@
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -232,7 +232,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120421Z-d6a2",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7172.357889999999
+      }
+    ],
+    "tokens": {
+      "input": 749,
+      "output": 1890,
+      "total": 2639
+    },
+    "wallclock_sec": 7.172357889999999
+  },
+  "output": {
+    "vcad_path": "20260429T120421Z-d6a2.vcad",
+    "vcad_sha256": "8d81f1cf16c9152321d339680b15ff32ab04a3444fdd0a3413236404be7e7581",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:21.911Z",
+    "ended_at": "2026-04-29T12:04:29.093Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120421Z-d6a2.vcad
@@ -1,0 +1,210 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cylinder": {
+      "id": "base_cylinder",
+      "name": "Base Cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 50,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "central_bore": {
+      "id": "central_bore",
+      "name": "Central Bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 20,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "without_bore": {
+      "id": "without_bore",
+      "name": "Without Central Bore",
+      "op": {
+        "type": "Difference",
+        "left": "base_cylinder",
+        "right": "central_bore"
+      }
+    },
+    "bolt_hole_1": {
+      "id": "bolt_hole_1",
+      "name": "Bolt Hole 1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1_positioned": {
+      "id": "bolt_hole_1_positioned",
+      "name": "Bolt Hole 1 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_1",
+        "offset": {"x": 37.5, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_2": {
+      "id": "bolt_hole_2",
+      "name": "Bolt Hole 2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2_positioned": {
+      "id": "bolt_hole_2_positioned",
+      "name": "Bolt Hole 2 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_2",
+        "offset": {"x": 18.75, "y": 32.475, "z": 0}
+      }
+    },
+    "bolt_hole_3": {
+      "id": "bolt_hole_3",
+      "name": "Bolt Hole 3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_3_positioned": {
+      "id": "bolt_hole_3_positioned",
+      "name": "Bolt Hole 3 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_3",
+        "offset": {"x": -18.75, "y": 32.475, "z": 0}
+      }
+    },
+    "bolt_hole_4": {
+      "id": "bolt_hole_4",
+      "name": "Bolt Hole 4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_4_positioned": {
+      "id": "bolt_hole_4_positioned",
+      "name": "Bolt Hole 4 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_4",
+        "offset": {"x": -37.5, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_5": {
+      "id": "bolt_hole_5",
+      "name": "Bolt Hole 5",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_5_positioned": {
+      "id": "bolt_hole_5_positioned",
+      "name": "Bolt Hole 5 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_5",
+        "offset": {"x": -18.75, "y": -32.475, "z": 0}
+      }
+    },
+    "bolt_hole_6": {
+      "id": "bolt_hole_6",
+      "name": "Bolt Hole 6",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "bolt_hole_6_positioned": {
+      "id": "bolt_hole_6_positioned",
+      "name": "Bolt Hole 6 Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "bolt_hole_6",
+        "offset": {"x": 18.75, "y": -32.475, "z": 0}
+      }
+    },
+    "combined_holes_1_2": {
+      "id": "combined_holes_1_2",
+      "name": "Combined Holes 1-2",
+      "op": {
+        "type": "Union",
+        "left": "bolt_hole_1_positioned",
+        "right": "bolt_hole_2_positioned"
+      }
+    },
+    "combined_holes_1_3": {
+      "id": "combined_holes_1_3",
+      "name": "Combined Holes 1-3",
+      "op": {
+        "type": "Union",
+        "left": "combined_holes_1_2",
+        "right": "bolt_hole_3_positioned"
+      }
+    },
+    "combined_holes_1_4": {
+      "id": "combined_holes_1_4",
+      "name": "Combined Holes 1-4",
+      "op": {
+        "type": "Union",
+        "left": "combined_holes_1_3",
+        "right": "bolt_hole_4_positioned"
+      }
+    },
+    "combined_holes_1_5": {
+      "id": "combined_holes_1_5",
+      "name": "Combined Holes 1-5",
+      "op": {
+        "type": "Union",
+        "left": "combined_holes_1_4",
+        "right": "bolt_hole_5_positioned"
+      }
+    },
+    "combined_holes_1_6": {
+      "id": "combined_holes_1_6",
+      "name": "Combined Holes 1-6",
+      "op": {
+        "type": "Union",
+        "left": "combined_holes_1_5",
+        "right": "bolt_hole_6_positioned"
+      }
+    },
+    "final_flange": {
+      "id": "final_flange",
+      "name": "Final Flange",
+      "op": {
+        "type": "Difference",
+        "left": "without_bore",
+        "right": "combined_holes_1_6"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_flange",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.json
@@ -1,0 +1,300 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120429Z-4eb8",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6868.804723
+      }
+    ],
+    "tokens": {
+      "input": 749,
+      "output": 1674,
+      "total": 2423
+    },
+    "wallclock_sec": 6.868804723
+  },
+  "output": {
+    "vcad_path": "20260429T120429Z-4eb8.vcad",
+    "vcad_sha256": "51ab2c6c4d34e346bc8f3604498bcf3307140a122628d1859eb76399b2813691",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:29.191Z",
+    "ended_at": "2026-04-29T12:04:36.069Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": []
@@ -123,51 +123,51 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -191,7 +191,7 @@
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -232,7 +232,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-haiku-4-5-20251001/20260429T120429Z-4eb8.vcad
@@ -1,0 +1,180 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "body": {
+      "id": "body",
+      "name": "Main flange cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 50,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "central_bore": {
+      "id": "central_bore",
+      "name": "Central bore cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 20,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "body_minus_bore": {
+      "id": "body_minus_bore",
+      "name": "Body with central bore",
+      "op": {
+        "type": "Difference",
+        "left": "body",
+        "right": "central_bore"
+      }
+    },
+    "bolt_hole_1": {
+      "id": "bolt_hole_1",
+      "name": "Bolt hole 1 at 0 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": 37.5, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_2": {
+      "id": "bolt_hole_2",
+      "name": "Bolt hole 2 at 60 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": 18.75, "y": 32.476, "z": 0}
+      }
+    },
+    "bolt_hole_3": {
+      "id": "bolt_hole_3",
+      "name": "Bolt hole 3 at 120 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": -18.75, "y": 32.476, "z": 0}
+      }
+    },
+    "bolt_hole_4": {
+      "id": "bolt_hole_4",
+      "name": "Bolt hole 4 at 180 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": -37.5, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_5": {
+      "id": "bolt_hole_5",
+      "name": "Bolt hole 5 at 240 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": -18.75, "y": -32.476, "z": 0}
+      }
+    },
+    "bolt_hole_6": {
+      "id": "bolt_hole_6",
+      "name": "Bolt hole 6 at 300 degrees",
+      "op": {
+        "type": "Translate",
+        "child": {
+          "type": "Cylinder",
+          "radius": 4,
+          "height": 12,
+          "segments": 32
+        },
+        "offset": {"x": 18.75, "y": -32.476, "z": 0}
+      }
+    },
+    "with_holes_1_2": {
+      "id": "with_holes_1_2",
+      "name": "Body with holes 1 and 2",
+      "op": {
+        "type": "Difference",
+        "left": "body_minus_bore",
+        "right": "bolt_hole_1"
+      }
+    },
+    "with_holes_1_2_3": {
+      "id": "with_holes_1_2_3",
+      "name": "Body with holes 1, 2 and 3",
+      "op": {
+        "type": "Difference",
+        "left": "with_holes_1_2",
+        "right": "bolt_hole_2"
+      }
+    },
+    "with_holes_1_2_3_4": {
+      "id": "with_holes_1_2_3_4",
+      "name": "Body with holes 1, 2, 3 and 4",
+      "op": {
+        "type": "Difference",
+        "left": "with_holes_1_2_3",
+        "right": "bolt_hole_3"
+      }
+    },
+    "with_holes_1_2_3_4_5": {
+      "id": "with_holes_1_2_3_4_5",
+      "name": "Body with holes 1, 2, 3, 4 and 5",
+      "op": {
+        "type": "Difference",
+        "left": "with_holes_1_2_3_4",
+        "right": "bolt_hole_4"
+      }
+    },
+    "with_holes_1_2_3_4_5_6": {
+      "id": "with_holes_1_2_3_4_5_6",
+      "name": "Body with holes 1, 2, 3, 4, 5 and 6",
+      "op": {
+        "type": "Difference",
+        "left": "with_holes_1_2_3_4_5",
+        "right": "bolt_hole_5"
+      }
+    },
+    "final_flange": {
+      "id": "final_flange",
+      "name": "Final flange with all holes",
+      "op": {
+        "type": "Difference",
+        "left": "with_holes_1_2_3_4_5_6",
+        "right": "bolt_hole_6"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_flange",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71803783817,
+          "deviation_pct": 0.16056060311812062,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.4759526419,
+            8
+          ],
+          [
+            18.75,
+            -32.4759526419,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.521250744673374,
+              "original_mm3": 75427.71803783819,
+              "pass": true,
+              "roundtripped_mm3": 75034.55049587582
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120533Z-dc14",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10930.704343
+      }
+    ],
+    "tokens": {
+      "input": 997,
+      "output": 1369,
+      "total": 2366
+    },
+    "wallclock_sec": 10.930704342999999
+  },
+  "output": {
+    "vcad_path": "20260429T120533Z-dc14.vcad",
+    "vcad_sha256": "f129770c53fa8cc00628ac78610b14dd7a1acf0356e8ce4a2b485f0568e5c1e1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:33.555Z",
+    "ended_at": "2026-04-29T12:05:46.004Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.4759526419,
-            8
+            8.0
           ],
           [
             18.75,
             -32.4759526419,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               32.4759526419
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               32.4759526419
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               -32.4759526419
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               -32.4759526419
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.521250744673374,
-              "original_mm3": 75427.71803783819,
+              "deviation_pct": 0.5212507446734316,
+              "original_mm3": 75427.71803783822,
               "pass": true,
-              "roundtripped_mm3": 75034.55049587582
+              "roundtripped_mm3": 75034.55049587581
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120533Z-dc14.vcad
@@ -1,0 +1,37 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cylinder", "radius": 50.0, "height": 12.0, "segments": 64}},
+    "2": {"id": 2, "name": "bore", "op": {"type": "Cylinder", "radius": 20.0, "height": 14.0, "segments": 64}},
+    "3": {"id": 3, "name": "bore_pos", "op": {"type": "Translate", "child": 2, "offset": {"x": 0.0, "y": 0.0, "z": -1.0}}},
+    "4": {"id": 4, "name": "body_bored", "op": {"type": "Difference", "left": 1, "right": 3}},
+
+    "10": {"id": 10, "name": "hole0", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "11": {"id": 11, "name": "hole0_pos", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0.0, "z": -1.0}}},
+
+    "20": {"id": 20, "name": "hole1", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "21": {"id": 21, "name": "hole1_pos", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": 32.4759526419, "z": -1.0}}},
+
+    "30": {"id": 30, "name": "hole2", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "31": {"id": 31, "name": "hole2_pos", "op": {"type": "Translate", "child": 30, "offset": {"x": -18.75, "y": 32.4759526419, "z": -1.0}}},
+
+    "40": {"id": 40, "name": "hole3", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "41": {"id": 41, "name": "hole3_pos", "op": {"type": "Translate", "child": 40, "offset": {"x": -37.5, "y": 0.0, "z": -1.0}}},
+
+    "50": {"id": 50, "name": "hole4", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "51": {"id": 51, "name": "hole4_pos", "op": {"type": "Translate", "child": 50, "offset": {"x": -18.75, "y": -32.4759526419, "z": -1.0}}},
+
+    "60": {"id": 60, "name": "hole5", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "61": {"id": 61, "name": "hole5_pos", "op": {"type": "Translate", "child": 60, "offset": {"x": 18.75, "y": -32.4759526419, "z": -1.0}}},
+
+    "100": {"id": 100, "name": "d1", "op": {"type": "Difference", "left": 4, "right": 11}},
+    "101": {"id": 101, "name": "d2", "op": {"type": "Difference", "left": 100, "right": 21}},
+    "102": {"id": 102, "name": "d3", "op": {"type": "Difference", "left": 101, "right": 31}},
+    "103": {"id": 103, "name": "d4", "op": {"type": "Difference", "left": 102, "right": 41}},
+    "104": {"id": 104, "name": "d5", "op": {"type": "Difference", "left": 103, "right": 51}},
+    "105": {"id": 105, "name": "flange", "op": {"type": "Difference", "left": 104, "right": 61}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 105, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71803783817,
-          "deviation_pct": 0.16056060311812062,
+          "actual_mm3": 75427.71803783807,
+          "deviation_pct": 0.16056060311825546,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.4759526419,
-            8
+            8.0
           ],
           [
             18.75,
             -32.4759526419,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               32.4759526419
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               32.4759526419
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               -32.4759526419
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               -32.4759526419
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212507446732583,
-              "original_mm3": 75427.71803783817,
+              "deviation_pct": 0.521250744673374,
+              "original_mm3": 75427.71803783819,
               "pass": true,
-              "roundtripped_mm3": 75034.5504958759
+              "roundtripped_mm3": 75034.55049587582
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71803783817,
+          "deviation_pct": 0.16056060311812062,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.4759526419,
+            8
+          ],
+          [
+            18.75,
+            -32.4759526419,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212507446732583,
+              "original_mm3": 75427.71803783817,
+              "pass": true,
+              "roundtripped_mm3": 75034.5504958759
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120546Z-2cc1",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9405.804792
+      }
+    ],
+    "tokens": {
+      "input": 997,
+      "output": 1093,
+      "total": 2090
+    },
+    "wallclock_sec": 9.405804792000001
+  },
+  "output": {
+    "vcad_path": "20260429T120546Z-2cc1.vcad",
+    "vcad_sha256": "e08b59d2c35304ab5d023ae307912b607e6955131bcf6c394072afadfc0411a9",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:46.069Z",
+    "ended_at": "2026-04-29T12:05:56.920Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120546Z-2cc1.vcad
@@ -1,0 +1,30 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "bore", "op": {"type": "Cylinder", "radius": 20, "height": 14, "segments": 64}},
+    "3": {"id": 3, "name": "bore_pos", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": -1}}},
+    "4": {"id": 4, "name": "flange_bored", "op": {"type": "Difference", "left": 1, "right": 3}},
+
+    "10": {"id": 10, "name": "bolt", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_z", "op": {"type": "Translate", "child": 10, "offset": {"x": 0, "y": 0, "z": -1}}},
+
+    "20": {"id": 20, "name": "bolt0", "op": {"type": "Translate", "child": 11, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+    "21": {"id": 21, "name": "bolt1", "op": {"type": "Translate", "child": 11, "offset": {"x": 18.75, "y": 32.4759526419, "z": 0}}},
+    "22": {"id": 22, "name": "bolt2", "op": {"type": "Translate", "child": 11, "offset": {"x": -18.75, "y": 32.4759526419, "z": 0}}},
+    "23": {"id": 23, "name": "bolt3", "op": {"type": "Translate", "child": 11, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+    "24": {"id": 24, "name": "bolt4", "op": {"type": "Translate", "child": 11, "offset": {"x": -18.75, "y": -32.4759526419, "z": 0}}},
+    "25": {"id": 25, "name": "bolt5", "op": {"type": "Translate", "child": 11, "offset": {"x": 18.75, "y": -32.4759526419, "z": 0}}},
+
+    "30": {"id": 30, "name": "u01", "op": {"type": "Union", "left": 20, "right": 21}},
+    "31": {"id": 31, "name": "u012", "op": {"type": "Union", "left": 30, "right": 22}},
+    "32": {"id": 32, "name": "u0123", "op": {"type": "Union", "left": 31, "right": 23}},
+    "33": {"id": 33, "name": "u01234", "op": {"type": "Union", "left": 32, "right": 24}},
+    "34": {"id": 34, "name": "all_bolts", "op": {"type": "Union", "left": 33, "right": 25}},
+
+    "40": {"id": 40, "name": "final", "op": {"type": "Difference", "left": 4, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71803783819,
-          "deviation_pct": 0.16056060311810136,
+          "actual_mm3": 75427.71803783817,
+          "deviation_pct": 0.16056060311812062,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.47595264191645,
-            8
+            8.0
           ],
           [
             -18.75,
             32.47595264191645,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.47595264191645,
-            8
+            8.0
           ],
           [
             18.75,
             -32.47595264191645,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               18.75,
               32.47595264191645
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               -18.75,
               32.47595264191645
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               -18.75,
               -32.47595264191645
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               18.75,
               -32.47595264191645
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212507446732583,
-              "original_mm3": 75427.71803783817,
+              "deviation_pct": 0.5212507446735085,
+              "original_mm3": 75427.71803783825,
               "pass": true,
-              "roundtripped_mm3": 75034.5504958759
+              "roundtripped_mm3": 75034.55049587578
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71803783819,
+          "deviation_pct": 0.16056060311810136,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.47595264191645,
+            8
+          ],
+          [
+            -18.75,
+            32.47595264191645,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.47595264191645,
+            8
+          ],
+          [
+            18.75,
+            -32.47595264191645,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              18.75,
+              32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              -18.75,
+              32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              -18.75,
+              -32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              18.75,
+              -32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212507446732583,
+              "original_mm3": 75427.71803783817,
+              "pass": true,
+              "roundtripped_mm3": 75034.5504958759
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120556Z-3633",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10254.719137
+      }
+    ],
+    "tokens": {
+      "input": 997,
+      "output": 1304,
+      "total": 2301
+    },
+    "wallclock_sec": 10.254719137
+  },
+  "output": {
+    "vcad_path": "20260429T120556Z-3633.vcad",
+    "vcad_sha256": "a1b4ebea5d39e2a4f6550ce0e93f440ac2f63a2604a9edcb9283149271301498",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:56.986Z",
+    "ended_at": "2026-04-29T12:06:08.755Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120556Z-3633.vcad
@@ -1,0 +1,37 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "bore_raw", "op": {"type": "Cylinder", "radius": 20, "height": 14, "segments": 64}},
+    "3": {"id": 3, "name": "bore", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": -1}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Difference", "left": 1, "right": 3}},
+
+    "10": {"id": 10, "name": "h0_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "11": {"id": 11, "name": "h0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": -1}}},
+
+    "20": {"id": 20, "name": "h1_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "21": {"id": 21, "name": "h1", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": 32.475952641916446, "z": -1}}},
+
+    "30": {"id": 30, "name": "h2_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "31": {"id": 31, "name": "h2", "op": {"type": "Translate", "child": 30, "offset": {"x": -18.75, "y": 32.475952641916446, "z": -1}}},
+
+    "40": {"id": 40, "name": "h3_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "41": {"id": 41, "name": "h3", "op": {"type": "Translate", "child": 40, "offset": {"x": -37.5, "y": 0, "z": -1}}},
+
+    "50": {"id": 50, "name": "h4_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "51": {"id": 51, "name": "h4", "op": {"type": "Translate", "child": 50, "offset": {"x": -18.75, "y": -32.475952641916446, "z": -1}}},
+
+    "60": {"id": 60, "name": "h5_raw", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "61": {"id": 61, "name": "h5", "op": {"type": "Translate", "child": 60, "offset": {"x": 18.75, "y": -32.475952641916446, "z": -1}}},
+
+    "100": {"id": 100, "name": "d1", "op": {"type": "Difference", "left": 4, "right": 11}},
+    "101": {"id": 101, "name": "d2", "op": {"type": "Difference", "left": 100, "right": 21}},
+    "102": {"id": 102, "name": "d3", "op": {"type": "Difference", "left": 101, "right": 31}},
+    "103": {"id": 103, "name": "d4", "op": {"type": "Difference", "left": 102, "right": 41}},
+    "104": {"id": 104, "name": "d5", "op": {"type": "Difference", "left": 103, "right": 51}},
+    "105": {"id": 105, "name": "flange", "op": {"type": "Difference", "left": 104, "right": 61}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 105, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71803783823,
-          "deviation_pct": 0.16056060311804357,
+          "actual_mm3": 75427.71803783816,
+          "deviation_pct": 0.16056060311813988,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.47595264191645,
-            8
+            8.0
           ],
           [
             -18.75,
             32.47595264191645,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.47595264191645,
-            8
+            8.0
           ],
           [
             18.75,
             -32.47595264191645,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               18.75,
               32.47595264191645
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               -18.75,
               32.47595264191645
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               -18.75,
               -32.47595264191645
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.000047358083548942886,
+            "distance_mm": 4.7358083548942886e-05,
             "matched_hole": [
               18.75,
               -32.47595264191645
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212507446731433,
-              "original_mm3": 75427.71803783807,
+              "deviation_pct": 0.5212507446733547,
+              "original_mm3": 75427.71803783817,
               "pass": true,
-              "roundtripped_mm3": 75034.55049587588
+              "roundtripped_mm3": 75034.55049587582
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71803783823,
+          "deviation_pct": 0.16056060311804357,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.47595264191645,
+            8
+          ],
+          [
+            -18.75,
+            32.47595264191645,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.47595264191645,
+            8
+          ],
+          [
+            18.75,
+            -32.47595264191645,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              18.75,
+              32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              -18.75,
+              32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              -18.75,
+              -32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.000047358083548942886,
+            "matched_hole": [
+              18.75,
+              -32.47595264191645
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212507446731433,
+              "original_mm3": 75427.71803783807,
+              "pass": true,
+              "roundtripped_mm3": 75034.55049587588
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120608Z-6050",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 11165.20354
+      }
+    ],
+    "tokens": {
+      "input": 997,
+      "output": 1314,
+      "total": 2311
+    },
+    "wallclock_sec": 11.16520354
+  },
+  "output": {
+    "vcad_path": "20260429T120608Z-6050.vcad",
+    "vcad_sha256": "d3b3dd140e447b7629d1271a318dc7a6ba8da7b3eeda8dd83fabdbe046c67339",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:08.816Z",
+    "ended_at": "2026-04-29T12:06:21.452Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120608Z-6050.vcad
@@ -1,0 +1,30 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "bore", "op": {"type": "Cylinder", "radius": 20, "height": 14, "segments": 64}},
+    "3": {"id": 3, "name": "bore_t", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": -1}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Difference", "left": 1, "right": 3}},
+    "10": {"id": 10, "name": "hole0_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "11": {"id": 11, "name": "hole0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": -1}}},
+    "12": {"id": 12, "name": "hole1_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "13": {"id": 13, "name": "hole1", "op": {"type": "Translate", "child": 12, "offset": {"x": 18.75, "y": 32.475952641916446, "z": -1}}},
+    "14": {"id": 14, "name": "hole2_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "15": {"id": 15, "name": "hole2", "op": {"type": "Translate", "child": 14, "offset": {"x": -18.75, "y": 32.475952641916446, "z": -1}}},
+    "16": {"id": 16, "name": "hole3_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "17": {"id": 17, "name": "hole3", "op": {"type": "Translate", "child": 16, "offset": {"x": -37.5, "y": 0, "z": -1}}},
+    "18": {"id": 18, "name": "hole4_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "19": {"id": 19, "name": "hole4", "op": {"type": "Translate", "child": 18, "offset": {"x": -18.75, "y": -32.475952641916446, "z": -1}}},
+    "20": {"id": 20, "name": "hole5_proto", "op": {"type": "Cylinder", "radius": 4, "height": 14, "segments": 32}},
+    "21": {"id": 21, "name": "hole5", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": -32.475952641916446, "z": -1}}},
+    "30": {"id": 30, "name": "u01", "op": {"type": "Union", "left": 11, "right": 13}},
+    "31": {"id": 31, "name": "u012", "op": {"type": "Union", "left": 30, "right": 15}},
+    "32": {"id": 32, "name": "u0123", "op": {"type": "Union", "left": 31, "right": 17}},
+    "33": {"id": 33, "name": "u01234", "op": {"type": "Union", "left": 32, "right": 19}},
+    "34": {"id": 34, "name": "all_holes", "op": {"type": "Union", "left": 33, "right": 21}},
+    "40": {"id": 40, "name": "flange", "op": {"type": "Difference", "left": 4, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.7180378381,
+          "deviation_pct": 0.16056060311821693,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -18.75,
+            32.4759526419,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.4759526419,
+            8
+          ],
+          [
+            18.75,
+            -32.4759526419,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              -18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004735809999800722,
+            "matched_hole": [
+              18.75,
+              -32.4759526419
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212507446733352,
+              "original_mm3": 75427.71803783822,
+              "pass": true,
+              "roundtripped_mm3": 75034.55049587588
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120621Z-8698",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9851.950324
+      }
+    ],
+    "tokens": {
+      "input": 997,
+      "output": 1120,
+      "total": 2117
+    },
+    "wallclock_sec": 9.851950323999999
+  },
+  "output": {
+    "vcad_path": "20260429T120621Z-8698.vcad",
+    "vcad_sha256": "05b1d3772800954c996c4ff7ceb726773d9f289152c6a93e3af417e14f939aeb",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:21.516Z",
+    "ended_at": "2026-04-29T12:06:32.836Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.7180378381,
-          "deviation_pct": 0.16056060311821693,
+          "actual_mm3": 75427.71803783822,
+          "deviation_pct": 0.16056060311806283,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -18.75,
             32.4759526419,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.4759526419,
-            8
+            8.0
           ],
           [
             18.75,
             -32.4759526419,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               32.4759526419
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               32.4759526419
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               -18.75,
               -32.4759526419
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004735809999800722,
+            "distance_mm": 4.735809999800722e-05,
             "matched_hole": [
               18.75,
               -32.4759526419
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212507446733352,
+              "deviation_pct": 0.5212507446733544,
               "original_mm3": 75427.71803783822,
               "pass": true,
-              "roundtripped_mm3": 75034.55049587588
+              "roundtripped_mm3": 75034.55049587587
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-opus-4-7/20260429T120621Z-8698.vcad
@@ -1,0 +1,30 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cylinder", "radius": 50.0, "height": 12.0, "segments": 64}},
+    "2": {"id": 2, "name": "bore", "op": {"type": "Cylinder", "radius": 20.0, "height": 14.0, "segments": 64}},
+    "3": {"id": 3, "name": "bore_pos", "op": {"type": "Translate", "child": 2, "offset": {"x": 0.0, "y": 0.0, "z": -1.0}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Difference", "left": 1, "right": 3}},
+
+    "10": {"id": 10, "name": "hole_proto", "op": {"type": "Cylinder", "radius": 4.0, "height": 14.0, "segments": 32}},
+    "11": {"id": 11, "name": "hole_lifted", "op": {"type": "Translate", "child": 10, "offset": {"x": 0.0, "y": 0.0, "z": -1.0}}},
+
+    "20": {"id": 20, "name": "h0", "op": {"type": "Translate", "child": 11, "offset": {"x": 37.5, "y": 0.0, "z": 0.0}}},
+    "21": {"id": 21, "name": "h1", "op": {"type": "Translate", "child": 11, "offset": {"x": 18.75, "y": 32.4759526419, "z": 0.0}}},
+    "22": {"id": 22, "name": "h2", "op": {"type": "Translate", "child": 11, "offset": {"x": -18.75, "y": 32.4759526419, "z": 0.0}}},
+    "23": {"id": 23, "name": "h3", "op": {"type": "Translate", "child": 11, "offset": {"x": -37.5, "y": 0.0, "z": 0.0}}},
+    "24": {"id": 24, "name": "h4", "op": {"type": "Translate", "child": 11, "offset": {"x": -18.75, "y": -32.4759526419, "z": 0.0}}},
+    "25": {"id": 25, "name": "h5", "op": {"type": "Translate", "child": 11, "offset": {"x": 18.75, "y": -32.4759526419, "z": 0.0}}},
+
+    "30": {"id": 30, "name": "u01", "op": {"type": "Union", "left": 20, "right": 21}},
+    "31": {"id": 31, "name": "u012", "op": {"type": "Union", "left": 30, "right": 22}},
+    "32": {"id": 32, "name": "u0123", "op": {"type": "Union", "left": 31, "right": 23}},
+    "33": {"id": 33, "name": "u01234", "op": {"type": "Union", "left": 32, "right": 24}},
+    "34": {"id": 34, "name": "all_holes", "op": {"type": "Union", "left": 33, "right": 25}},
+
+    "40": {"id": 40, "name": "flange", "op": {"type": "Difference", "left": 4, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71807397228,
+          "deviation_pct": 0.1605605552894286,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.4759,
+            8
+          ],
+          [
+            -18.75,
+            32.4759,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.4759,
+            8
+          ],
+          [
+            18.75,
+            -32.4759,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              18.75,
+              32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              -18.75,
+              32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              -18.75,
+              -32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              18.75,
+              -32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212506266371547,
+              "original_mm3": 75427.71807397234,
+              "pass": true,
+              "roundtripped_mm3": 75034.55062085365
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120533Z-283b",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10639.826268
+      }
+    ],
+    "tokens": {
+      "input": 750,
+      "output": 1230,
+      "total": 1980
+    },
+    "wallclock_sec": 10.639826268
+  },
+  "output": {
+    "vcad_path": "20260429T120533Z-283b.vcad",
+    "vcad_sha256": "99925b342d2583ddca26347bc37f3a84df0712c61732a2dea4597ddc547cc265",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:33.539Z",
+    "ended_at": "2026-04-29T12:05:45.365Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71807397228,
-          "deviation_pct": 0.1605605552894286,
+          "actual_mm3": 75427.71807397234,
+          "deviation_pct": 0.16056055528935156,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.4759,
-            8
+            8.0
           ],
           [
             -18.75,
             32.4759,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.4759,
-            8
+            8.0
           ],
           [
             18.75,
             -32.4759,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               18.75,
               32.4759
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               -18.75,
               32.4759
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               -18.75,
               -32.4759
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               18.75,
               -32.4759
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212506266371547,
+              "deviation_pct": 0.521250626637232,
               "original_mm3": 75427.71807397234,
               "pass": true,
-              "roundtripped_mm3": 75034.55062085365
+              "roundtripped_mm3": 75034.5506208536
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120533Z-283b.vcad
@@ -1,0 +1,39 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cylinder", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -0, "y": -0, "z": 0}}},
+    "3": {"id": 3, "name": "bore_cyl", "op": {"type": "Cylinder", "radius": 20, "height": 12, "segments": 64}},
+    "4": {"id": 4, "name": "bore_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "body_minus_bore", "op": {"type": "Difference", "left": 2, "right": 4}},
+
+    "10": {"id": 10, "name": "bolt0_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "bolt0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+
+    "12": {"id": 12, "name": "bolt1_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "13": {"id": 13, "name": "bolt1", "op": {"type": "Translate", "child": 12, "offset": {"x": 18.75, "y": 32.4759, "z": 0}}},
+
+    "14": {"id": 14, "name": "bolt2_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "15": {"id": 15, "name": "bolt2", "op": {"type": "Translate", "child": 14, "offset": {"x": -18.75, "y": 32.4759, "z": 0}}},
+
+    "16": {"id": 16, "name": "bolt3_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "17": {"id": 17, "name": "bolt3", "op": {"type": "Translate", "child": 16, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+
+    "18": {"id": 18, "name": "bolt4_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "19": {"id": 19, "name": "bolt4", "op": {"type": "Translate", "child": 18, "offset": {"x": -18.75, "y": -32.4759, "z": 0}}},
+
+    "20": {"id": 20, "name": "bolt5_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "bolt5", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": -32.4759, "z": 0}}},
+
+    "30": {"id": 30, "name": "bolts_01", "op": {"type": "Union", "left": 11, "right": 13}},
+    "31": {"id": 31, "name": "bolts_012", "op": {"type": "Union", "left": 30, "right": 15}},
+    "32": {"id": 32, "name": "bolts_0123", "op": {"type": "Union", "left": 31, "right": 17}},
+    "33": {"id": 33, "name": "bolts_01234", "op": {"type": "Union", "left": 32, "right": 19}},
+    "34": {"id": 34, "name": "all_bolts", "op": {"type": "Union", "left": 33, "right": 21}},
+
+    "40": {"id": 40, "name": "flange", "op": {"type": "Difference", "left": 5, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.475844,
-            8
+            8.0
           ],
           [
             -18.75,
             32.475844,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.475844,
-            8
+            8.0
           ],
           [
             18.75,
             -32.475844,
-            8
+            8.0
           ]
         ]
       }
@@ -191,55 +191,55 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
@@ -267,15 +267,15 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.521251105644223,
-              "original_mm3": 75427.71798860753,
+              "deviation_pct": 0.5212511056441466,
+              "original_mm3": 75427.71798860743,
               "pass": true,
-              "roundtripped_mm3": 75034.55017462971
+              "roundtripped_mm3": 75034.55017462966
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71798860747,
+          "deviation_pct": 0.1605606682820378,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.475844,
+            8
+          ],
+          [
+            -18.75,
+            32.475844,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.475844,
+            8
+          ],
+          [
+            18.75,
+            -32.475844,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00015599999999693637,
+            "matched_hole": [
+              18.75,
+              32.475844
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00015599999999693637,
+            "matched_hole": [
+              -18.75,
+              32.475844
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00015599999999693637,
+            "matched_hole": [
+              -18.75,
+              -32.475844
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00015599999999693637,
+            "matched_hole": [
+              18.75,
+              -32.475844
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.521251105644223,
+              "original_mm3": 75427.71798860753,
+              "pass": true,
+              "roundtripped_mm3": 75034.55017462971
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120545Z-1679",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9957.09513
+      }
+    ],
+    "tokens": {
+      "input": 750,
+      "output": 1214,
+      "total": 1964
+    },
+    "wallclock_sec": 9.957095129999999
+  },
+  "output": {
+    "vcad_path": "20260429T120545Z-1679.vcad",
+    "vcad_sha256": "971c598ee7d51bfc4ccbd2363c5d65de1ead4924d76076085b4b25756ef697ca",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:45.430Z",
+    "ended_at": "2026-04-29T12:05:56.573Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120545Z-1679.vcad
@@ -1,0 +1,38 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cylinder", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "3": {"id": 3, "name": "bore_cyl", "op": {"type": "Cylinder", "radius": 20, "height": 12, "segments": 64}},
+    "4": {"id": 4, "name": "body_minus_bore", "op": {"type": "Difference", "left": 2, "right": 3}},
+
+    "10": {"id": 10, "name": "bolt_hole_cyl_0", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_hole_0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+
+    "12": {"id": 12, "name": "bolt_hole_cyl_1", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "13": {"id": 13, "name": "bolt_hole_1", "op": {"type": "Translate", "child": 12, "offset": {"x": 18.75, "y": 32.475844, "z": 0}}},
+
+    "14": {"id": 14, "name": "bolt_hole_cyl_2", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "15": {"id": 15, "name": "bolt_hole_2", "op": {"type": "Translate", "child": 14, "offset": {"x": -18.75, "y": 32.475844, "z": 0}}},
+
+    "16": {"id": 16, "name": "bolt_hole_cyl_3", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "17": {"id": 17, "name": "bolt_hole_3", "op": {"type": "Translate", "child": 16, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+
+    "18": {"id": 18, "name": "bolt_hole_cyl_4", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "19": {"id": 19, "name": "bolt_hole_4", "op": {"type": "Translate", "child": 18, "offset": {"x": -18.75, "y": -32.475844, "z": 0}}},
+
+    "20": {"id": 20, "name": "bolt_hole_cyl_5", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "bolt_hole_5", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": -32.475844, "z": 0}}},
+
+    "30": {"id": 30, "name": "union_holes_01", "op": {"type": "Union", "left": 11, "right": 13}},
+    "31": {"id": 31, "name": "union_holes_012", "op": {"type": "Union", "left": 30, "right": 15}},
+    "32": {"id": 32, "name": "union_holes_0123", "op": {"type": "Union", "left": 31, "right": 17}},
+    "33": {"id": 33, "name": "union_holes_01234", "op": {"type": "Union", "left": 32, "right": 19}},
+    "34": {"id": 34, "name": "union_all_holes", "op": {"type": "Union", "left": 33, "right": 21}},
+
+    "40": {"id": 40, "name": "flange", "op": {"type": "Difference", "left": 4, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71798245473,
+          "deviation_pct": 0.16056067642607322,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.475951,
+            8
+          ],
+          [
+            -18.75,
+            32.475951,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.475951,
+            8
+          ],
+          [
+            18.75,
+            -32.475951,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004899999999707916,
+            "matched_hole": [
+              18.75,
+              32.475951
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004899999999707916,
+            "matched_hole": [
+              -18.75,
+              32.475951
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004899999999707916,
+            "matched_hole": [
+              -18.75,
+              -32.475951
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004899999999707916,
+            "matched_hole": [
+              18.75,
+              -32.475951
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212508597053436,
+              "original_mm3": 75427.7179824547,
+              "pass": true,
+              "roundtripped_mm3": 75034.55035401504
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120556Z-e111",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9837.514628
+      }
+    ],
+    "tokens": {
+      "input": 750,
+      "output": 1235,
+      "total": 1985
+    },
+    "wallclock_sec": 9.837514628000001
+  },
+  "output": {
+    "vcad_path": "20260429T120556Z-e111.vcad",
+    "vcad_sha256": "417b33e813a5cba778358c56bb16ccb29231b704326e3eb5b0a59c298f094d88",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:56.637Z",
+    "ended_at": "2026-04-29T12:06:07.935Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71798245473,
-          "deviation_pct": 0.16056067642607322,
+          "actual_mm3": 75427.71798245481,
+          "deviation_pct": 0.1605606764259769,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.475951,
-            8
+            8.0
           ],
           [
             -18.75,
             32.475951,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.475951,
-            8
+            8.0
           ],
           [
             18.75,
             -32.475951,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004899999999707916,
+            "distance_mm": 4.899999999707916e-05,
             "matched_hole": [
               18.75,
               32.475951
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004899999999707916,
+            "distance_mm": 4.899999999707916e-05,
             "matched_hole": [
               -18.75,
               32.475951
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004899999999707916,
+            "distance_mm": 4.899999999707916e-05,
             "matched_hole": [
               -18.75,
               -32.475951
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004899999999707916,
+            "distance_mm": 4.899999999707916e-05,
             "matched_hole": [
               18.75,
               -32.475951
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212508597053436,
-              "original_mm3": 75427.7179824547,
+              "deviation_pct": 0.5212508597055551,
+              "original_mm3": 75427.71798245481,
               "pass": true,
-              "roundtripped_mm3": 75034.55035401504
+              "roundtripped_mm3": 75034.55035401498
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120556Z-e111.vcad
@@ -1,0 +1,31 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cylinder", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "3": {"id": 3, "name": "bore_cyl", "op": {"type": "Cylinder", "radius": 20, "height": 12, "segments": 64}},
+    "4": {"id": 4, "name": "bore_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "body_minus_bore", "op": {"type": "Difference", "left": 2, "right": 4}},
+    "10": {"id": 10, "name": "bolt_cyl_0", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+    "20": {"id": 20, "name": "bolt_cyl_1", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "bolt_1", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": 32.475951, "z": 0}}},
+    "30": {"id": 30, "name": "bolt_cyl_2", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "bolt_2", "op": {"type": "Translate", "child": 30, "offset": {"x": -18.75, "y": 32.475951, "z": 0}}},
+    "40": {"id": 40, "name": "bolt_cyl_3", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "bolt_3", "op": {"type": "Translate", "child": 40, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+    "50": {"id": 50, "name": "bolt_cyl_4", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "51": {"id": 51, "name": "bolt_4", "op": {"type": "Translate", "child": 50, "offset": {"x": -18.75, "y": -32.475951, "z": 0}}},
+    "60": {"id": 60, "name": "bolt_cyl_5", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "61": {"id": 61, "name": "bolt_5", "op": {"type": "Translate", "child": 60, "offset": {"x": 18.75, "y": -32.475951, "z": 0}}},
+    "100": {"id": 100, "name": "d1", "op": {"type": "Difference", "left": 5, "right": 11}},
+    "101": {"id": 101, "name": "d2", "op": {"type": "Difference", "left": 100, "right": 21}},
+    "102": {"id": 102, "name": "d3", "op": {"type": "Difference", "left": 101, "right": 31}},
+    "103": {"id": 103, "name": "d4", "op": {"type": "Difference", "left": 102, "right": 41}},
+    "104": {"id": 104, "name": "d5", "op": {"type": "Difference", "left": 103, "right": 51}},
+    "105": {"id": 105, "name": "flange", "op": {"type": "Difference", "left": 104, "right": 61}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 105, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.71807397228,
-          "deviation_pct": 0.1605605552894286,
+          "actual_mm3": 75427.71807397227,
+          "deviation_pct": 0.16056055528944788,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.4759,
-            8
+            8.0
           ],
           [
             -18.75,
             32.4759,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.4759,
-            8
+            8.0
           ],
           [
             18.75,
             -32.4759,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               18.75,
               32.4759
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               -18.75,
               32.4759
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               -18.75,
               -32.4759
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00009999999999621423,
+            "distance_mm": 9.999999999621423e-05,
             "matched_hole": [
               18.75,
               -32.4759
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212506266372513,
-              "original_mm3": 75427.71807397233,
+              "deviation_pct": 0.5212506266372317,
+              "original_mm3": 75427.71807397237,
               "pass": true,
-              "roundtripped_mm3": 75034.55062085357
+              "roundtripped_mm3": 75034.55062085362
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.71807397228,
+          "deviation_pct": 0.1605605552894286,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.4759,
+            8
+          ],
+          [
+            -18.75,
+            32.4759,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.4759,
+            8
+          ],
+          [
+            18.75,
+            -32.4759,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              18.75,
+              32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              -18.75,
+              32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              -18.75,
+              -32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00009999999999621423,
+            "matched_hole": [
+              18.75,
+              -32.4759
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212506266372513,
+              "original_mm3": 75427.71807397233,
+              "pass": true,
+              "roundtripped_mm3": 75034.55062085357
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120608Z-f571",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9981.150988000001
+      }
+    ],
+    "tokens": {
+      "input": 750,
+      "output": 1207,
+      "total": 1957
+    },
+    "wallclock_sec": 9.981150988000001
+  },
+  "output": {
+    "vcad_path": "20260429T120608Z-f571.vcad",
+    "vcad_sha256": "082996c40d0410daf94fa3a6448534a8ea53c0a020e92c162fe228508d0070fd",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:08.000Z",
+    "ended_at": "2026-04-29T12:06:19.202Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120608Z-f571.vcad
@@ -1,0 +1,30 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cylinder", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "3": {"id": 3, "name": "bore_cyl", "op": {"type": "Cylinder", "radius": 20, "height": 12, "segments": 64}},
+    "4": {"id": 4, "name": "body_with_bore", "op": {"type": "Difference", "left": 2, "right": 3}},
+    "5": {"id": 5, "name": "bolt_hole_proto", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "6": {"id": 6, "name": "bolt_hole_0", "op": {"type": "Translate", "child": 5, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "bolt_hole_1_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_1", "op": {"type": "Translate", "child": 7, "offset": {"x": 18.75, "y": 32.4759, "z": 0}}},
+    "9": {"id": 9, "name": "bolt_hole_2_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "10": {"id": 10, "name": "bolt_hole_2", "op": {"type": "Translate", "child": 9, "offset": {"x": -18.75, "y": 32.4759, "z": 0}}},
+    "11": {"id": 11, "name": "bolt_hole_3_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "12": {"id": 12, "name": "bolt_hole_3", "op": {"type": "Translate", "child": 11, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt_hole_4_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "14": {"id": 14, "name": "bolt_hole_4", "op": {"type": "Translate", "child": 13, "offset": {"x": -18.75, "y": -32.4759, "z": 0}}},
+    "15": {"id": 15, "name": "bolt_hole_5_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "16": {"id": 16, "name": "bolt_hole_5", "op": {"type": "Translate", "child": 15, "offset": {"x": 18.75, "y": -32.4759, "z": 0}}},
+    "17": {"id": 17, "name": "holes_01", "op": {"type": "Union", "left": 6, "right": 8}},
+    "18": {"id": 18, "name": "holes_012", "op": {"type": "Union", "left": 17, "right": 10}},
+    "19": {"id": 19, "name": "holes_0123", "op": {"type": "Union", "left": 18, "right": 12}},
+    "20": {"id": 20, "name": "holes_01234", "op": {"type": "Union", "left": 19, "right": 14}},
+    "21": {"id": 21, "name": "all_bolt_holes", "op": {"type": "Union", "left": 20, "right": 16}},
+    "22": {"id": 22, "name": "body_minus_bolts", "op": {"type": "Difference", "left": 4, "right": 21}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 22, "material": "default"}]
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "tolerance_mm": 0.3
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          12
+          50.0,
+          50.0,
+          12.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.3
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 75427.7181702039,
-          "deviation_pct": 0.16056042791304218,
+          "actual_mm3": 75427.71817020397,
+          "deviation_pct": 0.16056042791294586,
           "pass": true,
           "spec_mm3": 75549.02,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 40,
+        "diameter_mm": 40.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,46 +142,46 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 6,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 6,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 6,
         "found": [
           [
             37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             18.75,
             32.475953,
-            8
+            8.0
           ],
           [
             -18.75,
             32.475953,
-            8
+            8.0
           ],
           [
             -37.5,
-            0,
-            8
+            0.0,
+            8.0
           ],
           [
             -18.75,
             -32.475953,
-            8
+            8.0
           ],
           [
             18.75,
             -32.475953,
-            8
+            8.0
           ]
         ]
       }
@@ -191,59 +191,59 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
             37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -18.75,
             32.476,
-            0
+            0.0
           ],
           [
             -37.5,
-            0,
-            0
+            0.0,
+            0.0
           ],
           [
             -18.75,
             -32.476,
-            0
+            0.0
           ],
           [
             18.75,
             -32.476,
-            0
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004700000000212867,
+            "distance_mm": 4.700000000212867e-05,
             "matched_hole": [
               18.75,
               32.475953
@@ -255,7 +255,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004700000000212867,
+            "distance_mm": 4.700000000212867e-05,
             "matched_hole": [
               -18.75,
               32.475953
@@ -267,19 +267,19 @@
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
               -37.5,
-              0
+              0.0
             ],
             "pass": true,
             "spec_xy": [
               -37.5,
-              0
+              0.0
             ]
           },
           {
-            "distance_mm": 0.00004700000000212867,
+            "distance_mm": 4.700000000212867e-05,
             "matched_hole": [
               -18.75,
               -32.475953
@@ -291,7 +291,7 @@
             ]
           },
           {
-            "distance_mm": 0.00004700000000212867,
+            "distance_mm": 4.700000000212867e-05,
             "matched_hole": [
               18.75,
               -32.475953
@@ -319,37 +319,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                12
+                50.0,
+                50.0,
+                12.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 2.1289433999052205
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5212506202068921,
-              "original_mm3": 75427.71817020397,
+              "deviation_pct": 0.5212506202069697,
+              "original_mm3": 75427.71817020391,
               "pass": true,
-              "roundtripped_mm3": 75034.55072143387
+              "roundtripped_mm3": 75034.55072143376
             }
           }
         ],
@@ -361,7 +361,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.json
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.json
@@ -1,0 +1,429 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-bolt-circle-flange-with-bore-01",
+  "task_sha256": "33b12253990b5195f437a7860d8bb23cc6aecef260562a70259d1210cd482458",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          12
+        ],
+        "tolerance_mm": 0.3
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          12
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.3
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 75549.02,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 75427.7181702039,
+          "deviation_pct": 0.16056042791304218,
+          "pass": true,
+          "spec_mm3": 75549.02,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 40,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 40,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            40
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 40,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 40,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 6,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 6,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 6,
+        "found": [
+          [
+            37.5,
+            0,
+            8
+          ],
+          [
+            18.75,
+            32.475953,
+            8
+          ],
+          [
+            -18.75,
+            32.475953,
+            8
+          ],
+          [
+            -37.5,
+            0,
+            8
+          ],
+          [
+            -18.75,
+            -32.475953,
+            8
+          ],
+          [
+            18.75,
+            -32.475953,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            37.5,
+            0,
+            0
+          ],
+          [
+            18.75,
+            32.476,
+            0
+          ],
+          [
+            -18.75,
+            32.476,
+            0
+          ],
+          [
+            -37.5,
+            0,
+            0
+          ],
+          [
+            -18.75,
+            -32.476,
+            0
+          ],
+          [
+            18.75,
+            -32.476,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004700000000212867,
+            "matched_hole": [
+              18.75,
+              32.475953
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004700000000212867,
+            "matched_hole": [
+              -18.75,
+              32.475953
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              32.476
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -37.5,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -37.5,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0.00004700000000212867,
+            "matched_hole": [
+              -18.75,
+              -32.475953
+            ],
+            "pass": true,
+            "spec_xy": [
+              -18.75,
+              -32.476
+            ]
+          },
+          {
+            "distance_mm": 0.00004700000000212867,
+            "matched_hole": [
+              18.75,
+              -32.475953
+            ],
+            "pass": true,
+            "spec_xy": [
+              18.75,
+              -32.476
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                12
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                12
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 2.1289433999052205
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5212506202068921,
+              "original_mm3": 75427.71817020397,
+              "pass": true,
+              "roundtripped_mm3": 75034.55072143387
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120619Z-c713",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-bolt-circle-flange-with-bore-01",
+    "rendered": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 648
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10429.735542
+      }
+    ],
+    "tokens": {
+      "input": 750,
+      "output": 1265,
+      "total": 2015
+    },
+    "wallclock_sec": 10.429735542
+  },
+  "output": {
+    "vcad_path": "20260429T120619Z-c713.vcad",
+    "vcad_sha256": "2b746e259775e01811a6eef1b0dd3f4456da374d7b05da55a633ec03f15c4d19",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:19.266Z",
+    "ended_at": "2026-04-29T12:06:30.913Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.vcad
+++ b/mecheval/runs/a4-bolt-circle-flange-with-bore-01/claude-direct-claude-sonnet-4-6/20260429T120619Z-c713.vcad
@@ -1,0 +1,39 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cylinder", "op": {"type": "Cylinder", "radius": 50, "height": 12, "segments": 64}},
+    "2": {"id": 2, "name": "outer_cylinder_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -0, "y": -0, "z": 0}}},
+    "3": {"id": 3, "name": "bore_cylinder", "op": {"type": "Cylinder", "radius": 20, "height": 12, "segments": 64}},
+    "4": {"id": 4, "name": "bore_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": 0, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "body_minus_bore", "op": {"type": "Difference", "left": 2, "right": 4}},
+
+    "10": {"id": 10, "name": "bolt_hole_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_hole_0", "op": {"type": "Translate", "child": 10, "offset": {"x": 37.5, "y": 0, "z": 0}}},
+
+    "12": {"id": 12, "name": "bolt_hole_cyl2", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "13": {"id": 13, "name": "bolt_hole_1", "op": {"type": "Translate", "child": 12, "offset": {"x": 18.75, "y": 32.475953, "z": 0}}},
+
+    "14": {"id": 14, "name": "bolt_hole_cyl3", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "15": {"id": 15, "name": "bolt_hole_2", "op": {"type": "Translate", "child": 14, "offset": {"x": -18.75, "y": 32.475953, "z": 0}}},
+
+    "16": {"id": 16, "name": "bolt_hole_cyl4", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "17": {"id": 17, "name": "bolt_hole_3", "op": {"type": "Translate", "child": 16, "offset": {"x": -37.5, "y": 0, "z": 0}}},
+
+    "18": {"id": 18, "name": "bolt_hole_cyl5", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "19": {"id": 19, "name": "bolt_hole_4", "op": {"type": "Translate", "child": 18, "offset": {"x": -18.75, "y": -32.475953, "z": 0}}},
+
+    "20": {"id": 20, "name": "bolt_hole_cyl6", "op": {"type": "Cylinder", "radius": 4, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "bolt_hole_5", "op": {"type": "Translate", "child": 20, "offset": {"x": 18.75, "y": -32.475953, "z": 0}}},
+
+    "30": {"id": 30, "name": "union_holes_01", "op": {"type": "Union", "left": 11, "right": 13}},
+    "31": {"id": 31, "name": "union_holes_012", "op": {"type": "Union", "left": 30, "right": 15}},
+    "32": {"id": 32, "name": "union_holes_0123", "op": {"type": "Union", "left": 31, "right": 17}},
+    "33": {"id": 33, "name": "union_holes_01234", "op": {"type": "Union", "left": 32, "right": 19}},
+    "34": {"id": 34, "name": "union_holes_all", "op": {"type": "Union", "left": 33, "right": 21}},
+
+    "40": {"id": 40, "name": "flange", "op": {"type": "Difference", "left": 5, "right": 34}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 40, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -144,14 +144,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -162,65 +162,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -233,7 +233,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -245,7 +245,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -273,7 +273,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.json
@@ -1,0 +1,313 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120127Z-a8a5",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7784.1269569999995
+      }
+    ],
+    "tokens": {
+      "input": 761,
+      "output": 2020,
+      "total": 2781
+    },
+    "wallclock_sec": 7.784126957
+  },
+  "output": {
+    "vcad_path": "20260429T120127Z-a8a5.vcad",
+    "vcad_sha256": "3a16e8c8eba548e0992444f1cd187be87aa2f93ef4751d2bc939e970823c79e1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:27.958Z",
+    "ended_at": "2026-04-29T12:01:35.753Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120127Z-a8a5.vcad
@@ -1,0 +1,254 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate": {
+      "id": 0,
+      "name": "plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 12}
+      }
+    },
+    "plate_centered": {
+      "id": 1,
+      "name": "plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "clearance_hole_1": {
+      "id": 2,
+      "name": "clearance_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_1_positioned": {
+      "id": 3,
+      "name": "clearance_hole_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": 20, "y": 20, "z": 0}
+      }
+    },
+    "recess_1": {
+      "id": 4,
+      "name": "recess_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_1_positioned": {
+      "id": 5,
+      "name": "recess_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": 20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_1": {
+      "id": 6,
+      "name": "counterbore_1",
+      "op": {
+        "type": "Union",
+        "left": 3,
+        "right": 5
+      }
+    },
+    "clearance_hole_2": {
+      "id": 7,
+      "name": "clearance_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_2_positioned": {
+      "id": 8,
+      "name": "clearance_hole_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {"x": -20, "y": 20, "z": 0}
+      }
+    },
+    "recess_2": {
+      "id": 9,
+      "name": "recess_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_2_positioned": {
+      "id": 10,
+      "name": "recess_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 9,
+        "offset": {"x": -20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_2": {
+      "id": 11,
+      "name": "counterbore_2",
+      "op": {
+        "type": "Union",
+        "left": 8,
+        "right": 10
+      }
+    },
+    "clearance_hole_3": {
+      "id": 12,
+      "name": "clearance_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_3_positioned": {
+      "id": 13,
+      "name": "clearance_hole_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 12,
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "recess_3": {
+      "id": 14,
+      "name": "recess_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_3_positioned": {
+      "id": 15,
+      "name": "recess_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 14,
+        "offset": {"x": -20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_3": {
+      "id": 16,
+      "name": "counterbore_3",
+      "op": {
+        "type": "Union",
+        "left": 13,
+        "right": 15
+      }
+    },
+    "clearance_hole_4": {
+      "id": 17,
+      "name": "clearance_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_4_positioned": {
+      "id": 18,
+      "name": "clearance_hole_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 17,
+        "offset": {"x": 20, "y": -20, "z": 0}
+      }
+    },
+    "recess_4": {
+      "id": 19,
+      "name": "recess_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_4_positioned": {
+      "id": 20,
+      "name": "recess_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 19,
+        "offset": {"x": 20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_4": {
+      "id": 21,
+      "name": "counterbore_4",
+      "op": {
+        "type": "Union",
+        "left": 18,
+        "right": 20
+      }
+    },
+    "all_counterbores": {
+      "id": 22,
+      "name": "all_counterbores",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 11
+      }
+    },
+    "all_counterbores_2": {
+      "id": 23,
+      "name": "all_counterbores_2",
+      "op": {
+        "type": "Union",
+        "left": 22,
+        "right": 16
+      }
+    },
+    "all_counterbores_3": {
+      "id": 24,
+      "name": "all_counterbores_3",
+      "op": {
+        "type": "Union",
+        "left": 23,
+        "right": 21
+      }
+    },
+    "final": {
+      "id": 25,
+      "name": "final",
+      "op": {
+        "type": "Difference",
+        "left": 1,
+        "right": 24
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 25,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -144,14 +144,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -162,65 +162,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -233,7 +233,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -245,7 +245,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -273,7 +273,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.json
@@ -1,0 +1,313 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120135Z-f79c",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9864.720017
+      }
+    ],
+    "tokens": {
+      "input": 761,
+      "output": 2016,
+      "total": 2777
+    },
+    "wallclock_sec": 9.864720017
+  },
+  "output": {
+    "vcad_path": "20260429T120135Z-f79c.vcad",
+    "vcad_sha256": "9c855a560387dfe68d01a4d27fd72fa013f046d944bb5b5abf896fc81571b1f2",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:35.865Z",
+    "ended_at": "2026-04-29T12:01:45.739Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120135Z-f79c.vcad
@@ -1,0 +1,254 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate_base": {
+      "id": 0,
+      "name": "plate_base",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 12}
+      }
+    },
+    "plate_centered": {
+      "id": 1,
+      "name": "plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "clearance_hole_1": {
+      "id": 2,
+      "name": "clearance_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_1_pos": {
+      "id": 3,
+      "name": "clearance_hole_1_pos",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": 20, "y": 20, "z": 0}
+      }
+    },
+    "recess_1": {
+      "id": 4,
+      "name": "recess_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_1_pos": {
+      "id": 5,
+      "name": "recess_1_pos",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": 20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_1": {
+      "id": 6,
+      "name": "counterbore_1",
+      "op": {
+        "type": "Union",
+        "left": 3,
+        "right": 5
+      }
+    },
+    "clearance_hole_2": {
+      "id": 7,
+      "name": "clearance_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_2_pos": {
+      "id": 8,
+      "name": "clearance_hole_2_pos",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {"x": -20, "y": 20, "z": 0}
+      }
+    },
+    "recess_2": {
+      "id": 9,
+      "name": "recess_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_2_pos": {
+      "id": 10,
+      "name": "recess_2_pos",
+      "op": {
+        "type": "Translate",
+        "child": 9,
+        "offset": {"x": -20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_2": {
+      "id": 11,
+      "name": "counterbore_2",
+      "op": {
+        "type": "Union",
+        "left": 8,
+        "right": 10
+      }
+    },
+    "clearance_hole_3": {
+      "id": 12,
+      "name": "clearance_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_3_pos": {
+      "id": 13,
+      "name": "clearance_hole_3_pos",
+      "op": {
+        "type": "Translate",
+        "child": 12,
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "recess_3": {
+      "id": 14,
+      "name": "recess_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_3_pos": {
+      "id": 15,
+      "name": "recess_3_pos",
+      "op": {
+        "type": "Translate",
+        "child": 14,
+        "offset": {"x": -20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_3": {
+      "id": 16,
+      "name": "counterbore_3",
+      "op": {
+        "type": "Union",
+        "left": 13,
+        "right": 15
+      }
+    },
+    "clearance_hole_4": {
+      "id": 17,
+      "name": "clearance_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_4_pos": {
+      "id": 18,
+      "name": "clearance_hole_4_pos",
+      "op": {
+        "type": "Translate",
+        "child": 17,
+        "offset": {"x": 20, "y": -20, "z": 0}
+      }
+    },
+    "recess_4": {
+      "id": 19,
+      "name": "recess_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_4_pos": {
+      "id": 20,
+      "name": "recess_4_pos",
+      "op": {
+        "type": "Translate",
+        "child": 19,
+        "offset": {"x": 20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_4": {
+      "id": 21,
+      "name": "counterbore_4",
+      "op": {
+        "type": "Union",
+        "left": 18,
+        "right": 20
+      }
+    },
+    "all_holes": {
+      "id": 22,
+      "name": "all_holes",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 11
+      }
+    },
+    "all_holes_2": {
+      "id": 23,
+      "name": "all_holes_2",
+      "op": {
+        "type": "Union",
+        "left": 22,
+        "right": 16
+      }
+    },
+    "all_holes_3": {
+      "id": 24,
+      "name": "all_holes_3",
+      "op": {
+        "type": "Union",
+        "left": 23,
+        "right": 21
+      }
+    },
+    "final_part": {
+      "id": 25,
+      "name": "final_part",
+      "op": {
+        "type": "Difference",
+        "left": 1,
+        "right": 24
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 25,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -144,14 +144,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -162,65 +162,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -233,7 +233,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -245,7 +245,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -273,7 +273,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.json
@@ -1,0 +1,313 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120145Z-9eb9",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8742.127096
+      }
+    ],
+    "tokens": {
+      "input": 761,
+      "output": 2297,
+      "total": 3058
+    },
+    "wallclock_sec": 8.742127096
+  },
+  "output": {
+    "vcad_path": "20260429T120145Z-9eb9.vcad",
+    "vcad_sha256": "a4338eb7c5d30b30766d4617bb4a2df1933549ba9f9891bbe7140bed28d07fa8",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:45.841Z",
+    "ended_at": "2026-04-29T12:01:54.594Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120145Z-9eb9.vcad
@@ -1,0 +1,254 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate_base": {
+      "id": "plate_base",
+      "name": "Base Plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 12}
+      }
+    },
+    "plate_centered": {
+      "id": "plate_centered",
+      "name": "Centered Plate",
+      "op": {
+        "type": "Translate",
+        "child": "plate_base",
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "hole1_clearance": {
+      "id": "hole1_clearance",
+      "name": "Hole 1 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole1_clearance_pos": {
+      "id": "hole1_clearance_pos",
+      "name": "Hole 1 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole1_clearance",
+        "offset": {"x": 20, "y": 20, "z": 0}
+      }
+    },
+    "hole1_recess": {
+      "id": "hole1_recess",
+      "name": "Hole 1 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole1_recess_pos": {
+      "id": "hole1_recess_pos",
+      "name": "Hole 1 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole1_recess",
+        "offset": {"x": 20, "y": 20, "z": 8}
+      }
+    },
+    "hole1_combined": {
+      "id": "hole1_combined",
+      "name": "Hole 1 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole1_clearance_pos",
+        "right": "hole1_recess_pos"
+      }
+    },
+    "hole2_clearance": {
+      "id": "hole2_clearance",
+      "name": "Hole 2 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole2_clearance_pos": {
+      "id": "hole2_clearance_pos",
+      "name": "Hole 2 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole2_clearance",
+        "offset": {"x": -20, "y": 20, "z": 0}
+      }
+    },
+    "hole2_recess": {
+      "id": "hole2_recess",
+      "name": "Hole 2 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole2_recess_pos": {
+      "id": "hole2_recess_pos",
+      "name": "Hole 2 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole2_recess",
+        "offset": {"x": -20, "y": 20, "z": 8}
+      }
+    },
+    "hole2_combined": {
+      "id": "hole2_combined",
+      "name": "Hole 2 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole2_clearance_pos",
+        "right": "hole2_recess_pos"
+      }
+    },
+    "hole3_clearance": {
+      "id": "hole3_clearance",
+      "name": "Hole 3 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole3_clearance_pos": {
+      "id": "hole3_clearance_pos",
+      "name": "Hole 3 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole3_clearance",
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "hole3_recess": {
+      "id": "hole3_recess",
+      "name": "Hole 3 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole3_recess_pos": {
+      "id": "hole3_recess_pos",
+      "name": "Hole 3 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole3_recess",
+        "offset": {"x": -20, "y": -20, "z": 8}
+      }
+    },
+    "hole3_combined": {
+      "id": "hole3_combined",
+      "name": "Hole 3 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole3_clearance_pos",
+        "right": "hole3_recess_pos"
+      }
+    },
+    "hole4_clearance": {
+      "id": "hole4_clearance",
+      "name": "Hole 4 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole4_clearance_pos": {
+      "id": "hole4_clearance_pos",
+      "name": "Hole 4 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole4_clearance",
+        "offset": {"x": 20, "y": -20, "z": 0}
+      }
+    },
+    "hole4_recess": {
+      "id": "hole4_recess",
+      "name": "Hole 4 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole4_recess_pos": {
+      "id": "hole4_recess_pos",
+      "name": "Hole 4 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole4_recess",
+        "offset": {"x": 20, "y": -20, "z": 8}
+      }
+    },
+    "hole4_combined": {
+      "id": "hole4_combined",
+      "name": "Hole 4 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole4_clearance_pos",
+        "right": "hole4_recess_pos"
+      }
+    },
+    "all_holes": {
+      "id": "all_holes",
+      "name": "All Holes Union",
+      "op": {
+        "type": "Union",
+        "left": "hole1_combined",
+        "right": "hole2_combined"
+      }
+    },
+    "all_holes_34": {
+      "id": "all_holes_34",
+      "name": "Holes 3 and 4 Union",
+      "op": {
+        "type": "Union",
+        "left": "hole3_combined",
+        "right": "hole4_combined"
+      }
+    },
+    "all_holes_final": {
+      "id": "all_holes_final",
+      "name": "All Four Holes",
+      "op": {
+        "type": "Union",
+        "left": "all_holes",
+        "right": "all_holes_34"
+      }
+    },
+    "final_part": {
+      "id": "final_part",
+      "name": "Counterbore Plate",
+      "op": {
+        "type": "Difference",
+        "left": "plate_centered",
+        "right": "all_holes_final"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_part",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -144,14 +144,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -162,65 +162,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -233,7 +233,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -245,7 +245,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -273,7 +273,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.json
@@ -1,0 +1,313 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120154Z-9ddf",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7898.735257
+      }
+    ],
+    "tokens": {
+      "input": 761,
+      "output": 2048,
+      "total": 2809
+    },
+    "wallclock_sec": 7.898735257
+  },
+  "output": {
+    "vcad_path": "20260429T120154Z-9ddf.vcad",
+    "vcad_sha256": "3d4cf65ae646e0aa0b60a2794732f9e4f8be4e33a40ad3afa92bba0fc1ab2f8e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:54.693Z",
+    "ended_at": "2026-04-29T12:02:02.602Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120154Z-9ddf.vcad
@@ -1,0 +1,254 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate_base": {
+      "id": 0,
+      "name": "plate_base",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 12}
+      }
+    },
+    "plate_centered": {
+      "id": 1,
+      "name": "plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "clearance_hole_1": {
+      "id": 2,
+      "name": "clearance_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_1_positioned": {
+      "id": 3,
+      "name": "clearance_hole_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": 20, "y": 20, "z": 0}
+      }
+    },
+    "recess_hole_1": {
+      "id": 4,
+      "name": "recess_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_hole_1_positioned": {
+      "id": 5,
+      "name": "recess_hole_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": 20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_1": {
+      "id": 6,
+      "name": "counterbore_1",
+      "op": {
+        "type": "Union",
+        "left": 3,
+        "right": 5
+      }
+    },
+    "clearance_hole_2": {
+      "id": 7,
+      "name": "clearance_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_2_positioned": {
+      "id": 8,
+      "name": "clearance_hole_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {"x": -20, "y": 20, "z": 0}
+      }
+    },
+    "recess_hole_2": {
+      "id": 9,
+      "name": "recess_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_hole_2_positioned": {
+      "id": 10,
+      "name": "recess_hole_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 9,
+        "offset": {"x": -20, "y": 20, "z": 8}
+      }
+    },
+    "counterbore_2": {
+      "id": 11,
+      "name": "counterbore_2",
+      "op": {
+        "type": "Union",
+        "left": 8,
+        "right": 10
+      }
+    },
+    "clearance_hole_3": {
+      "id": 12,
+      "name": "clearance_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_3_positioned": {
+      "id": 13,
+      "name": "clearance_hole_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 12,
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "recess_hole_3": {
+      "id": 14,
+      "name": "recess_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_hole_3_positioned": {
+      "id": 15,
+      "name": "recess_hole_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 14,
+        "offset": {"x": -20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_3": {
+      "id": 16,
+      "name": "counterbore_3",
+      "op": {
+        "type": "Union",
+        "left": 13,
+        "right": 15
+      }
+    },
+    "clearance_hole_4": {
+      "id": 17,
+      "name": "clearance_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "clearance_hole_4_positioned": {
+      "id": 18,
+      "name": "clearance_hole_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 17,
+        "offset": {"x": 20, "y": -20, "z": 0}
+      }
+    },
+    "recess_hole_4": {
+      "id": 19,
+      "name": "recess_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "recess_hole_4_positioned": {
+      "id": 20,
+      "name": "recess_hole_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 19,
+        "offset": {"x": 20, "y": -20, "z": 8}
+      }
+    },
+    "counterbore_4": {
+      "id": 21,
+      "name": "counterbore_4",
+      "op": {
+        "type": "Union",
+        "left": 18,
+        "right": 20
+      }
+    },
+    "all_holes": {
+      "id": 22,
+      "name": "all_holes",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 11
+      }
+    },
+    "all_holes_2": {
+      "id": 23,
+      "name": "all_holes_2",
+      "op": {
+        "type": "Union",
+        "left": 22,
+        "right": 16
+      }
+    },
+    "all_holes_3": {
+      "id": 24,
+      "name": "all_holes_3",
+      "op": {
+        "type": "Union",
+        "left": 23,
+        "right": 21
+      }
+    },
+    "final_part": {
+      "id": 25,
+      "name": "final_part",
+      "op": {
+        "type": "Difference",
+        "left": 1,
+        "right": 24
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 25,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.json
@@ -1,0 +1,313 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120202Z-79cb",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8616.408933
+      }
+    ],
+    "tokens": {
+      "input": 761,
+      "output": 2256,
+      "total": 3017
+    },
+    "wallclock_sec": 8.616408933
+  },
+  "output": {
+    "vcad_path": "20260429T120202Z-79cb.vcad",
+    "vcad_sha256": "3402f082de6f715e3c38811aa631ee62bef5a278151a2a1f1321cdb939bf99c4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:02.705Z",
+    "ended_at": "2026-04-29T12:02:11.332Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -144,14 +144,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -162,65 +162,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -233,7 +233,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -245,7 +245,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -273,7 +273,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-haiku-4-5-20251001/20260429T120202Z-79cb.vcad
@@ -1,0 +1,254 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate": {
+      "id": "plate",
+      "name": "Base Plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 12}
+      }
+    },
+    "plate_centered": {
+      "id": "plate_centered",
+      "name": "Centered Plate",
+      "op": {
+        "type": "Translate",
+        "child": "plate",
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "hole1_clear": {
+      "id": "hole1_clear",
+      "name": "Hole 1 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole1_clear_pos": {
+      "id": "hole1_clear_pos",
+      "name": "Hole 1 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole1_clear",
+        "offset": {"x": 20, "y": 20, "z": 0}
+      }
+    },
+    "hole1_recess": {
+      "id": "hole1_recess",
+      "name": "Hole 1 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole1_recess_pos": {
+      "id": "hole1_recess_pos",
+      "name": "Hole 1 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole1_recess",
+        "offset": {"x": 20, "y": 20, "z": 8}
+      }
+    },
+    "hole1_combined": {
+      "id": "hole1_combined",
+      "name": "Hole 1 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole1_clear_pos",
+        "right": "hole1_recess_pos"
+      }
+    },
+    "hole2_clear": {
+      "id": "hole2_clear",
+      "name": "Hole 2 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole2_clear_pos": {
+      "id": "hole2_clear_pos",
+      "name": "Hole 2 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole2_clear",
+        "offset": {"x": -20, "y": 20, "z": 0}
+      }
+    },
+    "hole2_recess": {
+      "id": "hole2_recess",
+      "name": "Hole 2 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole2_recess_pos": {
+      "id": "hole2_recess_pos",
+      "name": "Hole 2 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole2_recess",
+        "offset": {"x": -20, "y": 20, "z": 8}
+      }
+    },
+    "hole2_combined": {
+      "id": "hole2_combined",
+      "name": "Hole 2 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole2_clear_pos",
+        "right": "hole2_recess_pos"
+      }
+    },
+    "hole3_clear": {
+      "id": "hole3_clear",
+      "name": "Hole 3 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole3_clear_pos": {
+      "id": "hole3_clear_pos",
+      "name": "Hole 3 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole3_clear",
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "hole3_recess": {
+      "id": "hole3_recess",
+      "name": "Hole 3 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole3_recess_pos": {
+      "id": "hole3_recess_pos",
+      "name": "Hole 3 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole3_recess",
+        "offset": {"x": -20, "y": -20, "z": 8}
+      }
+    },
+    "hole3_combined": {
+      "id": "hole3_combined",
+      "name": "Hole 3 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole3_clear_pos",
+        "right": "hole3_recess_pos"
+      }
+    },
+    "hole4_clear": {
+      "id": "hole4_clear",
+      "name": "Hole 4 Clearance",
+      "op": {
+        "type": "Cylinder",
+        "radius": 2,
+        "height": 12,
+        "segments": 32
+      }
+    },
+    "hole4_clear_pos": {
+      "id": "hole4_clear_pos",
+      "name": "Hole 4 Clearance Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole4_clear",
+        "offset": {"x": 20, "y": -20, "z": 0}
+      }
+    },
+    "hole4_recess": {
+      "id": "hole4_recess",
+      "name": "Hole 4 Recess",
+      "op": {
+        "type": "Cylinder",
+        "radius": 4,
+        "height": 4,
+        "segments": 32
+      }
+    },
+    "hole4_recess_pos": {
+      "id": "hole4_recess_pos",
+      "name": "Hole 4 Recess Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole4_recess",
+        "offset": {"x": 20, "y": -20, "z": 8}
+      }
+    },
+    "hole4_combined": {
+      "id": "hole4_combined",
+      "name": "Hole 4 Combined",
+      "op": {
+        "type": "Union",
+        "left": "hole4_clear_pos",
+        "right": "hole4_recess_pos"
+      }
+    },
+    "all_holes": {
+      "id": "all_holes",
+      "name": "All Holes",
+      "op": {
+        "type": "Union",
+        "left": "hole1_combined",
+        "right": "hole2_combined"
+      }
+    },
+    "all_holes_3": {
+      "id": "all_holes_3",
+      "name": "All Holes 3",
+      "op": {
+        "type": "Union",
+        "left": "all_holes",
+        "right": "hole3_combined"
+      }
+    },
+    "all_holes_4": {
+      "id": "all_holes_4",
+      "name": "All Holes 4",
+      "op": {
+        "type": "Union",
+        "left": "all_holes_3",
+        "right": "hole4_combined"
+      }
+    },
+    "final": {
+      "id": "final",
+      "name": "Counterbore Plate",
+      "op": {
+        "type": "Difference",
+        "left": "plate_centered",
+        "right": "all_holes_4"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120120Z-2865",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12118.684033
+      }
+    ],
+    "tokens": {
+      "input": 985,
+      "output": 1562,
+      "total": 2547
+    },
+    "wallclock_sec": 12.118684033
+  },
+  "output": {
+    "vcad_path": "20260429T120120Z-2865.vcad",
+    "vcad_sha256": "e181a9e1d4833a82f7bf41821943a3947f2d35bdd2cadda5750d732ff75ce24a",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:20.594Z",
+    "ended_at": "2026-04-29T12:01:33.104Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120120Z-2865.vcad
@@ -1,0 +1,40 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "hole1_thru", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "hole1_thru_pos", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "hole1_cb", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "hole1_cb_pos", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+    "14": {"id": 14, "name": "hole1", "op": {"type": "Union", "left": 11, "right": 13}},
+
+    "20": {"id": 20, "name": "hole2_thru", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "hole2_thru_pos", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "hole2_cb", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "hole2_cb_pos", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+    "24": {"id": 24, "name": "hole2", "op": {"type": "Union", "left": 21, "right": 23}},
+
+    "30": {"id": 30, "name": "hole3_thru", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "hole3_thru_pos", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "hole3_cb", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "hole3_cb_pos", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+    "34": {"id": 34, "name": "hole3", "op": {"type": "Union", "left": 31, "right": 33}},
+
+    "40": {"id": 40, "name": "hole4_thru", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "hole4_thru_pos", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "hole4_cb", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "hole4_cb_pos", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+    "44": {"id": 44, "name": "hole4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "50": {"id": 50, "name": "holes12", "op": {"type": "Union", "left": 14, "right": 24}},
+    "51": {"id": 51, "name": "holes34", "op": {"type": "Union", "left": 34, "right": 44}},
+    "52": {"id": 52, "name": "all_holes", "op": {"type": "Union", "left": 50, "right": 51}},
+
+    "60": {"id": 60, "name": "result", "op": {"type": "Difference", "left": 2, "right": 52}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 60, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120133Z-dcba",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12693.406335000001
+      }
+    ],
+    "tokens": {
+      "input": 985,
+      "output": 1530,
+      "total": 2515
+    },
+    "wallclock_sec": 12.693406335000002
+  },
+  "output": {
+    "vcad_path": "20260429T120133Z-dcba.vcad",
+    "vcad_sha256": "fde9444aad196501b3118986531479df31c38c3b0c9c41b33e46600c2b26ec62",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:33.176Z",
+    "ended_at": "2026-04-29T12:01:46.284Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120133Z-dcba.vcad
@@ -1,0 +1,40 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "hole1", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "hole1_pos", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "cbore1", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "cbore1_pos", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+    "14": {"id": 14, "name": "cb_union1", "op": {"type": "Union", "left": 11, "right": 13}},
+
+    "20": {"id": 20, "name": "hole2", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "hole2_pos", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "cbore2", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "cbore2_pos", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+    "24": {"id": 24, "name": "cb_union2", "op": {"type": "Union", "left": 21, "right": 23}},
+
+    "30": {"id": 30, "name": "hole3", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "hole3_pos", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "cbore3", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "cbore3_pos", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+    "34": {"id": 34, "name": "cb_union3", "op": {"type": "Union", "left": 31, "right": 33}},
+
+    "40": {"id": 40, "name": "hole4", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "hole4_pos", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "cbore4", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "cbore4_pos", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+    "44": {"id": 44, "name": "cb_union4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "50": {"id": 50, "name": "all_12", "op": {"type": "Union", "left": 14, "right": 24}},
+    "51": {"id": 51, "name": "all_123", "op": {"type": "Union", "left": 50, "right": 34}},
+    "52": {"id": 52, "name": "all_holes", "op": {"type": "Union", "left": 51, "right": 44}},
+
+    "60": {"id": 60, "name": "result", "op": {"type": "Difference", "left": 2, "right": 52}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 60, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120146Z-866a",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12348.64952
+      }
+    ],
+    "tokens": {
+      "input": 985,
+      "output": 1564,
+      "total": 2549
+    },
+    "wallclock_sec": 12.34864952
+  },
+  "output": {
+    "vcad_path": "20260429T120146Z-866a.vcad",
+    "vcad_sha256": "474d0af020316ea7405d724c3e3ec93ef31a89d8e12a3198d024176abb8a2e50",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:46.352Z",
+    "ended_at": "2026-04-29T12:01:59.094Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120146Z-866a.vcad
@@ -1,0 +1,40 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "hole1_through_raw", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "hole1_through", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "hole1_cbore_raw", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "hole1_cbore", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+    "14": {"id": 14, "name": "hole1", "op": {"type": "Union", "left": 11, "right": 13}},
+
+    "20": {"id": 20, "name": "hole2_through_raw", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "hole2_through", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "hole2_cbore_raw", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "hole2_cbore", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+    "24": {"id": 24, "name": "hole2", "op": {"type": "Union", "left": 21, "right": 23}},
+
+    "30": {"id": 30, "name": "hole3_through_raw", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "hole3_through", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "hole3_cbore_raw", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "hole3_cbore", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+    "34": {"id": 34, "name": "hole3", "op": {"type": "Union", "left": 31, "right": 33}},
+
+    "40": {"id": 40, "name": "hole4_through_raw", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "hole4_through", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "hole4_cbore_raw", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "hole4_cbore", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+    "44": {"id": 44, "name": "hole4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "50": {"id": 50, "name": "holes_12", "op": {"type": "Union", "left": 14, "right": 24}},
+    "51": {"id": 51, "name": "holes_34", "op": {"type": "Union", "left": 34, "right": 44}},
+    "52": {"id": 52, "name": "all_holes", "op": {"type": "Union", "left": 50, "right": 51}},
+
+    "60": {"id": 60, "name": "result", "op": {"type": "Difference", "left": 2, "right": 52}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 60, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120159Z-74ce",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 13264.575569
+      }
+    ],
+    "tokens": {
+      "input": 985,
+      "output": 1564,
+      "total": 2549
+    },
+    "wallclock_sec": 13.264575569
+  },
+  "output": {
+    "vcad_path": "20260429T120159Z-74ce.vcad",
+    "vcad_sha256": "fbdffaf88400e4e28e17c8fbb0fc9627f7ebe0741662fa490e39db90a50834fe",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:59.160Z",
+    "ended_at": "2026-04-29T12:02:12.819Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120159Z-74ce.vcad
@@ -1,0 +1,40 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "hole1_through", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "hole1_through_pos", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "hole1_cbore", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "hole1_cbore_pos", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+    "14": {"id": 14, "name": "hole1", "op": {"type": "Union", "left": 11, "right": 13}},
+
+    "20": {"id": 20, "name": "hole2_through", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "hole2_through_pos", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "hole2_cbore", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "hole2_cbore_pos", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+    "24": {"id": 24, "name": "hole2", "op": {"type": "Union", "left": 21, "right": 23}},
+
+    "30": {"id": 30, "name": "hole3_through", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "hole3_through_pos", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "hole3_cbore", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "hole3_cbore_pos", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+    "34": {"id": 34, "name": "hole3", "op": {"type": "Union", "left": 31, "right": 33}},
+
+    "40": {"id": 40, "name": "hole4_through", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "hole4_through_pos", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "hole4_cbore", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "hole4_cbore_pos", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+    "44": {"id": 44, "name": "hole4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "50": {"id": 50, "name": "holes_12", "op": {"type": "Union", "left": 14, "right": 24}},
+    "51": {"id": 51, "name": "holes_34", "op": {"type": "Union", "left": 34, "right": 44}},
+    "52": {"id": 52, "name": "all_holes", "op": {"type": "Union", "left": 50, "right": 51}},
+
+    "100": {"id": 100, "name": "result", "op": {"type": "Difference", "left": 2, "right": 52}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 100, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120212Z-f6e6",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12993.858096999998
+      }
+    ],
+    "tokens": {
+      "input": 985,
+      "output": 1514,
+      "total": 2499
+    },
+    "wallclock_sec": 12.993858096999999
+  },
+  "output": {
+    "vcad_path": "20260429T120212Z-f6e6.vcad",
+    "vcad_sha256": "d519784614c0a6d2560372e68e838b663a3707307b8d74a23b6a10e7e96e074b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:12.885Z",
+    "ended_at": "2026-04-29T12:02:26.292Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-opus-4-7/20260429T120212Z-f6e6.vcad
@@ -1,0 +1,40 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "thru1", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "thru1_pos", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "cb1", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "cb1_pos", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+    "14": {"id": 14, "name": "hole1", "op": {"type": "Union", "left": 11, "right": 13}},
+
+    "20": {"id": 20, "name": "thru2", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "thru2_pos", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "cb2", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "cb2_pos", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+    "24": {"id": 24, "name": "hole2", "op": {"type": "Union", "left": 21, "right": 23}},
+
+    "30": {"id": 30, "name": "thru3", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "thru3_pos", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "cb3", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "cb3_pos", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+    "34": {"id": 34, "name": "hole3", "op": {"type": "Union", "left": 31, "right": 33}},
+
+    "40": {"id": 40, "name": "thru4", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "thru4_pos", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "cb4", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "cb4_pos", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+    "44": {"id": 44, "name": "hole4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "50": {"id": 50, "name": "holes12", "op": {"type": "Union", "left": 14, "right": 24}},
+    "51": {"id": 51, "name": "holes123", "op": {"type": "Union", "left": 50, "right": 34}},
+    "52": {"id": 52, "name": "holes_all", "op": {"type": "Union", "left": 51, "right": 44}},
+
+    "100": {"id": 100, "name": "result", "op": {"type": "Difference", "left": 2, "right": 52}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 100, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120123Z-17a3",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 13823.923267
+      }
+    ],
+    "tokens": {
+      "input": 762,
+      "output": 1418,
+      "total": 2180
+    },
+    "wallclock_sec": 13.823923267
+  },
+  "output": {
+    "vcad_path": "20260429T120123Z-17a3.vcad",
+    "vcad_sha256": "49a3c7b298308521bcbcfc06d54256c002c89f9e057da2283d17082488ab3bfd",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:23.859Z",
+    "ended_at": "2026-04-29T12:01:38.073Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120123Z-17a3.vcad
@@ -1,0 +1,41 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "cl_hole_pp", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "cl_hole_pp_t", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "cb_recess_pp", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "cb_recess_pp_t", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+
+    "20": {"id": 20, "name": "cl_hole_np", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "cl_hole_np_t", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "cb_recess_np", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "cb_recess_np_t", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+
+    "30": {"id": 30, "name": "cl_hole_nn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "cl_hole_nn_t", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "cb_recess_nn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "cb_recess_nn_t", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+
+    "40": {"id": 40, "name": "cl_hole_pn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "cl_hole_pn_t", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "cb_recess_pn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "cb_recess_pn_t", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+
+    "50": {"id": 50, "name": "union_pp_cl_cb", "op": {"type": "Union", "left": 11, "right": 13}},
+    "51": {"id": 51, "name": "union_np_cl_cb", "op": {"type": "Union", "left": 21, "right": 23}},
+    "52": {"id": 52, "name": "union_nn_cl_cb", "op": {"type": "Union", "left": 31, "right": 33}},
+    "53": {"id": 53, "name": "union_pn_cl_cb", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "60": {"id": 60, "name": "union_cut_1", "op": {"type": "Union", "left": 50, "right": 51}},
+    "61": {"id": 61, "name": "union_cut_2", "op": {"type": "Union", "left": 52, "right": 53}},
+    "62": {"id": 62, "name": "union_all_cuts", "op": {"type": "Union", "left": 60, "right": 61}},
+
+    "100": {"id": 100, "name": "result", "op": {"type": "Difference", "left": 2, "right": 62}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 100, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120138Z-b7b4",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10598.653898
+      }
+    ],
+    "tokens": {
+      "input": 762,
+      "output": 1371,
+      "total": 2133
+    },
+    "wallclock_sec": 10.598653898
+  },
+  "output": {
+    "vcad_path": "20260429T120138Z-b7b4.vcad",
+    "vcad_sha256": "ce8ce7022a9ed3af3586069a90d4eac598476a29f48bd4c35192e78006be480c",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:38.142Z",
+    "ended_at": "2026-04-29T12:01:49.138Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120138Z-b7b4.vcad
@@ -1,0 +1,41 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "ch1_small", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "ch1_small_t", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "ch1_large", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "ch1_large_t", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+
+    "20": {"id": 20, "name": "ch2_small", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "ch2_small_t", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "ch2_large", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "ch2_large_t", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+
+    "30": {"id": 30, "name": "ch3_small", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "ch3_small_t", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "ch3_large", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "ch3_large_t", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+
+    "40": {"id": 40, "name": "ch4_small", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "ch4_small_t", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "ch4_large", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "ch4_large_t", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+
+    "50": {"id": 50, "name": "union_ch1", "op": {"type": "Union", "left": 11, "right": 13}},
+    "51": {"id": 51, "name": "union_ch2", "op": {"type": "Union", "left": 21, "right": 23}},
+    "52": {"id": 52, "name": "union_ch3", "op": {"type": "Union", "left": 31, "right": 33}},
+    "53": {"id": 53, "name": "union_ch4", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "60": {"id": 60, "name": "union_12", "op": {"type": "Union", "left": 50, "right": 51}},
+    "61": {"id": 61, "name": "union_34", "op": {"type": "Union", "left": 52, "right": 53}},
+    "62": {"id": 62, "name": "all_holes", "op": {"type": "Union", "left": 60, "right": 61}},
+
+    "70": {"id": 70, "name": "result", "op": {"type": "Difference", "left": 2, "right": 62}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 70, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120149Z-6f3f",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10904.566246
+      }
+    ],
+    "tokens": {
+      "input": 762,
+      "output": 1411,
+      "total": 2173
+    },
+    "wallclock_sec": 10.904566246
+  },
+  "output": {
+    "vcad_path": "20260429T120149Z-6f3f.vcad",
+    "vcad_sha256": "f83bce4992faf835b937681d5123394621737434c0cd8617c00e6ebed36b9273",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:01:49.204Z",
+    "ended_at": "2026-04-29T12:02:00.514Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120149Z-6f3f.vcad
@@ -1,0 +1,41 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "clear_hole_1_cyl", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "clear_hole_1", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "cbore_hole_1_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "cbore_hole_1", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+
+    "20": {"id": 20, "name": "clear_hole_2_cyl", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "clear_hole_2", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "cbore_hole_2_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "cbore_hole_2", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+
+    "30": {"id": 30, "name": "clear_hole_3_cyl", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "clear_hole_3", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "cbore_hole_3_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "cbore_hole_3", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+
+    "40": {"id": 40, "name": "clear_hole_4_cyl", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "clear_hole_4", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "cbore_hole_4_cyl", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "cbore_hole_4", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+
+    "50": {"id": 50, "name": "holes_1_union", "op": {"type": "Union", "left": 11, "right": 13}},
+    "51": {"id": 51, "name": "holes_2_union", "op": {"type": "Union", "left": 21, "right": 23}},
+    "52": {"id": 52, "name": "holes_3_union", "op": {"type": "Union", "left": 31, "right": 33}},
+    "53": {"id": 53, "name": "holes_4_union", "op": {"type": "Union", "left": 41, "right": 43}},
+
+    "60": {"id": 60, "name": "all_holes_12", "op": {"type": "Union", "left": 50, "right": 51}},
+    "61": {"id": 61, "name": "all_holes_34", "op": {"type": "Union", "left": 52, "right": 53}},
+    "62": {"id": 62, "name": "all_holes", "op": {"type": "Union", "left": 60, "right": 61}},
+
+    "100": {"id": 100, "name": "result", "op": {"type": "Difference", "left": 2, "right": 62}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 100, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120200Z-8e34",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12912.90584
+      }
+    ],
+    "tokens": {
+      "input": 762,
+      "output": 1364,
+      "total": 2126
+    },
+    "wallclock_sec": 12.912905839999999
+  },
+  "output": {
+    "vcad_path": "20260429T120200Z-8e34.vcad",
+    "vcad_sha256": "a464850820b4a71c4fcc9d1cc29a75bbecf472793ef0c0e3a57aedd6cb91233b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:00.578Z",
+    "ended_at": "2026-04-29T12:02:13.972Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120200Z-8e34.vcad
@@ -1,0 +1,39 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "10": {"id": 10, "name": "thru_pp", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "thru_pp_t", "op": {"type": "Translate", "child": 10, "offset": {"x": 20, "y": 20, "z": 0}}},
+    "12": {"id": 12, "name": "cb_pp", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "13": {"id": 13, "name": "cb_pp_t", "op": {"type": "Translate", "child": 12, "offset": {"x": 20, "y": 20, "z": 8}}},
+
+    "20": {"id": 20, "name": "thru_np", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "21": {"id": 21, "name": "thru_np_t", "op": {"type": "Translate", "child": 20, "offset": {"x": -20, "y": 20, "z": 0}}},
+    "22": {"id": 22, "name": "cb_np", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "23": {"id": 23, "name": "cb_np_t", "op": {"type": "Translate", "child": 22, "offset": {"x": -20, "y": 20, "z": 8}}},
+
+    "30": {"id": 30, "name": "thru_nn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "31": {"id": 31, "name": "thru_nn_t", "op": {"type": "Translate", "child": 30, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "32": {"id": 32, "name": "cb_nn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "33": {"id": 33, "name": "cb_nn_t", "op": {"type": "Translate", "child": 32, "offset": {"x": -20, "y": -20, "z": 8}}},
+
+    "40": {"id": 40, "name": "thru_pn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "41": {"id": 41, "name": "thru_pn_t", "op": {"type": "Translate", "child": 40, "offset": {"x": 20, "y": -20, "z": 0}}},
+    "42": {"id": 42, "name": "cb_pn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "43": {"id": 43, "name": "cb_pn_t", "op": {"type": "Translate", "child": 42, "offset": {"x": 20, "y": -20, "z": 8}}},
+
+    "50": {"id": 50, "name": "d1", "op": {"type": "Difference", "left": 2, "right": 11}},
+    "51": {"id": 51, "name": "d2", "op": {"type": "Difference", "left": 50, "right": 13}},
+    "52": {"id": 52, "name": "d3", "op": {"type": "Difference", "left": 51, "right": 21}},
+    "53": {"id": 53, "name": "d4", "op": {"type": "Difference", "left": 52, "right": 23}},
+    "54": {"id": 54, "name": "d5", "op": {"type": "Difference", "left": 53, "right": 31}},
+    "55": {"id": 55, "name": "d6", "op": {"type": "Difference", "left": 54, "right": 33}},
+    "56": {"id": 56, "name": "d7", "op": {"type": "Difference", "left": 55, "right": 41}},
+    "57": {"id": 57, "name": "d8", "op": {"type": "Difference", "left": 56, "right": 43}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 57, "material": "default"}]
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.json
@@ -1,0 +1,451 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-counterbore-plate-01",
+  "task_sha256": "cfd43e4b06b57f9083f3574a94ff3334d151693aea721bd7fdce1521bd5ad111",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -30,
+          -30,
+          0
+        ],
+        "max": [
+          30,
+          30,
+          12
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          30,
+          30,
+          12
+        ],
+        "actual_min": [
+          -30,
+          -30,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 41993.63,
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 42001.36506291386,
+          "deviation_pct": 0.018419610102437013,
+          "pass": true,
+          "spec_mm3": 41993.63,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 4,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 4,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            4
+          ],
+          [
+            -20,
+            20,
+            4
+          ],
+          [
+            -20,
+            -20,
+            4
+          ],
+          [
+            20,
+            -20,
+            4
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 4,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 4,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 8,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 8,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            20,
+            20,
+            8
+          ],
+          [
+            -20,
+            20,
+            8
+          ],
+          [
+            -20,
+            -20,
+            8
+          ],
+          [
+            20,
+            -20,
+            8
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 8,
+        "positions": [
+          [
+            20,
+            20,
+            0
+          ],
+          [
+            -20,
+            20,
+            0
+          ],
+          [
+            -20,
+            -20,
+            0
+          ],
+          [
+            20,
+            -20,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 8,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              -20
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              -20
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              -20
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                30,
+                30,
+                12
+              ],
+              "original_min": [
+                -30,
+                -30,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                30,
+                30,
+                12
+              ],
+              "roundtripped_min": [
+                -30,
+                -30,
+                0
+              ],
+              "tolerance_mm": 0.856971411425142
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 42001.36506291386,
+              "pass": true,
+              "roundtripped_mm3": 42001.36506291386
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120214Z-f57e",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-counterbore-plate-01",
+    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 579
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 15652.403862
+      }
+    ],
+    "tokens": {
+      "input": 762,
+      "output": 1476,
+      "total": 2238
+    },
+    "wallclock_sec": 15.652403862
+  },
+  "output": {
+    "vcad_path": "20260429T120214Z-f57e.vcad",
+    "vcad_sha256": "3f9ece573569c6a277ea416f613309006638ddf23beae2845686c07a322d3223",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:14.040Z",
+    "ended_at": "2026-04-29T12:02:30.086Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.json
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          30,
-          30,
-          12
+          30.0,
+          30.0,
+          12.0
         ],
         "actual_min": [
-          -30,
-          -30,
-          0
+          -30.0,
+          -30.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,7 +64,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 41993.63,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -73,7 +73,7 @@
           "deviation_pct": 0.018419610102437013,
           "pass": true,
           "spec_mm3": 41993.63,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            4
+            20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            20,
-            4
+            -20.0,
+            20.0,
+            4.0
           ],
           [
-            -20,
-            -20,
-            4
+            -20.0,
+            -20.0,
+            4.0
           ],
           [
-            20,
-            -20,
-            4
+            20.0,
+            -20.0,
+            4.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 4,
+        "diameter_mm": 4.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -208,36 +208,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            20,
-            20,
-            8
+            20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            20,
-            8
+            -20.0,
+            20.0,
+            8.0
           ],
           [
-            -20,
-            -20,
-            8
+            -20.0,
+            -20.0,
+            8.0
           ],
           [
-            20,
-            -20,
-            8
+            20.0,
+            -20.0,
+            8.0
           ]
         ]
       }
@@ -247,81 +247,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "positions": [
           [
-            20,
-            20,
-            0
+            20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            20,
-            0
+            -20.0,
+            20.0,
+            0.0
           ],
           [
-            -20,
-            -20,
-            0
+            -20.0,
+            -20.0,
+            0.0
           ],
           [
-            20,
-            -20,
-            0
+            20.0,
+            -20.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 8,
+        "diameter_mm": 8.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              20
+              20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              20
+              20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              20
+              -20.0,
+              20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              20
+              -20.0,
+              20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              -20
+              -20.0,
+              -20.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              -20
+              20.0,
+              -20.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              -20
+              20.0,
+              -20.0
             ]
           }
         ],
@@ -334,48 +334,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "original_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                30,
-                30,
-                12
+                30.0,
+                30.0,
+                12.0
               ],
               "roundtripped_min": [
-                -30,
-                -30,
-                0
+                -30.0,
+                -30.0,
+                0.0
               ],
               "tolerance_mm": 0.856971411425142
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
+              "deviation_pct": 0.0,
               "original_mm3": 42001.36506291386,
               "pass": true,
               "roundtripped_mm3": 42001.36506291386
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -383,7 +383,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -411,7 +411,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-counterbore-plate-01",
-    "rendered": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+    "rendered": "Make a single solid: a flat plate 60mm \u00d7 60mm \u00d7 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.vcad
+++ b/mecheval/runs/a4-counterbore-plate-01/claude-direct-claude-sonnet-4-6/20260429T120214Z-f57e.vcad
@@ -1,0 +1,45 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_plate", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 12}}},
+    "2": {"id": 2, "name": "base_plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -30, "z": 0}}},
+
+    "3": {"id": 3, "name": "thru_cyl_pp", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "4": {"id": 4, "name": "thru_pp", "op": {"type": "Translate", "child": 3, "offset": {"x": 20, "y": 20, "z": 0}}},
+
+    "5": {"id": 5, "name": "recess_cyl_pp", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "6": {"id": 6, "name": "recess_pp", "op": {"type": "Translate", "child": 5, "offset": {"x": 20, "y": 20, "z": 8}}},
+
+    "7": {"id": 7, "name": "thru_cyl_np", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "8": {"id": 8, "name": "thru_np", "op": {"type": "Translate", "child": 7, "offset": {"x": -20, "y": 20, "z": 0}}},
+
+    "9": {"id": 9, "name": "recess_cyl_np", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "10": {"id": 10, "name": "recess_np", "op": {"type": "Translate", "child": 9, "offset": {"x": -20, "y": 20, "z": 8}}},
+
+    "11": {"id": 11, "name": "thru_cyl_nn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "12": {"id": 12, "name": "thru_nn", "op": {"type": "Translate", "child": 11, "offset": {"x": -20, "y": -20, "z": 0}}},
+
+    "13": {"id": 13, "name": "recess_cyl_nn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "14": {"id": 14, "name": "recess_nn", "op": {"type": "Translate", "child": 13, "offset": {"x": -20, "y": -20, "z": 8}}},
+
+    "15": {"id": 15, "name": "thru_cyl_pn", "op": {"type": "Cylinder", "radius": 2, "height": 12, "segments": 32}},
+    "16": {"id": 16, "name": "thru_pn", "op": {"type": "Translate", "child": 15, "offset": {"x": 20, "y": -20, "z": 0}}},
+
+    "17": {"id": 17, "name": "recess_cyl_pn", "op": {"type": "Cylinder", "radius": 4, "height": 4, "segments": 32}},
+    "18": {"id": 18, "name": "recess_pn", "op": {"type": "Translate", "child": 17, "offset": {"x": 20, "y": -20, "z": 8}}},
+
+    "19": {"id": 19, "name": "cutters_union_1", "op": {"type": "Union", "left": 4, "right": 6}},
+    "20": {"id": 20, "name": "cutters_union_2", "op": {"type": "Union", "left": 8, "right": 10}},
+    "21": {"id": 21, "name": "cutters_union_3", "op": {"type": "Union", "left": 12, "right": 14}},
+    "22": {"id": 22, "name": "cutters_union_4", "op": {"type": "Union", "left": 16, "right": 18}},
+
+    "23": {"id": 23, "name": "all_cutters_a", "op": {"type": "Union", "left": 19, "right": 20}},
+    "24": {"id": 24, "name": "all_cutters_b", "op": {"type": "Union", "left": 21, "right": 22}},
+    "25": {"id": 25, "name": "all_cutters", "op": {"type": "Union", "left": 23, "right": 24}},
+
+    "26": {"id": 26, "name": "result", "op": {"type": "Difference", "left": 2, "right": 25}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 26, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -123,65 +123,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -206,7 +206,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120225Z-fa65",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5255.746506
+      }
+    ],
+    "tokens": {
+      "input": 794,
+      "output": 1221,
+      "total": 2015
+    },
+    "wallclock_sec": 5.255746506
+  },
+  "output": {
+    "vcad_path": "20260429T120225Z-fa65.vcad",
+    "vcad_sha256": "3b4d35c6b3a7aed88e48cd17a86f278d2443765d725fa28f11ba940d1ee68901",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:25.047Z",
+    "ended_at": "2026-04-29T12:02:30.312Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120225Z-fa65.vcad
@@ -1,0 +1,98 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "flange_base": {
+      "id": 1,
+      "name": "flange_base",
+      "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 32}
+    },
+    "shaft_cyl": {
+      "id": 2,
+      "name": "shaft_cyl",
+      "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 32}
+    },
+    "shaft_translated": {
+      "id": 3,
+      "name": "shaft_translated",
+      "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}
+    },
+    "flange_and_shaft": {
+      "id": 4,
+      "name": "flange_and_shaft",
+      "op": {"type": "Union", "left": 1, "right": 3}
+    },
+    "center_bore": {
+      "id": 5,
+      "name": "center_bore",
+      "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 32}
+    },
+    "with_center_bore": {
+      "id": 6,
+      "name": "with_center_bore",
+      "op": {"type": "Difference", "left": 4, "right": 5}
+    },
+    "bolt_hole_1": {
+      "id": 7,
+      "name": "bolt_hole_1",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_1_positioned": {
+      "id": 8,
+      "name": "bolt_hole_1_positioned",
+      "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}
+    },
+    "bolt_hole_2": {
+      "id": 9,
+      "name": "bolt_hole_2",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_2_positioned": {
+      "id": 10,
+      "name": "bolt_hole_2_positioned",
+      "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}
+    },
+    "bolt_hole_3": {
+      "id": 11,
+      "name": "bolt_hole_3",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_3_positioned": {
+      "id": 12,
+      "name": "bolt_hole_3_positioned",
+      "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}
+    },
+    "bolt_hole_4": {
+      "id": 13,
+      "name": "bolt_hole_4",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_4_positioned": {
+      "id": 14,
+      "name": "bolt_hole_4_positioned",
+      "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}
+    },
+    "with_bolt_holes_1": {
+      "id": 15,
+      "name": "with_bolt_holes_1",
+      "op": {"type": "Difference", "left": 6, "right": 8}
+    },
+    "with_bolt_holes_2": {
+      "id": 16,
+      "name": "with_bolt_holes_2",
+      "op": {"type": "Difference", "left": 15, "right": 10}
+    },
+    "with_bolt_holes_3": {
+      "id": 17,
+      "name": "with_bolt_holes_3",
+      "op": {"type": "Difference", "left": 16, "right": 12}
+    },
+    "final_shaft": {
+      "id": 18,
+      "name": "final_shaft",
+      "op": {"type": "Difference", "left": 17, "right": 14}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120230Z-3962",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5945.953215
+      }
+    ],
+    "tokens": {
+      "input": 794,
+      "output": 1389,
+      "total": 2183
+    },
+    "wallclock_sec": 5.945953214999999
+  },
+  "output": {
+    "vcad_path": "20260429T120230Z-3962.vcad",
+    "vcad_sha256": "98ad65aebec9220111f0ed5c94f28489dd7534a3bf6ab49f33d0053f7112080e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:30.420Z",
+    "ended_at": "2026-04-29T12:02:36.375Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -123,65 +123,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -206,7 +206,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120230Z-3962.vcad
@@ -1,0 +1,98 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "flange_cyl": {
+      "id": "flange_cyl",
+      "name": "Flange cylinder",
+      "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 32}
+    },
+    "shaft_cyl": {
+      "id": "shaft_cyl",
+      "name": "Shaft cylinder",
+      "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 32}
+    },
+    "shaft_translated": {
+      "id": "shaft_translated",
+      "name": "Shaft translated to z=10",
+      "op": {"type": "Translate", "child": "shaft_cyl", "offset": {"x": 0, "y": 0, "z": 10}}
+    },
+    "flange_and_shaft": {
+      "id": "flange_and_shaft",
+      "name": "Flange and shaft combined",
+      "op": {"type": "Union", "left": "flange_cyl", "right": "shaft_translated"}
+    },
+    "central_bore": {
+      "id": "central_bore",
+      "name": "Central bore cylinder",
+      "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 32}
+    },
+    "bolt_hole_1": {
+      "id": "bolt_hole_1",
+      "name": "Bolt hole 1 at +X",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_1_trans": {
+      "id": "bolt_hole_1_trans",
+      "name": "Bolt hole 1 translated",
+      "op": {"type": "Translate", "child": "bolt_hole_1", "offset": {"x": 30, "y": 0, "z": 0}}
+    },
+    "bolt_hole_2": {
+      "id": "bolt_hole_2",
+      "name": "Bolt hole 2 at +Y",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_2_trans": {
+      "id": "bolt_hole_2_trans",
+      "name": "Bolt hole 2 translated",
+      "op": {"type": "Translate", "child": "bolt_hole_2", "offset": {"x": 0, "y": 30, "z": 0}}
+    },
+    "bolt_hole_3": {
+      "id": "bolt_hole_3",
+      "name": "Bolt hole 3 at -X",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_3_trans": {
+      "id": "bolt_hole_3_trans",
+      "name": "Bolt hole 3 translated",
+      "op": {"type": "Translate", "child": "bolt_hole_3", "offset": {"x": -30, "y": 0, "z": 0}}
+    },
+    "bolt_hole_4": {
+      "id": "bolt_hole_4",
+      "name": "Bolt hole 4 at -Y",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "bolt_hole_4_trans": {
+      "id": "bolt_hole_4_trans",
+      "name": "Bolt hole 4 translated",
+      "op": {"type": "Translate", "child": "bolt_hole_4", "offset": {"x": 0, "y": -30, "z": 0}}
+    },
+    "all_bolt_holes": {
+      "id": "all_bolt_holes",
+      "name": "Union of all bolt holes",
+      "op": {"type": "Union", "left": "bolt_hole_1_trans", "right": "bolt_hole_2_trans"}
+    },
+    "all_bolt_holes_2": {
+      "id": "all_bolt_holes_2",
+      "name": "Union of bolt holes 1,2,3",
+      "op": {"type": "Union", "left": "all_bolt_holes", "right": "bolt_hole_3_trans"}
+    },
+    "all_bolt_holes_3": {
+      "id": "all_bolt_holes_3",
+      "name": "Union of all 4 bolt holes",
+      "op": {"type": "Union", "left": "all_bolt_holes_2", "right": "bolt_hole_4_trans"}
+    },
+    "all_holes": {
+      "id": "all_holes",
+      "name": "Central bore and bolt holes",
+      "op": {"type": "Union", "left": "central_bore", "right": "all_bolt_holes_3"}
+    },
+    "final_shaft": {
+      "id": "final_shaft",
+      "name": "Flanged hollow shaft",
+      "op": {"type": "Difference", "left": "flange_and_shaft", "right": "all_holes"}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "final_shaft", "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -123,65 +123,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -206,7 +206,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120236Z-7bd7",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5854.118579999999
+      }
+    ],
+    "tokens": {
+      "input": 794,
+      "output": 1450,
+      "total": 2244
+    },
+    "wallclock_sec": 5.85411858
+  },
+  "output": {
+    "vcad_path": "20260429T120236Z-7bd7.vcad",
+    "vcad_sha256": "4d146360dd69f516e26dc9b3cf9059f5edf9de7af73f2b0d97086a7821000665",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:36.475Z",
+    "ended_at": "2026-04-29T12:02:42.340Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120236Z-7bd7.vcad
@@ -1,0 +1,202 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "flange_base": {
+      "id": 0,
+      "name": "flange_base",
+      "op": {
+        "type": "Cylinder",
+        "radius": 40,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "shaft_base": {
+      "id": 1,
+      "name": "shaft_base",
+      "op": {
+        "type": "Cylinder",
+        "radius": 15,
+        "height": 50,
+        "segments": 32
+      }
+    },
+    "shaft_translated": {
+      "id": 2,
+      "name": "shaft_translated",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 10
+        }
+      }
+    },
+    "flange_and_shaft": {
+      "id": 3,
+      "name": "flange_and_shaft",
+      "op": {
+        "type": "Union",
+        "left": 0,
+        "right": 2
+      }
+    },
+    "central_bore": {
+      "id": 4,
+      "name": "central_bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 7.5,
+        "height": 60,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1": {
+      "id": 5,
+      "name": "bolt_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1_positioned": {
+      "id": 6,
+      "name": "bolt_hole_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 5,
+        "offset": {
+          "x": 30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_2": {
+      "id": 7,
+      "name": "bolt_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2_positioned": {
+      "id": 8,
+      "name": "bolt_hole_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {
+          "x": 0,
+          "y": 30,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_3": {
+      "id": 9,
+      "name": "bolt_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_3_positioned": {
+      "id": 10,
+      "name": "bolt_hole_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 9,
+        "offset": {
+          "x": -30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_4": {
+      "id": 11,
+      "name": "bolt_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_4_positioned": {
+      "id": 12,
+      "name": "bolt_hole_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 11,
+        "offset": {
+          "x": 0,
+          "y": -30,
+          "z": 0
+        }
+      }
+    },
+    "all_bolt_holes": {
+      "id": 13,
+      "name": "all_bolt_holes",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 8
+      }
+    },
+    "all_bolt_holes_2": {
+      "id": 14,
+      "name": "all_bolt_holes_2",
+      "op": {
+        "type": "Union",
+        "left": 13,
+        "right": 10
+      }
+    },
+    "all_bolt_holes_3": {
+      "id": 15,
+      "name": "all_bolt_holes_3",
+      "op": {
+        "type": "Union",
+        "left": 14,
+        "right": 12
+      }
+    },
+    "with_central_bore": {
+      "id": 16,
+      "name": "with_central_bore",
+      "op": {
+        "type": "Difference",
+        "left": 3,
+        "right": 4
+      }
+    },
+    "final_shaft": {
+      "id": 17,
+      "name": "final_shaft",
+      "op": {
+        "type": "Difference",
+        "left": 16,
+        "right": 15
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 17,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -123,65 +123,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -206,7 +206,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120242Z-6a44",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5694.297339
+      }
+    ],
+    "tokens": {
+      "input": 794,
+      "output": 1407,
+      "total": 2201
+    },
+    "wallclock_sec": 5.694297338999999
+  },
+  "output": {
+    "vcad_path": "20260429T120242Z-6a44.vcad",
+    "vcad_sha256": "1c9fa204af2926f77ade456ff3884129d46c377570951505524173677058b865",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:42.440Z",
+    "ended_at": "2026-04-29T12:02:48.143Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120242Z-6a44.vcad
@@ -1,0 +1,182 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "flange_base": {
+      "id": 0,
+      "name": "flange_base",
+      "op": {
+        "type": "Cylinder",
+        "radius": 40,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "shaft_cyl": {
+      "id": 1,
+      "name": "shaft_cyl",
+      "op": {
+        "type": "Cylinder",
+        "radius": 15,
+        "height": 50,
+        "segments": 32
+      }
+    },
+    "shaft_positioned": {
+      "id": 2,
+      "name": "shaft_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {"x": 0, "y": 0, "z": 10}
+      }
+    },
+    "flange_with_shaft": {
+      "id": 3,
+      "name": "flange_with_shaft",
+      "op": {
+        "type": "Union",
+        "left": 0,
+        "right": 2
+      }
+    },
+    "central_bore": {
+      "id": 4,
+      "name": "central_bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 7.5,
+        "height": 60,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1": {
+      "id": 5,
+      "name": "bolt_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1_pos": {
+      "id": 6,
+      "name": "bolt_hole_1_pos",
+      "op": {
+        "type": "Translate",
+        "child": 5,
+        "offset": {"x": 30, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_2": {
+      "id": 7,
+      "name": "bolt_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2_pos": {
+      "id": 8,
+      "name": "bolt_hole_2_pos",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {"x": 0, "y": 30, "z": 0}
+      }
+    },
+    "bolt_hole_3": {
+      "id": 9,
+      "name": "bolt_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_3_pos": {
+      "id": 10,
+      "name": "bolt_hole_3_pos",
+      "op": {
+        "type": "Translate",
+        "child": 9,
+        "offset": {"x": -30, "y": 0, "z": 0}
+      }
+    },
+    "bolt_hole_4": {
+      "id": 11,
+      "name": "bolt_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_4_pos": {
+      "id": 12,
+      "name": "bolt_hole_4_pos",
+      "op": {
+        "type": "Translate",
+        "child": 11,
+        "offset": {"x": 0, "y": -30, "z": 0}
+      }
+    },
+    "all_bolt_holes": {
+      "id": 13,
+      "name": "all_bolt_holes",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 8
+      }
+    },
+    "all_bolt_holes_2": {
+      "id": 14,
+      "name": "all_bolt_holes_2",
+      "op": {
+        "type": "Union",
+        "left": 13,
+        "right": 10
+      }
+    },
+    "all_bolt_holes_3": {
+      "id": 15,
+      "name": "all_bolt_holes_3",
+      "op": {
+        "type": "Union",
+        "left": 14,
+        "right": 12
+      }
+    },
+    "with_central_bore": {
+      "id": 16,
+      "name": "with_central_bore",
+      "op": {
+        "type": "Difference",
+        "left": 3,
+        "right": 4
+      }
+    },
+    "final_shaft": {
+      "id": 17,
+      "name": "final_shaft",
+      "op": {
+        "type": "Difference",
+        "left": 16,
+        "right": 15
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 17,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": []
@@ -73,26 +73,26 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -105,14 +105,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -123,65 +123,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -206,7 +206,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 8,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.json
@@ -1,0 +1,274 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 8,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120248Z-3de0",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5929.487607
+      }
+    ],
+    "tokens": {
+      "input": 794,
+      "output": 1440,
+      "total": 2234
+    },
+    "wallclock_sec": 5.929487607
+  },
+  "output": {
+    "vcad_path": "20260429T120248Z-3de0.vcad",
+    "vcad_sha256": "cff5e618273b7767dec2e1e4bf6a5992628f0f57dccd7d7ed752afce71a8464a",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:48.243Z",
+    "ended_at": "2026-04-29T12:02:54.181Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-haiku-4-5-20251001/20260429T120248Z-3de0.vcad
@@ -1,0 +1,202 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "flange_base": {
+      "id": 0,
+      "name": "flange_base",
+      "op": {
+        "type": "Cylinder",
+        "radius": 40,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "shaft_cyl": {
+      "id": 1,
+      "name": "shaft_cyl",
+      "op": {
+        "type": "Cylinder",
+        "radius": 15,
+        "height": 50,
+        "segments": 32
+      }
+    },
+    "shaft_positioned": {
+      "id": 2,
+      "name": "shaft_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 10
+        }
+      }
+    },
+    "flange_and_shaft": {
+      "id": 3,
+      "name": "flange_and_shaft",
+      "op": {
+        "type": "Union",
+        "left": 0,
+        "right": 2
+      }
+    },
+    "center_bore": {
+      "id": 4,
+      "name": "center_bore",
+      "op": {
+        "type": "Cylinder",
+        "radius": 7.5,
+        "height": 60,
+        "segments": 32
+      }
+    },
+    "with_center_bore": {
+      "id": 5,
+      "name": "with_center_bore",
+      "op": {
+        "type": "Difference",
+        "left": 3,
+        "right": 4
+      }
+    },
+    "bolt_hole_1": {
+      "id": 6,
+      "name": "bolt_hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_1_pos": {
+      "id": 7,
+      "name": "bolt_hole_1_pos",
+      "op": {
+        "type": "Translate",
+        "child": 6,
+        "offset": {
+          "x": 30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_2": {
+      "id": 8,
+      "name": "bolt_hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_2_pos": {
+      "id": 9,
+      "name": "bolt_hole_2_pos",
+      "op": {
+        "type": "Translate",
+        "child": 8,
+        "offset": {
+          "x": 0,
+          "y": 30,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_3": {
+      "id": 10,
+      "name": "bolt_hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_3_pos": {
+      "id": 11,
+      "name": "bolt_hole_3_pos",
+      "op": {
+        "type": "Translate",
+        "child": 10,
+        "offset": {
+          "x": -30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "bolt_hole_4": {
+      "id": 12,
+      "name": "bolt_hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "bolt_hole_4_pos": {
+      "id": 13,
+      "name": "bolt_hole_4_pos",
+      "op": {
+        "type": "Translate",
+        "child": 12,
+        "offset": {
+          "x": 0,
+          "y": -30,
+          "z": 0
+        }
+      }
+    },
+    "holes_combined": {
+      "id": 14,
+      "name": "holes_combined",
+      "op": {
+        "type": "Union",
+        "left": 7,
+        "right": 9
+      }
+    },
+    "holes_combined_2": {
+      "id": 15,
+      "name": "holes_combined_2",
+      "op": {
+        "type": "Union",
+        "left": 14,
+        "right": 11
+      }
+    },
+    "holes_combined_3": {
+      "id": 16,
+      "name": "holes_combined_3",
+      "op": {
+        "type": "Union",
+        "left": 15,
+        "right": 13
+      }
+    },
+    "final_solid": {
+      "id": 17,
+      "name": "final_solid",
+      "op": {
+        "type": "Difference",
+        "left": 5,
+        "right": 16
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 17,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602801,
-          "deviation_pct": 0.16055853331355527,
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,27 +275,27 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602801,
+          "deviation_pct": 0.16055853331355527,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542345,
+              "original_mm3": 73755.93810602801,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120248Z-8807",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9900.730738999999
+      }
+    ],
+    "tokens": {
+      "input": 1052,
+      "output": 971,
+      "total": 2023
+    },
+    "wallclock_sec": 9.900730738999998
+  },
+  "output": {
+    "vcad_path": "20260429T120248Z-8807.vcad",
+    "vcad_sha256": "f9066484adb8e1d49621acc3fa0c6af61a14510979872a48f0c18a67b393132d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:48.911Z",
+    "ended_at": "2026-04-29T12:02:59.845Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120248Z-8807.vcad
@@ -1,0 +1,24 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_raw", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore_raw", "op": {"type": "Cylinder", "radius": 7.5, "height": 60.2, "segments": 64}},
+    "6": {"id": 6, "name": "bore", "op": {"type": "Translate", "child": 5, "offset": {"x": 0, "y": 0, "z": -0.1}}},
+    "7": {"id": 7, "name": "body_bored", "op": {"type": "Difference", "left": 4, "right": 6}},
+    "8": {"id": 8, "name": "bolt_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10.2, "segments": 32}},
+    "9": {"id": 9, "name": "bolt_px", "op": {"type": "Translate", "child": 8, "offset": {"x": 30, "y": 0, "z": -0.1}}},
+    "10": {"id": 10, "name": "bolt_py", "op": {"type": "Translate", "child": 8, "offset": {"x": 0, "y": 30, "z": -0.1}}},
+    "11": {"id": 11, "name": "bolt_nx", "op": {"type": "Translate", "child": 8, "offset": {"x": -30, "y": 0, "z": -0.1}}},
+    "12": {"id": 12, "name": "bolt_ny", "op": {"type": "Translate", "child": 8, "offset": {"x": 0, "y": -30, "z": -0.1}}},
+    "13": {"id": 13, "name": "bolts_a", "op": {"type": "Union", "left": 9, "right": 10}},
+    "14": {"id": 14, "name": "bolts_b", "op": {"type": "Union", "left": 11, "right": 12}},
+    "15": {"id": 15, "name": "bolts", "op": {"type": "Union", "left": 13, "right": 14}},
+    "16": {"id": 16, "name": "final", "op": {"type": "Difference", "left": 7, "right": 15}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 16, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602797,
-          "deviation_pct": 0.16055853331361436,
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989541752,
-              "original_mm3": 73755.93810602803,
+              "deviation_pct": 0.5223793989542341,
+              "original_mm3": 73755.93810602806,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985675
+              "roundtripped_mm3": 73370.65227985673
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602797,
+          "deviation_pct": 0.16055853331361436,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989541752,
+              "original_mm3": 73755.93810602803,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985675
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120259Z-93fe",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9068.261391
+      }
+    ],
+    "tokens": {
+      "input": 1052,
+      "output": 886,
+      "total": 1938
+    },
+    "wallclock_sec": 9.068261391
+  },
+  "output": {
+    "vcad_path": "20260429T120259Z-93fe.vcad",
+    "vcad_sha256": "2ca647fba092ee7230043fd505753be5ea804fd4bfbdb9ab04da67ea5b9ca388",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:59.909Z",
+    "ended_at": "2026-04-29T12:03:09.909Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120259Z-93fe.vcad
@@ -1,0 +1,23 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_raw", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "body_bored", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_proto", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt1", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt2", "op": {"type": "Translate", "child": 7, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "10": {"id": 10, "name": "bolt3", "op": {"type": "Translate", "child": 7, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "11": {"id": 11, "name": "bolt4", "op": {"type": "Translate", "child": 7, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "12": {"id": 12, "name": "bolts12", "op": {"type": "Union", "left": 8, "right": 9}},
+    "13": {"id": 13, "name": "bolts123", "op": {"type": "Union", "left": 12, "right": 10}},
+    "14": {"id": 14, "name": "bolts_all", "op": {"type": "Union", "left": 13, "right": 11}},
+    "15": {"id": 15, "name": "final", "op": {"type": "Difference", "left": 6, "right": 14}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 15, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989541756,
+              "original_mm3": 73755.93810602797,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120309Z-545f",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9473.824561000001
+      }
+    ],
+    "tokens": {
+      "input": 1052,
+      "output": 1064,
+      "total": 2116
+    },
+    "wallclock_sec": 9.473824561
+  },
+  "output": {
+    "vcad_path": "20260429T120309Z-545f.vcad",
+    "vcad_sha256": "c07f6a127e4e9e57f2abb12c0a8722447257bb167310251619efbb7764c92657",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:09.972Z",
+    "ended_at": "2026-04-29T12:03:20.361Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.938106028,
-          "deviation_pct": 0.16055853331357497,
+          "actual_mm3": 73755.93810602797,
+          "deviation_pct": 0.16055853331361436,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,35 +275,35 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989541756,
-              "original_mm3": 73755.93810602797,
+              "deviation_pct": 0.5223793989542541,
+              "original_mm3": 73755.93810602803,
               "pass": true,
               "roundtripped_mm3": 73370.65227985669
             }
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120309Z-545f.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_raw", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "body_bored", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt1_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt1", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt2_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "bolt2", "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "bolt3_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "bolt3", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt4_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt4", "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "bolts12", "op": {"type": "Union", "left": 8, "right": 10}},
+    "16": {"id": 16, "name": "bolts34", "op": {"type": "Union", "left": 12, "right": 14}},
+    "17": {"id": 17, "name": "bolts_all", "op": {"type": "Union", "left": 15, "right": 16}},
+    "18": {"id": 18, "name": "final", "op": {"type": "Difference", "left": 6, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602801,
+          "deviation_pct": 0.16055853331355527,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542149,
+              "original_mm3": 73755.938106028,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120320Z-9e8b",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 11455.512585
+      }
+    ],
+    "tokens": {
+      "input": 1052,
+      "output": 1064,
+      "total": 2116
+    },
+    "wallclock_sec": 11.455512585000001
+  },
+  "output": {
+    "vcad_path": "20260429T120320Z-9e8b.vcad",
+    "vcad_sha256": "3c539beef53d062078ddbc007e09e3050fe24ff438b66e01cf615eaa06833fd9",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:20.426Z",
+    "ended_at": "2026-04-29T12:03:32.834Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542149,
-              "original_mm3": 73755.938106028,
+              "deviation_pct": 0.5223793989542146,
+              "original_mm3": 73755.93810602803,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985669
+              "roundtripped_mm3": 73370.65227985672
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120320Z-9e8b.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_raw", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "body_bored", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt1_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt1", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt2_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "bolt2", "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "bolt3_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "bolt3", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt4_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt4", "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "bolts12", "op": {"type": "Union", "left": 8, "right": 10}},
+    "16": {"id": 16, "name": "bolts123", "op": {"type": "Union", "left": 15, "right": 12}},
+    "17": {"id": 17, "name": "bolts_all", "op": {"type": "Union", "left": 16, "right": 14}},
+    "18": {"id": 18, "name": "final", "op": {"type": "Difference", "left": 6, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602803,
-          "deviation_pct": 0.1605585333135356,
+          "actual_mm3": 73755.93810602807,
+          "deviation_pct": 0.16055853331347647,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542934,
-              "original_mm3": 73755.93810602806,
+              "deviation_pct": 0.5223793989542346,
+              "original_mm3": 73755.938106028,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985669
+              "roundtripped_mm3": 73370.65227985667
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602803,
+          "deviation_pct": 0.1605585333135356,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542934,
+              "original_mm3": 73755.93810602806,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120332Z-87b8",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8816.566268
+      }
+    ],
+    "tokens": {
+      "input": 1052,
+      "output": 916,
+      "total": 1968
+    },
+    "wallclock_sec": 8.816566268
+  },
+  "output": {
+    "vcad_path": "20260429T120332Z-87b8.vcad",
+    "vcad_sha256": "1050cd2ee4de7cbe2f9f68b97fd8338fbf90726ac8015194772b4bb044cb9ba8",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:32.898Z",
+    "ended_at": "2026-04-29T12:03:42.634Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-opus-4-7/20260429T120332Z-87b8.vcad
@@ -1,0 +1,23 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_raw", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "body", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "body_bored", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_hole_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_px", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt_hole_py", "op": {"type": "Translate", "child": 7, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "10": {"id": 10, "name": "bolt_hole_nx", "op": {"type": "Translate", "child": 7, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "11": {"id": 11, "name": "bolt_hole_ny", "op": {"type": "Translate", "child": 7, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "12": {"id": 12, "name": "bolt_holes_a", "op": {"type": "Union", "left": 8, "right": 9}},
+    "13": {"id": 13, "name": "bolt_holes_b", "op": {"type": "Union", "left": 10, "right": 11}},
+    "14": {"id": 14, "name": "bolt_holes", "op": {"type": "Union", "left": 12, "right": 13}},
+    "15": {"id": 15, "name": "final", "op": {"type": "Difference", "left": 6, "right": 14}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 15, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542145,
-              "original_mm3": 73755.93810602806,
+              "deviation_pct": 0.5223793989542541,
+              "original_mm3": 73755.93810602803,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985675
+              "roundtripped_mm3": 73370.65227985669
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602803,
+          "deviation_pct": 0.1605585333135356,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542145,
+              "original_mm3": 73755.93810602806,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985675
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120251Z-953e",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8266.99756
+      }
+    ],
+    "tokens": {
+      "input": 795,
+      "output": 968,
+      "total": 1763
+    },
+    "wallclock_sec": 8.26699756
+  },
+  "output": {
+    "vcad_path": "20260429T120251Z-953e.vcad",
+    "vcad_sha256": "6179732c486f59452298409f1a0abe86f8eac645c27cf0af10bda9e1ecefc09f",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:51.566Z",
+    "ended_at": "2026-04-29T12:03:00.750Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120251Z-953e.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange_cylinder", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_cylinder", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft_translated", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "flange_union_shaft", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore_cylinder", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "after_bore", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_hole_0", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_0_pos", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt_hole_1", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "bolt_hole_1_pos", "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "bolt_hole_2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "bolt_hole_2_pos", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt_hole_3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt_hole_3_pos", "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "bolt_holes_01", "op": {"type": "Union", "left": 8, "right": 10}},
+    "16": {"id": 16, "name": "bolt_holes_23", "op": {"type": "Union", "left": 12, "right": 14}},
+    "17": {"id": 17, "name": "bolt_holes_all", "op": {"type": "Union", "left": 15, "right": 16}},
+    "18": {"id": 18, "name": "flanged_shaft", "op": {"type": "Difference", "left": 6, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602797,
-          "deviation_pct": 0.16055853331361436,
+          "actual_mm3": 73755.93810602798,
+          "deviation_pct": 0.16055853331359465,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542541,
-              "original_mm3": 73755.93810602803,
+              "deviation_pct": 0.5223793989541754,
+              "original_mm3": 73755.938106028,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985669
+              "roundtripped_mm3": 73370.65227985672
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602797,
+          "deviation_pct": 0.16055853331361436,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542541,
+              "original_mm3": 73755.93810602803,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120300Z-8c32",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8261.665865
+      }
+    ],
+    "tokens": {
+      "input": 795,
+      "output": 974,
+      "total": 1769
+    },
+    "wallclock_sec": 8.261665865000001
+  },
+  "output": {
+    "vcad_path": "20260429T120300Z-8c32.vcad",
+    "vcad_sha256": "40a6d39b25cff0e74edbee3d67f424528956bea23da80b2bf0825cf98666bdd7",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:00.812Z",
+    "ended_at": "2026-04-29T12:03:09.982Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120300Z-8c32.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange_outer", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_outer", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft_translated", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "flange_union_shaft", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "central_bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "body_after_bore", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_hole_1", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_1_pos", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt_hole_2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "bolt_hole_2_pos", "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "bolt_hole_3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "bolt_hole_3_pos", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt_hole_4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt_hole_4_pos", "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "union_bh12", "op": {"type": "Union", "left": 8, "right": 10}},
+    "16": {"id": 16, "name": "union_bh34", "op": {"type": "Union", "left": 12, "right": 14}},
+    "17": {"id": 17, "name": "union_bh1234", "op": {"type": "Union", "left": 15, "right": 16}},
+    "18": {"id": 18, "name": "body_after_bolt_holes", "op": {"type": "Difference", "left": 6, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602803,
-          "deviation_pct": 0.1605585333135356,
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542149,
-              "original_mm3": 73755.938106028,
+              "deviation_pct": 0.5223793989542146,
+              "original_mm3": 73755.93810602803,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985669
+              "roundtripped_mm3": 73370.65227985672
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602803,
+          "deviation_pct": 0.1605585333135356,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542149,
+              "original_mm3": 73755.938106028,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985669
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120310Z-a67c",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8799.658287999999
+      }
+    ],
+    "tokens": {
+      "input": 795,
+      "output": 1035,
+      "total": 1830
+    },
+    "wallclock_sec": 8.799658287999998
+  },
+  "output": {
+    "vcad_path": "20260429T120310Z-a67c.vcad",
+    "vcad_sha256": "3ad8bc26ecd4d3c712b545b4d1b11916064609d1c48ac186ac60e75ad6b4e316",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:10.049Z",
+    "ended_at": "2026-04-29T12:03:19.888Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120310Z-a67c.vcad
@@ -1,0 +1,27 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange_cylinder", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_cylinder", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft_translated", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "flange_plus_shaft", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore_cylinder", "op": {"type": "Cylinder", "radius": 7.5, "height": 61, "segments": 64}},
+    "6": {"id": 6, "name": "bore_translated", "op": {"type": "Translate", "child": 5, "offset": {"x": 0, "y": 0, "z": -0.5}}},
+    "7": {"id": 7, "name": "body_with_bore", "op": {"type": "Difference", "left": 4, "right": 6}},
+    "8": {"id": 8, "name": "bolt_hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 12, "segments": 32}},
+    "9": {"id": 9, "name": "bolt_hole_1_translated", "op": {"type": "Translate", "child": 8, "offset": {"x": 30, "y": 0, "z": -1}}},
+    "10": {"id": 10, "name": "bolt_hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 12, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_hole_2_translated", "op": {"type": "Translate", "child": 10, "offset": {"x": 0, "y": 30, "z": -1}}},
+    "12": {"id": 12, "name": "bolt_hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 12, "segments": 32}},
+    "13": {"id": 13, "name": "bolt_hole_3_translated", "op": {"type": "Translate", "child": 12, "offset": {"x": -30, "y": 0, "z": -1}}},
+    "14": {"id": 14, "name": "bolt_hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 12, "segments": 32}},
+    "15": {"id": 15, "name": "bolt_hole_4_translated", "op": {"type": "Translate", "child": 14, "offset": {"x": 0, "y": -30, "z": -1}}},
+    "16": {"id": 16, "name": "bolt_holes_12", "op": {"type": "Union", "left": 9, "right": 11}},
+    "17": {"id": 17, "name": "bolt_holes_34", "op": {"type": "Union", "left": 13, "right": 15}},
+    "18": {"id": 18, "name": "bolt_holes_all", "op": {"type": "Union", "left": 16, "right": 17}},
+    "19": {"id": 19, "name": "final_solid", "op": {"type": "Difference", "left": 7, "right": 18}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 19, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.93810602798,
-          "deviation_pct": 0.16055853331359465,
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.522379398954195,
-              "original_mm3": 73755.93810602801,
+              "deviation_pct": 0.5223793989541164,
+              "original_mm3": 73755.93810602797,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985672
+              "roundtripped_mm3": 73370.65227985673
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.93810602798,
+          "deviation_pct": 0.16055853331359465,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.522379398954195,
+              "original_mm3": 73755.93810602801,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985672
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120319Z-7140",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8324.725466
+      }
+    ],
+    "tokens": {
+      "input": 795,
+      "output": 978,
+      "total": 1773
+    },
+    "wallclock_sec": 8.324725466
+  },
+  "output": {
+    "vcad_path": "20260429T120319Z-7140.vcad",
+    "vcad_sha256": "594c1703a75a309986183a273f61fd6abdaf13d97f34d0bc759a0cd30c2fa1cb",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:19.956Z",
+    "ended_at": "2026-04-29T12:03:29.340Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120319Z-7140.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange_outer", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_outer_base", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft_outer_translated", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "flange_union_shaft", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "central_bore", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "after_bore", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_hole_1_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_1", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "bolt_hole_2_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "bolt_hole_2", "op": {"type": "Translate", "child": 9, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "bolt_hole_3_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "bolt_hole_3", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "13": {"id": 13, "name": "bolt_hole_4_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt_hole_4", "op": {"type": "Translate", "child": 13, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "after_bolt1", "op": {"type": "Difference", "left": 6, "right": 8}},
+    "16": {"id": 16, "name": "after_bolt2", "op": {"type": "Difference", "left": 15, "right": 10}},
+    "17": {"id": 17, "name": "after_bolt3", "op": {"type": "Difference", "left": 16, "right": 12}},
+    "18": {"id": 18, "name": "flanged_hollow_shaft", "op": {"type": "Difference", "left": 17, "right": 14}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          60
+          40.0,
+          40.0,
+          60.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 73755.938106028,
-          "deviation_pct": 0.16055853331357497,
+          "actual_mm3": 73755.93810602803,
+          "deviation_pct": 0.1605585333135356,
           "pass": true,
           "spec_mm3": 73874.55,
           "tolerance_pct": 1.5
@@ -82,21 +82,21 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "expected": 1,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 1,
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 1,
         "found": [
           [
-            0,
-            0,
-            15
+            0.0,
+            0.0,
+            15.0
           ]
         ]
       }
@@ -106,30 +106,30 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "positions": [
           [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 15,
+        "diameter_mm": 15.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              0
+              0.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              0
+              0.0,
+              0.0
             ]
           }
         ],
@@ -142,36 +142,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            0,
-            6
+            30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            30,
-            6
+            0.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            0,
-            6
+            -30.0,
+            0.0,
+            6.0
           ],
           [
-            0,
-            -30,
-            6
+            0.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -181,81 +181,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            0,
-            0
+            30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            30,
-            0
+            0.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            0,
-            0
+            -30.0,
+            0.0,
+            0.0
           ],
           [
-            0,
-            -30,
-            0
+            0.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              0
+              30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              0
+              30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              30
+              0.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              30
+              0.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              0
+              -30.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              0
+              -30.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              0,
-              -30
+              0.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              0,
-              -30
+              0.0,
+              -30.0
             ]
           }
         ],
@@ -275,37 +275,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                60
+                40.0,
+                40.0,
+                60.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 1.9209372712298545
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.5223793989542346,
+              "deviation_pct": 0.522379398954136,
               "original_mm3": 73755.938106028,
               "pass": true,
-              "roundtripped_mm3": 73370.65227985667
+              "roundtripped_mm3": 73370.65227985675
             }
           }
         ],
@@ -317,7 +317,7 @@
     "passed": true,
     "checks_passed": 8,
     "checks_total": 8,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.json
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.json
@@ -1,0 +1,385 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-flanged-shaft-01",
+  "task_sha256": "70d8d5eb7fc1d94167fdbf0c0241a820f8e76ed8652cfdfdb23800cf351eacf4",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          60
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          60
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 73874.55,
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 73755.938106028,
+          "deviation_pct": 0.16055853331357497,
+          "pass": true,
+          "spec_mm3": 73874.55,
+          "tolerance_pct": 1.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 15,
+        "expected": 1,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 1,
+        "diameter_mm": 15,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 1,
+        "found": [
+          [
+            0,
+            0,
+            15
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 15,
+        "positions": [
+          [
+            0,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 15,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            0,
+            6
+          ],
+          [
+            0,
+            30,
+            6
+          ],
+          [
+            -30,
+            0,
+            6
+          ],
+          [
+            0,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 6,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            0,
+            0
+          ],
+          [
+            0,
+            30,
+            0
+          ],
+          [
+            -30,
+            0,
+            0
+          ],
+          [
+            0,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              0,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              0,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 7,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                60
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                60
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 1.9209372712298545
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.5223793989542346,
+              "original_mm3": 73755.938106028,
+              "pass": true,
+              "roundtripped_mm3": 73370.65227985667
+            }
+          }
+        ],
+        "tolerance_pct": 1.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 8,
+    "checks_total": 8,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120329Z-5b41",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-flanged-shaft-01",
+    "rendered": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 783
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8188.205115000001
+      }
+    ],
+    "tokens": {
+      "input": 795,
+      "output": 967,
+      "total": 1762
+    },
+    "wallclock_sec": 8.188205115
+  },
+  "output": {
+    "vcad_path": "20260429T120329Z-5b41.vcad",
+    "vcad_sha256": "e9c07626dff2be1476d340126a8f0e615e1a71299b23db53aa8f676cad0f150d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:29.407Z",
+    "ended_at": "2026-04-29T12:03:38.656Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.vcad
+++ b/mecheval/runs/a4-flanged-shaft-01/claude-direct-claude-sonnet-4-6/20260429T120329Z-5b41.vcad
@@ -1,0 +1,26 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "flange_cyl", "op": {"type": "Cylinder", "radius": 40, "height": 10, "segments": 64}},
+    "2": {"id": 2, "name": "shaft_cyl", "op": {"type": "Cylinder", "radius": 15, "height": 50, "segments": 64}},
+    "3": {"id": 3, "name": "shaft_translated", "op": {"type": "Translate", "child": 2, "offset": {"x": 0, "y": 0, "z": 10}}},
+    "4": {"id": 4, "name": "flange_union_shaft", "op": {"type": "Union", "left": 1, "right": 3}},
+    "5": {"id": 5, "name": "bore_cyl", "op": {"type": "Cylinder", "radius": 7.5, "height": 60, "segments": 64}},
+    "6": {"id": 6, "name": "after_bore", "op": {"type": "Difference", "left": 4, "right": 5}},
+    "7": {"id": 7, "name": "bolt_hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "8": {"id": 8, "name": "bolt_hole_0", "op": {"type": "Translate", "child": 7, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "after_bolt0", "op": {"type": "Difference", "left": 6, "right": 8}},
+    "10": {"id": 10, "name": "bolt_hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "bolt_hole_1", "op": {"type": "Translate", "child": 10, "offset": {"x": 0, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "after_bolt1", "op": {"type": "Difference", "left": 9, "right": 11}},
+    "13": {"id": 13, "name": "bolt_hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "bolt_hole_2", "op": {"type": "Translate", "child": 13, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "15": {"id": 15, "name": "after_bolt2", "op": {"type": "Difference", "left": 12, "right": 14}},
+    "16": {"id": 16, "name": "bolt_hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "17": {"id": 17, "name": "bolt_hole_3", "op": {"type": "Translate", "child": 16, "offset": {"x": 0, "y": -30, "z": 0}}},
+    "18": {"id": 18, "name": "final", "op": {"type": "Difference", "left": 15, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120211Z-4533",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3866.736682
+      }
+    ],
+    "tokens": {
+      "input": 736,
+      "output": 433,
+      "total": 1169
+    },
+    "wallclock_sec": 3.866736682
+  },
+  "output": {
+    "vcad_path": "20260429T120211Z-4533.vcad",
+    "vcad_sha256": "d7067992d7d60f0a2567dfe8b62b35d778576c7e7d39204a979fba71571f56e0",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:11.433Z",
+    "ended_at": "2026-04-29T12:02:15.309Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120211Z-4533.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "outer_cube": {
+      "id": 1,
+      "name": "outer_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 80}
+      }
+    },
+    "outer_centered": {
+      "id": 2,
+      "name": "outer_centered",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "inner_cube": {
+      "id": 3,
+      "name": "inner_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 28, "y": 28, "z": 80}
+      }
+    },
+    "inner_centered": {
+      "id": 4,
+      "name": "inner_centered",
+      "op": {
+        "type": "Translate",
+        "child": 3,
+        "offset": {"x": -14, "y": -14, "z": 0}
+      }
+    },
+    "hollow_tube": {
+      "id": 5,
+      "name": "hollow_tube",
+      "op": {
+        "type": "Difference",
+        "left": 2,
+        "right": 4
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 5,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120215Z-70b8",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2649.303851
+      }
+    ],
+    "tokens": {
+      "input": 736,
+      "output": 426,
+      "total": 1162
+    },
+    "wallclock_sec": 2.649303851
+  },
+  "output": {
+    "vcad_path": "20260429T120215Z-70b8.vcad",
+    "vcad_sha256": "9825cccdbee0329b96cf72a17b64548636c4436a256293ec126842aaf1a6f13b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:15.418Z",
+    "ended_at": "2026-04-29T12:02:18.077Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120215Z-70b8.vcad
@@ -1,0 +1,51 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "outer": {
+      "id": "outer",
+      "name": "outer_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 80}
+      }
+    },
+    "outer_centered": {
+      "id": "outer_centered",
+      "name": "outer_centered",
+      "op": {
+        "type": "Translate",
+        "child": "outer",
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "inner": {
+      "id": "inner",
+      "name": "inner_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 28, "y": 28, "z": 80}
+      }
+    },
+    "inner_centered": {
+      "id": "inner_centered",
+      "name": "inner_centered",
+      "op": {
+        "type": "Translate",
+        "child": "inner",
+        "offset": {"x": -14, "y": -14, "z": 0}
+      }
+    },
+    "tube": {
+      "id": "tube",
+      "name": "hollow_square_tube",
+      "op": {
+        "type": "Difference",
+        "left": "outer_centered",
+        "right": "inner_centered"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "tube", "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120218Z-f865",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2113.910144
+      }
+    ],
+    "tokens": {
+      "input": 736,
+      "output": 455,
+      "total": 1191
+    },
+    "wallclock_sec": 2.113910144
+  },
+  "output": {
+    "vcad_path": "20260429T120218Z-f865.vcad",
+    "vcad_sha256": "8168fc3261721349106d5962f6e36a1a2651ca47bc48c915028847bae4a37ba4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:18.177Z",
+    "ended_at": "2026-04-29T12:02:20.300Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120218Z-f865.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "outer_cube": {
+      "id": "outer_cube",
+      "name": "Outer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 80}
+      }
+    },
+    "outer_centered": {
+      "id": "outer_centered",
+      "name": "Outer cube centered",
+      "op": {
+        "type": "Translate",
+        "child": "outer_cube",
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "inner_cube": {
+      "id": "inner_cube",
+      "name": "Inner cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 28, "y": 28, "z": 80}
+      }
+    },
+    "inner_centered": {
+      "id": "inner_centered",
+      "name": "Inner cube centered",
+      "op": {
+        "type": "Translate",
+        "child": "inner_cube",
+        "offset": {"x": -14, "y": -14, "z": 0}
+      }
+    },
+    "hollow_tube": {
+      "id": "hollow_tube",
+      "name": "Hollow square tube",
+      "op": {
+        "type": "Difference",
+        "left": "outer_centered",
+        "right": "inner_centered"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "hollow_tube",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120220Z-293c",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2341.249871
+      }
+    ],
+    "tokens": {
+      "input": 736,
+      "output": 463,
+      "total": 1199
+    },
+    "wallclock_sec": 2.341249871
+  },
+  "output": {
+    "vcad_path": "20260429T120220Z-293c.vcad",
+    "vcad_sha256": "13924792106b39cdc5b74d5a25dd26c6527e923c8a6f5b57e57414607323e416",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:20.404Z",
+    "ended_at": "2026-04-29T12:02:22.759Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120220Z-293c.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "outer_cube": {
+      "id": "outer_cube",
+      "name": "Outer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 80}
+      }
+    },
+    "outer_translated": {
+      "id": "outer_translated",
+      "name": "Outer cube centered in XY",
+      "op": {
+        "type": "Translate",
+        "child": "outer_cube",
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "inner_cube": {
+      "id": "inner_cube",
+      "name": "Inner cavity cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 28, "y": 28, "z": 80}
+      }
+    },
+    "inner_translated": {
+      "id": "inner_translated",
+      "name": "Inner cavity cube centered in XY",
+      "op": {
+        "type": "Translate",
+        "child": "inner_cube",
+        "offset": {"x": -14, "y": -14, "z": 0}
+      }
+    },
+    "hollow_tube": {
+      "id": "hollow_tube",
+      "name": "Hollow rectangular tube",
+      "op": {
+        "type": "Difference",
+        "left": "outer_translated",
+        "right": "inner_translated"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "hollow_tube",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120222Z-798b",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2084.490037
+      }
+    ],
+    "tokens": {
+      "input": 736,
+      "output": 433,
+      "total": 1169
+    },
+    "wallclock_sec": 2.084490037
+  },
+  "output": {
+    "vcad_path": "20260429T120222Z-798b.vcad",
+    "vcad_sha256": "2245d4be24a21d7ebc3fc9b4d28e483e23eee673a8f3543f15e6f624e3520f6d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:22.856Z",
+    "ended_at": "2026-04-29T12:02:24.949Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-haiku-4-5-20251001/20260429T120222Z-798b.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "outer_cube": {
+      "id": 0,
+      "name": "outer_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 80}
+      }
+    },
+    "outer_centered": {
+      "id": 1,
+      "name": "outer_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -20, "y": -20, "z": 0}
+      }
+    },
+    "inner_cube": {
+      "id": 2,
+      "name": "inner_cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 28, "y": 28, "z": 80}
+      }
+    },
+    "inner_centered": {
+      "id": 3,
+      "name": "inner_centered",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": -14, "y": -14, "z": 0}
+      }
+    },
+    "hollow_tube": {
+      "id": 4,
+      "name": "hollow_tube",
+      "op": {
+        "type": "Difference",
+        "left": 1,
+        "right": 3
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 4,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120226Z-6a3e",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4372.7122899999995
+      }
+    ],
+    "tokens": {
+      "input": 964,
+      "output": 364,
+      "total": 1328
+    },
+    "wallclock_sec": 4.372712289999999
+  },
+  "output": {
+    "vcad_path": "20260429T120226Z-6a3e.vcad",
+    "vcad_sha256": "da92461165021f3ae2f89cf7c1e1e38200f83457230819e1bb04304bf15a3252",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:26.359Z",
+    "ended_at": "2026-04-29T12:02:30.752Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120226Z-6a3e.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner_cube", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120230Z-4c47",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4349.918683
+      }
+    ],
+    "tokens": {
+      "input": 964,
+      "output": 358,
+      "total": 1322
+    },
+    "wallclock_sec": 4.349918683
+  },
+  "output": {
+    "vcad_path": "20260429T120230Z-4c47.vcad",
+    "vcad_sha256": "3667704d59582b84c7cf2682ced8904bf175c4dea867bd2b5359fa1641c3bb94",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:30.849Z",
+    "ended_at": "2026-04-29T12:02:35.221Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120230Z-4c47.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120235Z-edd2",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4014.54751
+      }
+    ],
+    "tokens": {
+      "input": 964,
+      "output": 364,
+      "total": 1328
+    },
+    "wallclock_sec": 4.01454751
+  },
+  "output": {
+    "vcad_path": "20260429T120235Z-edd2.vcad",
+    "vcad_sha256": "da92461165021f3ae2f89cf7c1e1e38200f83457230819e1bb04304bf15a3252",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:35.309Z",
+    "ended_at": "2026-04-29T12:02:39.349Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120235Z-edd2.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner_cube", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120239Z-2d8e",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4728.905062999999
+      }
+    ],
+    "tokens": {
+      "input": 964,
+      "output": 358,
+      "total": 1322
+    },
+    "wallclock_sec": 4.728905062999999
+  },
+  "output": {
+    "vcad_path": "20260429T120239Z-2d8e.vcad",
+    "vcad_sha256": "3667704d59582b84c7cf2682ced8904bf175c4dea867bd2b5359fa1641c3bb94",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:39.436Z",
+    "ended_at": "2026-04-29T12:02:44.186Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120239Z-2d8e.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120244Z-b822",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4533.746375
+      }
+    ],
+    "tokens": {
+      "input": 964,
+      "output": 364,
+      "total": 1328
+    },
+    "wallclock_sec": 4.533746375
+  },
+  "output": {
+    "vcad_path": "20260429T120244Z-b822.vcad",
+    "vcad_sha256": "da92461165021f3ae2f89cf7c1e1e38200f83457230819e1bb04304bf15a3252",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:44.272Z",
+    "ended_at": "2026-04-29T12:02:48.827Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-opus-4-7/20260429T120244Z-b822.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner_cube", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120230Z-b581",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3804.622698
+      }
+    ],
+    "tokens": {
+      "input": 737,
+      "output": 301,
+      "total": 1038
+    },
+    "wallclock_sec": 3.804622698
+  },
+  "output": {
+    "vcad_path": "20260429T120230Z-b581.vcad",
+    "vcad_sha256": "273857b6215fd3c152bdcbc5f421cfad8f0b6560fdf2185d882876cec398d53b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:30.154Z",
+    "ended_at": "2026-04-29T12:02:33.980Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120230Z-b581.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "outer_cube", "op": {"type":"Cube", "size":{"x":40,"y":40,"z":80}} },
+    "2": { "id": 2, "name": "outer_centered", "op": {"type":"Translate", "child":1, "offset":{"x":-20,"y":-20,"z":0}} },
+    "3": { "id": 3, "name": "inner_cube", "op": {"type":"Cube", "size":{"x":28,"y":28,"z":80}} },
+    "4": { "id": 4, "name": "inner_centered", "op": {"type":"Translate", "child":3, "offset":{"x":-14,"y":-14,"z":0}} },
+    "5": { "id": 5, "name": "hollow_tube", "op": {"type":"Difference", "left":2, "right":4} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120234Z-105e",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4010.65324
+      }
+    ],
+    "tokens": {
+      "input": 737,
+      "output": 366,
+      "total": 1103
+    },
+    "wallclock_sec": 4.01065324
+  },
+  "output": {
+    "vcad_path": "20260429T120234Z-105e.vcad",
+    "vcad_sha256": "cfaeba226f1a49d81768789a5272566b05e24ea752dd04e7370d05fc90bec413",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:34.070Z",
+    "ended_at": "2026-04-29T12:02:38.103Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120234Z-105e.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "outer_cube",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}
+    },
+    "2": {
+      "id": 2,
+      "name": "outer_translated",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "inner_cube",
+      "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}
+    },
+    "4": {
+      "id": 4,
+      "name": "inner_translated",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "hollow_tube",
+      "op": {"type": "Difference", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120238Z-8c75",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4115.499347999999
+      }
+    ],
+    "tokens": {
+      "input": 737,
+      "output": 328,
+      "total": 1065
+    },
+    "wallclock_sec": 4.115499347999999
+  },
+  "output": {
+    "vcad_path": "20260429T120238Z-8c75.vcad",
+    "vcad_sha256": "4aac669b086f89a122b61952ed0dff4f96fcd5ba72ab989256ef7829e5031248",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:38.193Z",
+    "ended_at": "2026-04-29T12:02:42.330Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120238Z-8c75.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "outer_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}} },
+    "2": { "id": 2, "name": "outer_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}} },
+    "3": { "id": 3, "name": "inner_cube", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}} },
+    "4": { "id": 4, "name": "inner_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}} },
+    "5": { "id": 5, "name": "hollow_tube", "op": {"type": "Difference", "left": 2, "right": 4} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{ "root": 5, "material": "default" }]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120242Z-5cd0",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4843.738293
+      }
+    ],
+    "tokens": {
+      "input": 737,
+      "output": 366,
+      "total": 1103
+    },
+    "wallclock_sec": 4.843738293
+  },
+  "output": {
+    "vcad_path": "20260429T120242Z-5cd0.vcad",
+    "vcad_sha256": "cfaeba226f1a49d81768789a5272566b05e24ea752dd04e7370d05fc90bec413",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:42.418Z",
+    "ended_at": "2026-04-29T12:02:47.283Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120242Z-5cd0.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "outer_cube",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}
+    },
+    "2": {
+      "id": 2,
+      "name": "outer_translated",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "inner_cube",
+      "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}
+    },
+    "4": {
+      "id": 4,
+      "name": "inner_translated",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "hollow_tube",
+      "op": {"type": "Difference", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          20,
-          20,
-          80
+          20.0,
+          20.0,
+          80.0
         ],
         "actual_min": [
-          -20,
-          -20,
-          0
+          -20.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,42 +63,42 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 65280,
+        "volume_mm3": 65280.0,
         "center_of_mass": [
-          0,
-          0,
-          40
+          0.0,
+          0.0,
+          40.0
         ],
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            34.38395415472779
+            0.0,
+            0.0,
+            40.0
           ],
           "bbox_diagonal_mm": 97.97958971132712,
           "deviation": [
-            0,
-            0,
-            -5.616045845272211
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 5.616045845272211,
-          "pass": false,
+          "max_abs_deviation_mm": 0.0,
+          "pass": true,
           "spec": [
-            0,
-            0,
-            40
+            0.0,
+            0.0,
+            40.0
           ],
           "tolerance_mm": 0.4898979485566356
         },
         "volume": {
-          "actual_mm3": 148906.66666666666,
-          "deviation_pct": 128.1045751633987,
-          "pass": false,
-          "spec_mm3": 65280,
+          "actual_mm3": 65280.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 65280.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "original_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                20,
-                20,
-                80
+                20.0,
+                20.0,
+                80.0
               ],
               "roundtripped_min": [
-                -20,
-                -20,
-                0
+                -20.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.4898979485566356
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 148906.66666666666,
+              "deviation_pct": 0.0,
+              "original_mm3": 65280.0,
               "pass": true,
-              "roundtripped_mm3": 148906.66666666666
+              "roundtripped_mm3": 65280.0
             }
           }
         ],
@@ -154,10 +154,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rectangular-tube-01",
-    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm \u00d7 40mm square; the inner cavity is a 28mm \u00d7 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.json
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rectangular-tube-01",
+  "task_sha256": "26b7bf3bb00bfe8031a199347b2cd162efa46a3d1195cbc11957e5ccdb16aae1",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -20,
+          -20,
+          0
+        ],
+        "max": [
+          20,
+          20,
+          80
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          20,
+          20,
+          80
+        ],
+        "actual_min": [
+          -20,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 65280,
+        "center_of_mass": [
+          0,
+          0,
+          40
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            34.38395415472779
+          ],
+          "bbox_diagonal_mm": 97.97958971132712,
+          "deviation": [
+            0,
+            0,
+            -5.616045845272211
+          ],
+          "max_abs_deviation_mm": 5.616045845272211,
+          "pass": false,
+          "spec": [
+            0,
+            0,
+            40
+          ],
+          "tolerance_mm": 0.4898979485566356
+        },
+        "volume": {
+          "actual_mm3": 148906.66666666666,
+          "deviation_pct": 128.1045751633987,
+          "pass": false,
+          "spec_mm3": 65280,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                20,
+                20,
+                80
+              ],
+              "original_min": [
+                -20,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                20,
+                20,
+                80
+              ],
+              "roundtripped_min": [
+                -20,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.4898979485566356
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 148906.66666666666,
+              "pass": true,
+              "roundtripped_mm3": 148906.66666666666
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 3,
+    "checks_total": 4,
+    "score": 0.75,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120247Z-ee3c",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rectangular-tube-01",
+    "rendered": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 524
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4090.801106000001
+      }
+    ],
+    "tokens": {
+      "input": 737,
+      "output": 320,
+      "total": 1057
+    },
+    "wallclock_sec": 4.090801106000001
+  },
+  "output": {
+    "vcad_path": "20260429T120247Z-ee3c.vcad",
+    "vcad_sha256": "86b87bfac5659bc2222237aa99dfa5f8a85db870b8973189dfdc7c077cc05f71",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:47.368Z",
+    "ended_at": "2026-04-29T12:02:51.480Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.vcad
+++ b/mecheval/runs/a4-rectangular-tube-01/claude-direct-claude-sonnet-4-6/20260429T120247Z-ee3c.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "outer_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 80}}},
+    "2": {"id": 2, "name": "outer_translated", "op": {"type": "Translate", "child": 1, "offset": {"x": -20, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "inner_cube", "op": {"type": "Cube", "size": {"x": 28, "y": 28, "z": 80}}},
+    "4": {"id": 4, "name": "inner_translated", "op": {"type": "Translate", "child": 3, "offset": {"x": -14, "y": -14, "z": 0}}},
+    "5": {"id": 5, "name": "hollow_tube", "op": {"type": "Difference", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
@@ -44,11 +44,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -60,7 +60,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120436Z-c74f",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3196.814495
+      }
+    ],
+    "tokens": {
+      "input": 734,
+      "output": 661,
+      "total": 1395
+    },
+    "wallclock_sec": 3.196814495
+  },
+  "output": {
+    "vcad_path": "20260429T120436Z-c74f.vcad",
+    "vcad_sha256": "a0feade825fbc6e69f799f3c5ac4e733a56945b52c4ebcbee394a3e2e80a05b2",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:36.167Z",
+    "ended_at": "2026-04-29T12:04:39.373Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120436Z-c74f.vcad
@@ -1,0 +1,86 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "rect": {
+      "id": 0,
+      "name": "central_rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 20, "z": 10}
+      }
+    },
+    "rect_centered": {
+      "id": 1,
+      "name": "rect_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -30, "y": -10, "z": 0}
+      }
+    },
+    "cylinder_left": {
+      "id": 2,
+      "name": "left_semicircle_full",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_left_moved": {
+      "id": 3,
+      "name": "left_semicircle_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": -30, "y": 0, "z": 0}
+      }
+    },
+    "cylinder_right": {
+      "id": 4,
+      "name": "right_semicircle_full",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_right_moved": {
+      "id": 5,
+      "name": "right_semicircle_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": 30, "y": 0, "z": 0}
+      }
+    },
+    "union_left": {
+      "id": 6,
+      "name": "rect_with_left_cylinder",
+      "op": {
+        "type": "Union",
+        "left": 1,
+        "right": 3
+      }
+    },
+    "stadium": {
+      "id": 7,
+      "name": "stadium_bar",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 5
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 7,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
@@ -44,11 +44,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -60,7 +60,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120439Z-2b28",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3541.591605
+      }
+    ],
+    "tokens": {
+      "input": 734,
+      "output": 700,
+      "total": 1434
+    },
+    "wallclock_sec": 3.5415916050000003
+  },
+  "output": {
+    "vcad_path": "20260429T120439Z-2b28.vcad",
+    "vcad_sha256": "09315eef5544b55bfa732af96095074b9d107aadfe165826104ee53d8867f210",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:39.475Z",
+    "ended_at": "2026-04-29T12:04:43.026Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120439Z-2b28.vcad
@@ -1,0 +1,86 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "rect": {
+      "id": "rect",
+      "name": "Central rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 20, "z": 10}
+      }
+    },
+    "rect_centered": {
+      "id": "rect_centered",
+      "name": "Rectangle centered at origin in XY",
+      "op": {
+        "type": "Translate",
+        "child": "rect",
+        "offset": {"x": -30, "y": -10, "z": 0}
+      }
+    },
+    "cylinder_left": {
+      "id": "cylinder_left",
+      "name": "Left semicircle cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_left_positioned": {
+      "id": "cylinder_left_positioned",
+      "name": "Left semicircle at (-30, 0)",
+      "op": {
+        "type": "Translate",
+        "child": "cylinder_left",
+        "offset": {"x": -30, "y": 0, "z": 0}
+      }
+    },
+    "cylinder_right": {
+      "id": "cylinder_right",
+      "name": "Right semicircle cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_right_positioned": {
+      "id": "cylinder_right_positioned",
+      "name": "Right semicircle at (30, 0)",
+      "op": {
+        "type": "Translate",
+        "child": "cylinder_right",
+        "offset": {"x": 30, "y": 0, "z": 0}
+      }
+    },
+    "union_left": {
+      "id": "union_left",
+      "name": "Rectangle union left semicircle",
+      "op": {
+        "type": "Union",
+        "left": "rect_centered",
+        "right": "cylinder_left_positioned"
+      }
+    },
+    "final": {
+      "id": "final",
+      "name": "Stadium-shaped bar",
+      "op": {
+        "type": "Union",
+        "left": "union_left",
+        "right": "cylinder_right_positioned"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
@@ -44,11 +44,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -60,7 +60,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120443Z-0071",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3056.5452840000003
+      }
+    ],
+    "tokens": {
+      "input": 734,
+      "output": 671,
+      "total": 1405
+    },
+    "wallclock_sec": 3.0565452840000003
+  },
+  "output": {
+    "vcad_path": "20260429T120443Z-0071.vcad",
+    "vcad_sha256": "8bcb5778ee1687864975be1d1d037399e47410b65c5dbda2f2b6e61c79919ac4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:43.126Z",
+    "ended_at": "2026-04-29T12:04:46.192Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120443Z-0071.vcad
@@ -1,0 +1,79 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "center_rect": {
+      "id": "center_rect",
+      "name": "center_rect",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 20, "z": 10}
+      }
+    },
+    "center_rect_positioned": {
+      "id": "center_rect_positioned",
+      "name": "center_rect_positioned",
+      "op": {
+        "type": "Translate",
+        "child": "center_rect",
+        "offset": {"x": -30, "y": -10, "z": 0}
+      }
+    },
+    "left_sphere": {
+      "id": "left_sphere",
+      "name": "left_sphere",
+      "op": {
+        "type": "Sphere",
+        "radius": 10,
+        "segments": 32
+      }
+    },
+    "left_sphere_positioned": {
+      "id": "left_sphere_positioned",
+      "name": "left_sphere_positioned",
+      "op": {
+        "type": "Translate",
+        "child": "left_sphere",
+        "offset": {"x": -30, "y": 0, "z": 5}
+      }
+    },
+    "right_sphere": {
+      "id": "right_sphere",
+      "name": "right_sphere",
+      "op": {
+        "type": "Sphere",
+        "radius": 10,
+        "segments": 32
+      }
+    },
+    "right_sphere_positioned": {
+      "id": "right_sphere_positioned",
+      "name": "right_sphere_positioned",
+      "op": {
+        "type": "Translate",
+        "child": "right_sphere",
+        "offset": {"x": 30, "y": 0, "z": 5}
+      }
+    },
+    "union_left": {
+      "id": "union_left",
+      "name": "union_left",
+      "op": {
+        "type": "Union",
+        "left": "center_rect_positioned",
+        "right": "left_sphere_positioned"
+      }
+    },
+    "final_union": {
+      "id": "final_union",
+      "name": "final_union",
+      "op": {
+        "type": "Union",
+        "left": "union_left",
+        "right": "right_sphere_positioned"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "final_union", "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120446Z-159b",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3497.661051
+      }
+    ],
+    "tokens": {
+      "input": 734,
+      "output": 733,
+      "total": 1467
+    },
+    "wallclock_sec": 3.497661051
+  },
+  "output": {
+    "vcad_path": "20260429T120446Z-159b.vcad",
+    "vcad_sha256": "4c5914ba40b0a71471b2980cb9277d0c4209a4cb9f422f35162fcb786d6f86d9",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:46.291Z",
+    "ended_at": "2026-04-29T12:04:49.798Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
@@ -44,11 +44,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -60,7 +60,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120446Z-159b.vcad
@@ -1,0 +1,102 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "rect": {
+      "id": "rect",
+      "name": "Central rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {
+          "x": 60,
+          "y": 20,
+          "z": 10
+        }
+      }
+    },
+    "rect_translated": {
+      "id": "rect_translated",
+      "name": "Rectangle centered in XY",
+      "op": {
+        "type": "Translate",
+        "child": "rect",
+        "offset": {
+          "x": -30,
+          "y": -10,
+          "z": 0
+        }
+      }
+    },
+    "cylinder_left": {
+      "id": "cylinder_left",
+      "name": "Left semicircle extrusion",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_left_translated": {
+      "id": "cylinder_left_translated",
+      "name": "Left semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "cylinder_left",
+        "offset": {
+          "x": -30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "cylinder_right": {
+      "id": "cylinder_right",
+      "name": "Right semicircle extrusion",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cylinder_right_translated": {
+      "id": "cylinder_right_translated",
+      "name": "Right semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "cylinder_right",
+        "offset": {
+          "x": 30,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "union_left": {
+      "id": "union_left",
+      "name": "Rectangle + left cylinder",
+      "op": {
+        "type": "Union",
+        "left": "rect_translated",
+        "right": "cylinder_left_translated"
+      }
+    },
+    "stadium_bar": {
+      "id": "stadium_bar",
+      "name": "Stadium-shaped flat bar",
+      "op": {
+        "type": "Union",
+        "left": "union_left",
+        "right": "cylinder_right_translated"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "stadium_bar",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
@@ -44,11 +44,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -60,7 +60,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120449Z-ad3a",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3343.1872390000003
+      }
+    ],
+    "tokens": {
+      "input": 734,
+      "output": 710,
+      "total": 1444
+    },
+    "wallclock_sec": 3.343187239
+  },
+  "output": {
+    "vcad_path": "20260429T120449Z-ad3a.vcad",
+    "vcad_sha256": "2ff64d8cf4afa713d7c03bb90d4ca9262664ea77bd9c7c8ec7723914843e7a8e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:49.895Z",
+    "ended_at": "2026-04-29T12:04:53.247Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-haiku-4-5-20251001/20260429T120449Z-ad3a.vcad
@@ -1,0 +1,86 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "rect": {
+      "id": "rect",
+      "name": "Central rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 20, "z": 10}
+      }
+    },
+    "rect_translated": {
+      "id": "rect_translated",
+      "name": "Rectangle centered",
+      "op": {
+        "type": "Translate",
+        "child": "rect",
+        "offset": {"x": -30, "y": -10, "z": 0}
+      }
+    },
+    "cyl_left": {
+      "id": "cyl_left",
+      "name": "Left semicircle cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cyl_left_translated": {
+      "id": "cyl_left_translated",
+      "name": "Left semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "cyl_left",
+        "offset": {"x": -30, "y": 0, "z": 0}
+      }
+    },
+    "cyl_right": {
+      "id": "cyl_right",
+      "name": "Right semicircle cylinder",
+      "op": {
+        "type": "Cylinder",
+        "radius": 10,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "cyl_right_translated": {
+      "id": "cyl_right_translated",
+      "name": "Right semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "cyl_right",
+        "offset": {"x": 30, "y": 0, "z": 0}
+      }
+    },
+    "rect_and_left": {
+      "id": "rect_and_left",
+      "name": "Rectangle union left semicircle",
+      "op": {
+        "type": "Union",
+        "left": "rect_translated",
+        "right": "cyl_left_translated"
+      }
+    },
+    "stadium_bar": {
+      "id": "stadium_bar",
+      "name": "Stadium-shaped flat bar",
+      "op": {
+        "type": "Union",
+        "left": "rect_and_left",
+        "right": "cyl_right_translated"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "stadium_bar",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "max_abs_deviation_mm": 4.39629249700006e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.54874536396,
-          "deviation_pct": 0.033294090224608656,
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.06548108557483903,
-              "original_mm3": 15136.54874536396,
+              "deviation_pct": 0.2823713416216259,
+              "original_mm3": 15136.548745363963,
               "pass": true,
-              "roundtripped_mm3": 15126.63716892693
+              "roundtripped_mm3": 15093.807469596468
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.06548108557483903,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15126.63716892693
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120632Z-b1dd",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5073.404641
+      }
+    ],
+    "tokens": {
+      "input": 955,
+      "output": 510,
+      "total": 1465
+    },
+    "wallclock_sec": 5.073404641
+  },
+  "output": {
+    "vcad_path": "20260429T120632Z-b1dd.vcad",
+    "vcad_sha256": "f1d6be9f31bef2f5580bdf8a78b10946a71d77897825022e222813241995e9f4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:32.903Z",
+    "ended_at": "2026-04-29T12:06:38.059Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120632Z-b1dd.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "rect", "op": {"type":"Cube", "size": {"x":60,"y":20,"z":10}} },
+    "2": { "id": 2, "name": "rect_centered", "op": {"type":"Translate", "child":1, "offset":{"x":-30,"y":-10,"z":0}} },
+    "3": { "id": 3, "name": "cyl_left", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "4": { "id": 4, "name": "cyl_left_pos", "op": {"type":"Translate", "child":3, "offset":{"x":-30,"y":0,"z":0}} },
+    "5": { "id": 5, "name": "cyl_right", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "6": { "id": 6, "name": "cyl_right_pos", "op": {"type":"Translate", "child":5, "offset":{"x":30,"y":0,"z":0}} },
+    "7": { "id": 7, "name": "u1", "op": {"type":"Union", "left":2, "right":4} },
+    "8": { "id": 8, "name": "stadium", "op": {"type":"Union", "left":7, "right":6} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{ "root": 8, "material": "default" }]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 4.39629249700006e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.2823713416216259,
+              "original_mm3": 15136.548745363963,
+              "pass": true,
+              "roundtripped_mm3": 15093.807469596468
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120638Z-ddc6",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4984.44942
+      }
+    ],
+    "tokens": {
+      "input": 955,
+      "output": 510,
+      "total": 1465
+    },
+    "wallclock_sec": 4.98444942
+  },
+  "output": {
+    "vcad_path": "20260429T120638Z-ddc6.vcad",
+    "vcad_sha256": "bb0fb72ae9d39eae793980a673950c299a9086fdb7f9057269573a07d54c3c2e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:38.127Z",
+    "ended_at": "2026-04-29T12:06:43.197Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,11 +65,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -88,9 +88,9 @@
           "max_abs_deviation_mm": 4.39629249700006e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
@@ -99,7 +99,7 @@
           "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,34 +108,34 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
@@ -149,7 +149,7 @@
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120638Z-ddc6.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "rect", "op": {"type":"Cube", "size":{"x":60,"y":20,"z":10}} },
+    "2": { "id": 2, "name": "rect_centered", "op": {"type":"Translate", "child":1, "offset":{"x":-30,"y":-10,"z":0}} },
+    "3": { "id": 3, "name": "cyl_left", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "4": { "id": 4, "name": "cyl_left_pos", "op": {"type":"Translate", "child":3, "offset":{"x":-30,"y":0,"z":0}} },
+    "5": { "id": 5, "name": "cyl_right", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "6": { "id": 6, "name": "cyl_right_pos", "op": {"type":"Translate", "child":5, "offset":{"x":30,"y":0,"z":0}} },
+    "7": { "id": 7, "name": "union1", "op": {"type":"Union", "left":2, "right":4} },
+    "8": { "id": 8, "name": "stadium", "op": {"type":"Union", "left":7, "right":6} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{ "root": 8, "material": "default" }]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "max_abs_deviation_mm": 9.523631354549103e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.54874536396,
-          "deviation_pct": 0.033294090224608656,
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.28237134162160193,
-              "original_mm3": 15136.54874536396,
+              "deviation_pct": 0.2823713416216259,
+              "original_mm3": 15136.548745363963,
               "pass": true,
               "roundtripped_mm3": 15093.807469596468
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.28237134162160193,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15093.807469596468
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120643Z-5d96",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5145.969641
+      }
+    ],
+    "tokens": {
+      "input": 955,
+      "output": 530,
+      "total": 1485
+    },
+    "wallclock_sec": 5.145969641
+  },
+  "output": {
+    "vcad_path": "20260429T120643Z-5d96.vcad",
+    "vcad_sha256": "92ab3edd3e17a494ec6ed070d9ee9150817cf5b6a351be660475bd5374be1bf1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:43.261Z",
+    "ended_at": "2026-04-29T12:06:48.489Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120643Z-5d96.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "rect", "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "rect_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "cyl_left", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "4": {"id": 4, "name": "cyl_left_pos", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "cyl_right", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "6": {"id": 6, "name": "cyl_right_pos", "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "union1", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "union2", "op": {"type": "Union", "left": 7, "right": 6}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.28237134162160193,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15093.807469596468
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120648Z-5e06",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6035.939893000001
+      }
+    ],
+    "tokens": {
+      "input": 955,
+      "output": 515,
+      "total": 1470
+    },
+    "wallclock_sec": 6.035939893000001
+  },
+  "output": {
+    "vcad_path": "20260429T120648Z-5e06.vcad",
+    "vcad_sha256": "222d55f59a9e50aab4e8b25ba121091523a3467971035ce87f8d85349eb7e556",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:48.562Z",
+    "ended_at": "2026-04-29T12:06:54.682Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            3.0643861140820463e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "max_abs_deviation_mm": 4.39629249700006e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.54874536396,
-          "deviation_pct": 0.033294090224608656,
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.28237134162160193,
-              "original_mm3": 15136.54874536396,
+              "deviation_pct": 0.06548108557486305,
+              "original_mm3": 15136.548745363963,
               "pass": true,
-              "roundtripped_mm3": 15093.807469596468
+              "roundtripped_mm3": 15126.63716892693
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120648Z-5e06.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "rect", "op": {"type":"Cube", "size": {"x":60,"y":20,"z":10}} },
+    "2": { "id": 2, "name": "rect_centered", "op": {"type":"Translate", "child":1, "offset":{"x":-30,"y":-10,"z":0}} },
+    "3": { "id": 3, "name": "cyl_left", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "4": { "id": 4, "name": "cyl_left_pos", "op": {"type":"Translate", "child":3, "offset":{"x":-30,"y":0,"z":0}} },
+    "5": { "id": 5, "name": "cyl_right", "op": {"type":"Cylinder", "radius":10, "height":10, "segments":64} },
+    "6": { "id": 6, "name": "cyl_right_pos", "op": {"type":"Translate", "child":5, "offset":{"x":30,"y":0,"z":0}} },
+    "7": { "id": 7, "name": "rect_plus_left", "op": {"type":"Union", "left":2, "right":4} },
+    "8": { "id": 8, "name": "stadium", "op": {"type":"Union", "left":7, "right":6} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{ "root": 8, "material": "default" }]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            8.191724971631091e-15,
-            2.7069995799438013e-17,
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            8.191724971631091e-15,
-            2.7069995799438013e-17,
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 8.191724971631091e-15,
+          "max_abs_deviation_mm": 9.523631354549103e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.54874536396,
-          "deviation_pct": 0.033294090224608656,
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.06548108557483903,
-              "original_mm3": 15136.54874536396,
+              "deviation_pct": 0.06548108557486305,
+              "original_mm3": 15136.548745363963,
               "pass": true,
               "roundtripped_mm3": 15126.63716892693
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            8.191724971631091e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            8.191724971631091e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 8.191724971631091e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.06548108557483903,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15126.63716892693
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120654Z-e23a",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5037.41589
+      }
+    ],
+    "tokens": {
+      "input": 955,
+      "output": 530,
+      "total": 1485
+    },
+    "wallclock_sec": 5.03741589
+  },
+  "output": {
+    "vcad_path": "20260429T120654Z-e23a.vcad",
+    "vcad_sha256": "92ab3edd3e17a494ec6ed070d9ee9150817cf5b6a351be660475bd5374be1bf1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:54.750Z",
+    "ended_at": "2026-04-29T12:06:59.870Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-opus-4-7/20260429T120654Z-e23a.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "rect", "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "rect_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "cyl_left", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "4": {"id": 4, "name": "cyl_left_pos", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "cyl_right", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "6": {"id": 6, "name": "cyl_right_pos", "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "union1", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "union2", "op": {"type": "Union", "left": 7, "right": 6}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            4.39629249700006e-15,
-            -5.946010638026846e-17,
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            4.39629249700006e-15,
-            -5.946010638026846e-17,
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 4.39629249700006e-15,
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.548745363963,
-          "deviation_pct": 0.03329409022458463,
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.2823713416216259,
-              "original_mm3": 15136.548745363963,
+              "deviation_pct": 0.06548108557483903,
+              "original_mm3": 15136.54874536396,
               "pass": true,
-              "roundtripped_mm3": 15093.807469596468
+              "roundtripped_mm3": 15126.63716892693
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 4.39629249700006e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.2823713416216259,
+              "original_mm3": 15136.548745363963,
+              "pass": true,
+              "roundtripped_mm3": 15093.807469596468
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120630Z-bb6b",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5324.725886
+      }
+    ],
+    "tokens": {
+      "input": 735,
+      "output": 468,
+      "total": 1203
+    },
+    "wallclock_sec": 5.324725886
+  },
+  "output": {
+    "vcad_path": "20260429T120630Z-bb6b.vcad",
+    "vcad_sha256": "f9b5e3a35cf9a966b417e5707711fc6962d8632ee28fb82d762fc44d6d6fcaf7",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:30.979Z",
+    "ended_at": "2026-04-29T12:06:36.386Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120630Z-bb6b.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "center_box", "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "center_box_translated", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "left_cylinder", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "4": {"id": 4, "name": "left_cylinder_translated", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "right_cylinder", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "6": {"id": 6, "name": "right_cylinder_translated", "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "union_left", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "stadium_bar", "op": {"type": "Union", "left": 7, "right": 6}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            8.191724971631091e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            8.191724971631091e-15,
-            2.7069995799438013e-17,
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 8.191724971631091e-15,
+          "max_abs_deviation_mm": 4.39629249700006e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.54874536396,
-          "deviation_pct": 0.033294090224608656,
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.06548108557483903,
-              "original_mm3": 15136.54874536396,
+              "deviation_pct": 0.2823713416216259,
+              "original_mm3": 15136.548745363963,
               "pass": true,
-              "roundtripped_mm3": 15126.63716892693
+              "roundtripped_mm3": 15093.807469596468
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            8.191724971631091e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            8.191724971631091e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 8.191724971631091e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.06548108557483903,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15126.63716892693
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120636Z-f7ea",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5470.135895
+      }
+    ],
+    "tokens": {
+      "input": 735,
+      "output": 503,
+      "total": 1238
+    },
+    "wallclock_sec": 5.470135895
+  },
+  "output": {
+    "vcad_path": "20260429T120636Z-f7ea.vcad",
+    "vcad_sha256": "0c70607be6f2634179b7bd9d297ccfc5825be62f583c3fc790b4132291192deb",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:36.452Z",
+    "ended_at": "2026-04-29T12:06:42.005Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120636Z-f7ea.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "center_box", "op": { "type": "Cube", "size": { "x": 60, "y": 20, "z": 10 } } },
+    "2": { "id": 2, "name": "center_box_translated", "op": { "type": "Translate", "child": 1, "offset": { "x": -30, "y": -10, "z": 0 } } },
+    "3": { "id": 3, "name": "left_cylinder", "op": { "type": "Cylinder", "radius": 10, "height": 10, "segments": 64 } },
+    "4": { "id": 4, "name": "left_cylinder_translated", "op": { "type": "Translate", "child": 3, "offset": { "x": -30, "y": 0, "z": 0 } } },
+    "5": { "id": 5, "name": "right_cylinder", "op": { "type": "Cylinder", "radius": 10, "height": 10, "segments": 64 } },
+    "6": { "id": 6, "name": "right_cylinder_translated", "op": { "type": "Translate", "child": 5, "offset": { "x": 30, "y": 0, "z": 0 } } },
+    "7": { "id": 7, "name": "union_left", "op": { "type": "Union", "left": 2, "right": 4 } },
+    "8": { "id": 8, "name": "stadium_bar", "op": { "type": "Union", "left": 7, "right": 6 } }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{ "root": 8, "material": "default" }]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,32 +65,32 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            3.0643861140820463e-15,
+            8.191724971631091e-15,
             2.7069995799438013e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            3.0643861140820463e-15,
+            8.191724971631091e-15,
             2.7069995799438013e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "max_abs_deviation_mm": 8.191724971631091e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
@@ -99,7 +99,7 @@
           "deviation_pct": 0.033294090224608656,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.28237134162160193,
+              "deviation_pct": 0.06548108557483903,
               "original_mm3": 15136.54874536396,
               "pass": true,
-              "roundtripped_mm3": 15093.807469596468
+              "roundtripped_mm3": 15126.63716892693
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.28237134162160193,
+              "original_mm3": 15136.54874536396,
+              "pass": true,
+              "roundtripped_mm3": 15093.807469596468
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120642Z-2ed6",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6272.866584
+      }
+    ],
+    "tokens": {
+      "input": 735,
+      "output": 543,
+      "total": 1278
+    },
+    "wallclock_sec": 6.272866584
+  },
+  "output": {
+    "vcad_path": "20260429T120642Z-2ed6.vcad",
+    "vcad_sha256": "1ee776b60bcb4e0f330d2d394f6a892a289f7928becac816ab1eca4d6457b1c4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:42.074Z",
+    "ended_at": "2026-04-29T12:06:48.431Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120642Z-2ed6.vcad
@@ -1,0 +1,48 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "center_box",
+      "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "center_box_translated",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "left_cylinder",
+      "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}
+    },
+    "4": {
+      "id": 4,
+      "name": "left_cylinder_translated",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "right_cylinder",
+      "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}
+    },
+    "6": {
+      "id": 6,
+      "name": "right_cylinder_translated",
+      "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}
+    },
+    "7": {
+      "id": 7,
+      "name": "union_box_left",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    },
+    "8": {
+      "id": 8,
+      "name": "stadium_bar",
+      "op": {"type": "Union", "left": 7, "right": 6}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            4.39629249700006e-15,
+            -5.946010638026846e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 4.39629249700006e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.065481085574827,
+              "original_mm3": 15136.548745363963,
+              "pass": true,
+              "roundtripped_mm3": 15126.637168926936
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120648Z-bc3c",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5461.006164
+      }
+    ],
+    "tokens": {
+      "input": 735,
+      "output": 468,
+      "total": 1203
+    },
+    "wallclock_sec": 5.4610061640000005
+  },
+  "output": {
+    "vcad_path": "20260429T120648Z-bc3c.vcad",
+    "vcad_sha256": "f9b5e3a35cf9a966b417e5707711fc6962d8632ee28fb82d762fc44d6d6fcaf7",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:48.499Z",
+    "ended_at": "2026-04-29T12:06:54.043Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,41 +65,41 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "center_of_mass": {
           "actual": [
-            4.39629249700006e-15,
-            -5.946010638026846e-17,
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
             4.999999999999997
           ],
           "bbox_diagonal_mm": 83.06623862918075,
           "deviation": [
-            4.39629249700006e-15,
-            -5.946010638026846e-17,
+            3.0643861140820463e-15,
+            2.7069995799438013e-17,
             -2.6645352591003757e-15
           ],
-          "max_abs_deviation_mm": 4.39629249700006e-15,
+          "max_abs_deviation_mm": 3.0643861140820463e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
         "volume": {
-          "actual_mm3": 15136.548745363963,
-          "deviation_pct": 0.03329409022458463,
+          "actual_mm3": 15136.54874536396,
+          "deviation_pct": 0.033294090224608656,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,48 +108,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.065481085574827,
-              "original_mm3": 15136.548745363963,
+              "deviation_pct": 0.06548108557480298,
+              "original_mm3": 15136.54874536396,
               "pass": true,
               "roundtripped_mm3": 15126.637168926936
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120648Z-bc3c.vcad
@@ -1,0 +1,16 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "center_box", "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "center_box_translated", "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "left_cylinder", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "4": {"id": 4, "name": "left_cylinder_translated", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}},
+    "5": {"id": 5, "name": "right_cylinder", "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}},
+    "6": {"id": 6, "name": "right_cylinder_translated", "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "union_left", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "stadium_bar", "op": {"type": "Union", "left": 7, "right": 6}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          10,
-          10
+          40.0,
+          10.0,
+          10.0
         ],
         "actual_min": [
-          -40,
-          -10,
-          0
+          -40.0,
+          -10.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.2
       }
     },
@@ -65,11 +65,11 @@
         "type": "mass_props",
         "volume_mm3": 15141.59,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
@@ -88,9 +88,9 @@
           "max_abs_deviation_mm": 9.523631354549103e-15,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.8306623862918074
         },
@@ -99,7 +99,7 @@
           "deviation_pct": 0.03329409022458463,
           "pass": true,
           "spec_mm3": 15141.59,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -108,34 +108,34 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "original_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                10,
-                10
+                40.0,
+                10.0,
+                10.0
               ],
               "roundtripped_min": [
-                -40,
-                -10,
-                0
+                -40.0,
+                -10.0,
+                0.0
               ],
               "tolerance_mm": 0.8306623862918074
             },
@@ -149,7 +149,7 @@
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-rounded-bar-01",
-    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm \u00d7 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.json
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-rounded-bar-01",
+  "task_sha256": "7d784df0d0a2093508ecd8afc9682f361b3ac3936400a370796a57e039c78acb",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -10,
+          0
+        ],
+        "max": [
+          40,
+          10,
+          10
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          10,
+          10
+        ],
+        "actual_min": [
+          -40,
+          -10,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.2
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 15141.59,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
+            4.999999999999997
+          ],
+          "bbox_diagonal_mm": 83.06623862918075,
+          "deviation": [
+            9.523631354549103e-15,
+            -5.946010638026846e-17,
+            -2.6645352591003757e-15
+          ],
+          "max_abs_deviation_mm": 9.523631354549103e-15,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.8306623862918074
+        },
+        "volume": {
+          "actual_mm3": 15136.548745363963,
+          "deviation_pct": 0.03329409022458463,
+          "pass": true,
+          "spec_mm3": 15141.59,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                10,
+                10
+              ],
+              "original_min": [
+                -40,
+                -10,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                10,
+                10
+              ],
+              "roundtripped_min": [
+                -40,
+                -10,
+                0
+              ],
+              "tolerance_mm": 0.8306623862918074
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.06548108557486305,
+              "original_mm3": 15136.548745363963,
+              "pass": true,
+              "roundtripped_mm3": 15126.63716892693
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120654Z-501a",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-rounded-bar-01",
+    "rendered": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 500
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6273.9072209999995
+      }
+    ],
+    "tokens": {
+      "input": 735,
+      "output": 543,
+      "total": 1278
+    },
+    "wallclock_sec": 6.273907220999999
+  },
+  "output": {
+    "vcad_path": "20260429T120654Z-501a.vcad",
+    "vcad_sha256": "1ee776b60bcb4e0f330d2d394f6a892a289f7928becac816ab1eca4d6457b1c4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:06:54.114Z",
+    "ended_at": "2026-04-29T12:07:00.471Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.vcad
+++ b/mecheval/runs/a4-rounded-bar-01/claude-direct-claude-sonnet-4-6/20260429T120654Z-501a.vcad
@@ -1,0 +1,48 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "center_box",
+      "op": {"type": "Cube", "size": {"x": 60, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "center_box_translated",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -30, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "left_cylinder",
+      "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}
+    },
+    "4": {
+      "id": 4,
+      "name": "left_cylinder_translated",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": 0, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "right_cylinder",
+      "op": {"type": "Cylinder", "radius": 10, "height": 10, "segments": 64}
+    },
+    "6": {
+      "id": 6,
+      "name": "right_cylinder_translated",
+      "op": {"type": "Translate", "child": 5, "offset": {"x": 30, "y": 0, "z": 0}}
+    },
+    "7": {
+      "id": 7,
+      "name": "union_box_left",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    },
+    "8": {
+      "id": 8,
+      "name": "stadium_bar",
+      "op": {"type": "Union", "left": 7, "right": 6}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 8, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": []
@@ -73,39 +73,39 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -118,7 +118,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -130,7 +130,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -158,7 +158,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120254Z-b488",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4203.859662
+      }
+    ],
+    "tokens": {
+      "input": 781,
+      "output": 887,
+      "total": 1668
+    },
+    "wallclock_sec": 4.203859662
+  },
+  "output": {
+    "vcad_path": "20260429T120254Z-b488.vcad",
+    "vcad_sha256": "860a491cccb146ce8cd82e4b8b149081ba8af1f68508d7ea901b498d24b0a08e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:54.279Z",
+    "ended_at": "2026-04-29T12:02:58.492Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120254Z-b488.vcad
@@ -1,0 +1,112 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_plate": {
+      "id": 1,
+      "name": "base_plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 40, "z": 8}
+      }
+    },
+    "base_plate_centered": {
+      "id": 2,
+      "name": "base_plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {"x": -40, "y": -20, "z": 0}
+      }
+    },
+    "slot_rect": {
+      "id": 3,
+      "name": "slot_rect",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 10, "z": 10}
+      }
+    },
+    "slot_rect_positioned": {
+      "id": 4,
+      "name": "slot_rect_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 3,
+        "offset": {"x": -20, "y": -5, "z": -1}
+      }
+    },
+    "slot_left_semi": {
+      "id": 5,
+      "name": "slot_left_semi",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_left_semi_positioned": {
+      "id": 6,
+      "name": "slot_left_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 5,
+        "offset": {"x": -20, "y": 0, "z": -1}
+      }
+    },
+    "slot_right_semi": {
+      "id": 7,
+      "name": "slot_right_semi",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_right_semi_positioned": {
+      "id": 8,
+      "name": "slot_right_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 7,
+        "offset": {"x": 20, "y": 0, "z": -1}
+      }
+    },
+    "slot_rect_and_left": {
+      "id": 9,
+      "name": "slot_rect_and_left",
+      "op": {
+        "type": "Union",
+        "left": 4,
+        "right": 6
+      }
+    },
+    "slot_complete": {
+      "id": 10,
+      "name": "slot_complete",
+      "op": {
+        "type": "Union",
+        "left": 9,
+        "right": 8
+      }
+    },
+    "bracket": {
+      "id": 11,
+      "name": "bracket",
+      "op": {
+        "type": "Difference",
+        "left": 2,
+        "right": 10
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 11,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": []
@@ -73,39 +73,39 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -118,7 +118,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -130,7 +130,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -158,7 +158,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120258Z-8f99",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4529.272886
+      }
+    ],
+    "tokens": {
+      "input": 781,
+      "output": 958,
+      "total": 1739
+    },
+    "wallclock_sec": 4.529272885999999
+  },
+  "output": {
+    "vcad_path": "20260429T120258Z-8f99.vcad",
+    "vcad_sha256": "97e292fdd24dddb1ee7b6a65d879a6927757058e5abc230c322ca6b5a49a7b63",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:02:58.591Z",
+    "ended_at": "2026-04-29T12:03:03.130Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120258Z-8f99.vcad
@@ -1,0 +1,112 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate": {
+      "id": "plate",
+      "name": "Base plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 40, "z": 8}
+      }
+    },
+    "plate_centered": {
+      "id": "plate_centered",
+      "name": "Centered plate",
+      "op": {
+        "type": "Translate",
+        "child": "plate",
+        "offset": {"x": -40, "y": -20, "z": 0}
+      }
+    },
+    "slot_rect": {
+      "id": "slot_rect",
+      "name": "Rectangular section of slot",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 10, "z": 10}
+      }
+    },
+    "slot_rect_positioned": {
+      "id": "slot_rect_positioned",
+      "name": "Rectangular section positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_rect",
+        "offset": {"x": -20, "y": -5, "z": -1}
+      }
+    },
+    "slot_left_semicircle": {
+      "id": "slot_left_semicircle",
+      "name": "Left semicircle of slot",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_left_positioned": {
+      "id": "slot_left_positioned",
+      "name": "Left semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_left_semicircle",
+        "offset": {"x": -20, "y": 0, "z": -1}
+      }
+    },
+    "slot_right_semicircle": {
+      "id": "slot_right_semicircle",
+      "name": "Right semicircle of slot",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_right_positioned": {
+      "id": "slot_right_positioned",
+      "name": "Right semicircle positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_right_semicircle",
+        "offset": {"x": 20, "y": 0, "z": -1}
+      }
+    },
+    "slot_left_and_rect": {
+      "id": "slot_left_and_rect",
+      "name": "Left semicircle union with rect",
+      "op": {
+        "type": "Union",
+        "left": "slot_left_positioned",
+        "right": "slot_rect_positioned"
+      }
+    },
+    "slot_combined": {
+      "id": "slot_combined",
+      "name": "Full stadium slot",
+      "op": {
+        "type": "Union",
+        "left": "slot_left_and_rect",
+        "right": "slot_right_positioned"
+      }
+    },
+    "result": {
+      "id": "result",
+      "name": "Slotted bracket",
+      "op": {
+        "type": "Difference",
+        "left": "plate_centered",
+        "right": "slot_combined"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "result",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120303Z-8b44",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4074.2367030000005
+      }
+    ],
+    "tokens": {
+      "input": 781,
+      "output": 891,
+      "total": 1672
+    },
+    "wallclock_sec": 4.074236703
+  },
+  "output": {
+    "vcad_path": "20260429T120303Z-8b44.vcad",
+    "vcad_sha256": "eb07b0df41de9124927bd04fdea1ab08b9898840352911a75474bdf2c280362c",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:03.243Z",
+    "ended_at": "2026-04-29T12:03:07.326Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": []
@@ -73,39 +73,39 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -118,7 +118,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -130,7 +130,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -158,7 +158,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120303Z-8b44.vcad
@@ -1,0 +1,112 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate": {
+      "id": 0,
+      "name": "base_plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 40, "z": 8}
+      }
+    },
+    "plate_centered": {
+      "id": 1,
+      "name": "plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -40, "y": -20, "z": 0}
+      }
+    },
+    "slot_rect": {
+      "id": 2,
+      "name": "slot_rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 10, "z": 8}
+      }
+    },
+    "slot_rect_centered": {
+      "id": 3,
+      "name": "slot_rect_centered",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": -20, "y": -5, "z": 0}
+      }
+    },
+    "slot_left_semicircle": {
+      "id": 4,
+      "name": "slot_left_semicircle",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 8,
+        "segments": 32
+      }
+    },
+    "slot_left_semi_positioned": {
+      "id": 5,
+      "name": "slot_left_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": -20, "y": 0, "z": 0}
+      }
+    },
+    "slot_right_semicircle": {
+      "id": 6,
+      "name": "slot_right_semicircle",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 8,
+        "segments": 32
+      }
+    },
+    "slot_right_semi_positioned": {
+      "id": 7,
+      "name": "slot_right_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 6,
+        "offset": {"x": 20, "y": 0, "z": 0}
+      }
+    },
+    "slot_union_1": {
+      "id": 8,
+      "name": "slot_union_1",
+      "op": {
+        "type": "Union",
+        "left": 3,
+        "right": 5
+      }
+    },
+    "slot_complete": {
+      "id": 9,
+      "name": "slot_complete",
+      "op": {
+        "type": "Union",
+        "left": 8,
+        "right": 7
+      }
+    },
+    "final_bracket": {
+      "id": 10,
+      "name": "slotted_bracket",
+      "op": {
+        "type": "Difference",
+        "left": 1,
+        "right": 9
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 10,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": []
@@ -73,39 +73,39 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -118,7 +118,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -130,7 +130,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -158,7 +158,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120307Z-c947",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4602.601043000001
+      }
+    ],
+    "tokens": {
+      "input": 781,
+      "output": 1013,
+      "total": 1794
+    },
+    "wallclock_sec": 4.602601043000001
+  },
+  "output": {
+    "vcad_path": "20260429T120307Z-c947.vcad",
+    "vcad_sha256": "917c9d9e40d4b7049b3faf2ebbb62325787effc37bf22b58b7f0cc9ad4664cb2",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:07.425Z",
+    "ended_at": "2026-04-29T12:03:12.038Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120307Z-c947.vcad
@@ -1,0 +1,112 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_plate": {
+      "id": "base_plate",
+      "name": "Base Plate",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 40, "z": 8}
+      }
+    },
+    "base_plate_centered": {
+      "id": "base_plate_centered",
+      "name": "Base Plate Centered",
+      "op": {
+        "type": "Translate",
+        "child": "base_plate",
+        "offset": {"x": -40, "y": -20, "z": 0}
+      }
+    },
+    "slot_rect": {
+      "id": "slot_rect",
+      "name": "Slot Rectangle",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 10, "z": 10}
+      }
+    },
+    "slot_rect_positioned": {
+      "id": "slot_rect_positioned",
+      "name": "Slot Rectangle Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_rect",
+        "offset": {"x": -20, "y": -5, "z": -1}
+      }
+    },
+    "slot_semicircle_left": {
+      "id": "slot_semicircle_left",
+      "name": "Slot Semicircle Left",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_semicircle_left_positioned": {
+      "id": "slot_semicircle_left_positioned",
+      "name": "Slot Semicircle Left Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_semicircle_left",
+        "offset": {"x": -20, "y": 0, "z": -1}
+      }
+    },
+    "slot_semicircle_right": {
+      "id": "slot_semicircle_right",
+      "name": "Slot Semicircle Right",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "slot_semicircle_right_positioned": {
+      "id": "slot_semicircle_right_positioned",
+      "name": "Slot Semicircle Right Positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_semicircle_right",
+        "offset": {"x": 20, "y": 0, "z": -1}
+      }
+    },
+    "slot_union_1": {
+      "id": "slot_union_1",
+      "name": "Slot Union 1",
+      "op": {
+        "type": "Union",
+        "left": "slot_rect_positioned",
+        "right": "slot_semicircle_left_positioned"
+      }
+    },
+    "slot_union_2": {
+      "id": "slot_union_2",
+      "name": "Slot Union 2",
+      "op": {
+        "type": "Union",
+        "left": "slot_union_1",
+        "right": "slot_semicircle_right_positioned"
+      }
+    },
+    "final_bracket": {
+      "id": "final_bracket",
+      "name": "Slotted Bracket",
+      "op": {
+        "type": "Difference",
+        "left": "base_plate_centered",
+        "right": "slot_union_2"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_bracket",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.json
@@ -1,0 +1,198 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120312Z-f9fe",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4229.9625209999995
+      }
+    ],
+    "tokens": {
+      "input": 781,
+      "output": 1002,
+      "total": 1783
+    },
+    "wallclock_sec": 4.229962520999999
+  },
+  "output": {
+    "vcad_path": "20260429T120312Z-f9fe.vcad",
+    "vcad_sha256": "f4224c375f2b85436fb83d656b107adce74b58c3dbc4c8a30d9cdcb0bc319131",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:12.141Z",
+    "ended_at": "2026-04-29T12:03:16.380Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
@@ -43,7 +43,7 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": []
@@ -73,39 +73,39 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -118,7 +118,7 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
@@ -130,7 +130,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -158,7 +158,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-haiku-4-5-20251001/20260429T120312Z-f9fe.vcad
@@ -1,0 +1,136 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "plate": {
+      "id": "plate",
+      "name": "base_plate",
+      "op": {
+        "type": "Cube",
+        "size": {
+          "x": 80,
+          "y": 40,
+          "z": 8
+        }
+      }
+    },
+    "plate_centered": {
+      "id": "plate_centered",
+      "name": "plate_centered",
+      "op": {
+        "type": "Translate",
+        "child": "plate",
+        "offset": {
+          "x": -40,
+          "y": -20,
+          "z": 0
+        }
+      }
+    },
+    "slot_rect": {
+      "id": "slot_rect",
+      "name": "slot_rect",
+      "op": {
+        "type": "Cube",
+        "size": {
+          "x": 40,
+          "y": 10,
+          "z": 8
+        }
+      }
+    },
+    "slot_rect_centered": {
+      "id": "slot_rect_centered",
+      "name": "slot_rect_centered",
+      "op": {
+        "type": "Translate",
+        "child": "slot_rect",
+        "offset": {
+          "x": -20,
+          "y": -5,
+          "z": 0
+        }
+      }
+    },
+    "slot_left_semi": {
+      "id": "slot_left_semi",
+      "name": "slot_left_semi",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 8,
+        "segments": 32
+      }
+    },
+    "slot_left_semi_positioned": {
+      "id": "slot_left_semi_positioned",
+      "name": "slot_left_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_left_semi",
+        "offset": {
+          "x": -20,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "slot_right_semi": {
+      "id": "slot_right_semi",
+      "name": "slot_right_semi",
+      "op": {
+        "type": "Cylinder",
+        "radius": 5,
+        "height": 8,
+        "segments": 32
+      }
+    },
+    "slot_right_semi_positioned": {
+      "id": "slot_right_semi_positioned",
+      "name": "slot_right_semi_positioned",
+      "op": {
+        "type": "Translate",
+        "child": "slot_right_semi",
+        "offset": {
+          "x": 20,
+          "y": 0,
+          "z": 0
+        }
+      }
+    },
+    "slot_union_1": {
+      "id": "slot_union_1",
+      "name": "slot_union_1",
+      "op": {
+        "type": "Union",
+        "left": "slot_rect_centered",
+        "right": "slot_left_semi_positioned"
+      }
+    },
+    "slot_complete": {
+      "id": "slot_complete",
+      "name": "slot_complete",
+      "op": {
+        "type": "Union",
+        "left": "slot_union_1",
+        "right": "slot_right_semi_positioned"
+      }
+    },
+    "bracket": {
+      "id": "bracket",
+      "name": "bracket",
+      "op": {
+        "type": "Difference",
+        "left": "plate_centered",
+        "right": "slot_complete"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "bracket",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120342Z-79e2",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7414.688185
+      }
+    ],
+    "tokens": {
+      "input": 1019,
+      "output": 712,
+      "total": 1731
+    },
+    "wallclock_sec": 7.414688185
+  },
+  "output": {
+    "vcad_path": "20260429T120342Z-79e2.vcad",
+    "vcad_sha256": "870423dfe8c40180e1c1951ed32ec8cbcf0d7c5046b0b186303a806805db16c8",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:42.701Z",
+    "ended_at": "2026-04-29T12:03:50.209Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120342Z-79e2.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "slot_cap_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "slot_cap_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "slot_cap_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "slot_cap_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_partial", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "bracket", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24325.236963687425,
+          "deviation_pct": 11.72880073419885,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 24325.236963687425,
+              "pass": true,
+              "roundtripped_mm3": 24325.236963687425
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120350Z-d857",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7181.493474000001
+      }
+    ],
+    "tokens": {
+      "input": 1019,
+      "output": 712,
+      "total": 1731
+    },
+    "wallclock_sec": 7.181493474000001
+  },
+  "output": {
+    "vcad_path": "20260429T120350Z-d857.vcad",
+    "vcad_sha256": "695982c1bb7835fadca3a076ace003c5010278dd6cd26977a0392e20ba19b656",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:50.275Z",
+    "ended_at": "2026-04-29T12:03:57.506Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24325.236963687425,
-          "deviation_pct": 11.72880073419885,
+          "actual_mm3": 22191.903630354092,
+          "deviation_pct": 1.93013874149396,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 24325.236963687425,
+              "deviation_pct": 0.0,
+              "original_mm3": 22191.903630354092,
               "pass": true,
-              "roundtripped_mm3": 24325.236963687425
+              "roundtripped_mm3": 22191.903630354092
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120350Z-d857.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "slot_cap_left", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 32}},
+    "6": {"id": 6, "name": "slot_cap_left_pos", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "slot_cap_right", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 32}},
+    "8": {"id": 8, "name": "slot_cap_right_pos", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_partial", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "bracket", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120357Z-ce24",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7061.629539
+      }
+    ],
+    "tokens": {
+      "input": 1019,
+      "output": 700,
+      "total": 1719
+    },
+    "wallclock_sec": 7.061629538999999
+  },
+  "output": {
+    "vcad_path": "20260429T120357Z-ce24.vcad",
+    "vcad_sha256": "ad39c7176c44b1f3f0c3df8a912be9f53df8221aaa5ab8d8df209de880032af2",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:57.568Z",
+    "ended_at": "2026-04-29T12:04:04.724Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120357Z-ce24.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "cap_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "cap_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "cap_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "cap_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_partial", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "bracket", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120404Z-a94e",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7884.2308490000005
+      }
+    ],
+    "tokens": {
+      "input": 1019,
+      "output": 708,
+      "total": 1727
+    },
+    "wallclock_sec": 7.884230849000001
+  },
+  "output": {
+    "vcad_path": "20260429T120404Z-a94e.vcad",
+    "vcad_sha256": "27378dcf0b4572721350d71e591914ac59fa223ac568b5eb686027a13c9d015a",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:04.789Z",
+    "ended_at": "2026-04-29T12:04:12.766Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120404Z-a94e.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "slot_end_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "slot_end_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "slot_end_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "slot_end_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_partial", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "bracket", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120412Z-c796",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7050.043121
+      }
+    ],
+    "tokens": {
+      "input": 1019,
+      "output": 702,
+      "total": 1721
+    },
+    "wallclock_sec": 7.050043121
+  },
+  "output": {
+    "vcad_path": "20260429T120412Z-c796.vcad",
+    "vcad_sha256": "a94a3280f8f8bf122fc1f75c7e1016fb6f48e59575d4091ae8ac9ac684cf19c7",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:12.828Z",
+    "ended_at": "2026-04-29T12:04:19.971Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-opus-4-7/20260429T120412Z-c796.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "cyl_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "cyl_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "cyl_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "cyl_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_partial", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "result", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120338Z-100e",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7170.3176730000005
+      }
+    ],
+    "tokens": {
+      "input": 782,
+      "output": 628,
+      "total": 1410
+    },
+    "wallclock_sec": 7.1703176730000004
+  },
+  "output": {
+    "vcad_path": "20260429T120338Z-100e.vcad",
+    "vcad_sha256": "c28d7e9d5dd7be93a160c53f23858748c5908bf6505366abdc4a7123c4ebdf08",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:38.717Z",
+    "ended_at": "2026-04-29T12:03:45.986Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120338Z-100e.vcad
@@ -1,0 +1,24 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+
+    "5": {"id": 5, "name": "slot_cyl_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "slot_cyl_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+
+    "7": {"id": 7, "name": "slot_cyl_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "slot_cyl_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+
+    "9": {"id": 9, "name": "slot_union_1", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot_full", "op": {"type": "Union", "left": 9, "right": 8}},
+
+    "11": {"id": 11, "name": "result", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120346Z-971e",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6563.430442000001
+      }
+    ],
+    "tokens": {
+      "input": 782,
+      "output": 720,
+      "total": 1502
+    },
+    "wallclock_sec": 6.5634304420000005
+  },
+  "output": {
+    "vcad_path": "20260429T120346Z-971e.vcad",
+    "vcad_sha256": "ac0fd9bbe9e9df38b9a943e748869326243358d033c44c48939c51244a2db392",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:46.053Z",
+    "ended_at": "2026-04-29T12:03:52.710Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120346Z-971e.vcad
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "plate",
+      "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}
+    },
+    "2": {
+      "id": 2,
+      "name": "plate_centered",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "slot_rect",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}
+    },
+    "4": {
+      "id": 4,
+      "name": "slot_rect_centered",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "left_cyl",
+      "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}
+    },
+    "6": {
+      "id": 6,
+      "name": "left_cyl_placed",
+      "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}
+    },
+    "7": {
+      "id": 7,
+      "name": "right_cyl",
+      "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}
+    },
+    "8": {
+      "id": 8,
+      "name": "right_cyl_placed",
+      "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}
+    },
+    "9": {
+      "id": 9,
+      "name": "slot_union_1",
+      "op": {"type": "Union", "left": 4, "right": 6}
+    },
+    "10": {
+      "id": 10,
+      "name": "slot_full",
+      "op": {"type": "Union", "left": 9, "right": 8}
+    },
+    "11": {
+      "id": 11,
+      "name": "result",
+      "op": {"type": "Difference", "left": 2, "right": 10}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120352Z-90c7",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 7000.114611
+      }
+    ],
+    "tokens": {
+      "input": 782,
+      "output": 627,
+      "total": 1409
+    },
+    "wallclock_sec": 7.000114611
+  },
+  "output": {
+    "vcad_path": "20260429T120352Z-90c7.vcad",
+    "vcad_sha256": "eb1ffec019e4edf35d9dfc02a64ea3626babdd2de38291662bb71ebb0bba9b0c",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:52.776Z",
+    "ended_at": "2026-04-29T12:03:59.869Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120352Z-90c7.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "slot_cyl_left_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "slot_cyl_left", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "slot_cyl_right_raw", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "slot_cyl_right", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_union1", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot_full", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "result", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120359Z-4cd3",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8191.984262
+      }
+    ],
+    "tokens": {
+      "input": 782,
+      "output": 724,
+      "total": 1506
+    },
+    "wallclock_sec": 8.191984262
+  },
+  "output": {
+    "vcad_path": "20260429T120359Z-4cd3.vcad",
+    "vcad_sha256": "f8b105d3c847694114f92ec02153b785c4f84ddd82804c9fac35b43e310da6a6",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:59.933Z",
+    "ended_at": "2026-04-29T12:04:08.218Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120359Z-4cd3.vcad
@@ -1,0 +1,63 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "plate",
+      "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}
+    },
+    "2": {
+      "id": 2,
+      "name": "plate_centered",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "slot_rect",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}
+    },
+    "4": {
+      "id": 4,
+      "name": "slot_rect_centered",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "left_semicircle",
+      "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}
+    },
+    "6": {
+      "id": 6,
+      "name": "left_semicircle_placed",
+      "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}
+    },
+    "7": {
+      "id": 7,
+      "name": "right_semicircle",
+      "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}
+    },
+    "8": {
+      "id": 8,
+      "name": "right_semicircle_placed",
+      "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}
+    },
+    "9": {
+      "id": 9,
+      "name": "slot_union_1",
+      "op": {"type": "Union", "left": 4, "right": 6}
+    },
+    "10": {
+      "id": 10,
+      "name": "slot_full",
+      "op": {"type": "Union", "left": 9, "right": 8}
+    },
+    "11": {
+      "id": 11,
+      "name": "result",
+      "op": {"type": "Difference", "left": 2, "right": 10}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.json
@@ -1,0 +1,281 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-slotted-bracket-01",
+  "task_sha256": "42dec6ce3ad22666a5e0bbbc713fc117990f88a187b14ebb904cc8d43af0b039",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -20,
+          0
+        ],
+        "max": [
+          40,
+          20,
+          8
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          20,
+          8
+        ],
+        "actual_min": [
+          -40,
+          -20,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 21771.68,
+        "tolerance_pct": 1
+      },
+      "result": "fail",
+      "details": {
+        "volume": {
+          "actual_mm3": 24324.230069357087,
+          "deviation_pct": 11.724175944883843,
+          "pass": false,
+          "spec_mm3": 21771.68,
+          "tolerance_pct": 1
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 10,
+        "expected": 2,
+        "diameter_tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual": 2,
+        "diameter_mm": 10,
+        "diameter_tolerance_mm": 0.1,
+        "expected": 2,
+        "found": [
+          [
+            -20,
+            0,
+            10
+          ],
+          [
+            20,
+            0,
+            10
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 10,
+        "positions": [
+          [
+            -20,
+            0,
+            0
+          ],
+          [
+            20,
+            0,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.2
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 10,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              -20,
+              0
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              20,
+              0
+            ],
+            "pass": true,
+            "spec_xy": [
+              20,
+              0
+            ]
+          }
+        ],
+        "tolerance_mm": 0.2,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 1
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                20,
+                8
+              ],
+              "original_min": [
+                -40,
+                -20,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                20,
+                8
+              ],
+              "roundtripped_min": [
+                -40,
+                -20,
+                0
+              ],
+              "tolerance_mm": 0.897997772825746
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.008278899396057558,
+              "original_mm3": 24324.230069357087,
+              "pass": true,
+              "roundtripped_mm3": 24326.243847893395
+            }
+          }
+        ],
+        "tolerance_pct": 1
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120408Z-4945",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-slotted-bracket-01",
+    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 660
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6867.703885999999
+      }
+    ],
+    "tokens": {
+      "input": 782,
+      "output": 628,
+      "total": 1410
+    },
+    "wallclock_sec": 6.867703885999999
+  },
+  "output": {
+    "vcad_path": "20260429T120408Z-4945.vcad",
+    "vcad_sha256": "a0530c0de871503a76679dc6c89a176cc596d7932c22f8eee20af44081180431",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:08.282Z",
+    "ended_at": "2026-04-29T12:04:15.243Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.json
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          20,
-          8
+          40.0,
+          20.0,
+          8.0
         ],
         "actual_min": [
-          -40,
-          -20,
-          0
+          -40.0,
+          -20.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -64,16 +64,16 @@
       "params": {
         "type": "mass_props",
         "volume_mm3": 21771.68,
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "fail",
       "details": {
         "volume": {
-          "actual_mm3": 24324.230069357087,
-          "deviation_pct": 11.724175944883843,
+          "actual_mm3": 22190.896736023755,
+          "deviation_pct": 1.9255139521789522,
           "pass": false,
           "spec_mm3": 21771.68,
-          "tolerance_pct": 1
+          "tolerance_pct": 1.0
         }
       }
     },
@@ -82,26 +82,26 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "expected": 2,
         "diameter_tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual": 2,
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "diameter_tolerance_mm": 0.1,
         "expected": 2,
         "found": [
           [
-            -20,
-            0,
-            10
+            -20.0,
+            0.0,
+            10.0
           ],
           [
-            20,
-            0,
-            10
+            20.0,
+            0.0,
+            10.0
           ]
         ]
       }
@@ -111,47 +111,47 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "positions": [
           [
-            -20,
-            0,
-            0
+            -20.0,
+            0.0,
+            0.0
           ],
           [
-            20,
-            0,
-            0
+            20.0,
+            0.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.2
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 10,
+        "diameter_mm": 10.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -20,
-              0
+              -20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              -20,
-              0
+              -20.0,
+              0.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              20,
-              0
+              20.0,
+              0.0
             ],
             "pass": true,
             "spec_xy": [
-              20,
-              0
+              20.0,
+              0.0
             ]
           }
         ],
@@ -164,48 +164,48 @@
       "type": "step_roundtrip",
       "params": {
         "type": "step_roundtrip",
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       },
       "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "original_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                20,
-                8
+                40.0,
+                20.0,
+                8.0
               ],
               "roundtripped_min": [
-                -40,
-                -20,
-                0
+                -40.0,
+                -20.0,
+                0.0
               ],
               "tolerance_mm": 0.897997772825746
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.008278899396057558,
-              "original_mm3": 24324.230069357087,
+              "deviation_pct": 0.009074795670778697,
+              "original_mm3": 22190.896736023755,
               "pass": true,
-              "roundtripped_mm3": 24326.243847893395
+              "roundtripped_mm3": 22192.910514560062
             }
           }
         ],
-        "tolerance_pct": 1
+        "tolerance_pct": 1.0
       }
     }
   ],
@@ -241,7 +241,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-slotted-bracket-01",
-    "rendered": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+    "rendered": "Make a flat rectangular plate 80mm \u00d7 40mm \u00d7 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.vcad
+++ b/mecheval/runs/a4-slotted-bracket-01/claude-direct-claude-sonnet-4-6/20260429T120408Z-4945.vcad
@@ -1,0 +1,19 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "plate", "op": {"type": "Cube", "size": {"x": 80, "y": 40, "z": 8}}},
+    "2": {"id": 2, "name": "plate_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -20, "z": 0}}},
+    "3": {"id": 3, "name": "slot_rect", "op": {"type": "Cube", "size": {"x": 40, "y": 10, "z": 8}}},
+    "4": {"id": 4, "name": "slot_rect_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -20, "y": -5, "z": 0}}},
+    "5": {"id": 5, "name": "slot_cyl_left", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "6": {"id": 6, "name": "slot_cyl_left_pos", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": 0, "z": 0}}},
+    "7": {"id": 7, "name": "slot_cyl_right", "op": {"type": "Cylinder", "radius": 5, "height": 8, "segments": 64}},
+    "8": {"id": 8, "name": "slot_cyl_right_pos", "op": {"type": "Translate", "child": 7, "offset": {"x": 20, "y": 0, "z": 0}}},
+    "9": {"id": 9, "name": "slot_union_1", "op": {"type": "Union", "left": 4, "right": 6}},
+    "10": {"id": 10, "name": "slot_full", "op": {"type": "Union", "left": 9, "right": 8}},
+    "11": {"id": 11, "name": "result", "op": {"type": "Difference", "left": 2, "right": 10}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 11, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120316Z-5316",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6612.428787
+      }
+    ],
+    "tokens": {
+      "input": 805,
+      "output": 1651,
+      "total": 2456
+    },
+    "wallclock_sec": 6.612428787
+  },
+  "output": {
+    "vcad_path": "20260429T120316Z-5316.vcad",
+    "vcad_sha256": "a677097d25bf3fb7725f4ad788a0cd93b1b347bf2d4cf7559e919f671d7d95b3",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:16.478Z",
+    "ended_at": "2026-04-29T12:03:23.100Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -156,7 +156,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -184,7 +184,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120316Z-5316.vcad
@@ -1,0 +1,194 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cube": {
+      "id": "base_cube",
+      "name": "Base layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 80, "z": 10}
+      }
+    },
+    "base_centered": {
+      "id": "base_centered",
+      "name": "Base layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "base_cube",
+        "offset": {"x": -40, "y": -40, "z": 0}
+      }
+    },
+    "middle_cube": {
+      "id": "middle_cube",
+      "name": "Middle layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 10}
+      }
+    },
+    "middle_centered": {
+      "id": "middle_centered",
+      "name": "Middle layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "middle_cube",
+        "offset": {"x": -30, "y": -30, "z": 10}
+      }
+    },
+    "top_cube": {
+      "id": "top_cube",
+      "name": "Top layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 10}
+      }
+    },
+    "top_centered": {
+      "id": "top_centered",
+      "name": "Top layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "top_cube",
+        "offset": {"x": -20, "y": -20, "z": 20}
+      }
+    },
+    "base_middle_union": {
+      "id": "base_middle_union",
+      "name": "Base and middle union",
+      "op": {
+        "type": "Union",
+        "left": "base_centered",
+        "right": "middle_centered"
+      }
+    },
+    "pyramid_fused": {
+      "id": "pyramid_fused",
+      "name": "Stepped pyramid fused",
+      "op": {
+        "type": "Union",
+        "left": "base_middle_union",
+        "right": "top_centered"
+      }
+    },
+    "hole_1": {
+      "id": "hole_1",
+      "name": "Hole at (30, 30)",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_1_positioned": {
+      "id": "hole_1_positioned",
+      "name": "Hole 1 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole_1",
+        "offset": {"x": 30, "y": 30, "z": 0}
+      }
+    },
+    "hole_2": {
+      "id": "hole_2",
+      "name": "Hole at (-30, 30)",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_2_positioned": {
+      "id": "hole_2_positioned",
+      "name": "Hole 2 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole_2",
+        "offset": {"x": -30, "y": 30, "z": 0}
+      }
+    },
+    "hole_3": {
+      "id": "hole_3",
+      "name": "Hole at (-30, -30)",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_3_positioned": {
+      "id": "hole_3_positioned",
+      "name": "Hole 3 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole_3",
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "hole_4": {
+      "id": "hole_4",
+      "name": "Hole at (30, -30)",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_4_positioned": {
+      "id": "hole_4_positioned",
+      "name": "Hole 4 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole_4",
+        "offset": {"x": 30, "y": -30, "z": 0}
+      }
+    },
+    "holes_union": {
+      "id": "holes_union",
+      "name": "All holes unioned",
+      "op": {
+        "type": "Union",
+        "left": "hole_1_positioned",
+        "right": "hole_2_positioned"
+      }
+    },
+    "holes_union_2": {
+      "id": "holes_union_2",
+      "name": "Holes union 2",
+      "op": {
+        "type": "Union",
+        "left": "holes_union",
+        "right": "hole_3_positioned"
+      }
+    },
+    "holes_union_3": {
+      "id": "holes_union_3",
+      "name": "Holes union 3",
+      "op": {
+        "type": "Union",
+        "left": "holes_union_2",
+        "right": "hole_4_positioned"
+      }
+    },
+    "final_solid": {
+      "id": "final_solid",
+      "name": "Stepped pyramid with holes",
+      "op": {
+        "type": "Difference",
+        "left": "pyramid_fused",
+        "right": "holes_union_3"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final_solid",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120323Z-21da",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6533.323144
+      }
+    ],
+    "tokens": {
+      "input": 805,
+      "output": 1597,
+      "total": 2402
+    },
+    "wallclock_sec": 6.533323144
+  },
+  "output": {
+    "vcad_path": "20260429T120323Z-21da.vcad",
+    "vcad_sha256": "f965cc074b97756c4b0f955ebabc755114346a00262ee1ae7336b86422ae2ca3",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:23.199Z",
+    "ended_at": "2026-04-29T12:03:29.742Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -156,7 +156,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -184,7 +184,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120323Z-21da.vcad
@@ -1,0 +1,194 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cube": {
+      "id": "base_cube",
+      "name": "Base layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 80, "z": 10}
+      }
+    },
+    "base_centered": {
+      "id": "base_centered",
+      "name": "Base layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "base_cube",
+        "offset": {"x": -40, "y": -40, "z": 0}
+      }
+    },
+    "middle_cube": {
+      "id": "middle_cube",
+      "name": "Middle layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 10}
+      }
+    },
+    "middle_centered": {
+      "id": "middle_centered",
+      "name": "Middle layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "middle_cube",
+        "offset": {"x": -30, "y": -30, "z": 10}
+      }
+    },
+    "top_cube": {
+      "id": "top_cube",
+      "name": "Top layer cube",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 10}
+      }
+    },
+    "top_centered": {
+      "id": "top_centered",
+      "name": "Top layer centered",
+      "op": {
+        "type": "Translate",
+        "child": "top_cube",
+        "offset": {"x": -20, "y": -20, "z": 20}
+      }
+    },
+    "base_middle": {
+      "id": "base_middle",
+      "name": "Base and middle fused",
+      "op": {
+        "type": "Union",
+        "left": "base_centered",
+        "right": "middle_centered"
+      }
+    },
+    "pyramid": {
+      "id": "pyramid",
+      "name": "Stepped pyramid",
+      "op": {
+        "type": "Union",
+        "left": "base_middle",
+        "right": "top_centered"
+      }
+    },
+    "hole1": {
+      "id": "hole1",
+      "name": "Bolt hole 1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole1_positioned": {
+      "id": "hole1_positioned",
+      "name": "Bolt hole 1 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole1",
+        "offset": {"x": 30, "y": 30, "z": 0}
+      }
+    },
+    "hole2": {
+      "id": "hole2",
+      "name": "Bolt hole 2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole2_positioned": {
+      "id": "hole2_positioned",
+      "name": "Bolt hole 2 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole2",
+        "offset": {"x": -30, "y": 30, "z": 0}
+      }
+    },
+    "hole3": {
+      "id": "hole3",
+      "name": "Bolt hole 3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole3_positioned": {
+      "id": "hole3_positioned",
+      "name": "Bolt hole 3 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole3",
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "hole4": {
+      "id": "hole4",
+      "name": "Bolt hole 4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole4_positioned": {
+      "id": "hole4_positioned",
+      "name": "Bolt hole 4 positioned",
+      "op": {
+        "type": "Translate",
+        "child": "hole4",
+        "offset": {"x": 30, "y": -30, "z": 0}
+      }
+    },
+    "holes_combined": {
+      "id": "holes_combined",
+      "name": "All holes combined",
+      "op": {
+        "type": "Union",
+        "left": "hole1_positioned",
+        "right": "hole2_positioned"
+      }
+    },
+    "holes_combined_3": {
+      "id": "holes_combined_3",
+      "name": "All holes combined 3",
+      "op": {
+        "type": "Union",
+        "left": "holes_combined",
+        "right": "hole3_positioned"
+      }
+    },
+    "holes_combined_4": {
+      "id": "holes_combined_4",
+      "name": "All holes combined 4",
+      "op": {
+        "type": "Union",
+        "left": "holes_combined_3",
+        "right": "hole4_positioned"
+      }
+    },
+    "final": {
+      "id": "final",
+      "name": "Stepped pyramid with bolt holes",
+      "op": {
+        "type": "Difference",
+        "left": "pyramid",
+        "right": "holes_combined_4"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "final",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120329Z-c74b",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6114.902969999999
+      }
+    ],
+    "tokens": {
+      "input": 805,
+      "output": 1443,
+      "total": 2248
+    },
+    "wallclock_sec": 6.114902969999999
+  },
+  "output": {
+    "vcad_path": "20260429T120329Z-c74b.vcad",
+    "vcad_sha256": "3d0271cdfc4ca12576800411f7a989a6845c89f4cd9198fc67754d9cd8eafa5b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:29.843Z",
+    "ended_at": "2026-04-29T12:03:35.967Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -156,7 +156,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -184,7 +184,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120329Z-c74b.vcad
@@ -1,0 +1,108 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cube": {
+      "id": "base_cube",
+      "name": "Base layer cube",
+      "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}
+    },
+    "base_translated": {
+      "id": "base_translated",
+      "name": "Base layer centered",
+      "op": {"type": "Translate", "child": "base_cube", "offset": {"x": -40, "y": -40, "z": 0}}
+    },
+    "middle_cube": {
+      "id": "middle_cube",
+      "name": "Middle layer cube",
+      "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}
+    },
+    "middle_translated": {
+      "id": "middle_translated",
+      "name": "Middle layer centered",
+      "op": {"type": "Translate", "child": "middle_cube", "offset": {"x": -30, "y": -30, "z": 10}}
+    },
+    "top_cube": {
+      "id": "top_cube",
+      "name": "Top layer cube",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}
+    },
+    "top_translated": {
+      "id": "top_translated",
+      "name": "Top layer centered",
+      "op": {"type": "Translate", "child": "top_cube", "offset": {"x": -20, "y": -20, "z": 20}}
+    },
+    "base_and_middle": {
+      "id": "base_and_middle",
+      "name": "Base and middle fused",
+      "op": {"type": "Union", "left": "base_translated", "right": "middle_translated"}
+    },
+    "pyramid_unfused": {
+      "id": "pyramid_unfused",
+      "name": "All three layers fused",
+      "op": {"type": "Union", "left": "base_and_middle", "right": "top_translated"}
+    },
+    "hole1_cylinder": {
+      "id": "hole1_cylinder",
+      "name": "Hole 1 cylinder",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole1_translated": {
+      "id": "hole1_translated",
+      "name": "Hole 1 positioned",
+      "op": {"type": "Translate", "child": "hole1_cylinder", "offset": {"x": 30, "y": 30, "z": 0}}
+    },
+    "hole2_cylinder": {
+      "id": "hole2_cylinder",
+      "name": "Hole 2 cylinder",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole2_translated": {
+      "id": "hole2_translated",
+      "name": "Hole 2 positioned",
+      "op": {"type": "Translate", "child": "hole2_cylinder", "offset": {"x": -30, "y": 30, "z": 0}}
+    },
+    "hole3_cylinder": {
+      "id": "hole3_cylinder",
+      "name": "Hole 3 cylinder",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole3_translated": {
+      "id": "hole3_translated",
+      "name": "Hole 3 positioned",
+      "op": {"type": "Translate", "child": "hole3_cylinder", "offset": {"x": -30, "y": -30, "z": 0}}
+    },
+    "hole4_cylinder": {
+      "id": "hole4_cylinder",
+      "name": "Hole 4 cylinder",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole4_translated": {
+      "id": "hole4_translated",
+      "name": "Hole 4 positioned",
+      "op": {"type": "Translate", "child": "hole4_cylinder", "offset": {"x": 30, "y": -30, "z": 0}}
+    },
+    "holes_union_1": {
+      "id": "holes_union_1",
+      "name": "Holes 1 and 2 combined",
+      "op": {"type": "Union", "left": "hole1_translated", "right": "hole2_translated"}
+    },
+    "holes_union_2": {
+      "id": "holes_union_2",
+      "name": "Holes 3 and 4 combined",
+      "op": {"type": "Union", "left": "hole3_translated", "right": "hole4_translated"}
+    },
+    "all_holes": {
+      "id": "all_holes",
+      "name": "All holes combined",
+      "op": {"type": "Union", "left": "holes_union_1", "right": "holes_union_2"}
+    },
+    "final_pyramid": {
+      "id": "final_pyramid",
+      "name": "Stepped pyramid with holes",
+      "op": {"type": "Difference", "left": "pyramid_unfused", "right": "all_holes"}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "final_pyramid", "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120336Z-2fa3",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5895.869744
+      }
+    ],
+    "tokens": {
+      "input": 805,
+      "output": 1378,
+      "total": 2183
+    },
+    "wallclock_sec": 5.895869744
+  },
+  "output": {
+    "vcad_path": "20260429T120336Z-2fa3.vcad",
+    "vcad_sha256": "db0a55b7a30a46467094e29198b34d56def86d7e96a8296b26e0cbe111e82cb1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:36.064Z",
+    "ended_at": "2026-04-29T12:03:41.969Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -156,7 +156,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -184,7 +184,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120336Z-2fa3.vcad
@@ -1,0 +1,108 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_cube": {
+      "id": "base_cube",
+      "name": "base_cube",
+      "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}
+    },
+    "base_centered": {
+      "id": "base_centered",
+      "name": "base_centered",
+      "op": {"type": "Translate", "child": "base_cube", "offset": {"x": -40, "y": -40, "z": 0}}
+    },
+    "middle_cube": {
+      "id": "middle_cube",
+      "name": "middle_cube",
+      "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}
+    },
+    "middle_centered": {
+      "id": "middle_centered",
+      "name": "middle_centered",
+      "op": {"type": "Translate", "child": "middle_cube", "offset": {"x": -30, "y": -30, "z": 10}}
+    },
+    "top_cube": {
+      "id": "top_cube",
+      "name": "top_cube",
+      "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}
+    },
+    "top_centered": {
+      "id": "top_centered",
+      "name": "top_centered",
+      "op": {"type": "Translate", "child": "top_cube", "offset": {"x": -20, "y": -20, "z": 20}}
+    },
+    "base_and_middle": {
+      "id": "base_and_middle",
+      "name": "base_and_middle",
+      "op": {"type": "Union", "left": "base_centered", "right": "middle_centered"}
+    },
+    "pyramid_undrilled": {
+      "id": "pyramid_undrilled",
+      "name": "pyramid_undrilled",
+      "op": {"type": "Union", "left": "base_and_middle", "right": "top_centered"}
+    },
+    "hole1": {
+      "id": "hole1",
+      "name": "hole1",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole1_positioned": {
+      "id": "hole1_positioned",
+      "name": "hole1_positioned",
+      "op": {"type": "Translate", "child": "hole1", "offset": {"x": 30, "y": 30, "z": 0}}
+    },
+    "hole2": {
+      "id": "hole2",
+      "name": "hole2",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole2_positioned": {
+      "id": "hole2_positioned",
+      "name": "hole2_positioned",
+      "op": {"type": "Translate", "child": "hole2", "offset": {"x": -30, "y": 30, "z": 0}}
+    },
+    "hole3": {
+      "id": "hole3",
+      "name": "hole3",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole3_positioned": {
+      "id": "hole3_positioned",
+      "name": "hole3_positioned",
+      "op": {"type": "Translate", "child": "hole3", "offset": {"x": -30, "y": -30, "z": 0}}
+    },
+    "hole4": {
+      "id": "hole4",
+      "name": "hole4",
+      "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}
+    },
+    "hole4_positioned": {
+      "id": "hole4_positioned",
+      "name": "hole4_positioned",
+      "op": {"type": "Translate", "child": "hole4", "offset": {"x": 30, "y": -30, "z": 0}}
+    },
+    "holes_union_1": {
+      "id": "holes_union_1",
+      "name": "holes_union_1",
+      "op": {"type": "Union", "left": "hole1_positioned", "right": "hole2_positioned"}
+    },
+    "holes_union_2": {
+      "id": "holes_union_2",
+      "name": "holes_union_2",
+      "op": {"type": "Union", "left": "holes_union_1", "right": "hole3_positioned"}
+    },
+    "all_holes": {
+      "id": "all_holes",
+      "name": "all_holes",
+      "op": {"type": "Union", "left": "holes_union_2", "right": "hole4_positioned"}
+    },
+    "final": {
+      "id": "final",
+      "name": "final",
+      "op": {"type": "Difference", "left": "pyramid_undrilled", "right": "all_holes"}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "final", "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.json
@@ -1,0 +1,224 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "actual": 0,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": []
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "fail",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "pass": false,
+            "reason": "no candidate cylindrical feature of this diameter remained unmatched",
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 6,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120342Z-dbf3",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6241.602495
+      }
+    ],
+    "tokens": {
+      "input": 805,
+      "output": 1501,
+      "total": 2306
+    },
+    "wallclock_sec": 6.241602495
+  },
+  "output": {
+    "vcad_path": "20260429T120342Z-dbf3.vcad",
+    "vcad_sha256": "207c2603a0207447802b530efea8d56a80c69160f62b42c88124d82c763f790e",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:42.067Z",
+    "ended_at": "2026-04-29T12:03:48.318Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
@@ -55,14 +55,14 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual": 0,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": []
@@ -73,65 +73,65 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "fail",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
             "pass": false,
             "reason": "no candidate cylindrical feature of this diameter remained unmatched",
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -156,7 +156,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 6,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -184,7 +184,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-haiku-4-5-20251001/20260429T120342Z-dbf3.vcad
@@ -1,0 +1,189 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "base_layer": {
+      "id": 0,
+      "name": "base_layer",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 80, "y": 80, "z": 10}
+      }
+    },
+    "base_centered": {
+      "id": 1,
+      "name": "base_centered",
+      "op": {
+        "type": "Translate",
+        "child": 0,
+        "offset": {"x": -40, "y": -40, "z": 0}
+      }
+    },
+    "middle_layer": {
+      "id": 2,
+      "name": "middle_layer",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 60, "y": 60, "z": 10}
+      }
+    },
+    "middle_centered": {
+      "id": 3,
+      "name": "middle_centered",
+      "op": {
+        "type": "Translate",
+        "child": 2,
+        "offset": {"x": -30, "y": -30, "z": 10}
+      }
+    },
+    "top_layer": {
+      "id": 4,
+      "name": "top_layer",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 40, "y": 40, "z": 10}
+      }
+    },
+    "top_centered": {
+      "id": 5,
+      "name": "top_centered",
+      "op": {
+        "type": "Translate",
+        "child": 4,
+        "offset": {"x": -20, "y": -20, "z": 20}
+      }
+    },
+    "base_middle_union": {
+      "id": 6,
+      "name": "base_middle_union",
+      "op": {
+        "type": "Union",
+        "left": 1,
+        "right": 3
+      }
+    },
+    "pyramid_union": {
+      "id": 7,
+      "name": "pyramid_union",
+      "op": {
+        "type": "Union",
+        "left": 6,
+        "right": 5
+      }
+    },
+    "hole_1": {
+      "id": 8,
+      "name": "hole_1",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_1_positioned": {
+      "id": 9,
+      "name": "hole_1_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 8,
+        "offset": {"x": 30, "y": 30, "z": 0}
+      }
+    },
+    "hole_2": {
+      "id": 10,
+      "name": "hole_2",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_2_positioned": {
+      "id": 11,
+      "name": "hole_2_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 10,
+        "offset": {"x": -30, "y": 30, "z": 0}
+      }
+    },
+    "hole_3": {
+      "id": 12,
+      "name": "hole_3",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_3_positioned": {
+      "id": 13,
+      "name": "hole_3_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 12,
+        "offset": {"x": -30, "y": -30, "z": 0}
+      }
+    },
+    "hole_4": {
+      "id": 14,
+      "name": "hole_4",
+      "op": {
+        "type": "Cylinder",
+        "radius": 3,
+        "height": 10,
+        "segments": 32
+      }
+    },
+    "hole_4_positioned": {
+      "id": 15,
+      "name": "hole_4_positioned",
+      "op": {
+        "type": "Translate",
+        "child": 14,
+        "offset": {"x": 30, "y": -30, "z": 0}
+      }
+    },
+    "with_hole_1": {
+      "id": 16,
+      "name": "with_hole_1",
+      "op": {
+        "type": "Difference",
+        "left": 7,
+        "right": 9
+      }
+    },
+    "with_hole_2": {
+      "id": 17,
+      "name": "with_hole_2",
+      "op": {
+        "type": "Difference",
+        "left": 16,
+        "right": 11
+      }
+    },
+    "with_hole_3": {
+      "id": 18,
+      "name": "with_hole_3",
+      "op": {
+        "type": "Difference",
+        "left": 17,
+        "right": 13
+      }
+    },
+    "final_solid": {
+      "id": 19,
+      "name": "final_solid",
+      "op": {
+        "type": "Difference",
+        "left": 18,
+        "right": 15
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 19, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.1627680038305869,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 114876.28004918595
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120420Z-7572",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9843.151523999999
+      }
+    ],
+    "tokens": {
+      "input": 1050,
+      "output": 1184,
+      "total": 2234
+    },
+    "wallclock_sec": 9.843151524
+  },
+  "output": {
+    "vcad_path": "20260429T120420Z-7572.vcad",
+    "vcad_sha256": "f61afbb7d6495662a1923c10637b4aa2c0bc7d0f72f19a4aa6edb14728696eb1",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:20.041Z",
+    "ended_at": "2026-04-29T12:04:30.072Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -210,42 +210,42 @@
         "type": "step_roundtrip",
         "tolerance_pct": 0.5
       },
-      "result": "pass",
+      "result": "fail",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
-            "pass": true,
+            "pass": false,
             "volume": {
-              "deviation_pct": 0.1627680038305869,
+              "deviation_pct": 0.6842188842251653,
               "original_mm3": 115063.56671987216,
-              "pass": true,
-              "roundtripped_mm3": 114876.28004918595
+              "pass": false,
+              "roundtripped_mm3": 114276.28006751178
             }
           }
         ],
@@ -254,10 +254,10 @@
     }
   ],
   "summary": {
-    "passed": true,
-    "checks_passed": 6,
+    "passed": false,
+    "checks_passed": 5,
     "checks_total": 6,
-    "score": 1,
+    "score": 0.8333333333333334,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120420Z-7572.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "mid_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "mid", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "base_mid", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "10": {"id": 10, "name": "hole_cyl1", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "hole1", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "13": {"id": 13, "name": "hole2", "op": {"type": "Translate", "child": 12, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "14": {"id": 14, "name": "hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "15": {"id": 15, "name": "hole3", "op": {"type": "Translate", "child": 14, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "16": {"id": 16, "name": "hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "17": {"id": 17, "name": "hole4", "op": {"type": "Translate", "child": 16, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "18": {"id": 18, "name": "holes12", "op": {"type": "Union", "left": 11, "right": 13}},
+    "19": {"id": 19, "name": "holes123", "op": {"type": "Union", "left": 18, "right": 15}},
+    "20": {"id": 20, "name": "holes_all", "op": {"type": "Union", "left": 19, "right": 17}},
+    "21": {"id": 21, "name": "result", "op": {"type": "Difference", "left": 8, "right": 20}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 21, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987213,
-          "deviation_pct": 0.1693552386331947,
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,37 +215,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.16276800383058693,
-              "original_mm3": 115063.56671987213,
+              "deviation_pct": 0.3586828765639789,
+              "original_mm3": 115063.56671987216,
               "pass": true,
-              "roundtripped_mm3": 114876.28004918592
+              "roundtripped_mm3": 115476.28003086011
             }
           }
         ],
@@ -257,7 +257,7 @@
     "passed": true,
     "checks_passed": 6,
     "checks_total": 6,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.16276800383058693,
+              "original_mm3": 115063.56671987213,
+              "pass": true,
+              "roundtripped_mm3": 114876.28004918592
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120430Z-af74",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10596.049936
+      }
+    ],
+    "tokens": {
+      "input": 1050,
+      "output": 1183,
+      "total": 2233
+    },
+    "wallclock_sec": 10.596049936
+  },
+  "output": {
+    "vcad_path": "20260429T120430Z-af74.vcad",
+    "vcad_sha256": "08b303411f35c74867c70846abf34df2c3e5780ce5d05221fcdb6e64fd6460c4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:30.135Z",
+    "ended_at": "2026-04-29T12:04:40.916Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120430Z-af74.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "mid_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "mid", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "base_mid", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "10": {"id": 10, "name": "hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "hole1", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "13": {"id": 13, "name": "hole2", "op": {"type": "Translate", "child": 12, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "14": {"id": 14, "name": "hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "15": {"id": 15, "name": "hole3", "op": {"type": "Translate", "child": 14, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "16": {"id": 16, "name": "hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "17": {"id": 17, "name": "hole4", "op": {"type": "Translate", "child": 16, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "20": {"id": 20, "name": "holes12", "op": {"type": "Union", "left": 11, "right": 13}},
+    "21": {"id": 21, "name": "holes123", "op": {"type": "Union", "left": 20, "right": 15}},
+    "22": {"id": 22, "name": "holes_all", "op": {"type": "Union", "left": 21, "right": 17}},
+    "30": {"id": 30, "name": "result", "op": {"type": "Difference", "left": 8, "right": 22}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 30, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.3586828765639789,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 115476.28003086011
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120440Z-2613",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9446.801727
+      }
+    ],
+    "tokens": {
+      "input": 1050,
+      "output": 1183,
+      "total": 2233
+    },
+    "wallclock_sec": 9.446801727
+  },
+  "output": {
+    "vcad_path": "20260429T120440Z-2613.vcad",
+    "vcad_sha256": "08b303411f35c74867c70846abf34df2c3e5780ce5d05221fcdb6e64fd6460c4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:40.982Z",
+    "ended_at": "2026-04-29T12:04:50.615Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -210,42 +210,42 @@
         "type": "step_roundtrip",
         "tolerance_pct": 0.5
       },
-      "result": "pass",
+      "result": "fail",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
-            "pass": true,
+            "pass": false,
             "volume": {
-              "deviation_pct": 0.3586828765639789,
+              "deviation_pct": 1.2056697646197438,
               "original_mm3": 115063.56671987216,
-              "pass": true,
-              "roundtripped_mm3": 115476.28003086011
+              "pass": false,
+              "roundtripped_mm3": 113676.2800858376
             }
           }
         ],
@@ -254,10 +254,10 @@
     }
   ],
   "summary": {
-    "passed": true,
-    "checks_passed": 6,
+    "passed": false,
+    "checks_passed": 5,
     "checks_total": 6,
-    "score": 1,
+    "score": 0.8333333333333334,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120440Z-2613.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "mid_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "mid", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "base_mid", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "10": {"id": 10, "name": "hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "hole1", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "13": {"id": 13, "name": "hole2", "op": {"type": "Translate", "child": 12, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "14": {"id": 14, "name": "hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "15": {"id": 15, "name": "hole3", "op": {"type": "Translate", "child": 14, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "16": {"id": 16, "name": "hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "17": {"id": 17, "name": "hole4", "op": {"type": "Translate", "child": 16, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "20": {"id": 20, "name": "holes12", "op": {"type": "Union", "left": 11, "right": 13}},
+    "21": {"id": 21, "name": "holes123", "op": {"type": "Union", "left": 20, "right": 15}},
+    "22": {"id": 22, "name": "holes_all", "op": {"type": "Union", "left": 21, "right": 17}},
+    "30": {"id": 30, "name": "result", "op": {"type": "Difference", "left": 8, "right": 22}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 30, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987213,
-          "deviation_pct": 0.1693552386331947,
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -210,42 +210,42 @@
         "type": "step_roundtrip",
         "tolerance_pct": 0.5
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
-            "pass": false,
+            "pass": true,
             "volume": {
-              "deviation_pct": 0.8801337569585701,
-              "original_mm3": 115063.56671987213,
-              "pass": false,
-              "roundtripped_mm3": 116076.28001253428
+              "deviation_pct": 0.3586828765639789,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 115476.28003086011
             }
           }
         ],
@@ -254,10 +254,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 5,
+    "passed": true,
+    "checks_passed": 6,
     "checks_total": 6,
-    "score": 0.8333333333333334,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": false,
+            "volume": {
+              "deviation_pct": 0.8801337569585701,
+              "original_mm3": 115063.56671987213,
+              "pass": false,
+              "roundtripped_mm3": 116076.28001253428
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120450Z-ff11",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 8759.465962
+      }
+    ],
+    "tokens": {
+      "input": 1050,
+      "output": 1004,
+      "total": 2054
+    },
+    "wallclock_sec": 8.759465962
+  },
+  "output": {
+    "vcad_path": "20260429T120450Z-ff11.vcad",
+    "vcad_sha256": "36b9b693a7c651e3ce19d255fee9bc6a1ef1c38ea3f5214b81a090dd7bae939d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:50.679Z",
+    "ended_at": "2026-04-29T12:04:59.622Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120450Z-ff11.vcad
@@ -1,0 +1,25 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "mid_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "mid", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "base_mid", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "10": {"id": 10, "name": "hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "hole1", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "hole2", "op": {"type": "Translate", "child": 10, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "13": {"id": 13, "name": "hole3", "op": {"type": "Translate", "child": 10, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "14": {"id": 14, "name": "hole4", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "h12", "op": {"type": "Union", "left": 11, "right": 12}},
+    "16": {"id": 16, "name": "h34", "op": {"type": "Union", "left": 13, "right": 14}},
+    "17": {"id": 17, "name": "all_holes", "op": {"type": "Union", "left": 15, "right": 16}},
+    "18": {"id": 18, "name": "result", "op": {"type": "Difference", "left": 8, "right": 17}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 18, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.3586828765639789,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 115476.28003086011
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120459Z-ee4c",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9757.610063
+      }
+    ],
+    "tokens": {
+      "input": 1050,
+      "output": 1183,
+      "total": 2233
+    },
+    "wallclock_sec": 9.757610063
+  },
+  "output": {
+    "vcad_path": "20260429T120459Z-ee4c.vcad",
+    "vcad_sha256": "deecf21e6ad419277c342d1149541f42b8d73b25755c53af8fb6a09557175b59",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:59.686Z",
+    "ended_at": "2026-04-29T12:05:09.628Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987216,
-          "deviation_pct": 0.16935523863322005,
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,37 +215,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.3586828765639789,
-              "original_mm3": 115063.56671987216,
+              "deviation_pct": 0.35868287656399156,
+              "original_mm3": 115063.56671987213,
               "pass": true,
-              "roundtripped_mm3": 115476.28003086011
+              "roundtripped_mm3": 115476.2800308601
             }
           }
         ],
@@ -257,7 +257,7 @@
     "passed": true,
     "checks_passed": 6,
     "checks_total": 6,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-opus-4-7/20260429T120459Z-ee4c.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "mid_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "mid", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "base_mid", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "10": {"id": 10, "name": "hole_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "11": {"id": 11, "name": "hole1", "op": {"type": "Translate", "child": 10, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "12": {"id": 12, "name": "hole_cyl2", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "13": {"id": 13, "name": "hole2", "op": {"type": "Translate", "child": 12, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "14": {"id": 14, "name": "hole_cyl3", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "15": {"id": 15, "name": "hole3", "op": {"type": "Translate", "child": 14, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "16": {"id": 16, "name": "hole_cyl4", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "17": {"id": 17, "name": "hole4", "op": {"type": "Translate", "child": 16, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "20": {"id": 20, "name": "holes12", "op": {"type": "Union", "left": 11, "right": 13}},
+    "21": {"id": 21, "name": "holes123", "op": {"type": "Union", "left": 20, "right": 15}},
+    "22": {"id": 22, "name": "all_holes", "op": {"type": "Union", "left": 21, "right": 17}},
+    "30": {"id": 30, "name": "result", "op": {"type": "Difference", "left": 8, "right": 22}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 30, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987216,
-          "deviation_pct": 0.16935523863322005,
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,37 +215,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0.1627680038305869,
-              "original_mm3": 115063.56671987216,
+              "deviation_pct": 0.35868287656399156,
+              "original_mm3": 115063.56671987213,
               "pass": true,
-              "roundtripped_mm3": 114876.28004918595
+              "roundtripped_mm3": 115476.2800308601
             }
           }
         ],
@@ -257,7 +257,7 @@
     "passed": true,
     "checks_passed": 6,
     "checks_total": 6,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.1627680038305869,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 114876.28004918595
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120415Z-10c6",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10823.976311
+      }
+    ],
+    "tokens": {
+      "input": 806,
+      "output": 1061,
+      "total": 1867
+    },
+    "wallclock_sec": 10.823976311000001
+  },
+  "output": {
+    "vcad_path": "20260429T120415Z-10c6.vcad",
+    "vcad_sha256": "47bc6c6ad21983542207c8aaa32fa252f4042fa3cf6d9d76a16c1fc3992923b9",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:15.309Z",
+    "ended_at": "2026-04-29T12:04:26.320Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120415Z-10c6.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_box", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base_box_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "middle_box", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "middle_box_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_box", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top_box_centered", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "union_base_middle", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "9": {"id": 9, "name": "hole1_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "hole1", "op": {"type": "Translate", "child": 9, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "hole2_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "hole2", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "13": {"id": 13, "name": "hole3_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "hole3", "op": {"type": "Translate", "child": 13, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "hole4_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "16": {"id": 16, "name": "hole4", "op": {"type": "Translate", "child": 15, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "17": {"id": 17, "name": "holes_12", "op": {"type": "Union", "left": 10, "right": 12}},
+    "18": {"id": 18, "name": "holes_34", "op": {"type": "Union", "left": 14, "right": 16}},
+    "19": {"id": 19, "name": "all_holes", "op": {"type": "Union", "left": 17, "right": 18}},
+    "20": {"id": 20, "name": "final", "op": {"type": "Difference", "left": 8, "right": 19}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 20, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,27 +215,27 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
@@ -257,7 +257,7 @@
     "passed": true,
     "checks_passed": 6,
     "checks_total": 6,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.1627680038305869,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 114876.28004918595
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120426Z-bbdc",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 11484.538153000001
+      }
+    ],
+    "tokens": {
+      "input": 806,
+      "output": 1061,
+      "total": 1867
+    },
+    "wallclock_sec": 11.484538153
+  },
+  "output": {
+    "vcad_path": "20260429T120426Z-bbdc.vcad",
+    "vcad_sha256": "47bc6c6ad21983542207c8aaa32fa252f4042fa3cf6d9d76a16c1fc3992923b9",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:26.384Z",
+    "ended_at": "2026-04-29T12:04:38.052Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120426Z-bbdc.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_box", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base_box_centered", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "middle_box", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "middle_box_centered", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_box", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top_box_centered", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "union_base_middle", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "9": {"id": 9, "name": "hole1_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "hole1", "op": {"type": "Translate", "child": 9, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "hole2_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "hole2", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "13": {"id": 13, "name": "hole3_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "hole3", "op": {"type": "Translate", "child": 13, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "hole4_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "16": {"id": 16, "name": "hole4", "op": {"type": "Translate", "child": 15, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "17": {"id": 17, "name": "holes_12", "op": {"type": "Union", "left": 10, "right": 12}},
+    "18": {"id": 18, "name": "holes_34", "op": {"type": "Union", "left": 14, "right": 16}},
+    "19": {"id": 19, "name": "all_holes", "op": {"type": "Union", "left": 17, "right": 18}},
+    "20": {"id": 20, "name": "final", "op": {"type": "Difference", "left": 8, "right": 19}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 20, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987213,
-          "deviation_pct": 0.1693552386331947,
+          "actual_mm3": 115063.56671987208,
+          "deviation_pct": 0.16935523863314406,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,37 +215,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
             "pass": false,
             "volume": {
-              "deviation_pct": 1.2056697646197314,
-              "original_mm3": 115063.56671987213,
+              "deviation_pct": 0.8801337569585707,
+              "original_mm3": 115063.56671987208,
               "pass": false,
-              "roundtripped_mm3": 113676.28008583758
+              "roundtripped_mm3": 116076.28001253422
             }
           }
         ],
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": false,
+            "volume": {
+              "deviation_pct": 1.2056697646197314,
+              "original_mm3": 115063.56671987213,
+              "pass": false,
+              "roundtripped_mm3": 113676.28008583758
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120438Z-e0b6",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 10860.798093000001
+      }
+    ],
+    "tokens": {
+      "input": 806,
+      "output": 1079,
+      "total": 1885
+    },
+    "wallclock_sec": 10.860798093000001
+  },
+  "output": {
+    "vcad_path": "20260429T120438Z-e0b6.vcad",
+    "vcad_sha256": "f4bd18980231522b4fcba16c62b7bf0342e2b6fba8a62c07d240a3bd96d020be",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:38.115Z",
+    "ended_at": "2026-04-29T12:04:49.183Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120438Z-e0b6.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_cube", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base_cube_translate", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "middle_cube", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "middle_cube_translate", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_cube", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top_cube_translate", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "union_base_middle", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "union_all_layers", "op": {"type": "Union", "left": 7, "right": 6}},
+    "9": {"id": 9, "name": "hole1_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "hole1_translate", "op": {"type": "Translate", "child": 9, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "hole2_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "hole2_translate", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "13": {"id": 13, "name": "hole3_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "hole3_translate", "op": {"type": "Translate", "child": 13, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "hole4_cyl", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "16": {"id": 16, "name": "hole4_translate", "op": {"type": "Translate", "child": 15, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "17": {"id": 17, "name": "diff_hole1", "op": {"type": "Difference", "left": 8, "right": 10}},
+    "18": {"id": 18, "name": "diff_hole2", "op": {"type": "Difference", "left": 17, "right": 12}},
+    "19": {"id": 19, "name": "diff_hole3", "op": {"type": "Difference", "left": 18, "right": 14}},
+    "20": {"id": 20, "name": "final", "op": {"type": "Difference", "left": 19, "right": 16}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 20, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0.1627680038305869,
+              "original_mm3": 115063.56671987216,
+              "pass": true,
+              "roundtripped_mm3": 114876.28004918595
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 6,
+    "checks_total": 6,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120449Z-2893",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 12381.465315000001
+      }
+    ],
+    "tokens": {
+      "input": 806,
+      "output": 1063,
+      "total": 1869
+    },
+    "wallclock_sec": 12.381465315000002
+  },
+  "output": {
+    "vcad_path": "20260429T120449Z-2893.vcad",
+    "vcad_sha256": "bc95e96a9662e82de7c91a04603cde17919c78c1afa227b186c493538adfab9a",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:49.246Z",
+    "ended_at": "2026-04-29T12:05:01.811Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,27 +215,27 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
@@ -257,7 +257,7 @@
     "passed": true,
     "checks_passed": 6,
     "checks_total": 6,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120449Z-2893.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "base_box_raw", "op": {"type": "Cube", "size": {"x": 80, "y": 80, "z": 10}}},
+    "2": {"id": 2, "name": "base_box", "op": {"type": "Translate", "child": 1, "offset": {"x": -40, "y": -40, "z": 0}}},
+    "3": {"id": 3, "name": "middle_box_raw", "op": {"type": "Cube", "size": {"x": 60, "y": 60, "z": 10}}},
+    "4": {"id": 4, "name": "middle_box", "op": {"type": "Translate", "child": 3, "offset": {"x": -30, "y": -30, "z": 10}}},
+    "5": {"id": 5, "name": "top_box_raw", "op": {"type": "Cube", "size": {"x": 40, "y": 40, "z": 10}}},
+    "6": {"id": 6, "name": "top_box", "op": {"type": "Translate", "child": 5, "offset": {"x": -20, "y": -20, "z": 20}}},
+    "7": {"id": 7, "name": "union_base_middle", "op": {"type": "Union", "left": 2, "right": 4}},
+    "8": {"id": 8, "name": "pyramid", "op": {"type": "Union", "left": 7, "right": 6}},
+    "9": {"id": 9, "name": "hole1_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "10": {"id": 10, "name": "hole1", "op": {"type": "Translate", "child": 9, "offset": {"x": 30, "y": 30, "z": 0}}},
+    "11": {"id": 11, "name": "hole2_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "12": {"id": 12, "name": "hole2", "op": {"type": "Translate", "child": 11, "offset": {"x": -30, "y": 30, "z": 0}}},
+    "13": {"id": 13, "name": "hole3_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "14": {"id": 14, "name": "hole3", "op": {"type": "Translate", "child": 13, "offset": {"x": -30, "y": -30, "z": 0}}},
+    "15": {"id": 15, "name": "hole4_raw", "op": {"type": "Cylinder", "radius": 3, "height": 10, "segments": 32}},
+    "16": {"id": 16, "name": "hole4", "op": {"type": "Translate", "child": 15, "offset": {"x": 30, "y": -30, "z": 0}}},
+    "17": {"id": 17, "name": "holes_12", "op": {"type": "Union", "left": 10, "right": 12}},
+    "18": {"id": 18, "name": "holes_34", "op": {"type": "Union", "left": 14, "right": 16}},
+    "19": {"id": 19, "name": "all_holes", "op": {"type": "Union", "left": 17, "right": 18}},
+    "20": {"id": 20, "name": "stepped_pyramid_with_holes", "op": {"type": "Difference", "left": 8, "right": 19}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 20, "material": "default"}]
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "tolerance_mm": 0.1
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          40,
-          40,
-          30
+          40.0,
+          40.0,
+          30.0
         ],
         "actual_min": [
-          -40,
-          -40,
-          0
+          -40.0,
+          -40.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.1
       }
     },
@@ -69,8 +69,8 @@
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 115063.56671987216,
-          "deviation_pct": 0.16935523863322005,
+          "actual_mm3": 115063.56671987213,
+          "deviation_pct": 0.1693552386331947,
           "pass": true,
           "spec_mm3": 114869.03,
           "tolerance_pct": 0.5
@@ -82,36 +82,36 @@
       "type": "hole_count",
       "params": {
         "type": "hole_count",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "expected": 4,
         "diameter_tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual": 4,
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "diameter_tolerance_mm": 0.05,
         "expected": 4,
         "found": [
           [
-            30,
-            30,
-            6
+            30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            30,
-            6
+            -30.0,
+            30.0,
+            6.0
           ],
           [
-            -30,
-            -30,
-            6
+            -30.0,
+            -30.0,
+            6.0
           ],
           [
-            30,
-            -30,
-            6
+            30.0,
+            -30.0,
+            6.0
           ]
         ]
       }
@@ -121,81 +121,81 @@
       "type": "hole_positions",
       "params": {
         "type": "hole_positions",
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "positions": [
           [
-            30,
-            30,
-            0
+            30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            30,
-            0
+            -30.0,
+            30.0,
+            0.0
           ],
           [
-            -30,
-            -30,
-            0
+            -30.0,
+            -30.0,
+            0.0
           ],
           [
-            30,
-            -30,
-            0
+            30.0,
+            -30.0,
+            0.0
           ]
         ],
         "tolerance_mm": 0.15
       },
       "result": "pass",
       "details": {
-        "diameter_mm": 6,
+        "diameter_mm": 6.0,
         "per_expected": [
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              30
+              30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              30
+              30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              30
+              -30.0,
+              30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              30
+              -30.0,
+              30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              -30,
-              -30
+              -30.0,
+              -30.0
             ]
           },
           {
-            "distance_mm": 0,
+            "distance_mm": 0.0,
             "matched_hole": [
-              30,
-              -30
+              30.0,
+              -30.0
             ],
             "pass": true,
             "spec_xy": [
-              30,
-              -30
+              30.0,
+              -30.0
             ]
           }
         ],
@@ -215,37 +215,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "original_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                40,
-                40,
-                30
+                40.0,
+                40.0,
+                30.0
               ],
               "roundtripped_min": [
-                -40,
-                -40,
-                0
+                -40.0,
+                -40.0,
+                0.0
               ],
               "tolerance_mm": 0.5852349955359814
             },
             "index": 0,
             "pass": false,
             "volume": {
-              "deviation_pct": 1.2056697646197438,
-              "original_mm3": 115063.56671987216,
+              "deviation_pct": 1.2056697646197314,
+              "original_mm3": 115063.56671987213,
               "pass": false,
-              "roundtripped_mm3": 113676.2800858376
+              "roundtripped_mm3": 113676.28008583758
             }
           }
         ],
@@ -285,7 +285,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-stepped-pyramid-with-holes-01",
-    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm \u00d7 80mm \u00d7 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm \u00d7 60mm \u00d7 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm \u00d7 40mm \u00d7 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.json
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.json
@@ -1,0 +1,325 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-stepped-pyramid-with-holes-01",
+  "task_sha256": "88075d4c0f433c11de63509246e3538b6e9f22062f2c513df094a766a402ce70",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -40,
+          -40,
+          0
+        ],
+        "max": [
+          40,
+          40,
+          30
+        ],
+        "tolerance_mm": 0.1
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          40,
+          40,
+          30
+        ],
+        "actual_min": [
+          -40,
+          -40,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.1
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 114869.03,
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "volume": {
+          "actual_mm3": 115063.56671987216,
+          "deviation_pct": 0.16935523863322005,
+          "pass": true,
+          "spec_mm3": 114869.03,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "hole_count",
+      "params": {
+        "type": "hole_count",
+        "diameter_mm": 6,
+        "expected": 4,
+        "diameter_tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual": 4,
+        "diameter_mm": 6,
+        "diameter_tolerance_mm": 0.05,
+        "expected": 4,
+        "found": [
+          [
+            30,
+            30,
+            6
+          ],
+          [
+            -30,
+            30,
+            6
+          ],
+          [
+            -30,
+            -30,
+            6
+          ],
+          [
+            30,
+            -30,
+            6
+          ]
+        ]
+      }
+    },
+    {
+      "n": 4,
+      "type": "hole_positions",
+      "params": {
+        "type": "hole_positions",
+        "diameter_mm": 6,
+        "positions": [
+          [
+            30,
+            30,
+            0
+          ],
+          [
+            -30,
+            30,
+            0
+          ],
+          [
+            -30,
+            -30,
+            0
+          ],
+          [
+            30,
+            -30,
+            0
+          ]
+        ],
+        "tolerance_mm": 0.15
+      },
+      "result": "pass",
+      "details": {
+        "diameter_mm": 6,
+        "per_expected": [
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              -30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              -30,
+              -30
+            ]
+          },
+          {
+            "distance_mm": 0,
+            "matched_hole": [
+              30,
+              -30
+            ],
+            "pass": true,
+            "spec_xy": [
+              30,
+              -30
+            ]
+          }
+        ],
+        "tolerance_mm": 0.15,
+        "unmatched_extras": []
+      }
+    },
+    {
+      "n": 5,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                40,
+                40,
+                30
+              ],
+              "original_min": [
+                -40,
+                -40,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                40,
+                40,
+                30
+              ],
+              "roundtripped_min": [
+                -40,
+                -40,
+                0
+              ],
+              "tolerance_mm": 0.5852349955359814
+            },
+            "index": 0,
+            "pass": false,
+            "volume": {
+              "deviation_pct": 1.2056697646197438,
+              "original_mm3": 115063.56671987216,
+              "pass": false,
+              "roundtripped_mm3": 113676.2800858376
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 5,
+    "checks_total": 6,
+    "score": 0.8333333333333334,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120501Z-977a",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-stepped-pyramid-with-holes-01",
+    "rendered": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 703
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 9488.83818
+      }
+    ],
+    "tokens": {
+      "input": 806,
+      "output": 983,
+      "total": 1789
+    },
+    "wallclock_sec": 9.48883818
+  },
+  "output": {
+    "vcad_path": "20260429T120501Z-977a.vcad",
+    "vcad_sha256": "b6af28a21162dd93212750847ce464694bb8eb5969530da4b1e4458ccc2a6b94",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:01.881Z",
+    "ended_at": "2026-04-29T12:05:11.555Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.vcad
+++ b/mecheval/runs/a4-stepped-pyramid-with-holes-01/claude-direct-claude-sonnet-4-6/20260429T120501Z-977a.vcad
@@ -1,0 +1,28 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1":  { "id": 1,  "name": "base_cube",       "op": {"type":"Cube","size":{"x":80,"y":80,"z":10}} },
+    "2":  { "id": 2,  "name": "base_centered",    "op": {"type":"Translate","child":1,"offset":{"x":-40,"y":-40,"z":0}} },
+    "3":  { "id": 3,  "name": "mid_cube",         "op": {"type":"Cube","size":{"x":60,"y":60,"z":10}} },
+    "4":  { "id": 4,  "name": "mid_centered",     "op": {"type":"Translate","child":3,"offset":{"x":-30,"y":-30,"z":10}} },
+    "5":  { "id": 5,  "name": "top_cube",         "op": {"type":"Cube","size":{"x":40,"y":40,"z":10}} },
+    "6":  { "id": 6,  "name": "top_centered",     "op": {"type":"Translate","child":5,"offset":{"x":-20,"y":-20,"z":20}} },
+    "7":  { "id": 7,  "name": "union_base_mid",   "op": {"type":"Union","left":2,"right":4} },
+    "8":  { "id": 8,  "name": "pyramid",          "op": {"type":"Union","left":7,"right":6} },
+    "9":  { "id": 9,  "name": "hole_cyl",         "op": {"type":"Cylinder","radius":3,"height":10,"segments":32} },
+    "10": { "id": 10, "name": "hole1",            "op": {"type":"Translate","child":9,"offset":{"x":30,"y":30,"z":0}} },
+    "11": { "id": 11, "name": "hole_cyl2",        "op": {"type":"Cylinder","radius":3,"height":10,"segments":32} },
+    "12": { "id": 12, "name": "hole2",            "op": {"type":"Translate","child":11,"offset":{"x":-30,"y":30,"z":0}} },
+    "13": { "id": 13, "name": "hole_cyl3",        "op": {"type":"Cylinder","radius":3,"height":10,"segments":32} },
+    "14": { "id": 14, "name": "hole3",            "op": {"type":"Translate","child":13,"offset":{"x":-30,"y":-30,"z":0}} },
+    "15": { "id": 15, "name": "hole_cyl4",        "op": {"type":"Cylinder","radius":3,"height":10,"segments":32} },
+    "16": { "id": 16, "name": "hole4",            "op": {"type":"Translate","child":15,"offset":{"x":30,"y":-30,"z":0}} },
+    "17": { "id": 17, "name": "holes_12",         "op": {"type":"Union","left":10,"right":12} },
+    "18": { "id": 18, "name": "holes_34",         "op": {"type":"Union","left":14,"right":16} },
+    "19": { "id": 19, "name": "all_holes",        "op": {"type":"Union","left":17,"right":18} },
+    "20": { "id": 20, "name": "stepped_pyramid",  "op": {"type":"Difference","left":8,"right":19} }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 20, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120057Z-41aa",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3279.19535
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 452,
+      "total": 1239
+    },
+    "wallclock_sec": 3.27919535
+  },
+  "output": {
+    "vcad_path": "20260429T120057Z-41aa.vcad",
+    "vcad_sha256": "ab8582b9fff381e7966685bc527f2b38c61cd6030c93eef45f68549882c54d99",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:00:57.241Z",
+    "ended_at": "2026-04-29T12:01:01.500Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120057Z-41aa.vcad
@@ -1,0 +1,51 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "bar_a": {
+      "id": "bar_a",
+      "name": "Bar A",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 100, "y": 20, "z": 10}
+      }
+    },
+    "bar_a_centered": {
+      "id": "bar_a_centered",
+      "name": "Bar A Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_a",
+        "offset": {"x": -50, "y": -10, "z": 0}
+      }
+    },
+    "bar_b": {
+      "id": "bar_b",
+      "name": "Bar B",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 20, "y": 100, "z": 10}
+      }
+    },
+    "bar_b_centered": {
+      "id": "bar_b_centered",
+      "name": "Bar B Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_b",
+        "offset": {"x": -10, "y": -50, "z": 0}
+      }
+    },
+    "cross_frame": {
+      "id": "cross_frame",
+      "name": "Cross Frame",
+      "op": {
+        "type": "Union",
+        "left": "bar_a_centered",
+        "right": "bar_b_centered"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "cross_frame", "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120348Z-5e51",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2356.898928
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 500,
+      "total": 1287
+    },
+    "wallclock_sec": 2.356898928
+  },
+  "output": {
+    "vcad_path": "20260429T120348Z-5e51.vcad",
+    "vcad_sha256": "c56febaf3fe38908468bb4d6f625cab4eb35cd244103fee9aad5dbfd5270aa26",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:48.421Z",
+    "ended_at": "2026-04-29T12:03:50.786Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120348Z-5e51.vcad
@@ -1,0 +1,72 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "bar_a": {
+      "id": "bar_a",
+      "name": "Bar A",
+      "op": {
+        "type": "Cube",
+        "size": {
+          "x": 100,
+          "y": 20,
+          "z": 10
+        }
+      }
+    },
+    "bar_a_centered": {
+      "id": "bar_a_centered",
+      "name": "Bar A Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_a",
+        "offset": {
+          "x": -50,
+          "y": -10,
+          "z": 0
+        }
+      }
+    },
+    "bar_b": {
+      "id": "bar_b",
+      "name": "Bar B",
+      "op": {
+        "type": "Cube",
+        "size": {
+          "x": 20,
+          "y": 100,
+          "z": 10
+        }
+      }
+    },
+    "bar_b_centered": {
+      "id": "bar_b_centered",
+      "name": "Bar B Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_b",
+        "offset": {
+          "x": -10,
+          "y": -50,
+          "z": 0
+        }
+      }
+    },
+    "cross_frame": {
+      "id": "cross_frame",
+      "name": "Cross Frame",
+      "op": {
+        "type": "Union",
+        "left": "bar_a_centered",
+        "right": "bar_b_centered"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "cross_frame",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120350Z-7599",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4901.0579290000005
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 456,
+      "total": 1243
+    },
+    "wallclock_sec": 4.901057929
+  },
+  "output": {
+    "vcad_path": "20260429T120350Z-7599.vcad",
+    "vcad_sha256": "67c9538321f68a8adaec4d19cfe3b120db6a9187d841c4455c7e7399e846cfb3",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:50.887Z",
+    "ended_at": "2026-04-29T12:03:55.797Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120350Z-7599.vcad
@@ -1,0 +1,51 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "bar_a": {
+      "id": "bar_a",
+      "name": "Bar A (horizontal)",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 100, "y": 20, "z": 10}
+      }
+    },
+    "bar_a_centered": {
+      "id": "bar_a_centered",
+      "name": "Bar A centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_a",
+        "offset": {"x": -50, "y": -10, "z": 0}
+      }
+    },
+    "bar_b": {
+      "id": "bar_b",
+      "name": "Bar B (vertical)",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 20, "y": 100, "z": 10}
+      }
+    },
+    "bar_b_centered": {
+      "id": "bar_b_centered",
+      "name": "Bar B centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_b",
+        "offset": {"x": -10, "y": -50, "z": 0}
+      }
+    },
+    "cross_frame": {
+      "id": "cross_frame",
+      "name": "Cross-shaped frame",
+      "op": {
+        "type": "Union",
+        "left": "bar_a_centered",
+        "right": "bar_b_centered"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "cross_frame", "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120355Z-9322",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2314.720221
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 425,
+      "total": 1212
+    },
+    "wallclock_sec": 2.314720221
+  },
+  "output": {
+    "vcad_path": "20260429T120355Z-9322.vcad",
+    "vcad_sha256": "cc34a56872bc7a9d357c1ca5ca34ce8ade0b8c70fc6ac9b3f5b997f4abe81009",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:55.897Z",
+    "ended_at": "2026-04-29T12:03:58.233Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120355Z-9322.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "BarA",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 100, "y": 20, "z": 10}
+      }
+    },
+    "2": {
+      "id": 2,
+      "name": "BarA_translated",
+      "op": {
+        "type": "Translate",
+        "child": 1,
+        "offset": {"x": -50, "y": -10, "z": 0}
+      }
+    },
+    "3": {
+      "id": 3,
+      "name": "BarB",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 20, "y": 100, "z": 10}
+      }
+    },
+    "4": {
+      "id": 4,
+      "name": "BarB_translated",
+      "op": {
+        "type": "Translate",
+        "child": 3,
+        "offset": {"x": -10, "y": -50, "z": 0}
+      }
+    },
+    "5": {
+      "id": 5,
+      "name": "CrossFrame",
+      "op": {
+        "type": "Union",
+        "left": 2,
+        "right": 4
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": 5,
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120358Z-8075",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2323.118124
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 464,
+      "total": 1251
+    },
+    "wallclock_sec": 2.323118124
+  },
+  "output": {
+    "vcad_path": "20260429T120358Z-8075.vcad",
+    "vcad_sha256": "abcf2162bb04d751e84ad1f8df2b94138a4aca20ac3d468fa3e1b3d683425d0c",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:03:58.320Z",
+    "ended_at": "2026-04-29T12:04:00.652Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120358Z-8075.vcad
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "bar_a": {
+      "id": "bar_a",
+      "name": "Bar A",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 100, "y": 20, "z": 10}
+      }
+    },
+    "bar_a_translated": {
+      "id": "bar_a_translated",
+      "name": "Bar A Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_a",
+        "offset": {"x": -50, "y": -10, "z": 0}
+      }
+    },
+    "bar_b": {
+      "id": "bar_b",
+      "name": "Bar B",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 20, "y": 100, "z": 10}
+      }
+    },
+    "bar_b_translated": {
+      "id": "bar_b_translated",
+      "name": "Bar B Centered",
+      "op": {
+        "type": "Translate",
+        "child": "bar_b",
+        "offset": {"x": -10, "y": -50, "z": 0}
+      }
+    },
+    "cross_frame": {
+      "id": "cross_frame",
+      "name": "Cross Frame",
+      "op": {
+        "type": "Union",
+        "left": "bar_a_translated",
+        "right": "bar_b_translated"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [
+    {
+      "root": "cross_frame",
+      "material": "default"
+    }
+  ]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "fail",
+      "details": {
+        "error": "parse: Invalid JSON vcad file: invalid value: expected key to be a number in quotes at line 4 column 5",
+        "reason": "fatal evaluation error"
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to measure"
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "fail",
+      "details": {
+        "reason": "no valid solid to round-trip"
+      }
+    }
+  ],
+  "summary": {
+    "passed": false,
+    "checks_passed": 0,
+    "checks_total": 4,
+    "score": 0,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120400Z-7f59",
+  "model": {
+    "id": "claude-direct-claude-haiku-4-5-20251001",
+    "name": "Claude (direct, claude-haiku-4-5-20251001)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-haiku-4-5-20251001",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-haiku-4-5-20251001",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 2183.023095
+      }
+    ],
+    "tokens": {
+      "input": 787,
+      "output": 452,
+      "total": 1239
+    },
+    "wallclock_sec": 2.183023095
+  },
+  "output": {
+    "vcad_path": "20260429T120400Z-7f59.vcad",
+    "vcad_sha256": "704d053f0a8e344b27a59aded6e787e54b05b87b395f3b7e7141e7f170af461b",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:04:00.749Z",
+    "ended_at": "2026-04-29T12:04:02.941Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,11 +42,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -72,7 +72,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -100,7 +100,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-haiku-4-5-20251001/20260429T120400Z-7f59.vcad
@@ -1,0 +1,51 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "bar_a": {
+      "id": "bar_a",
+      "name": "Bar A",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 100, "y": 20, "z": 10}
+      }
+    },
+    "bar_a_translated": {
+      "id": "bar_a_translated",
+      "name": "Bar A Translated",
+      "op": {
+        "type": "Translate",
+        "child": "bar_a",
+        "offset": {"x": -50, "y": -10, "z": 0}
+      }
+    },
+    "bar_b": {
+      "id": "bar_b",
+      "name": "Bar B",
+      "op": {
+        "type": "Cube",
+        "size": {"x": 20, "y": 100, "z": 10}
+      }
+    },
+    "bar_b_translated": {
+      "id": "bar_b_translated",
+      "name": "Bar B Translated",
+      "op": {
+        "type": "Translate",
+        "child": "bar_b",
+        "offset": {"x": -10, "y": -50, "z": 0}
+      }
+    },
+    "cross_frame": {
+      "id": "cross_frame",
+      "name": "Cross Frame",
+      "op": {
+        "type": "Union",
+        "left": "bar_a_translated",
+        "right": "bar_b_translated"
+      }
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": "cross_frame", "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120509Z-b120",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4781.033877
+      }
+    ],
+    "tokens": {
+      "input": 1027,
+      "output": 355,
+      "total": 1382
+    },
+    "wallclock_sec": 4.781033877
+  },
+  "output": {
+    "vcad_path": "20260429T120509Z-b120.vcad",
+    "vcad_sha256": "501ac23cad9be0c3719d5fa7de48e7eae6599528e3b9991e9b219f53a9e0b5aa",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:09.697Z",
+    "ended_at": "2026-04-29T12:05:14.499Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120509Z-b120.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "barA", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "barA_t", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "barB", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "barB_t", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "cross", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120514Z-fbd7",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 5181.870043
+      }
+    ],
+    "tokens": {
+      "input": 1027,
+      "output": 357,
+      "total": 1384
+    },
+    "wallclock_sec": 5.181870043
+  },
+  "output": {
+    "vcad_path": "20260429T120514Z-fbd7.vcad",
+    "vcad_sha256": "b579df4bc2782f67c8a5a4d8a42648af104b5d87ba026eb149229d9689bd581d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:14.587Z",
+    "ended_at": "2026-04-29T12:05:19.790Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120514Z-fbd7.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "barA_cube", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "barA", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "barB_cube", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "barB", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "cross", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120519Z-8621",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4588.279501
+      }
+    ],
+    "tokens": {
+      "input": 1027,
+      "output": 362,
+      "total": 1389
+    },
+    "wallclock_sec": 4.588279501
+  },
+  "output": {
+    "vcad_path": "20260429T120519Z-8621.vcad",
+    "vcad_sha256": "0b4a943631a8b428e3b3c2bcc64b6a41610a74b1c5c1efd7dd75cb2830cf1ed3",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:19.879Z",
+    "ended_at": "2026-04-29T12:05:24.488Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120519Z-8621.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "BarA_cube", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "BarA", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "BarB_cube", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "BarB", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "Cross", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120524Z-c5b7",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4394.997488
+      }
+    ],
+    "tokens": {
+      "input": 1027,
+      "output": 360,
+      "total": 1387
+    },
+    "wallclock_sec": 4.394997488
+  },
+  "output": {
+    "vcad_path": "20260429T120524Z-c5b7.vcad",
+    "vcad_sha256": "b36575ee39cefbbed5f8aeffe42d24aa5f108f82afd098f91f79966463fdb0b7",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:24.575Z",
+    "ended_at": "2026-04-29T12:05:28.991Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120524Z-c5b7.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "BarA", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "BarA_T", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "BarB", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "BarB_T", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "Cross", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120529Z-c230",
+  "model": {
+    "id": "claude-direct-claude-opus-4-7",
+    "name": "Claude (direct, claude-opus-4-7)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-opus-4-7",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-opus-4-7",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 4370.535942
+      }
+    ],
+    "tokens": {
+      "input": 1027,
+      "output": 357,
+      "total": 1384
+    },
+    "wallclock_sec": 4.370535942
+  },
+  "output": {
+    "vcad_path": "20260429T120529Z-c230.vcad",
+    "vcad_sha256": "b579df4bc2782f67c8a5a4d8a42648af104b5d87ba026eb149229d9689bd581d",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:29.079Z",
+    "ended_at": "2026-04-29T12:05:33.469Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-opus-4-7/20260429T120529Z-c230.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "barA_cube", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "barA", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "barB_cube", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "barB", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "cross", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120511Z-8649",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3397.765507
+      }
+    ],
+    "tokens": {
+      "input": 788,
+      "output": 322,
+      "total": 1110
+    },
+    "wallclock_sec": 3.397765507
+  },
+  "output": {
+    "vcad_path": "20260429T120511Z-8649.vcad",
+    "vcad_sha256": "1a2169bd9cb4ce8875d1703618de99b2e29e03f8afb8170cfd09bb8c85a23fb3",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:11.618Z",
+    "ended_at": "2026-04-29T12:05:15.036Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120511Z-8649.vcad
@@ -1,0 +1,13 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {"id": 1, "name": "BarA_raw", "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}},
+    "2": {"id": 2, "name": "BarA", "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}},
+    "3": {"id": 3, "name": "BarB_raw", "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}},
+    "4": {"id": 4, "name": "BarB", "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}},
+    "5": {"id": 5, "name": "CrossFrame", "op": {"type": "Union", "left": 2, "right": 4}}
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120515Z-9923",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3992.270908
+      }
+    ],
+    "tokens": {
+      "input": 788,
+      "output": 364,
+      "total": 1152
+    },
+    "wallclock_sec": 3.992270908
+  },
+  "output": {
+    "vcad_path": "20260429T120515Z-9923.vcad",
+    "vcad_sha256": "39fb97849e952c61347a0e906251f49ab5ffe14317b58b49d1aeeedf9c87e374",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:15.120Z",
+    "ended_at": "2026-04-29T12:05:19.133Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120515Z-9923.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "Bar A raw",
+      "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "Bar A centered",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "Bar B raw",
+      "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}
+    },
+    "4": {
+      "id": 4,
+      "name": "Bar B centered",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "Cross Frame",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120519Z-e5b7",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3871.711064
+      }
+    ],
+    "tokens": {
+      "input": 788,
+      "output": 364,
+      "total": 1152
+    },
+    "wallclock_sec": 3.871711064
+  },
+  "output": {
+    "vcad_path": "20260429T120519Z-e5b7.vcad",
+    "vcad_sha256": "46aba928ca5c4002798bc4b58c4ce551d0c6a25453c29c7093f662143c7a5274",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:19.223Z",
+    "ended_at": "2026-04-29T12:05:23.115Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120519Z-e5b7.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "Bar A",
+      "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "Bar A Translated",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "Bar B",
+      "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}
+    },
+    "4": {
+      "id": 4,
+      "name": "Bar B Translated",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "Cross Frame",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120523Z-3f5c",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 6464.937843000001
+      }
+    ],
+    "tokens": {
+      "input": 788,
+      "output": 364,
+      "total": 1152
+    },
+    "wallclock_sec": 6.464937843
+  },
+  "output": {
+    "vcad_path": "20260429T120523Z-3f5c.vcad",
+    "vcad_sha256": "992795d6c34d5181ea9d63e194a7a156435c0ee3c223aec04c51ed40e7740da4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:23.203Z",
+    "ended_at": "2026-04-29T12:05:29.688Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120523Z-3f5c.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "Bar A",
+      "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "Bar A Centered",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "Bar B",
+      "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}
+    },
+    "4": {
+      "id": 4,
+      "name": "Bar B Centered",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "Cross Frame",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          50,
-          50,
-          10
+          50.0,
+          50.0,
+          10.0
         ],
         "actual_min": [
-          -50,
-          -50,
-          0
+          -50.0,
+          -50.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,11 +63,11 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 36000,
+        "volume_mm3": 36000.0,
         "center_of_mass": [
-          0,
-          0,
-          5
+          0.0,
+          0.0,
+          5.0
         ],
         "tolerance_pct": 0.5
       },
@@ -75,30 +75,30 @@
       "details": {
         "center_of_mass": {
           "actual": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "bbox_diagonal_mm": 141.77446878757826,
           "deviation": [
-            0,
-            0,
-            0
+            0.0,
+            0.0,
+            0.0
           ],
-          "max_abs_deviation_mm": 0,
+          "max_abs_deviation_mm": 0.0,
           "pass": true,
           "spec": [
-            0,
-            0,
-            5
+            0.0,
+            0.0,
+            5.0
           ],
           "tolerance_mm": 0.7088723439378913
         },
         "volume": {
-          "actual_mm3": 36000,
-          "deviation_pct": 0,
+          "actual_mm3": 36000.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 36000,
+          "spec_mm3": 36000.0,
           "tolerance_pct": 0.5
         }
       }
@@ -115,37 +115,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "original_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                50,
-                10
+                50.0,
+                50.0,
+                10.0
               ],
               "roundtripped_min": [
-                -50,
-                -50,
-                0
+                -50.0,
+                -50.0,
+                0.0
               ],
               "tolerance_mm": 0.7088723439378913
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 36000,
+              "deviation_pct": 0.0,
+              "original_mm3": 36000.0,
               "pass": true,
-              "roundtripped_mm3": 36000
+              "roundtripped_mm3": 36000.0
             }
           }
         ],
@@ -157,7 +157,7 @@
     "passed": true,
     "checks_passed": 4,
     "checks_total": 4,
-    "score": 1,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -185,7 +185,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a4-x-frame-01",
-    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm \u00d7 20mm \u00d7 10mm overlap is counted only once. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.json
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.json
@@ -1,0 +1,225 @@
+{
+  "schema_version": 0,
+  "task_id": "a4-x-frame-01",
+  "task_sha256": "984c72e685616e39f1a57a059ec6b4f41560402835e80466730906ced3fa2f3b",
+  "checks": [
+    {
+      "n": 0,
+      "type": "valid_solid",
+      "params": {
+        "type": "valid_solid"
+      },
+      "result": "pass",
+      "details": {
+        "root_count": 1,
+        "solids_produced": 1
+      }
+    },
+    {
+      "n": 1,
+      "type": "bbox",
+      "params": {
+        "type": "bbox",
+        "min": [
+          -50,
+          -50,
+          0
+        ],
+        "max": [
+          50,
+          50,
+          10
+        ],
+        "tolerance_mm": 0.05
+      },
+      "result": "pass",
+      "details": {
+        "actual_max": [
+          50,
+          50,
+          10
+        ],
+        "actual_min": [
+          -50,
+          -50,
+          0
+        ],
+        "deviation_max": [
+          0,
+          0,
+          0
+        ],
+        "deviation_min": [
+          0,
+          0,
+          0
+        ],
+        "max_abs_deviation_mm": 0,
+        "tolerance_mm": 0.05
+      }
+    },
+    {
+      "n": 2,
+      "type": "mass_props",
+      "params": {
+        "type": "mass_props",
+        "volume_mm3": 36000,
+        "center_of_mass": [
+          0,
+          0,
+          5
+        ],
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "center_of_mass": {
+          "actual": [
+            0,
+            0,
+            5
+          ],
+          "bbox_diagonal_mm": 141.77446878757826,
+          "deviation": [
+            0,
+            0,
+            0
+          ],
+          "max_abs_deviation_mm": 0,
+          "pass": true,
+          "spec": [
+            0,
+            0,
+            5
+          ],
+          "tolerance_mm": 0.7088723439378913
+        },
+        "volume": {
+          "actual_mm3": 36000,
+          "deviation_pct": 0,
+          "pass": true,
+          "spec_mm3": 36000,
+          "tolerance_pct": 0.5
+        }
+      }
+    },
+    {
+      "n": 3,
+      "type": "step_roundtrip",
+      "params": {
+        "type": "step_roundtrip",
+        "tolerance_pct": 0.5
+      },
+      "result": "pass",
+      "details": {
+        "per_solid": [
+          {
+            "bbox": {
+              "max_abs_deviation_mm": 0,
+              "original_max": [
+                50,
+                50,
+                10
+              ],
+              "original_min": [
+                -50,
+                -50,
+                0
+              ],
+              "pass": true,
+              "roundtripped_max": [
+                50,
+                50,
+                10
+              ],
+              "roundtripped_min": [
+                -50,
+                -50,
+                0
+              ],
+              "tolerance_mm": 0.7088723439378913
+            },
+            "index": 0,
+            "pass": true,
+            "volume": {
+              "deviation_pct": 0,
+              "original_mm3": 36000,
+              "pass": true,
+              "roundtripped_mm3": 36000
+            }
+          }
+        ],
+        "tolerance_pct": 0.5
+      }
+    }
+  ],
+  "summary": {
+    "passed": true,
+    "checks_passed": 4,
+    "checks_total": 4,
+    "score": 1,
+    "anti_cheese_violated": false,
+    "limits_exceeded": []
+  },
+  "run_id": "20260429T120529Z-56ba",
+  "model": {
+    "id": "claude-direct-claude-sonnet-4-6",
+    "name": "Claude (direct, claude-sonnet-4-6)",
+    "provider": "anthropic",
+    "params": {
+      "mode": "direct",
+      "model": "claude-sonnet-4-6",
+      "max_tokens": 8000
+    }
+  },
+  "harness": {
+    "version": "0.0.1",
+    "commit": null,
+    "vcad_version": null,
+    "phyz_version": null,
+    "host": {
+      "os": "linux-v22.22.2",
+      "arch": "x64"
+    }
+  },
+  "submission_kind": "self-run",
+  "prompt": {
+    "seed": "a4-x-frame-01",
+    "rendered": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+    "attachments": []
+  },
+  "trace": {
+    "tool_calls": [
+      {
+        "n": 0,
+        "tool": "anthropic.messages.create",
+        "args": {
+          "model": "claude-sonnet-4-6",
+          "max_tokens": 8000,
+          "system_chars": 1674,
+          "user_chars": 662
+        },
+        "result_kind": "ok",
+        "wallclock_ms": 3651.163846
+      }
+    ],
+    "tokens": {
+      "input": 788,
+      "output": 364,
+      "total": 1152
+    },
+    "wallclock_sec": 3.6511638459999998
+  },
+  "output": {
+    "vcad_path": "20260429T120529Z-56ba.vcad",
+    "vcad_sha256": "992795d6c34d5181ea9d63e194a7a156435c0ee3c223aec04c51ed40e7740da4",
+    "control_policy": null,
+    "renders": []
+  },
+  "sim": null,
+  "timestamps": {
+    "started_at": "2026-04-29T12:05:29.777Z",
+    "ended_at": "2026-04-29T12:05:33.449Z"
+  },
+  "signature": null
+}

--- a/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.vcad
+++ b/mecheval/runs/a4-x-frame-01/claude-direct-claude-sonnet-4-6/20260429T120529Z-56ba.vcad
@@ -1,0 +1,33 @@
+{
+  "version": "0.1",
+  "nodes": {
+    "1": {
+      "id": 1,
+      "name": "Bar A",
+      "op": {"type": "Cube", "size": {"x": 100, "y": 20, "z": 10}}
+    },
+    "2": {
+      "id": 2,
+      "name": "Bar A Centered",
+      "op": {"type": "Translate", "child": 1, "offset": {"x": -50, "y": -10, "z": 0}}
+    },
+    "3": {
+      "id": 3,
+      "name": "Bar B",
+      "op": {"type": "Cube", "size": {"x": 20, "y": 100, "z": 10}}
+    },
+    "4": {
+      "id": 4,
+      "name": "Bar B Centered",
+      "op": {"type": "Translate", "child": 3, "offset": {"x": -10, "y": -50, "z": 0}}
+    },
+    "5": {
+      "id": 5,
+      "name": "Cross Frame",
+      "op": {"type": "Union", "left": 2, "right": 4}
+    }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [{"root": 5, "material": "default"}]
+}

--- a/mecheval/tasks/a4-bolt-circle-flange-with-bore-01.json
+++ b/mecheval/tasks/a4-bolt-circle-flange-with-bore-01.json
@@ -1,0 +1,64 @@
+{
+  "id": "a4-bolt-circle-flange-with-bore-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Round flange with central bore and 6-bolt circle",
+  "prompt": "Make a round flange as a single solid. The outer body is a cylinder of diameter 100mm and thickness 12mm, with its bottom face on the XY plane (z = 0 to z = 12), centered on the Z axis. A central through-bore of diameter 40mm runs along the Z axis through the full thickness. Six bolt holes of diameter 8mm, axes parallel to Z, are arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, passing through the full thickness. The first bolt hole is on the +X axis, and the remaining five are evenly spaced every 60 degrees. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-50, -50, 0],
+      "max": [50, 50, 12],
+      "tolerance_mm": 0.3
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 75549.02,
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 40.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 40.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 6,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [37.5, 0.0, 0],
+        [18.75, 32.476, 0],
+        [-18.75, 32.476, 0],
+        [-37.5, 0.0, 0],
+        [-18.75, -32.476, 0],
+        [18.75, -32.476, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["flange", "bolt-circle", "central-bore", "trigonometry", "advanced"]
+}

--- a/mecheval/tasks/a4-counterbore-plate-01.json
+++ b/mecheval/tasks/a4-counterbore-plate-01.json
@@ -1,0 +1,67 @@
+{
+  "id": "a4-counterbore-plate-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Plate with four counterbore holes",
+  "prompt": "Make a single solid: a flat plate 60mm × 60mm × 12mm, centered in X and Y with the bottom face on the XY plane (z = 0 to z = 12). Drill four counterbore holes at corners (20, 20), (-20, 20), (-20, -20), (20, -20). Each counterbore consists of two coaxial Z-aligned through-features: a clearance through-hole of diameter 4mm running the full thickness (z = 0 to z = 12), and a coaxial recess of diameter 8mm machined 4mm deep from the top face (so the larger diameter spans z = 8 to z = 12). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-30, -30, 0],
+      "max": [30, 30, 12],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 41993.63,
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 4.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 4.0,
+      "positions": [
+        [20.0, 20.0, 0],
+        [-20.0, 20.0, 0],
+        [-20.0, -20.0, 0],
+        [20.0, -20.0, 0]
+      ],
+      "tolerance_mm": 0.15
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [20.0, 20.0, 0],
+        [-20.0, 20.0, 0],
+        [-20.0, -20.0, 0],
+        [20.0, -20.0, 0]
+      ],
+      "tolerance_mm": 0.15
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["plate", "counterbore", "multi-diameter-hole", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a4-flanged-shaft-01.json
+++ b/mecheval/tasks/a4-flanged-shaft-01.json
@@ -1,0 +1,62 @@
+{
+  "id": "a4-flanged-shaft-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Flanged hollow shaft with bolt circle",
+  "prompt": "Make a flanged hollow shaft as a single solid. The base is a circular flange of outer diameter 80mm and thickness 10mm, with its bottom face on the XY plane (z = 0 to z = 10). Above the flange and concentric with it sits a cylindrical shaft of outer diameter 30mm extending 50mm upward (z = 10 to z = 60). A central through-bore of diameter 15mm runs along the Z axis through both the flange and the shaft (z = 0 to z = 60). The flange has four bolt holes of diameter 6mm, axes parallel to Z, on a bolt circle of diameter 60mm (radius 30mm) centered on the Z axis. The first bolt hole is on the +X axis; the others are spaced every 90 degrees. The bolt holes pass through the full flange thickness. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -40, 0],
+      "max": [40, 40, 60],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 73874.55,
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 15.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 15.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 6.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 6.0,
+      "positions": [
+        [30.0, 0.0, 0],
+        [0.0, 30.0, 0],
+        [-30.0, 0.0, 0],
+        [0.0, -30.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["flange", "shaft", "bolt-circle", "central-bore", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a4-rectangular-tube-01.json
+++ b/mecheval/tasks/a4-rectangular-tube-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a4-rectangular-tube-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Hollow square tube",
+  "prompt": "Make a hollow square tube. The outer cross-section is a 40mm × 40mm square; the inner cavity is a 28mm × 28mm square, concentric with the outer. The cavity passes all the way through. The tube is 80mm long along Z, with the bottom face on the XY plane (so it spans x in [-20, 20], y in [-20, 20], z in [0, 80] for the outer envelope). The inner cavity spans x in [-14, 14], y in [-14, 14], z in [0, 80]. Wall thickness is 6mm uniformly. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-20, -20, 0],
+      "max": [20, 20, 80],
+      "tolerance_mm": 0.05
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 65280.0,
+      "center_of_mass": [0, 0, 40],
+      "tolerance_pct": 0.5
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 0.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["tube", "hollow", "boolean", "rectangular", "advanced"]
+}

--- a/mecheval/tasks/a4-rounded-bar-01.json
+++ b/mecheval/tasks/a4-rounded-bar-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a4-rounded-bar-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Stadium-shaped flat bar",
+  "prompt": "Make a flat bar with a stadium-shaped (rectangle with semicircular ends) footprint, extruded 10mm along Z. Total end-to-end length is 80mm along X; total width is 20mm along Y. The footprint is the union of a 60mm × 20mm rectangle (x in [-30, 30], y in [-10, 10]) and two semicircles of radius 10mm centered at (-30, 0) and (30, 0). The bottom face sits on the XY plane (z = 0 to z = 10). Output a single solid (no holes or other features).",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -10, 0],
+      "max": [40, 10, 10],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 15141.59,
+      "center_of_mass": [0, 0, 5],
+      "tolerance_pct": 1.0
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["stadium", "bar", "union", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a4-slotted-bracket-01.json
+++ b/mecheval/tasks/a4-slotted-bracket-01.json
@@ -1,0 +1,48 @@
+{
+  "id": "a4-slotted-bracket-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Plate with stadium-shaped through-slot",
+  "prompt": "Make a flat rectangular plate 80mm × 40mm × 8mm thick, centered in X and Y with the bottom face on the XY plane (so it spans x in [-40, 40], y in [-20, 20], z in [0, 8]). Cut a stadium-shaped (rectangle with semicircular ends) slot all the way through the plate, axes along the X direction. The slot has total end-to-end length 50mm and width 10mm: the centers of the two semicircular ends are at (-20, 0) and (20, 0), each of radius 5mm, joined by a 40mm-long, 10mm-wide rectangular section (x in [-20, 20], y in [-5, 5]). The slot is cut through the full plate thickness. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -20, 0],
+      "max": [40, 20, 8],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 21771.68,
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 10.0,
+      "expected": 2,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 10.0,
+      "positions": [
+        [-20.0, 0.0, 0],
+        [20.0, 0.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["plate", "slot", "stadium", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a4-stepped-pyramid-with-holes-01.json
+++ b/mecheval/tasks/a4-stepped-pyramid-with-holes-01.json
@@ -1,0 +1,50 @@
+{
+  "id": "a4-stepped-pyramid-with-holes-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Three-step pyramid with bolt holes through base",
+  "prompt": "Make a stepped pyramid composed of three concentric square layers stacked along Z, fused into a single solid. Base layer: 80mm × 80mm × 10mm, centered in X and Y, bottom face on the XY plane (z = 0 to z = 10). Middle layer: 60mm × 60mm × 10mm, centered, sitting on top of the base layer (z = 10 to z = 20). Top layer: 40mm × 40mm × 10mm, centered, sitting on top of the middle layer (z = 20 to z = 30). The base layer has four bolt holes of diameter 6mm, axes parallel to Z, drilled through the full 10mm thickness of the base only (z = 0 to z = 10), located at (30, 30), (-30, 30), (-30, -30), (30, -30). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -40, 0],
+      "max": [40, 40, 30],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 114869.03,
+      "tolerance_pct": 0.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 6.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 6.0,
+      "positions": [
+        [30.0, 30.0, 0],
+        [-30.0, 30.0, 0],
+        [-30.0, -30.0, 0],
+        [30.0, -30.0, 0]
+      ],
+      "tolerance_mm": 0.15
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 0.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["stepped", "pyramid", "bolt-holes", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a4-x-frame-01.json
+++ b/mecheval/tasks/a4-x-frame-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a4-x-frame-01",
+  "suite": "A",
+  "tier": "A4",
+  "title": "Cross frame from two perpendicular bars",
+  "prompt": "Make a cross-shaped frame in the XY plane by fusing two rectangular bars at right angles. Bar A is 100mm long along X, 20mm wide along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-50, 50], y in [-10, 10], z in [0, 10]). Bar B is 20mm wide along X, 100mm long along Y, and 10mm tall along Z, centered in X and Y with its bottom face on the XY plane (so it spans x in [-10, 10], y in [-50, 50], z in [0, 10]). Union the two bars into a single plus-sign-shaped solid; the central 20mm × 20mm × 10mm overlap is counted only once. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-50, -50, 0],
+      "max": [50, 50, 10],
+      "tolerance_mm": 0.05
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 36000.0,
+      "center_of_mass": [0, 0, 5],
+      "tolerance_pct": 0.5
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 0.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["frame", "cross", "union", "boolean", "advanced"]
+}


### PR DESCRIPTION
## Summary

Adds an A4 mecheval tier (8 tasks) that combines multiple operations to push the frontier-model score ceiling back down, plus a kernel fix uncovered by triaging the resulting failures. Two of the new tasks turned out to be reproducers for an existing kernel bug (#161); fixing it improved every cube-minus-cube case across the corpus, including two pre-existing failures (`a2-cube-with-pocket-01` and `a2-stepped-block-01`).

## Commits (4)

1. **`mecheval: add A4 tier — 8 multi-feature tasks`** — Eight new tasks with computed expected values matched at 0% deviation: counterbore-plate, rectangular-tube, flanged-shaft, slotted-bracket, stepped-pyramid-with-holes, x-frame, bolt-circle-flange-with-bore, rounded-bar.

2. **`mecheval: a4 sweep — pass^5 results across 3 Claude direct solvers`** — 8 tasks × 3 models × 5 runs = 120 official runs against Opus 4.7, Sonnet 4.6, Haiku 4.5.

3. **`kernel: trust face.orientation in planar tessellator`** — Removes the heuristic at `vcad-kernel-tessellate/src/lib.rs` that overrode `Orientation::Reversed` whenever loop winding disagreed with `surface_normal × reversed_flag`. The booleans (per the contract documented at `sew.rs:254-270`) deliberately keep loop winding original and rely on the orientation flag — the heuristic was inverting truth on every Difference-produced cavity wall. The core tessellator already honors `reversed`; the planar wrapper just passes it through. Tightens `test_difference_hole_in_center` (was [600,1100] for expected 840; now ±1) and adds `test_difference_hollow_tube_volume` regression for the exact #161 case.

4. **`mecheval: regrade A4 runs against fixed kernel`** — Re-graded all 121 .vcad outputs against the fixed kernel; .vcad files (frozen LLM outputs) unchanged, only .json grader output updated.

## A4 sweep — discriminating power

Top frontier models (Opus 4.7, Sonnet 4.6, GPT-5, GPT-5-mini) saturate at 1.00 on nearly every A1–A3 task. Pre-fix A4 results (post-fix in parens):

| task | opus 4.7 | sonnet 4.6 | haiku 4.5 |
|---|---|---|---|
| bolt-circle-flange-with-bore | 1.00 (1.00) | 1.00 (1.00) | 0.00 |
| counterbore-plate | 1.00 (1.00) | 1.00 (1.00) | 0.00 |
| flanged-shaft | 1.00 (1.00) | 1.00 (1.00) | 0.00 |
| **rectangular-tube** | **0.75 → 1.00** | **0.75 → 1.00** | 0.00 |
| rounded-bar | 1.00 (1.00) | 1.00 (1.00) | 0.00 |
| slotted-bracket | 0.83 (0.83†) | 0.83 (0.83†) | 0.00 |
| stepped-pyramid-with-holes | 0.97 (0.97‡) | 0.93 (0.80‡) | 0.00 |
| x-frame | 1.00 (1.00) | 1.00 (1.00) | 0.20 |

† Slotted-bracket dropped from 11.7% over to 1.93% over after the fix. Residual is a separate Union-of-tangent-primitives bug — filed as #165 with a minimal repro.

‡ Stepped-pyramid: mass_props now passes consistently (vol=115063.57 within tolerance). The remaining sub-1.0 scores come from pre-existing STEP-roundtrip variance on cylindrical bolt holes (0.16%–1.21% drift), which the volume bug had been masking — exposed, not introduced, by this fix.

## Kernel diagnosis (recap from commit `79ab4d0`)

The bug: `Difference(40×40×80, 28×28×80)` returned vol = **148906.67 mm³** instead of expected **65280**. The `valid_solid` check passes, the topology has 4 inner cavity walls correctly tagged `Orientation::Reversed`, but the volume integrator saw them facing outward. Discrepancy `148906.67 − 65280 = 83626.67` matches exactly **4 walls × 2 × wall_centroid_contribution**, the sign-flip integral on every cavity wall.

Root cause: the planar-face tessellator computed `expected_normal = surface_normal × (reversed ? -1 : 1)`, then computed `geom_normal` from loop winding via Newell's method, and **flipped the `reversed` flag** if they disagreed. On Difference output:
- Inner-cube primitive's +X face has surface_normal=+X, outward (CCW-from-+X) winding
- After Difference it's tagged `Reversed` (correct: it's a cavity wall facing -X)
- The booleans deliberately don't reverse the loop (sew.rs:254-270)
- Heuristic computes `expected_normal=-X`, `geom_normal=+X`, dot<0 → "winding doesn't match" → `effective_reversed = !reversed = false`
- Triangles emitted with outward winding for the cavity wall
- Volume integral sees the wall pointing the wrong way

Fix: trust the orientation flag, since the booleans already maintain the contract the heuristic was trying to "correct". My 5-variant bisect (cutter flush both ends, flush one end, fully extended, fully enclosed) showed all box-minus-box cases produce the same wrong result — disproving the issue's "shared/coplanar boundary faces" framing — and post-fix all five report 65280 exactly.

This closes the cube-minus-cube portion of #161. The Union-of-tangent-primitives bug surfaced by `a4-slotted-bracket-01` is filed separately as #165.

## Test plan

- [x] Bisect (5 variants) all return correct volume post-fix
- [x] `a2-cube-with-pocket-01`: 57333.33 → 60000 ✓
- [x] `a2-stepped-block-01`: 17500 → 22500 ✓
- [x] `cargo test -p vcad-kernel-tessellate -p vcad-kernel-booleans -p vcad-kernel -p vcad-kernel-topo -p vcad-kernel-geom -p vcad-kernel-primitives -p vcad-kernel-fillet -p vcad-kernel-sweep -p vcad-kernel-shell -p vcad-kernel-step -p vcad-eval -p vcad-ir -p mecheval-grader` — all 280+ pass
- [x] New regression `test_difference_hollow_tube_volume` covering 40×40×80 minus 28×28×80
- [x] Existing `test_difference_hole_in_center` tightened from [600,1100] to ±1 of expected 840
- [x] All 121 A4 .vcad outputs re-graded against fixed kernel; .json blobs reflect post-fix scores
- [ ] Manual visual check in the web app on the affected mecheval tasks (couldn't run UI in this environment — flagging for reviewer)

## Refs

- Closes the cube-minus-cube portion of #161
- Filed #165 for the residual Union-of-tangent-primitives bug surfaced by `a4-slotted-bracket-01`
- Related: #160 (Steinmetz cylinder Union dedup) — same family of tangent-boundary failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01JUbxiqPRaVxbkCeTdVw35k)_