### PR TITLE
Fix Difference with tangent Union'd cylinder under-subtracting

### DIFF
--- a/changelog/entries/2026-04-29-difference-tangent-cyl-union.json
+++ b/changelog/entries/2026-04-29-difference-tangent-cyl-union.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-04-29-difference-tangent-cyl-union",
+  "version": "0.9.4",
+  "date": "2026-04-29",
+  "category": "fix",
+  "title": "Difference cutter with tangent Union'd cylinder no longer under-subtracts",
+  "summary": "When a Difference uses a Union of primitives whose lateral surfaces share a tangent boundary as the cutter (e.g. a slot built from a rect plus tangent cylinders), the cylinder's full SSI circle on the target face fell entirely inside the polygon, tangent to two edges. The arc-based splitter saw both circle halves as 'inside' and arbitrarily picked one — leaving ~66% of the cylinder's external lobe un-subtracted. The polygon is now split along the chord between the two tangent points first, so each sub-polygon contains exactly one arc and the inside check resolves unambiguously.",
+  "features": ["kernel", "boolean"]
+}

--- a/crates/vcad-kernel-booleans/src/lib.rs
+++ b/crates/vcad-kernel-booleans/src/lib.rs
@@ -1851,4 +1851,99 @@ mod tests {
             "Result mesh should have triangles"
         );
     }
+
+    /// Regression test for issue #165: `Difference(plate, Union(rect, cyl))`
+    /// where a cylinder is tangent to a rect must subtract the full
+    /// stadium-shaped cutout, not under-subtract the cylinder's external lobe.
+    ///
+    /// Before the fix, the SSI between the half-cylinder and the plate's caps
+    /// produced a full circle, which fell on the boundary between the rect
+    /// interior and the strip beside it on the plate's cap face. The arc-based
+    /// splitter saw both circle halves as "inside the polygon" and arbitrarily
+    /// picked one — so the kept face's outline traced the inside arc rather
+    /// than the outside arc, leaving ~66% of the cylinder's external lobe
+    /// un-subtracted.
+    #[test]
+    fn test_difference_with_tangent_cyl_union_cutter() {
+        use vcad_kernel_primitives::make_cylinder;
+
+        // Plate 80×40×8 centered on (0,0).
+        let mut plate = make_cube(80.0, 40.0, 8.0);
+        translate_brep(&mut plate, -40.0, -20.0, 0.0);
+
+        // Rect 40×10×8 centered on (0,0).
+        let mut rect = make_cube(40.0, 10.0, 8.0);
+        translate_brep(&mut rect, -20.0, -5.0, 0.0);
+
+        // Cylinder R=5, H=8 at (-20, 0) — tangent to rect's left edge at (-20, ±5).
+        let mut cyl_l = make_cylinder(5.0, 8.0, 64);
+        translate_brep(&mut cyl_l, -20.0, 0.0, 0.0);
+
+        let union1 = boolean_op(&rect, &cyl_l, BooleanOp::Union, 64)
+            .into_brep()
+            .unwrap();
+        let result = boolean_op(&plate, &union1, BooleanOp::Difference, 64);
+        let mesh = result.to_mesh(64);
+        let actual = compute_mesh_volume(&mesh);
+
+        let plate_vol = 80.0 * 40.0 * 8.0;
+        let rect_vol = 40.0 * 10.0 * 8.0;
+        let half_disk_vol = std::f64::consts::PI * 25.0 / 2.0 * 8.0;
+        let expected = plate_vol - rect_vol - half_disk_vol;
+
+        let dev = ((actual - expected) / expected).abs();
+        assert!(
+            dev < 0.001,
+            "Difference(plate, Union(rect, tangent_cyl)) should subtract the \
+             full stadium cutout. Got {:.4} mm³, expected {:.4} (dev {:.3}%).",
+            actual,
+            expected,
+            dev * 100.0
+        );
+    }
+
+    /// Regression test for issue #165 with two tangent cylinders (one on each
+    /// end of the rect). The error was linear in cylinder count, so this case
+    /// is the most sensitive.
+    #[test]
+    fn test_difference_with_two_tangent_cyls_union_cutter() {
+        use vcad_kernel_primitives::make_cylinder;
+
+        let mut plate = make_cube(80.0, 40.0, 8.0);
+        translate_brep(&mut plate, -40.0, -20.0, 0.0);
+
+        let mut rect = make_cube(40.0, 10.0, 8.0);
+        translate_brep(&mut rect, -20.0, -5.0, 0.0);
+
+        let mut cyl_l = make_cylinder(5.0, 8.0, 64);
+        translate_brep(&mut cyl_l, -20.0, 0.0, 0.0);
+
+        let mut cyl_r = make_cylinder(5.0, 8.0, 64);
+        translate_brep(&mut cyl_r, 20.0, 0.0, 0.0);
+
+        let u1 = boolean_op(&rect, &cyl_l, BooleanOp::Union, 64)
+            .into_brep()
+            .unwrap();
+        let u2 = boolean_op(&u1, &cyl_r, BooleanOp::Union, 64)
+            .into_brep()
+            .unwrap();
+        let result = boolean_op(&plate, &u2, BooleanOp::Difference, 64);
+        let mesh = result.to_mesh(64);
+        let actual = compute_mesh_volume(&mesh);
+
+        let plate_vol = 80.0 * 40.0 * 8.0;
+        let rect_vol = 40.0 * 10.0 * 8.0;
+        let two_half_disks_vol = std::f64::consts::PI * 25.0 * 8.0;
+        let expected = plate_vol - rect_vol - two_half_disks_vol;
+
+        let dev = ((actual - expected) / expected).abs();
+        assert!(
+            dev < 0.001,
+            "Difference with two-cylinder slot should match analytic stadium \
+             cutout. Got {:.4} mm³, expected {:.4} (dev {:.3}%).",
+            actual,
+            expected,
+            dev * 100.0
+        );
+    }
 }

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -1195,6 +1195,22 @@ pub fn split_planar_face_by_arc(
     let arc1_mid_y = center_2d.1 + circle.radius * arc1_mid_angle.sin();
     let arc1_inside = point_in_polygon_2d(arc1_mid_x, arc1_mid_y, &poly_2d);
 
+    // Tangent-inside case: when the circle is fully inside the polygon but
+    // tangent to two polygon edges, both arcs (the two halves of the circle
+    // separated by the chord through the tangent points) lie inside the
+    // polygon. Picking either arc arbitrarily produces a face whose boundary
+    // bulges through the disk in the wrong direction (issue #165). Split the
+    // polygon along the chord first, then recurse: each sub-polygon contains
+    // exactly one of the two arcs, so the inside/outside check resolves
+    // unambiguously.
+    let arc2_mid_angle = arc1_mid_angle + std::f64::consts::PI;
+    let arc2_mid_x = center_2d.0 + circle.radius * arc2_mid_angle.cos();
+    let arc2_mid_y = center_2d.1 + circle.radius * arc2_mid_angle.sin();
+    let arc2_inside = point_in_polygon_2d(arc2_mid_x, arc2_mid_y, &poly_2d);
+    if arc1_inside && arc2_inside {
+        return split_planar_face_tangent_inside(brep, face_id, circle, segments, int1, int2);
+    }
+
     // Determine which arc is inside and which edge indices to walk
     let (inside_start, inside_end, inside_start_angle, inside_end_angle) = if arc1_inside {
         (int1, int2, angle1, angle2)
@@ -1378,6 +1394,72 @@ pub fn split_planar_face_by_arc(
 
     SplitResult {
         sub_faces: vec![face1, face2],
+    }
+}
+
+/// Handle the tangent-inside case where a circle lies fully inside a polygon
+/// but is tangent to two polygon edges.
+///
+/// Strategy: split the polygon along the chord between the two tangent points
+/// using `split_face_by_curve` (line-based), producing two simple sub-polygons.
+/// Each sub-polygon contains exactly one of the two circle arcs, so calling
+/// `split_planar_face_by_arc` on each resolves the disk's relevant half-circle
+/// unambiguously.
+///
+/// This is essential when a Difference cutter is itself a Union of primitives
+/// whose lateral surfaces share a tangent boundary (e.g. a rect with a tangent
+/// cylinder), where the cylinder's full SSI circle on the target's planar face
+/// would otherwise straddle two regions of different classification.
+fn split_planar_face_tangent_inside(
+    brep: &mut BRepSolid,
+    face_id: FaceId,
+    circle: &vcad_kernel_geom::Circle3d,
+    segments: u32,
+    int1: &CirclePolygonIntersection,
+    int2: &CirclePolygonIntersection,
+) -> SplitResult {
+    // Build a Line3d through the two tangent points to act as the chord.
+    let chord_dir = int2.point - int1.point;
+    let chord_len = chord_dir.norm();
+    if chord_len < 1e-9 {
+        return SplitResult {
+            sub_faces: vec![face_id],
+        };
+    }
+    let chord_line = vcad_kernel_geom::Line3d {
+        origin: int1.point,
+        direction: chord_dir / chord_len,
+    };
+    let chord_curve = IntersectionCurve::Line(chord_line);
+
+    // Split the polygon along the chord; sub-faces split on the original face's
+    // outer loop at int1 and int2.
+    let chord_result = split_face_by_curve(brep, face_id, &chord_curve, &int1.point, &int2.point);
+    if chord_result.sub_faces.len() < 2 {
+        return chord_result;
+    }
+
+    // Now split each sub-face by the arc. Each sub-polygon should contain
+    // exactly one of the two arc midpoints, so the inside/outside check
+    // resolves correctly.
+    let mut all_sub_faces = Vec::new();
+    for sub_id in chord_result.sub_faces {
+        if !brep.topology.faces.contains_key(sub_id) {
+            continue;
+        }
+        let sub_result = split_planar_face_by_arc(brep, sub_id, circle, segments);
+        // If the recursive split made progress (>= 2 sub-faces), use those;
+        // otherwise the sub-face was left intact (e.g. its arc midpoint missed
+        // the polygon by a tolerance margin) — keep the unsplit sub-face.
+        if sub_result.sub_faces.len() >= 2 {
+            all_sub_faces.extend(sub_result.sub_faces);
+        } else {
+            all_sub_faces.push(sub_id);
+        }
+    }
+
+    SplitResult {
+        sub_faces: all_sub_faces,
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes issue #165 where a `Difference` operation using a `Union` of primitives with tangent lateral surfaces (e.g., a rect with tangent cylinders) as the cutter would under-subtract the cylinder's external lobe by ~66%.

## Root Cause
When a cylinder is tangent to a rectangle's edge, their solid-solid intersection (SSI) on the target face's planar cap produces a full circle that lies entirely inside the polygon but is tangent to two polygon edges. The arc-based splitter would check both circle halves and find both "inside the polygon," then arbitrarily pick one. This caused the kept face's boundary to trace the wrong arc, leaving most of the cylinder's external lobe un-subtracted.

## Key Changes

- **`split.rs`**: Added `split_planar_face_tangent_inside()` function that detects when a circle is fully inside a polygon but tangent to two edges. Instead of arbitrarily choosing an arc, it:
  1. Splits the polygon along the chord between the two tangent points
  2. Recursively calls the arc splitter on each sub-polygon
  3. Each sub-polygon now contains exactly one arc, resolving the inside/outside check unambiguously

- **`split.rs`**: Enhanced `split_planar_face_by_arc()` to detect the tangent-inside case by checking if both arc midpoints (180° apart) fall inside the polygon, then delegating to the new handler

- **`lib.rs`**: Added two regression tests:
  - `test_difference_with_tangent_cyl_union_cutter()`: Single tangent cylinder case
  - `test_difference_with_two_tangent_cyls_union_cutter()`: Two tangent cylinders (most sensitive to the error)
  
  Both verify that the result volume matches the analytic expectation within 0.1% tolerance.

## Implementation Details
The fix leverages the existing `split_face_by_curve()` infrastructure to perform a line-based split along the chord, then reuses the arc splitter recursively. This ensures the solution is robust and maintains consistency with the existing splitting pipeline.

https://claude.ai/code/session_016FZCLfePD7JPShixaQk3Ho