### PR TITLE
mecheval: regrade a2-stepped-block-01 + add flush-corner regression tests

### DIFF
--- a/crates/vcad-kernel-booleans/tests/degenerate_cases.rs
+++ b/crates/vcad-kernel-booleans/tests/degenerate_cases.rs
@@ -102,6 +102,77 @@ fn coplanar_adjacent_difference_no_change() {
     );
 }
 
+/// A2 stepped-block regression (mecheval task `a2-stepped-block-01`):
+/// cut box is flush with 4 of the base box's faces (+X, ±Y, +Z), interior
+/// faces only at x=0 and z=10. The result is an L-shape with volume
+/// 22500 mm³ = 30000 - 7500. Pre-79ab4d0 the kernel computed 17500 mm³
+/// because the planar tessellator overrode `Orientation::Reversed` on
+/// the cut's exposed cavity walls, inverting their contribution to the
+/// divergence-theorem volume integral.
+#[test]
+fn flush_corner_step_block_difference_volume_pos_x() {
+    let mut base = make_cube(50.0, 30.0, 20.0);
+    translate(&mut base, -25.0, -15.0, 0.0);
+    let mut cut = make_cube(25.0, 30.0, 10.0);
+    translate(&mut cut, 0.0, -15.0, 10.0);
+
+    let result = boolean_op(&base, &cut, BooleanOp::Difference, 32);
+    let mesh = result.to_mesh(32);
+    assert_valid_mesh(&mesh);
+
+    let vol = mesh_volume(&mesh);
+    assert!(
+        (vol - 22500.0).abs() / 22500.0 < 0.01,
+        "stepped-block diff (+X corner): expected ~22500, got {vol:.2}"
+    );
+}
+
+/// Mirror of `flush_corner_step_block_difference_volume_pos_x` cutting the −X
+/// corner instead. Same flush-on-four-faces topology, opposite-direction
+/// outward normals — guards against any sign-only fix.
+#[test]
+fn flush_corner_step_block_difference_volume_neg_x() {
+    let mut base = make_cube(50.0, 30.0, 20.0);
+    translate(&mut base, -25.0, -15.0, 0.0);
+    let mut cut = make_cube(25.0, 30.0, 10.0);
+    translate(&mut cut, -25.0, -15.0, 10.0);
+
+    let result = boolean_op(&base, &cut, BooleanOp::Difference, 32);
+    let mesh = result.to_mesh(32);
+    assert_valid_mesh(&mesh);
+
+    let vol = mesh_volume(&mesh);
+    assert!(
+        (vol - 22500.0).abs() / 22500.0 < 0.01,
+        "stepped-block diff (−X corner): expected ~22500, got {vol:.2}"
+    );
+}
+
+/// Vertical-step variant: cut is flush with ±X and ±Y of the base, only
+/// the bottom (−Z) face of the cut is interior. Exercises the same
+/// coincident-face routing on a different axis.
+#[test]
+fn flush_corner_step_block_difference_volume_vertical() {
+    // Base 30×30×40 spanning (-15..15, -15..15, 0..40).
+    let mut base = make_cube(30.0, 30.0, 40.0);
+    translate(&mut base, -15.0, -15.0, 0.0);
+    // Cut 30×30×20 spanning (-15..15, -15..15, 20..40) — flush on ±X, ±Y, +Z.
+    // Only the −Z face (z=20) is interior, leaving the lower half of the base.
+    let mut cut = make_cube(30.0, 30.0, 20.0);
+    translate(&mut cut, -15.0, -15.0, 20.0);
+
+    let result = boolean_op(&base, &cut, BooleanOp::Difference, 32);
+    let mesh = result.to_mesh(32);
+    assert_valid_mesh(&mesh);
+
+    let vol = mesh_volume(&mesh);
+    let expected = 30.0 * 30.0 * 20.0; // 18000
+    assert!(
+        (vol - expected).abs() / expected < 0.01,
+        "stepped-block diff (vertical): expected ~{expected}, got {vol:.2}"
+    );
+}
+
 /// Co-planar face union where both operands share an entire face in the Z direction.
 /// A occupies z=[0,10], B occupies z=[10,20]; they touch at the z=10 plane.
 #[test]

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211835Z-6f1a.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211835Z-6f1a.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211838Z-0d90.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211838Z-0d90.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211841Z-e0bd.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211841Z-e0bd.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211843Z-e7bf.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211843Z-e7bf.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211846Z-a13c.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-haiku-4-5-20251001/20260428T211846Z-a13c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212011Z-aa4a.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212011Z-aa4a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212015Z-22d6.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212015Z-22d6.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212019Z-9a3f.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212019Z-9a3f.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212023Z-5717.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212023Z-5717.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212027Z-c240.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-opus-4-7/20260428T212027Z-c240.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212150Z-da5a.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212150Z-da5a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212154Z-84fc.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212154Z-84fc.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212159Z-73e0.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212159Z-73e0.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212203Z-f259.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212203Z-f259.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212208Z-d16a.json
+++ b/mecheval/runs/a2-stepped-block-01/claude-direct-claude-sonnet-4-6/20260428T212208Z-d16a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213622Z-8108.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213622Z-8108.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213628Z-ff20.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213628Z-ff20.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213633Z-c6c9.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213633Z-c6c9.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213639Z-3b25.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213639Z-3b25.json
@@ -21,14 +21,14 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
@@ -42,7 +42,7 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "fail",
@@ -67,7 +67,7 @@
     "passed": false,
     "checks_passed": 0,
     "checks_total": 4,
-    "score": 0,
+    "score": 0.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -95,7 +95,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213644Z-bd9a.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-4o-mini/20260428T213644Z-bd9a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "fail",
       "details": {
         "actual_max": [
-          50,
-          30,
-          20
+          50.0,
+          30.0,
+          20.0
         ],
         "actual_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_max": [
-          25,
-          15,
-          0
+          25.0,
+          15.0,
+          0.0
         ],
         "deviation_min": [
-          25,
-          15,
-          0
+          25.0,
+          15.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 25,
+        "max_abs_deviation_mm": 25.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
       "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 22500,
-          "deviation_pct": 0,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
           "pass": true,
-          "spec_mm3": 22500,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                50,
-                30,
-                20
+                50.0,
+                30.0,
+                20.0
               ],
               "original_min": [
-                0,
-                0,
-                0
+                0.0,
+                0.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                50,
-                30,
-                20
+                50.0,
+                30.0,
+                20.0
               ],
               "roundtripped_min": [
-                0,
-                0,
-                0
+                0.0,
+                0.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 22500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 22500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215009Z-e754.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215009Z-e754.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215019Z-cc5d.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215019Z-cc5d.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215030Z-538f.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215030Z-538f.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215041Z-c90d.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215041Z-c90d.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215050Z-ad1a.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5-mini/20260428T215050Z-ad1a.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215259Z-4dd1.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215259Z-4dd1.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215312Z-6765.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215312Z-6765.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215331Z-f073.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215331Z-f073.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215341Z-d935.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215341Z-d935.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {

--- a/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215353Z-9f7c.json
+++ b/mecheval/runs/a2-stepped-block-01/openai-direct-gpt-5/20260428T215353Z-9f7c.json
@@ -21,40 +21,40 @@
       "params": {
         "type": "bbox",
         "min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "tolerance_mm": 0.05
       },
       "result": "pass",
       "details": {
         "actual_max": [
-          25,
-          15,
-          20
+          25.0,
+          15.0,
+          20.0
         ],
         "actual_min": [
-          -25,
-          -15,
-          0
+          -25.0,
+          -15.0,
+          0.0
         ],
         "deviation_max": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
         "deviation_min": [
-          0,
-          0,
-          0
+          0.0,
+          0.0,
+          0.0
         ],
-        "max_abs_deviation_mm": 0,
+        "max_abs_deviation_mm": 0.0,
         "tolerance_mm": 0.05
       }
     },
@@ -63,16 +63,16 @@
       "type": "mass_props",
       "params": {
         "type": "mass_props",
-        "volume_mm3": 22500,
+        "volume_mm3": 22500.0,
         "tolerance_pct": 0.1
       },
-      "result": "fail",
+      "result": "pass",
       "details": {
         "volume": {
-          "actual_mm3": 17500,
-          "deviation_pct": 22.22222222222222,
-          "pass": false,
-          "spec_mm3": 22500,
+          "actual_mm3": 22500.0,
+          "deviation_pct": 0.0,
+          "pass": true,
+          "spec_mm3": 22500.0,
           "tolerance_pct": 0.1
         }
       }
@@ -89,37 +89,37 @@
         "per_solid": [
           {
             "bbox": {
-              "max_abs_deviation_mm": 0,
+              "max_abs_deviation_mm": 0.0,
               "original_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "original_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "pass": true,
               "roundtripped_max": [
-                25,
-                15,
-                20
+                25.0,
+                15.0,
+                20.0
               ],
               "roundtripped_min": [
-                -25,
-                -15,
-                0
+                -25.0,
+                -15.0,
+                0.0
               ],
               "tolerance_mm": 0.061644140029689765
             },
             "index": 0,
             "pass": true,
             "volume": {
-              "deviation_pct": 0,
-              "original_mm3": 17500,
+              "deviation_pct": 0.0,
+              "original_mm3": 22500.0,
               "pass": true,
-              "roundtripped_mm3": 17500
+              "roundtripped_mm3": 22500.0
             }
           }
         ],
@@ -128,10 +128,10 @@
     }
   ],
   "summary": {
-    "passed": false,
-    "checks_passed": 3,
+    "passed": true,
+    "checks_passed": 4,
     "checks_total": 4,
-    "score": 0.75,
+    "score": 1.0,
     "anti_cheese_violated": false,
     "limits_exceeded": []
   },
@@ -159,7 +159,7 @@
   "submission_kind": "self-run",
   "prompt": {
     "seed": "a2-stepped-block-01",
-    "rendered": "Start with a rectangular block 50mm long (X) × 30mm wide (Y) × 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
+    "rendered": "Start with a rectangular block 50mm long (X) \u00d7 30mm wide (Y) \u00d7 20mm tall (Z), centered in X and Y with the bottom face on the XY plane (so it spans x in [-25, 25], y in [-15, 15], z in [0, 20]). Cut away the upper +X corner: remove material in the region x in [0, 25], y in [-15, 15], z in [10, 20]. The result has an L-shape when viewed from +Y. Output a single solid.",
     "attachments": []
   },
   "trace": {


### PR DESCRIPTION
## Summary

- The `a2-stepped-block-01` task was scoring 0.75 across all 5 evaluated models with `mass_props` off by exactly 22.22% (17500 mm³ vs 22500 mm³). The kernel bug was already fixed by **79ab4d0** (planar tessellator orientation), but the runs in `mecheval/runs/` were generated the day before and never regraded.
- Regraded all 30 .vcad files against the current kernel: **19 of them flip 0.75 → 1.00**.
- Added 3 unit tests in `vcad-kernel-booleans` to lock in the flush-corner difference pattern so this regression can't sneak back.

## Why

A flush-corner difference (cut box shares 4 of 6 faces with the base, leaving an L-shape) is a degenerate configuration that depends on `Orientation::Reversed` flowing correctly from the booleans pipeline through the planar tessellator. The pre-79ab4d0 tessellator's "smart" winding heuristic systematically inverted cavity walls, dropping exactly `4 × 2 × wall_centroid_contribution` = 5000 mm³ from this shape's volume integral. The 5 LLMs all produced mathematically-correct IR; the kernel was wrong.

## What changed

**`crates/vcad-kernel-booleans/tests/degenerate_cases.rs`** — three regression tests:
- `flush_corner_step_block_difference_volume_pos_x` — exact mecheval scenario
- `flush_corner_step_block_difference_volume_neg_x` — mirrored, guards sign-only fixes
- `flush_corner_step_block_difference_volume_vertical` — same topology on a different axis

**`mecheval/runs/a2-stepped-block-01/`** — 30 grader-output JSONs refreshed (no .vcad touched). Score deltas:

| change | count | notes |
| --- | --- | --- |
| 0.75 → 1.00 | 19 | mass_props now passes for opus-4-7, sonnet-4-6, gpt-5, gpt-5-mini, haiku (1) |
| 0.75 → 0.75 | 1 | gpt-4o-mini run with the cut placed at x=12.5 — bbox legitimately fails |
| 0 → 0 | 9 | unrelated `valid_solid` failures from haiku/gpt-4o-mini IR errors |

Same regrade pattern as **6def0c0** (A4 sweep against the same kernel fix).

## Test plan

- [x] `cargo test -p vcad-kernel-booleans` — all 22 tests pass (19 existing + 3 new)
- [x] `target/debug/mecheval-grade mecheval/tasks/a2-stepped-block-01.json <vcad>` — every valid solid reports volume = 22500 mm³
- [x] `npm run build --workspaces` — leaderboard rebuilds; `dist/task/a2-stepped-block-01.html` shows 21 runs at 1.00, 1 at 0.75
- [ ] Reviewer spot-check: pick any run JSON in the diff and confirm only `checks`, `summary`, and `task_sha256` changed (plus float-formatting and unicode-escape side effects from the regrade tooling, matching the 6def0c0 precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)