### PR TITLE
Add WebXR support with bimanual gestures and voice input

### DIFF
--- a/changelog/entries/2026-05-03-webxr-foundation.json
+++ b/changelog/entries/2026-05-03-webxr-foundation.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-05-03-webxr-foundation",
+  "version": "0.9.4",
+  "date": "2026-05-03",
+  "category": "feat",
+  "title": "WebXR — view your models in VR/AR",
+  "summary": "Enter VR or AR from the viewport to see your CAD model in 3D space. Works on Apple Vision Pro Safari, Meta Quest Browser, and any WebXR-capable headset.",
+  "details": "## What's New\n\n- **Enter XR button** appears top-right when a WebXR-capable runtime is detected (Vision Pro, Quest, etc.)\n- **VR mode** — fully immersive view of your scene\n- **AR mode** — passthrough so the model floats in your room\n- **Hand tracking** is enabled by default; controllers also supported\n- Ray tracing falls back to the standard tessellated renderer while in XR\n\nThis is the foundation for in-headset editing — bimanual gestures and voice-driven AI design land in upcoming releases.",
+  "features": [
+    "vr",
+    "ar",
+    "webxr",
+    "vision-pro"
+  ]
+}

--- a/changelog/entries/2026-05-03-xr-bimanual-fillet.json
+++ b/changelog/entries/2026-05-03-xr-bimanual-fillet.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-05-03-xr-bimanual-fillet",
+  "version": "0.9.4",
+  "date": "2026-05-03",
+  "category": "feat",
+  "title": "Bimanual fillet — round edges with your hands",
+  "summary": "In WebXR, pinch a part with both hands and the distance between your hands becomes the fillet radius. Release to commit a real parametric Fillet to the document.",
+  "details": "## What's New\n\n- Pinch a part with one hand to capture it as the fillet target\n- Pinch with the other hand to enter bimanual mode\n- Distance between pinch midpoints maps to fillet radius (1 m = 1000 mm at desktop scale)\n- Release either hand to commit `Fillet` op — single undo entry, fully scrubbable\n- Scene auto-scales to desktop scale (1 mm = 1 mm physical) on entering XR\n\nThis is the trailer-clip gesture for vcad in space — the first parametric CAD fillet you can dial in with your hands.",
+  "features": [
+    "vr",
+    "ar",
+    "webxr",
+    "fillet",
+    "bimanual"
+  ]
+}

--- a/changelog/entries/2026-05-03-xr-scale-teleport.json
+++ b/changelog/entries/2026-05-03-xr-scale-teleport.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-05-03-xr-scale-teleport",
+  "version": "0.9.4",
+  "date": "2026-05-03",
+  "category": "feat",
+  "title": "Scale teleport — step inside your model",
+  "summary": "Bimanual pinch in empty space grabs the world. Spread your hands to scale the model up; pull them together to shrink it back down. The point under your hands stays under your hands.",
+  "details": "## What's New\n\n- **Bimanual pinch** in empty space (no part picked) enters scale-teleport mode\n- **Spread hands** → scale up; **pull together** → scale down\n- **Translate both hands** → pan the scene\n- The grabbed anchor point stays pinned to the bimanual midpoint, so scaling feels physical\n- Fillet still triggers when one hand grabs a part — gestures don't fight each other\n- View transform persists between sessions, so re-entering picks up where you left off\n\nWalk around your robot at 1:1, sit inside your chair, dial back out to dial in fillets.",
+  "features": [
+    "vr",
+    "ar",
+    "webxr",
+    "scale-teleport",
+    "bimanual"
+  ]
+}

--- a/changelog/entries/2026-05-03-xr-shared-table.json
+++ b/changelog/entries/2026-05-03-xr-shared-table.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-05-03-xr-shared-table",
+  "version": "0.9.4",
+  "date": "2026-05-03",
+  "category": "feat",
+  "title": "Shared table — see your collaborators in XR",
+  "summary": "Two engineers in the same cloud document now see each other's headset and hands in their VR/AR session, anchored to the same point on the same model.",
+  "details": "## What's New\n\n- New per-document realtime channel for XR pose updates, sibling to the existing collab op channel\n- Headset + left/right wrist poses broadcast at ~10 Hz\n- Poses are exchanged in scene-local coordinates, so two users with different desks still see each other at the same point on the same model — no shared spatial anchor required\n- Stale peers are pruned automatically after 5 s if their session crashes\n- Floating head + hand avatars rendered for each remote participant\n\nThis is the foundation for true co-presence design review in XR. Spatial annotations and Personas integration land in follow-ups.",
+  "features": [
+    "vr",
+    "ar",
+    "webxr",
+    "collab",
+    "presence"
+  ]
+}

--- a/changelog/entries/2026-05-03-xr-voice.json
+++ b/changelog/entries/2026-05-03-xr-voice.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-05-03-xr-voice",
+  "version": "0.9.4",
+  "date": "2026-05-03",
+  "category": "feat",
+  "title": "Voice in XR — talk to the assistant in headset",
+  "summary": "Hold a single pinch in empty space for a moment to start voice push-to-talk. Release to ship the transcript to the AI assistant with your current selection as context.",
+  "details": "## What's New\n\n- **Push-to-talk** — hold a pinch in empty space (no part captured, other hand open) for ~0.8 s, voice recognition starts; release ends it\n- The transcript is sent through the existing chat handler with the user's current selection as `SelectionContext`, so phrases like \"make this 20% smaller\" reference the right part\n- The AI's tool-call results land in the document just like a typed chat message — full undo, full feature tree integration\n- Falls back gracefully on browsers without `webkitSpeechRecognition`\n\nVision Pro Safari supports the WebSpeech API, so this works hands-free on AVP. The 3-variant ghost UI will land in a follow-up.",
+  "features": [
+    "vr",
+    "ar",
+    "webxr",
+    "voice",
+    "ai"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3131,6 +3131,12 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@chevrotain/cst-dts-gen": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
@@ -3307,6 +3313,21 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -4005,6 +4026,53 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
+      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "deprecated": "v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -4698,6 +4766,51 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@iwer/devui": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@iwer/devui/-/devui-1.1.2.tgz",
+      "integrity": "sha512-ggF1lXSX14BTYP0QzB4xaurySr2PC+3+rtK/dpCR++giWquzFv2mBw3LW/PaCtdl5mqkZMrQ2GSwfUNg9ZoO+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "6.6.0",
+        "@fortawesome/free-solid-svg-icons": "6.6.0",
+        "@fortawesome/react-fontawesome": "0.2.2",
+        "@pmndrs/handle": "^6.6.17",
+        "@pmndrs/pointer-events": "^6.6.17",
+        "react": ">=18.3.1",
+        "react-dom": ">=18.3.1",
+        "styled-components": "^6.1.13",
+        "three": "^0.165.0"
+      },
+      "peerDependencies": {
+        "iwer": "^2.0.1"
+      }
+    },
+    "node_modules/@iwer/devui/node_modules/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "license": "MIT"
+    },
+    "node_modules/@iwer/sem": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@iwer/sem/-/sem-0.2.5.tgz",
+      "integrity": "sha512-vMCfpu/7Qqc+hkBiGD9pxjeObgrhXOrL0KX94CA3yzJaU0dq0y49HXZT6fC+6X/jOmjaM3hjyE1m2h7ZmLzzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "three": "^0.165.0",
+        "ts-proto": "^2.6.0"
+      },
+      "peerDependencies": {
+        "iwer": "^2.0.0"
+      }
+    },
+    "node_modules/@iwer/sem/node_modules/three": {
+      "version": "0.165.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.165.0.tgz",
+      "integrity": "sha512-cc96IlVYGydeceu0e5xq70H8/yoVT/tXBxV/W8A/U6uOq7DXc4/s1Mkmnu6SqoYGhSRWWYFOhVwvq6V0VtbplA==",
+      "license": "MIT"
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -5385,6 +5498,95 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@pmndrs/handle": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@pmndrs/handle/-/handle-6.6.29.tgz",
+      "integrity": "sha512-zfvakgxva2P5nB6HeOuSMGyFFFP6B5cRO61DeHKSm4z7WRW2FT8baaxW5izsYqymzc4Xutc9fpeIxbFL/GbmAw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/pointer-events": "~6.6.29",
+        "zustand": "^4.5.2"
+      }
+    },
+    "node_modules/@pmndrs/handle/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@pmndrs/pointer-events": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@pmndrs/pointer-events/-/pointer-events-6.6.29.tgz",
+      "integrity": "sha512-o4YD6VfJgDYjFgde/YyAw2X5KY454tdmOXrHGOvKTWJBHzkL90B5vH4rqmexwRVvaDfT3YLvVh/Dm5cBbgZXMg==",
+      "license": "SEE LICENSE IN LICENSE"
+    },
+    "node_modules/@pmndrs/xr": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@pmndrs/xr/-/xr-6.6.29.tgz",
+      "integrity": "sha512-+17cGaV6tlYM6UJznKiPR1qw39NQDAvYchb2TRg8MnxUc9hOXKe/3a62DlLIe3uGfK9dnd7DlZlegeR/jIDEWg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@iwer/devui": "^1.1.1",
+        "@iwer/sem": "~0.2.5",
+        "@pmndrs/pointer-events": "~6.6.29",
+        "iwer": "^2.1.0",
+        "meshline": "^3.3.1",
+        "zustand": "^4.5.2"
+      },
+      "peerDependencies": {
+        "three": "*"
+      }
+    },
+    "node_modules/@pmndrs/xr/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@posthog/core": {
@@ -7161,6 +7363,53 @@
       "peerDependencies": {
         "@types/three": ">=0.144.0",
         "three": ">=0.144.0"
+      }
+    },
+    "node_modules/@react-three/xr": {
+      "version": "6.6.29",
+      "resolved": "https://registry.npmjs.org/@react-three/xr/-/xr-6.6.29.tgz",
+      "integrity": "sha512-qHegmgqTuao+8WC3MylTqg1HZWCw0b4hRH+rF4Em0kRaWU8gYCGpSYnq8fDrG6QlzfEUTTz5b235BwjUvi6oWw==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@pmndrs/pointer-events": "~6.6.29",
+        "@pmndrs/xr": "~6.6.29",
+        "suspend-react": "^0.1.3",
+        "tunnel-rat": "^0.1.2",
+        "zustand": "^4.5.2"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=8",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "three": "*"
+      }
+    },
+    "node_modules/@react-three/xr/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -11020,6 +11269,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/camera-controls": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
@@ -11066,6 +11324,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/ccount": {
@@ -11598,6 +11868,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/css-color-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/css-to-react-native": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "camelize": "^1.0.0",
+        "css-color-keywords": "^1.0.0",
+        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -12455,6 +12745,27 @@
       "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dprint-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
+      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "node_modules/dprint-node/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/draco3d": {
@@ -14467,6 +14778,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -15836,6 +16153,16 @@
         "react": "^19.0.0"
       }
     },
+    "node_modules/iwer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/iwer/-/iwer-2.2.1.tgz",
+      "integrity": "sha512-TBGgUlOpYsJpYmBCDRrW2KDHC70XZeFrlOwlDNiso+dp83wwRyCLaeN50/qo4JRIKyn08+cD6iaw5+t+D7U+uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-matrix": "^3.4.3",
+        "webxr-layers-polyfill": "^1.1.0"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -16507,6 +16834,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -19033,6 +19372,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -19199,6 +19544,23 @@
         "is-promise": "^2.1.0",
         "lie": "^3.0.2"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -21291,6 +21653,42 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/styled-components": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.1.tgz",
+      "integrity": "sha512-ADu2dF53esUzzM4I0ewxhxFtsDd6v4V6dNkg3vG0iFKhnt06sJneTZnRvujAosZwW0XD58IKgGMQoqri4wHRqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/styled-components"
+      },
+      "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
+        "react": ">= 16.8.0",
+        "react-dom": ">= 16.8.0",
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -21877,6 +22275,39 @@
         "@swc/wasm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-poet": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.12.0.tgz",
+      "integrity": "sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dprint-node": "^1.0.8"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.11.6.tgz",
+      "integrity": "sha512-2rPkH5W/KeXOyVUC6o06RdRabVK8zSDmQpnRz4XbRiYMHRdI12KqDjAdGW7ebxzzMNE5cw/j+ptA0WMVqZILrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.10.2",
+        "case-anything": "^2.1.13",
+        "ts-poet": "^6.12.0",
+        "ts-proto-descriptors": "2.1.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.1.0.tgz",
+      "integrity": "sha512-S5EZYEQ6L9KLFfjSRpZWDIXDV/W7tAj8uW7pLsihIxyr62EAVSiKuVPwE8iWnr849Bqa53enex1jhDUcpgquzA==",
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0"
       }
     },
     "node_modules/ts-toolbelt": {
@@ -23726,6 +24157,15 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/webxr-layers-polyfill": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/webxr-layers-polyfill/-/webxr-layers-polyfill-1.1.0.tgz",
+      "integrity": "sha512-GqWE6IFlut8a1Lnh9t1RPnOXud1rZ7wLPvWp7mqTDOYtgorXqlNMhEnI9EqjU33grBx0v3jm0Oc13opkAdmgMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gl-matrix": "^3.4.3"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
@@ -24636,6 +25076,7 @@
         "@react-three/drei": "^10.0.0",
         "@react-three/fiber": "^9.0.0",
         "@react-three/postprocessing": "^3.0.4",
+        "@react-three/xr": "^6.6.29",
         "@streamdown/cjk": "^1.0.3",
         "@streamdown/code": "^1.1.1",
         "@streamdown/math": "^1.0.2",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -29,6 +29,7 @@
     "@react-three/drei": "^10.0.0",
     "@react-three/fiber": "^9.0.0",
     "@react-three/postprocessing": "^3.0.4",
+    "@react-three/xr": "^6.6.29",
     "@streamdown/cjk": "^1.0.3",
     "@streamdown/code": "^1.1.1",
     "@streamdown/math": "^1.0.2",

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -831,6 +831,7 @@ export const SceneMesh = memo(function SceneMesh({
       onPointerOver={handlePointerOver}
       onPointerOut={handlePointerOut}
       material={shaderMaterial ?? undefined}
+      userData={{ partId: partInfo.id }}
     >
       <bufferGeometry ref={geoRef} />
       {/* Use procedural shader if available, otherwise standard PBR */}

--- a/packages/app/src/components/Viewport.tsx
+++ b/packages/app/src/components/Viewport.tsx
@@ -1,11 +1,14 @@
 import { useRef, useEffect, Suspense, lazy } from "react";
 import * as THREE from "three";
 import { Canvas, useThree } from "@react-three/fiber";
+import { XR } from "@react-three/xr";
 import { ViewportContent } from "./ViewportContent";
 import { DrawingView } from "./DrawingView";
 import { TriangleInspectionPanel } from "./TriangleInspector";
 import { RayTracedViewportOverlay } from "./RayTracedViewport";
 import { FollowModeToggle } from "./FollowModeToggle";
+import { EnterXRButton } from "./xr/EnterXRButton";
+import { xrStore, useXRPresenting } from "@/stores/xr-store";
 import {
   useUiStore,
   useDocumentStore,
@@ -223,6 +226,7 @@ export function Viewport() {
   const { isDark } = useTheme();
   const viewMode = useDrawingStore((s) => s.viewMode);
   const electronicsActive = useElectronicsStore((s) => s.active);
+  const xrPresenting = useXRPresenting();
 
   // Run electronics sync when in electronics mode
   useElectronicsSync();
@@ -283,7 +287,7 @@ export function Viewport() {
       style={{ touchAction: "none", userSelect: "none", WebkitUserSelect: "none" }}
     >
       <Canvas
-        frameloop="demand"
+        frameloop={xrPresenting ? "always" : "demand"}
         camera={{ position: [50, 50, 50], fov: 50, near: 0.1, far: 10000 }}
         onPointerMissed={() => {
           // Ignore the click that follows a drag/rotate gesture.
@@ -306,8 +310,10 @@ export function Viewport() {
         }}
         style={{ background: canvasBg }}
       >
-        <ViewportContent mode={electronicsActive ? "pcb" : "3d"} />
-        {!electronicsActive && <BoxSelectHandler containerRef={containerRef} />}
+        <XR store={xrStore}>
+          <ViewportContent mode={electronicsActive ? "pcb" : "3d"} />
+          {!electronicsActive && <BoxSelectHandler containerRef={containerRef} />}
+        </XR>
       </Canvas>
 
       {/* Electronics overlay panels (outside Canvas, on top) */}
@@ -328,8 +334,11 @@ export function Viewport() {
         </>
       )}
 
-      {/* Ray-traced overlay - rendered outside Canvas to avoid R3F reconciler issues */}
-      {!electronicsActive && renderMode === "raytrace" && raytraceAvailable && (
+      {/* Ray-traced overlay - rendered outside Canvas to avoid R3F reconciler
+          issues. Suppressed in XR: WebGPU compute shaders aren't compatible
+          with the WebXR layer pipeline, so we fall back to the standard
+          tessellated rasterizer for the duration of the session. */}
+      {!electronicsActive && !xrPresenting && renderMode === "raytrace" && raytraceAvailable && (
         <RayTracedViewportOverlay />
       )}
 
@@ -340,7 +349,8 @@ export function Viewport() {
           Pointer-events none on the wrapper so the canvas still receives orbit
           drags in the gaps; the toggle itself re-enables them. */}
       {!electronicsActive && (
-        <div className="pointer-events-none absolute top-3 right-3 z-10">
+        <div className="pointer-events-none absolute top-3 right-3 z-10 flex items-center gap-2">
+          <EnterXRButton />
           <FollowModeToggle />
         </div>
       )}

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -70,6 +70,7 @@ import { BG_DARK, BG_LIGHT } from "./Viewport";
 import { useXRPresenting } from "@/stores/xr-store";
 import { XRSceneTransform } from "./xr/XRSceneTransform";
 import { XRGestures } from "./xr/XRGestures";
+import { XRPresence } from "./xr/XRPresence";
 
 // Reused per-frame in the participant-sync hook (Lock + Follow).
 const _syncGoalPos = new Vector3();
@@ -1765,6 +1766,11 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
 
           {/* Other participants' camera frustums (AI for now, peers later) */}
           <ParticipantCameraOverlay />
+
+          {/* XR presence — broadcasts local headset/hand pose and renders
+              remote peers. No-op outside XR / outside cloud-sync. Inside the
+              rotation+scale group so its avatars are in scene-local space. */}
+          <XRPresence />
           </group>
           </XRSceneTransform>
 

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -68,6 +68,8 @@ import { PcbScene } from "./electronics/pcb3d/PcbScene";
 import { usePcbCamera } from "./electronics/pcb3d/usePcbCamera";
 import { BG_DARK, BG_LIGHT } from "./Viewport";
 import { useXRPresenting } from "@/stores/xr-store";
+import { XRSceneTransform } from "./xr/XRSceneTransform";
+import { XRGestures } from "./xr/XRGestures";
 
 // Reused per-frame in the participant-sync hook (Lock + Follow).
 const _syncGoalPos = new Vector3();
@@ -1676,7 +1678,10 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
 
           {/* Scene meshes - always render (ray trace overlays on top for BRep parts) */}
           {/* Wrap all kernel geometry in Z-up → Y-up rotation so the kernel
-              stays in standard CAD Z-up while Three.js renders Y-up */}
+              stays in standard CAD Z-up while Three.js renders Y-up.
+              `XRSceneTransform` rescales + repositions to desktop-scale while
+              a WebXR session is active; outside XR it is a passthrough. */}
+          <XRSceneTransform>
           <group rotation={[-Math.PI / 2, 0, 0]}>
             {/* Plane gizmo at origin - inside rotation group so kernel planes display correctly */}
             <PlaneGizmo />
@@ -1761,6 +1766,12 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
           {/* Other participants' camera frustums (AI for now, peers later) */}
           <ParticipantCameraOverlay />
           </group>
+          </XRSceneTransform>
+
+          {/* XR gesture interpreter — only does work while a WebXR session
+              is presenting. Outside the scene transform so its raycasts run
+              in unscaled world space. */}
+          <XRGestures />
 
           {/* Transform gizmo — outside rotation group; does its own Z-up ↔ Y-up conversion
               so that gizmo handle colors (RGB=XYZ) match the kernel axis colors */}

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -67,6 +67,7 @@ import type {
 import { PcbScene } from "./electronics/pcb3d/PcbScene";
 import { usePcbCamera } from "./electronics/pcb3d/usePcbCamera";
 import { BG_DARK, BG_LIGHT } from "./Viewport";
+import { useXRPresenting } from "@/stores/xr-store";
 
 // Reused per-frame in the participant-sync hook (Lock + Follow).
 const _syncGoalPos = new Vector3();
@@ -308,6 +309,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   const renderMode = useUiStore((s) => s.renderMode);
   const raytraceAvailable = useUiStore((s) => s.raytraceAvailable);
   const sketchActive = useSketchStore((s) => s.active);
+  const xrPresenting = useXRPresenting();
   const orbitRef = useRef<OrbitControlsImpl>(null);
   usePcbCamera(orbitRef, isPcbMode);
   const { camera, invalidate } = useThree();
@@ -1505,10 +1507,13 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
       {/* Grid (3D mode only — PCB mode has its own grid) */}
       {!isPcbMode && <GridPlane />}
 
-      {/* Controls - mouse buttons configured by control scheme */}
+      {/* Controls - mouse buttons configured by control scheme.
+          Disabled while a WebXR session is active — the headset drives the
+          camera and orbit gestures would fight head-tracking. */}
       <OrbitControls
         ref={orbitRef}
         makeDefault
+        enabled={!xrPresenting}
         enableDamping={false}
         // Desktop uses a custom wheel zoom handler; touch devices need the
         // built-in pinch-to-dolly path, so enable zoom when the pointer is coarse.
@@ -1527,8 +1532,10 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         })()}
       />
 
-      {/* Orientation gizmo - RGB axes, click to snap view (3D mode only) */}
-      {!isPcbMode && (
+      {/* Orientation gizmo - RGB axes, click to snap view (3D mode only).
+          Hidden in XR — it's a 2D screen-space overlay that doesn't make
+          sense in stereo. */}
+      {!isPcbMode && !xrPresenting && (
         <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
           <GizmoViewport
             axisColors={["#e06c75", "#61afef", "#98c379"]}

--- a/packages/app/src/components/xr/EnterXRButton.tsx
+++ b/packages/app/src/components/xr/EnterXRButton.tsx
@@ -1,0 +1,55 @@
+import { useXR } from "@react-three/xr";
+import { xrStore, useXRSupportStore } from "@/stores/xr-store";
+
+/**
+ * Floating Enter-XR control. Renders nothing if neither VR nor AR is
+ * supported, so desktop users never see it.
+ */
+export function EnterXRButton() {
+  const checked = useXRSupportStore((s) => s.checked);
+  const vr = useXRSupportStore((s) => s.vr);
+  const ar = useXRSupportStore((s) => s.ar);
+  // `mode` becomes a string (e.g. "immersive-vr") while a session is active.
+  const mode = useXR((s) => s.mode);
+
+  if (!checked || (!vr && !ar)) return null;
+  const presenting = mode != null;
+
+  if (presenting) {
+    return (
+      <button
+        type="button"
+        className="pointer-events-auto rounded-md border border-border/40 bg-bg/80 px-2 py-1 text-xs text-text shadow-sm backdrop-blur hover:bg-bg"
+        onClick={() => xrStore.getState().session?.end()}
+        title="Exit XR"
+      >
+        Exit XR
+      </button>
+    );
+  }
+
+  return (
+    <div className="pointer-events-auto flex gap-1 rounded-md border border-border/40 bg-bg/80 p-1 shadow-sm backdrop-blur">
+      {ar && (
+        <button
+          type="button"
+          className="rounded px-2 py-1 text-xs text-text hover:bg-border/40"
+          onClick={() => xrStore.enterAR()}
+          title="Enter AR — passthrough on Vision Pro / Quest"
+        >
+          AR
+        </button>
+      )}
+      {vr && (
+        <button
+          type="button"
+          className="rounded px-2 py-1 text-xs text-text hover:bg-border/40"
+          onClick={() => xrStore.enterVR()}
+          title="Enter VR — fully immersive"
+        >
+          VR
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/xr/XRGestures.tsx
+++ b/packages/app/src/components/xr/XRGestures.tsx
@@ -1,0 +1,226 @@
+import { useFrame, useThree } from "@react-three/fiber";
+import { useRef } from "react";
+import * as THREE from "three";
+import { useDocumentStore } from "@vcad/core";
+import { useXRPresenting } from "@/stores/xr-store";
+
+/**
+ * WebXR pinch / bimanual gesture interpreter.
+ *
+ * Reads thumb-tip and index-finger-tip joint poses from the active XRSession
+ * each frame, detects pinches, and runs a small state machine that maps the
+ * canonical CAD-in-XR gesture — bimanual pinch on a part — to the existing
+ * `useDocumentStore.addFillet` op:
+ *
+ *   1. One hand pinches near a part   → that part becomes the fillet target.
+ *   2. The other hand pinches anywhere → bimanual capture; the distance
+ *      between the two pinch midpoints becomes the live radius candidate.
+ *   3. Either hand releases            → if a target was captured, commit
+ *      `addFillet(targetPartId, radius)`. Single undo entry.
+ *
+ * Outside an XR session this component renders nothing and does no work.
+ *
+ * The pose math runs in Three.js world space, which is also the WebXR
+ * reference space, so we can compare hand positions directly against the
+ * raycaster's intersect results without manual coordinate transforms — the
+ * `XRSceneTransform` group's scale is handled implicitly by the raycaster.
+ */
+
+const PINCH_CLOSE = 0.025; // 2.5 cm — index-tip to thumb-tip
+const PINCH_OPEN = 0.04; // hysteresis: must open past this to count as released
+const REACH_RADIUS = 0.4; // 40 cm sphere of "I'm grabbing this"
+const MIN_RADIUS_M = 0.005; // 5 mm physical at desktop scale; below this we skip
+const MAX_RADIUS_M = 0.5;
+/** Convert meters of separation to millimeters of model-space radius. The
+ * XR transform scales the scene by 1/1000, so 1 physical metre between
+ * hands = 1000 mm of fillet radius. */
+const M_TO_MODEL_MM = 1000;
+
+interface PinchSample {
+  pinching: boolean;
+  midpoint: THREE.Vector3;
+  /** Direction from wrist toward pinch midpoint — used as a "reach ray". */
+  reach: THREE.Vector3;
+}
+
+/** Read joint position in world space; returns false if pose unavailable. */
+function readJoint(
+  frame: XRFrame,
+  hand: XRHand,
+  jointName: XRHandJoint,
+  refSpace: XRReferenceSpace,
+  out: THREE.Vector3,
+): boolean {
+  const joint = hand.get(jointName);
+  if (!joint) return false;
+  const pose = frame.getJointPose?.(joint, refSpace);
+  if (!pose) return false;
+  const p = pose.transform.position;
+  out.set(p.x, p.y, p.z);
+  return true;
+}
+
+const _thumb = new THREE.Vector3();
+const _index = new THREE.Vector3();
+const _wrist = new THREE.Vector3();
+
+function samplePinch(
+  frame: XRFrame,
+  hand: XRHand,
+  refSpace: XRReferenceSpace,
+  prevPinching: boolean,
+  out: PinchSample,
+): boolean {
+  if (
+    !readJoint(frame, hand, "thumb-tip", refSpace, _thumb) ||
+    !readJoint(frame, hand, "index-finger-tip", refSpace, _index) ||
+    !readJoint(frame, hand, "wrist", refSpace, _wrist)
+  ) {
+    return false;
+  }
+  const dist = _thumb.distanceTo(_index);
+  // Hysteresis so the pinch doesn't chatter at the boundary.
+  const pinching = prevPinching ? dist < PINCH_OPEN : dist < PINCH_CLOSE;
+  out.pinching = pinching;
+  out.midpoint.copy(_thumb).add(_index).multiplyScalar(0.5);
+  out.reach.copy(out.midpoint).sub(_wrist).normalize();
+  return true;
+}
+
+interface FilletCapture {
+  partId: string;
+  initialMidpoint: THREE.Vector3;
+}
+
+interface HandState {
+  pinching: boolean;
+  midpoint: THREE.Vector3;
+}
+
+/** Walk the scene graph to find the part ID associated with a hit object. */
+function partIdFromHit(obj: THREE.Object3D | null): string | null {
+  let cur: THREE.Object3D | null = obj;
+  while (cur) {
+    const id = (cur.userData as { partId?: unknown } | undefined)?.partId;
+    if (typeof id === "string") return id;
+    cur = cur.parent;
+  }
+  return null;
+}
+
+const _raycaster = new THREE.Raycaster();
+const _rayOrigin = new THREE.Vector3();
+const _rayDir = new THREE.Vector3();
+
+/** Cast a short reach-ray from the pinch midpoint toward the part being
+ * pointed at. Returns the partId whose mesh is hit, or null. */
+function pickPartId(
+  scene: THREE.Scene,
+  midpoint: THREE.Vector3,
+  reach: THREE.Vector3,
+): string | null {
+  // Start the ray slightly behind the midpoint so a hand inside a mesh still
+  // produces a hit.
+  _rayOrigin.copy(midpoint).addScaledVector(reach, -0.02);
+  _rayDir.copy(reach);
+  _raycaster.set(_rayOrigin, _rayDir);
+  _raycaster.far = REACH_RADIUS + 0.02;
+  const hits = _raycaster.intersectObject(scene, true);
+  for (const hit of hits) {
+    const id = partIdFromHit(hit.object);
+    if (id) return id;
+  }
+  return null;
+}
+
+export function XRGestures() {
+  const presenting = useXRPresenting();
+  const { gl, scene } = useThree();
+
+  const leftRef = useRef<HandState>({
+    pinching: false,
+    midpoint: new THREE.Vector3(),
+  });
+  const rightRef = useRef<HandState>({
+    pinching: false,
+    midpoint: new THREE.Vector3(),
+  });
+  const captureRef = useRef<FilletCapture | null>(null);
+  const sampleRef = useRef<PinchSample>({
+    pinching: false,
+    midpoint: new THREE.Vector3(),
+    reach: new THREE.Vector3(),
+  });
+
+  useFrame((_, __, frame) => {
+    if (!presenting) return;
+    const xrFrame = frame as XRFrame | undefined;
+    if (!xrFrame) return;
+    const session = gl.xr.getSession();
+    const refSpace = gl.xr.getReferenceSpace();
+    if (!session || !refSpace) return;
+
+    let leftSample: HandState | null = null;
+    let rightSample: HandState | null = null;
+
+    for (const src of session.inputSources) {
+      if (!src.hand) continue;
+      const handRef = src.handedness === "left" ? leftRef : rightRef;
+      const sample = sampleRef.current;
+      if (!samplePinch(xrFrame, src.hand, refSpace, handRef.current.pinching, sample)) {
+        continue;
+      }
+      handRef.current.pinching = sample.pinching;
+      handRef.current.midpoint.copy(sample.midpoint);
+      const snapshot: HandState = {
+        pinching: sample.pinching,
+        midpoint: sample.midpoint.clone(),
+      };
+      if (src.handedness === "left") {
+        leftSample = snapshot;
+      } else if (src.handedness === "right") {
+        rightSample = snapshot;
+      }
+
+      // First-pinch capture: if no target yet and this hand just pinched,
+      // try to pick a part under the reach ray.
+      if (sample.pinching && !captureRef.current) {
+        const partId = pickPartId(scene, sample.midpoint, sample.reach);
+        if (partId) {
+          captureRef.current = {
+            partId,
+            initialMidpoint: sample.midpoint.clone(),
+          };
+        }
+      }
+    }
+
+    // Commit on release. We commit when at least one of the hands transitions
+    // out of pinch while a capture is active and the *other* hand is/was
+    // pinching too (i.e. we had a bimanual moment). Single hand alone just
+    // selects the part — no fillet.
+    const capture = captureRef.current;
+    if (!capture) return;
+
+    const left = leftSample ?? leftRef.current;
+    const right = rightSample ?? rightRef.current;
+    const bothPinching = left.pinching && right.pinching;
+    const eitherReleased = !left.pinching || !right.pinching;
+
+    if (bothPinching || !eitherReleased) {
+      // Still in capture; nothing to commit yet. (Live preview lands in a
+      // follow-up — for now we just hold state.)
+      return;
+    }
+
+    // Released. If we ever hit bimanual (both midpoints are valid and the
+    // distance is non-degenerate), commit the fillet.
+    const distance = left.midpoint.distanceTo(right.midpoint);
+    captureRef.current = null;
+    if (distance < MIN_RADIUS_M || distance > MAX_RADIUS_M) return;
+    const radius = distance * M_TO_MODEL_MM;
+    useDocumentStore.getState().addFillet(capture.partId, radius);
+  });
+
+  return null;
+}

--- a/packages/app/src/components/xr/XRGestures.tsx
+++ b/packages/app/src/components/xr/XRGestures.tsx
@@ -1,8 +1,9 @@
 import { useFrame, useThree } from "@react-three/fiber";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import * as THREE from "three";
-import { useDocumentStore } from "@vcad/core";
+import { useChatStore, useDocumentStore, useUiStore } from "@vcad/core";
 import { useXRPresenting, useXRSupportStore, type XRViewTransform } from "@/stores/xr-store";
+import { isVoiceSupported, startVoice } from "@/lib/xr-voice";
 
 /**
  * WebXR pinch / bimanual gesture interpreter.
@@ -145,6 +146,15 @@ interface ScaleCapture {
 
 type Capture = FilletCapture | ScaleCapture | null;
 
+/** How long a single pinch must hold in empty space before voice mode
+ * activates. Long enough that "I'm about to bimanual pinch" doesn't
+ * accidentally trigger it. */
+const VOICE_HOLD_MS = 800;
+
+interface VoiceSessionHandle {
+  stop(): void;
+}
+
 const _midA = new THREE.Vector3();
 const _midB = new THREE.Vector3();
 const _bimid = new THREE.Vector3();
@@ -168,6 +178,23 @@ export function XRGestures() {
     midpoint: new THREE.Vector3(),
     reach: new THREE.Vector3(),
   });
+
+  // --- Voice push-to-talk state -------------------------------------------
+  // A single-hand pinch held in empty space for VOICE_HOLD_MS triggers
+  // speech recognition; release ends it and ships the transcript through
+  // the existing chat handler.
+  const voiceCandidateRef = useRef<{ startedAt: number } | null>(null);
+  const voiceActiveRef = useRef<VoiceSessionHandle | null>(null);
+  const voiceFinalRef = useRef<string>("");
+
+  // Stop any in-flight voice session if the component unmounts (e.g. user
+  // exits XR while talking).
+  useEffect(() => {
+    return () => {
+      voiceActiveRef.current?.stop();
+      voiceActiveRef.current = null;
+    };
+  }, []);
 
   useFrame((_, __, frame) => {
     if (!presenting) return;
@@ -203,6 +230,74 @@ export function XRGestures() {
     const left = leftRef.current;
     const right = rightRef.current;
     const bothPinching = left.pinching && right.pinching;
+    const oneHandPinching =
+      (left.pinching && !right.pinching) ||
+      (!left.pinching && right.pinching);
+
+    // --- 2.5 Voice push-to-talk: long single-pinch in empty space. -------
+    // Fillet capture takes precedence; a captured pinch never becomes voice.
+    if (
+      oneHandPinching &&
+      captureRef.current == null &&
+      isVoiceSupported()
+    ) {
+      const now = performance.now();
+      const c = voiceCandidateRef.current;
+      if (c == null) {
+        voiceCandidateRef.current = { startedAt: now };
+      } else if (
+        voiceActiveRef.current == null &&
+        now - c.startedAt >= VOICE_HOLD_MS
+      ) {
+        voiceFinalRef.current = "";
+        const handle = startVoice({
+          lang: "en-US",
+          onTranscript: (text, isFinal) => {
+            if (isFinal) voiceFinalRef.current = text;
+          },
+          onEnd: () => {
+            const text = voiceFinalRef.current.trim();
+            voiceActiveRef.current = null;
+            voiceFinalRef.current = "";
+            if (!text) return;
+            // Build selection context from current part selection so the
+            // assistant knows what "this", "that", "it" refer to.
+            const selectedIds = Array.from(
+              useUiStore.getState().selectedPartIds,
+            );
+            const parts = useDocumentStore.getState().parts;
+            const context = selectedIds
+              .map((id: string) => {
+                const p = parts.find((x: { id: string }) => x.id === id);
+                return p
+                  ? {
+                      partId: p.id,
+                      partName: p.name ?? p.id,
+                      geometryType: "part" as const,
+                    }
+                  : null;
+              })
+              .filter(
+                (x: unknown): x is { partId: string; partName: string; geometryType: "part" } =>
+                  x != null,
+              );
+            useChatStore.getState().sendMessage(text, context, []);
+          },
+          onError: () => {
+            voiceActiveRef.current = null;
+          },
+        });
+        if (handle) voiceActiveRef.current = handle;
+      }
+    } else {
+      // No single-pinch this frame: cancel candidate and stop active session.
+      if (voiceCandidateRef.current) voiceCandidateRef.current = null;
+      if (voiceActiveRef.current) {
+        const h = voiceActiveRef.current;
+        voiceActiveRef.current = null;
+        h.stop();
+      }
+    }
 
     // --- 3. Scale-teleport entry: bimanual pinch with no part captured. ---
     if (bothPinching && captureRef.current == null) {

--- a/packages/app/src/components/xr/XRGestures.tsx
+++ b/packages/app/src/components/xr/XRGestures.tsx
@@ -2,46 +2,37 @@ import { useFrame, useThree } from "@react-three/fiber";
 import { useRef } from "react";
 import * as THREE from "three";
 import { useDocumentStore } from "@vcad/core";
-import { useXRPresenting } from "@/stores/xr-store";
+import { useXRPresenting, useXRSupportStore, type XRViewTransform } from "@/stores/xr-store";
 
 /**
  * WebXR pinch / bimanual gesture interpreter.
  *
  * Reads thumb-tip and index-finger-tip joint poses from the active XRSession
- * each frame, detects pinches, and runs a small state machine that maps the
- * canonical CAD-in-XR gesture — bimanual pinch on a part — to the existing
- * `useDocumentStore.addFillet` op:
+ * each frame, detects pinches, and runs a small state machine that maps two
+ * canonical XR-CAD gestures onto existing app affordances:
  *
- *   1. One hand pinches near a part   → that part becomes the fillet target.
- *   2. The other hand pinches anywhere → bimanual capture; the distance
- *      between the two pinch midpoints becomes the live radius candidate.
- *   3. Either hand releases            → if a target was captured, commit
- *      `addFillet(targetPartId, radius)`. Single undo entry.
+ *   - **Fillet (M2):** pinch a part with one hand, pinch with the other,
+ *     release → commit `addFillet(partId, distanceBetweenHands)`.
+ *   - **Scale teleport (M3):** bimanual pinch in empty space → grab the
+ *     scene; spreading hands scales it up, drawing them together scales it
+ *     down. Translating both hands together pans the scene. Release to
+ *     freeze the new view.
  *
  * Outside an XR session this component renders nothing and does no work.
- *
- * The pose math runs in Three.js world space, which is also the WebXR
- * reference space, so we can compare hand positions directly against the
- * raycaster's intersect results without manual coordinate transforms — the
- * `XRSceneTransform` group's scale is handled implicitly by the raycaster.
  */
 
 const PINCH_CLOSE = 0.025; // 2.5 cm — index-tip to thumb-tip
 const PINCH_OPEN = 0.04; // hysteresis: must open past this to count as released
-const REACH_RADIUS = 0.4; // 40 cm sphere of "I'm grabbing this"
+const REACH_RADIUS = 0.4; // 40 cm reach-ray length for part picking
 const MIN_RADIUS_M = 0.005; // 5 mm physical at desktop scale; below this we skip
 const MAX_RADIUS_M = 0.5;
-/** Convert meters of separation to millimeters of model-space radius. The
- * XR transform scales the scene by 1/1000, so 1 physical metre between
- * hands = 1000 mm of fillet radius. */
+/** Convert metres of separation to millimetres of model-space radius. The
+ * default XR transform scales the scene by 1/1000, so 1 physical metre
+ * between hands = 1000 mm of fillet radius. */
 const M_TO_MODEL_MM = 1000;
 
-interface PinchSample {
-  pinching: boolean;
-  midpoint: THREE.Vector3;
-  /** Direction from wrist toward pinch midpoint — used as a "reach ray". */
-  reach: THREE.Vector3;
-}
+const SCALE_MIN = 0.0001; // 1 mm scene = 0.1 mm physical (zoomed way out)
+const SCALE_MAX = 10.0; // 1 mm scene = 10 mm physical (way zoomed in)
 
 /** Read joint position in world space; returns false if pose unavailable. */
 function readJoint(
@@ -58,6 +49,13 @@ function readJoint(
   const p = pose.transform.position;
   out.set(p.x, p.y, p.z);
   return true;
+}
+
+interface PinchSample {
+  pinching: boolean;
+  midpoint: THREE.Vector3;
+  /** Direction from wrist toward pinch midpoint — used as a "reach ray". */
+  reach: THREE.Vector3;
 }
 
 const _thumb = new THREE.Vector3();
@@ -85,16 +83,6 @@ function samplePinch(
   out.midpoint.copy(_thumb).add(_index).multiplyScalar(0.5);
   out.reach.copy(out.midpoint).sub(_wrist).normalize();
   return true;
-}
-
-interface FilletCapture {
-  partId: string;
-  initialMidpoint: THREE.Vector3;
-}
-
-interface HandState {
-  pinching: boolean;
-  midpoint: THREE.Vector3;
 }
 
 /** Walk the scene graph to find the part ID associated with a hit object. */
@@ -133,6 +121,35 @@ function pickPartId(
   return null;
 }
 
+interface HandState {
+  pinching: boolean;
+  midpoint: THREE.Vector3;
+}
+
+interface FilletCapture {
+  kind: "fillet";
+  partId: string;
+}
+
+interface ScaleCapture {
+  kind: "scale";
+  /** Midpoint of the two pinch midpoints when the gesture began (world). */
+  initialAnchor: THREE.Vector3;
+  /** Distance between the two pinches when the gesture began (metres). */
+  initialDistance: number;
+  /** View transform when the gesture began. */
+  initialView: XRViewTransform;
+  /** Anchor in scene-local space (i.e. unscaled, untranslated). */
+  sceneAnchor: THREE.Vector3;
+}
+
+type Capture = FilletCapture | ScaleCapture | null;
+
+const _midA = new THREE.Vector3();
+const _midB = new THREE.Vector3();
+const _bimid = new THREE.Vector3();
+const _newPos = new THREE.Vector3();
+
 export function XRGestures() {
   const presenting = useXRPresenting();
   const { gl, scene } = useThree();
@@ -145,7 +162,7 @@ export function XRGestures() {
     pinching: false,
     midpoint: new THREE.Vector3(),
   });
-  const captureRef = useRef<FilletCapture | null>(null);
+  const captureRef = useRef<Capture>(null);
   const sampleRef = useRef<PinchSample>({
     pinching: false,
     midpoint: new THREE.Vector3(),
@@ -160,9 +177,7 @@ export function XRGestures() {
     const refSpace = gl.xr.getReferenceSpace();
     if (!session || !refSpace) return;
 
-    let leftSample: HandState | null = null;
-    let rightSample: HandState | null = null;
-
+    // --- 1. Sample both hands ----------------------------------------------
     for (const src of session.inputSources) {
       if (!src.hand) continue;
       const handRef = src.handedness === "left" ? leftRef : rightRef;
@@ -172,54 +187,101 @@ export function XRGestures() {
       }
       handRef.current.pinching = sample.pinching;
       handRef.current.midpoint.copy(sample.midpoint);
-      const snapshot: HandState = {
-        pinching: sample.pinching,
-        midpoint: sample.midpoint.clone(),
-      };
-      if (src.handedness === "left") {
-        leftSample = snapshot;
-      } else if (src.handedness === "right") {
-        rightSample = snapshot;
-      }
 
-      // First-pinch capture: if no target yet and this hand just pinched,
-      // try to pick a part under the reach ray.
-      if (sample.pinching && !captureRef.current) {
+      // --- 2. First-pinch capture: try to grab a part for fillet mode ----
+      // Only enter fillet mode if no capture is active and this hand just
+      // pinched; the "second hand pinches first" case is handled below as
+      // scale-teleport.
+      if (sample.pinching && captureRef.current == null) {
         const partId = pickPartId(scene, sample.midpoint, sample.reach);
         if (partId) {
-          captureRef.current = {
-            partId,
-            initialMidpoint: sample.midpoint.clone(),
-          };
+          captureRef.current = { kind: "fillet", partId };
         }
       }
     }
 
-    // Commit on release. We commit when at least one of the hands transitions
-    // out of pinch while a capture is active and the *other* hand is/was
-    // pinching too (i.e. we had a bimanual moment). Single hand alone just
-    // selects the part — no fillet.
-    const capture = captureRef.current;
-    if (!capture) return;
-
-    const left = leftSample ?? leftRef.current;
-    const right = rightSample ?? rightRef.current;
+    const left = leftRef.current;
+    const right = rightRef.current;
     const bothPinching = left.pinching && right.pinching;
-    const eitherReleased = !left.pinching || !right.pinching;
 
-    if (bothPinching || !eitherReleased) {
-      // Still in capture; nothing to commit yet. (Live preview lands in a
-      // follow-up — for now we just hold state.)
+    // --- 3. Scale-teleport entry: bimanual pinch with no part captured. ---
+    if (bothPinching && captureRef.current == null) {
+      _midA.copy(left.midpoint);
+      _midB.copy(right.midpoint);
+      const initialDistance = _midA.distanceTo(_midB);
+      _bimid.copy(_midA).add(_midB).multiplyScalar(0.5);
+      const initialView = useXRSupportStore.getState().view;
+      // sceneAnchor = (worldAnchor - viewPosition) / viewScale  — the point
+      // in the kernel scene's local frame the user just "grabbed".
+      const sceneAnchor = new THREE.Vector3()
+        .copy(_bimid)
+        .sub(new THREE.Vector3(...initialView.position))
+        .divideScalar(initialView.scale);
+      captureRef.current = {
+        kind: "scale",
+        initialAnchor: _bimid.clone(),
+        initialDistance,
+        initialView,
+        sceneAnchor,
+      };
+    }
+
+    // --- 4. Active scale-teleport: drive the view transform live. ---------
+    const capture = captureRef.current;
+    if (capture && capture.kind === "scale" && bothPinching) {
+      _midA.copy(left.midpoint);
+      _midB.copy(right.midpoint);
+      const distance = _midA.distanceTo(_midB);
+      _bimid.copy(_midA).add(_midB).multiplyScalar(0.5);
+      const ratio =
+        capture.initialDistance > 1e-6
+          ? distance / capture.initialDistance
+          : 1;
+      let scale = capture.initialView.scale * ratio;
+      if (scale < SCALE_MIN) scale = SCALE_MIN;
+      if (scale > SCALE_MAX) scale = SCALE_MAX;
+      // Keep the grabbed scene point pinned to the current bimanual midpoint:
+      // worldPoint = sceneAnchor * scale + position  ⇒  position = bimid − sceneAnchor·scale.
+      _newPos
+        .copy(capture.sceneAnchor)
+        .multiplyScalar(scale)
+        .multiplyScalar(-1)
+        .add(_bimid);
+      useXRSupportStore.getState().setView({
+        scale,
+        position: [_newPos.x, _newPos.y, _newPos.z],
+      });
       return;
     }
 
-    // Released. If we ever hit bimanual (both midpoints are valid and the
-    // distance is non-degenerate), commit the fillet.
-    const distance = left.midpoint.distanceTo(right.midpoint);
-    captureRef.current = null;
-    if (distance < MIN_RADIUS_M || distance > MAX_RADIUS_M) return;
-    const radius = distance * M_TO_MODEL_MM;
-    useDocumentStore.getState().addFillet(capture.partId, radius);
+    // --- 5. Release handling ----------------------------------------------
+    if (!capture) return;
+
+    // Capture remains active until both hands are open — stops the rare
+    // single-frame chatter where one hand registers as released a frame
+    // before the other.
+    const eitherReleased = !left.pinching || !right.pinching;
+    if (!eitherReleased) return;
+
+    if (capture.kind === "fillet") {
+      const distance = left.midpoint.distanceTo(right.midpoint);
+      captureRef.current = null;
+      if (distance < MIN_RADIUS_M || distance > MAX_RADIUS_M) return;
+      // Convert physical distance to model-space mm. Use the live view scale
+      // so a fillet feels the same regardless of how zoomed-in we are: 1 cm
+      // hand-spread always reads as 1 cm at the current scale.
+      const view = useXRSupportStore.getState().view;
+      const scaleFactor = view.scale > 1e-9 ? 0.001 / view.scale : 1;
+      const radius = distance * M_TO_MODEL_MM * scaleFactor;
+      useDocumentStore.getState().addFillet(capture.partId, radius);
+      return;
+    }
+
+    if (capture.kind === "scale") {
+      // The view transform was already committed live; just exit.
+      captureRef.current = null;
+      return;
+    }
   });
 
   return null;

--- a/packages/app/src/components/xr/XRPresence.tsx
+++ b/packages/app/src/components/xr/XRPresence.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef } from "react";
+import { useFrame, useThree } from "@react-three/fiber";
+import * as THREE from "three";
+import {
+  joinXRCollabChannel,
+  type XRCollabChannel,
+  useAuthStore,
+} from "@vcad/auth";
+import { useXRPresenting, useXRSupportStore } from "@/stores/xr-store";
+import { useCollabSessionStore } from "@/stores/collab-session-store";
+import { useXRPresenceStore } from "@/stores/xr-presence-store";
+
+/**
+ * XR presence — broadcasts the local headset + hand poses on a per-document
+ * realtime channel and renders incoming peer poses as floating avatars.
+ *
+ * Mounted *inside* `XRSceneTransform` so its rendered avatars share the same
+ * scene-local frame as the kernel geometry. Poses are exchanged in this
+ * scene-local frame too, so two users on different desks still see each
+ * other's heads and hands at the same point on the same model.
+ *
+ * The local broadcast is throttled to ~10 Hz (every 100 ms). This is
+ * smooth enough for floating avatars without saturating the realtime
+ * channel — interpolation on the receive side absorbs the gaps.
+ *
+ * Outside XR, or while the document isn't cloud-synced, this component
+ * renders nothing and never opens a channel.
+ */
+
+/** Broadcast period in ms. ~10 Hz. */
+const SEND_PERIOD = 100;
+/** Sweep stale peers at this period. */
+const PRUNE_PERIOD = 2_000;
+
+const _camPos = new THREE.Vector3();
+const _camQuat = new THREE.Quaternion();
+const _scenePos = new THREE.Vector3();
+
+/** Convert a world-space position into the scene-local frame defined by
+ * the current `XRSceneTransform` (`scale`, `position`). */
+function worldToScene(
+  world: THREE.Vector3,
+  out: THREE.Vector3,
+  view: { scale: number; position: readonly [number, number, number] },
+) {
+  out
+    .copy(world)
+    .sub(new THREE.Vector3(view.position[0], view.position[1], view.position[2]))
+    .divideScalar(view.scale);
+}
+
+export function XRPresence() {
+  const presenting = useXRPresenting();
+  const { camera, gl } = useThree();
+  const cloudId = useCollabSessionStore((s) => s.cloudId);
+  const user = useAuthStore((s) => s.user);
+  const userName = user?.user_metadata?.name as string | undefined;
+
+  const channelRef = useRef<XRCollabChannel | null>(null);
+  const lastSentRef = useRef(0);
+
+  // Open / close the channel when XR + cloud-sync are both available.
+  useEffect(() => {
+    if (!presenting || !cloudId) return;
+    const ingest = useXRPresenceStore.getState().ingest;
+    const drop = useXRPresenceStore.getState().drop;
+    const channel = joinXRCollabChannel(cloudId, ingest, drop);
+    channelRef.current = channel;
+    return () => {
+      channel?.leave();
+      channelRef.current = null;
+      useXRPresenceStore.getState().clear();
+    };
+  }, [presenting, cloudId]);
+
+  // Periodically prune peers we haven't heard from recently — covers the
+  // case where a peer crashed without sending a `leave` event.
+  useEffect(() => {
+    if (!presenting) return;
+    const interval = window.setInterval(
+      () => useXRPresenceStore.getState().pruneStale(),
+      PRUNE_PERIOD,
+    );
+    return () => window.clearInterval(interval);
+  }, [presenting]);
+
+  // Throttled broadcast of local pose in scene-local coords.
+  useFrame((_, __, frame) => {
+    if (!presenting || !channelRef.current) return;
+    const now = performance.now();
+    if (now - lastSentRef.current < SEND_PERIOD) return;
+    lastSentRef.current = now;
+
+    const view = useXRSupportStore.getState().view;
+
+    // Headset world pose. In WebXR the camera tracks the head.
+    camera.getWorldPosition(_camPos);
+    camera.getWorldQuaternion(_camQuat);
+    worldToScene(_camPos, _scenePos, view);
+
+    // Hand wrist positions, scene-local. Optional — not all sessions have
+    // hand tracking.
+    let leftHand: [number, number, number] | undefined;
+    let rightHand: [number, number, number] | undefined;
+    const xrFrame = frame as XRFrame | undefined;
+    const session = gl.xr.getSession();
+    const refSpace = gl.xr.getReferenceSpace();
+    if (xrFrame && session && refSpace) {
+      for (const src of session.inputSources) {
+        if (!src.hand) continue;
+        const wrist = src.hand.get("wrist");
+        if (!wrist) continue;
+        const pose = xrFrame.getJointPose?.(wrist, refSpace);
+        if (!pose) continue;
+        const w = new THREE.Vector3(
+          pose.transform.position.x,
+          pose.transform.position.y,
+          pose.transform.position.z,
+        );
+        const local = new THREE.Vector3();
+        worldToScene(w, local, view);
+        const triple: [number, number, number] = [local.x, local.y, local.z];
+        if (src.handedness === "left") leftHand = triple;
+        else if (src.handedness === "right") rightHand = triple;
+      }
+    }
+
+    channelRef.current.broadcast({
+      name: userName,
+      pose: {
+        head: [_scenePos.x, _scenePos.y, _scenePos.z],
+        headRot: [_camQuat.x, _camQuat.y, _camQuat.z, _camQuat.w],
+        leftHand,
+        rightHand,
+      },
+    });
+  });
+
+  return <RemoteAvatars />;
+}
+
+/** Renders one floating avatar per remote peer. */
+function RemoteAvatars() {
+  const peers = useXRPresenceStore((s) => s.peers);
+  const entries = Array.from(peers.values());
+  if (entries.length === 0) return null;
+  return (
+    <group>
+      {entries.map((p) => (
+        <RemoteAvatar key={p.userId} update={p} />
+      ))}
+    </group>
+  );
+}
+
+interface RemoteAvatarProps {
+  update: import("@vcad/auth").XRPresenceUpdate;
+}
+
+const _q = new THREE.Quaternion();
+const _e = new THREE.Euler();
+
+function RemoteAvatar({ update }: RemoteAvatarProps) {
+  const color = update.color ?? "#c084fc";
+  const head = update.pose.head;
+  _q.set(
+    update.pose.headRot[0],
+    update.pose.headRot[1],
+    update.pose.headRot[2],
+    update.pose.headRot[3],
+  );
+  _e.setFromQuaternion(_q);
+
+  return (
+    <group>
+      {/* Head — small rounded box facing the peer's gaze direction. The
+          scene-local frame is in kernel mm, so 100-unit cube ≈ 10 cm at
+          desktop scale. */}
+      <mesh position={head} rotation={[_e.x, _e.y, _e.z]}>
+        <boxGeometry args={[140, 100, 100]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.3} />
+      </mesh>
+      {/* Hand wrists — small spheres so the peer's gestures read at a
+          glance even if hand-tracking isn't available on their headset. */}
+      {update.pose.leftHand && (
+        <mesh position={update.pose.leftHand}>
+          <sphereGeometry args={[40, 12, 12]} />
+          <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.25} />
+        </mesh>
+      )}
+      {update.pose.rightHand && (
+        <mesh position={update.pose.rightHand}>
+          <sphereGeometry args={[40, 12, 12]} />
+          <meshStandardMaterial color={color} emissive={color} emissiveIntensity={0.25} />
+        </mesh>
+      )}
+    </group>
+  );
+}

--- a/packages/app/src/components/xr/XRSceneTransform.tsx
+++ b/packages/app/src/components/xr/XRSceneTransform.tsx
@@ -1,37 +1,29 @@
 import { type ReactNode, useMemo } from "react";
-import { useXRPresenting } from "@/stores/xr-store";
+import { useXRPresenting, useXRSupportStore } from "@/stores/xr-store";
 
 /**
- * Mounts the kernel scene at "desktop scale" while a WebXR session is active.
- *
- * Kernel coordinates are millimeters (1 unit = 1 mm). WebXR works in meters.
- * A scale factor of 1/1000 makes the model appear at true physical size in
- * the headset — a 100 mm cube reads as a 10 cm cube on your desk. The model
- * is anchored at headset-height (1 m) and 0.7 m forward so it floats just in
- * front of where the user is sitting on entry.
+ * Mounts the kernel scene with the live XR view transform while a session is
+ * active. The transform's scale + position are driven by `useXRSupportStore`
+ * — initialized to 1/1000 (mm → m) at desktop height on entry, then updated
+ * live by the bimanual scale-teleport gesture in `XRGestures`.
  *
  * Outside XR, this component is a passthrough so the existing orbit-camera
  * UX is untouched.
  */
-const XR_SCALE = 0.001;
-const XR_POSITION: [number, number, number] = [0, 1.0, -0.7];
-
 export function XRSceneTransform({ children }: { children: ReactNode }) {
   const presenting = useXRPresenting();
+  const view = useXRSupportStore((s) => s.view);
 
-  // Memo so the prop identity is stable; otherwise R3F reconciles the group
-  // every render and forces children to remount.
-  const transform = useMemo(
-    () => ({
-      scale: presenting ? XR_SCALE : 1,
-      position: presenting ? XR_POSITION : ([0, 0, 0] as [number, number, number]),
-    }),
-    [presenting],
+  // Memo the position tuple so the prop identity is stable for R3F's
+  // reconciler when only `scale` changes.
+  const position = useMemo<[number, number, number]>(
+    () => [view.position[0], view.position[1], view.position[2]],
+    [view.position],
   );
 
   if (!presenting) return <>{children}</>;
   return (
-    <group scale={transform.scale} position={transform.position}>
+    <group scale={view.scale} position={position}>
       {children}
     </group>
   );

--- a/packages/app/src/components/xr/XRSceneTransform.tsx
+++ b/packages/app/src/components/xr/XRSceneTransform.tsx
@@ -1,0 +1,38 @@
+import { type ReactNode, useMemo } from "react";
+import { useXRPresenting } from "@/stores/xr-store";
+
+/**
+ * Mounts the kernel scene at "desktop scale" while a WebXR session is active.
+ *
+ * Kernel coordinates are millimeters (1 unit = 1 mm). WebXR works in meters.
+ * A scale factor of 1/1000 makes the model appear at true physical size in
+ * the headset — a 100 mm cube reads as a 10 cm cube on your desk. The model
+ * is anchored at headset-height (1 m) and 0.7 m forward so it floats just in
+ * front of where the user is sitting on entry.
+ *
+ * Outside XR, this component is a passthrough so the existing orbit-camera
+ * UX is untouched.
+ */
+const XR_SCALE = 0.001;
+const XR_POSITION: [number, number, number] = [0, 1.0, -0.7];
+
+export function XRSceneTransform({ children }: { children: ReactNode }) {
+  const presenting = useXRPresenting();
+
+  // Memo so the prop identity is stable; otherwise R3F reconciles the group
+  // every render and forces children to remount.
+  const transform = useMemo(
+    () => ({
+      scale: presenting ? XR_SCALE : 1,
+      position: presenting ? XR_POSITION : ([0, 0, 0] as [number, number, number]),
+    }),
+    [presenting],
+  );
+
+  if (!presenting) return <>{children}</>;
+  return (
+    <group scale={transform.scale} position={transform.position}>
+      {children}
+    </group>
+  );
+}

--- a/packages/app/src/hooks/useCollabSync.ts
+++ b/packages/app/src/hooks/useCollabSync.ts
@@ -20,6 +20,7 @@ import {
   type CollabChannel,
 } from "@vcad/auth";
 import { useBootStore } from "@/stores/boot-store";
+import { useCollabSessionStore } from "@/stores/collab-session-store";
 import { loadDocument as loadStoredDocument } from "@/lib/storage";
 
 export function useCollabSync() {
@@ -31,8 +32,17 @@ export function useCollabSync() {
   // Anonymous Supabase sessions exist for chat-thread RLS scoping; cloud
   // sync + collab features are gated to permanent identities only.
   const isCloudUser = !!user && !isAnonymous;
-  const [cloudId, setCloudId] = useState<string | null>(null);
+  const [cloudId, setCloudIdLocal] = useState<string | null>(null);
   const channelRef = useRef<CollabChannel | null>(null);
+  const publishCloudId = useCollabSessionStore((s) => s.setCloudId);
+
+  // Mirror the resolved cloudId into the shared collab-session store so
+  // sibling realtime features (XR presence, future cursor sync) don't have
+  // to re-resolve it from local storage.
+  const setCloudId = (id: string | null) => {
+    setCloudIdLocal(id);
+    publishCloudId(id);
+  };
 
   // Don't do anything until bootstrap is complete — the CRDT engine,
   // document store, and auth session aren't ready before that.

--- a/packages/app/src/lib/xr-voice.ts
+++ b/packages/app/src/lib/xr-voice.ts
@@ -1,0 +1,129 @@
+/**
+ * Push-to-talk voice recognizer for XR (and any other context that wants
+ * speech-to-text without a keyboard).
+ *
+ * Uses the browser's `webkitSpeechRecognition` (the standard in Chromium
+ * and Safari, including Vision Pro). Falls back gracefully on browsers
+ * that don't expose it — `isVoiceSupported()` returns false and
+ * `startVoice()` is a no-op.
+ *
+ * Single global recognizer because the WebSpeech API is single-instance —
+ * starting two simultaneously errors. The XR gesture interpreter is the
+ * only caller for now.
+ */
+
+interface SpeechRecognitionResultLike {
+  isFinal: boolean;
+  0: { transcript: string };
+}
+interface SpeechRecognitionEventLike extends Event {
+  resultIndex: number;
+  results: ArrayLike<SpeechRecognitionResultLike>;
+}
+interface SpeechRecognitionLike extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((ev: SpeechRecognitionEventLike) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onend: (() => void) | null;
+}
+type SpeechRecognitionCtor = new () => SpeechRecognitionLike;
+
+function getCtor(): SpeechRecognitionCtor | null {
+  if (typeof window === "undefined") return null;
+  const w = window as unknown as {
+    SpeechRecognition?: SpeechRecognitionCtor;
+    webkitSpeechRecognition?: SpeechRecognitionCtor;
+  };
+  return w.SpeechRecognition ?? w.webkitSpeechRecognition ?? null;
+}
+
+export function isVoiceSupported(): boolean {
+  return getCtor() != null;
+}
+
+interface VoiceSession {
+  /** Stop recognition and finalize. Calls `onTranscript` with the final
+   * accumulated transcript if any, then `onEnd`. Idempotent. */
+  stop(): void;
+}
+
+interface VoiceOptions {
+  /** Called with the latest interim or final transcript. */
+  onTranscript: (text: string, isFinal: boolean) => void;
+  /** Called when the session ends (release or error). */
+  onEnd?: () => void;
+  /** Called on error with a short reason. */
+  onError?: (reason: string) => void;
+  /** BCP-47 language tag, default `"en-US"`. */
+  lang?: string;
+}
+
+/**
+ * Start a push-to-talk voice session. The returned handle's `stop()` ends
+ * recognition and produces the final transcript.
+ *
+ * Returns null if speech recognition isn't available in this UA.
+ */
+export function startVoice(opts: VoiceOptions): VoiceSession | null {
+  const Ctor = getCtor();
+  if (!Ctor) {
+    opts.onError?.("Speech recognition not supported in this browser.");
+    return null;
+  }
+  const recognition = new Ctor();
+  recognition.continuous = true;
+  recognition.interimResults = true;
+  recognition.lang = opts.lang ?? "en-US";
+  let stopped = false;
+  let lastFinal = "";
+  let lastInterim = "";
+
+  recognition.onresult = (ev: SpeechRecognitionEventLike) => {
+    let interim = "";
+    let final = lastFinal;
+    for (let i = ev.resultIndex; i < ev.results.length; i++) {
+      const r = ev.results[i];
+      if (!r) continue;
+      const text = r[0]?.transcript ?? "";
+      if (r.isFinal) final += text;
+      else interim += text;
+    }
+    lastFinal = final;
+    lastInterim = interim;
+    opts.onTranscript((final + interim).trim(), false);
+  };
+  recognition.onerror = (ev: Event) => {
+    const reason = (ev as unknown as { error?: string }).error ?? "unknown";
+    opts.onError?.(reason);
+  };
+  recognition.onend = () => {
+    if (stopped) return;
+    stopped = true;
+    const finalText = (lastFinal + lastInterim).trim();
+    if (finalText) opts.onTranscript(finalText, true);
+    opts.onEnd?.();
+  };
+
+  try {
+    recognition.start();
+  } catch (err) {
+    opts.onError?.((err as Error).message);
+    return null;
+  }
+
+  return {
+    stop() {
+      if (stopped) return;
+      try {
+        recognition.stop();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/packages/app/src/stores/collab-session-store.ts
+++ b/packages/app/src/stores/collab-session-store.ts
@@ -1,0 +1,19 @@
+import { create } from "zustand";
+
+/**
+ * Shared collab-session metadata produced by `useCollabSync` and consumed
+ * by other realtime features (XR presence, future cursor sync).
+ *
+ * `cloudId` is the resolved Supabase document id, or null when the doc
+ * isn't cloud-synced yet. It is null while signed-out, in read-only share
+ * mode, or before the boot phase is ready.
+ */
+interface CollabSessionState {
+  cloudId: string | null;
+  setCloudId: (id: string | null) => void;
+}
+
+export const useCollabSessionStore = create<CollabSessionState>((set) => ({
+  cloudId: null,
+  setCloudId: (cloudId) => set({ cloudId }),
+}));

--- a/packages/app/src/stores/xr-presence-store.ts
+++ b/packages/app/src/stores/xr-presence-store.ts
@@ -1,0 +1,54 @@
+import { create } from "zustand";
+import type { XRPresenceUpdate } from "@vcad/auth";
+
+/** Time after which a peer is considered stale and dropped from the map. */
+const STALE_MS = 5_000;
+
+/**
+ * Remote XR participant tracking — populated by inbound broadcasts on the
+ * XR collab channel. Poses are stored in scene-local coordinates so they
+ * can be rendered inside the same `XRSceneTransform` group regardless of
+ * each user's physical room frame.
+ */
+interface XRPresenceState {
+  peers: Map<string, XRPresenceUpdate>;
+  /** Ingest a pose update from the wire. */
+  ingest: (update: XRPresenceUpdate) => void;
+  /** Drop a peer (remote user explicitly left). */
+  drop: (userId: string) => void;
+  /** Sweep stale peers based on `ts`. Call from a slow interval. */
+  pruneStale: () => void;
+  /** Drop everything (e.g. on session end). */
+  clear: () => void;
+}
+
+export const useXRPresenceStore = create<XRPresenceState>((set, get) => ({
+  peers: new Map(),
+  ingest: (update) =>
+    set((s) => {
+      const next = new Map(s.peers);
+      next.set(update.userId, update);
+      return { peers: next };
+    }),
+  drop: (userId) =>
+    set((s) => {
+      if (!s.peers.has(userId)) return s;
+      const next = new Map(s.peers);
+      next.delete(userId);
+      return { peers: next };
+    }),
+  pruneStale: () => {
+    const now = Date.now();
+    const peers = get().peers;
+    let removed = false;
+    const next = new Map(peers);
+    for (const [id, p] of peers) {
+      if (now - p.ts > STALE_MS) {
+        next.delete(id);
+        removed = true;
+      }
+    }
+    if (removed) set({ peers: next });
+  },
+  clear: () => set({ peers: new Map() }),
+}));

--- a/packages/app/src/stores/xr-store.ts
+++ b/packages/app/src/stores/xr-store.ts
@@ -23,14 +23,42 @@ type SupportState = {
   checked: boolean;
 };
 
+/**
+ * Default scene scale on entering XR. 1/1000 maps the kernel's millimetre
+ * units to physical metres, so a 100 mm cube reads as a 10 cm cube on the
+ * desk. Exported for `XRSceneTransform` and the scale-teleport reset.
+ */
+export const XR_DEFAULT_SCALE = 0.001;
+/** Headset-height + slightly forward, world units (metres). */
+export const XR_DEFAULT_POSITION: readonly [number, number, number] = [0, 1.0, -0.7];
+
+export interface XRViewTransform {
+  /** Uniform scale applied to the kernel scene group. */
+  scale: number;
+  /** World-space position of the scene origin. */
+  position: readonly [number, number, number];
+}
+
 interface XRSupportStore extends SupportState {
   refresh: () => Promise<void>;
+  /** Live view transform — driven by scale-teleport gestures. */
+  view: XRViewTransform;
+  setView: (view: XRViewTransform) => void;
+  resetView: () => void;
 }
+
+const DEFAULT_VIEW: XRViewTransform = {
+  scale: XR_DEFAULT_SCALE,
+  position: XR_DEFAULT_POSITION,
+};
 
 export const useXRSupportStore = create<XRSupportStore>((set) => ({
   vr: false,
   ar: false,
   checked: false,
+  view: DEFAULT_VIEW,
+  setView: (view) => set({ view }),
+  resetView: () => set({ view: DEFAULT_VIEW }),
   refresh: async () => {
     const xr = (navigator as unknown as { xr?: XRSystem }).xr;
     if (!xr) {

--- a/packages/app/src/stores/xr-store.ts
+++ b/packages/app/src/stores/xr-store.ts
@@ -1,0 +1,66 @@
+import { createXRStore } from "@react-three/xr";
+import { create, useStore } from "zustand";
+
+/**
+ * The shared @react-three/xr store. Hand tracking + transient pointers are
+ * enabled by default; we bind it to our scene via `<XR store={xrStore}>`.
+ *
+ * `foveation` is set to 0 (sharpest) so CAD edges read crisply at near-field
+ * Vision Pro distances. Tweak down to 1.0 if framerate suffers on Quest.
+ */
+export const xrStore = createXRStore({
+  hand: true,
+  controller: true,
+  foveation: 0,
+});
+
+type SupportState = {
+  /** WebXR `immersive-vr` session is supported by this UA. */
+  vr: boolean;
+  /** WebXR `immersive-ar` session is supported by this UA. */
+  ar: boolean;
+  /** Whether we've finished the async support check. Until then UI hides buttons. */
+  checked: boolean;
+};
+
+interface XRSupportStore extends SupportState {
+  refresh: () => Promise<void>;
+}
+
+export const useXRSupportStore = create<XRSupportStore>((set) => ({
+  vr: false,
+  ar: false,
+  checked: false,
+  refresh: async () => {
+    const xr = (navigator as unknown as { xr?: XRSystem }).xr;
+    if (!xr) {
+      set({ vr: false, ar: false, checked: true });
+      return;
+    }
+    try {
+      const [vr, ar] = await Promise.all([
+        xr.isSessionSupported("immersive-vr").catch(() => false),
+        xr.isSessionSupported("immersive-ar").catch(() => false),
+      ]);
+      set({ vr, ar, checked: true });
+    } catch {
+      set({ vr: false, ar: false, checked: true });
+    }
+  },
+}));
+
+/** Kick off the support check once at module load. */
+if (typeof navigator !== "undefined") {
+  void useXRSupportStore.getState().refresh();
+}
+
+/**
+ * React hook that returns true while a WebXR session is active.
+ *
+ * Usable outside the `<Canvas>` / `<XR>` tree (where `useXR` from
+ * `@react-three/xr` won't work). Drives the Canvas `frameloop` prop so
+ * we ride the WebXR rAF instead of `"demand"` while presenting.
+ */
+export function useXRPresenting(): boolean {
+  return useStore(xrStore, (s) => s.mode != null);
+}

--- a/packages/app/src/test/demand-rendering.test.ts
+++ b/packages/app/src/test/demand-rendering.test.ts
@@ -22,10 +22,15 @@ function readSrc(rel: string): string {
 // 1. Canvas must use demand rendering
 // ---------------------------------------------------------------------------
 describe("Canvas frameloop", () => {
-  it("uses frameloop='demand' (not always)", () => {
+  it("defaults to 'demand', only switches to 'always' while in WebXR", () => {
     const src = readSrc("components/Viewport.tsx");
-    expect(src).toContain('frameloop="demand"');
-    expect(src).not.toContain('frameloop="always"');
+    // Default must remain "demand" so the GPU idles outside XR.
+    expect(src).toContain('"demand"');
+    // The only allowed source of "always" is the XR-presenting branch:
+    // `frameloop={xrPresenting ? "always" : "demand"}`.
+    if (src.includes('"always"')) {
+      expect(src).toMatch(/xrPresenting\s*\?\s*"always"\s*:\s*"demand"/);
+    }
   });
 });
 

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -108,6 +108,16 @@ export {
 // AI
 export { textToCAD, isAIAvailable } from "./ai";
 
+// XR presence transport
+export {
+  joinXRCollabChannel,
+  type XRCollabChannel,
+  type XRPose,
+  type XRPresenceUpdate,
+  type XRPresenceListener,
+  type XRPresenceLeaveListener,
+} from "./xr-collab";
+
 // Chat persistence
 export {
   loadOrCreateThread,

--- a/packages/auth/src/xr-collab.ts
+++ b/packages/auth/src/xr-collab.ts
@@ -1,0 +1,119 @@
+/**
+ * Realtime transport for XR presence (head + hand poses).
+ *
+ * A *sibling* channel to {@link joinCollabChannel} — on the same Supabase
+ * realtime backend, keyed by document ID, but on its own topic so the
+ * higher broadcast rate of pose updates (~10 Hz) doesn't compete with
+ * document op delivery.
+ *
+ * Poses are exchanged in the kernel scene's local frame (NOT each user's
+ * physical room frame), so two users with different desks still see each
+ * other's avatars at the same point on the same model.
+ */
+
+import { requireSupabase, isAuthEnabled } from "./client";
+import { useAuthStore } from "./stores/auth-store";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+
+export interface XRPose {
+  /** Headset position in scene-local coords (kernel mm). */
+  head: [number, number, number];
+  /** Headset orientation as a unit quaternion (x, y, z, w). */
+  headRot: [number, number, number, number];
+  /** Optional left wrist position. */
+  leftHand?: [number, number, number];
+  /** Optional right wrist position. */
+  rightHand?: [number, number, number];
+}
+
+export interface XRPresenceUpdate {
+  userId: string;
+  /** Display name; optional, falls back to user id. */
+  name?: string;
+  /** Display color; optional, falls back to a default. */
+  color?: string;
+  pose: XRPose;
+  /** Sender clock for staleness detection on the receiver side. */
+  ts: number;
+}
+
+export interface XRCollabChannel {
+  /** Broadcast the local user's XR pose. Drop if not yet subscribed. */
+  broadcast: (update: Omit<XRPresenceUpdate, "userId" | "ts">) => void;
+  /** Stop sending and close the channel. */
+  leave: () => void;
+}
+
+export type XRPresenceListener = (update: XRPresenceUpdate) => void;
+/** Emitted when a remote peer leaves so the receiver can drop their avatar. */
+export type XRPresenceLeaveListener = (userId: string) => void;
+
+/**
+ * Join the XR presence channel for a document.
+ *
+ * @returns null when auth is disabled or the user isn't signed in — the
+ * caller should treat presence as unavailable in that case rather than
+ * crashing the XR session.
+ */
+export function joinXRCollabChannel(
+  documentId: string,
+  onUpdate: XRPresenceListener,
+  onLeave?: XRPresenceLeaveListener,
+): XRCollabChannel | null {
+  if (!isAuthEnabled()) return null;
+  const { user } = useAuthStore.getState();
+  if (!user) return null;
+
+  const supabase = requireSupabase();
+  const channelName = `doc:${documentId}:xr`;
+
+  let subscribed = false;
+  let channel: RealtimeChannel | null = supabase.channel(channelName, {
+    config: { broadcast: { self: false } },
+  });
+
+  channel.on("broadcast", { event: "pose" }, (payload) => {
+    const update = payload.payload as XRPresenceUpdate | undefined;
+    if (!update?.pose || !update.userId) return;
+    onUpdate(update);
+  });
+
+  channel.on("broadcast", { event: "leave" }, (payload) => {
+    const userId = (payload.payload as { userId?: string } | undefined)?.userId;
+    if (userId) onLeave?.(userId);
+  });
+
+  channel.subscribe((status) => {
+    if (status === "SUBSCRIBED") subscribed = true;
+  });
+
+  return {
+    broadcast: (update) => {
+      if (!channel || !subscribed) return;
+      const payload: XRPresenceUpdate = {
+        ...update,
+        userId: user.id,
+        ts: Date.now(),
+      };
+      channel.send({
+        type: "broadcast",
+        event: "pose",
+        payload,
+      });
+    },
+    leave: () => {
+      if (!channel) return;
+      // Best-effort goodbye so peers can drop the avatar immediately.
+      if (subscribed) {
+        channel.send({
+          type: "broadcast",
+          event: "leave",
+          payload: { userId: user.id },
+        });
+      }
+      subscribed = false;
+      supabase.removeChannel(channel);
+      channel = null;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive WebXR support to the CAD application, enabling users to view and interact with 3D models in VR/AR headsets (Vision Pro, Meta Quest, etc.). The implementation includes bimanual gesture recognition for parametric operations, voice push-to-talk input, real-time presence sharing between collaborators, and a scene transform system for intuitive spatial navigation.

## Key Changes

**WebXR Foundation & Session Management**
- Added `xrStore` (from `@react-three/xr`) with hand tracking and controller support enabled
- Created `useXRPresenting()` hook to detect active XR sessions outside the Canvas tree
- Implemented `useXRSupportStore` to track VR/AR capability detection and manage the live view transform (scale + position)
- Added `EnterXRButton` component that appears when WebXR is available

**Bimanual Gesture Interpreter (`XRGestures.tsx`)**
- Reads thumb-tip and index-finger-tip joint poses each frame to detect pinches with hysteresis
- **Fillet gesture (M2):** Pinch a part with one hand, pinch with the other, release → commits a parametric `addFillet()` with distance between hands as radius
- **Scale-teleport gesture (M3):** Bimanual pinch in empty space grabs the scene; spreading hands scales up, pulling together scales down; the grabbed point stays under the hands
- Implements reach-ray casting from pinch midpoint to pick parts for fillet mode
- Converts physical hand distances to model-space millimeters using the live view scale

**Voice Push-to-Talk (`xr-voice.ts`)**
- Wraps the browser's `webkitSpeechRecognition` API with graceful fallback
- Single-hand pinch held in empty space for ~800ms triggers speech recognition
- Release finalizes the transcript and sends it through the chat handler with current selection as context
- Supports interim and final transcript callbacks

**XR Presence & Collaboration (`XRPresence.tsx` + `xr-collab.ts`)**
- New realtime channel (`doc:{documentId}:xr`) for broadcasting headset + hand poses at ~10 Hz
- Poses are exchanged in scene-local coordinates (not physical room frames) so collaborators see each other anchored to the same model point
- Renders remote peers as floating avatars with head geometry and optional hand spheres
- Implements staleness detection and automatic peer cleanup

**Scene Transform (`XRSceneTransform.tsx`)**
- Wraps kernel geometry in a group with live scale + position from `useXRSupportStore`
- Defaults to 1/1000 scale (mm → m) at desktop height on XR entry
- Driven by scale-teleport gestures; passthrough when not in XR

**Supporting Infrastructure**
- Added `useCollabSessionStore` to track cloud document ID for presence channel subscription
- Updated `useCollabSync` to populate `cloudId` when document is cloud-synced
- Modified `SceneMesh` to attach `partId` to mesh userData for gesture picking
- Updated Canvas `frameloop` to switch from `"demand"` to `"always"` while in XR session
- Added `@react-three/xr` dependency

## Notable Implementation Details

- **Hysteresis on pinch detection** prevents chatter at the boundary (close at 2.5 cm, open at 4 cm)
- **Reach-ray casting** starts slightly behind the pinch midpoint so hands inside a mesh still produce hits
- **Scale-teleport math** keeps the grabbed scene point pinned to the bimanual midpoint as hands move and spread
- **Voice context building** extracts selected part IDs and names to send with the transcript so the AI assistant understands what "this" and "that" refer to
- **Presence throttling** at ~10 Hz balances smooth avatar motion with realtime channel bandwidth
- **Foveation set to 0** for crisp CAD edge rendering at near-field Vision Pro distances

https://claude.ai/code/session_01Fwh7n9A8vgqCVZyCm2Ys7o