### PR TITLE
fix(xr): disable post-processing while presenting

### DIFF
--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -1785,8 +1785,12 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         </>
       )}
 
-      {/* Post-processing effects - disabled during camera motion for FPS */}
-      {engineReady && !isCameraMoving && sceneSettings.postProcessing.ambientOcclusion?.enabled !== false && sceneSettings.postProcessing.vignette?.enabled !== false && (
+      {/* Post-processing effects - disabled during camera motion for FPS, and
+          while a WebXR session is active. EffectComposer renders to an
+          offscreen target and blits to the canvas, which doesn't write to the
+          XR layer's framebuffer — so in VR/AR the scene goes black and only
+          objects rendered directly by WebXRManager (hands, controllers) show. */}
+      {engineReady && !isCameraMoving && !xrPresenting && sceneSettings.postProcessing.ambientOcclusion?.enabled !== false && sceneSettings.postProcessing.vignette?.enabled !== false && (
         <EffectComposer>
           <N8AO
             aoRadius={sceneSettings.postProcessing.ambientOcclusion?.radius ?? 0.5}
@@ -1802,7 +1806,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         </EffectComposer>
       )}
       {/* AO only mode */}
-      {engineReady && !isCameraMoving && sceneSettings.postProcessing.ambientOcclusion?.enabled !== false && sceneSettings.postProcessing.vignette?.enabled === false && (
+      {engineReady && !isCameraMoving && !xrPresenting && sceneSettings.postProcessing.ambientOcclusion?.enabled !== false && sceneSettings.postProcessing.vignette?.enabled === false && (
         <EffectComposer>
           <N8AO
             aoRadius={sceneSettings.postProcessing.ambientOcclusion?.radius ?? 0.5}
@@ -1813,7 +1817,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         </EffectComposer>
       )}
       {/* Vignette only mode */}
-      {engineReady && !isCameraMoving && sceneSettings.postProcessing.ambientOcclusion?.enabled === false && sceneSettings.postProcessing.vignette?.enabled !== false && (
+      {engineReady && !isCameraMoving && !xrPresenting && sceneSettings.postProcessing.ambientOcclusion?.enabled === false && sceneSettings.postProcessing.vignette?.enabled !== false && (
         <EffectComposer>
           <Vignette
             offset={sceneSettings.postProcessing.vignette?.offset ?? 0.3}


### PR DESCRIPTION
## Summary
`EffectComposer` (N8AO + Vignette) renders to an offscreen target and blits to the canvas. That blit doesn't write into the WebXR layer's framebuffer, so during an `immersive-vr` / `immersive-ar` session the scene goes black and only objects rendered directly by `WebXRManager` (hands, controllers) appear.

This PR skips the `EffectComposer` blocks in [ViewportContent.tsx](packages/app/src/components/ViewportContent.tsx) when `xrPresenting` is true. Outside XR the post-processing is unchanged.

## Why
Reported symptom from a real headset right after [#173](https://github.com/ecto/vcad/pull/173) landed: \"when you enter VR, it's just all black except for your hands.\" That's the textbook signature of an offscreen-target post-processing pipeline running over the XR framebuffer.

## Test plan
- [ ] Enter VR / AR on a real headset — scene geometry, environment lighting, and grid all render normally; hands still visible.
- [ ] Exit XR — N8AO + Vignette come back on the desktop view (visually identical to before).