### PR TITLE
Add 13 advanced CAD modeling tasks (A5–A6 tier)

### DIFF
--- a/mecheval/tasks/a5-disc-hub-01.json
+++ b/mecheval/tasks/a5-disc-hub-01.json
@@ -1,0 +1,65 @@
+{
+  "id": "a5-disc-hub-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Flanged disc with raised central hub, bore, and bolt circle",
+  "prompt": "Make a flanged disc with a raised hub as a single solid. The outer flange is a cylinder of diameter 100mm and height 10mm, base on the XY plane (z = 0 to z = 10), centered on the Z axis. Concentric with the flange and sitting on top of it is a raised hub cylinder of diameter 40mm and height 20mm (z = 10 to z = 30). A central through-bore of diameter 18mm runs along the Z axis through the full combined height (z = 0 to z = 30). Six bolt holes of diameter 8mm, axes parallel to Z, pass through the flange only (z = 0 to z = 10), arranged on a bolt circle of diameter 75mm (radius 37.5mm) centered on the Z axis, evenly spaced every 60 degrees with the first hole on the +X axis: positions (37.5, 0), (18.75, 32.476), (-18.75, 32.476), (-37.5, 0), (-18.75, -32.476), (18.75, -32.476). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-50, -50, 0],
+      "max": [50, 50, 30],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 93022.56,
+      "center_of_mass": [0, 0, 8.23],
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 18.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 18.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 6,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [37.5, 0.0, 0],
+        [18.75, 32.476, 0],
+        [-18.75, 32.476, 0],
+        [-37.5, 0.0, 0],
+        [-18.75, -32.476, 0],
+        [18.75, -32.476, 0]
+      ],
+      "tolerance_mm": 0.3
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 50
+  },
+  "pass_k": 5,
+  "tags": ["disc", "hub", "bolt-circle", "central-bore", "flanged", "advanced"]
+}

--- a/mecheval/tasks/a5-double-d-shaft-01.json
+++ b/mecheval/tasks/a5-double-d-shaft-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a5-double-d-shaft-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Cylindrical shaft with two opposing flats (double-D profile)",
+  "prompt": "Make a double-D profile shaft as a single solid. Start with a cylinder of diameter 40mm (radius 20mm) and height 60mm, with its base on the XY plane (z = 0 to z = 60), centered on the Z axis. Mill a flat on each side by subtracting a rectangular block from the left and from the right. The left flat is at x = -14: subtract all material at x < -14 (i.e. remove the cylindrical segment from x = -20 to x = -14, running the full height z = 0 to z = 60 and the full cylinder width in Y). The right flat is at x = +14: subtract all material at x > 14. The result is a shaft with flat-to-flat width 28mm and circular arc sections of radius 20mm on the front and back (+Y and -Y sides). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-14, -20, 0],
+      "max": [14, 20, 60],
+      "tolerance_mm": 0.15
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 61214.28,
+      "center_of_mass": [0, 0, 30],
+      "tolerance_pct": 1.0
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["shaft", "double-d", "flat", "boolean", "machined"]
+}

--- a/mecheval/tasks/a5-hex-bolt-blank-01.json
+++ b/mecheval/tasks/a5-hex-bolt-blank-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a5-hex-bolt-blank-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Hex-head bolt blank (head + shank, no thread)",
+  "prompt": "Make a hex-head bolt blank as a single solid with no holes. The hexagonal head is a regular hexagonal prism with flat-to-flat distance 24mm and height 14mm, base on the XY plane (z = 0 to z = 14), centered on the Z axis, oriented so two flats are parallel to the X axis (flat-to-flat distance 24mm in the Y direction, so the head spans y in [-12, 12] and x in [-13.856, 13.856]). Directly above the head and concentric with it is a cylindrical shank of diameter 14mm and height 46mm (z = 14 to z = 60). The combined part is a single solid: hexagonal head at bottom, cylindrical shank extending upward. Output a single solid with no bores or holes.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-13.856, -12, 0],
+      "max": [13.856, 12, 60],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 14068.14,
+      "center_of_mass": [0, 0, 22.10],
+      "tolerance_pct": 1.5
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["bolt", "hex-head", "shank", "polygon", "machined"]
+}

--- a/mecheval/tasks/a5-hollow-cap-01.json
+++ b/mecheval/tasks/a5-hollow-cap-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a5-hollow-cap-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Hollow cylindrical cap with 8mm base wall",
+  "prompt": "Make a hollow cylindrical cap (like a cup or thimble) as a single solid. The outer body is a cylinder of diameter 60mm and height 50mm, base on the XY plane (z = 0 to z = 50), centered on the Z axis. The inside of the cap is hollow: subtract a coaxial inner cylinder of diameter 50mm and height 42mm that opens from the top (z = 8 to z = 50), leaving a solid base wall 8mm thick at the bottom (z = 0 to z = 8) and a cylindrical wall 5mm thick all around. The top is open. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-30, -30, 0],
+      "max": [30, 30, 50],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 58904.77,
+      "center_of_mass": [0, 0, 19.40],
+      "tolerance_pct": 1.0
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["hollow", "cap", "cup", "thin-wall", "blind-bore"]
+}

--- a/mecheval/tasks/a5-lightened-disc-01.json
+++ b/mecheval/tasks/a5-lightened-disc-01.json
@@ -1,0 +1,65 @@
+{
+  "id": "a5-lightened-disc-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Disc with central bore and six lightening holes",
+  "prompt": "Make a lightened disc as a single solid. The outer disc is a cylinder of diameter 120mm and height 15mm, base on the XY plane (z = 0 to z = 15), centered on the Z axis. Subtract a central through-bore of diameter 22mm along the Z axis. Subtract six through-holes of diameter 16mm, axes parallel to Z, arranged on a bolt circle of diameter 76mm (radius 38mm) centered on the Z axis, evenly spaced every 60 degrees with the first hole on the +X axis: positions (38, 0), (19, 32.909), (-19, 32.909), (-38, 0), (-19, -32.909), (19, -32.909). All holes pass through the full disc height (z = 0 to z = 15). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-60, -60, 0],
+      "max": [60, 60, 15],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 145848.66,
+      "center_of_mass": [0, 0, 7.5],
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 22.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 22.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 16.0,
+      "expected": 6,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 16.0,
+      "positions": [
+        [38.0, 0.0, 0],
+        [19.0, 32.909, 0],
+        [-19.0, 32.909, 0],
+        [-38.0, 0.0, 0],
+        [-19.0, -32.909, 0],
+        [19.0, -32.909, 0]
+      ],
+      "tolerance_mm": 0.3
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 50
+  },
+  "pass_k": 5,
+  "tags": ["disc", "lightening-holes", "bolt-circle", "central-bore", "advanced"]
+}

--- a/mecheval/tasks/a5-ribbed-plate-01.json
+++ b/mecheval/tasks/a5-ribbed-plate-01.json
@@ -1,0 +1,51 @@
+{
+  "id": "a5-ribbed-plate-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Plate with three longitudinal stiffening ribs and corner bolts",
+  "prompt": "Make a ribbed plate as a single solid. The top plate is 120mm × 80mm × 10mm with its bottom face at z = 10 and top face at z = 20, centered in X and Y (x in [-60, 60], y in [-40, 40]). Three stiffening ribs run along the full length of the plate (along X) on the underside: each rib is 120mm long × 8mm wide × 10mm tall (z = 0 to z = 10). Rib A is centered at y = -24: it spans x in [-60, 60], y in [-28, -20], z in [0, 10]. Rib B is centered at y = 0: it spans x in [-60, 60], y in [-4, 4], z in [0, 10]. Rib C is centered at y = 24: it spans x in [-60, 60], y in [20, 28], z in [0, 10]. Four bolt holes of diameter 8mm, axes parallel to Z, pass through the entire assembly height (z = 0 to z = 20), located at the four corners: (45, 30), (-45, 30), (-45, -30), (45, -30). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-60, -40, 0],
+      "max": [60, 40, 20],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 120778.76,
+      "center_of_mass": [0, 0, 12.78],
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [45.0, 30.0, 0],
+        [-45.0, 30.0, 0],
+        [-45.0, -30.0, 0],
+        [45.0, -30.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["plate", "ribs", "stiffener", "boolean", "structural"]
+}

--- a/mecheval/tasks/a5-stepped-boss-plate-01.json
+++ b/mecheval/tasks/a5-stepped-boss-plate-01.json
@@ -1,0 +1,63 @@
+{
+  "id": "a5-stepped-boss-plate-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "Rectangular plate with raised central boss and through features",
+  "prompt": "Make a stepped boss plate as a single solid. The base is a rectangular plate 80mm × 60mm × 10mm, centered in X and Y with its bottom face on the XY plane (x in [-40, 40], y in [-30, 30], z in [0, 10]). Centered on top of the base plate sits a rectangular boss 40mm × 30mm × 8mm (x in [-20, 20], y in [-15, 15], z in [10, 18]). A central through-bore of diameter 18mm, axis parallel to Z, passes through the entire assembly from bottom to top (z = 0 to z = 18), centered at the origin. Four corner bolt holes of diameter 6mm, axes parallel to Z, pass through the base plate only (z = 0 to z = 10), located at (28, 22), (-28, 22), (-28, -22), (28, -22). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -30, 0],
+      "max": [40, 30, 18],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 51888.59,
+      "center_of_mass": [0, 0, 6.31],
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 18.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 18.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 6.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 6.0,
+      "positions": [
+        [28.0, 22.0, 0],
+        [-28.0, 22.0, 0],
+        [-28.0, -22.0, 0],
+        [28.0, -22.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 50
+  },
+  "pass_k": 5,
+  "tags": ["plate", "boss", "stepped", "multi-diameter", "boolean", "advanced"]
+}

--- a/mecheval/tasks/a5-u-bracket-01.json
+++ b/mecheval/tasks/a5-u-bracket-01.json
@@ -1,0 +1,46 @@
+{
+  "id": "a5-u-bracket-01",
+  "suite": "A",
+  "tier": "A5",
+  "title": "U-channel bracket with mounting holes",
+  "prompt": "Make a U-channel bracket as a single solid. The base is a rectangular plate 100mm × 30mm × 8mm with its bottom face on the XY plane, centered in X and Y (so it spans x in [-50, 50], y in [-15, 15], z in [0, 8]). From the left end of the base, a vertical leg rises: 8mm × 30mm × 35mm, at x in [-50, -42], y in [-15, 15], z in [8, 43]. A matching vertical leg rises from the right end: 8mm × 30mm × 35mm, at x in [42, 50], y in [-15, 15], z in [8, 43]. Drill two through-holes of diameter 6mm, axes parallel to Z, through the base only (z = 0 to z = 8), centered at (-25, 0) and (25, 0). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-50, -15, 0],
+      "max": [50, 15, 43],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 40347.61,
+      "center_of_mass": [0, 0, 12.95],
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 6.0,
+      "expected": 2,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 6.0,
+      "positions": [[-25.0, 0.0, 0], [25.0, 0.0, 0]],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["u-bracket", "channel", "legs", "boolean", "mounting-holes"]
+}

--- a/mecheval/tasks/a6-compound-bore-ring-01.json
+++ b/mecheval/tasks/a6-compound-bore-ring-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a6-compound-bore-ring-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Thick ring with stepped counterbore from each end",
+  "prompt": "Make a stepped-bore ring as a single solid. The outer body is a cylinder of diameter 80mm and height 50mm, base on the XY plane (z = 0 to z = 50), centered on the Z axis. From the bottom face, subtract a coaxial blind bore of diameter 30mm that extends 25mm deep (z = 0 to z = 25). From the top face, subtract a coaxial blind bore of diameter 50mm that extends 25mm deep (z = 25 to z = 50). The two bores meet exactly at z = 25, forming a stepped interior: a narrow (30mm) chamber below and a wide (50mm) chamber above, connected at the mid-plane. The outer wall is 25mm thick at the bottom half and 15mm thick at the top half. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -40, 0],
+      "max": [40, 40, 50],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 184568.57,
+      "center_of_mass": [0, 0, 22.87],
+      "tolerance_pct": 1.0
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 40000,
+    "max_wallclock_sec": 240,
+    "max_tool_calls": 40
+  },
+  "pass_k": 5,
+  "tags": ["ring", "stepped-bore", "counterbore", "blind-bore", "advanced"]
+}

--- a/mecheval/tasks/a6-compound-boss-01.json
+++ b/mecheval/tasks/a6-compound-boss-01.json
@@ -1,0 +1,63 @@
+{
+  "id": "a6-compound-boss-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Rectangular base with two raised cylindrical bosses, dual bores, and corner holes",
+  "prompt": "Make a compound boss plate as a single solid. The base is a rectangular plate 120mm × 80mm × 15mm, centered in X and Y with its bottom face on the XY plane (x in [-60, 60], y in [-40, 40], z in [0, 15]). Two cylindrical bosses of diameter 30mm and height 20mm rise from the top face of the base plate: the left boss is centered at (-30, 0) and spans z in [15, 35]; the right boss is centered at (30, 0) and spans z in [15, 35]. Through each boss and through the base plate below it, drill a coaxial through-bore of diameter 16mm along the Z axis: the left bore is centered at (-30, 0) and passes through z in [0, 35]; the right bore is centered at (30, 0) and passes through z in [0, 35]. Four corner bolt holes of diameter 8mm, axes parallel to Z, pass through the base plate only (z = 0 to z = 15), at positions (50, 30), (-50, 30), (-50, -30), (50, -30). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-60, -40, 0],
+      "max": [60, 40, 35],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 155184.95,
+      "center_of_mass": [0, 0, 9.78],
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 16.0,
+      "expected": 2,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 16.0,
+      "positions": [[-30.0, 0.0, 0], [30.0, 0.0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [50.0, 30.0, 0],
+        [-50.0, 30.0, 0],
+        [-50.0, -30.0, 0],
+        [50.0, -30.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 50000,
+    "max_wallclock_sec": 300,
+    "max_tool_calls": 60
+  },
+  "pass_k": 5,
+  "tags": ["compound", "boss", "dual-bore", "rectangular-base", "bolt-holes", "advanced"]
+}

--- a/mecheval/tasks/a6-motor-flange-01.json
+++ b/mecheval/tasks/a6-motor-flange-01.json
@@ -1,0 +1,63 @@
+{
+  "id": "a6-motor-flange-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Motor mounting flange with register boss, central shaft bore, and bolt pattern",
+  "prompt": "Make a motor mounting flange as a single solid. The main flange is a disc of diameter 120mm and thickness 12mm, base on the XY plane (z = 0 to z = 12), centered on the Z axis. On top of the flange sits a coaxial register boss (spigot) of diameter 72mm and height 6mm (z = 12 to z = 18); this raised boss is used for accurate pilot location. A central through-bore of diameter 32mm runs along the Z axis through both the flange and the register boss (z = 0 to z = 18). Four mounting bolt holes of diameter 9mm, axes parallel to Z, pass through the flange only (z = 0 to z = 12), arranged on a bolt circle of diameter 96mm (radius 48mm) centered on the Z axis at 90-degree intervals: (48, 0), (0, 48), (-48, 0), (0, -48). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-60, -60, 0],
+      "max": [60, 60, 18],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 142616.81,
+      "center_of_mass": [0, 0, 7.24],
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 32.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.15
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 32.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 9.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 9.0,
+      "positions": [
+        [48.0, 0.0, 0],
+        [0.0, 48.0, 0],
+        [-48.0, 0.0, 0],
+        [0.0, -48.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 50000,
+    "max_wallclock_sec": 300,
+    "max_tool_calls": 60
+  },
+  "pass_k": 5,
+  "tags": ["motor", "flange", "register", "boss", "bolt-circle", "central-bore", "advanced"]
+}

--- a/mecheval/tasks/a6-pulley-01.json
+++ b/mecheval/tasks/a6-pulley-01.json
@@ -1,0 +1,46 @@
+{
+  "id": "a6-pulley-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Flanged belt pulley with narrow groove section and central bore",
+  "prompt": "Make a flanged belt pulley as a single solid. The pulley has three coaxial sections stacked along Z, all centered on the Z axis, with the base on the XY plane. Bottom flange: a cylinder of diameter 80mm and height 8mm (z = 0 to z = 8). Belt groove section: a cylinder of diameter 50mm and height 24mm (z = 8 to z = 32). Top flange: a cylinder of diameter 80mm and height 8mm (z = 32 to z = 40). A central through-bore of diameter 16mm runs along the Z axis through the full height (z = 0 to z = 40). The three outer sections form the stepped outer profile of the pulley when unioned together; the belt rides in the groove between the two flanges. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -40, 0],
+      "max": [40, 40, 40],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 119506.19,
+      "center_of_mass": [0, 0, 20.0],
+      "tolerance_pct": 1.0
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 16.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 16.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.0 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 50000,
+    "max_wallclock_sec": 300,
+    "max_tool_calls": 60
+  },
+  "pass_k": 5,
+  "tags": ["pulley", "flanged", "belt-groove", "stepped-cylinder", "central-bore", "advanced"]
+}

--- a/mecheval/tasks/a6-sprocket-blank-01.json
+++ b/mecheval/tasks/a6-sprocket-blank-01.json
@@ -1,0 +1,62 @@
+{
+  "id": "a6-sprocket-blank-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Sprocket blank: disc, raised hub, keyway, central bore, and 4-bolt circle",
+  "prompt": "Make a sprocket blank as a single solid. The main disc is a cylinder of diameter 100mm and height 20mm, base on the XY plane (z = 0 to z = 20), centered on the Z axis. Concentric with the disc and sitting on top of it is a raised hub cylinder of diameter 40mm and height 20mm (z = 20 to z = 40). A central through-bore of diameter 20mm runs along the Z axis through the full height (z = 0 to z = 40). Cut a rectangular keyway slot through the entire height: the keyway is 6mm wide (x in [-3, 3]) and 6mm deep, starting at the bore wall and extending radially outward to y = 16 (so y in [10, 16], x in [-3, 3], z in [0, 40]). Four bolt holes of diameter 8mm, axes parallel to Z, pass through the disc only (z = 0 to z = 20), arranged on a bolt circle of diameter 70mm (radius 35mm) centered on the Z axis at 90-degree intervals: (35, 0), (0, 35), (-35, 0), (0, -35). Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-50, -50, 0],
+      "max": [50, 50, 40],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 164184.76,
+      "tolerance_pct": 1.5
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 20.0,
+      "expected": 1,
+      "diameter_tolerance_mm": 0.1
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 20.0,
+      "positions": [[0, 0, 0]],
+      "tolerance_mm": 0.2
+    },
+    {
+      "type": "hole_count",
+      "diameter_mm": 8.0,
+      "expected": 4,
+      "diameter_tolerance_mm": 0.05
+    },
+    {
+      "type": "hole_positions",
+      "diameter_mm": 8.0,
+      "positions": [
+        [35.0, 0.0, 0],
+        [0.0, 35.0, 0],
+        [-35.0, 0.0, 0],
+        [0.0, -35.0, 0]
+      ],
+      "tolerance_mm": 0.2
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 50000,
+    "max_wallclock_sec": 300,
+    "max_tool_calls": 60
+  },
+  "pass_k": 5,
+  "tags": ["sprocket", "hub", "keyway", "bolt-circle", "central-bore", "disc", "advanced"]
+}

--- a/mecheval/tasks/a6-yoke-block-01.json
+++ b/mecheval/tasks/a6-yoke-block-01.json
@@ -1,0 +1,34 @@
+{
+  "id": "a6-yoke-block-01",
+  "suite": "A",
+  "tier": "A6",
+  "title": "Fork yoke with cross-bore through both tines",
+  "prompt": "Make a fork yoke as a single solid. The base block is 80mm × 40mm × 12mm, centered in X and Y with its bottom face on the XY plane (x in [-40, 40], y in [-20, 20], z in [0, 12]). Two vertical tines (fork arms) rise from the base. The left tine is 14mm × 40mm × 45mm at x in [-40, -26], y in [-20, 20], z in [12, 57]. The right tine is 14mm × 40mm × 45mm at x in [26, 40], y in [-20, 20], z in [12, 57]. The gap between the tines (x in [-26, 26]) is open. Through both tines, drill a coaxial cross-bore of diameter 18mm whose axis is parallel to X, centered at y = 0, z = 44.5, passing through the left tine (x in [-40, -26]) and the right tine (x in [26, 40]). The cross-bore removes a cylindrical channel of diameter 18mm from each tine; the open gap between the tines is unaffected. Output a single solid.",
+  "inputs": [],
+  "checks": [
+    { "type": "valid_solid" },
+    {
+      "type": "bbox",
+      "min": [-40, -20, 0],
+      "max": [40, 20, 57],
+      "tolerance_mm": 0.1
+    },
+    {
+      "type": "mass_props",
+      "volume_mm3": 81674.78,
+      "center_of_mass": [0, 0, 20.23],
+      "tolerance_pct": 1.5
+    },
+    { "type": "step_roundtrip", "tolerance_pct": 1.5 }
+  ],
+  "anti_cheese": {
+    "max_solid_count": 1
+  },
+  "limits": {
+    "max_tokens": 50000,
+    "max_wallclock_sec": 300,
+    "max_tool_calls": 60
+  },
+  "pass_k": 5,
+  "tags": ["yoke", "fork", "tine", "cross-bore", "pin-hole", "advanced"]
+}


### PR DESCRIPTION
## Summary
This PR adds 13 new advanced CAD modeling tasks to the mecheval benchmark suite, spanning tiers A5 and A6. These tasks cover a range of mechanical engineering features including flanged discs, lightened components, stepped bosses, compound assemblies, and specialized parts like pulleys and sprockets.

## Tasks Added

**Tier A5 (7 tasks):**
- `a5-disc-hub-01`: Flanged disc with raised central hub, central bore, and 6-bolt circle
- `a5-lightened-disc-01`: Disc with central bore and six lightening holes
- `a5-stepped-boss-plate-01`: Rectangular plate with raised central boss and through features
- `a5-ribbed-plate-01`: Plate with three longitudinal stiffening ribs and corner bolts
- `a5-u-bracket-01`: U-channel bracket with mounting holes
- `a5-double-d-shaft-01`: Cylindrical shaft with two opposing flats (double-D profile)
- `a5-hex-bolt-blank-01`: Hex-head bolt blank (head + shank, no thread)
- `a5-hollow-cap-01`: Hollow cylindrical cap with 8mm base wall

**Tier A6 (5 tasks):**
- `a6-compound-boss-01`: Rectangular base with two raised cylindrical bosses and dual bores
- `a6-motor-flange-01`: Motor mounting flange with register boss and bolt pattern
- `a6-sprocket-blank-01`: Sprocket blank with disc, raised hub, keyway, and 4-bolt circle
- `a6-pulley-01`: Flanged belt pulley with narrow groove section and central bore
- `a6-compound-bore-ring-01`: Thick ring with stepped counterbore from each end
- `a6-yoke-block-01`: Fork yoke with cross-bore through both tines

## Key Features
- **Comprehensive validation**: Each task includes detailed geometric checks (bounding box, mass properties, hole detection and positioning)
- **Realistic engineering scenarios**: Tasks model common mechanical components (flanges, bosses, pulleys, brackets, yokes)
- **Progressive complexity**: A5 tasks focus on single features or simple combinations; A6 tasks introduce compound geometries and multi-axis features
- **Strict anti-cheesing**: All tasks enforce `max_solid_count: 1` to ensure proper boolean operations and single-solid output
- **Generous resource limits**: A5 tasks allow up to 40,000 tokens and 50 tool calls; A6 tasks allow up to 50,000 tokens and 60 tool calls

## Notable Implementation Details
- Tasks use precise geometric specifications (e.g., bolt circle positions calculated to 3 decimal places)
- Hole detection checks validate both diameter and position with tight tolerances (0.05–0.3 mm)
- Mass properties and center-of-mass calculations are pre-computed with 1.0–1.5% tolerance bands
- STEP roundtrip validation ensures CAD model persistence and format compatibility
- Keyway and cross-bore features test advanced boolean subtraction operations

https://claude.ai/code/session_017FkXxRjwdnXmGp91TVY8pe