### PR TITLE
Fix sheet corner border positioning and styling

### DIFF
--- a/mecheval/leaderboard/src/build.ts
+++ b/mecheval/leaderboard/src/build.ts
@@ -266,10 +266,10 @@ const STYLES = `
     background: var(--ground);
     padding: 0 4px;
   }
-  .sheet::before { content: "┌"; top: -10px; left: -1px; }
-  .sheet::after  { content: "┐"; top: -10px; right: -1px; }
-  .sheet .corner-bl { content: "└"; bottom: -10px; left: -1px; }
-  .sheet .corner-br { content: "┘"; bottom: -10px; right: -1px; }
+  .sheet::before { content: "┌"; top: -9px; left: -10px; }
+  .sheet::after  { content: "┐"; top: -9px; right: -10px; }
+  .sheet .corner-bl { bottom: -9px; left: -10px; }
+  .sheet .corner-br { bottom: -9px; right: -10px; }
 
   .crumb { color: var(--ink-soft); font-size: 11px; margin: 0 0 18px 0; letter-spacing: 0.04em; }
   .crumb a { color: var(--ink); }


### PR DESCRIPTION
## Summary
Adjusted the positioning and styling of the sheet corner borders to improve visual alignment and consistency.

## Key Changes
- Updated vertical positioning of top corners (`.sheet::before` and `.sheet::after`) from `top: -10px` to `top: -9px`
- Updated horizontal positioning of all corners from `±1px` to `±10px` for consistent offset
- Removed `content` property from bottom corner selectors (`.corner-bl` and `.corner-br`) as it was invalid for non-pseudo-elements
- Updated vertical positioning of bottom corners from `bottom: -10px` to `bottom: -9px`

## Implementation Details
The changes normalize the corner border positioning to use consistent `-9px` vertical offset and `-10px` horizontal offset across all four corners. The removal of the `content` property from the bottom corner classes suggests these elements rely on their HTML content rather than CSS-generated content.

https://claude.ai/code/session_01A7yh22bp9YqwdmTdbMfXee