### PR TITLE
Support ray tracing of assembly instances with transforms

### DIFF
--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -102,7 +102,9 @@ export function RayTracedViewportSync() {
       return;
     }
 
-    if (!solidScene.parts?.length) {
+    const hasParts = (solidScene.parts?.length ?? 0) > 0;
+    const hasInstances = (solidScene.instances?.length ?? 0) > 0;
+    if (!hasParts && !hasInstances) {
       uploadedRef.current = false;
       return;
     }
@@ -113,6 +115,11 @@ export function RayTracedViewportSync() {
     //
     // All calls go through queueWasm so they can't race with an in-flight
     // render() and trip wasm-bindgen's recursive-use guard.
+    type SolidHandle = {
+      scale: (x: number, y: number, z: number) => SolidHandle;
+      rotate: (x_deg: number, y_deg: number, z_deg: number) => SolidHandle;
+      translate: (x: number, y: number, z: number) => SolidHandle;
+    };
     const rt = rayTracer as {
       clearScene?: () => void;
       uploadSolid: (s: unknown) => void;
@@ -122,7 +129,9 @@ export function RayTracedViewportSync() {
 
     let uploaded = false;
     let firstMaterialKey: string | undefined;
-    for (const p of solidScene.parts) {
+
+    // Top-level parts (non-assembly docs, or root-level parts in mixed docs).
+    for (const p of solidScene.parts ?? []) {
       const solid = (p as { solid?: unknown }).solid;
       if (!solid) continue;
 
@@ -131,6 +140,37 @@ export function RayTracedViewportSync() {
       });
       if (firstMaterialKey === undefined) firstMaterialKey = p.material;
       uploaded = true;
+    }
+
+    // Assembly instances. Each instance references a partDef by id; we
+    // transform the partDef's solid by the instance's world transform
+    // (translate ∘ rotate ∘ scale, matching the Three.js TRS path used by
+    // the tessellated renderer in `SceneMesh.tsx`) and upload one merged
+    // copy per instance. Re-using the partDef solid is safe — translate/
+    // rotate/scale return *new* solids without mutating the original.
+    if (hasInstances && solidScene.partDefs?.length) {
+      const partDefSolids = new Map<string, SolidHandle>();
+      for (const pd of solidScene.partDefs) {
+        const s = (pd as { solid?: unknown }).solid as SolidHandle | undefined;
+        if (s) partDefSolids.set(pd.id, s);
+      }
+
+      for (const inst of solidScene.instances ?? []) {
+        const baseSolid = partDefSolids.get(inst.partDefId);
+        if (!baseSolid) continue;
+        const tf = inst.transform;
+        const placed = tf
+          ? baseSolid
+              .scale(tf.scale.x, tf.scale.y, tf.scale.z)
+              .rotate(tf.rotation.x, tf.rotation.y, tf.rotation.z)
+              .translate(tf.translation.x, tf.translation.y, tf.translation.z)
+          : baseSolid;
+        queueWasm(() => rt.uploadSolid(placed)).catch((e) => {
+          logger.debug("gpu", `uploadSolid (instance) failed: ${e}`);
+        });
+        if (firstMaterialKey === undefined) firstMaterialKey = inst.material;
+        uploaded = true;
+      }
     }
 
     // Apply material — document overrides take precedence, fall back to preset library.

--- a/packages/engine/src/evaluate.ts
+++ b/packages/engine/src/evaluate.ts
@@ -513,7 +513,7 @@ export function evaluateDocumentTS(
         const solid = evaluateNode(partDef.root, doc.nodes, Solid, cache, 0);
         const mesh = solidToMesh(solid);
         partDefMeshes.set(id, mesh);
-        evaluatedPartDefs.push({ id, mesh });
+        evaluatedPartDefs.push({ id, mesh, solid });
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         failures.push({ scope: `partDef[${JSON.stringify(id)}]`, node_id: partDef.root, error: msg });

--- a/packages/engine/src/mesh.ts
+++ b/packages/engine/src/mesh.ts
@@ -26,6 +26,11 @@ export interface EvaluatedPart {
 export interface EvaluatedPartDef {
   id: string;
   mesh: TriangleMesh;
+  /** Optional BRep solid handle (only set on the main-thread TS evaluator
+   *  via `evaluateWithSolids` — used by direct-BRep ray tracing to upload
+   *  per-instance geometry). Worker-evaluated scenes don't carry handles. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  solid?: any;
 }
 
 /** An instance of a part definition with transform and material. */


### PR DESCRIPTION
## Summary
This PR extends the ray-traced viewport to support rendering assembly instances with their world transforms, enabling direct BRep ray tracing of assemblies in addition to flat part documents.

## Key Changes

- **RayTracedViewport.tsx**: 
  - Added check for both `solidScene.parts` and `solidScene.instances` to determine if there's geometry to render
  - Added `SolidHandle` type definition for the WASM solid API (scale, rotate, translate methods)
  - Implemented instance rendering loop that transforms each instance's base solid by its world transform (scale → rotate → translate, matching Three.js TRS order)
  - Each instance's transformed solid is uploaded separately to the ray tracer
  - Material assignment falls back to instance material if available

- **mesh.ts**:
  - Added optional `solid` field to `EvaluatedPartDef` interface to carry BRep solid handles from the main-thread evaluator
  - Documented that worker-evaluated scenes don't include solid handles

- **evaluate.ts**:
  - Modified `evaluateDocumentTS` to include the evaluated solid in `EvaluatedPartDef` objects, enabling downstream ray tracing to access the geometry

## Implementation Details

The instance rendering reuses the base part definition's solid without mutation—the transform methods (scale, rotate, translate) return new solids, allowing safe per-instance transformation. This approach mirrors the tessellated renderer's transform handling in `SceneMesh.tsx`.

https://claude.ai/code/session_01Pim5fb7Bn4zQkuDGdrDMLi