### PR TITLE
Fix FPS spike when tab visibility resumes in perf monitor

### DIFF
--- a/packages/app/src/components/footer/usePerfMonitor.ts
+++ b/packages/app/src/components/footer/usePerfMonitor.ts
@@ -57,6 +57,11 @@ export function usePerfMonitor(): PerfSnapshot {
     let smoothedFps = 60;
     let smoothedMs = 16.67;
     let longTasks = 0;
+    // After the tab is hidden, rAF pauses and the queue can flush several
+    // callbacks back-to-back on return, producing dt ≈ 0 and an FPS spike
+    // into the millions. Skip the delta on the first frame after visibility
+    // resumes so smoothing isn't poisoned.
+    let resetTiming = false;
     const fpsSamples: number[] = [];
     const frameMsSamples: number[] = [];
     const heapSamples: number[] = [];
@@ -78,6 +83,13 @@ export function usePerfMonitor(): PerfSnapshot {
 
     const step = (now: number) => {
       if (cancelled) return;
+      if (resetTiming) {
+        resetTiming = false;
+        lastFrame = now;
+        lastEmit = now;
+        raf = requestAnimationFrame(step);
+        return;
+      }
       const dt = Math.max(0.001, now - lastFrame);
       lastFrame = now;
       const instFps = 1000 / dt;
@@ -116,11 +128,17 @@ export function usePerfMonitor(): PerfSnapshot {
       raf = requestAnimationFrame(step);
     };
 
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") resetTiming = true;
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
     raf = requestAnimationFrame(step);
     return () => {
       cancelled = true;
       cancelAnimationFrame(raf);
       observer?.disconnect();
+      document.removeEventListener("visibilitychange", onVisibility);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
Fixed a performance monitoring issue where resuming a hidden tab would cause an FPS spike due to requestAnimationFrame callbacks queuing up while the tab was hidden.

## Key Changes
- Added `resetTiming` flag to track when tab visibility resumes
- Added `visibilitychange` event listener that sets the flag when the tab becomes visible again
- Modified the `step` function to skip delta time calculation on the first frame after visibility resumes, preventing the FPS spike caused by back-to-back queued callbacks with near-zero delta times
- Properly clean up the event listener in the cleanup function

## Implementation Details
When a tab is hidden, `requestAnimationFrame` pauses execution. Upon returning to the tab, multiple queued callbacks can execute back-to-back with very small time deltas (≈ 0ms), which would cause the FPS calculation to spike into the millions and poison the smoothed FPS metric. By detecting visibility changes and resetting the timing reference on the first frame after resumption, we avoid this anomaly while maintaining accurate metrics during normal operation.

https://claude.ai/code/session_01AYigxwZJNJpmFaNSFwiAJ4