### PR TITLE
Update CSP headers to allow blob scripts and additional external services

### DIFF
--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://yteuhwciuxcbjwmabawj.supabase.co wss://yteuhwciuxcbjwmabawj.supabase.co https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://yteuhwciuxcbjwmabawj.supabase.co wss://yteuhwciuxcbjwmabawj.supabase.co https://db.vcad.io wss://db.vcad.io https://github.com https://*.githubusercontent.com https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },

--- a/vercel.json
+++ b/vercel.json
@@ -16,7 +16,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://yteuhwciuxcbjwmabawj.supabase.co wss://yteuhwciuxcbjwmabawj.supabase.co https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' blob: https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://yteuhwciuxcbjwmabawj.supabase.co wss://yteuhwciuxcbjwmabawj.supabase.co https://db.vcad.io wss://db.vcad.io https://github.com https://*.githubusercontent.com https://*.vercel-insights.com https://*.vercel-analytics.com https://us.i.posthog.com https://us-assets.i.posthog.com; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; form-action 'self'"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## Summary
Updated Content Security Policy (CSP) headers in both root and app-level Vercel configuration files to support new functionality and external service integrations.

## Key Changes
- **script-src directive**: Added `blob:` to allow scripts loaded from blob URLs (needed for dynamic script generation or worker-related functionality)
- **connect-src directive**: Expanded to include:
  - `https://db.vcad.io` and `wss://db.vcad.io` (new database service)
  - `https://github.com` and `https://*.githubusercontent.com` (GitHub API and asset access)

## Details
These changes were applied consistently to both:
- `packages/app/vercel.json`
- `vercel.json` (root configuration)

The CSP updates enable the application to:
1. Execute dynamically generated scripts from blob sources
2. Connect to a new database service at db.vcad.io
3. Integrate with GitHub for API calls and asset loading from GitHub's CDN

https://claude.ai/code/session_01UqxUGaDvJkQucivVNqWJcF