### PR TITLE
feat(mecheval): bump phyz to 0.3.1, tighten F-suite physics thresholds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tang",
 ]

--- a/mecheval/graders/Cargo.toml
+++ b/mecheval/graders/Cargo.toml
@@ -18,7 +18,7 @@ vcad-kernel-geom = { workspace = true }
 vcad-kernel-topo = { workspace = true }
 vcad-kernel-physics = { workspace = true }
 vcad-kernel-dfm = { workspace = true }
-phyz = { path = "../../../phyz/crates/phyz", version = "0.3" }
+phyz = { path = "../../../phyz/crates/phyz", version = "0.3.1" }
 
 [[bin]]
 name = "mecheval-grade"

--- a/mecheval/tasks/f2-collar-shaft-axial-01.json
+++ b/mecheval/tasks/f2-collar-shaft-axial-01.json
@@ -3,7 +3,7 @@
   "suite": "F",
   "tier": "F2",
   "title": "Axial gravity hold on a flanged shaft",
-  "prompt": "Reference images of a stepped shaft are attached. The shaft has two coaxial flanges separated by a narrower middle waist. Gravity acts downward along -Z, pulling a tube collar that slides over the waist toward the bottom flange. Design the collar so it sits on the waist between the flanges; the bottom flange should arrest its slide.\n\nRequirements:\n- Single solid, single-root .vcad.\n- The collar's bore must clear the 20mm waist with 0.1–0.3mm radial clearance.\n- The collar's outer diameter must not exceed the flange OD (40mm).\n- The collar's length must be 25–30mm (it sits in the 30mm gap, gravity rests it on the bottom flange).\n- Wall thickness ≥ 1.5mm.\n\nOutput the collar in the host's coordinate frame: shaft axis +Z, bottom flange's bottom face at z = 0, waist runs z = 10 to z = 40. Place the collar centred over the waist so it starts in contact with (or just above) the bottom flange.",
+  "prompt": "Reference images of a stepped shaft are attached. The shaft has two coaxial flanges separated by a narrower middle waist. Gravity acts downward along -Z, pulling a tube collar that slides over the waist toward the bottom flange. Design the collar so it sits on the waist between the flanges; the bottom flange should arrest its slide.\n\nRequirements:\n- Single solid, single-root .vcad.\n- The collar's bore must clear the 20mm waist with 0.1\u20130.3mm radial clearance.\n- The collar's outer diameter must not exceed the flange OD (40mm).\n- The collar's length must be 25\u201330mm (it sits in the 30mm gap, gravity rests it on the bottom flange).\n- Wall thickness \u2265 1.5mm.\n\nOutput the collar in the host's coordinate frame: shaft axis +Z, bottom flange's bottom face at z = 0, waist runs z = 10 to z = 40. Place the collar centred over the waist so it starts in contact with (or just above) the bottom flange.",
   "inputs": [
     {
       "kind": "reference_image",
@@ -11,7 +11,10 @@
       "agent_visible": true,
       "view": "front",
       "image_kind": "photo",
-      "scale_fiducial": { "type": "aruco_4x4_50mm", "marker_id": 0 }
+      "scale_fiducial": {
+        "type": "aruco_4x4_50mm",
+        "marker_id": 0
+      }
     },
     {
       "kind": "reference_image",
@@ -19,7 +22,10 @@
       "agent_visible": true,
       "view": "side",
       "image_kind": "photo",
-      "scale_fiducial": { "type": "aruco_4x4_50mm", "marker_id": 0 }
+      "scale_fiducial": {
+        "type": "aruco_4x4_50mm",
+        "marker_id": 0
+      }
     },
     {
       "kind": "reference_image",
@@ -27,13 +33,27 @@
       "agent_visible": true,
       "view": "top",
       "image_kind": "photo",
-      "scale_fiducial": { "type": "aruco_4x4_50mm", "marker_id": 0 }
+      "scale_fiducial": {
+        "type": "aruco_4x4_50mm",
+        "marker_id": 0
+      }
     },
     {
       "kind": "host_geometry",
       "path": "assets/f2-collar-shaft-axial-01/host.vcad",
       "agent_visible": false,
-      "frame": { "origin": [0, 0, 0], "axis": [0, 0, 1] }
+      "frame": {
+        "origin": [
+          0,
+          0,
+          0
+        ],
+        "axis": [
+          0,
+          0,
+          1
+        ]
+      }
     },
     {
       "kind": "known_dimensions",
@@ -42,7 +62,9 @@
     }
   ],
   "checks": [
-    { "type": "valid_solid" },
+    {
+      "type": "valid_solid"
+    },
     {
       "type": "interference_volume",
       "host": "host_geometry",
@@ -56,7 +78,11 @@
     },
     {
       "type": "envelope",
-      "max_mm": [40.5, 40.5, 30.5]
+      "max_mm": [
+        40.5,
+        40.5,
+        30.5
+      ]
     },
     {
       "type": "mate_clearance",
@@ -68,13 +94,20 @@
       "type": "gravity_hold",
       "host": "host_geometry",
       "host_mass_kg": 1.0,
-      "gravity_dir": [0, 0, -1],
+      "gravity_dir": [
+        0,
+        0,
+        -1
+      ],
       "duration_sec": 0.5,
       "max_drift_mm": 50.0
     },
     {
       "type": "dfm",
-      "rules": ["min_wall_1.5mm", "no_undercut"]
+      "rules": [
+        "min_wall_1.5mm",
+        "no_undercut"
+      ]
     }
   ],
   "anti_cheese": {
@@ -87,5 +120,12 @@
     "max_tool_calls": 60
   },
   "pass_k": 5,
-  "tags": ["fit", "collar", "axisymmetric", "image-conditioned", "gravity-hold", "physics"]
+  "tags": [
+    "fit",
+    "collar",
+    "axisymmetric",
+    "image-conditioned",
+    "gravity-hold",
+    "physics"
+  ]
 }

--- a/mecheval/tasks/f2-plug-port-tilted-01.json
+++ b/mecheval/tasks/f2-plug-port-tilted-01.json
@@ -100,7 +100,7 @@
         -0.866
       ],
       "duration_sec": 0.5,
-      "max_drift_mm": 100000.0
+      "max_drift_mm": 2000.0
     },
     {
       "type": "dfm",

--- a/mecheval/tasks/f2-shim-gap-tilted-01.json
+++ b/mecheval/tasks/f2-shim-gap-tilted-01.json
@@ -100,7 +100,7 @@
         -0.866
       ],
       "duration_sec": 0.5,
-      "max_drift_mm": 100000.0
+      "max_drift_mm": 2000.0
     },
     {
       "type": "dfm",

--- a/mecheval/tasks/f3-cap-snap-bottle-01.json
+++ b/mecheval/tasks/f3-cap-snap-bottle-01.json
@@ -96,18 +96,6 @@
       "min_interference_gain_mm3": 15.0
     },
     {
-      "type": "pull_force",
-      "host": "host_geometry",
-      "force_n": 5.0,
-      "direction": [
-        0,
-        0,
-        1
-      ],
-      "duration_sec": 0.25,
-      "max_drift_mm": 100000.0
-    },
-    {
       "type": "dfm",
       "rules": [
         "min_wall_1.5mm",


### PR DESCRIPTION
Bumps `mecheval-grader`'s phyz pin from 0.3 → 0.3.1 (the EPA-determinism
fix) and tightens F2/F3 physics-check thresholds where 0.3.1's behaviour
actually allows it.

## What's different on 0.3.1

Across 3 sequential runs (was 8/10 deterministic before, now 10/10):

| Task | Threshold | Drift (consistent across runs) | Note |
|---|---|---|---|
| f2-collar-shaft-axial-01 | **50mm** | ~21mm | Showcase — clean axial settling |
| f2-shim-gap-tilted-01 | 2000mm | ~1153mm | Tilted gravity slides; physics doesn't catch multi-axis constraint |
| f2-plug-port-tilted-01 | 2000mm | ~1191mm | Same |
| f2-spacer-shaft-sideways-01 | *(dropped)* | EPA panic in ~1/3 runs | Still nondeterministic |
| f3-cap-snap-bottle-01 | *(dropped)* | 85m every run | Implicit contact doesn't engage at snap lip |
| f3-clip-pipe-01 | *(dropped)* | Deterministic panic | Likely collision-geometry bug |

`f2-collar-shaft-axial-01` is now the tight showcase for `gravity_hold`
(50mm — physical reality). The two tilted tasks accept large drift
because the contact physics genuinely doesn't model the multi-axis
sliding constraint the geometry provides — geometric checks
(interference_volume, contact_area, mate_clearance, envelope) carry
the precision signal there.

The three dropped checks represent residual phyz limitations that
ecto/phyz 0.3.1 didn't fully address; reverting those drops will be a
clean follow-up once cylindrical-glancing-contact EPA and snap-lip
contact engagement are firm.

## Test plan

- [x] `cargo test -p mecheval-grader` — 51 passing
- [x] `cargo clippy -p mecheval-grader --all-targets -- -D warnings`
- [x] `cargo fmt -p mecheval-grader --check`
- [x] All 10 F-suite reference candidates pass `summary.passed: true`
      across 3 sequential `mecheval-grade` runs
- [x] DEFAULT_CUBE fails ≥2 checks on every F-suite task

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A4tQKjtbrjqr8r8zFFH627)_