### PR TITLE
Enable source maps in production build for debugging

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -371,6 +371,11 @@ export default defineConfig(({ mode }) => {
       plugins: () => [wasm(), topLevelAwait()],
     },
     build: {
+      // TEMPORARY: source maps in production so the minified React #185
+      // ("Maximum update depth exceeded") stack on vcad.io resolves to a
+      // real component. Revert this once we've identified and fixed the
+      // looping component — source maps add ~10 MB to the deploy.
+      sourcemap: true,
       rollupOptions: {
         output: {
           manualChunks: {


### PR DESCRIPTION
## Summary
Temporarily enable source maps in the production build to aid in debugging a React error occurring on vcad.io.

## Changes
- Enable `sourcemap: true` in the Vite production build configuration
- Added explanatory comment noting this is a temporary measure to resolve issue #185 ("Maximum update depth exceeded" error)
- Source maps will be reverted once the looping component causing the error is identified and fixed

## Implementation Details
- This change adds approximately 10 MB to the production deploy size
- The source maps are necessary to map minified React stack traces back to actual component names and source locations
- This is explicitly marked as temporary and should be reverted after the underlying issue is resolved

https://claude.ai/code/session_01UqxUGaDvJkQucivVNqWJcF