### PR TITLE
fix(dfm): stop infinite render loop from unstable visibleIssues selector

### DIFF
--- a/packages/app/src/components/DfmAnnotations.tsx
+++ b/packages/app/src/components/DfmAnnotations.tsx
@@ -14,7 +14,7 @@
 
 import { useMemo } from "react";
 import { Html } from "@react-three/drei";
-import { useDfmStore, visibleIssues } from "@/stores/dfm-store";
+import { useDfmStore } from "@/stores/dfm-store";
 import type { DfmIssue, DfmSeverity } from "@vcad/engine";
 import { cn } from "@/lib/utils";
 
@@ -32,13 +32,21 @@ const SEVERITY_GLYPH: Record<DfmSeverity, string> = {
 
 export function DfmAnnotations() {
   const enabled = useDfmStore((s) => s.enabled);
-  const issues = useDfmStore(visibleIssues);
+  const report = useDfmStore((s) => s.report);
+  const visibleSeverities = useDfmStore((s) => s.visibleSeverities);
   const selectedId = useDfmStore((s) => s.selectedIssueId);
   const selectIssue = useDfmStore((s) => s.selectIssue);
 
-  // Group issues at the same anchor so we don't stack a dozen badges
-  // on one face. Quantize anchors to 0.5 mm.
-  const grouped = useMemo(() => groupByAnchor(issues), [issues]);
+  // Filter + group issues at the same anchor so we don't stack a dozen
+  // badges on one face. Quantize anchors to 0.5 mm. Filtering is done
+  // here (not in a zustand selector) so the snapshot returned from the
+  // store stays referentially stable — otherwise useSyncExternalStore
+  // sees a new array every render and loops.
+  const grouped = useMemo(() => {
+    if (!report) return [];
+    const issues = report.issues.filter((i) => visibleSeverities.has(i.severity));
+    return groupByAnchor(issues);
+  }, [report, visibleSeverities]);
 
   if (!enabled || grouped.length === 0) return null;
 

--- a/packages/app/src/stores/dfm-store.ts
+++ b/packages/app/src/stores/dfm-store.ts
@@ -13,7 +13,6 @@ import { create } from "zustand";
 import {
   runDfm,
   type DfmReport,
-  type DfmIssue,
   type DfmProcess,
   type DfmSeverity,
 } from "@vcad/engine";
@@ -91,14 +90,6 @@ export const useDfmStore = create<DfmStoreState>((set, get) => ({
     }, RUN_DEBOUNCE_MS);
   },
 }));
-
-/** Issues filtered by the visible-severity toggles. */
-export function visibleIssues(state: DfmStoreState): DfmIssue[] {
-  if (!state.report) return [];
-  return state.report.issues.filter((i) =>
-    state.visibleSeverities.has(i.severity),
-  );
-}
 
 /** Per-severity issue counts for the badge display. */
 export function severityCounts(report: DfmReport | null): {


### PR DESCRIPTION
## Summary
- DFM live-check was causing \`Maximum update depth exceeded\` inside \`<CanvasImpl>\` whenever the panel rendered.
- The root cause is in \`DfmAnnotations\`: \`useDfmStore(visibleIssues)\` ran a \`.filter()\` inside the selector, so \`useSyncExternalStore\` got a new array reference on every read and React looped trying to reach a stable snapshot (\"The result of getSnapshot should be cached to avoid an infinite loop\").
- Select \`report\` and \`visibleSeverities\` from the store separately, then filter + group inside the existing \`useMemo\`. Removed the now-unused \`visibleIssues\` export.

## Test plan
- [x] Reload the app on the Unitree Go2 example with the Manufacturability \"Live check\" enabled — no more error boundary, no \`getSnapshot\` warnings in the console, DFM panel renders normally.
- [ ] Toggle severity filters and confirm badges update.

Note: there's a separate \`Cannot convert 8 to a BigInt\` error surfaced by \`runDfm\` on complex models — tracked in a follow-up task, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)