### PR TITLE
fix(dfm): pass BigInt for u64 root_node_id wasm binding

### DIFF
--- a/packages/engine/src/dfm.ts
+++ b/packages/engine/src/dfm.ts
@@ -89,7 +89,9 @@ interface DfmKernelBindings {
 }
 
 interface DfmSolidHandle {
-  runDfm: (process: string, rule_pack_toml: string, root_node_id: number) => string;
+  // `root_node_id` is a Rust `u64` — wasm-bindgen marshals it as a JS
+  // BigInt, so callers must convert their Number-based NodeIds.
+  runDfm: (process: string, rule_pack_toml: string, root_node_id: bigint) => string;
 }
 
 async function bindings(): Promise<DfmKernelBindings> {
@@ -135,7 +137,7 @@ export async function runDfm(
     const rootNodeId = visibleRoots[i]?.root ?? 0;
     const solid = (part as unknown as { solid?: DfmSolidHandle }).solid;
     if (!solid || typeof solid.runDfm !== "function") continue;
-    const reportJson = solid.runDfm(opts.process, pack, rootNodeId);
+    const reportJson = solid.runDfm(opts.process, pack, BigInt(rootNodeId));
     if (!reportJson) continue;
     const report = JSON.parse(reportJson) as DfmReport;
     packName = packName || report.rule_pack_name;


### PR DESCRIPTION
## Summary
- Enabling the Manufacturability **Live check** threw \`Cannot convert 8 to a BigInt\` immediately and emitted no issues.
- The kernel binding [\`Solid::run_dfm\`](https://github.com/ecto/vcad/blob/main/crates/vcad-kernel-wasm/src/lib.rs#L1027-L1033) takes \`root_node_id: u64\`, which wasm-bindgen marshals as a JS BigInt — but the TS shim was passing a plain Number.
- Wrap the node id in \`BigInt(...)\` at the call site and tighten the local \`DfmSolidHandle\` interface to type \`root_node_id: bigint\`. Left a comment on the field so the next reader doesn't repeat the mistake.

## Test plan
- [x] Open the Bracket example, enable \"Live check\" — DFM now reports \`fdm.steep_overhang\` instead of erroring.
- [x] No new console errors.
- [ ] Sanity check Unitree Go2 (large model with many parts) to confirm it still completes.

Stacks on top of #210 (the React loop fix is required to even render the panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)