### PR TITLE
feat(desktop): native Tauri splashscreen window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.1"
+version = "0.3.0"
 dependencies = [
  "tang",
 ]

--- a/crates/vcad-desktop/src/main.rs
+++ b/crates/vcad-desktop/src/main.rs
@@ -8,6 +8,23 @@ use tauri::Manager;
 
 use commands::{bambu, context_menu, local_ai};
 
+/// Closes the native splashscreen window and reveals the main window.
+///
+/// Called by the frontend once React has mounted, so the user transitions
+/// from the static splash HTML directly into the in-app `<Splash>` (which
+/// owns the rest of bootstrap progress).
+#[tauri::command]
+fn close_splashscreen(app: tauri::AppHandle) {
+    if let Some(splash) = app.get_webview_window("splashscreen") {
+        let _ = splash.close();
+    }
+    if let Some(main) = app.get_webview_window("main") {
+        platform::apply_window_effects(&main);
+        let _ = main.show();
+        let _ = main.set_focus();
+    }
+}
+
 fn main() {
     vcad_i18n::init(&vcad_i18n::Locale::from_env());
     tauri::Builder::default()
@@ -31,11 +48,10 @@ fn main() {
             // closures — Tauri's popup is fire-and-forget and the OS keeps
             // a weak ref to the menu object.
             app.manage(context_menu::ContextMenuState::<tauri::Wry>::new());
-            if let Some(window) = app.get_webview_window("main") {
-                platform::apply_window_effects(&window);
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            // Main window stays hidden until the frontend invokes
+            // `close_splashscreen` (after React mounts). The splashscreen
+            // window declared in tauri.conf.json is the only thing visible
+            // during the cold-start gap.
             Ok(())
         })
         .on_menu_event(|app, event| {
@@ -49,6 +65,7 @@ fn main() {
             context_menu::handle_event(app, id);
         })
         .invoke_handler(tauri::generate_handler![
+            close_splashscreen,
             bambu::bambu_discover,
             bambu::bambu_connect,
             bambu::bambu_status,

--- a/crates/vcad-desktop/src/platform.rs
+++ b/crates/vcad-desktop/src/platform.rs
@@ -12,7 +12,7 @@
 use tauri::{AppHandle, Manager, Runtime, WebviewWindow};
 
 /// Apply any platform-specific window effects (vibrancy, etc.) to `window`.
-pub fn apply_window_effects(window: &WebviewWindow) {
+pub fn apply_window_effects<R: Runtime>(window: &WebviewWindow<R>) {
     #[cfg(target_os = "macos")]
     mac::apply_vibrancy(window);
 
@@ -52,7 +52,7 @@ mod mac {
     use cocoa::appkit::NSWindow;
     use cocoa::base::{id, nil, BOOL, NO, YES};
     use cocoa::foundation::NSString;
-    use tauri::WebviewWindow;
+    use tauri::{Runtime, WebviewWindow};
     use window_vibrancy::{apply_vibrancy as apply_v, NSVisualEffectMaterial, NSVisualEffectState};
 
     /// Sidebar material — the strong, lively blur used for the leftmost
@@ -60,7 +60,7 @@ mod mac {
     /// whole window: chrome panels paint translucent over it, the 3D
     /// viewport canvas paints opaque. "Active" state keeps the blur lit
     /// even when the window loses focus, matching system apps.
-    pub fn apply_vibrancy(window: &WebviewWindow) {
+    pub fn apply_vibrancy<R: Runtime>(window: &WebviewWindow<R>) {
         if let Err(err) = apply_v(
             window,
             NSVisualEffectMaterial::Sidebar,
@@ -73,7 +73,7 @@ mod mac {
 
     /// `[[NSWindow setDocumentEdited:]]` — the dot inside the close traffic
     /// light. Cheapest possible "this is a real Mac app" signal.
-    pub fn set_document_edited(window: &WebviewWindow, edited: bool) {
+    pub fn set_document_edited<R: Runtime>(window: &WebviewWindow<R>, edited: bool) {
         if let Ok(ptr) = window.ns_window() {
             unsafe {
                 let ns_window = ptr as id;
@@ -86,7 +86,7 @@ mod mac {
     /// `[[NSWindow setRepresentedFilename:]]` — surfaces the proxy icon and
     /// path popover when the title is visible, and unlocks Window menu's
     /// "Recent Documents" automatically. Empty string clears it.
-    pub fn set_represented_filename(window: &WebviewWindow, path: &str) {
+    pub fn set_represented_filename<R: Runtime>(window: &WebviewWindow<R>, path: &str) {
         if let Ok(ptr) = window.ns_window() {
             unsafe {
                 let ns_window = ptr as id;

--- a/crates/vcad-desktop/tauri.conf.json
+++ b/crates/vcad-desktop/tauri.conf.json
@@ -20,16 +20,31 @@
     "macOSPrivateApi": true,
     "windows": [
       {
+        "label": "main",
         "title": "vcad",
         "width": 1400,
         "height": 900,
         "resizable": true,
         "fullscreen": false,
-        "visible": true,
+        "visible": false,
         "focus": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "transparent": true
+      },
+      {
+        "label": "splashscreen",
+        "url": "splashscreen.html",
+        "title": "vcad",
+        "width": 468,
+        "height": 328,
+        "resizable": false,
+        "decorations": false,
+        "transparent": true,
+        "center": true,
+        "alwaysOnTop": true,
+        "skipTaskbar": true,
+        "focus": true
       }
     ],
     "security": {

--- a/mecheval/graders/Cargo.toml
+++ b/mecheval/graders/Cargo.toml
@@ -18,7 +18,7 @@ vcad-kernel-geom = { workspace = true }
 vcad-kernel-topo = { workspace = true }
 vcad-kernel-physics = { workspace = true }
 vcad-kernel-dfm = { workspace = true }
-phyz = { path = "../../../phyz/crates/phyz", version = "0.3.1" }
+phyz = { path = "../../../phyz/crates/phyz", version = "0.3" }
 
 [[bin]]
 name = "mecheval-grade"

--- a/packages/app/public/splashscreen.html
+++ b/packages/app/public/splashscreen.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>vcad</title>
+    <style>
+      :root {
+        --bg: #1c1c1c;
+        --border: rgba(255, 255, 255, 0.10);
+        --text: #f8f8f2;
+        --text-muted: #75715e;
+        --brand: #f92672;
+      }
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        background: transparent;
+        font-family:
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+        color: var(--text);
+        overflow: hidden;
+        -webkit-user-select: none;
+        user-select: none;
+        cursor: default;
+      }
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .panel {
+        /* Inset margin keeps the window's rectangular bounds clear of the
+           panel, so the splash floats with no visible rectangle outline. */
+        margin: 24px;
+        width: calc(100% - 48px);
+        height: calc(100% - 48px);
+        padding: 28px 32px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 20px;
+        background-color: var(--bg);
+        border-radius: 18px;
+        text-align: center;
+        -webkit-app-region: drag;
+      }
+      .wordmark {
+        font-size: 56px;
+        font-weight: 700;
+        letter-spacing: -0.04em;
+        line-height: 1;
+      }
+      .wordmark .dot {
+        color: var(--brand);
+      }
+      .tagline {
+        margin-top: 6px;
+        font-size: 12px;
+        color: var(--text-muted);
+      }
+      .progress {
+        width: 260px;
+        max-width: 100%;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .bar {
+        position: relative;
+        height: 3px;
+        width: 100%;
+        border-radius: 999px;
+        overflow: hidden;
+        background: var(--border);
+      }
+      .bar::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: -33%;
+        width: 33%;
+        border-radius: 999px;
+        background: var(--brand);
+        animation: slide 1.2s ease-in-out infinite;
+      }
+      @keyframes slide {
+        0% {
+          left: -33%;
+        }
+        50% {
+          left: 50%;
+        }
+        100% {
+          left: 100%;
+        }
+      }
+      .status {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        font-size: 11px;
+        color: var(--text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+      .status .version {
+        opacity: 0.6;
+      }
+      .tip {
+        font-size: 10px;
+        color: var(--text-muted);
+        opacity: 0.6;
+        font-style: italic;
+        min-height: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <div>
+        <div class="wordmark">vcad<span class="dot">.</span></div>
+        <div class="tagline">Free parametric CAD for everyone</div>
+      </div>
+      <div class="progress">
+        <div class="bar" aria-label="Loading"></div>
+        <div class="status">
+          <span>Starting…</span>
+          <span class="version">v0.9.4</span>
+        </div>
+      </div>
+      <div class="tip" id="tip"></div>
+    </div>
+    <script>
+      // Mirrors the tip list in src/components/Splash.tsx so the native
+      // splash and the in-app splash share the same vocabulary.
+      const TIPS = [
+        "Press ⌘K anywhere for the command palette.",
+        "Drag a .step file into the viewport to import it.",
+        "Sketches support parallel, tangent, and equal-length constraints.",
+        "Ray-traced mode renders BRep directly — no tessellation artifacts.",
+        "Every parameter is scrubbable. Click, drag, watch it rebuild.",
+        "Export to STL, GLB, or STEP from the File menu.",
+        "Physics via phyz. Build a robot, give it joints, watch it move.",
+        "Booleans run on exact BRep, not triangle-mesh hacks.",
+        "Ask the AI chat to build geometry. It has real CAD tools.",
+        "Shell hollows a solid to a given wall thickness.",
+        "Undo and redo — experiment freely.",
+        "Patterns stay linked to their source. Edit once, update everywhere.",
+        "Joints: revolute, prismatic, cylindrical, ball, fixed.",
+        "Drafting views project your parts to 2D orthographic drawings.",
+        "Rust compiled to WebAssembly, running in your browser.",
+        "Z is up. CAD convention, not Three.js.",
+        "Shewchuk's exact predicates power the boolean face classifier.",
+        "Every .vcad file is plain JSON — inspect it in any text editor.",
+        "Sign in with Google or GitHub to sync across devices.",
+        "Half-edge topology. Full-edge respect.",
+        "Built by hand. Rendered by math.",
+        "Open source. Free for everyone. Always.",
+      ];
+      document.getElementById("tip").textContent =
+        TIPS[Math.floor(Math.random() * TIPS.length)];
+    </script>
+  </body>
+</html>

--- a/packages/app/src/components/Splash.tsx
+++ b/packages/app/src/components/Splash.tsx
@@ -79,15 +79,10 @@ export function Splash() {
       className={`fixed inset-0 z-[100] flex items-center justify-center bg-bg transition-opacity duration-300 ${
         fadingOut ? "opacity-0" : "opacity-100"
       }`}
-      style={{
-        backgroundImage:
-          "url(\"data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='56' height='48' viewBox='0 0 56 48'><path d='M14 0l14 8v16l-14 8L0 24V8zM42 0l14 8v16l-14 8-14-8V8zM28 24l14 8v16l-14 8-14-8V32z' fill='none' stroke='%23ffffff' stroke-opacity='0.04' stroke-width='1'/></svg>\")",
-        backgroundRepeat: "repeat",
-      }}
       aria-busy={phase !== "ready"}
       aria-live="polite"
     >
-      <div className="flex w-[420px] max-w-[92vw] flex-col items-center gap-5 rounded-2xl border border-border bg-surface/80 px-8 py-9 text-center shadow-2xl backdrop-blur-sm">
+      <div className="flex w-[260px] max-w-[92vw] flex-col items-center gap-5 text-center">
         <div className="flex flex-col items-center gap-2">
           <div className="text-6xl font-bold tracking-tighter text-text select-none leading-none">
             vcad<span className="text-brand">.</span>

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -132,6 +132,21 @@ createRoot(document.getElementById("root")!).render(
   </StrictMode>,
 );
 
+// Tauri desktop: close the native splashscreen window and reveal the main
+// window once the React tree has painted. The in-app <Splash> takes over
+// from here for the rest of bootstrap.
+requestAnimationFrame(() => {
+  void (async () => {
+    try {
+      const { isTauri, invoke } = await import("@/lib/tauri");
+      if (isTauri()) await invoke("close_splashscreen");
+    } catch {
+      // Splash close is best-effort — if it fails the user just sees both
+      // windows briefly. Never block startup on it.
+    }
+  })();
+});
+
 // Vercel Analytics + Speed Insights — prod only, silently skip if blocked
 if (import.meta.env.PROD) {
   import("@vercel/analytics").then(({ inject }) => inject()).catch(() => {});


### PR DESCRIPTION
## Summary

Adds a native Tauri v2 splashscreen window so the desktop app shows vcad branding **instantly** at launch, instead of a blank window while the WebView and WASM kernel finish loading.

- New static `packages/app/public/splashscreen.html` — opens immediately as a borderless, transparent, rounded panel with the `vcad.` wordmark, indeterminate progress bar, version, and a random tip.
- Main window now starts `visible: false`. Once React mounts in `main.tsx`, the frontend invokes a new `close_splashscreen` Tauri command which closes the splash and shows + focuses the main window. The in-app `<Splash>` continues handling bootstrap progress from there.

## Drive-by fixes (needed for the branch to build)

- `crates/vcad-desktop/src/platform.rs`: `apply_window_effects` / `set_document_edited` / `set_represented_filename` now generic over `R: Runtime` so the `&WebviewWindow<R>` from the call sites matches.
- `mecheval/graders/Cargo.toml`: relax `phyz` version from `"0.3.1"` to `"0.3"` so it matches `vcad-kernel-physics` and resolves against the sibling `../phyz` checkout (currently at 0.3.0).

## Visual design

- Single rounded dark panel filling the splash window with a 24px transparent inset, so macOS's auto-shadow traces the rounded shape — no double border, no CSS box-shadow, no inner card.
- Brand-pink dot on the wordmark (`#F92672`), matching the in-app `<Splash>`.
- Tip list mirrors the one in `Splash.tsx` so the splash → in-app transition is seamless.

## Test plan

- [ ] `npm run tauri:dev -w @vcad/app` — splash window appears immediately on launch, transitions to the main window once React mounts.
- [ ] Splash window has a single soft shadow (no doubling) on macOS.
- [ ] Main window stays hidden until splash closes.
- [ ] Web (`npm run dev -w @vcad/app`) still loads — `close_splashscreen` invoke is guarded by `isTauri()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)