### PR TITLE
feat(app): adopt v3 design system tokens + transparent 3D viewport

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,7 +6,7 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": [
         "-c",
-        "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0"
+        "if [ -f .env ]; then set -a && source .env && set +a; fi && CLAUDE_PREVIEW=1 npm run dev -w @vcad/app -- --host 0.0.0.0 --port ${PORT:-5173} --strictPort"
       ],
       "port": 5173,
       "autoPort": true

--- a/packages/app/src/components/AboutModal.tsx
+++ b/packages/app/src/components/AboutModal.tsx
@@ -100,7 +100,7 @@ export function AboutModal({
           data-tauri-drag-region=""
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
-            "bg-surface p-8 shadow-2xl select-none",
+            "rounded-xl border border-border bg-surface p-8 shadow-xl select-none",
             "focus:outline-none",
           )}
         >

--- a/packages/app/src/components/AppShell.tsx
+++ b/packages/app/src/components/AppShell.tsx
@@ -138,7 +138,7 @@ export function AppShell({
   return (
     <div className="flex h-[100dvh] w-screen flex-col overflow-hidden bg-bg">
       {header && (
-        <div className="shrink-0 border-b border-border/40">
+        <div className="shrink-0 border-b border-border">
           {header}
         </div>
       )}
@@ -157,7 +157,7 @@ export function AppShell({
         )}
         {rightSidebar && (
           <div
-            className="relative shrink-0 min-h-0 overflow-visible border-l border-border/40 bg-surface"
+            className="relative shrink-0 min-h-0 overflow-visible border-l border-border bg-surface"
             style={{ width: `${rightWidth}px` }}
           >
             <ResizeHandle side="right" width={rightWidth} onResize={setRightWidth} />

--- a/packages/app/src/components/ChatSidebar.tsx
+++ b/packages/app/src/components/ChatSidebar.tsx
@@ -309,7 +309,7 @@ function VcadMessage({ msg, userName }: { msg: ChatMessage; userName: string }) 
             {msg.context.map((ctx) => (
               <span
                 key={ctx.partId}
-                className="inline-flex items-center gap-1 rounded border border-brand/30 bg-brand/10 px-1.5 py-0.5 text-[9px] text-brand"
+                className="inline-flex items-center gap-1 rounded-sm border border-border bg-fill px-1.5 py-0.5 text-[10px] font-mono text-text-muted"
               >
                 {ctx.partName}
               </span>
@@ -848,12 +848,12 @@ export function ChatSidebar() {
                     {selectionContext.map((ctx) => (
                       <span
                         key={ctx.partId}
-                        className="inline-flex items-center gap-1 rounded-full border border-brand/30 bg-brand/10 py-0.5 pl-2 pr-1 text-[9px] text-brand"
+                        className="inline-flex items-center gap-1 rounded-full border border-border bg-fill py-0.5 pl-2 pr-1 text-[10px] font-mono text-text-muted"
                       >
                         {ctx.partName}
                         <button
                           onClick={() => removeContextPart(ctx.partId)}
-                          className="flex h-3 w-3 items-center justify-center rounded-full hover:bg-brand/20 hover:text-brand/80 transition-colors"
+                          className="flex h-3 w-3 items-center justify-center rounded-full hover:bg-hover hover:text-text transition-colors"
                           aria-label={`Remove ${ctx.partName}`}
                         >
                           <X size={8} />

--- a/packages/app/src/components/CommandPalette.tsx
+++ b/packages/app/src/components/CommandPalette.tsx
@@ -442,7 +442,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/30" />
         <Dialog.Content
-          className="fixed left-1/2 top-[20%] z-50 w-full max-w-md -translate-x-1/2  border border-border bg-surface shadow-2xl"
+          className="fixed left-1/2 top-[20%] z-50 w-full max-w-md -translate-x-1/2 rounded-xl border border-border bg-surface shadow-xl overflow-hidden"
           onKeyDown={handleKeyDown}
           aria-describedby={undefined}
         >
@@ -460,7 +460,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
               className="flex-1 bg-transparent text-sm text-text outline-none placeholder:text-text-muted"
               autoFocus
             />
-            <kbd className=" bg-border/50 px-1.5 py-0.5 text-[10px] text-text-muted">esc</kbd>
+            <kbd className="rounded-sm bg-fill px-1.5 py-0.5 text-[10px] font-mono text-text-muted">esc</kbd>
           </div>
           {/* Hidden file input */}
           <input
@@ -521,7 +521,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
                 >
                   <FolderOpen size={16} className="shrink-0 text-text-muted" />
                   <span className="flex-1">{t("palette.action.open_file")}</span>
-                  <kbd className="bg-border/50 px-1.5 py-0.5 text-[10px] text-text-muted">⌘O</kbd>
+                  <kbd className="rounded-sm bg-fill px-1.5 py-0.5 text-[10px] font-mono text-text-muted">⌘O</kbd>
                 </button>
 
                 {/* Examples */}
@@ -586,7 +586,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
                       <Icon size={16} className="shrink-0 text-text-muted" />
                       <span className="flex-1">{highlightMatch(cmd.label, query)}</span>
                       {cmd.shortcut && (
-                        <kbd className="bg-border/50 px-1.5 py-0.5 text-[10px] text-text-muted">
+                        <kbd className="rounded-sm bg-fill px-1.5 py-0.5 text-[10px] font-mono text-text-muted">
                           {cmd.shortcut}
                         </kbd>
                       )}
@@ -623,7 +623,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
                     <span className="flex-1">
                       {t("palette.generate_label")} <span className="text-brand">{aiPrompt}</span>
                     </span>
-                    <kbd className="bg-border/50 px-1.5 py-0.5 text-[10px] text-text-muted">
+                    <kbd className="rounded-sm bg-fill px-1.5 py-0.5 text-[10px] font-mono text-text-muted">
                       {t("palette.kbd_server")}
                     </kbd>
                   </button>

--- a/packages/app/src/components/ContextMenu.tsx
+++ b/packages/app/src/components/ContextMenu.tsx
@@ -38,7 +38,7 @@ function MenuItem({
 }) {
   return (
     <RadixContextMenu.Item
-      className="group flex items-center gap-2  px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[disabled]:opacity-40 data-[disabled]:cursor-default data-[highlighted]:bg-brand/20 data-[highlighted]:text-brand"
+      className="group flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[disabled]:opacity-40 data-[disabled]:cursor-default data-[highlighted]:bg-hover"
       disabled={disabled}
       onClick={onClick}
     >
@@ -209,7 +209,7 @@ export function ContextMenu({ children }: { children: ReactNode }) {
     <RadixContextMenu.Root>
       <RadixContextMenu.Trigger asChild>{children}</RadixContextMenu.Trigger>
       <RadixContextMenu.Portal>
-        <RadixContextMenu.Content className="z-50 min-w-[180px]  border border-border bg-card p-1 shadow-xl">
+        <RadixContextMenu.Content className="z-50 min-w-[180px] rounded-lg border border-border bg-card p-1 shadow-md">
           <MenuItem
             icon={Copy}
             label="Duplicate"
@@ -236,7 +236,7 @@ export function ContextMenu({ children }: { children: ReactNode }) {
           <RadixContextMenu.Separator className="my-1 h-px bg-border" />
 
           <RadixContextMenu.Sub>
-            <RadixContextMenu.SubTrigger className="group flex items-center gap-2  px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-brand/20 data-[highlighted]:text-brand data-[state=open]:bg-brand/20 data-[state=open]:text-brand">
+            <RadixContextMenu.SubTrigger className="group flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-hover data-[state=open]:bg-hover">
               <CrosshairSimple size={14} className="shrink-0" />
               <span className="flex-1">Selection priority</span>
               <span className="ml-4 text-[10px] text-text-muted uppercase tracking-wide">
@@ -245,7 +245,7 @@ export function ContextMenu({ children }: { children: ReactNode }) {
             </RadixContextMenu.SubTrigger>
             <RadixContextMenu.Portal>
               <RadixContextMenu.SubContent
-                className="z-50 min-w-[200px] border border-border bg-card p-1 shadow-xl"
+                className="z-50 min-w-[200px] rounded-lg border border-border bg-card p-1 shadow-md"
                 sideOffset={2}
                 alignOffset={-4}
               >
@@ -254,7 +254,7 @@ export function ContextMenu({ children }: { children: ReactNode }) {
                   return (
                     <RadixContextMenu.Item
                       key={value}
-                      className="group flex items-center gap-2 px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-brand/20 data-[highlighted]:text-brand"
+                      className="group flex items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-text outline-none cursor-pointer data-[highlighted]:bg-hover"
                       onClick={() => setSelectionFilter(value)}
                     >
                       {active ? (

--- a/packages/app/src/components/DocumentPicker.tsx
+++ b/packages/app/src/components/DocumentPicker.tsx
@@ -478,7 +478,7 @@ export function DocumentPicker({
         <Dialog.Content
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
-            "border border-border bg-card shadow-2xl",
+            "rounded-xl border border-border bg-card shadow-xl overflow-hidden",
             "max-h-[85vh] flex flex-col select-none",
             "focus:outline-none"
           )}

--- a/packages/app/src/components/DrawingToolbar.tsx
+++ b/packages/app/src/components/DrawingToolbar.tsx
@@ -90,7 +90,7 @@ export function DrawingToolbar() {
           isOrbiting && "opacity-0 pointer-events-none"
         )}
       >
-        <div className="relative flex items-center gap-1 border border-border bg-card px-2 py-1.5 shadow-2xl">
+        <div className="relative flex items-center gap-1 rounded-full border border-border bg-card px-2 py-1.5 shadow-md">
           {/* View direction dropdown */}
           <div className="relative">
             <select

--- a/packages/app/src/components/FeatureTree.tsx
+++ b/packages/app/src/components/FeatureTree.tsx
@@ -223,14 +223,14 @@ function SketchTreeSection() {
                 confirmExit();
                 addToast(t("tree.sketch.discarded"), "info");
               }}
-              className="flex-1 px-2 py-1 text-xs bg-red-600 hover:bg-red-700 text-white"
+              className="flex-1 rounded-md px-2 py-1.5 text-xs font-medium bg-red-600 hover:bg-red-700 text-white transition-colors"
             >
               {t("tree.sketch.discard")}
             </button>
             <button
               type="button"
               onClick={cancelExit}
-              className="flex-1 px-2 py-1 text-xs hover:bg-hover/60"
+              className="flex-1 rounded-md px-2 py-1.5 text-xs font-medium hover:bg-hover transition-colors"
             >
               {t("tree.sketch.keep_editing")}
             </button>
@@ -365,7 +365,7 @@ function FeatureTreeEmptyState() {
           <button
             key={kind}
             onClick={() => addPrimitive(kind)}
-            className="flex flex-col items-center justify-center gap-1 aspect-square border border-border bg-card hover:bg-hover hover:border-brand/50 transition-colors"
+            className="flex flex-col items-center justify-center gap-1 aspect-square rounded-md border border-border bg-card hover:bg-hover hover:border-text-muted transition-colors"
             title={`Add ${label}`}
           >
             <Icon size={20} className="text-text-muted" />
@@ -407,7 +407,7 @@ function getPartIcon(part: PartInfo): typeof Cube {
 function DragPreview({ part }: { part: PartInfo }) {
   const Icon = getPartIcon(part);
   return (
-    <div className="flex items-center gap-1.5 px-2 py-1 bg-surface border border-brand rounded shadow-lg text-xs text-text">
+    <div className="flex items-center gap-1.5 px-2 py-1 bg-surface border border-border rounded-md shadow-md text-xs text-text">
       <Icon size={12} className="shrink-0 text-text-muted" />
       <span className="truncate max-w-32">{part.name}</span>
     </div>
@@ -450,7 +450,7 @@ function InlineRenameInput({
         if (e.key === "Enter") commit();
         if (e.key === "Escape") onDone();
       }}
-      className="flex-1 border border-brand bg-surface px-1 py-0.5 text-xs text-text outline-none w-0"
+      className="flex-1 rounded-md border border-border bg-surface px-1.5 py-0.5 text-xs text-text outline-none w-0 focus:border-brand focus:ring-2 focus:ring-brand/30"
       autoFocus
     />
   );

--- a/packages/app/src/components/FeedbackModal.tsx
+++ b/packages/app/src/components/FeedbackModal.tsx
@@ -32,7 +32,7 @@ export function FeedbackModal({
         <Dialog.Content
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
-            "bg-surface p-6 shadow-2xl",
+            "rounded-xl border border-border bg-surface p-6 shadow-xl",
             "focus:outline-none",
           )}
         >

--- a/packages/app/src/components/ForkPromptModal.tsx
+++ b/packages/app/src/components/ForkPromptModal.tsx
@@ -77,7 +77,7 @@ export function ForkPromptModal() {
             data-tauri-drag-region=""
             className={cn(
               "fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2",
-              "bg-surface p-6 shadow-2xl select-none",
+              "rounded-xl border border-border bg-surface p-6 shadow-xl select-none",
               "focus:outline-none",
             )}
           >

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -78,10 +78,10 @@ const TRIGGER_CLASS = cn(
 );
 
 const CONTENT_CLASS =
-  "z-50 min-w-[200px] border border-border/80 bg-surface py-1 shadow-md";
+  "z-50 min-w-[200px] rounded-lg border border-border/80 bg-surface p-1 shadow-md";
 
 const ITEM_CLASS = cn(
-  "flex w-full items-center gap-2 px-2.5 py-1 text-[11px] text-text outline-none cursor-default select-none",
+  "flex w-full items-center gap-2 rounded-sm px-2.5 py-1.5 text-[12px] text-text outline-none cursor-default select-none",
   "data-[highlighted]:bg-hover data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed",
 );
 
@@ -140,7 +140,7 @@ function MenuItem({
 }
 
 function MenuSeparator() {
-  return <Menubar.Separator className="my-1 border-t border-border/30" />;
+  return <Menubar.Separator className="my-1 mx-1.5 h-px bg-border-soft" />;
 }
 
 /** A submenu that opens on hover/right-arrow. Menubar.Sub handles all the
@@ -175,7 +175,7 @@ function Submenu({
           sideOffset={0}
           alignOffset={-5}
           className={cn(
-            "z-50 min-w-[180px] border border-border/80 bg-surface py-1 shadow-md",
+            "z-50 min-w-[180px] rounded-lg border border-border/80 bg-surface p-1 shadow-md",
             contentClassName,
           )}
         >

--- a/packages/app/src/components/InlineOnboarding.tsx
+++ b/packages/app/src/components/InlineOnboarding.tsx
@@ -176,7 +176,7 @@ export function InlineOnboarding({ visible }: InlineOnboardingProps) {
       <div
         data-tauri-drag-region=""
         className={cn(
-          "relative border border-border bg-surface/95 backdrop-blur-md shadow-2xl select-none",
+          "relative rounded-xl border border-border bg-surface/95 backdrop-blur-md shadow-xl select-none overflow-hidden",
           "w-[560px] max-w-[92vw]",
           "transition-all duration-300 ease-out",
           visible ? "scale-100 translate-y-0 pointer-events-auto" : "scale-95 translate-y-2 pointer-events-none",

--- a/packages/app/src/components/InlineProperties.tsx
+++ b/packages/app/src/components/InlineProperties.tsx
@@ -41,7 +41,7 @@ function InlineRenameInput({
         if (e.key === "Enter") commit();
         if (e.key === "Escape") onDone();
       }}
-      className="w-full  border border-brand bg-surface px-1.5 py-0.5 text-xs text-text outline-none"
+      className="w-full rounded-md border border-border bg-surface px-1.5 py-0.5 text-xs text-text outline-none focus:border-brand focus:ring-2 focus:ring-brand/30"
       autoFocus
     />
   );

--- a/packages/app/src/components/InputPreferencesDialog.tsx
+++ b/packages/app/src/components/InputPreferencesDialog.tsx
@@ -39,7 +39,7 @@ export function InputPreferencesDialog({
           className={cn(
             "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
             "w-[640px] max-w-[92vw] h-[560px] max-h-[88vh]",
-            "flex flex-col bg-surface shadow-2xl border border-border select-none",
+            "flex flex-col rounded-xl bg-surface shadow-xl border border-border select-none overflow-hidden",
             "focus:outline-none",
           )}
         >

--- a/packages/app/src/components/ParametersPanel.tsx
+++ b/packages/app/src/components/ParametersPanel.tsx
@@ -133,7 +133,7 @@ function ParameterRow({
             }
           }}
           spellCheck={false}
-          className="flex-1 min-w-0 bg-card border border-border text-text text-xs font-mono outline-none px-2 py-1 focus:border-brand"
+          className="flex-1 min-w-0 rounded-md bg-card border border-border text-text text-xs font-mono outline-none px-2 py-1 focus:border-brand focus:ring-2 focus:ring-brand/30 transition-colors"
           aria-label="Parameter name"
         />
         <button
@@ -174,8 +174,8 @@ function ParameterRow({
           }}
           spellCheck={false}
           className={cn(
-            "flex-1 min-w-0 bg-card border text-text text-xs font-mono outline-none px-2 py-1 focus:border-brand",
-            error ? "border-red-500" : "border-border",
+            "flex-1 min-w-0 rounded-md bg-card border text-text text-xs font-mono outline-none px-2 py-1 focus:ring-2 focus:ring-brand/30 transition-colors",
+            error ? "border-red-500" : "border-border focus:border-brand",
           )}
           aria-label={`${name} value`}
         />

--- a/packages/app/src/components/ProductModal.tsx
+++ b/packages/app/src/components/ProductModal.tsx
@@ -102,7 +102,7 @@ export function ProductModal({
           data-tauri-drag-region=""
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2",
-            "bg-surface shadow-2xl select-none",
+            "rounded-xl border border-border bg-surface shadow-xl select-none",
             "focus:outline-none",
             "max-h-[90vh] overflow-y-auto scrollbar-thin",
           )}

--- a/packages/app/src/components/PropertyPanel.tsx
+++ b/packages/app/src/components/PropertyPanel.tsx
@@ -476,7 +476,7 @@ function ReadOnlyParam({ label, value, tooltip }: { label: string; value: string
   const content = (
     <div className="flex items-center gap-1.5 text-xs">
       <span className="shrink-0 text-[10px] w-4 text-text-muted font-medium">{label}</span>
-      <span className="flex-1 min-w-0 bg-card border border-border px-2 py-1 text-xs text-text-muted truncate opacity-60 cursor-not-allowed">
+      <span className="flex-1 min-w-0 rounded-md bg-card border border-border px-2 py-1 text-xs text-text-muted truncate opacity-60 cursor-not-allowed">
         {value}
       </span>
     </div>
@@ -1717,9 +1717,9 @@ export function PropertyPanel() {
             <button
               type="button"
               onClick={() => useElectronicsStore.getState().enter()}
-              className="w-full mt-2 px-3 py-2 text-xs font-medium rounded
-                bg-brand/10 text-brand border border-brand/30
-                hover:bg-brand/20 transition-colors"
+              className="w-full mt-2 px-3 py-2 text-xs font-medium rounded-md
+                bg-fill text-text border border-border
+                hover:bg-fill-strong hover:border-text-muted transition-colors"
             >
               {t("panel.edit_circuit")}
             </button>
@@ -1733,9 +1733,9 @@ export function PropertyPanel() {
             <button
               type="button"
               onClick={() => useEmbroideryStore.getState().openPanel()}
-              className="w-full mt-2 px-3 py-2 text-xs font-medium rounded
-                bg-brand/10 text-brand border border-brand/30
-                hover:bg-brand/20 transition-colors"
+              className="w-full mt-2 px-3 py-2 text-xs font-medium rounded-md
+                bg-fill text-text border border-border
+                hover:bg-fill-strong hover:border-text-muted transition-colors"
             >
               {t("panel.open_embroidery")}
             </button>

--- a/packages/app/src/components/QuotePanel.tsx
+++ b/packages/app/src/components/QuotePanel.tsx
@@ -212,7 +212,7 @@ export function QuotePanel() {
       <div
         ref={panelRef}
         className={cn(
-          "fixed z-50 bg-surface border border-border shadow-2xl",
+          "fixed z-50 rounded-xl bg-surface border border-border shadow-xl overflow-hidden",
           "animate-in fade-in-0",
           // Desktop: side panel
           "sm:top-14 sm:right-3 sm:w-80 sm:slide-in-from-right-4",

--- a/packages/app/src/components/ShareDialog.tsx
+++ b/packages/app/src/components/ShareDialog.tsx
@@ -235,7 +235,7 @@ export function ShareDialog({ open, onOpenChange }: ShareDialogProps) {
             data-tauri-drag-region=""
             className={cn(
               "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
-              "bg-surface p-6 shadow-2xl select-none",
+              "rounded-xl border border-border bg-surface p-6 shadow-xl select-none",
               "focus:outline-none",
             )}
           >

--- a/packages/app/src/components/UpgradeModal.tsx
+++ b/packages/app/src/components/UpgradeModal.tsx
@@ -551,7 +551,7 @@ export function UpgradeModal({ open, onOpenChange, reason }: UpgradeModalProps) 
           data-tauri-drag-region=""
           className={cn(
             "upgrade-content fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
-            "border border-border bg-card/95 backdrop-blur-md shadow-2xl focus:outline-none select-none",
+            "rounded-xl border border-border bg-card/95 backdrop-blur-md shadow-xl focus:outline-none select-none overflow-hidden",
             isLimitReached
               ? "w-[min(540px,94vw)]"
               : "w-[min(720px,92vw)]",

--- a/packages/app/src/components/UsernamePickerModal.tsx
+++ b/packages/app/src/components/UsernamePickerModal.tsx
@@ -133,7 +133,7 @@ export function UsernamePickerModal({
           data-tauri-drag-region=""
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-sm -translate-x-1/2 -translate-y-1/2",
-            "bg-surface p-6 shadow-2xl select-none",
+            "rounded-xl border border-border bg-surface p-6 shadow-xl select-none",
             "focus:outline-none",
           )}
         >

--- a/packages/app/src/components/VersionHistoryModal.tsx
+++ b/packages/app/src/components/VersionHistoryModal.tsx
@@ -63,7 +63,7 @@ export function VersionHistoryModal({
           data-tauri-drag-region=""
           className={cn(
             "fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2",
-            "bg-surface shadow-2xl focus:outline-none max-h-[80vh] overflow-auto select-none",
+            "rounded-xl border border-border bg-surface shadow-xl focus:outline-none max-h-[80vh] overflow-auto select-none",
           )}
         >
           <Dialog.Close className="absolute right-3 top-3 p-1.5 text-text-muted hover:text-text transition-colors cursor-pointer">

--- a/packages/app/src/components/Viewport.tsx
+++ b/packages/app/src/components/Viewport.tsx
@@ -45,9 +45,12 @@ const PcbGettingStarted = lazy(() =>
   })),
 );
 
-// Monokai Soda from tmTheme
-export const BG_DARK = "#222222";
-export const BG_LIGHT = "#e8eaec";
+// v3 design system: the 3D viewport is transparent — chrome / page bg shows
+// through, leaving only the grid, part, and lighting visible. These constants
+// are retained for legacy consumers; current renderers should pass
+// `transparent` instead.
+export const BG_DARK = "transparent";
+export const BG_LIGHT = "transparent";
 const MIN_DRAG_THRESHOLD = 5;
 
 function BoxSelectHandler({
@@ -273,10 +276,8 @@ export function Viewport() {
     );
   }
 
-  // Render 3D Canvas (shared for CAD and PCB modes)
-  const canvasBg = electronicsActive
-    ? (isDark ? "#0a0a0a" : "#f5f5f5")
-    : (isDark ? BG_DARK : BG_LIGHT);
+  // v3: viewport canvas is transparent; the chrome / page bg (var(--bg))
+  // shows through, leaving only the grid, part, and lighting visible.
 
   return (
     <div
@@ -296,6 +297,7 @@ export function Viewport() {
         onCreated={() => performance.mark("canvas-ready")}
         shadows
         gl={{
+          alpha: true,
           antialias: true,
           logarithmicDepthBuffer: true,
           toneMapping: THREE.ACESFilmicToneMapping,
@@ -307,7 +309,7 @@ export function Viewport() {
           outputColorSpace: THREE.SRGBColorSpace,
           preserveDrawingBuffer: true,
         }}
-        style={{ background: canvasBg }}
+        style={{ background: "transparent" }}
       >
         <XR store={xrStore}>
           <ViewportContent mode={electronicsActive ? "pcb" : "3d"} />

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -71,7 +71,6 @@ import type {
 } from "@vcad/ir";
 import { PcbScene } from "./electronics/pcb3d/PcbScene";
 import { usePcbCamera } from "./electronics/pcb3d/usePcbCamera";
-import { BG_DARK, BG_LIGHT } from "./Viewport";
 import { useXRPresenting } from "@/stores/xr-store";
 import { XRSceneTransform } from "./xr/XRSceneTransform";
 import { XRGestures } from "./xr/XRGestures";
@@ -1659,17 +1658,14 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
         </Environment>
       )}
 
-      {/* Background: match UI chrome so the viewport blends with the app.
+      {/* v3: the canvas is alpha:true and the page bg shows through, so the
+          default is no scene background — only the grid, part, and lighting
+          paint. A doc-defined Solid background still wins; Transparent is a
+          no-op (leave scene.background null so the alpha clear takes over).
           The <Environment> above still produces IBL via scene.environment,
           so metallic reflections keep their studio highlights. */}
-      {!isPcbMode && !docScene?.background && (
-        <color attach="background" args={[isDark ? BG_DARK : BG_LIGHT]} />
-      )}
       {!isPcbMode && docScene?.background?.type === "Solid" && (
         <color attach="background" args={[docScene.background.color[0], docScene.background.color[1], docScene.background.color[2]]} />
-      )}
-      {!isPcbMode && docScene?.background?.type === "Transparent" && (
-        <color attach="background" args={[0, 0, 0]} />
       )}
 
       {/* ═══════════════════════════════════════════════════════════════════

--- a/packages/app/src/components/WhatsNewPanel.tsx
+++ b/packages/app/src/components/WhatsNewPanel.tsx
@@ -73,7 +73,7 @@ export function WhatsNewPanel() {
           className={cn(
             "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
             "w-full max-w-md max-h-[70vh]",
-            "bg-surface shadow-2xl flex flex-col select-none",
+            "rounded-xl border border-border bg-surface shadow-xl flex flex-col select-none overflow-hidden",
             "focus:outline-none",
           )}
         >

--- a/packages/app/src/components/ui/button.tsx
+++ b/packages/app/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 import type { ButtonHTMLAttributes } from "react";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-1.5 text-xs font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+  "inline-flex items-center justify-center gap-1.5 rounded-md text-xs font-medium transition-colors duration-150 [transition-timing-function:cubic-bezier(0.32,0.72,0,1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
   {
     variants: {
       variant: {
@@ -15,7 +15,7 @@ const buttonVariants = cva(
         danger: "bg-danger text-white hover:opacity-90",
       },
       size: {
-        sm: "h-7 px-2",
+        sm: "h-7 px-2.5",
         md: "h-8 px-3",
         lg: "h-9 px-4",
         icon: "h-8 w-8",

--- a/packages/app/src/components/ui/dialog.tsx
+++ b/packages/app/src/components/ui/dialog.tsx
@@ -33,7 +33,7 @@ export function DialogContent({
         className={cn(
           "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
           "w-full max-w-md select-none",
-          "border border-border bg-surface shadow-xl",
+          "rounded-xl border border-border bg-surface shadow-xl overflow-hidden",
           "focus:outline-none",
           className,
         )}

--- a/packages/app/src/components/ui/expression-input.tsx
+++ b/packages/app/src/components/ui/expression-input.tsx
@@ -207,13 +207,13 @@ export function ExpressionInput({
         }}
         title={parseErr ?? `${boundFormula ?? "(unbound)"} ${previewText}`}
         className={cn(
-          "flex-1 min-w-0 bg-card border text-text outline-none transition-colors font-mono",
+          "flex-1 min-w-0 rounded-md bg-card border text-text outline-none transition-colors font-mono",
           parseErr
             ? "border-red-500"
             : isBound
               ? "border-brand focus:border-brand"
               : "border-border focus:border-brand",
-          compact ? "px-1 py-0.5 text-[10px]" : "px-2 py-1 text-xs",
+          compact ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-1 text-xs",
         )}
       />
       <span

--- a/packages/app/src/components/ui/scrub-input.tsx
+++ b/packages/app/src/components/ui/scrub-input.tsx
@@ -185,7 +185,7 @@ export function ScrubInput({
         <button
           type="button"
           onClick={() => bump(-1)}
-          className="flex h-9 w-9 shrink-0 items-center justify-center border border-border bg-card text-text-muted active:bg-hover"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-card text-text-muted active:bg-hover"
           aria-label={`Decrease ${label}`}
         >
           <Minus size={14} />
@@ -215,7 +215,7 @@ export function ScrubInput({
         onDoubleClick={handleDoubleClick}
         readOnly={!isEditing && !isCoarsePointer}
         className={cn(
-          "flex-1 min-w-0 bg-card border border-border text-text outline-none transition-colors text-center",
+          "flex-1 min-w-0 rounded-md bg-card border border-border text-text outline-none transition-colors text-center",
           "hover:border-text-muted focus:border-brand",
           !isEditing && !isCoarsePointer && "cursor-ew-resize select-none",
           isScrubbing && "cursor-ew-resize",
@@ -227,7 +227,7 @@ export function ScrubInput({
         <button
           type="button"
           onClick={() => bump(1)}
-          className="flex h-9 w-9 shrink-0 items-center justify-center border border-border bg-card text-text-muted active:bg-hover"
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-card text-text-muted active:bg-hover"
           aria-label={`Increase ${label}`}
         >
           <Plus size={14} />

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -39,9 +39,14 @@
 }
 
 @theme {
-  --font-mono: "Berkeley Mono", ui-monospace, monospace;
-  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "Berkeley Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
+  /* v3: SF Pro Display / SF Pro Text first on Apple platforms, Inter as the
+     designed-identity fallback elsewhere. Body chrome uses --font-sans, large
+     display / wordmark uses --font-display. */
+  --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter",
+    system-ui, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-display: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Inter",
+    system-ui, sans-serif;
 
   /* These get overridden by .light class below */
   --color-bg: var(--bg);
@@ -52,10 +57,9 @@
   --color-text-muted: var(--text-muted);
   --color-hover: var(--hover);
 
-  /* vcad brand color (Monokai Soda pink). This is the "loud" action color used
-     for primary buttons, focus rings, brand chips, etc. Renamed from the
-     historical `accent` namespace so the `accent` slot can carry shadcn's
-     subtler hover semantic without fighting it. */
+  /* vcad brand color (Monokai Soda pink). v3: still the single "loud" action
+     color — wordmark `.`, primary actions, focus rings, selection rail, the
+     footer heartbeat. Used sparingly so it earns its weight. */
   --color-brand: #F92672;
   --color-brand-hover: #d91e63;
   --color-danger: #F92672;
@@ -115,28 +119,59 @@
   --safe-right: env(safe-area-inset-right, 0px);
 }
 
-/* Dark mode (default) - Monokai Soda from tmTheme */
+/* v3 — Dark mode (default, no class). Tuned-warm Apple neutrals; never pure
+   black. One unified surface for chrome (#1A1A1D) lifted above the viewport
+   stage (#0E0E10) with a visible border doing the elevation work. */
 :root {
   color-scheme: dark;
-  --bg: #222222;
-  --surface: #2a2a2a;
-  --card: #333333;
-  --border: #444444;
-  --text: #F8F8F2;
-  --text-muted: #75715E;
-  --hover: rgba(255, 255, 255, 0.1);
+  --bg: #0E0E10;          /* viewport stage */
+  --surface: #1A1A1D;     /* chrome (header / footer / sidebars) */
+  --card: #1A1A1D;        /* raised content matches chrome — single material */
+  --border: #3A3A40;      /* visible above the grid */
+  --border-soft: #2F2F34;
+  --text: #F5F5F5;
+  --text-2: #D4D4D4;
+  --text-muted: #9C9CA3;
+  --text-tert: #6A6A70;
+  --hover: #26262B;
+  --fill: #232327;
+  --fill-strong: #2F2F34;
+  --selection-bg: rgba(249, 38, 114, 0.18);
+  --selection-fg: #FF5E9C;
 }
 
-/* Light mode - macOS-style neutral grey chrome */
+/* v3 — Light mode (Vercel-clean). Pure white chrome and stage on one sheet,
+   with #D4D4D4 hairlines doing all the structural work. Brand pink reserved
+   for wordmark dot, primary actions, focus rings, and selection. */
 :root.light {
   color-scheme: light;
-  --bg: #e8eaec;          /* macOS window grey */
-  --surface: #dde0e3;     /* recessed panels */
-  --card: #f4f5f7;        /* raised cards, lighter than bg */
-  --border: #c4c8cc;      /* neutral grey border */
-  --text: #1d1f23;        /* near-black text */
-  --text-muted: #6e7278;  /* mid-grey muted */
-  --hover: rgba(0, 0, 0, 0.05);
+  --bg: #FFFFFF;          /* viewport stage */
+  --surface: #FFFFFF;     /* chrome (header / footer / sidebars) */
+  --card: #FFFFFF;        /* raised content matches chrome — single material */
+  --border: #D4D4D4;      /* visible above the grid */
+  --border-soft: #D4D4D4;
+  --text: #000000;
+  --text-2: #171717;
+  --text-muted: #666666;
+  --text-tert: #999999;
+  --hover: #F4F4F5;
+  --fill: #F4F4F5;
+  --fill-strong: #E5E5E5;
+  --selection-bg: rgba(249, 38, 114, 0.08);
+  --selection-fg: #C0185A;
+}
+
+/* v3 — Geometry, motion, hairline. AppKit spring used in `appkit-spring`. */
+:root {
+  --hairline: 0.5px;
+  --ease-spring: cubic-bezier(0.32, 0.72, 0, 1);
+
+  --radius-xs: 3px;
+  --radius-sm: 6px;     /* buttons, inputs, kbd */
+  --radius-md: 10px;    /* popovers, menus, small cards */
+  --radius-lg: 14px;    /* cards, panels */
+  --radius-xl: 20px;    /* sheets, hero callouts */
+  --radius-pill: 999px;
 }
 
 /* Body typography. Two deliberate calls here, in order of importance:
@@ -460,19 +495,21 @@ body {
  *  - border          → softer to match macOS hairlines
  * ──────────────────────────────────────────────────────────────────────── */
 body.tauri-mac {
-  /* Dark theme — UnderWindowBackground reads as charcoal at ~0.7-0.8 alpha.
-     We tune surfaces just dark enough to keep text contrast >= 7:1. */
-  --bg: rgba(28, 28, 28, 0.0);
-  --surface: rgba(38, 38, 38, 0.62);
-  --card: rgba(48, 48, 48, 0.72);
+  /* Dark — let AppKit's UnderWindow vibrancy carry the wash. Surfaces sit
+     just above it so chrome reads as material, not a hole. Tuned to keep
+     ≥7:1 contrast against the v3 dark text. */
+  --bg: rgba(14, 14, 16, 0.0);
+  --surface: rgba(26, 26, 29, 0.72);
+  --card: rgba(26, 26, 29, 0.82);
   --border: rgba(255, 255, 255, 0.10);
   --hover: rgba(255, 255, 255, 0.06);
 }
 body.tauri-mac:has(:root.light) {
-  /* Light theme — Sidebar material reads as ~#e8e8e8 with subtle blur. */
-  --bg: rgba(0, 0, 0, 0.0);
-  --surface: rgba(245, 245, 247, 0.55);
-  --card: rgba(255, 255, 255, 0.72);
+  /* Light — Sidebar material reads as near-white with subtle blur. Chrome
+     stays effectively pure white so the v3 Vercel-clean read survives. */
+  --bg: rgba(255, 255, 255, 0.0);
+  --surface: rgba(255, 255, 255, 0.78);
+  --card: rgba(255, 255, 255, 0.92);
   --border: rgba(0, 0, 0, 0.08);
   --hover: rgba(0, 0, 0, 0.04);
 }

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -53,9 +53,14 @@
   --color-surface: var(--surface);
   --color-card: var(--card);
   --color-border: var(--border);
+  --color-border-soft: var(--border-soft);
   --color-text: var(--text);
+  --color-text-2: var(--text-2);
   --color-text-muted: var(--text-muted);
+  --color-text-tert: var(--text-tert);
   --color-hover: var(--hover);
+  --color-fill: var(--fill);
+  --color-fill-strong: var(--fill-strong);
 
   /* vcad brand color (Monokai Soda pink). v3: still the single "loud" action
      color — wordmark `.`, primary actions, focus rings, selection rail, the
@@ -296,7 +301,7 @@ body {
   }
 }
 .vcad-footer > * {
-  animation: vcad-chip-in 0.35s ease-out backwards;
+  animation: vcad-chip-in 0.4s var(--ease-spring) backwards;
 }
 .vcad-footer > *:nth-child(1) { animation-delay: 0.05s; }
 .vcad-footer > *:nth-child(2) { animation-delay: 0.10s; }
@@ -311,11 +316,12 @@ body {
 .changelog-tooltip {
   background: var(--surface);
   border: 1px solid var(--border);
+  border-radius: var(--radius-md);
   color: var(--text);
   padding: 0.5rem 0.75rem;
   font-size: 0.75rem;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  animation: changelog-tooltip-in 0.2s ease-out;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+  animation: changelog-tooltip-in 220ms var(--ease-spring);
   white-space: nowrap;
 }
 
@@ -377,7 +383,7 @@ body {
   animation: upgrade-overlay-out 140ms ease-in;
 }
 .upgrade-content[data-state="open"] {
-  animation: upgrade-content-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  animation: upgrade-content-in 220ms var(--ease-spring);
 }
 .upgrade-content[data-state="closed"] {
   animation: upgrade-content-out 140ms ease-in;
@@ -425,7 +431,7 @@ body {
   animation: upgrade-overlay-out 140ms ease-in;
 }
 .auth-content[data-state="open"] {
-  animation: upgrade-content-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+  animation: upgrade-content-in 220ms var(--ease-spring);
 }
 .auth-content[data-state="closed"] {
   animation: upgrade-content-out 140ms ease-in;
@@ -455,7 +461,7 @@ body {
   }
 }
 .auth-success-in {
-  animation: vcad-success-in 360ms cubic-bezier(0.16, 1, 0.3, 1);
+  animation: vcad-success-in 360ms var(--ease-spring);
 }
 
 /* Bottom toolbar: remove focus outlines in the bar and its menus */
@@ -624,10 +630,11 @@ body.tauri-mac {
 .path-popover {
   background: var(--card);
   border: 1px solid var(--border);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(16px) saturate(140%);
   -webkit-backdrop-filter: blur(16px) saturate(140%);
-  animation: path-popover-in 220ms cubic-bezier(0.32, 0.72, 0, 1);
+  animation: path-popover-in 220ms var(--ease-spring);
 }
 @keyframes path-popover-in {
   from { opacity: 0; transform: translate(-50%, -4px) scale(0.98); }


### PR DESCRIPTION
## Summary

Applies the canonical vcad **v3 design system** from the design bundle (`ui_kits/app/`) to the running app, and removes the colored 3D viewport background so only the grid, part, and lighting paint.

## What changed

**[packages/app/src/index.css](packages/app/src/index.css) — design tokens**

- **Light (`.light`):** Vercel-clean — `#FFFFFF` bg/surface, `#D4D4D4` hairlines, pure-black text, `#666` muted, `#F4F4F5` fills.
- **Dark (default):** tuned-warm Apple neutrals — `#0E0E10` stage, `#1A1A1D` chrome, `#3A3A40` border, `#F5F5F5 / #9C9CA3 / #6A6A70` text scale, `#26262B` hover. No more pure-black voids.
- **Fonts:** `--font-sans` and new `--font-display` lead with SF Pro Text / SF Pro Display on Apple platforms; Inter remains the designed-identity fallback. Berkeley Mono kept for code-shaped surfaces only.
- **New tokens:** `--hairline` (0.5px), `--ease-spring` (AppKit cubic-bezier), full `--radius-xs/sm/md/lg/xl/pill` stack, `--border-soft`, `--text-2/-tert`, `--fill/-strong`, `--selection-bg/-fg`.
- **Brand pink `#F92672`** unchanged — same hot-spot usage (wordmark dot, primary actions, focus, selection rail, footer heartbeat). Used sparingly so it earns its weight.
- **Tauri-mac vibrancy block** retuned so chrome rides the new palette over AppKit's UnderWindow / Sidebar materials without losing contrast.

**[Viewport.tsx](packages/app/src/components/Viewport.tsx) + [ViewportContent.tsx](packages/app/src/components/ViewportContent.tsx) — transparent 3D viewport**

- `<Canvas>` now uses `gl={{ alpha: true }}` with `style={{ background: "transparent" }}`. The page bg (`var(--bg)`) shows through, leaving only grid + part + lighting visible.
- Removed the fallback `<color attach="background" args={[isDark ? BG_DARK : BG_LIGHT]} />` — `scene.background` stays null so the alpha clear takes over. Doc-defined Solid backgrounds still win.
- `BG_DARK`/`BG_LIGHT` exports retained as `"transparent"` for legacy callers; unused import dropped from `ViewportContent`.

**[.claude/launch.json](.claude/launch.json) — preview port fix**

- The dev-server preview was hitting `chrome-error://` when another worktree owned `:5173`. Forwarding the launcher's `$PORT` to Vite (`--port ${PORT:-5173} --strictPort`) makes the preview work in any worktree.

## Why

The handoff bundle from `claude.ai/design` locks v3 (Vercel-clean light + warm-Apple dark + SF Pro / Berkeley Mono + pink reserved) as the canonical direction. This PR brings the running app in line with the bundle's `ui_kits/app/chrome.css` and `colors_and_type.css` token contract.

## Test plan

- [x] Browser preview verified in both light and dark — tokens resolve to the v3 spec values (`--bg`, `--surface`, `--border`, `--text`, `--hover`).
- [x] 3D viewport renders grid + robot arm + shadows on a transparent canvas; no scene-background regression.
- [x] No new console errors (only pre-existing Radix `DialogTitle` warnings).
- [ ] Sanity-check Tauri-mac vibrancy on a real macOS build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)