### PR TITLE
Modeless PCB editing: edit boards on the unified canvas

### DIFF
--- a/changelog/entries/2026-06-03-pcb-modeless-phase234.json
+++ b/changelog/entries/2026-06-03-pcb-modeless-phase234.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-03-pcb-modeless-phase234",
+  "version": "0.9.4",
+  "date": "2026-06-03",
+  "category": "feat",
+  "title": "PCB: live interference, auto-route, draggable traces",
+  "summary": "On-canvas PCB editing now flags components that clash with the enclosure in red, rubber-bands connected traces when you drag a footprint, adds one-click ratsnest auto-route, and a schematic overlay toggle.",
+  "features": ["pcb", "ecad", "electronics", "routing", "interference"]
+}

--- a/changelog/entries/2026-06-03-pcb-on-canvas.json
+++ b/changelog/entries/2026-06-03-pcb-on-canvas.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-03-pcb-on-canvas",
+  "version": "0.9.4",
+  "date": "2026-06-03",
+  "category": "feat",
+  "title": "Edit PCBs in the main 3D scene",
+  "summary": "PCB editing now happens in the main canvas alongside the mechanical assembly (ghosted), instead of a separate full-screen electronics mode that hid the rest of the app.",
+  "features": ["pcb", "ecad", "electronics", "viewport"]
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -95,6 +95,7 @@ import { useChatHandler } from "@/hooks/useChatHandler";
 import { useChatHydration } from "@/hooks/useChatHydration";
 import { useUrlSync } from "@/hooks/useUrlSync";
 import { useSketchAutoFit } from "@/hooks/useSketchAutoFit";
+import { usePcbAutoFit } from "@/hooks/usePcbAutoFit";
 import { saveDocument } from "@/lib/save-load";
 import { openLocalDocumentById } from "@/lib/open-document";
 import { bootstrap } from "@/lib/bootstrap";
@@ -231,6 +232,7 @@ export function App() {
   useUrlSync();
   useOperationPreview();
   useSketchAutoFit();
+  usePcbAutoFit();
 
   const [aboutOpen, setAboutOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);
@@ -1131,7 +1133,7 @@ export function App() {
             </MobileShell>
           ) : (
           <AppShell
-            header={!electronicsActive && (
+            header={(
               <Header
                 onAboutOpen={() => setAboutOpen(true)}
                 onProductOpen={() => setProductOpen(true)}
@@ -1143,20 +1145,20 @@ export function App() {
                 <ToolPalette />
               </Header>
             )}
-            leftSidebar={!electronicsActive && !showOnboarding && featureTreeOpen && (
+            leftSidebar={!showOnboarding && featureTreeOpen && (
               <FeatureTreeSlot sketchActive={sketchActive} />
             )}
-            rightSidebar={!electronicsActive && !showOnboarding && chatOpen && (
+            rightSidebar={!showOnboarding && chatOpen && (
               <AsyncBoundary region="chat-sidebar" fallback={null}>
                 <ChatSidebar />
               </AsyncBoundary>
             )}
-            bottomDock={!electronicsActive && (
+            bottomDock={(
               <AsyncBoundary region="log-viewer" fallback={null}>
                 <LogViewer />
               </AsyncBoundary>
             )}
-            footer={!electronicsActive && statusBarVisible && <StatusBar />}
+            footer={statusBarVisible && <StatusBar />}
           >
           {viewportStack}
           {dragOverlay}

--- a/packages/app/src/components/PostProcessingBoundary.tsx
+++ b/packages/app/src/components/PostProcessingBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, type ReactNode } from "react";
+
+/**
+ * R3F-safe error boundary for the post-processing pipeline.
+ *
+ * The `@react-three/postprocessing` EffectComposer reads
+ * `renderer.getContext().getContextAttributes().alpha` when wiring passes. On a
+ * degraded/lost WebGL context — Safari under GPU pressure, tab restore, or "too
+ * many live contexts" in automation/preview — `getContextAttributes()` returns
+ * null and the composer throws, which would otherwise white-screen the whole
+ * viewport. Here we catch it and render nothing, so the scene falls back to
+ * rendering without AO/vignette instead of crashing.
+ *
+ * Renders `null` (not a DOM fallback) so it's valid inside the Canvas tree.
+ */
+export class PostProcessingBoundary extends Component<
+  { children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.warn(
+      "[viewport] post-processing disabled after EffectComposer error:",
+      error?.message,
+    );
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -40,6 +40,10 @@ interface PbrMaterialProps {
   attenuationColor?: [number, number, number];
   clearcoat?: number;
   clearcoatRoughness?: number;
+  /** Ghosting overrides (used when another part has edit focus). */
+  transparent?: boolean;
+  opacity?: number;
+  depthWrite?: boolean;
 }
 
 /**
@@ -64,6 +68,9 @@ function PbrMaterial({
   attenuationColor,
   clearcoat,
   clearcoatRoughness,
+  transparent,
+  opacity,
+  depthWrite,
 }: PbrMaterialProps) {
   const usePhysical =
     (transmission !== undefined && transmission > 0) ||
@@ -93,7 +100,9 @@ function PbrMaterial({
         attenuationColor={attColor}
         clearcoat={clearcoat ?? 0}
         clearcoatRoughness={clearcoatRoughness ?? 0}
-        transparent={(transmission ?? 0) > 0}
+        transparent={transparent || (transmission ?? 0) > 0}
+        opacity={opacity ?? 1}
+        depthWrite={depthWrite ?? true}
       />
     );
   }
@@ -109,6 +118,9 @@ function PbrMaterial({
       envMapIntensity={envMapIntensity}
       flatShading={false}
       side={side}
+      transparent={transparent}
+      opacity={opacity ?? 1}
+      depthWrite={depthWrite ?? true}
     />
   );
 }
@@ -223,6 +235,10 @@ interface SceneMeshProps {
   transform?: Transform3D;
   /** Override ID used for selection (e.g., instance ID instead of part ID) */
   selectionId?: string;
+  /** Dim + make non-interactive while another part (e.g. a focused PCB) is
+   *  being edited, so the user can see and route against this geometry as
+   *  context without selecting it. */
+  ghosted?: boolean;
 }
 
 /** Compute face info from a raycast hit.
@@ -474,6 +490,7 @@ export const SceneMesh = memo(function SceneMesh({
   selected,
   transform,
   selectionId,
+  ghosted = false,
 }: SceneMeshProps) {
   const geoRef = useRef<THREE.BufferGeometry>(null);
   const meshRef = useRef<THREE.Mesh>(null);
@@ -912,14 +929,15 @@ export const SceneMesh = memo(function SceneMesh({
       originalRaycastRef.current = m.raycast.bind(m);
     }
 
-    if (isOrbiting) {
-      // Disable raycasting during orbit
+    if (isOrbiting || ghosted) {
+      // Disable raycasting during orbit, or while ghosted so pointer events
+      // pass through to the focused PCB's interaction plane.
       m.raycast = () => {};
     } else {
       // Restore original raycast
       m.raycast = originalRaycastRef.current;
     }
-  }, [isOrbiting]);
+  }, [isOrbiting, ghosted]);
 
   return (
     <mesh
@@ -950,6 +968,9 @@ export const SceneMesh = memo(function SceneMesh({
           attenuationColor={materialDef?.attenuationColor}
           clearcoat={materialDef?.clearcoat}
           clearcoatRoughness={materialDef?.clearcoatRoughness}
+          transparent={ghosted || undefined}
+          opacity={ghosted ? 0.16 : undefined}
+          depthWrite={ghosted ? false : undefined}
         />
       )}
       {showWireframe && geoReady && <Edges threshold={15} color="#666" />}

--- a/packages/app/src/components/Viewport.tsx
+++ b/packages/app/src/components/Viewport.tsx
@@ -12,6 +12,7 @@ import {
   useUiStore,
   useDocumentStore,
   useEngineStore,
+  useCoreElectronicsStore,
 } from "@vcad/core";
 import { useTheme } from "@/hooks/useTheme";
 import { useDrawingStore } from "@/stores/drawing-store";
@@ -230,6 +231,10 @@ export function Viewport() {
   const { isDark } = useTheme();
   const viewMode = useDrawingStore((s) => s.viewMode);
   const electronicsActive = useElectronicsStore((s) => s.active);
+  // A board has edit focus when the core store points at a PcbBoard node.
+  // Drives in-canvas PCB rendering; rendered alongside the rest of the scene
+  // rather than swapping into a separate PCB-only viewport.
+  const pcbEditFocus = useCoreElectronicsStore((s) => s.activeBoardNodeId) != null;
   const xrPresenting = useXRPresenting();
 
   // Run electronics sync when in electronics mode
@@ -315,7 +320,7 @@ export function Viewport() {
         style={{ background: "transparent" }}
       >
         <XR store={xrStore}>
-          <ViewportContent mode={electronicsActive ? "pcb" : "3d"} />
+          <ViewportContent mode="3d" pcbEditFocus={pcbEditFocus} />
           {!electronicsActive && <BoxSelectHandler containerRef={containerRef} />}
         </XR>
       </Canvas>

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -47,6 +47,7 @@ import {
   useSketchStore,
   useParticipantStore,
   kernelToDisplay,
+  isPcbBoardPart,
 } from "@vcad/core";
 import type { PartInfo, CameraGoal } from "@vcad/core";
 import { useCameraControls } from "@/hooks/useCameraControls";
@@ -71,7 +72,6 @@ import type {
   Light as IrLight,
 } from "@vcad/ir";
 import { PcbScene } from "./electronics/pcb3d/PcbScene";
-import { usePcbCamera } from "./electronics/pcb3d/usePcbCamera";
 import { useXRPresenting } from "@/stores/xr-store";
 import { XRSceneTransform } from "./xr/XRSceneTransform";
 import { XRGestures } from "./xr/XRGestures";
@@ -291,7 +291,15 @@ function DebugTriangleInspector() {
   return <InspectedTriangleMarker />;
 }
 
-export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
+export function ViewportContent({
+  mode = "3d",
+  pcbEditFocus = false,
+}: {
+  mode?: "3d" | "pcb";
+  /** When true, a PcbBoard has edit focus: render its copper/footprints/
+   *  ratsnest in the main scene and ghost the rest of the assembly. */
+  pcbEditFocus?: boolean;
+}) {
   useCameraControls();
   useInputDeviceDetection();
   usePhysicsSimulation();
@@ -319,7 +327,6 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
   const sketchActive = useSketchStore((s) => s.active);
   const xrPresenting = useXRPresenting();
   const orbitRef = useRef<OrbitControlsImpl>(null);
-  usePcbCamera(orbitRef, isPcbMode);
   const { camera, invalidate } = useThree();
   const { isDark } = useTheme();
 
@@ -1682,11 +1689,14 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
       )}
 
       {/* ═══════════════════════════════════════════════════════════════════
-          PCB MODE: Render PcbScene inside the rotation group
+          PCB EDIT FOCUS: render the board's copper/footprints/ratsnest in the
+          main scene, alongside (not instead of) the mechanical assembly. The
+          FR4 slab is suppressed (showBoard=false) because the board's kernel
+          body already renders as a normal part via SceneMesh below.
           ═══════════════════════════════════════════════════════════════════ */}
-      {isPcbMode && (
+      {pcbEditFocus && (
         <group rotation={[-Math.PI / 2, 0, 0]}>
-          <PcbScene />
+          <PcbScene showBoard={false} />
         </group>
       )}
 
@@ -1735,6 +1745,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
                     materialKey={inst.material}
                     selected={selectedPartIds.has(instanceSelectionId)}
                     transform={inst.transform}
+                    ghosted={pcbEditFocus}
                   />
                 );
               })}
@@ -1763,6 +1774,7 @@ export function ViewportContent({ mode = "3d" }: { mode?: "3d" | "pcb" }) {
                       mesh={evalPart.mesh}
                       materialKey={evalPart.material}
                       selected={isPartSelected(partInfo.id, idx)}
+                      ghosted={pcbEditFocus && !isPcbBoardPart(partInfo)}
                     />
                   );
                 })}

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -74,6 +74,7 @@ import type {
 } from "@vcad/ir";
 import { PcbScene } from "./electronics/pcb3d/PcbScene";
 import { PcbBoardBodies } from "./electronics/pcb3d/PcbBoardBodies";
+import { PostProcessingBoundary } from "./PostProcessingBoundary";
 import { useXRPresenting } from "@/stores/xr-store";
 import { XRSceneTransform } from "./xr/XRSceneTransform";
 import { XRGestures } from "./xr/XRGestures";
@@ -1850,6 +1851,15 @@ export function ViewportContent({
         const aoEnabled = sceneSettings.postProcessing.ambientOcclusion?.enabled !== false;
         const vignetteEnabled = sceneSettings.postProcessing.vignette?.enabled !== false;
         if (!aoEnabled && !vignetteEnabled) return null;
+        // Skip post-processing when the WebGL context can't report attributes
+        // (lost / degraded / "too many live contexts"): EffectComposer reads
+        // getContextAttributes().alpha and would crash on a null result. The
+        // PostProcessingBoundary below catches any residual composer error so a
+        // failure degrades to "no effects" instead of white-screening.
+        const glCtx = gl.getContext?.();
+        if (!glCtx || typeof glCtx.getContextAttributes !== "function" || !glCtx.getContextAttributes()) {
+          return null;
+        }
         // EffectComposer's children type is strict (`JSX.Element | JSX.Element[]`),
         // so we build the array up-front rather than inlining `cond && <Effect/>`
         // expressions, which would resolve to `false` when disabled.
@@ -1877,7 +1887,11 @@ export function ViewportContent({
             />,
           );
         }
-        return <EffectComposer>{effects}</EffectComposer>;
+        return (
+          <PostProcessingBoundary>
+            <EffectComposer>{effects}</EffectComposer>
+          </PostProcessingBoundary>
+        );
       })()}
     </>
   );

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -1689,14 +1689,14 @@ export function ViewportContent({
       )}
 
       {/* ═══════════════════════════════════════════════════════════════════
-          PCB EDIT FOCUS: render the board's copper/footprints/ratsnest in the
-          main scene, alongside (not instead of) the mechanical assembly. The
-          FR4 slab is suppressed (showBoard=false) because the board's kernel
-          body already renders as a normal part via SceneMesh below.
+          PCB EDIT FOCUS: render the board (FR4 slab + copper/footprints/
+          ratsnest) in the main scene, alongside (not instead of) the
+          mechanical assembly. PcbScene draws the slab itself — the PcbBoard
+          kernel op evaluates to Solid.empty(), so there is no duplicate body.
           ═══════════════════════════════════════════════════════════════════ */}
       {pcbEditFocus && (
         <group rotation={[-Math.PI / 2, 0, 0]}>
-          <PcbScene showBoard={false} />
+          <PcbScene />
         </group>
       )}
 

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -48,6 +48,7 @@ import {
   useParticipantStore,
   kernelToDisplay,
   isPcbBoardPart,
+  useCoreElectronicsStore,
 } from "@vcad/core";
 import type { PartInfo, CameraGoal } from "@vcad/core";
 import { useCameraControls } from "@/hooks/useCameraControls";
@@ -72,6 +73,7 @@ import type {
   Light as IrLight,
 } from "@vcad/ir";
 import { PcbScene } from "./electronics/pcb3d/PcbScene";
+import { PcbBoardBodies } from "./electronics/pcb3d/PcbBoardBodies";
 import { useXRPresenting } from "@/stores/xr-store";
 import { XRSceneTransform } from "./xr/XRSceneTransform";
 import { XRGestures } from "./xr/XRGestures";
@@ -325,6 +327,9 @@ export function ViewportContent({
   const renderMode = useUiStore((s) => s.renderMode);
   const raytraceAvailable = useUiStore((s) => s.raytraceAvailable);
   const sketchActive = useSketchStore((s) => s.active);
+  // Board with edit focus (null when not editing). Used to skip the focused
+  // board in PcbBoardBodies — PcbScene already draws that one.
+  const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
   const xrPresenting = useXRPresenting();
   const orbitRef = useRef<OrbitControlsImpl>(null);
   const { camera, invalidate } = useThree();
@@ -1719,6 +1724,10 @@ export function ViewportContent({
           <group rotation={[-Math.PI / 2, 0, 0]}>
             {/* Plane gizmo at origin - inside rotation group so kernel planes display correctly */}
             <PlaneGizmo />
+
+            {/* PCB board slabs — visible as bodies even when not being edited
+                (the focused board is drawn by PcbScene instead). */}
+            <PcbBoardBodies excludeNodeId={activeBoardNodeId} />
 
             {/* KILL-SWITCH: was `<SilhouetteTarget enabled={silhouetteEnabled}>`
                 feeding the Outline post-effect via Selection context. Bypassing

--- a/packages/app/src/components/electronics/ElectronicsToolbar.tsx
+++ b/packages/app/src/components/electronics/ElectronicsToolbar.tsx
@@ -23,6 +23,7 @@ import { MagnetStraight } from "@phosphor-icons/react/dist/ssr/MagnetStraight";
 import { Package } from "@phosphor-icons/react/dist/ssr/Package";
 import { Ruler } from "@phosphor-icons/react/dist/ssr/Ruler";
 import { ArrowSquareDown } from "@phosphor-icons/react/dist/ssr/ArrowSquareDown";
+import { Lightning } from "@phosphor-icons/react/dist/ssr/Lightning";
 import { TabDropdown, ToolbarButton } from "@/components/ui/toolbar";
 import {
   ELECTRONICS_TAB_COLORS,
@@ -35,6 +36,7 @@ import { useUiStore } from "@vcad/core";
 import type { PcbLayer } from "@vcad/ir";
 
 import { SYMBOL_LIBRARY } from "./symbol-library";
+import { autorouteRatsnest } from "@/lib/pcb-autoroute";
 
 // ---------------------------------------------------------------------------
 // Tab definitions
@@ -171,6 +173,8 @@ export function ElectronicsToolbar() {
   const setLayerVisible = useElectronicsStore((s) => s.setLayerVisible);
   const setSchLabelName = useElectronicsStore((s) => s.setSchLabelName);
   const exit = useElectronicsStore((s) => s.exit);
+  const schematicDocked = useElectronicsStore((s) => s.schematicDocked);
+  const setSchematicDocked = useElectronicsStore((s) => s.setSchematicDocked);
 
   const unplacedComponents = useElectronicsStore((s) => s.unplacedComponents);
   const syncSchematicToPcb = useDocumentStore((s) => s.syncSchematicToPcb);
@@ -474,6 +478,15 @@ export function ElectronicsToolbar() {
       >
         <Trash size={20} />
       </ToolbarButton>
+      <ToolbarButton
+        tooltip="Auto-route ratsnest"
+        onClick={() => {
+          void autorouteRatsnest();
+        }}
+        iconColor={ELECTRONICS_TAB_COLORS.pcb}
+      >
+        <Lightning size={20} />
+      </ToolbarButton>
       {unplacedComponents.length > 0 && (
         <ToolbarButton
           tooltip={`Place ${unplacedComponents.length} unplaced component(s)`}
@@ -519,6 +532,22 @@ export function ElectronicsToolbar() {
         expanded
       >
         <Square size={20} />
+      </ToolbarButton>
+
+      <div className="w-px h-5 bg-border mx-0.5" />
+
+      {/* Toggle the dockable schematic overlay on the 3D canvas */}
+      <ToolbarButton
+        tooltip={schematicDocked === "hidden" ? "Show schematic" : "Hide schematic"}
+        active={schematicDocked !== "hidden"}
+        onClick={() =>
+          setSchematicDocked(schematicDocked === "hidden" ? "left" : "hidden")
+        }
+        iconColor={ELECTRONICS_TAB_COLORS.view}
+        label="Sch"
+        expanded
+      >
+        <PencilSimple size={20} />
       </ToolbarButton>
 
       <div className="w-px h-5 bg-border mx-0.5" />

--- a/packages/app/src/components/electronics/pcb3d/PcbBoardBodies.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbBoardBodies.tsx
@@ -1,0 +1,38 @@
+/**
+ * Renders the FR4 slab for every PcbBoard in the document so a board is
+ * visible as a body in the main scene even when it is NOT being edited.
+ *
+ * The board's geometry comes straight from its PCB data (via the proven
+ * PcbBoardMesh), independent of the kernel evaluator — the app's live WASM
+ * evaluator still returns an empty solid for PcbBoard, so without this a board
+ * would be invisible outside edit focus.
+ *
+ * The board with edit focus is skipped: PcbScene already draws its slab.
+ */
+
+import { useDocumentStore, getPcbNodeIds, getNodePcb } from "@vcad/core";
+import type { NodeId } from "@vcad/ir";
+import { PcbBoardMesh } from "./PcbBoardMesh";
+
+export function PcbBoardBodies({ excludeNodeId }: { excludeNodeId: NodeId | null }) {
+  const doc = useDocumentStore((s) => s.document);
+  const boardIds = getPcbNodeIds(doc);
+
+  if (boardIds.length === 0) {
+    // CRDT dual-path: the board lives in doc.pcb with no PcbBoard node id.
+    // When a board has edit focus (excludeNodeId set) PcbScene draws it.
+    return doc.pcb && excludeNodeId == null ? (
+      <PcbBoardMesh pcb={doc.pcb} explosion={0} />
+    ) : null;
+  }
+
+  return (
+    <>
+      {boardIds.map((id) => {
+        if (id === excludeNodeId) return null;
+        const pcb = getNodePcb(doc, id);
+        return pcb ? <PcbBoardMesh key={String(id)} pcb={pcb} explosion={0} /> : null;
+      })}
+    </>
+  );
+}

--- a/packages/app/src/components/electronics/pcb3d/PcbFootprint3D.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbFootprint3D.tsx
@@ -17,6 +17,8 @@ interface Props {
   boardThickness: number;
   highlight: boolean;
   explosion: number;
+  /** Component body clashes with a mechanical part — render in red. */
+  interfering?: boolean;
 }
 
 function graphicToLines(
@@ -72,7 +74,7 @@ function graphicToLines(
   }
 }
 
-export function PcbFootprint3D({ footprint, layers, boardThickness, highlight, explosion }: Props) {
+export function PcbFootprint3D({ footprint, layers, boardThickness, highlight, explosion, interfering }: Props) {
   const fpRot = (footprint.rotation ?? 0) * Math.PI / 180;
 
   const lineSegments = useMemo(() => {
@@ -96,7 +98,7 @@ export function PcbFootprint3D({ footprint, layers, boardThickness, highlight, e
             />
           </bufferGeometry>
           <lineBasicMaterial
-            color={highlight ? "#3b82f6" : getLayerColor(layers, seg.layer)}
+            color={interfering ? "#ef4444" : highlight ? "#3b82f6" : getLayerColor(layers, seg.layer)}
             linewidth={1}
           />
         </line>
@@ -107,7 +109,7 @@ export function PcbFootprint3D({ footprint, layers, boardThickness, highlight, e
         position={[footprint.position.x, footprint.position.y, refZ + 0.05]}
         rotation={[0, 0, fpRot]}
         fontSize={0.8}
-        color={highlight ? "#3b82f6" : "#FFEB3B"}
+        color={interfering ? "#ef4444" : highlight ? "#3b82f6" : "#FFEB3B"}
         anchorX="center"
         anchorY="middle"
         outlineWidth={0.05}

--- a/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
@@ -45,6 +45,7 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const pcbTool = useElectronicsStore((s) => s.pcbTool);
   const pcbDragging = useElectronicsStore((s) => s.pcbDragging);
   const stackupExplosion = useElectronicsStore((s) => s.stackupExplosion);
+  const interferingFootprints = useElectronicsStore((s) => s.interferingFootprints);
 
   const select = useElectronicsStore((s) => s.select);
   const setHoveredNet = useElectronicsStore((s) => s.setHoveredNet);
@@ -307,6 +308,7 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
           layers={pcbLayers}
           boardThickness={boardThickness}
           highlight={activeFootprintRef === fp.ref}
+          interfering={interferingFootprints.includes(fp.ref)}
           explosion={stackupExplosion}
         />
       ))}

--- a/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
@@ -26,6 +26,7 @@ import { PcbDrcMarkers3D } from "./PcbDrcMarkers3D";
 export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const { invalidate } = useThree();
   const planeRef = useRef<THREE.Mesh>(null);
+  const groupRef = useRef<THREE.Group>(null);
 
   const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
   const document = useDocumentStore((s) => s.document);
@@ -79,7 +80,12 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
       if (!pcb || e.button !== 0) return;
       e.stopPropagation();
 
-      const point = e.point as THREE.Vector3;
+      // Convert the world-space ray/plane intersection into the board's local
+      // (kernel) frame so picking is correct from ANY camera angle — the
+      // interaction plane is coplanar with the board, so the ray lands where
+      // the geometry actually is.
+      const world = e.point as THREE.Vector3;
+      const point = groupRef.current ? groupRef.current.worldToLocal(world.clone()) : world;
       const pcbPos = worldToPcb(point, pcbGridSize, pcbSnapToGrid);
 
       // Move tool: start footprint drag
@@ -213,7 +219,8 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const onPlanePointerMove = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
       if (!pcb) return;
-      const point = e.point as THREE.Vector3;
+      const world = e.point as THREE.Vector3;
+      const point = groupRef.current ? groupRef.current.worldToLocal(world.clone()) : world;
       const pcbPos = worldToPcb(point, pcbGridSize, pcbSnapToGrid);
 
       // Footprint drag
@@ -241,12 +248,24 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   if (!pcb) return null;
 
   const boardThickness = pcb.outline.thickness;
+  // Board outline center — anchors the interaction plane + grid on the board
+  // (was previously hardcoded to a 50x30 board's center).
+  let bMinX = Infinity, bMaxX = -Infinity, bMinY = Infinity, bMaxY = -Infinity;
+  for (const v of pcb.outline.vertices) {
+    if (v.x < bMinX) bMinX = v.x;
+    if (v.x > bMaxX) bMaxX = v.x;
+    if (v.y < bMinY) bMinY = v.y;
+    if (v.y > bMaxY) bMaxY = v.y;
+  }
+  const boardCx = isFinite(bMinX) ? (bMinX + bMaxX) / 2 : 0;
+  const boardCy = isFinite(bMinY) ? (bMinY + bMaxY) / 2 : 0;
+  const surfaceZ = layerZ("FCu", boardThickness);
 
   return (
-    <group>
+    <group ref={groupRef}>
       {/* Grid (infinite fading dots) */}
       <Grid
-        position={[25, layerZ("FCu", boardThickness) - 0.05, -15]}
+        position={[boardCx, boardCy, surfaceZ - 0.05]}
         rotation={[Math.PI / 2, 0, 0]}
         args={[200, 200]}
         cellSize={pcbGridSize}
@@ -257,12 +276,14 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
         infiniteGrid
       />
 
-      {/* Invisible interaction plane at board surface */}
+      {/* Invisible interaction plane, coplanar with the board surface (kernel
+          XY at z=surfaceZ, normal +Z) so cursor raycasts map to the right
+          board coords from any camera angle. PlaneGeometry already lies in
+          local XY, so no rotation. */}
       <Plane
         ref={planeRef}
         args={[500, 500]}
-        position={[25, layerZ("FCu", boardThickness), -15]}
-        rotation={[Math.PI / 2, 0, 0]}
+        position={[boardCx, boardCy, surfaceZ]}
         visible={false}
         onPointerDown={onPlanePointerDown}
         onPointerMove={onPlanePointerMove}

--- a/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
@@ -23,7 +23,7 @@ import { PcbRatsnest3D } from "./PcbRatsnest3D";
 import { PcbRoutePreview3D } from "./PcbRoutePreview3D";
 import { PcbDrcMarkers3D } from "./PcbDrcMarkers3D";
 
-export function PcbScene() {
+export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const { invalidate } = useThree();
   const planeRef = useRef<THREE.Mesh>(null);
 
@@ -268,8 +268,10 @@ export function PcbScene() {
         onPointerUp={onPlanePointerUp}
       />
 
-      {/* Board outline */}
-      <PcbBoardMesh pcb={pcb} explosion={stackupExplosion} />
+      {/* Board outline — suppressed (showBoard=false) when the board's kernel
+          body already renders as a part in the main scene during modeless
+          edit focus, to avoid a duplicate / z-fighting FR4 slab. */}
+      {showBoard && <PcbBoardMesh pcb={pcb} explosion={stackupExplosion} />}
 
       {/* Traces */}
       <PcbTraceMesh

--- a/packages/app/src/hooks/useElectronicsSync.ts
+++ b/packages/app/src/hooks/useElectronicsSync.ts
@@ -4,18 +4,29 @@
  * Implements:
  * - Principle 7: Continuous netlist regeneration on schematic change
  * - Principle 3: Real-time DRC/ERC validation
+ * - Phase 3: Live route-vs-enclosure interference (component bodies vs the
+ *   mechanical parts sharing the canvas)
  */
 
 import { useEffect } from "react";
-import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/core";
-import { generateNetlist, runDrc, runErc } from "@vcad/engine";
+import {
+  useDocumentStore,
+  useCoreElectronicsStore,
+  useEngineStore,
+  getNodePcb,
+  isPcbBoardPart,
+} from "@vcad/core";
+import { generateNetlist, runDrc, runErc, componentMeshes } from "@vcad/engine";
 import { useElectronicsStore } from "@/stores/electronics-store";
+import { aabbOfPositions, interferingRefs, type Aabb } from "@/lib/pcb-interference";
 
 export function useElectronicsSync() {
   const active = useElectronicsStore((s) => s.active);
   const schematic = useDocumentStore((s) => s.document.schematic);
   const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
   const document = useDocumentStore((s) => s.document);
+  const scene = useEngineStore((s) => s.scene);
+  const parts = useDocumentStore((s) => s.parts);
   const pcb = activeBoardNodeId != null ? getNodePcb(document, activeBoardNodeId) : null;
 
   // Principle 7: Continuous netlist sync
@@ -54,4 +65,28 @@ export function useElectronicsSync() {
     }, 300);
     return () => clearTimeout(timer);
   }, [schematic, active]);
+
+  // Phase 3: route-vs-enclosure interference. AABB overlap between each
+  // component's 3D body and the surrounding mechanical parts (the board body
+  // itself is excluded). Debounced; runs alongside DRC.
+  useEffect(() => {
+    if (!active || !pcb) {
+      useElectronicsStore.getState().setInterferingFootprints([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      const comps = await componentMeshes(pcb);
+      const mech: Aabb[] = [];
+      scene?.parts.forEach((ep, idx) => {
+        const pi = parts[idx];
+        if (pi && isPcbBoardPart(pi)) return; // don't clash with the board itself
+        const bb = aabbOfPositions(ep.mesh?.positions);
+        if (bb) mech.push(bb);
+      });
+      useElectronicsStore
+        .getState()
+        .setInterferingFootprints(interferingRefs(comps, mech));
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [pcb, active, scene, parts]);
 }

--- a/packages/app/src/hooks/usePcbAutoFit.ts
+++ b/packages/app/src/hooks/usePcbAutoFit.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+import { useCoreElectronicsStore, useDocumentStore, getNodePcb } from "@vcad/core";
+
+/**
+ * Auto-fit the viewport camera to the focused PCB board the first time a
+ * board gains edit focus. Fires `vcad:face-selected` (kernel Z-up) — the
+ * handler in ViewportContent swings the camera perpendicular to the board
+ * and then re-enables OrbitControls, so this is a one-off framing, not a
+ * camera lock. Skips when a share URL supplied a `?at=` viewer-state hint,
+ * since that hint owns the camera.
+ *
+ * Mirrors `useSketchAutoFit`: fires once per focus session. Leaving and
+ * re-entering a board re-frames it; editing within a session does not yank
+ * the camera away from wherever the user orbited to.
+ */
+export function usePcbAutoFit(): void {
+  const boardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
+  const firedRef = useRef(false);
+
+  // Reset the one-shot guard when edit focus clears.
+  useEffect(() => {
+    if (boardNodeId == null) firedRef.current = false;
+  }, [boardNodeId]);
+
+  useEffect(() => {
+    if (boardNodeId == null || firedRef.current) return;
+
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      if (params.has("at")) return;
+    }
+
+    const pcb = getNodePcb(useDocumentStore.getState().document, boardNodeId);
+    const verts = pcb?.outline?.vertices;
+    if (!pcb || !verts || verts.length < 3) return;
+
+    let minX = Infinity,
+      maxX = -Infinity,
+      minY = Infinity,
+      maxY = -Infinity;
+    for (const v of verts) {
+      if (v.x < minX) minX = v.x;
+      if (v.x > maxX) maxX = v.x;
+      if (v.y < minY) minY = v.y;
+      if (v.y > maxY) maxY = v.y;
+    }
+
+    // The board lies in the kernel XY plane; its top surface normal is +Z.
+    // Frame from the top so the swing lands on a familiar top-down-ish view
+    // that the user can then orbit away from.
+    const z = pcb.outline.thickness ?? 1.6;
+    const centroid = { x: (minX + maxX) / 2, y: (minY + maxY) / 2, z };
+    const vertices = verts.map((v) => ({ x: v.x, y: v.y, z }));
+
+    firedRef.current = true;
+    window.dispatchEvent(
+      new CustomEvent("vcad:face-selected", {
+        detail: { normal: { x: 0, y: 0, z: 1 }, centroid, vertices },
+      }),
+    );
+  }, [boardNodeId]);
+}

--- a/packages/app/src/lib/pcb-autoroute.ts
+++ b/packages/app/src/lib/pcb-autoroute.ts
@@ -1,0 +1,49 @@
+/**
+ * Best-effort autoroute of unrouted ratsnest connections on the focused board
+ * (Phase 2/3). Routes each ratsnest line with the grid router (engine
+ * `routeNet`) and commits successful routes as FCu traces.
+ *
+ * This is the in-app twin of the `route_nets` MCP tool the AI calls — same
+ * engine, same live focused board — so "route the power nets" from chat and
+ * the toolbar button drive identical paths.
+ */
+
+import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/core";
+import { computeRatsnest, routeNet } from "@vcad/engine";
+import { useElectronicsStore } from "@/stores/electronics-store";
+
+export async function autorouteRatsnest(): Promise<{ routed: number; failed: number }> {
+  const boardNodeId = useCoreElectronicsStore.getState().activeBoardNodeId;
+  if (boardNodeId == null) return { routed: 0, failed: 0 };
+  const netlist = useElectronicsStore.getState().netlist;
+  let pcb = getNodePcb(useDocumentStore.getState().document, boardNodeId);
+  if (!pcb || !netlist) return { routed: 0, failed: 0 };
+
+  const width = pcb.rules?.defaultRules?.traceWidth ?? 0.15;
+  const rats = await computeRatsnest(pcb, netlist);
+
+  let routed = 0;
+  let failed = 0;
+  for (const line of rats) {
+    // Re-read the board each pass so freshly committed traces are seen as
+    // obstacles by the router (avoids stacking routes on top of each other).
+    pcb = getNodePcb(useDocumentStore.getState().document, boardNodeId);
+    if (!pcb) break;
+    const res = await routeNet(pcb, line.net, line.from, line.to, width);
+    if (res.success && res.segments.length > 0) {
+      for (const [start, end] of res.segments) {
+        useDocumentStore.getState().addTrace(boardNodeId, {
+          start: { x: start.x, y: start.y, z: 0 },
+          end: { x: end.x, y: end.y, z: 0 },
+          width,
+          layer: "FCu",
+          net: line.net,
+        });
+      }
+      routed++;
+    } else {
+      failed++;
+    }
+  }
+  return { routed, failed };
+}

--- a/packages/app/src/lib/pcb-interference.ts
+++ b/packages/app/src/lib/pcb-interference.ts
@@ -63,11 +63,13 @@ export function interferingRefs(
   margin = 0,
 ): string[] {
   if (mechanical.length === 0) return [];
-  const out: string[] = [];
+  const out = new Set<string>();
   for (const c of components) {
     const cb = aabbOfPositions(c.positions);
     if (!cb) continue;
-    if (mechanical.some((m) => aabbsOverlap(cb, m, margin))) out.push(c.footprint_ref);
+    if (mechanical.some((m) => aabbsOverlap(cb, m, margin))) out.add(c.footprint_ref);
   }
-  return out;
+  // A footprint can yield several component sub-meshes (body + caps); collapse
+  // to unique refs so callers get each interfering footprint once.
+  return [...out];
 }

--- a/packages/app/src/lib/pcb-interference.ts
+++ b/packages/app/src/lib/pcb-interference.ts
@@ -1,0 +1,73 @@
+/**
+ * Route-vs-enclosure interference (Phase 3).
+ *
+ * Axis-aligned bounding-box overlap test between PCB component 3D bodies
+ * (from `componentMeshes`) and the mechanical parts sharing the canvas. This
+ * is what makes the unified MCAD/ECAD canvas pay off: a tall capacitor or a
+ * connector that pokes through the enclosure lights up live while you place
+ * and route.
+ *
+ * First cut: AABB-vs-AABB in the kernel frame, which is exact enough to catch
+ * real clashes (and assumes the board sits at the origin — see the modeless
+ * Phase 1 constraint). Mesh-accurate clash + assembly-instance obstacles are
+ * follow-ups.
+ */
+
+import type { ComponentMesh } from "@vcad/engine";
+
+export type Aabb = { min: [number, number, number]; max: [number, number, number] };
+
+/** Compute an AABB from a flat [x,y,z,...] position buffer. */
+export function aabbOfPositions(positions: ArrayLike<number> | undefined): Aabb | null {
+  if (!positions || positions.length < 3) return null;
+  let minX = Infinity,
+    minY = Infinity,
+    minZ = Infinity;
+  let maxX = -Infinity,
+    maxY = -Infinity,
+    maxZ = -Infinity;
+  for (let i = 0; i + 2 < positions.length; i += 3) {
+    const x = positions[i]!;
+    const y = positions[i + 1]!;
+    const z = positions[i + 2]!;
+    if (x < minX) minX = x;
+    if (x > maxX) maxX = x;
+    if (y < minY) minY = y;
+    if (y > maxY) maxY = y;
+    if (z < minZ) minZ = z;
+    if (z > maxZ) maxZ = z;
+  }
+  if (!isFinite(minX)) return null;
+  return { min: [minX, minY, minZ], max: [maxX, maxY, maxZ] };
+}
+
+/** True when two AABBs overlap (optionally expanded by a clearance margin). */
+export function aabbsOverlap(a: Aabb, b: Aabb, margin = 0): boolean {
+  return (
+    a.min[0] - margin <= b.max[0] &&
+    a.max[0] + margin >= b.min[0] &&
+    a.min[1] - margin <= b.max[1] &&
+    a.max[1] + margin >= b.min[1] &&
+    a.min[2] - margin <= b.max[2] &&
+    a.max[2] + margin >= b.min[2]
+  );
+}
+
+/**
+ * Footprint refs whose component body intersects any mechanical AABB.
+ * `margin` adds a clearance band so near-misses also flag.
+ */
+export function interferingRefs(
+  components: ComponentMesh[],
+  mechanical: Aabb[],
+  margin = 0,
+): string[] {
+  if (mechanical.length === 0) return [];
+  const out: string[] = [];
+  for (const c of components) {
+    const cb = aabbOfPositions(c.positions);
+    if (!cb) continue;
+    if (mechanical.some((m) => aabbsOverlap(cb, m, margin))) out.push(c.footprint_ref);
+  }
+  return out;
+}

--- a/packages/app/src/stores/electronics-store.ts
+++ b/packages/app/src/stores/electronics-store.ts
@@ -107,6 +107,10 @@ export interface ElectronicsState {
   drcViolations: DrcViolationResult[];
   ercViolations: ErcViolationResult[];
 
+  // Route-vs-enclosure: footprint refs whose 3D body intersects a mechanical
+  // part (Phase 3 — live MCAD/ECAD interference).
+  interferingFootprints: string[];
+
   // PCB 3D view state (Phase 2: tilt-to-3D + exploded stackup)
   tiltAngle: number; // degrees, 0 = top-down, >5 = tilted 3D
   stackupExplosion: number; // 0 = flat, 1 = fully exploded
@@ -144,6 +148,7 @@ export interface ElectronicsState {
   setLayerOpacity: (layer: PcbLayer, opacity: number) => void;
   setDrcViolations: (v: DrcViolationResult[]) => void;
   setErcViolations: (v: ErcViolationResult[]) => void;
+  setInterferingFootprints: (refs: string[]) => void;
   setNetlist: (n: NetlistResult) => void;
   setOrphanFootprints: (refs: string[]) => void;
   setUnplacedComponents: (refs: string[]) => void;
@@ -218,6 +223,7 @@ export const useElectronicsStore = create<ElectronicsState>((set, get) => ({
 
   drcViolations: [],
   ercViolations: [],
+  interferingFootprints: [],
 
   tiltAngle: 0,
   stackupExplosion: 0,
@@ -336,6 +342,7 @@ export const useElectronicsStore = create<ElectronicsState>((set, get) => ({
 
   setDrcViolations: (drcViolations) => set({ drcViolations }),
   setErcViolations: (ercViolations) => set({ ercViolations }),
+  setInterferingFootprints: (interferingFootprints) => set({ interferingFootprints }),
   setNetlist: (netlist) => set({ netlist }),
   setOrphanFootprints: (orphanFootprints) => set({ orphanFootprints }),
   setUnplacedComponents: (unplacedComponents) => set({ unplacedComponents }),

--- a/packages/app/src/test/pcb-interference.test.ts
+++ b/packages/app/src/test/pcb-interference.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import type { ComponentMesh } from "@vcad/engine";
+import { aabbOfPositions, aabbsOverlap, interferingRefs } from "@/lib/pcb-interference";
+
+/** Unit cube [0,0,0]..[s,s,s] translated by (tx,ty,tz) as a flat position buffer. */
+function boxPositions(s: number, tx = 0, ty = 0, tz = 0): number[] {
+  const c = [
+    [0, 0, 0], [s, 0, 0], [s, s, 0], [0, s, 0],
+    [0, 0, s], [s, 0, s], [s, s, s], [0, s, s],
+  ];
+  return c.flatMap(([x, y, z]) => [x! + tx, y! + ty, z! + tz]);
+}
+
+function comp(ref: string, positions: number[]): ComponentMesh {
+  return { footprint_ref: ref, positions, indices: [], normals: [], color: [0, 0, 0], metalness: 0 };
+}
+
+describe("pcb-interference", () => {
+  it("computes an AABB from a position buffer", () => {
+    const bb = aabbOfPositions(boxPositions(2, 1, 1, 1));
+    expect(bb).toEqual({ min: [1, 1, 1], max: [3, 3, 3] });
+  });
+
+  it("returns null for empty/short buffers", () => {
+    expect(aabbOfPositions([])).toBeNull();
+    expect(aabbOfPositions(undefined)).toBeNull();
+  });
+
+  it("detects overlap and separation", () => {
+    const a = { min: [0, 0, 0] as [number, number, number], max: [10, 10, 10] as [number, number, number] };
+    const near = { min: [9, 9, 9] as [number, number, number], max: [12, 12, 12] as [number, number, number] };
+    const far = { min: [20, 20, 20] as [number, number, number], max: [25, 25, 25] as [number, number, number] };
+    expect(aabbsOverlap(a, near)).toBe(true);
+    expect(aabbsOverlap(a, far)).toBe(false);
+    // margin expands the test so near-misses flag
+    expect(aabbsOverlap(a, { min: [11, 0, 0], max: [12, 5, 5] }, 1.5)).toBe(true);
+  });
+
+  it("flags only components overlapping a mechanical AABB (no false positives)", () => {
+    const mech = [aabbOfPositions(boxPositions(10, 0, 0, 0))!]; // [0,10]^3
+    const inside = comp("R1", boxPositions(2, 1, 1, 1)); // overlaps
+    const outside = comp("C1", boxPositions(2, 50, 50, 50)); // clear
+    expect(interferingRefs([inside, outside], mech)).toEqual(["R1"]);
+  });
+
+  it("returns no interference when there are no mechanical parts", () => {
+    const c = comp("R1", boxPositions(2, 1, 1, 1));
+    expect(interferingRefs([c], [])).toEqual([]);
+  });
+
+  it("de-duplicates refs when a footprint yields several sub-meshes", () => {
+    const mech = [aabbOfPositions(boxPositions(10))!];
+    // Same ref appears 3x (body + 2 caps), all overlapping.
+    const parts = [
+      comp("R1", boxPositions(1, 1, 1, 1)),
+      comp("R1", boxPositions(1, 2, 2, 2)),
+      comp("R1", boxPositions(1, 3, 3, 3)),
+    ];
+    expect(interferingRefs(parts, mech)).toEqual(["R1"]);
+  });
+});

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -2049,7 +2049,37 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     const state = get();
     if (!state.document.pcb) return;
     const pcb = structuredClone(state.document.pcb);
-    if (pcb.footprints[idx]) pcb.footprints[idx]!.position = { x: position.x, y: position.y };
+    const fp = pcb.footprints[idx];
+    if (!fp) return;
+    const dx = position.x - fp.position.x;
+    const dy = position.y - fp.position.y;
+    // Direct manipulation: drag connected trace endpoints along with the
+    // footprint so routed copper stays attached to its pads. Pad world
+    // positions are computed with the (unchanged) footprint rotation; any
+    // trace endpoint coincident with a pad shifts by the same delta.
+    if (dx !== 0 || dy !== 0) {
+      const TOL = 0.08; // mm
+      const ang = ((fp.rotation ?? 0) * Math.PI) / 180;
+      const cos = Math.cos(ang);
+      const sin = Math.sin(ang);
+      const padWorld = fp.pads.map((p) => ({
+        x: fp.position.x + (p.position.x * cos - p.position.y * sin),
+        y: fp.position.y + (p.position.x * sin + p.position.y * cos),
+      }));
+      for (const tr of pcb.traces) {
+        for (const end of [tr.start, tr.end]) {
+          if (
+            padWorld.some(
+              (pw) => Math.abs(end.x - pw.x) < TOL && Math.abs(end.y - pw.y) < TOL,
+            )
+          ) {
+            end.x += dx;
+            end.y += dy;
+          }
+        }
+      }
+    }
+    fp.position = { x: position.x, y: position.y };
     set({ ...setCrdtPcb(state, pcb), isDirty: true });
   },
 

--- a/packages/engine/src/__tests__/evaluate.test.ts
+++ b/packages/engine/src/__tests__/evaluate.test.ts
@@ -924,3 +924,52 @@ describe("Assembly evaluation", () => {
     expect(scene.clashes[0].positions.length).toBeGreaterThan(0);
   });
 });
+
+describe("PcbBoard", () => {
+  it("evaluates a PCB board outline to a real FR4 slab solid", () => {
+    const board = {
+      outline: {
+        vertices: [
+          { x: 0, y: 0 },
+          { x: 50, y: 0 },
+          { x: 50, y: 30 },
+          { x: 0, y: 30 },
+        ],
+        thickness: 1.6,
+      },
+      stackup: { layers: [] },
+      nets: [],
+      rules: {},
+      footprints: [],
+      traces: [],
+      vias: [],
+      zones: [],
+    } as unknown as import("@vcad/ir").Pcb;
+    const doc = singlePartDoc(
+      [{ id: 1, name: "pcb", op: { type: "PcbBoard", board } }],
+      1,
+    );
+    // evaluateWithSolids routes through the TS evaluator (the path used for
+    // STEP export / ray tracing). The WASM evaluator still returns empty for
+    // PcbBoard until the kernel is rebuilt — tracked as a follow-up.
+    const scene = engine.evaluateWithSolids(doc);
+    expect(scene.parts).toHaveLength(1);
+    const pos = scene.parts[0].mesh.positions;
+    expect(pos.length).toBeGreaterThan(0);
+    expect(scene.parts[0].mesh.indices.length).toBeGreaterThan(0);
+
+    // Bounding box ≈ 50 × 30 × 1.6, centered on z=0 (matches the rendered slab).
+    let minX = Infinity, maxX = -Infinity;
+    let minY = Infinity, maxY = -Infinity;
+    let minZ = Infinity, maxZ = -Infinity;
+    for (let i = 0; i + 2 < pos.length; i += 3) {
+      minX = Math.min(minX, pos[i]!); maxX = Math.max(maxX, pos[i]!);
+      minY = Math.min(minY, pos[i + 1]!); maxY = Math.max(maxY, pos[i + 1]!);
+      minZ = Math.min(minZ, pos[i + 2]!); maxZ = Math.max(maxZ, pos[i + 2]!);
+    }
+    expect(maxX - minX).toBeCloseTo(50, 1);
+    expect(maxY - minY).toBeCloseTo(30, 1);
+    expect(maxZ - minZ).toBeCloseTo(1.6, 1);
+    expect((minZ + maxZ) / 2).toBeCloseTo(0, 1);
+  });
+});

--- a/packages/engine/src/evaluate.ts
+++ b/packages/engine/src/evaluate.ts
@@ -873,8 +873,27 @@ function evaluateOp(
     case "Text2D":
       return Solid.empty();
 
-    case "PcbBoard":
-      return Solid.empty();
+    case "PcbBoard": {
+      // Extrude the board outline into a real FR4 slab so the board is a
+      // genuine body — visible as a part, exportable to STEP, ray-traceable —
+      // rather than an empty placeholder. Centered on z=0 to match the
+      // rendered slab (PcbBoardMesh positions its extrude at -thickness/2).
+      const outline = op.board.outline;
+      const verts = outline?.vertices ?? [];
+      if (verts.length < 3) return Solid.empty();
+      const t = outline.thickness;
+      const segments = verts.map((v, i) => {
+        const next = verts[(i + 1) % verts.length]!;
+        return { type: "Line" as const, start: [v.x, v.y], end: [next.x, next.y] };
+      });
+      const profile = {
+        origin: [0, 0, -t / 2],
+        x_dir: [1, 0, 0],
+        y_dir: [0, 1, 0],
+        segments,
+      };
+      return Solid.extrude(JSON.stringify(profile), new Float64Array([0, 0, t]));
+    }
 
     case "EmbroideryPattern":
       return Solid.empty();

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -143,6 +143,8 @@ export {
   fillZones,
   parseKicadPcb,
   builtinSymbols,
+  computeRatsnest,
+  componentMeshes,
 } from "./ecad.js";
 export type {
   DrcViolationResult,
@@ -152,6 +154,8 @@ export type {
   NetConnection,
   RouteResult,
   FilledZoneResult,
+  RatsnestLine,
+  ComponentMesh,
 } from "./ecad.js";
 
 // Parts library


### PR DESCRIPTION
## Why

Editing a PCB used to drop you into a full-screen "electronics mode" that hid the entire app (header, feature tree, chat, status bar), swapped the viewport to a PCB-only scene, and locked the camera top-down. That contradicts vcad's "never leave the canvas" / unified MCAD-ECAD direction. This PR makes PCB editing happen **in the main 3D scene**, alongside the mechanical assembly, and builds the co-presence payoffs on top.

## What changed (5 commits)

1. **Phase 1 — PCB on the canvas.** Editing a board no longer takes over the app. Driven off per-board edit focus (`activeBoardNodeId`): the app shell stays visible, the board's copper/footprints/ratsnest render in the main scene with the rest of the assembly **ghosted**, the camera does a one-off align (then free orbit — top-down lock removed via a `usePcbAutoFit` hook mirroring sketch).
2. **Phases 2–4 — co-presence payoffs.** Dragging a footprint **rubber-bands** its connected traces; one-click **ratsnest auto-route** (the in-app twin of the `route_nets` MCP tool); live **route-vs-enclosure interference** (component bodies clashing with mechanical parts turn red, debounced alongside DRC); a **schematic overlay toggle**.
3. **Fixes from preview testing.** Interaction plane was perpendicular to the board (drei `<Plane>` vs `<Grid>` default orientation), so angled-camera clicks mis-placed traces/footprints — now coplanar + raycast projected into the board's local frame (correct at any angle). Deduped interference refs.
4. **Real board solid.** `PcbBoard` evaluated to `Solid.empty()`; now extrudes the outline into a genuine FR4 slab (flows through `evaluateWithSolids` → STEP export / ray tracing), and the slab renders in-scene from PCB data so the board is visible outside edit focus. Unit-tested (bbox assertion).
5. **Post-processing crash made non-fatal.** The `EffectComposer` could white-screen the viewport on a degraded WebGL context (`getContextAttributes().alpha` of null). Now gated on a healthy context + wrapped in an R3F-safe boundary, so it degrades to "no effects" instead of crashing. Effects unchanged for supported contexts.

## Verification

`tsc -b` + `vite build` and the app/core/engine test suites all pass. Added unit tests: `pcb-interference` (6) and a `PcbBoard` evaluator bbox test. A local agent verified the behavioral scenarios in preview (chrome stays, ghosting, free orbit, rubber-banding, auto-route, interference detect/clear, schematic toggle, exit, regressions) and the fixes were confirmed against its findings.

## Known follow-ups (not in this PR)

- The app's live viewport uses the **Rust WASM evaluator**, which still returns empty for `PcbBoard` — the in-scene slab covers display; mirroring the extrusion in the Rust evaluator (for the WASM export path) needs a `wasm-pack` rebuild.
- Board-with-non-identity-transform placement (Phase 1 assumes board at origin).
- Unifying the ECAD selection model into the main selection/PropertyPanel, and promoting the schematic to a first-class canvas surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxCxuwpMz1qG3pGkdNLWpC

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxCxuwpMz1qG3pGkdNLWpC)_