### PR TITLE
feat(pcb): unify ECAD inspector into the main property panel

### DIFF
--- a/changelog/entries/2026-06-04-unified-ecad-inspector.json
+++ b/changelog/entries/2026-06-04-unified-ecad-inspector.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-04-unified-ecad-inspector",
+  "version": "0.9.4",
+  "date": "2026-06-04",
+  "category": "feat",
+  "title": "Unified ECAD inspector in the property panel",
+  "summary": "Selecting a footprint, net, trace, via, or pad now opens its inspector in the main contextual panel, with the floating overlay reduced to an always-on board summary.",
+  "features": ["electronics", "pcb", "property-panel"]
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -166,10 +166,13 @@ function FeatureTreeSlot({ sketchActive }: { sketchActive: boolean }) {
   const sidebarPane = useUiStore((s) => s.sidebarPane);
   const inspectorTarget = useUiStore((s) => s.inspectorTarget);
   const selectionLen = useUiStore((s) => s.selection.length);
+  // An ECAD selection (footprint / net / trace / via / pad) feeds the same
+  // contextual inspector as a part, so it must open the inspector pane too.
+  const ecadSelected = useElectronicsStore((s) => s.selection.type !== "none");
 
   const showParameters = !sketchActive && sidebarPane === "parameters";
   const hasInspectorContent =
-    inspectorTarget?.kind === "scene" || selectionLen > 0;
+    inspectorTarget?.kind === "scene" || selectionLen > 0 || ecadSelected;
   const showInspector = !sketchActive && !showParameters && hasInspectorContent;
 
   return (
@@ -332,15 +335,16 @@ export function App() {
   // the full selection length so sub-feature picks (face / edge / vertex)
   // open the inspector too.
   const selectionLen = useUiStore((s) => s.selection.length);
+  const ecadSelected = useElectronicsStore((s) => s.selection.type !== "none");
   useEffect(() => {
     const { setSidebarPane, setInspectorTarget } = useUiStore.getState();
-    if (selectionLen >= 1) {
+    if (selectionLen >= 1 || ecadSelected) {
       setInspectorTarget(null);
       setSidebarPane("inspector");
     } else if (useUiStore.getState().inspectorTarget == null) {
       setSidebarPane("tree");
     }
-  }, [selectionLen]);
+  }, [selectionLen, ecadSelected]);
 
   const handleSave = useCallback(() => {
     const state = useDocumentStore.getState();

--- a/packages/app/src/components/PropertyPanel.tsx
+++ b/packages/app/src/components/PropertyPanel.tsx
@@ -23,6 +23,7 @@ import { Vector3 } from "three";
 import { findCoplanarTriangles, getEdgeEndpoints, getVertex } from "@/lib/sub-feature-geometry";
 import { useLocaleStore } from "@/stores/locale-store";
 import { useElectronicsStore } from "@/stores/electronics-store";
+import { EcadFeatureInspector } from "@/components/electronics/EcadFeatureInspector";
 import { useEmbroideryStore } from "@/stores/embroidery-store";
 import type { PartInfo, PrimitivePartInfo, BooleanPartInfo, BooleanType, SweepPartInfo, ExtrudePartInfo, RevolvePartInfo, FilletPartInfo, ChamferPartInfo, ShellPartInfo, LinearPatternPartInfo, CircularPatternPartInfo, LoftPartInfo, TextPartInfo, MirrorPartInfo } from "@vcad/core";
 import type { Vec3, PartInstance, Joint, JointKind } from "@vcad/ir";
@@ -1460,21 +1461,33 @@ export function PropertyPanel() {
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const selection = useUiStore((s) => s.selection);
   const clearSelection = useUiStore((s) => s.clearSelection);
+  const ecadSelection = useElectronicsStore((s) => s.selection);
   const parts = useDocumentStore((s) => s.parts);
   const document = useDocumentStore((s) => s.document);
   const panelRef = useRef<HTMLDivElement>(null);
   useLocaleStore((s) => s.locale);
 
-  // Close panel on Escape
+  const hasEcadSelection = ecadSelection.type !== "none";
+
+  // Close panel on Escape — clears whichever selection is active (mechanical
+  // sub-feature/part selection and/or the ECAD selection that drives the
+  // adaptive inspector below).
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape" && selection.length > 0) {
-        clearSelection();
+      if (e.key !== "Escape") return;
+      if (selection.length > 0) clearSelection();
+      if (useElectronicsStore.getState().selection.type !== "none") {
+        useElectronicsStore.getState().select({ type: "none" });
       }
     }
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [selection.length, clearSelection]);
+
+  // Adaptive ECAD inspector: an electronics selection (footprint / net /
+  // trace / via / pad) drives the same contextual panel as a part, so PCB
+  // editing reuses the unified inspector instead of a separate surface.
+  if (hasEcadSelection) return <EcadFeatureInspector />;
 
   if (selection.length === 0) return null;
 

--- a/packages/app/src/components/electronics/EcadFeatureInspector.tsx
+++ b/packages/app/src/components/electronics/EcadFeatureInspector.tsx
@@ -1,0 +1,317 @@
+/**
+ * Per-item ECAD inspector, rendered inline inside the main PropertyPanel.
+ *
+ * Task 3 (modeless PCB editing): ECAD selections — component / footprint /
+ * net / trace / via / pad — flow into the SAME contextual inspector as
+ * mechanical parts instead of a separate floating panel. This component is
+ * the shared body; `ElectronicsPropertyPanel` keeps the board-overview HUD.
+ *
+ * Reads the current selection from the electronics store and adapts. Returns
+ * `null` for the `none` selection (the board HUD owns that state), so callers
+ * can mount it unconditionally.
+ */
+
+import { useState } from "react";
+import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/core";
+import { useElectronicsStore } from "@/stores/electronics-store";
+
+export function EcadFeatureInspector() {
+  const selection = useElectronicsStore((s) => s.selection);
+  const netlist = useElectronicsStore((s) => s.netlist);
+  const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
+  const document = useDocumentStore((s) => s.document);
+  const pcb = activeBoardNodeId != null ? getNodePcb(document, activeBoardNodeId) : null;
+
+  if (selection.type === "component" || selection.type === "footprint") {
+    return <ComponentFootprintPanel key={selection.ref} compRef={selection.ref} />;
+  }
+
+  if (selection.type === "net") {
+    const netName = selection.netId;
+    const netInfo = netlist?.nets.find((n) => n.name === netName);
+    const traceCount = pcb?.traces.filter((t) => t.net === netName).length ?? 0;
+    const totalLength = (pcb?.traces ?? [])
+      .filter((t) => t.net === netName)
+      .reduce((sum, t) => {
+        const dx = t.end.x - t.start.x;
+        const dy = t.end.y - t.start.y;
+        return sum + Math.hypot(dx, dy);
+      }, 0);
+
+    return (
+      <Section>
+        <div className="font-medium text-brand mb-2">{netName}</div>
+        <div className="space-y-1 text-text-muted">
+          <Row label="Pads" value={String(netInfo?.connections.length ?? 0)} />
+          <Row label="Traces" value={String(traceCount)} />
+          <Row label="Total Length" value={`${totalLength.toFixed(2)}mm`} />
+          {netInfo && netInfo.connections.length > 0 && (
+            <div className="pt-1 border-t border-border mt-1">
+              <div className="text-[10px] text-text-muted mb-0.5">Connections:</div>
+              {netInfo.connections.slice(0, 8).map((c, i) => (
+                <div key={i} className="text-[10px]">
+                  {c.component_ref}.{c.pin_number}
+                </div>
+              ))}
+              {netInfo.connections.length > 8 && (
+                <div className="text-[9px] text-text-muted">
+                  +{netInfo.connections.length - 8} more
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </Section>
+    );
+  }
+
+  if (selection.type === "trace") {
+    const trace = pcb?.traces[selection.idx];
+    if (!trace) return null;
+    const dx = trace.end.x - trace.start.x;
+    const dy = trace.end.y - trace.start.y;
+    const len = Math.hypot(dx, dy);
+
+    return (
+      <Section>
+        <div className="flex justify-between items-center mb-2">
+          <span className="font-medium text-text">Trace</span>
+          <button
+            className="px-1.5 py-0.5 text-[10px] text-danger hover:bg-danger/10 rounded transition-colors"
+            onClick={() => {
+              const bId = useCoreElectronicsStore.getState().activeBoardNodeId;
+              if (bId != null) useDocumentStore.getState().removeTrace(bId, selection.idx);
+              useElectronicsStore.getState().select({ type: "none" });
+            }}
+          >
+            Delete
+          </button>
+        </div>
+        <div className="space-y-1 text-text-muted">
+          <Row label="Net" value={trace.net} />
+          <Row label="Layer" value={trace.layer} />
+          <Row label="Width" value={`${trace.width}mm`} />
+          <Row label="Length" value={`${len.toFixed(2)}mm`} />
+        </div>
+      </Section>
+    );
+  }
+
+  if (selection.type === "via") {
+    const via = pcb?.vias[selection.idx];
+    if (!via) return null;
+
+    return (
+      <Section>
+        <div className="flex justify-between items-center mb-2">
+          <span className="font-medium text-text">Via</span>
+          <button
+            className="px-1.5 py-0.5 text-[10px] text-danger hover:bg-danger/10 rounded transition-colors"
+            onClick={() => {
+              const bId = useCoreElectronicsStore.getState().activeBoardNodeId;
+              if (bId != null) useDocumentStore.getState().removeVia(bId, selection.idx);
+              useElectronicsStore.getState().select({ type: "none" });
+            }}
+          >
+            Delete
+          </button>
+        </div>
+        <div className="space-y-1 text-text-muted">
+          <Row label="Net" value={via.net} />
+          <Row label="Diameter" value={`${via.diameter}mm`} />
+          <Row label="Drill" value={`${via.drill}mm`} />
+          <Row label="Layers" value={`${via.startLayer} - ${via.endLayer}`} />
+          <Row
+            label="Position"
+            value={`${via.position.x.toFixed(2)}, ${via.position.y.toFixed(2)}`}
+          />
+        </div>
+      </Section>
+    );
+  }
+
+  if (selection.type === "pad") {
+    return (
+      <Section>
+        <div className="font-medium text-text mb-2">
+          {selection.fpRef}.{selection.padNum}
+        </div>
+        <div className="space-y-1 text-text-muted">
+          <Row label="Net" value={selection.net} />
+        </div>
+      </Section>
+    );
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Editable component/footprint panel
+// ---------------------------------------------------------------------------
+
+function ComponentFootprintPanel({ compRef }: { compRef: string }) {
+  const netlist = useElectronicsStore((s) => s.netlist);
+  const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
+  const cpDocument = useDocumentStore((s) => s.document);
+  const pcb = activeBoardNodeId != null ? getNodePcb(cpDocument, activeBoardNodeId) : null;
+  const schematic = cpDocument.schematic;
+
+  const schComp = schematic?.components.find((c) => c.ref === compRef);
+  const schIdx = schematic?.components.findIndex((c) => c.ref === compRef) ?? -1;
+  const fp = pcb?.footprints.find((f) => f.ref === compRef);
+  const fpIdx = pcb?.footprints.findIndex((f) => f.ref === compRef) ?? -1;
+
+  const [editValue, setEditValue] = useState(schComp?.value ?? "");
+  const [editFpX, setEditFpX] = useState(String(fp?.position.x ?? 0));
+  const [editFpY, setEditFpY] = useState(String(fp?.position.y ?? 0));
+  const [editFpRot, setEditFpRot] = useState(String(fp?.rotation ?? 0));
+
+  const nets = new Set<string>();
+  if (netlist) {
+    for (const net of netlist.nets) {
+      for (const conn of net.connections) {
+        if (conn.component_ref === compRef) {
+          nets.add(net.name);
+          break;
+        }
+      }
+    }
+  }
+
+  const commitValue = () => {
+    if (schIdx >= 0 && editValue !== schComp?.value) {
+      useDocumentStore.getState().updateSchematicComponent(schIdx, { value: editValue }, activeBoardNodeId ?? undefined);
+    }
+  };
+
+  const commitFpPosition = () => {
+    const x = parseFloat(editFpX);
+    const y = parseFloat(editFpY);
+    if (fpIdx >= 0 && !isNaN(x) && !isNaN(y)) {
+      if (activeBoardNodeId != null) useDocumentStore.getState().moveFootprint(activeBoardNodeId, fpIdx, { x, y, z: 0 });
+    }
+  };
+
+  const commitFpRotation = () => {
+    const rot = parseFloat(editFpRot);
+    if (fpIdx >= 0 && !isNaN(rot) && rot !== (fp?.rotation ?? 0)) {
+      // rotateFootprint adds to current, so we compute delta
+      const delta = rot - (fp?.rotation ?? 0);
+      if (activeBoardNodeId != null) useDocumentStore.getState().rotateFootprint(activeBoardNodeId, fpIdx, delta);
+    }
+  };
+
+  return (
+    <Section>
+      <div className="font-medium text-text mb-2">{compRef}</div>
+      <div className="space-y-1.5 text-text-muted">
+        {/* Editable value */}
+        {schComp && (
+          <div className="flex justify-between items-center">
+            <span>Value</span>
+            <input
+              type="text"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitValue}
+              onKeyDown={(e) => e.key === "Enter" && commitValue()}
+              className="w-20 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
+            />
+          </div>
+        )}
+        {fp && (
+          <>
+            <Row label="Footprint" value={fp.footprintName} />
+            {/* Editable position */}
+            <div className="flex justify-between items-center">
+              <span>X</span>
+              <input
+                type="number"
+                value={editFpX}
+                onChange={(e) => setEditFpX(e.target.value)}
+                onBlur={commitFpPosition}
+                onKeyDown={(e) => e.key === "Enter" && commitFpPosition()}
+                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
+                step={0.1}
+              />
+            </div>
+            <div className="flex justify-between items-center">
+              <span>Y</span>
+              <input
+                type="number"
+                value={editFpY}
+                onChange={(e) => setEditFpY(e.target.value)}
+                onBlur={commitFpPosition}
+                onKeyDown={(e) => e.key === "Enter" && commitFpPosition()}
+                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
+                step={0.1}
+              />
+            </div>
+            {/* Editable rotation */}
+            <div className="flex justify-between items-center">
+              <span>Rotation</span>
+              <input
+                type="number"
+                value={editFpRot}
+                onChange={(e) => setEditFpRot(e.target.value)}
+                onBlur={commitFpRotation}
+                onKeyDown={(e) => e.key === "Enter" && commitFpRotation()}
+                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
+                step={90}
+              />
+            </div>
+            <Row label="Side" value={fp.front !== false ? "Front" : "Back"} />
+            <Row label="Pads" value={String(fp.pads.length)} />
+          </>
+        )}
+        {nets.size > 0 && (
+          <div className="pt-1 border-t border-border mt-1">
+            <div className="text-[10px] text-text-muted mb-0.5">Nets:</div>
+            <div className="flex flex-wrap gap-1">
+              {[...nets].map((n) => (
+                <span
+                  key={n}
+                  className="px-1 py-0.5 bg-brand/10 text-brand rounded text-[9px] cursor-pointer hover:bg-brand/20"
+                  onClick={() =>
+                    useElectronicsStore.getState().select({ type: "net", netId: n })
+                  }
+                >
+                  {n}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+/** Inline panel section — matches the contextual-inspector padding. */
+function Section({ children }: { children: React.ReactNode }) {
+  return <div className="p-3 text-[11px]">{children}</div>;
+}
+
+export function Row({
+  label,
+  value,
+  danger,
+}: {
+  label: string;
+  value: string;
+  danger?: boolean;
+}) {
+  return (
+    <div className="flex justify-between">
+      <span>{label}</span>
+      <span className={danger ? "text-danger font-medium" : "text-text"}>
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/packages/app/src/components/electronics/ElectronicsPropertyPanel.tsx
+++ b/packages/app/src/components/electronics/ElectronicsPropertyPanel.tsx
@@ -1,16 +1,18 @@
 /**
- * Floating property panel for electronics workspace.
- * Adapts content to current selection type.
- * Supports inline editing for component/footprint properties.
+ * Floating board-overview HUD for the electronics workspace.
+ *
+ * Per-item inspectors (component / footprint / net / trace / via / pad) now
+ * render in the main contextual PropertyPanel via `EcadFeatureInspector`
+ * (Task 3, modeless PCB editing). This overlay is the always-on board summary:
+ * counts + DRC/ERC health, so the board's state stays glanceable while you
+ * inspect an individual feature on the left.
  */
 
-import { useState } from "react";
 import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/core";
 import { useElectronicsStore } from "@/stores/electronics-store";
+import { Row } from "./EcadFeatureInspector";
 
 export function ElectronicsPropertyPanel() {
-  const selection = useElectronicsStore((s) => s.selection);
-  const netlist = useElectronicsStore((s) => s.netlist);
   const drcViolations = useElectronicsStore((s) => s.drcViolations);
   const ercViolations = useElectronicsStore((s) => s.ercViolations);
   const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
@@ -18,333 +20,42 @@ export function ElectronicsPropertyPanel() {
   const pcb = activeBoardNodeId != null ? getNodePcb(document, activeBoardNodeId) : null;
   const schematic = document.schematic;
 
-  if (selection.type === "none") {
-    // Board overview
-    return (
-      <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-        <div className="font-medium text-text mb-2">Board Overview</div>
-        <div className="space-y-1 text-text-muted">
-          {pcb && (
-            <>
-              <Row label="Footprints" value={String(pcb.footprints.length)} />
-              <Row label="Traces" value={String(pcb.traces.length)} />
-              <Row label="Vias" value={String(pcb.vias.length)} />
-              <Row label="Nets" value={String(pcb.nets.length)} />
-              <Row
-                label="Layers"
-                value={String(pcb.stackup.layers.filter((l) => l.copperThickness).length)}
-              />
-            </>
-          )}
-          {schematic && (
-            <Row label="Components" value={String(schematic.components.length)} />
-          )}
-          <div className="pt-1 border-t border-border mt-1">
+  return (
+    <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
+      <div className="font-medium text-text mb-2">Board Overview</div>
+      <div className="space-y-1 text-text-muted">
+        {pcb && (
+          <>
+            <Row label="Footprints" value={String(pcb.footprints.length)} />
+            <Row label="Traces" value={String(pcb.traces.length)} />
+            <Row label="Vias" value={String(pcb.vias.length)} />
+            <Row label="Nets" value={String(pcb.nets.length)} />
             <Row
-              label="DRC Errors"
-              value={String(drcViolations.filter((v) => v.severity === "Error").length)}
-              danger={drcViolations.some((v) => v.severity === "Error")}
+              label="Layers"
+              value={String(pcb.stackup.layers.filter((l) => l.copperThickness).length)}
             />
-            <Row
-              label="DRC Warnings"
-              value={String(drcViolations.filter((v) => v.severity === "Warning").length)}
-            />
-            <Row
-              label="ERC Issues"
-              value={String(ercViolations.length)}
-              danger={ercViolations.length > 0}
-            />
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (selection.type === "component" || selection.type === "footprint") {
-    return <ComponentFootprintPanel compRef={selection.ref} />;
-  }
-
-  if (selection.type === "net") {
-    const netName = selection.netId;
-    const netInfo = netlist?.nets.find((n) => n.name === netName);
-    const traceCount = pcb?.traces.filter((t) => t.net === netName).length ?? 0;
-    const totalLength = (pcb?.traces ?? [])
-      .filter((t) => t.net === netName)
-      .reduce((sum, t) => {
-        const dx = t.end.x - t.start.x;
-        const dy = t.end.y - t.start.y;
-        return sum + Math.hypot(dx, dy);
-      }, 0);
-
-    return (
-      <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-        <div className="font-medium text-brand mb-2">{netName}</div>
-        <div className="space-y-1 text-text-muted">
-          <Row label="Pads" value={String(netInfo?.connections.length ?? 0)} />
-          <Row label="Traces" value={String(traceCount)} />
-          <Row label="Total Length" value={`${totalLength.toFixed(2)}mm`} />
-          {netInfo && netInfo.connections.length > 0 && (
-            <div className="pt-1 border-t border-border mt-1">
-              <div className="text-[10px] text-text-muted mb-0.5">Connections:</div>
-              {netInfo.connections.slice(0, 8).map((c, i) => (
-                <div key={i} className="text-[10px]">
-                  {c.component_ref}.{c.pin_number}
-                </div>
-              ))}
-              {netInfo.connections.length > 8 && (
-                <div className="text-[9px] text-text-muted">
-                  +{netInfo.connections.length - 8} more
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-    );
-  }
-
-  if (selection.type === "trace") {
-    const trace = pcb?.traces[selection.idx];
-    if (!trace) return null;
-    const dx = trace.end.x - trace.start.x;
-    const dy = trace.end.y - trace.start.y;
-    const len = Math.hypot(dx, dy);
-
-    return (
-      <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-        <div className="flex justify-between items-center mb-2">
-          <span className="font-medium text-text">Trace</span>
-          <button
-            className="px-1.5 py-0.5 text-[10px] text-danger hover:bg-danger/10 rounded transition-colors"
-            onClick={() => {
-              const bId = useCoreElectronicsStore.getState().activeBoardNodeId;
-              if (bId != null) useDocumentStore.getState().removeTrace(bId, selection.idx);
-              useElectronicsStore.getState().select({ type: "none" });
-            }}
-          >
-            Delete
-          </button>
-        </div>
-        <div className="space-y-1 text-text-muted">
-          <Row label="Net" value={trace.net} />
-          <Row label="Layer" value={trace.layer} />
-          <Row label="Width" value={`${trace.width}mm`} />
-          <Row label="Length" value={`${len.toFixed(2)}mm`} />
-        </div>
-      </div>
-    );
-  }
-
-  if (selection.type === "via") {
-    const via = pcb?.vias[selection.idx];
-    if (!via) return null;
-
-    return (
-      <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-        <div className="flex justify-between items-center mb-2">
-          <span className="font-medium text-text">Via</span>
-          <button
-            className="px-1.5 py-0.5 text-[10px] text-danger hover:bg-danger/10 rounded transition-colors"
-            onClick={() => {
-              const bId = useCoreElectronicsStore.getState().activeBoardNodeId;
-              if (bId != null) useDocumentStore.getState().removeVia(bId, selection.idx);
-              useElectronicsStore.getState().select({ type: "none" });
-            }}
-          >
-            Delete
-          </button>
-        </div>
-        <div className="space-y-1 text-text-muted">
-          <Row label="Net" value={via.net} />
-          <Row label="Diameter" value={`${via.diameter}mm`} />
-          <Row label="Drill" value={`${via.drill}mm`} />
-          <Row label="Layers" value={`${via.startLayer} - ${via.endLayer}`} />
+          </>
+        )}
+        {schematic && (
+          <Row label="Components" value={String(schematic.components.length)} />
+        )}
+        <div className="pt-1 border-t border-border mt-1">
           <Row
-            label="Position"
-            value={`${via.position.x.toFixed(2)}, ${via.position.y.toFixed(2)}`}
+            label="DRC Errors"
+            value={String(drcViolations.filter((v) => v.severity === "Error").length)}
+            danger={drcViolations.some((v) => v.severity === "Error")}
+          />
+          <Row
+            label="DRC Warnings"
+            value={String(drcViolations.filter((v) => v.severity === "Warning").length)}
+          />
+          <Row
+            label="ERC Issues"
+            value={String(ercViolations.length)}
+            danger={ercViolations.length > 0}
           />
         </div>
       </div>
-    );
-  }
-
-  if (selection.type === "pad") {
-    return (
-      <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-        <div className="font-medium text-text mb-2">
-          {selection.fpRef}.{selection.padNum}
-        </div>
-        <div className="space-y-1 text-text-muted">
-          <Row label="Net" value={selection.net} />
-        </div>
-      </div>
-    );
-  }
-
-  return null;
-}
-
-// ---------------------------------------------------------------------------
-// Editable component/footprint panel
-// ---------------------------------------------------------------------------
-
-function ComponentFootprintPanel({ compRef }: { compRef: string }) {
-  const netlist = useElectronicsStore((s) => s.netlist);
-  const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
-  const cpDocument = useDocumentStore((s) => s.document);
-  const pcb = activeBoardNodeId != null ? getNodePcb(cpDocument, activeBoardNodeId) : null;
-  const schematic = cpDocument.schematic;
-
-  const schComp = schematic?.components.find((c) => c.ref === compRef);
-  const schIdx = schematic?.components.findIndex((c) => c.ref === compRef) ?? -1;
-  const fp = pcb?.footprints.find((f) => f.ref === compRef);
-  const fpIdx = pcb?.footprints.findIndex((f) => f.ref === compRef) ?? -1;
-
-  const [editValue, setEditValue] = useState(schComp?.value ?? "");
-  const [editFpX, setEditFpX] = useState(String(fp?.position.x ?? 0));
-  const [editFpY, setEditFpY] = useState(String(fp?.position.y ?? 0));
-  const [editFpRot, setEditFpRot] = useState(String(fp?.rotation ?? 0));
-
-  const nets = new Set<string>();
-  if (netlist) {
-    for (const net of netlist.nets) {
-      for (const conn of net.connections) {
-        if (conn.component_ref === compRef) {
-          nets.add(net.name);
-          break;
-        }
-      }
-    }
-  }
-
-  const commitValue = () => {
-    if (schIdx >= 0 && editValue !== schComp?.value) {
-      useDocumentStore.getState().updateSchematicComponent(schIdx, { value: editValue }, activeBoardNodeId ?? undefined);
-    }
-  };
-
-  const commitFpPosition = () => {
-    const x = parseFloat(editFpX);
-    const y = parseFloat(editFpY);
-    if (fpIdx >= 0 && !isNaN(x) && !isNaN(y)) {
-      if (activeBoardNodeId != null) useDocumentStore.getState().moveFootprint(activeBoardNodeId, fpIdx, { x, y, z: 0 });
-    }
-  };
-
-  const commitFpRotation = () => {
-    const rot = parseFloat(editFpRot);
-    if (fpIdx >= 0 && !isNaN(rot) && rot !== (fp?.rotation ?? 0)) {
-      // rotateFootprint adds to current, so we compute delta
-      const delta = rot - (fp?.rotation ?? 0);
-      if (activeBoardNodeId != null) useDocumentStore.getState().rotateFootprint(activeBoardNodeId, fpIdx, delta);
-    }
-  };
-
-  return (
-    <div className="absolute top-3 right-3 w-56 rounded-lg border border-border bg-surface/95 backdrop-blur-sm shadow-lg p-3 text-[11px] pointer-events-auto">
-      <div className="font-medium text-text mb-2">{compRef}</div>
-      <div className="space-y-1.5 text-text-muted">
-        {/* Editable value */}
-        {schComp && (
-          <div className="flex justify-between items-center">
-            <span>Value</span>
-            <input
-              type="text"
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              onBlur={commitValue}
-              onKeyDown={(e) => e.key === "Enter" && commitValue()}
-              className="w-20 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
-            />
-          </div>
-        )}
-        {fp && (
-          <>
-            <Row label="Footprint" value={fp.footprintName} />
-            {/* Editable position */}
-            <div className="flex justify-between items-center">
-              <span>X</span>
-              <input
-                type="number"
-                value={editFpX}
-                onChange={(e) => setEditFpX(e.target.value)}
-                onBlur={commitFpPosition}
-                onKeyDown={(e) => e.key === "Enter" && commitFpPosition()}
-                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
-                step={0.1}
-              />
-            </div>
-            <div className="flex justify-between items-center">
-              <span>Y</span>
-              <input
-                type="number"
-                value={editFpY}
-                onChange={(e) => setEditFpY(e.target.value)}
-                onBlur={commitFpPosition}
-                onKeyDown={(e) => e.key === "Enter" && commitFpPosition()}
-                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
-                step={0.1}
-              />
-            </div>
-            {/* Editable rotation */}
-            <div className="flex justify-between items-center">
-              <span>Rotation</span>
-              <input
-                type="number"
-                value={editFpRot}
-                onChange={(e) => setEditFpRot(e.target.value)}
-                onBlur={commitFpRotation}
-                onKeyDown={(e) => e.key === "Enter" && commitFpRotation()}
-                className="w-16 text-[11px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
-                step={90}
-              />
-            </div>
-            <Row label="Side" value={fp.front !== false ? "Front" : "Back"} />
-            <Row label="Pads" value={String(fp.pads.length)} />
-          </>
-        )}
-        {nets.size > 0 && (
-          <div className="pt-1 border-t border-border mt-1">
-            <div className="text-[10px] text-text-muted mb-0.5">Nets:</div>
-            <div className="flex flex-wrap gap-1">
-              {[...nets].map((n) => (
-                <span
-                  key={n}
-                  className="px-1 py-0.5 bg-brand/10 text-brand rounded text-[9px] cursor-pointer hover:bg-brand/20"
-                  onClick={() =>
-                    useElectronicsStore.getState().select({ type: "net", netId: n })
-                  }
-                >
-                  {n}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared Row component
-// ---------------------------------------------------------------------------
-
-function Row({
-  label,
-  value,
-  danger,
-}: {
-  label: string;
-  value: string;
-  danger?: boolean;
-}) {
-  return (
-    <div className="flex justify-between">
-      <span>{label}</span>
-      <span className={danger ? "text-danger font-medium" : "text-text"}>
-        {value}
-      </span>
     </div>
   );
 }

--- a/packages/app/src/test/ecad-feature-inspector.test.tsx
+++ b/packages/app/src/test/ecad-feature-inspector.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Task 3 (modeless PCB editing): the per-item ECAD inspector renders inside
+ * the main contextual PropertyPanel. These tests pin the component's dispatch
+ * — the selection type alone drives what shows — so the unified inspector
+ * can't silently regress to the old floating-panel behaviour.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { EcadFeatureInspector } from "@/components/electronics/EcadFeatureInspector";
+import { useElectronicsStore } from "@/stores/electronics-store";
+
+describe("EcadFeatureInspector", () => {
+  beforeEach(() => {
+    cleanup();
+    useElectronicsStore.setState({ selection: { type: "none" }, netlist: null });
+  });
+
+  it("renders nothing for the empty selection (the board HUD owns that state)", () => {
+    useElectronicsStore.setState({ selection: { type: "none" } });
+    const { container } = render(<EcadFeatureInspector />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders a pad inspector from the selection alone (no board data needed)", () => {
+    useElectronicsStore.setState({
+      selection: { type: "pad", fpRef: "R1", padNum: "2", net: "GND" },
+    });
+    const { container } = render(<EcadFeatureInspector />);
+    expect(container.textContent).toContain("R1.2");
+    expect(container.textContent).toContain("GND");
+  });
+
+  it("renders a net inspector with its name as the heading", () => {
+    useElectronicsStore.setState({
+      selection: { type: "net", netId: "VCC" },
+      netlist: { nets: [] } as never,
+    });
+    const { container } = render(<EcadFeatureInspector />);
+    expect(container.textContent).toContain("VCC");
+    // With no netlist connections, counts fall back to zero rather than crash.
+    expect(container.textContent).toContain("Pads");
+  });
+});


### PR DESCRIPTION
## What

Part of the modeless PCB editing effort (**Task 3** — unify ECAD selection into the adaptive property panel). Selecting a PCB **footprint / net / trace / via / pad** now opens its inspector in the **main contextual PropertyPanel** (left sidebar) — the same surface mechanical parts use — instead of a separate floating panel.

The floating overlay is reduced to an always-on **Board Overview HUD** (footprint/trace/via/net counts + DRC/ERC health), so board state stays glanceable while you inspect an individual feature on the left.

## Changes

- **New `EcadFeatureInspector`** — the per-item inspectors (component/footprint editor, net, trace, via, pad) extracted into one reusable, inline component.
- **`PropertyPanel`** dispatches to it when an ECAD item is selected (precedence over the part panel); **Escape** now clears the ECAD selection alongside the mechanical one.
- **`showInspector` + the sidebar auto-drill** (`App.tsx`) react to ECAD selection, so the inspector pane opens/closes with it.
- **`ElectronicsPropertyPanel`** slimmed from a 350-line selection-switch to the board-overview HUD (net **−333 LOC**).

The net cross-probe (hover a net → highlights in both 3D copper and the schematic) already works via the shared `hoveredNet` and is unchanged.

## Verification

Verified **live in the running app** (not just type-checked):

| Check | Result |
|---|---|
| Pad selection → inspector renders in **left** inspector pane (`x=12`) | ✅ `R1.1 / Net: GND` |
| Switching pad → net re-dispatches | ✅ `VCC` shows |
| Clearing selection tears down inspector, sidebar returns to tree | ✅ `sidebarPane: "tree"` |
| Board HUD overlay always shown | ✅ |
| Console errors | ✅ none |
| `EcadFeatureInspector` component test | ✅ 3/3 |
| App production build + `tsc --noEmit` | ✅ clean |

## Follow-up (out of scope here)

This unifies the inspector **surface**. Fully retiring `electronics-store.selection` in favour of the unified `SelectionItem` model (so the 3D-highlight consumers also read one selection source) is a larger, separable migration and is left for a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)