### PR TITLE
fix(electronics): all kernel symbols in palette + a11y labels

### DIFF
--- a/changelog/entries/2026-06-04-symbol-palette-reactive.json
+++ b/changelog/entries/2026-06-04-symbol-palette-reactive.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-04-symbol-palette-reactive",
+  "version": "0.9.4",
+  "date": "2026-06-04",
+  "category": "fix",
+  "title": "Component palette lists all symbols + accessible labels",
+  "summary": "The schematic component palette now shows every kernel symbol (MCU, transistors, regulators, headers…) instead of only the 4 fallbacks, and toolbar icon buttons expose their tooltip as an accessible name.",
+  "features": ["electronics", "accessibility"]
+}

--- a/packages/app/src/components/electronics/ElectronicsToolbar.tsx
+++ b/packages/app/src/components/electronics/ElectronicsToolbar.tsx
@@ -33,7 +33,7 @@ import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/cor
 import { useUiStore } from "@vcad/core";
 import type { PcbLayer } from "@vcad/ir";
 
-import { SYMBOL_LIBRARY } from "./symbol-library";
+import { useSymbolLibrary } from "./symbol-library";
 import { autorouteRatsnest } from "@/lib/pcb-autoroute";
 
 // ---------------------------------------------------------------------------
@@ -172,6 +172,7 @@ export function ElectronicsToolbar() {
   const setSchLabelName = useElectronicsStore((s) => s.setSchLabelName);
   const exit = useElectronicsStore((s) => s.exit);
   const toggleLayout = useElectronicsStore((s) => s.toggleLayout);
+  const symbols = useSymbolLibrary();
 
   const unplacedComponents = useElectronicsStore((s) => s.unplacedComponents);
   const syncSchematicToPcb = useDocumentStore((s) => s.syncSchematicToPcb);
@@ -414,7 +415,7 @@ export function ElectronicsToolbar() {
 
   const renderComponentsContent = () => (
     <>
-      {SYMBOL_LIBRARY.map((sym) => (
+      {symbols.map((sym) => (
         <ToolbarButton
           key={sym.id}
           tooltip={`${sym.name} (${sym.defaultValue})`}

--- a/packages/app/src/components/electronics/PcbGettingStarted.tsx
+++ b/packages/app/src/components/electronics/PcbGettingStarted.tsx
@@ -10,7 +10,7 @@ import { useDocumentStore, useCoreElectronicsStore, getNodePcb } from "@vcad/cor
 import { useElectronicsStore } from "@/stores/electronics-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { useTheme } from "@/hooks/useTheme";
-import { SYMBOL_LIBRARY } from "./symbol-library";
+import { useSymbolLibrary } from "./symbol-library";
 import type { Pcb } from "@vcad/ir";
 
 function boardSummary(pcb: Pcb): string {
@@ -43,6 +43,7 @@ export function PcbGettingStarted() {
   const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
   const doc = useDocumentStore((s) => s.document);
   const pcb = activeBoardNodeId != null ? getNodePcb(doc, activeBoardNodeId) : null;
+  const symbols = useSymbolLibrary();
 
   const hasComponents = pcb ? pcb.footprints.length > 0 : false;
 
@@ -128,7 +129,7 @@ export function PcbGettingStarted() {
             Add a component
           </span>
           <div className="grid grid-cols-4 gap-1.5 mt-1.5">
-            {SYMBOL_LIBRARY.map((sym) => (
+            {symbols.map((sym) => (
               <button
                 key={sym.id}
                 onClick={() => placeComponent(sym.id)}

--- a/packages/app/src/components/electronics/symbol-library.ts
+++ b/packages/app/src/components/electronics/symbol-library.ts
@@ -6,6 +6,7 @@
  * Callers that render SYMBOL_LIBRARY should re-render when ECAD features init.
  */
 
+import { useSyncExternalStore } from "react";
 import type { SchematicPin, Pad, FootprintGraphic, PcbLayer } from "@vcad/ir";
 import { builtinSymbols as wasmBuiltinSymbols } from "@vcad/engine";
 
@@ -52,12 +53,20 @@ export interface SymbolDef {
 let _cachedLibrary: SymbolDef[] | null = null;
 let _initPromise: Promise<void> | null = null;
 
+// React subscribers, so components re-render when the WASM library loads
+// (the proxy below is not reactive on its own).
+const _listeners = new Set<() => void>();
+function _notify() {
+  for (const l of _listeners) l();
+}
+
 /** Initialize the symbol library from WASM. Call early in app startup. */
 export function initSymbolLibrary(): Promise<void> {
   if (!_initPromise) {
     _initPromise = wasmBuiltinSymbols().then((symbols) => {
       if (symbols.length > 0) {
         _cachedLibrary = symbols as unknown as SymbolDef[];
+        _notify();
       }
     }).catch(() => {
       // WASM not available — SYMBOL_LIBRARY stays as hardcoded fallback
@@ -157,4 +166,22 @@ export const SYMBOL_LIBRARY: SymbolDef[] = new Proxy(FALLBACK_LIBRARY, {
 export function getSymbol(id: string): SymbolDef | undefined {
   const source = _cachedLibrary ?? FALLBACK_LIBRARY;
   return source.find((s) => s.id === id);
+}
+
+function _subscribe(cb: () => void): () => void {
+  _listeners.add(cb);
+  return () => _listeners.delete(cb);
+}
+function _snapshot(): SymbolDef[] {
+  return _cachedLibrary ?? FALLBACK_LIBRARY;
+}
+
+/**
+ * Reactive symbol library for React components. Returns the hardcoded fallback
+ * until the WASM kernel library loads, then re-renders with the full set. Use
+ * this instead of `SYMBOL_LIBRARY` in render paths so the component palette
+ * doesn't get stuck showing only the fallback symbols.
+ */
+export function useSymbolLibrary(): SymbolDef[] {
+  return useSyncExternalStore(_subscribe, _snapshot, _snapshot);
 }

--- a/packages/app/src/components/ui/toolbar.tsx
+++ b/packages/app/src/components/ui/toolbar.tsx
@@ -74,6 +74,8 @@ export function ToolbarButton({
         )}
         disabled={disabled}
         onClick={onClick}
+        aria-label={tooltip}
+        aria-pressed={active}
       >
         <span
           className={cn(


### PR DESCRIPTION
## Why

Found by **dogfooding** — trying to build an ESC (MCU + 3 half-bridges + power) by clicking in the schematic. Two bugs blocked it:

1. **The component palette only showed 4 symbols.** It listed the hardcoded fallback (resistor / capacitor / VCC / GND) and *never* the 16 the kernel actually provides — MCU, NPN transistor, voltage regulator, op-amp, IC header, pin headers, etc. `SYMBOL_LIBRARY` is a non-reactive `Proxy`, so the toolbar (and getting-started overlay) rendered the fallback before the WASM symbols loaded and never re-rendered. There was literally no way to *click* to place an MCU or a transistor.

2. **The toolbar icon buttons had no accessible name.** The tooltip is a hover-only `RichTooltip`, so the icon buttons were invisible to screen readers and keyboard users (and unidentifiable to automation/testing).

## Fix

- `symbol-library.ts` — add a reactive `useSymbolLibrary()` hook (`useSyncExternalStore`) that notifies subscribers when the WASM library loads. Use it in `ElectronicsToolbar` (the palette) and `PcbGettingStarted` (the "Add a component" overlay) instead of reading the proxy directly.
- `toolbar.tsx` — `ToolbarButton` now sets `aria-label` (and `aria-pressed`) from its `tooltip`, giving every icon button an accessible name.

## Verification (live in preview)

- Palette now renders **all 16 kernel symbols**, each with an accessible label (`Microcontroller 32-pin (STM32F0)`, `NPN Transistor (2N2222)`, `Voltage Regulator (LDO) (AMS1117-3.3)`, `Pin Header 1x4`, …). The getting-started "Add a component" grid shows them too, with text labels.
- `tsc --noEmit` + app production build clean.

Stacked on #232 (shares `ElectronicsToolbar`).

> Part of an ongoing "build an ESC by clicking" UX pass. Next issue found: dense schematic wiring shorts nets because the NPN symbol's collector/emitter pins are tightly collinear, so the wire-snap grabs the wrong pin — to be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)