### PR TITLE
feat(electronics): map schematic nets onto pads when syncing to PCB

### DIFF
--- a/changelog/entries/2026-06-05-schematic-pcb-net-sync.json
+++ b/changelog/entries/2026-06-05-schematic-pcb-net-sync.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-05-schematic-pcb-net-sync",
+  "version": "0.9.4",
+  "date": "2026-06-05",
+  "category": "feat",
+  "title": "Update PCB from schematic maps nets onto pads",
+  "summary": "Placing unplaced components from the schematic now assigns each pad's net from the netlist and registers the nets on the board, and parts without a footprint template get pin-derived pads so they're routable.",
+  "features": ["electronics", "pcb", "schematic"]
+}

--- a/packages/app/src/components/electronics/ElectronicsToolbar.tsx
+++ b/packages/app/src/components/electronics/ElectronicsToolbar.tsx
@@ -484,7 +484,12 @@ export function ElectronicsToolbar() {
           tooltip={`Place ${unplacedComponents.length} unplaced component(s)`}
           onClick={() => {
             const boardNodeId = useCoreElectronicsStore.getState().activeBoardNodeId;
-            if (boardNodeId != null) syncSchematicToPcb(boardNodeId);
+            if (boardNodeId != null) {
+              // Pass the live netlist so the sync also maps schematic nets onto
+              // the board (assigns pad.net + populates pcb.nets), not just
+              // placing footprints.
+              syncSchematicToPcb(boardNodeId, useElectronicsStore.getState().netlist ?? undefined);
+            }
           }}
           iconColor={ELECTRONICS_TAB_COLORS.pcb}
         >

--- a/packages/app/src/components/electronics/PcbGettingStarted.tsx
+++ b/packages/app/src/components/electronics/PcbGettingStarted.tsx
@@ -132,6 +132,7 @@ export function PcbGettingStarted() {
               <button
                 key={sym.id}
                 onClick={() => placeComponent(sym.id)}
+                aria-label={`Add ${sym.name}`}
                 className="flex flex-col items-center gap-1 p-2 rounded border transition-colors"
                 style={{ backgroundColor: cardBg, borderColor: border }}
                 onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = cardHover; }}

--- a/packages/app/src/components/ui/toolbar.tsx
+++ b/packages/app/src/components/ui/toolbar.tsx
@@ -74,6 +74,8 @@ export function ToolbarButton({
         )}
         disabled={disabled}
         onClick={onClick}
+        aria-label={tooltip}
+        aria-pressed={active}
       >
         <span
           className={cn(

--- a/packages/app/src/hooks/useElectronicsSync.ts
+++ b/packages/app/src/hooks/useElectronicsSync.ts
@@ -50,9 +50,21 @@ export function useElectronicsSync() {
       const pcbRefs = new Set((pcb?.footprints ?? []).map((f) => f.ref));
       store.setOrphanFootprints([...pcbRefs].filter((r) => !schRefs.has(r)));
       store.setUnplacedComponents([...schRefs].filter((r) => !pcbRefs.has(r)));
+
+      // Keep the board's nets in sync with the schematic continuously: assign
+      // each pad's net from the netlist and register the net names on the PCB.
+      // `placeUnplaced: false` means this never auto-drops footprints (only the
+      // explicit "place unplaced" action does that); it's idempotent, so it
+      // no-ops once pad.net + pcb.nets already match. Without it, footprints
+      // auto-created on component-add stay net-less and routing/DRC are blind.
+      if (activeBoardNodeId != null) {
+        useDocumentStore
+          .getState()
+          .syncSchematicToPcb(activeBoardNodeId, netlist, { placeUnplaced: false });
+      }
     }, 200);
     return () => clearTimeout(timer);
-  }, [schematic, pcb, active]);
+  }, [schematic, pcb, active, activeBoardNodeId]);
 
   // Principle 3: Real-time DRC
   useEffect(() => {

--- a/packages/core/src/__tests__/ecad-sync.test.ts
+++ b/packages/core/src/__tests__/ecad-sync.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import type { Pcb, SchematicSheet, SchematicComponent } from "@vcad/ir";
+import { syncSchematicToPcbData, padsFromPins, type SyncNetlist } from "../stores/ecad-sync.js";
+
+/** Minimal empty PCB — the sync only reads/writes `footprints` and `nets`. */
+function makePcb(partial: Partial<Pcb> = {}): Pcb {
+  return {
+    outline: { vertices: [], thickness: 1.6 },
+    stackup: {},
+    nets: [],
+    rules: {},
+    footprints: [],
+    traces: [],
+    vias: [],
+    zones: [],
+    ...partial,
+  } as unknown as Pcb;
+}
+
+function comp(
+  ref: string,
+  pins: { number: string; name: string }[],
+  properties?: Record<string, string>,
+): SchematicComponent {
+  return {
+    ref,
+    value: ref,
+    footprintId: "",
+    position: { x: 0, y: 0 },
+    pins: pins.map((p) => ({
+      number: p.number,
+      name: p.name,
+      pin_type: "Passive",
+      position: { x: 0, y: 0 },
+    })),
+    ...(properties ? { properties } : {}),
+  } as unknown as SchematicComponent;
+}
+
+function sheet(components: SchematicComponent[]): SchematicSheet {
+  return { components, wires: [], junctions: [], labels: [] } as unknown as SchematicSheet;
+}
+
+describe("padsFromPins", () => {
+  it("makes one pad per pin, numbered to match, centered single row", () => {
+    const pads = padsFromPins([{ number: "1" }, { number: "2" }, { number: "3" }]);
+    expect(pads.map((p) => p.number)).toEqual(["1", "2", "3"]);
+    // centered: middle pad at x=0, outer pads symmetric
+    expect(pads[1]!.position.x).toBe(0);
+    expect(pads[0]!.position.x).toBeCloseTo(-2.54);
+    expect(pads[2]!.position.x).toBeCloseTo(2.54);
+    expect(pads.every((p) => p.layers.includes("FCu"))).toBe(true);
+  });
+});
+
+describe("syncSchematicToPcbData — placement", () => {
+  it("places an unplaced component with pin-derived pads", () => {
+    const pcb = makePcb();
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }])]);
+    const { pcb: next, changed } = syncSchematicToPcbData(pcb, sch);
+    expect(changed).toBe(true);
+    expect(next.footprints).toHaveLength(1);
+    expect(next.footprints[0]!.ref).toBe("R1");
+    expect(next.footprints[0]!.pads.map((p) => p.number)).toEqual(["1", "2"]);
+  });
+
+  it("prefers an explicit footprintTemplate over pin-derived pads", () => {
+    const template = JSON.stringify({
+      pads: [
+        { number: "1", padType: "THT", shape: { type: "Circle", diameter: 1 }, position: { x: -2, y: 0 }, layers: ["FCu"] },
+        { number: "2", padType: "THT", shape: { type: "Circle", diameter: 1 }, position: { x: 2, y: 0 }, layers: ["FCu"] },
+      ],
+    });
+    const sch = sheet([comp("D1", [{ number: "1", name: "A" }, { number: "2", name: "K" }], { footprintTemplate: template })]);
+    const { pcb: next } = syncSchematicToPcbData(makePcb(), sch);
+    expect(next.footprints[0]!.pads[0]!.padType).toBe("THT");
+    expect(next.footprints[0]!.pads[0]!.position.x).toBe(-2);
+  });
+
+  it("does not duplicate an already-placed footprint and is idempotent", () => {
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }])]);
+    const first = syncSchematicToPcbData(makePcb(), sch);
+    expect(first.changed).toBe(true);
+    const second = syncSchematicToPcbData(first.pcb, sch);
+    expect(second.changed).toBe(false);
+    expect(second.pcb.footprints).toHaveLength(1);
+  });
+
+  it("does not mutate the input pcb", () => {
+    const pcb = makePcb();
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }])]);
+    syncSchematicToPcbData(pcb, sch);
+    expect(pcb.footprints).toHaveLength(0);
+  });
+});
+
+describe("syncSchematicToPcbData — net mapping", () => {
+  const netlist: SyncNetlist = {
+    nets: [
+      { name: "NET-001", connections: [{ component_ref: "R1", pin_number: "2" }, { component_ref: "R2", pin_number: "1" }] },
+      { name: "GND", connections: [{ component_ref: "R1", pin_number: "1" }] },
+    ],
+  };
+
+  it("assigns pad.net from the netlist and unions net names into pcb.nets", () => {
+    const sch = sheet([
+      comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }]),
+      comp("R2", [{ number: "1", name: "A" }, { number: "2", name: "B" }]),
+    ]);
+    const { pcb: next } = syncSchematicToPcbData(makePcb(), sch, netlist);
+    const r1 = next.footprints.find((f) => f.ref === "R1")!;
+    const r2 = next.footprints.find((f) => f.ref === "R2")!;
+    expect(r1.pads.find((p) => p.number === "1")!.net).toBe("GND");
+    expect(r1.pads.find((p) => p.number === "2")!.net).toBe("NET-001");
+    expect(r2.pads.find((p) => p.number === "1")!.net).toBe("NET-001");
+    // R2 pin 2 is on no net → unassigned
+    expect(r2.pads.find((p) => p.number === "2")!.net).toBeUndefined();
+    expect(next.nets.map((n) => n.name).sort()).toEqual(["GND", "NET-001"]);
+  });
+
+  it("clears a stale pad.net no longer present in the netlist", () => {
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }])]);
+    // Place + assign nets, then re-sync with an empty netlist.
+    const placed = syncSchematicToPcbData(makePcb(), sch, netlist);
+    expect(placed.pcb.footprints[0]!.pads.find((p) => p.number === "1")!.net).toBe("GND");
+    const cleared = syncSchematicToPcbData(placed.pcb, sch, { nets: [] });
+    expect(cleared.changed).toBe(true);
+    expect(cleared.pcb.footprints[0]!.pads.every((p) => p.net === undefined)).toBe(true);
+  });
+
+  it("preserves existing nets (additive union, never removes)", () => {
+    const pcb = makePcb({ nets: [{ id: "VBAT", name: "VBAT" }] as Pcb["nets"] });
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }])]);
+    const { pcb: next } = syncSchematicToPcbData(pcb, sch, netlist);
+    expect(next.nets.map((n) => n.name).sort()).toEqual(["GND", "NET-001", "VBAT"]);
+  });
+});

--- a/packages/core/src/__tests__/ecad-sync.test.ts
+++ b/packages/core/src/__tests__/ecad-sync.test.ts
@@ -135,3 +135,45 @@ describe("syncSchematicToPcbData — net mapping", () => {
     expect(next.nets.map((n) => n.name).sort()).toEqual(["GND", "NET-001", "VBAT"]);
   });
 });
+
+describe("syncSchematicToPcbData — net-only mode (continuous sync)", () => {
+  const netlist: SyncNetlist = {
+    nets: [
+      { name: "NET-001", connections: [{ component_ref: "R1", pin_number: "2" }, { component_ref: "R2", pin_number: "1" }] },
+    ],
+  };
+
+  it("does not place unplaced footprints when placeUnplaced is false", () => {
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }])]);
+    const { pcb: next } = syncSchematicToPcbData(makePcb(), sch, netlist, { placeUnplaced: false });
+    expect(next.footprints).toHaveLength(0);
+  });
+
+  it("still registers net names even with no footprints to touch", () => {
+    const sch = sheet([comp("R1", [{ number: "1", name: "A" }])]);
+    const { pcb: next, changed } = syncSchematicToPcbData(makePcb(), sch, netlist, { placeUnplaced: false });
+    expect(changed).toBe(true);
+    expect(next.nets.map((n) => n.name)).toEqual(["NET-001"]);
+  });
+
+  it("assigns pad.net to footprints created earlier (the auto-place flow)", () => {
+    // Mirrors the real app: components auto-place footprints (net-less), then
+    // the continuous sync must net-map them WITHOUT re-placing anything.
+    const sch = sheet([
+      comp("R1", [{ number: "1", name: "A" }, { number: "2", name: "B" }]),
+      comp("R2", [{ number: "1", name: "A" }, { number: "2", name: "B" }]),
+    ]);
+    const placed = syncSchematicToPcbData(makePcb(), sch); // footprints, no nets
+    expect(placed.pcb.footprints).toHaveLength(2);
+    expect(placed.pcb.footprints.every((f) => f.pads.every((p) => p.net === undefined))).toBe(true);
+
+    const netted = syncSchematicToPcbData(placed.pcb, sch, netlist, { placeUnplaced: false });
+    expect(netted.changed).toBe(true);
+    expect(netted.pcb.footprints).toHaveLength(2); // no new footprints
+    const r1 = netted.pcb.footprints.find((f) => f.ref === "R1")!;
+    const r2 = netted.pcb.footprints.find((f) => f.ref === "R2")!;
+    expect(r1.pads.find((p) => p.number === "2")!.net).toBe("NET-001");
+    expect(r2.pads.find((p) => p.number === "1")!.net).toBe("NET-001");
+    expect(netted.pcb.nets.map((n) => n.name)).toEqual(["NET-001"]);
+  });
+});

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -53,6 +53,7 @@ import {
 } from "../types.js";
 import { useUiStore } from "./ui-store.js";
 import { useParametersStore } from "./parameters-store.js";
+import { syncSchematicToPcbData } from "./ecad-sync.js";
 
 // ---------------------------------------------------------------------------
 // CRDT bridge types
@@ -427,7 +428,12 @@ export interface DocumentState {
   initSchematic: (title?: string) => void;
   initPcb: (options?: PcbCreateOptions) => NodeId;
   importPcb: (pcb: Pcb, name?: string) => NodeId;
-  syncSchematicToPcb: (boardNodeId: NodeId) => void;
+  syncSchematicToPcb: (
+    boardNodeId: NodeId,
+    netlist?: {
+      nets: { name: string; connections: { component_ref: string; pin_number: string }[] }[];
+    },
+  ) => void;
   moveSchematicComponent: (idx: number, position: Vec3) => void;
   moveSchematicComponentWithWires: (idx: number, position: Vec3, wireUpdates: { wireIdx: number; endpoint: "start" | "end"; pos: { x: number; y: number } }[]) => void;
   moveFootprint: (nodeId: NodeId, idx: number, position: Vec3) => void;
@@ -2025,39 +2031,14 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     return addPcbToDocument(get, set, pcb, name ?? "Imported PCB");
   },
 
-  syncSchematicToPcb: (boardNodeId) => {
+  syncSchematicToPcb: (boardNodeId, netlist) => {
     const state = get();
-    const engine = state._crdtEngine!;
-
-    const pcb = state.document.pcb ? structuredClone(state.document.pcb) : null;
+    const pcb = state.document.pcb;
     const schematic = state.document.schematic;
     if (!pcb || !schematic) return;
-
-    const existingRefs = new Set(pcb.footprints.map((fp) => fp.ref));
-    let added = 0;
-    for (const comp of schematic.components) {
-      if (existingRefs.has(comp.ref)) continue;
-      let pads: Footprint["pads"] = [];
-      let graphics: Footprint["graphics"] = [];
-      if (comp.properties?.footprintTemplate) {
-        try {
-          const template = JSON.parse(comp.properties.footprintTemplate);
-          pads = template.pads ?? [];
-          graphics = template.graphics ?? [];
-        } catch { /* skip */ }
-      }
-      const fpCount = pcb.footprints.length;
-      const staggerX = 10 + ((fpCount + added) % 5) * 10;
-      const staggerY = 10 + Math.floor((fpCount + added) / 5) * 10;
-      pcb.footprints.push({
-        ref: comp.ref, value: comp.value,
-        footprintName: comp.footprintId ?? comp.ref,
-        position: { x: staggerX, y: staggerY }, pads, graphics,
-      });
-      added++;
-    }
-    if (added === 0) return;
-    const patch = setCrdtPcb(state, pcb);
+    const { pcb: nextPcb, changed } = syncSchematicToPcbData(pcb, schematic, netlist);
+    if (!changed) return;
+    const patch = setCrdtPcb(state, nextPcb);
     set({ ...patch, isDirty: true });
   },
 

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -433,6 +433,7 @@ export interface DocumentState {
     netlist?: {
       nets: { name: string; connections: { component_ref: string; pin_number: string }[] }[];
     },
+    opts?: { placeUnplaced?: boolean },
   ) => void;
   moveSchematicComponent: (idx: number, position: Vec3) => void;
   moveSchematicComponentWithWires: (idx: number, position: Vec3, wireUpdates: { wireIdx: number; endpoint: "start" | "end"; pos: { x: number; y: number } }[]) => void;
@@ -2031,12 +2032,12 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     return addPcbToDocument(get, set, pcb, name ?? "Imported PCB");
   },
 
-  syncSchematicToPcb: (boardNodeId, netlist) => {
+  syncSchematicToPcb: (boardNodeId, netlist, opts) => {
     const state = get();
     const pcb = state.document.pcb;
     const schematic = state.document.schematic;
     if (!pcb || !schematic) return;
-    const { pcb: nextPcb, changed } = syncSchematicToPcbData(pcb, schematic, netlist);
+    const { pcb: nextPcb, changed } = syncSchematicToPcbData(pcb, schematic, netlist, opts);
     if (!changed) return;
     const patch = setCrdtPcb(state, nextPcb);
     set({ ...patch, isDirty: true });

--- a/packages/core/src/stores/ecad-sync.ts
+++ b/packages/core/src/stores/ecad-sync.ts
@@ -1,0 +1,121 @@
+/**
+ * Pure schematic→PCB reconciliation.
+ *
+ * Splitting this out of the document store keeps it free of the CRDT engine so
+ * it can be unit-tested on plain `Pcb`/`SchematicSheet` values. The store action
+ * `syncSchematicToPcb` is a thin wrapper that runs this and commits the result.
+ */
+
+import type { Pcb, Footprint, SchematicSheet, PcbLayer } from "@vcad/ir";
+
+/** Minimal netlist shape consumed by the sync (matches the engine's
+ *  `NetlistResult`): named nets, each a set of pin connections. */
+export interface SyncNetlist {
+  nets: { name: string; connections: { component_ref: string; pin_number: string }[] }[];
+}
+
+const FALLBACK_PAD_LAYERS: PcbLayer[] = ["FCu", "FPaste", "FMask"];
+
+/**
+ * Derive a generic single-row pad layout from a component's schematic pins,
+ * used when the component carries no explicit `footprintTemplate`. One pad per
+ * pin (numbered to match the schematic) so every placed part is visible and
+ * routable instead of landing as an empty, padless footprint.
+ */
+export function padsFromPins(pins: { number: string }[]): Footprint["pads"] {
+  const n = pins.length;
+  const pitch = 2.54;
+  return pins.map((pin, i) => ({
+    number: pin.number,
+    padType: "SMD",
+    shape: { type: "RoundRect", width: 1.5, height: 1.5, cornerRatio: 0.25 },
+    position: { x: (i - (n - 1) / 2) * pitch, y: 0 },
+    layers: [...FALLBACK_PAD_LAYERS],
+  }));
+}
+
+/**
+ * Reconcile a PCB against its schematic:
+ *  1. Place any schematic component that has no footprint yet. Pads come from
+ *     the component's `footprintTemplate` when present, otherwise from its pins.
+ *     New footprints are staggered on a coarse grid.
+ *  2. Map schematic nets onto the board: assign `pad.net` for every pad the
+ *     netlist connects, and union new net names into `pcb.nets`. The schematic
+ *     is the source of truth, so a pad no longer on any net has its stale
+ *     assignment cleared; net entries are only added (never removed) so
+ *     already-routed nets keep their identity. Runs over all footprints, not
+ *     just newly placed ones, so re-syncing repairs drift.
+ *
+ * Returns a fresh `Pcb` (the input is not mutated) and whether anything changed.
+ */
+export function syncSchematicToPcbData(
+  pcb: Pcb,
+  schematic: SchematicSheet,
+  netlist?: SyncNetlist,
+): { pcb: Pcb; changed: boolean } {
+  const next = structuredClone(pcb);
+  let changed = false;
+
+  // 1. Place missing footprints.
+  const existingRefs = new Set(next.footprints.map((fp) => fp.ref));
+  let added = 0;
+  for (const comp of schematic.components) {
+    if (existingRefs.has(comp.ref)) continue;
+    let pads: Footprint["pads"] = [];
+    let graphics: Footprint["graphics"] = [];
+    if (comp.properties?.footprintTemplate) {
+      try {
+        const template = JSON.parse(comp.properties.footprintTemplate);
+        pads = template.pads ?? [];
+        graphics = template.graphics ?? [];
+      } catch {
+        /* malformed template — fall through to pin-derived pads */
+      }
+    }
+    if (pads.length === 0) pads = padsFromPins(comp.pins);
+    const fpCount = next.footprints.length;
+    const staggerX = 10 + ((fpCount + added) % 5) * 10;
+    const staggerY = 10 + Math.floor((fpCount + added) / 5) * 10;
+    next.footprints.push({
+      ref: comp.ref,
+      value: comp.value,
+      footprintName: comp.footprintId ?? comp.ref,
+      position: { x: staggerX, y: staggerY },
+      pads,
+      graphics,
+    });
+    added++;
+    changed = true;
+  }
+
+  // 2. Map nets onto pads + pcb.nets.
+  if (netlist) {
+    const padNet = new Map<string, string>();
+    const netNames = new Set<string>();
+    for (const net of netlist.nets) {
+      netNames.add(net.name);
+      for (const c of net.connections) {
+        padNet.set(`${c.component_ref}:${c.pin_number}`, net.name);
+      }
+    }
+    for (const fp of next.footprints) {
+      for (const pad of fp.pads) {
+        const wanted = padNet.get(`${fp.ref}:${pad.number}`);
+        if (wanted !== pad.net) {
+          if (wanted) pad.net = wanted;
+          else delete pad.net;
+          changed = true;
+        }
+      }
+    }
+    const known = new Set(next.nets.map((n) => n.name));
+    for (const name of netNames) {
+      if (!known.has(name)) {
+        next.nets.push({ id: name, name });
+        changed = true;
+      }
+    }
+  }
+
+  return { pcb: next, changed };
+}

--- a/packages/core/src/stores/ecad-sync.ts
+++ b/packages/core/src/stores/ecad-sync.ts
@@ -52,14 +52,19 @@ export function syncSchematicToPcbData(
   pcb: Pcb,
   schematic: SchematicSheet,
   netlist?: SyncNetlist,
+  opts?: { placeUnplaced?: boolean },
 ): { pcb: Pcb; changed: boolean } {
+  // Placement is opt-out so the continuous sync can keep nets current without
+  // ever yanking a not-yet-placed component onto the board (only the explicit
+  // "place unplaced" action should do that).
+  const placeUnplaced = opts?.placeUnplaced ?? true;
   const next = structuredClone(pcb);
   let changed = false;
 
   // 1. Place missing footprints.
   const existingRefs = new Set(next.footprints.map((fp) => fp.ref));
   let added = 0;
-  for (const comp of schematic.components) {
+  for (const comp of placeUnplaced ? schematic.components : []) {
     if (existingRefs.has(comp.ref)) continue;
     let pads: Footprint["pads"] = [];
     let graphics: Footprint["graphics"] = [];


### PR DESCRIPTION
## What

Makes the schematic→PCB workflow actually wire up nets, and hardens it via live UI testing.

## The journey

**1. Net mapping (initial commit).** `syncSchematicToPcbData` now assigns `pad.net` from the netlist, registers net names in `pcb.nets`, and gives template-less parts pin-derived pads. Extracted as a pure, unit-tested helper.

**2. The bug live testing found.** Click-driving the real UI (create board → place components → board view) revealed: components **auto-create their footprint on add**, so the "Place N unplaced" button — the only trigger for net mapping — *never appears* in the normal flow. The board showed 2 footprints + a correct ratsnest but **Nets: 0**: pads net-less, routing/DRC blind.

**3. The fix.** Net mapping moved into the **continuous sync** (`useElectronicsSync`): every netlist regeneration assigns `pad.net` + registers `pcb.nets`. A `placeUnplaced: false` option keeps it net-only (never auto-drops a footprint — the button keeps that job). Idempotent, so it converges with no render loop.

## Tests

`ecad-sync.test.ts` — 11 cases incl. the exact discovered scenario (net-map footprints created earlier, without re-placing). Core 100, app 28, typecheck clean.

## Also (a11y, found while testing)

The shared `ToolbarButton` rendered icon-only buttons with **no accessible name** — every tool button (Box, PCB, …) was unlabeled for screen readers. Added `aria-label`/`aria-pressed`, plus labels on the PCB quick-add buttons. Pure a11y, no behavior change.

Branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)