### PR TITLE
fix(electronics): empty 'Start blank' + wire tool connects to pins

### DIFF
--- a/packages/app/src/components/InlineOnboarding.tsx
+++ b/packages/app/src/components/InlineOnboarding.tsx
@@ -15,7 +15,7 @@ import { Waveform } from "@phosphor-icons/react/dist/ssr/Waveform";
 import { Star } from "@phosphor-icons/react/dist/ssr/Star";
 import type { Icon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
-import { useDocumentStore, useUiStore, useChatStore, parseVcadFile } from "@vcad/core";
+import { useDocumentStore, useChatStore, parseVcadFile } from "@vcad/core";
 import { useAuth, isAuthEnabled, AuthModal } from "@vcad/auth";
 import { useOnboardingStore } from "@/stores/onboarding-store";
 import { examples, exampleToVcadFile } from "@/data/examples";
@@ -51,9 +51,6 @@ export function InlineOnboarding({ visible }: InlineOnboardingProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadDocument = useDocumentStore((s) => s.loadDocument);
-  const addPrimitive = useDocumentStore((s) => s.addPrimitive);
-  const select = useUiStore((s) => s.select);
-  const setTransformMode = useUiStore((s) => s.setTransformMode);
   const setChatOpen = useChatStore((s) => s.setOpen);
   const incrementProjectsCreated = useOnboardingStore(
     (s) => s.incrementProjectsCreated,
@@ -95,10 +92,8 @@ export function InlineOnboarding({ visible }: InlineOnboardingProps) {
   }
 
   function handleStartBlank() {
+    // "empty canvas" — start with a truly blank scene (no stray primitive).
     incrementProjectsCreated();
-    const partId = addPrimitive("cube");
-    select(partId);
-    setTransformMode("translate");
     hide();
   }
 

--- a/packages/app/src/components/electronics/SchematicCanvas.tsx
+++ b/packages/app/src/components/electronics/SchematicCanvas.tsx
@@ -605,6 +605,10 @@ export function SchematicCanvas() {
 
   const onComponentClick = useCallback(
     (e: React.MouseEvent, idx: number, ref: string) => {
+      // Wire tool: let the click fall through to the canvas handler so it snaps
+      // to this component's pin — clicking a pin should start/finish a wire, not
+      // select the part. (Without this, stopPropagation swallows the wire click.)
+      if (schTool === "wire") return;
       e.stopPropagation();
       if (schTool === "delete") {
         removeSchematicComponent(idx);


### PR DESCRIPTION
Two bug fixes found by dogfooding circuit creation through the UI (clicking only).

## 1. "Start blank" left a stray cube
`handleStartBlank()` called `addPrimitive("cube")` despite the action being labelled **"empty canvas"** (the footer koan even reads *"an empty canvas is potential"*). Every new-from-blank user got a 20×20×20 cube to delete. Now it just dismisses the onboarding — truly blank. Removes the now-unused store hooks.

## 2. The Wire tool couldn't connect to component pins
`onComponentClick` **unconditionally** `stopPropagation()` + selected the component, regardless of the active tool. With the **Wire** tool active, clicking a component's pin therefore *selected the part* instead of letting the canvas wire handler (`onSvgClick`) snap a wire to that pin — so the most natural wiring gesture (click pin → click pin) did nothing. Wiring only worked by clicking empty grid near a pin, defeating the pin-snap.

Now wire-mode clicks fall through to the canvas so they snap to the pin.

### Verified live
Built an LED + current-limiting-resistor circuit by clicking: VCC → R1 → D1 → GND wires cleanly to **ERC 0**, then added a decoupling cap (C1) wired into the existing nets — also ERC 0. Before the fix, every wire attempt just selected a component.

### Noted for follow-up (not in this PR)
- `onWireClick` / `onLabelClick` share the same unconditional-`stopPropagation` pattern — likely the same issue for wire-to-wire T-taps and labelling pins. Worth verifying + applying the consistent fix.
- No Escape-to-cancel for an in-progress wire (right-click works, but Esc is the reflex).
- The welcome gallery has no Circuit/PCB example to start from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)