### PR TITLE
fix(electronics): Escape cancels an in-progress schematic wire

### DIFF
--- a/changelog/entries/2026-06-05-schematic-wire-escape-cancel.json
+++ b/changelog/entries/2026-06-05-schematic-wire-escape-cancel.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-05-schematic-wire-escape-cancel",
+  "version": "0.9.4",
+  "date": "2026-06-05",
+  "category": "fix",
+  "title": "Press Escape to cancel an in-progress schematic wire",
+  "summary": "Drawing a wire and want out? Escape now drops it — the universal EDA reflex, complementing right-click cancel and double-click finish.",
+  "features": ["electronics", "schematic", "ux"]
+}

--- a/packages/app/src/components/electronics/SchematicCanvas.tsx
+++ b/packages/app/src/components/electronics/SchematicCanvas.tsx
@@ -6,7 +6,7 @@
  * Supports place, wire, label, delete, and move tools.
  */
 
-import { useRef, useCallback, useState, useMemo } from "react";
+import { useRef, useCallback, useState, useMemo, useEffect } from "react";
 import { useDocumentStore, getPcbNodeIds } from "@vcad/core";
 import type { SchematicComponent, SchematicWire } from "@vcad/ir";
 import { useElectronicsStore } from "@/stores/electronics-store";
@@ -261,6 +261,18 @@ export function SchematicCanvas() {
 
   const select = useElectronicsStore((s) => s.select);
   const setHoveredNet = useElectronicsStore((s) => s.setHoveredNet);
+
+  // Escape cancels an in-progress wire (the universal EDA reflex; complements
+  // the right-click cancel and double-click finish).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && schTool === "wire") {
+        useElectronicsStore.getState().cancelSchWire();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [schTool]);
   const zoomAt = useElectronicsStore((s) => s.zoomSchAt);
   const adjustPan = useElectronicsStore((s) => s.adjustSchPan);
   const startSchWire = useElectronicsStore((s) => s.startSchWire);


### PR DESCRIPTION
## What

While dogfooding the schematic editor — and especially while wiring up the DC-motor co-sim demo from #242 — the missing **Escape-to-cancel** for an in-progress wire was the single biggest friction point. Once a wire chain started, the only way out was a right-click, which is easy to miss and (as I hit repeatedly) impossible to script reliably.

This adds a `window` keydown handler in `SchematicCanvas` that calls `cancelSchWire()` on **Escape** while the wire tool is active — the universal EDA reflex, complementing the existing right-click-cancel and double-click-finish.

## Why it's the right shape

- Follows the **Escape-to-dismiss** pattern already used across ~10 other components (`CommandPalette`, `InlineProperties`, `FeatureTree`, …).
- `cancelSchWire()` already exists in the electronics store — this just gives it a keyboard affordance.
- Cleans up its listener on unmount and only fires while `schTool === "wire"`, so it never swallows Escape elsewhere.

## Test

- `tsc -b` clean
- `vitest run` — 34/34 app tests pass
- Verified by hand in the preview: starting a wire and pressing Escape drops the in-progress segment; the next click starts a fresh wire instead of continuing the chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)