### PR TITLE
fix(mcp): pass full kernel module to Engine in Vercel entry

### DIFF
--- a/changelog/entries/2026-06-10-hosted-mcp-sheet-metal-fix.json
+++ b/changelog/entries/2026-06-10-hosted-mcp-sheet-metal-fix.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-10-hosted-mcp-sheet-metal-fix",
+  "version": "0.9.4",
+  "date": "2026-06-10",
+  "category": "fix",
+  "title": "Hosted MCP: sheet metal and parts tools work again",
+  "summary": "The mcp.vcad.io entry point now passes the full kernel module to the Engine, restoring sheet_metal_*, search_parts, place_part, and URDF import on the hosted server.",
+  "features": ["sheet-metal", "mcp"],
+  "mcpTools": ["sheet_metal_create", "sheet_metal_unfold", "sheet_metal_check", "sheet_metal_materials", "search_parts", "place_part"]
+}

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -41,21 +41,13 @@ async function getEngine(): Promise<Engine> {
     .getCompiledModule as (() => WebAssembly.Module | undefined) | undefined;
   const compiledWasmModule = getCompiledModule?.();
 
-  // Construct Engine directly with WASM bindings — same as Engine.init()
-  // does at packages/engine/src/index.ts:320-329
+  // Construct Engine directly, passing the whole initialized module as the
+  // kernel. Hand-picking bindings here once broke sheet metal: the list
+  // drifted from Engine.init()'s as new kernel exports landed. The module
+  // namespace is a superset of KernelModule, so every current and future
+  // export rides along automatically.
   _engine = new Engine(
-    {
-      Solid: wasmModule.Solid,
-      WasmAnnotationLayer: wasmModule.WasmAnnotationLayer,
-      projectMesh: wasmModule.projectMesh,
-      importStepBuffer: wasmModule.importStepBuffer,
-      exportProjectedViewToDxf: wasmModule.exportProjectedViewToDxf,
-      createDetailView: wasmModule.createDetailView,
-      evaluateDocument: (wasmModule as Record<string, unknown>)
-        .evaluateDocument as Parameters<typeof Engine.prototype.evaluate>[1],
-      evalVcadSource: (wasmModule as Record<string, unknown>)
-        .evalVcadSource as Parameters<typeof Engine.prototype.evaluate>[1],
-    } as ConstructorParameters<typeof Engine>[0],
+    wasmModule as unknown as ConstructorParameters<typeof Engine>[0],
     compiledWasmModule,
   );
 


### PR DESCRIPTION
## Summary

- `services/mcp/entry.ts` constructed the Engine from a hand-picked list of WASM bindings copied from `Engine.init()`. The list drifted as new kernel exports landed, so the hosted MCP at mcp.vcad.io advertised sheet metal tools but failed with `no sheetMetal bundle` and returned an empty materials registry. `search_parts` / `place_part` (`getPartsManifest`, `buildPart`) and URDF import bindings were missing too.
- Fix: pass the whole initialized WASM module as the kernel, so every current and future export rides along automatically.
- Adds a changelog entry.

## Test plan

- [x] Entry-style engine construction (`initSync` from buffer): 6 materials, sheet metal evaluates
- [x] `build.sh` produces the Build Output API bundle cleanly
- [x] Smoke test against the bundled function via real MCP JSON-RPC over HTTP: `sheet_metal_create` / `unfold` / `check` / `cost` / `sequence` / `nest` / `bend_table` / `materials` / `search_parts` / `inspect_cad` all pass
- [ ] Verify on Vercel preview deployment before merging

Made with [Cursor](https://cursor.com)