### PR TITLE
fix(mcp): assign pad nets in place_components so route_nets can route

### DIFF
--- a/changelog/entries/2026-06-10-place-components-pad-nets.json
+++ b/changelog/entries/2026-06-10-place-components-pad-nets.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-10-place-components-pad-nets",
+  "version": "0.9.4",
+  "date": "2026-06-10",
+  "category": "fix",
+  "title": "place_components now assigns pad nets",
+  "summary": "MCP place_components assigns nets to footprint pads from schematic pin names, so route_nets can route without manual net patching.",
+  "features": ["pcb", "ecad"],
+  "mcpTools": ["place_components", "route_nets"]
+}

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -33,6 +33,11 @@ import {
   gymObserve,
   gymClose,
 } from "../tools/gym.js";
+import {
+  createSchematic,
+  placeComponents,
+  routeNets,
+} from "../tools/ecad.js";
 import { existsSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -815,5 +820,65 @@ describe("sheet-metal tools", () => {
     expect(flangeFix).toBeDefined();
     expect(flangeFix.fix.new_length_mm).toBeGreaterThanOrEqual(5);
     expect(flangeFix.fix.description.toLowerCase()).toContain("flange");
+  });
+});
+
+describe("ecad place_components → route_nets pipeline", () => {
+  it("assigns pad nets during placement so routing produces traces", () => {
+    const schematicOut = JSON.parse(
+      createSchematic({
+        components: [
+          {
+            ref: "R1",
+            value: "10k",
+            footprint: "Resistor_SMD:R_0805",
+            x: 0,
+            y: 0,
+            pins: [
+              { number: "1", name: "VCC", type: "Passive" },
+              { number: "2", name: "OUT", type: "Passive" },
+            ],
+          },
+          {
+            ref: "R2",
+            value: "4k7",
+            footprint: "Resistor_SMD:R_0805",
+            x: 20,
+            y: 0,
+            pins: [
+              { number: "1", name: "OUT", type: "Passive" },
+              { number: "2", name: "GND", type: "Passive" },
+            ],
+          },
+        ],
+      }).content[0].text,
+    );
+
+    const placedOut = JSON.parse(
+      placeComponents({
+        document: schematicOut.document,
+        board_width: 50,
+        board_height: 50,
+      }).content[0].text,
+    );
+    expect(placedOut.success).toBe(true);
+    expect(placedOut.footprints_placed).toBe(2);
+
+    const placedDoc = placedOut.document as Document;
+    const pcbNode = Object.values(placedDoc.nodes).find(
+      (n) => (n.op as { type: string }).type === "PcbBoard",
+    );
+    expect(pcbNode).toBeDefined();
+    const board = (pcbNode!.op as unknown as { board: { footprints: Array<{ pads: Array<{ net?: string }> }> } }).board;
+    const padNets = board.footprints.flatMap((fp) => fp.pads.map((p) => p.net));
+    expect(padNets).toEqual(["VCC", "OUT", "OUT", "GND"]);
+
+    const routedOut = JSON.parse(
+      routeNets({ document: placedDoc }).content[0].text,
+    );
+    expect(routedOut.success).toBe(true);
+    // Only OUT has 2+ pads — VCC and GND are single-pad nets.
+    expect(routedOut.nets_routed).toBe(1);
+    expect(routedOut.traces_added).toBe(1);
   });
 });

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -372,12 +372,11 @@ export function placeComponents(args: Record<string, unknown>) {
     const pads: Pad[] = comp.pins.map((pin, pi) => {
       const padX = pi === 0 ? -1.0 : 1.0;
 
-      // Track nets
-      if (pin.name && pin.name !== "~") {
-        if (!netSet.has(pin.name)) {
-          netSet.add(pin.name);
-          nets.push({ id: pin.name, name: pin.name });
-        }
+      // Track nets; pin name doubles as the net id
+      const netId = pin.name && pin.name !== "~" ? pin.name : undefined;
+      if (netId && !netSet.has(netId)) {
+        netSet.add(netId);
+        nets.push({ id: netId, name: netId });
       }
 
       return {
@@ -385,6 +384,7 @@ export function placeComponents(args: Record<string, unknown>) {
         padType: "SMD" as PadType,
         shape: { type: "Rect" as const, width: 1.0, height: 1.2 },
         position: { x: padX, y: 0 },
+        net: netId,
         layers: ["FCu" as PcbLayer, "FPaste" as PcbLayer, "FMask" as PcbLayer],
       };
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The MCP `place_components` tool tracked nets from schematic pin names into `pcb.nets`, but never assigned `pad.net` on the generated footprint pads. Since `route_nets` only considers pads with `pad.net` set, a `place_components` → `route_nets` pipeline always routed zero traces unless nets were patched into the document manually.

## Fix

`placeComponents` now assigns the derived net id (the schematic pin name, skipping `"~"`) to each pad it creates, matching the net ids it already registers in `pcb.nets`.

## Testing

- Added a regression test covering the `createSchematic` → `placeComponents` → `routeNets` pipeline: verifies pads carry the expected nets and that a shared net produces a trace.
- `npm test -w @vcad/mcp`: 32 tests pass.

## Changelog

Added `changelog/entries/2026-06-10-place-components-pad-nets.json` (category: fix).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c0ed5de-a5e0-4855-a2b0-75209b2e1f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c0ed5de-a5e0-4855-a2b0-75209b2e1f62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

