### PR TITLE
feat(mcp): spec-compliant MCP Apps inline 3D viewer across geometry tools

### DIFF
--- a/changelog/entries/2026-06-10-mcp-apps-inline-viewer.json
+++ b/changelog/entries/2026-06-10-mcp-apps-inline-viewer.json
@@ -1,0 +1,22 @@
+{
+  "id": "2026-06-10-mcp-apps-inline-viewer",
+  "version": "0.9.4",
+  "date": "2026-06-10",
+  "category": "feat",
+  "title": "Inline 3D viewer in MCP hosts (MCP Apps)",
+  "summary": "Geometry tools now render an interactive 3D viewport inline in MCP Apps hosts like Cursor and Claude, using the official SEP-1865 handshake.",
+  "features": ["mcp", "viewer"],
+  "mcpTools": [
+    "create_cad_loon",
+    "import_step",
+    "sheet_metal_create",
+    "place_part",
+    "create",
+    "update",
+    "delete",
+    "set_material",
+    "dfm_apply_fix",
+    "open_document",
+    "get_document"
+  ]
+}

--- a/packages/engine/src/wasm-singleton.ts
+++ b/packages/engine/src/wasm-singleton.ts
@@ -63,20 +63,32 @@ async function loadAndInit(): Promise<WasmModule> {
     process.versions.node != null;
 
   if (isNode) {
-    // Dynamic imports keep these out of browser bundles.
-    const fs = await import("node:fs");
-    const url = await import("node:url");
-    const path = await import("node:path");
+    // A primed buffer takes precedence — bundlers (esbuild) relocate this
+    // module, breaking the source-relative path below. Serverless entries
+    // read the .wasm co-located with their bundle and prime it instead.
+    const hint = wasmInputHint;
+    wasmInputHint = undefined;
+    const isBuffer = (v: BufferSource | Response): v is BufferSource =>
+      typeof Response === "undefined" || !(v instanceof Response);
+    let wasmBuffer: BufferSource;
+    if (hint && isBuffer(hint)) {
+      wasmBuffer = hint;
+    } else {
+      // Dynamic imports keep these out of browser bundles.
+      const fs = await import("node:fs");
+      const url = await import("node:url");
+      const path = await import("node:path");
 
-    const here = url.fileURLToPath(import.meta.url);
-    const wasmPath = path.join(
-      path.dirname(here),
-      "..",
-      "..",
-      "kernel-wasm",
-      "vcad_kernel_wasm_bg.wasm",
-    );
-    const wasmBuffer = fs.readFileSync(wasmPath);
+      const here = url.fileURLToPath(import.meta.url);
+      const wasmPath = path.join(
+        path.dirname(here),
+        "..",
+        "..",
+        "kernel-wasm",
+        "vcad_kernel_wasm_bg.wasm",
+      );
+      wasmBuffer = fs.readFileSync(wasmPath);
+    }
     bindgenStarted = true;
     mod.initSync({ module: wasmBuffer });
   } else {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -110,10 +110,18 @@ import {
   MCP_APP_MIME_TYPE,
 } from "./viewer.js";
 
-/** Tools that produce or modify geometry and should show the 3D viewer. */
+/** Tools that produce or modify geometry and should show the 3D viewer.
+ *  Registry-driven kernel tools (create, update, delete, …) are added
+ *  dynamically in `createServer` once their names are known. */
 const GEOMETRY_TOOLS = new Set([
   "create_cad_loon",
   "import_step",
+  "open_document",
+  "get_document",
+  "place_part",
+  "set_material",
+  "dfm_apply_fix",
+  "sheet_metal_create",
 ]);
 
 /** MCP Apps UI metadata for geometry tools. */
@@ -163,6 +171,11 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
   // route by name without re-querying the registry per tool call.
   const dispatchableTools = registryDispatchableNames();
 
+  // Every geometry-mutating tool shows the inline 3D viewer: the static
+  // set plus all registry-driven kernel tools (they all mutate a session
+  // document, so a preview is always meaningful).
+  const uiTools = new Set([...GEOMETRY_TOOLS, ...dispatchableTools]);
+
   const server = new Server(
     {
       name: "vcad",
@@ -188,12 +201,14 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         description:
           "Open an editing session for a CAD document. Returns a `document_id` to pass to subsequent tool calls (create, update, place_part, inspect_cad, …). Pass an `initial` IR to begin editing an existing document; omit it for a fresh empty document.",
         inputSchema: openDocumentSchema,
+        _meta: UI_META,
       },
       {
         name: "get_document",
         description:
           "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`.",
         inputSchema: getDocumentSchema,
+        _meta: UI_META,
       },
       {
         name: "close_document",
@@ -213,14 +228,16 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         description:
           "Insert a stdlib part into the session's document. Takes a `document_id`, a `path` (from `search_parts.id`), and an optional `params` map; missing params use declared defaults. The part remains parametric — end users can edit its params from the feature tree.",
         inputSchema: placePartSchema,
+        _meta: UI_META,
       },
       // ── Registry-driven kernel tools (auto-exposed) ───────────
       // The next block iterates `commandRegistry.toAnthropicTools()` so the
       // schema lives in one place — the kernel WASM. Same tools, same
       // behavior as the in-app chat surface; viewport-only tools (camera
       // and scene-evaluation tools) are filtered out via blocklists in
-      // tools/registry-dispatch.ts.
-      ...registryToolDescriptors(),
+      // tools/registry-dispatch.ts. All of them mutate a session document,
+      // so they all get the inline 3D viewer.
+      ...registryToolDescriptors().map((t) => ({ ...t, _meta: UI_META })),
       // ── Loon DSL one-shot ──────────────────────────────────────
       {
         name: "create_cad_loon",
@@ -272,6 +289,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         description:
           "Apply an approved DFM fix to the session document. v1 supports `set_param` patches (raise a fillet radius, thicken a wall) — other kinds throw and require manual edits. Re-run `dfm_check` afterwards to confirm the issue cleared.",
         inputSchema: dfmApplyFixSchema,
+        _meta: UI_META,
       },
       // ── Sheet metal (AI-native manufacturability surface) ───────
       {
@@ -279,6 +297,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         description:
           "Create a sheet-metal part: a rectangular base flange plus an ordered chain of edge flanges. Returns a `document_id` (usable with sheet_metal_unfold/check, inspect_cad, export_cad, open_in_browser), the panel/bend model summary, flat bbox + area, and DFM violations vs. the generic shop.",
         inputSchema: sheetMetalCreateSchema,
+        _meta: UI_META,
       },
       {
         name: "sheet_metal_unfold",
@@ -512,15 +531,19 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
     const { name, arguments: args = {} } = request.params;
 
     try {
+      let result: { content: Array<{ type: string; text: string; annotations?: unknown }>; isError?: boolean };
+
       // Registry-driven dispatch: any kernel tool from
       // `commandRegistry.toAnthropicTools()` (minus the browser-only and
       // deferred sets in tools/registry-dispatch.ts) routes through the
-      // shared planner + applyToolOutcome path.
+      // shared planner + applyToolOutcome path. Falls through to the GLB
+      // preview block below so these mutations render in the inline viewer.
       if (dispatchableTools.has(name)) {
-        return dispatchRegistryTool(name, args);
+        result = dispatchRegistryTool(name, args);
+        const irDoc = extractIrDocument(name, result, args, engine);
+        if (irDoc) appendGlbPreview(result, irDoc, engine);
+        return result;
       }
-
-      let result: { content: Array<{ type: string; text: string; annotations?: unknown }> };
 
       switch (name) {
         case "open_document":
@@ -687,7 +710,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       }
 
       // ── MCP Apps: Append GLB preview for geometry tools ──────
-      if (GEOMETRY_TOOLS.has(name) && result.content.length > 0) {
+      if (uiTools.has(name) && result.content.length > 0 && !result.isError) {
         const irDoc = extractIrDocument(name, result, args, engine);
         if (irDoc) {
           appendGlbPreview(result, irDoc, engine);
@@ -711,6 +734,9 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
  * Extract an IR Document from a tool result for GLB preview generation.
  *
  * Strategy per tool:
+ * - session-backed tools (registry CRUD, place_part, dfm_apply_fix,
+ *   sheet_metal_create, …): resolve the live session doc by `document_id`
+ *   from the args or the result payload
  * - create_cad_loon: re-evaluate loon source via engine
  * - import_step: parse JSON result to extract the document field
  */
@@ -737,8 +763,20 @@ function extractIrDocument(
       if (parsed.version && parsed.nodes) {
         return parsed as Document;
       }
+
+      // Session-backed result (e.g. sheet_metal_create, open_document)
+      if (typeof parsed.document_id === "string") {
+        const doc = documents.get(parsed.document_id);
+        if (doc) return doc;
+      }
     } catch {
       // Not JSON — likely VCode format, handle below
+    }
+
+    // Session-backed args (registry CRUD tools, place_part, dfm_apply_fix)
+    if (typeof args.document_id === "string") {
+      const doc = documents.get(args.document_id);
+      if (doc) return doc;
     }
 
     // For create_cad_loon with VCode output, re-evaluate with JSON format

--- a/packages/mcp/src/viewer.ts
+++ b/packages/mcp/src/viewer.ts
@@ -2,11 +2,15 @@
  * Embedded MCP Apps viewer HTML for inline 3D CAD preview.
  *
  * This module exports a self-contained HTML string that renders GLB models
- * using Three.js in a sandboxed iframe. It communicates with the MCP Apps
- * host via the postMessage JSON-RPC protocol to receive tool results.
+ * using Three.js in a sandboxed iframe. Host communication uses the official
+ * `@modelcontextprotocol/ext-apps` App class (SEP-1865), which owns the
+ * `ui/initialize` → `ui/notifications/initialized` handshake — hosts MUST
+ * NOT deliver tool results before that handshake completes, so a hand-rolled
+ * protocol that gets it wrong renders nothing in spec-compliant hosts
+ * (Cursor, Claude Desktop).
  */
 
-/** CSP resource domains needed by the viewer (Three.js CDN). */
+/** CSP resource domains needed by the viewer (Three.js + ext-apps CDN). */
 export const VIEWER_CSP = {
   resourceDomains: ["https://cdn.jsdelivr.net"],
 };
@@ -33,9 +37,17 @@ export function getViewerHtml(): string {
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>vcad 3D Viewer</title>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+  }
+}
+</script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  html, body { width: 100%; height: 100%; overflow: hidden; background: #1a1a2e; }
+  html, body { width: 100%; height: 100%; min-height: 380px; overflow: hidden; background: #1a1a2e; }
   canvas { display: block; width: 100%; height: 100%; }
   #loading {
     position: absolute; inset: 0;
@@ -66,16 +78,18 @@ export function getViewerHtml(): string {
 const CDN = 'https://cdn.jsdelivr.net/npm/three@0.170.0';
 const errEl = document.getElementById('error');
 
-let THREE, OrbitControls, GLTFLoader;
+let THREE, OrbitControls, GLTFLoader, App;
 try {
   THREE = await import(CDN + '/build/three.module.js');
   const oc = await import(CDN + '/examples/jsm/controls/OrbitControls.js');
   OrbitControls = oc.OrbitControls;
   const gl = await import(CDN + '/examples/jsm/loaders/GLTFLoader.js');
   GLTFLoader = gl.GLTFLoader;
+  const ea = await import('https://cdn.jsdelivr.net/npm/@modelcontextprotocol/ext-apps@1.7.4/+esm');
+  App = ea.App;
   document.querySelector('#loading div').textContent = 'vcad 3D Viewer — waiting for model...';
 } catch (e) {
-  errEl.textContent = 'Three.js load failed: ' + e.message;
+  errEl.textContent = 'Viewer dependencies failed to load: ' + e.message;
   throw e;
 }
 
@@ -184,7 +198,6 @@ function loadGlb(base64Data) {
     controls.update();
 
     document.getElementById('loading').classList.add('hidden');
-    reportHeight(400);
     renderer.render(scene, camera);
   }, (error) => {
     console.error('GLB parse error:', error);
@@ -192,77 +205,18 @@ function loadGlb(base64Data) {
   });
 }
 
-// ── MCP Apps protocol ────────────────────────────────────────
-let messageId = 1;
+// ── MCP Apps protocol (official ext-apps App class) ──────────
+// The App owns the SEP-1865 handshake: it sends ui/initialize with
+// appCapabilities, emits ui/notifications/initialized, and dispatches
+// ui/notifications/tool-result to the handler below. It also auto-reports
+// size changes to the host via a ResizeObserver.
+const app = new App({ name: 'vcad-viewer', version: '1.0.0' });
 
-// The host iframe origin is not known until the first inbound message
-// arrives. Until then we have to fall back to '*' (the initial handshake
-// has to reach whoever embedded us), but after we learn the real origin
-// we pin postMessage to it so a second frame opened in parallel can't
-// intercept subsequent responses.
-let hostOrigin = '*';
-
-function sendToHost(message) {
-  window.parent.postMessage(message, hostOrigin);
-}
-
-// Report content height to host so iframe is properly sized
-function reportHeight(h) {
-  sendToHost({
-    jsonrpc: '2.0',
-    method: 'ui/notifications/contentHeight',
-    params: { height: h || 400 },
-  });
-}
-
-// Send ui/initialize handshake
-sendToHost({
-  jsonrpc: '2.0',
-  id: messageId++,
-  method: 'ui/initialize',
-  params: {
-    capabilities: { contentHeight: true },
-    clientInfo: { name: 'vcad-viewer', version: '1.0.0' },
-    protocolVersion: '2026-01-26',
-  },
-});
-
-// Report initial height immediately
-reportHeight(400);
-
-// Listen for ALL host messages and extract GLB data
-window.addEventListener('message', (event) => {
-  const data = event.data;
-  if (!data || typeof data !== 'object') return;
-  // Pin postMessage replies to the origin we first heard from. Once
-  // hostOrigin is set, silently drop messages from any other origin.
-  if (event.origin && event.origin !== 'null') {
-    if (hostOrigin === '*') {
-      hostOrigin = event.origin;
-    } else if (event.origin !== hostOrigin) {
-      return;
-    }
-  }
-
-  // Log all messages for debugging
-  console.log('[vcad-viewer] message:', data.method || (data.result ? 'response' : 'unknown'));
-
-  // Handle tool result notification (method-based)
-  if (data.method === 'ui/notifications/tool-result') {
-    extractGlb(data.params?.result);
-    extractGlb(data.params);
-  }
-
-  // Handle JSON-RPC response (id-based, like PostHog receives)
-  if (data.result) {
-    extractGlb(data.result);
-  }
-
-  // Handle structuredContent (PostHog-style)
-  if (data.result?.structuredContent) {
-    extractGlb(data.result.structuredContent);
-  }
-});
+// Set before connect() so the initial tool result is not missed.
+app.ontoolresult = (result) => {
+  console.log('[vcad-viewer] tool result received');
+  extractGlb(result);
+};
 
 // ── "Open in vcad.io" deep link ──────────────────────────────
 let vcodeDoc = null;
@@ -270,19 +224,10 @@ const openBtn = document.getElementById('open-btn');
 
 openBtn.addEventListener('click', () => {
   if (!vcodeDoc) return;
-  // Compress with pako (lightweight gzip) and base64url-encode
-  // For now, use uncompressed base64url as fallback
   const encoded = btoa(unescape(encodeURIComponent(vcodeDoc)))
     .replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '');
   const url = 'https://vcad.io/#/new?doc=' + encoded;
-  // Use MCP Apps openLinks capability if available, else window.open
-  sendToHost({
-    jsonrpc: '2.0',
-    id: messageId++,
-    method: 'ui/openLink',
-    params: { url },
-  });
-  window.open(url, '_blank');
+  app.openLink({ url }).catch(() => window.open(url, '_blank'));
 });
 
 function extractGlb(obj) {
@@ -319,6 +264,9 @@ function extractGlb(obj) {
     }
   }
 }
+
+await app.connect();
+console.log('[vcad-viewer] connected to host');
 </script>
 </body>
 </html>`;

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -2,13 +2,12 @@
  * Vercel serverless function entry point for the vcad MCP server.
  *
  * Solves the WASM path problem: after esbuild bundles everything into a
- * single file, Engine.init()'s relative path to the .wasm file breaks
- * (it resolves to /kernel-wasm/... outside the function sandbox).
- *
- * We bypass Engine.init() entirely and construct the Engine directly:
- * 1. Read the .wasm file from next to this bundle
- * 2. Call initSync() to initialize the WASM module
- * 3. Construct Engine with the bindings from the initialized module
+ * single file, the wasm-singleton's source-relative path to the .wasm file
+ * breaks (it resolves to /kernel-wasm/... outside the function sandbox).
+ * We read the .wasm co-located with the bundle and prime it into
+ * Engine.init(), so the engine AND every other consumer of the shared
+ * wasm-singleton (e.g. the commandRegistry bootstrap behind the registry
+ * CRUD tools) use the same initialized module.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
@@ -28,29 +27,7 @@ let _engine: Engine | undefined;
 
 async function getEngine(): Promise<Engine> {
   if (_engine) return _engine;
-
-  // Initialize WASM from the co-located .wasm file.
-  // We bypass Engine.init() because it calculates the WASM path relative
-  // to the original source location, which breaks after esbuild bundling.
-  const wasmModule = await import("@vcad/kernel-wasm");
-  const wasmBuffer = readFileSync(WASM_PATH);
-  wasmModule.initSync({ module: wasmBuffer });
-
-  // Extract the compiled module for potential worker sharing
-  const getCompiledModule = (wasmModule as Record<string, unknown>)
-    .getCompiledModule as (() => WebAssembly.Module | undefined) | undefined;
-  const compiledWasmModule = getCompiledModule?.();
-
-  // Construct Engine directly, passing the whole initialized module as the
-  // kernel. Hand-picking bindings here once broke sheet metal: the list
-  // drifted from Engine.init()'s as new kernel exports landed. The module
-  // namespace is a superset of KernelModule, so every current and future
-  // export rides along automatically.
-  _engine = new Engine(
-    wasmModule as unknown as ConstructorParameters<typeof Engine>[0],
-    compiledWasmModule,
-  );
-
+  _engine = await Engine.init({ wasmInput: readFileSync(WASM_PATH) });
   return _engine;
 }
 


### PR DESCRIPTION
## Summary
- The inline MCP Apps viewer never rendered in spec-compliant hosts (Cursor, Claude Desktop). Two root causes: the hand-rolled postMessage protocol predated the final SEP-1865 handshake (no `appCapabilities`, no `ui/notifications/initialized` — hosts MUST NOT deliver tool results before that, so the iframe sat empty), and the Three.js addon modules failed to resolve their bare `three` import inside the sandboxed iframe.
- Rebuilt the viewer on the official `@modelcontextprotocol/ext-apps` App class (handles handshake, tool-result dispatch, auto size reporting) and added an import map for `three` / `three/addons/`.
- Extended inline previews from 2 tools to 12: all registry CRUD tools (`create`, `update`, `delete`, `set_material`, `read`), `place_part`, `dfm_apply_fix`, `sheet_metal_create`, `open_document`, `get_document` now carry `_meta.ui.resourceUri` and append a GLB preview block, resolving session documents by `document_id`.
- Fixed registry CRUD tools on the bundled Vercel server: the `commandRegistry` wasm bootstrap ENOENTed on its source-relative path post-esbuild ("Rust planner unavailable"). The wasm-singleton now honors a primed buffer, and `entry.ts` collapses to `Engine.init({ wasmInput })` so the engine and registry share one initialized module.

## Verification
Built the Vercel bundle and drove it with a local SEP-1865 host harness (sandboxed iframe + spec handshake):

- `ui/initialize` → `initialized` → `tool-input` → `tool-result` completes; viewer renders the sheet-metal lotus GLB and reports size-changed
- 12 tools advertise UI meta; `sheet_metal_create` / `create` / `place_part` results all carry `_vcad_glb` preview blocks (`audience: ["user"]`)
- Registry `create` works in the bundle (planner bootstrap fixed)
- `npm test -w @vcad/mcp` passes (32 tests)

## Test plan
- [ ] Merge + Vercel deploy of mcp.vcad.io
- [ ] Call a geometry tool from Cursor and confirm the inline viewer renders

Made with [Cursor](https://cursor.com)