### PR TITLE
fix(mcp): Cursor inline 3D viewer (CSP + lean results)

### DIFF
--- a/changelog/entries/2026-06-10-mcp-cursor-inline-viewer-fix.json
+++ b/changelog/entries/2026-06-10-mcp-cursor-inline-viewer-fix.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-10-mcp-cursor-inline-viewer-fix",
+  "version": "0.9.4",
+  "date": "2026-06-10",
+  "category": "fix",
+  "title": "MCP inline viewer works in Cursor",
+  "summary": "Cursor MCP Apps now render the 3D viewer: CSP allows blob URLs for Three.js GLB loading, and geometry tool results stay small so hosts do not suppress the inline UI.",
+  "features": ["mcp", "viewer"],
+  "mcpTools": ["create_cad_loon", "get_preview_glb"]
+}

--- a/packages/mcp/scripts/test-local-mcp-apps.mjs
+++ b/packages/mcp/scripts/test-local-mcp-apps.mjs
@@ -1,0 +1,147 @@
+/**
+ * Smoke-test the stdio MCP server for MCP Apps metadata and lean geometry results.
+ * Run: node scripts/test-local-mcp-apps.mjs
+ */
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.dirname(fileURLToPath(import.meta.url));
+const serverPath = path.join(root, "../dist/index.js");
+
+function send(proc, msg) {
+  proc.stdin.write(JSON.stringify(msg) + "\n");
+}
+
+function readMessages(proc, onMessage) {
+  let buf = "";
+  proc.stdout.on("data", (chunk) => {
+    buf += chunk.toString();
+    let idx;
+    while ((idx = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, idx).trim();
+      buf = buf.slice(idx + 1);
+      if (!line) continue;
+      try {
+        onMessage(JSON.parse(line));
+      } catch (e) {
+        console.error("bad json:", line.slice(0, 200));
+      }
+    }
+  });
+}
+
+const proc = spawn("node", [serverPath], {
+  cwd: path.join(root, ".."),
+  env: { ...process.env, VCAD_WASM_SKIP: "1" },
+  stdio: ["pipe", "pipe", "inherit"],
+});
+
+const pending = new Map();
+let nextId = 1;
+
+readMessages(proc, (msg) => {
+  if (msg.id != null && pending.has(msg.id)) {
+    const { resolve, reject } = pending.get(msg.id);
+    pending.delete(msg.id);
+    if (msg.error) reject(msg.error);
+    else resolve(msg.result);
+  }
+});
+
+function request(method, params) {
+  const id = nextId++;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    send(proc, { jsonrpc: "2.0", id, method, params });
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error(`timeout: ${method}`));
+      }
+    }, 120000);
+  });
+}
+
+async function main() {
+  await request("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {
+      extensions: {
+        "io.modelcontextprotocol/ui": {
+          mimeTypes: ["text/html;profile=mcp-app"],
+        },
+      },
+    },
+    clientInfo: { name: "local-test", version: "1.0" },
+  });
+  send(proc, { jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+
+  const tools = await request("tools/list", {});
+  const loon = tools.tools.find((t) => t.name === "create_cad_loon");
+  if (!loon?._meta?.ui?.resourceUri) {
+    throw new Error("create_cad_loon missing _meta.ui.resourceUri");
+  }
+  console.log("OK tools/list _meta:", loon._meta.ui.resourceUri);
+
+  const resources = await request("resources/list", {});
+  const viewer = resources.resources.find((r) => r.uri === "ui://vcad/viewer");
+  const csp = viewer?._meta?.ui?.csp?.resourceDomains ?? [];
+  if (!csp.includes("blob:")) {
+    throw new Error(`viewer CSP missing blob: — got ${JSON.stringify(csp)}`);
+  }
+  console.log("OK resources/list CSP:", csp);
+
+  const read = await request("resources/read", { uri: "ui://vcad/viewer" });
+  const html = read.contents[0];
+  if (html.mimeType !== "text/html;profile=mcp-app") {
+    throw new Error("wrong viewer mimeType");
+  }
+  if (!html.text?.includes("vcad-viewer")) {
+    throw new Error("viewer HTML missing expected bundle marker");
+  }
+  const readCsp = html._meta?.ui?.csp?.resourceDomains ?? [];
+  if (!readCsp.includes("blob:")) {
+    throw new Error(`resources/read CSP missing blob: — got ${JSON.stringify(readCsp)}`);
+  }
+  console.log("OK resources/read html bytes:", html.text.length, "csp:", readCsp);
+
+  const call = await request("tools/call", {
+    name: "create_cad_loon",
+    arguments: {
+      source: "[root [pipe [cube 60 40 10] [fillet 3]] \"aluminum\"]",
+    },
+  });
+  const totalChars = call.content.reduce((n, c) => n + (c.text?.length ?? 0), 0);
+  if (totalChars > 2048) {
+    throw new Error(`create_cad_loon result too large (${totalChars} chars) — inline UI may be suppressed`);
+  }
+  if (!call.structuredContent?.document_id) {
+    throw new Error("create_cad_loon missing structuredContent.document_id");
+  }
+  console.log(
+    "OK create_cad_loon lean result:",
+    totalChars,
+    "chars, document_id:",
+    call.structuredContent.document_id,
+  );
+
+  const preview = await request("tools/call", {
+    name: "get_preview_glb",
+    arguments: { document_id: call.structuredContent.document_id },
+  });
+  const glbBlock = preview.content[0]?.text ?? "";
+  if (!glbBlock.includes("_vcad_glb")) {
+    throw new Error("get_preview_glb missing _vcad_glb envelope");
+  }
+  console.log("OK get_preview_glb bytes:", glbBlock.length);
+
+  proc.kill();
+  console.log("\nAll local MCP Apps checks passed.");
+}
+
+main().catch((e) => {
+  console.error("FAIL:", e.message ?? e);
+  proc.kill();
+  process.exit(1);
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -564,7 +564,10 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       if (dispatchableTools.has(name)) {
         result = dispatchRegistryTool(name, args);
         const docId = resolvePreviewDocumentId(name, result, args, engine);
-        if (docId) attachPreviewHandle(result, docId);
+        if (docId) {
+          attachPreviewHandle(result, docId);
+          slimPreviewForInlineUi(result, docId, name);
+        }
         return result;
       }
 
@@ -741,7 +744,10 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       // `get_preview_glb` tool, so results stay lean for the model.
       if (uiTools.has(name) && result.content.length > 0 && !result.isError) {
         const docId = resolvePreviewDocumentId(name, result, args, engine);
-        if (docId) attachPreviewHandle(result, docId);
+        if (docId) {
+          attachPreviewHandle(result, docId);
+          slimPreviewForInlineUi(result, docId, name);
+        }
       }
 
       return result;
@@ -764,6 +770,32 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
  * structuredContent to widgets, and the id is useful to agents anyway
  * (it opens the result up for follow-up mutations).
  */
+/**
+ * Replace bulky tool-result text (full VCode, large JSON IR, …) with a short
+ * summary. Cursor suppresses inline MCP App UI when tool results are huge —
+ * the same spill behavior we hit with inlined GLB payloads.
+ */
+function slimPreviewForInlineUi(
+  result: { content: Array<{ type: string; text: string }> },
+  docId: string,
+  toolName: string,
+): void {
+  const alwaysSlim = toolName === "create_cad_loon";
+  const totalChars = result.content.reduce(
+    (n, c) => n + (c.type === "text" ? c.text.length : 0),
+    0,
+  );
+  if (!alwaysSlim && totalChars <= 8192) return;
+
+  const summary =
+    `CAD document ready (${docId}). Geometry is available in the inline 3D viewer. ` +
+    "Use get_document for the full IR, inspect_cad for metrics, or export_cad to export.";
+  result.content = [
+    { type: "text", text: summary },
+    { type: "text", text: JSON.stringify({ document_id: docId }) },
+  ];
+}
+
 function attachPreviewHandle(
   result: {
     content: Array<{ type: string; text: string; annotations?: unknown }>;

--- a/packages/mcp/src/viewer.ts
+++ b/packages/mcp/src/viewer.ts
@@ -11,9 +11,14 @@
 
 import { VIEWER_HTML } from "./viewer-html.generated.js";
 
-/** CSP for the viewer. Everything is inlined, so no external domains. */
+/**
+ * CSP for the viewer. Everything is inlined, so no external domains.
+ * `blob:` is allowed because GLTFLoader uses createObjectURL for embedded
+ * textures; hosts like Cursor enforce the declared CSP strictly (tldraw's
+ * working app whitelists blob: for the same reason).
+ */
 export const VIEWER_CSP: { resourceDomains: string[] } = {
-  resourceDomains: [],
+  resourceDomains: ["blob:"],
 };
 
 /** The ui:// URI for the viewer resource. */

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -253,6 +253,7 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
     setStatus("no geometry to preview");
     return;
   }
+  lastDocumentId = docId;
   setStatus("fetching geometry…");
   try {
     const previewResult = (await app.callServerTool({
@@ -274,10 +275,24 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
 
 // ── "Open in vcad.io" deep link ──────────────────────────────
 let vcodeDoc: string | null = null;
+let lastDocumentId: string | null = null;
 
-openBtn.addEventListener("click", () => {
-  if (!vcodeDoc) return;
-  const encoded = btoa(unescape(encodeURIComponent(vcodeDoc)))
+openBtn.addEventListener("click", async () => {
+  let doc = vcodeDoc;
+  if (!doc && lastDocumentId) {
+    try {
+      const fetched = (await app.callServerTool({
+        name: "get_document",
+        arguments: { document_id: lastDocumentId },
+      })) as ToolResultLike;
+      const text = fetched.content?.find((c) => c.type === "text")?.text;
+      if (text) doc = text;
+    } catch (e) {
+      console.warn("[vcad-viewer] get_document for open link failed:", e);
+    }
+  }
+  if (!doc) return;
+  const encoded = btoa(unescape(encodeURIComponent(doc)))
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=+$/, "");


### PR DESCRIPTION
## Summary
- Allow `blob:` in the MCP App viewer CSP so Three.js GLTFLoader can load GLB previews inside Cursor's strict sandbox (matches tldraw's working pattern).
- Slim geometry tool results (`create_cad_loon` always, others when >8 KB) so Cursor does not suppress inline MCP App UI on large text payloads.
- Viewer "Open in vcad.io" fetches IR via `get_document` when VCode is not in the tool result.
- Add `packages/mcp/scripts/test-local-mcp-apps.mjs` to verify stdio MCP Apps metadata, CSP, lean results, and GLB preview end-to-end.

## Local test (Option A)
```bash
VCAD_WASM_SKIP=1 npm run build -w @vcad/engine -w @vcad/mcp
node packages/mcp/scripts/test-local-mcp-apps.mjs
```

In Cursor, add a stdio server (`.cursor/mcp.json` is gitignored locally):
```json
"vcad-local": {
  "command": "node",
  "args": ["${workspaceFolder}/packages/mcp/dist/index.js"]
}
```
Disable remote `vcad`, enable `vcad-local`, reload, fresh chat: create a simple filleted plate.

## Deploy test (Option B)
Merge this PR, wait for `mcp.vcad.io` deploy, toggle the remote `vcad` MCP server off/on, retry in a fresh chat.

## Test plan
- [x] `node packages/mcp/scripts/test-local-mcp-apps.mjs` passes
- [x] `npm test -w @vcad/mcp` passes
- [ ] Cursor + `vcad-local`: `create_cad_loon` shows inline 3D viewer
- [ ] After deploy: Cursor + remote `vcad` shows inline viewer for simple geometry


Made with [Cursor](https://cursor.com)