### PR TITLE
Guard center-of-mass calculation against open meshes

### DIFF
--- a/changelog/entries/2026-06-11-inspect-com-bbox-guard.json
+++ b/changelog/entries/2026-06-11-inspect-com-bbox-guard.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-11-inspect-com-bbox-guard",
+  "version": "0.9.4",
+  "date": "2026-06-11",
+  "category": "fix",
+  "title": "inspect_cad center of mass stays inside the bounding box",
+  "summary": "Center-of-mass integration now falls back to the surface centroid when the signed-volume integral is unreliable (open meshes, e.g. sheet-metal bodies), instead of reporting a COM outside the bbox.",
+  "features": ["mcp", "inspect", "sheet-metal", "kernel"],
+  "mcpTools": ["inspect_cad"]
+}

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -1210,6 +1210,14 @@ fn compute_center_of_mass(mesh: &TriangleMesh) -> [f64; 3] {
     let mut cy = 0.0;
     let mut cz = 0.0;
     let mut total_vol = 0.0;
+    // Area-weighted surface centroid — fallback when the signed-volume
+    // integral is unreliable (open or inconsistently wound meshes, e.g.
+    // thin sheet bodies). A convex combination of triangle centroids, so
+    // it always lands inside the bounding box.
+    let mut acx = 0.0;
+    let mut acy = 0.0;
+    let mut acz = 0.0;
+    let mut total_area = 0.0;
     for tri in indices.chunks(3) {
         let (i0, i1, i2) = (
             tri[0] as usize * 3,
@@ -1225,12 +1233,42 @@ fn compute_center_of_mass(mesh: &TriangleMesh) -> [f64; 3] {
         cx += vol * (v0[0] + v1[0] + v2[0]);
         cy += vol * (v0[1] + v1[1] + v2[1]);
         cz += vol * (v0[2] + v1[2] + v2[2]);
+
+        let e1 = Vec3::new(v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]);
+        let e2 = Vec3::new(v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]);
+        let area = e1.cross(e2).norm() / 2.0;
+        total_area += area;
+        acx += area * (v0[0] + v1[0] + v2[0]) / 3.0;
+        acy += area * (v0[1] + v1[1] + v2[1]) / 3.0;
+        acz += area * (v0[2] + v1[2] + v2[2]) / 3.0;
     }
+    let area_centroid = if total_area > 0.0 {
+        [acx / total_area, acy / total_area, acz / total_area]
+    } else {
+        [0.0; 3]
+    };
     if total_vol.abs() < 1e-15 {
-        return [0.0; 3];
+        return area_centroid;
     }
     let s = 1.0 / (4.0 * total_vol);
-    [cx * s, cy * s, cz * s]
+    let com = [cx * s, cy * s, cz * s];
+    // The volume-weighted centroid is only valid for a closed,
+    // consistently wound mesh — on open meshes the signed-tet
+    // contributions partially cancel and the division can throw the
+    // centroid outside the bounding box, which is impossible for a real
+    // COM. Fall back to the surface centroid when that happens.
+    let (min, max) = compute_bounding_box(mesh);
+    let eps = 1e-9
+        * (max[0] - min[0])
+            .max(max[1] - min[1])
+            .max(max[2] - min[2])
+            .max(1.0);
+    let in_bbox = (0..3).all(|i| com[i] >= min[i] - eps && com[i] <= max[i] + eps);
+    if in_bbox {
+        com
+    } else {
+        area_centroid
+    }
 }
 
 #[cfg(test)]
@@ -1380,6 +1418,36 @@ mod tests {
         assert!((com[0] - 5.0).abs() < 0.1, "cx: {}", com[0]);
         assert!((com[1] - 5.0).abs() < 0.1, "cy: {}", com[1]);
         assert!((com[2] - 5.0).abs() < 0.1, "cz: {}", com[2]);
+    }
+
+    #[test]
+    fn test_center_of_mass_open_mesh_stays_in_bbox() {
+        // A single triangle far from the origin: the divergence-theorem
+        // integral sees a nonzero signed volume and the naive division
+        // places the centroid at (v0+v1+v2)/4 — pulled toward the origin,
+        // outside the triangle's own bbox (z would be 7.5 vs bbox z=10).
+        // The guard must fall back to the surface centroid instead.
+        let mesh = TriangleMesh {
+            vertices: vec![4.0, 0.0, 10.0, 0.0, 4.0, 10.0, -4.0, -4.0, 10.0],
+            indices: vec![0, 1, 2],
+            normals: vec![0.0; 9],
+            face_kinds: Vec::new(),
+        };
+        let com = compute_center_of_mass(&mesh);
+        let (min, max) = compute_bounding_box(&mesh);
+        for i in 0..3 {
+            assert!(
+                com[i] >= min[i] - 1e-9 && com[i] <= max[i] + 1e-9,
+                "com[{i}] = {} outside bbox [{}, {}]",
+                com[i],
+                min[i],
+                max[i]
+            );
+        }
+        // Area centroid of the lone triangle.
+        assert!((com[0] - 0.0).abs() < 1e-9, "cx: {}", com[0]);
+        assert!((com[1] - 0.0).abs() < 1e-9, "cy: {}", com[1]);
+        assert!((com[2] - 10.0).abs() < 1e-9, "cz: {}", com[2]);
     }
 
     #[test]

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -436,6 +436,52 @@ describe("sheet-metal tools", () => {
     ).toBe(true);
   });
 
+  it("inspect_cad center of mass stays inside the bounding box", () => {
+    // Regression: this flange chain tessellates to a non-watertight mesh
+    // whose signed-volume integral partially cancels, which used to throw
+    // the centroid below the bbox (z = -32.277 vs bbox min z = -31.439).
+    const created = JSON.parse(
+      sheetMetalCreate(
+        {
+          outline: [
+            { x: 20, y: 0 },
+            { x: 40, y: 0 },
+            { x: 60, y: 40 },
+            { x: 40, y: 80 },
+            { x: 20, y: 80 },
+            { x: 0, y: 40 },
+          ],
+          thickness: 0.5,
+          material: "Al-soft",
+          flanges: [
+            { edge_index: 0, length: 35, angle: 1.1, direction: "Up" },
+            {
+              panel_id: 1,
+              edge_index: 2,
+              length: 12,
+              angle: 2.2,
+              direction: "Down",
+            },
+            { edge_index: 2, length: 50, angle: 0.6, direction: "Up" },
+            { edge_index: 3, length: 30, angle: 0.9, direction: "Up" },
+            { edge_index: 4, length: 50, angle: 0.6, direction: "Up" },
+          ],
+        },
+        engine,
+      ).content[0].text,
+    );
+
+    const result = JSON.parse(
+      inspectCad({ document_id: created.document_id }, engine).content[0]
+        .text,
+    );
+    const { bounding_box: bbox, center_of_mass: com } = result;
+    for (const axis of ["x", "y", "z"] as const) {
+      expect(com[axis]).toBeGreaterThanOrEqual(bbox.min[axis]);
+      expect(com[axis]).toBeLessThanOrEqual(bbox.max[axis]);
+    }
+  });
+
   it("unfold on an unknown document id throws", () => {
     expect(() =>
       sheetMetalUnfold({ document_id: "nope" }, engine),

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -107,6 +107,12 @@ function computeMeshProperties(mesh: TriangleMesh): {
   let cx = 0,
     cy = 0,
     cz = 0;
+  // Area-weighted surface centroid — fallback when the signed-volume
+  // integral is unreliable (open or inconsistently wound meshes, e.g.
+  // thin sheet-metal bodies). Always lands inside the bounding box.
+  let acx = 0,
+    acy = 0,
+    acz = 0;
 
   const bbox: BoundingBox = {
     min: { x: Infinity, y: Infinity, z: Infinity },
@@ -127,12 +133,18 @@ function computeMeshProperties(mesh: TriangleMesh): {
     volume += v;
 
     // Surface area
-    area += triangleArea(p1, p2, p3);
+    const a = triangleArea(p1, p2, p3);
+    area += a;
 
     // Centroid contribution (weighted by signed volume)
     cx += v * (p1[0] + p2[0] + p3[0]) / 4;
     cy += v * (p1[1] + p2[1] + p3[1]) / 4;
     cz += v * (p1[2] + p2[2] + p3[2]) / 4;
+
+    // Area-weighted centroid contribution
+    acx += (a * (p1[0] + p2[0] + p3[0])) / 3;
+    acy += (a * (p1[1] + p2[1] + p3[1])) / 3;
+    acz += (a * (p1[2] + p2[2] + p3[2])) / 3;
 
     // Bounding box
     for (const p of [p1, p2, p3]) {
@@ -145,19 +157,45 @@ function computeMeshProperties(mesh: TriangleMesh): {
     }
   }
 
-  // Normalize centroid by volume
+  // Normalize centroid by volume. The volume-weighted centroid is only
+  // valid for a closed, consistently wound mesh — on open meshes the
+  // signed-tet contributions partially cancel and the division can throw
+  // the centroid anywhere, including outside the bounding box (which is
+  // geometrically impossible for a real COM). Validate against the bbox
+  // and fall back to the area-weighted surface centroid when it fails.
   const absVolume = Math.abs(volume);
+  let centroid: { x: number; y: number; z: number } | null = null;
   if (absVolume > 1e-10) {
-    cx /= volume;
-    cy /= volume;
-    cz /= volume;
+    centroid = { x: cx / volume, y: cy / volume, z: cz / volume };
+    const eps =
+      1e-9 *
+      Math.max(
+        bbox.max.x - bbox.min.x,
+        bbox.max.y - bbox.min.y,
+        bbox.max.z - bbox.min.z,
+        1,
+      );
+    const inBbox =
+      centroid.x >= bbox.min.x - eps &&
+      centroid.x <= bbox.max.x + eps &&
+      centroid.y >= bbox.min.y - eps &&
+      centroid.y <= bbox.max.y + eps &&
+      centroid.z >= bbox.min.z - eps &&
+      centroid.z <= bbox.max.z + eps;
+    if (!inBbox) centroid = null;
+  }
+  if (centroid === null) {
+    centroid =
+      area > 0
+        ? { x: acx / area, y: acy / area, z: acz / area }
+        : { x: 0, y: 0, z: 0 };
   }
 
   return {
     volume: absVolume,
     area,
     bbox,
-    centroid: { x: cx, y: cy, z: cz },
+    centroid,
     triangles: numTriangles,
   };
 }


### PR DESCRIPTION
## Summary

The center-of-mass calculation now validates that the computed centroid lies within the mesh's bounding box. For open or inconsistently-wound meshes (e.g., sheet-metal bodies), the signed-volume integral can produce unreliable results that place the centroid outside the bounding box—geometrically impossible for a real center of mass. The fix falls back to an area-weighted surface centroid in such cases.

## Changes

- **Rust kernel** (`crates/vcad-kernel/src/lib.rs`):
  - Compute area-weighted surface centroid as a fallback during mesh iteration
  - After volume-weighted centroid calculation, validate it against the bounding box
  - Return area-weighted centroid if volume-weighted result is outside bbox or volume is near-zero
  - Add regression test for single-triangle mesh (open mesh case)

- **TypeScript MCP tools** (`packages/mcp/src/tools/inspect.ts`):
  - Mirror the Rust logic: compute area-weighted centroid alongside volume-weighted
  - Validate volume-weighted centroid against bbox with epsilon tolerance
  - Fall back to area-weighted centroid if validation fails
  - Handles both closed (watertight) and open mesh geometries

- **Integration test** (`packages/mcp/src/__tests__/tools.test.ts`):
  - Add regression test for a flange-chain tessellation that produces a non-watertight mesh
  - Verify centroid stays within bounding box bounds

- **Changelog** entry documenting the fix

## Implementation Details

- Area-weighted centroid is computed as a convex combination of triangle centroids, so it always lands inside the bounding box
- Epsilon tolerance for bbox validation scales with the largest bbox dimension (1e-9 × max dimension, minimum 1e-9)
- Fallback is transparent to callers; the API returns a valid centroid in all cases
- Fixes regression where sheet-metal bodies with complex flange patterns could report invalid centroids

https://claude.ai/code/session_01VTMRfuu8CnWAVqPzpSroDu