### PR TITLE
fix(mcp-deploy): externalize @resvg/resvg-js in esbuild bundle

### DIFF
--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -24,17 +24,29 @@ echo "[vcad-mcp] Bundling with esbuild..."
 # ── 3. Bundle entry.ts with esbuild ─────────────────────────
 # Uses npx esbuild@latest because the repo's esbuild (0.14) is too
 # old for `import ... with { type: "json" }` (needs 0.21+).
+# @resvg/resvg-js ships native .node binaries that esbuild cannot
+# bundle; keep it external and ship the package alongside the bundle.
 npx esbuild@latest entry.ts \
   --bundle \
   --platform=node \
   --target=node20 \
   --format=esm \
+  --external:@resvg/resvg-js \
   --outfile="$OUT/functions/mcp.func/index.mjs" \
   --banner:js="import { createRequire } from 'module'; const require = createRequire(import.meta.url);"
 
 # ── 4. Copy WASM binary next to the bundle ───────────────────
 cp "$REPO_ROOT/packages/kernel-wasm/vcad_kernel_wasm_bg.wasm" \
    "$OUT/functions/mcp.func/"
+
+# ── 4b. Ship resvg (native PNG rasterizer) next to the bundle ─
+# render.ts degrades to raw SVG if the import fails, so a missing
+# package is non-fatal — but include it when installed.
+if [ -d "$REPO_ROOT/node_modules/@resvg" ]; then
+  mkdir -p "$OUT/functions/mcp.func/node_modules/@resvg"
+  cp -R "$REPO_ROOT/node_modules/@resvg/." \
+        "$OUT/functions/mcp.func/node_modules/@resvg/"
+fi
 
 # ── 5. Function config ──────────────────────────────────────
 cat > "$OUT/functions/mcp.func/.vc-config.json" << 'EOF'


### PR DESCRIPTION
Fixes the Vercel build failure on the vcad-mcp deploy:

```
✘ [ERROR] No loader is configured for ".node" files: ../../node_modules/@resvg/resvg-js-linux-x64-gnu/resvgjs.linux-x64-gnu.node
```

`@vcad/mcp`'s `render_view` tool dynamically imports `@resvg/resvg-js` (native PNG rasterizer), and esbuild can't bundle its `.node` binaries.

- Mark `@resvg/resvg-js` as `--external` in the esbuild step
- Copy `node_modules/@resvg` (including the platform-native binary package) next to the function bundle so the runtime import still resolves
- If the package is missing, `render.ts` already degrades gracefully to raw SVG output

Verified locally: `bash build.sh` completes, the bundle keeps `import("@resvg/resvg-js")` external, and loading resvg from the function dir renders a test PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)