### PR TITLE
MCP app UI: official vcad chrome, app-matched renderer, first-principles tool surface

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -18,6 +18,16 @@
       "port": 3001
     },
     {
+      "name": "mcp-viewer",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "cd packages/mcp && npx vite --config vite.viewer.config.ts --host 0.0.0.0 --port ${PORT:-5180} --strictPort"
+      ],
+      "port": 5180,
+      "autoPort": true
+    },
+    {
       "name": "mecheval-leaderboard",
       "runtimeExecutable": "node",
       "runtimeArgs": ["mecheval/leaderboard/dist/serve.js"],

--- a/changelog/entries/2026-06-11-mcp-agent-loop.json
+++ b/changelog/entries/2026-06-11-mcp-agent-loop.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-11-mcp-agent-loop",
+  "version": "0.9.4",
+  "date": "2026-06-11",
+  "category": "feat",
+  "title": "Tighter MCP agent loop: diffs, instructions, flat patterns",
+  "summary": "Mutations report a compact changed diff; the kernel's type catalog, materials, and orientation rules ship as MCP server instructions; sheet_metal_unfold renders its flat pattern in the inline viewer.",
+  "features": ["mcp", "agents", "sheet-metal", "viewer"],
+  "mcpTools": ["create", "update", "delete", "set_material", "create_cad_loon", "sheet_metal_unfold"]
+}

--- a/changelog/entries/2026-06-11-vcad-branded-mcp-viewer.json
+++ b/changelog/entries/2026-06-11-vcad-branded-mcp-viewer.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-11-vcad-branded-mcp-viewer",
+  "version": "0.9.4",
+  "date": "2026-06-11",
+  "category": "feat",
+  "title": "vcad-branded MCP viewer and tool packs",
+  "summary": "The inline MCP Apps viewer now wears official vcad chrome and renders with the app's exact rig (studio IBL, grid, contact shadow); VCAD_MCP_PACKS trims the tool surface to core + chosen domain packs.",
+  "features": ["mcp", "viewer", "agents"],
+  "mcpTools": ["open_document", "get_preview_glb", "create_cad_loon"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,6 +35,19 @@ Unset, every pack is enabled. A smaller surface costs fewer schema
 tokens per request and measurably improves tool-selection accuracy for
 focused workflows.
 
+## Agent feedback loop
+
+- **Server instructions** — the kernel's type catalog, material preset
+  keys, Z-up orientation rules, and transform semantics are published as
+  MCP server `instructions` (extracted from the kernel registry at boot,
+  so they never drift). Hosts surface them to the agent automatically.
+- **Mutation diffs** — `create`/`update`/`delete`/`set_material` results
+  carry a compact `changed: {added, removed, modified}` part diff, so
+  agents see what a mutation actually did without a follow-up `read`.
+- **Inline viewer** — geometry tools render in an embedded vcad viewport
+  (MCP Apps hosts); `sheet_metal_unfold` draws its flat pattern as a 2D
+  drawing with cut and bend-line layers.
+
 ## Tools
 
 ### `create_cad_document`

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,6 +14,27 @@ Or add to your MCP configuration directly:
 claude mcp add vcad --command "npx @vcad/mcp"
 ```
 
+## Tool packs
+
+The surface is a small always-on core — the make → see → measure → verify →
+ship loop (session lifecycle, Loon/CRUD authoring, parts library,
+`inspect_cad`, `render_view`, `export_cad`, `import_step`,
+`open_in_browser`, `get_changelog`) — plus opt-out domain packs:
+
+| Pack | Tools |
+|------|-------|
+| `dfm` | `dfm_check`, `dfm_explain`, `dfm_suggest_fix`, `dfm_apply_fix` |
+| `sheet_metal` | `sheet_metal_create/unfold/check/materials/bend_table/cost/suggest_fix/sequence/nest` |
+| `physics` | `create_robot_env`, `gym_*`, `batch_*` |
+| `ecad` | `create_schematic`, `place_components`, `route_nets`, `run_drc`, `run_erc`, `export_gerber`, `calc_impedance` |
+| `eval` | `verify_part`, `list_eval_tasks` (mecheval self-grading oracle) |
+
+Set `VCAD_MCP_PACKS` to a comma-separated list of packs to enable
+(e.g. `VCAD_MCP_PACKS=sheet_metal,dfm`), or `none` for core only.
+Unset, every pack is enabled. A smaller surface costs fewer schema
+tokens per request and measurably improves tool-selection accuracy for
+focused workflows.
+
 ## Tools
 
 ### `create_cad_document`

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1325,3 +1325,121 @@ describe("ecad place_components → route_nets pipeline", () => {
     }
   });
 });
+
+describe("mutation diff (changed)", () => {
+  let document_id: string;
+
+  beforeEach(() => {
+    const open = openDocument({});
+    document_id = JSON.parse(open.content[0].text).document_id;
+  });
+
+  it("create reports the new part under changed.added", () => {
+    const out = dispatchRegistryTool("create", {
+      document_id,
+      type: "cube",
+      name: "Base",
+      params: { size: { x: 50, y: 30, z: 10 } },
+    });
+    const parsed = JSON.parse(out.content[0].text);
+    expect(parsed.changed.added).toEqual([{ part_id: parsed.part_id, name: "Base" }]);
+    expect(parsed.changed.removed).toEqual([]);
+    expect(parsed.changed.modified).toEqual([]);
+  });
+
+  it("update reports the touched part under changed.modified; no-ops report nothing", () => {
+    const created = JSON.parse(
+      dispatchRegistryTool("create", {
+        document_id,
+        type: "cube",
+        name: "Base",
+        params: { size: { x: 50, y: 30, z: 10 } },
+      }).content[0].text,
+    );
+    const updated = JSON.parse(
+      dispatchRegistryTool("update", {
+        document_id,
+        node_id: created.node_id,
+        params: { size: { x: 80, y: 30, z: 10 } },
+      }).content[0].text,
+    );
+    expect(updated.changed.modified).toEqual([
+      { part_id: created.part_id, name: "Base" },
+    ]);
+
+    const noop = JSON.parse(
+      dispatchRegistryTool("update", {
+        document_id,
+        node_id: created.node_id,
+        params: { size: { x: 80, y: 30, z: 10 } },
+      }).content[0].text,
+    );
+    expect(noop.changed).toBeUndefined();
+  });
+
+  it("delete reports the part under changed.removed", () => {
+    const created = JSON.parse(
+      dispatchRegistryTool("create", {
+        document_id,
+        type: "cube",
+        name: "Doomed",
+        params: { size: { x: 5, y: 5, z: 5 } },
+      }).content[0].text,
+    );
+    const out = JSON.parse(
+      dispatchRegistryTool("delete", {
+        document_id,
+        part_id: created.part_id,
+      }).content[0].text,
+    );
+    expect(out.changed.removed).toEqual([
+      { part_id: created.part_id, name: "Doomed" },
+    ]);
+  });
+});
+
+describe("MCP description steering", () => {
+  it("create steers whole-part work to create_cad_loon", () => {
+    const create = registryToolDescriptors().find((t) => t.name === "create");
+    expect(create?.description).toContain("create_cad_loon");
+    const params = (create?.inputSchema.properties as Record<string, { description?: string }>).params;
+    expect(params.description).not.toContain("system prompt");
+  });
+
+  it("set_material lists the preset keys inline", () => {
+    const tool = registryToolDescriptors().find((t) => t.name === "set_material");
+    expect(tool?.description).toContain("aluminum");
+    expect(tool?.description).toContain("carbon-fiber");
+  });
+});
+
+describe("tool packs (VCAD_MCP_PACKS)", () => {
+  it("unset env disables nothing", async () => {
+    const { disabledToolNames } = await import("../server.js");
+    delete process.env.VCAD_MCP_PACKS;
+    expect(disabledToolNames().size).toBe(0);
+  });
+
+  it("'none' disables every pack but leaves the core untouched", async () => {
+    const { disabledToolNames } = await import("../server.js");
+    process.env.VCAD_MCP_PACKS = "none";
+    const disabled = disabledToolNames();
+    delete process.env.VCAD_MCP_PACKS;
+    expect(disabled.has("sheet_metal_create")).toBe(true);
+    expect(disabled.has("run_drc")).toBe(true);
+    expect(disabled.has("gym_step")).toBe(true);
+    expect(disabled.has("verify_part")).toBe(true);
+    expect(disabled.has("create")).toBe(false);
+    expect(disabled.has("create_cad_loon")).toBe(false);
+    expect(disabled.has("render_view")).toBe(false);
+  });
+
+  it("a named pack stays enabled while others drop", async () => {
+    const { disabledToolNames } = await import("../server.js");
+    process.env.VCAD_MCP_PACKS = "sheet_metal";
+    const disabled = disabledToolNames();
+    delete process.env.VCAD_MCP_PACKS;
+    expect(disabled.has("sheet_metal_unfold")).toBe(false);
+    expect(disabled.has("run_drc")).toBe(true);
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -131,6 +131,9 @@ const GEOMETRY_TOOLS = new Set([
   "set_material",
   "dfm_apply_fix",
   "sheet_metal_create",
+  // Doesn't mutate, but its result carries the flat pattern the viewer
+  // renders as a 2D drawing (cut profile + bend lines).
+  "sheet_metal_unfold",
 ]);
 
 /** MCP Apps UI metadata for geometry tools. */
@@ -191,8 +194,51 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
   eval: ["verify_part", "list_eval_tasks"],
 };
 
-/** Tool names hidden by the `VCAD_MCP_PACKS` env var (empty = none). */
-function disabledToolNames(): Set<string> {
+/**
+ * Kernel system-prompt sections forwarded to MCP agents via the
+ * protocol-native server `instructions` field. The in-app chat surface
+ * gets this knowledge through its system prompt; MCP agents otherwise
+ * never see it (type catalog, material keys, Z-up orientation gotchas,
+ * world-origin rotation semantics). Extracted by header at boot so the
+ * catalog never drifts from the kernel registry; a renamed or missing
+ * section is silently skipped.
+ */
+const INSTRUCTION_SECTIONS = [
+  "Available Materials",
+  "Orientation Notes",
+  "How translate/rotate/scale work (IMPORTANT)",
+  "Sketch rules — READ CAREFULLY",
+  "Type Catalog",
+];
+
+/** Build MCP server instructions: a short workflow framing plus the
+ *  durable knowledge sections of the kernel chat system prompt. */
+function buildInstructions(kernelPrompt: string | null): string {
+  const header = [
+    "vcad — parametric CAD with a real BRep kernel. Coordinate system: Z-up (X right, Y forward, Z up). Units: millimeters.",
+    "",
+    "Workflow: `open_document` → author → see → measure → ship.",
+    "- Author whole parts with `create_cad_loon` (the full modeling vocabulary in one call); make surgical edits with `create`/`update`/`delete` (one node per call — mutation results report a compact `changed` diff of affected parts).",
+    "- See your work with `render_view` (isometric PNG); measure with `inspect_cad` (volume, area, bbox, center of mass).",
+    "- Ship with `export_cad` (STL/GLB/STEP) or `open_in_browser` (vcad.io deep link).",
+    "- Fix in place: when geometry is wrong, prefer `update` on the offending node over deleting parts and starting over.",
+  ].join("\n");
+  if (!kernelPrompt) return header;
+  const sections = new Map<string, string>();
+  for (const part of kernelPrompt.split(/^## /m).slice(1)) {
+    const nl = part.indexOf("\n");
+    if (nl < 0) continue;
+    sections.set(part.slice(0, nl).trim(), part.slice(nl + 1).trimEnd());
+  }
+  const picked = INSTRUCTION_SECTIONS.filter((t) => sections.has(t)).map(
+    (t) => `## ${t}\n${sections.get(t)}`,
+  );
+  return [header, ...picked].join("\n\n");
+}
+
+/** Tool names hidden by the `VCAD_MCP_PACKS` env var (empty = none).
+ *  Exported for tests. */
+export function disabledToolNames(): Set<string> {
   const env = process.env.VCAD_MCP_PACKS?.trim();
   if (!env) return new Set();
   const enabled = new Set(
@@ -214,6 +260,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
   // as `initEngineLifecycle` in @vcad/core, minus the docstore subscription
   // — we don't have a docstore here. Without this, registryToolDescriptors
   // returns the static-schemas fallback and planCrud returns null.
+  let kernelPrompt: string | null = null;
   try {
     const wasm = (await getKernelWasm()) as unknown as Record<string, unknown>;
     const getToolSchemas = wasm.get_tool_schemas as (() => string) | undefined;
@@ -233,6 +280,9 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         build_chat_system_prompt: buildChatSystemPrompt,
         plan_chat_tool: planChatTool,
       });
+      // Empty parts / no selection — we only want the durable knowledge
+      // sections (type catalog, materials, orientation), not scene state.
+      kernelPrompt = buildChatSystemPrompt("[]", "null");
     }
   } catch (e) {
     console.warn("[mcp] commandRegistry wasm bootstrap failed:", e);
@@ -264,6 +314,10 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         // The extension key is not in the typed ServerCapabilities schema so we spread as object.
         ...({ extensions: { "io.modelcontextprotocol/ui": { mimeTypes: [MCP_APP_MIME_TYPE] } } } as object),
       },
+      // Protocol-native equivalent of the in-app chat system prompt:
+      // workflow framing + the kernel's type catalog, material keys, and
+      // orientation semantics. Hosts surface this to the agent once.
+      instructions: buildInstructions(kernelPrompt),
     },
   );
 
@@ -334,7 +388,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       {
         name: "create_cad_loon",
         description:
-          "Create a CAD document from loon source code. Loon is a Lisp-like language for parametric CAD — the FULL modeling vocabulary (patterns, sketches, extrude/revolve/sweep/loft, assemblies) is available here even where no dedicated MCP tool exists.\n\n" +
+          "The preferred authoring tool for whole parts and multi-feature models — one call, full vocabulary. Create a CAD document from loon source code. Loon is a Lisp-like language for parametric CAD — the FULL modeling vocabulary (patterns, sketches, extrude/revolve/sweep/loft, assemblies) is available here even where no dedicated MCP tool exists. For incremental single-node edits to an open session, use create/update/delete instead.\n\n" +
           "Primitives: [cube x y z], [cylinder r h], [sphere r], [cone r-bottom r-top h]\n" +
           "Booleans (subject-last): [difference tool subject], [union other subject], [intersection other subject]\n" +
           "Transforms (subject-last): [translate x y z s], [rotate rx ry rz s], [scale sx sy sz s]\n" +
@@ -419,6 +473,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         description:
           "Return the flat pattern (panel outlines, holes, creases, area, bbox) for a sheet-metal session document, plus a fab-ready merged single-silhouette DXF (millimetres): one closed exterior polyline + holes on CUT, DASHED bend centerlines on BEND_UP/BEND_DOWN. DXF carries no bend angles (entered in the fab's UI); for zero data entry export the folded body as STEP via export_cad instead.",
         inputSchema: sheetMetalUnfoldSchema,
+        _meta: UI_META,
       },
       {
         name: "sheet_metal_check",
@@ -920,6 +975,9 @@ function slimPreviewForInlineUi(
   clientHasInlineUi: boolean,
 ): void {
   if (!clientHasInlineUi) return;
+  // The flat-pattern coordinates ARE the deliverable — the viewer draws
+  // them, but the agent needs the numbers too. Never slim.
+  if (toolName === "sheet_metal_unfold") return;
   const alwaysSlim = toolName === "create_cad_loon";
   const totalChars = result.content.reduce(
     (n, c) => n + (c.type === "text" ? c.text.length : 0),

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -142,6 +142,69 @@ const UI_META = {
   "ui/resourceUri": VIEWER_RESOURCE_URI,
 };
 
+/**
+ * Domain tool packs. The surface is a small always-on core — the
+ * make → see → measure → verify → ship loop (session, loon/CRUD
+ * authoring, parts library, inspect, render, export, share) — plus
+ * these opt-out packs for specialized workflows.
+ *
+ * `VCAD_MCP_PACKS` trims what is advertised: a comma-separated list of
+ * pack names to enable (e.g. "sheet_metal,dfm"), or "none" for core
+ * only. Unset enables every pack — backward compatible. Calls to a
+ * tool in a disabled pack return an error pointing at the env var.
+ */
+const TOOL_PACKS: Record<string, readonly string[]> = {
+  dfm: ["dfm_check", "dfm_explain", "dfm_suggest_fix", "dfm_apply_fix"],
+  sheet_metal: [
+    "sheet_metal_create",
+    "sheet_metal_unfold",
+    "sheet_metal_check",
+    "sheet_metal_materials",
+    "sheet_metal_bend_table",
+    "sheet_metal_cost",
+    "sheet_metal_suggest_fix",
+    "sheet_metal_sequence",
+    "sheet_metal_nest",
+  ],
+  physics: [
+    "create_robot_env",
+    "gym_step",
+    "gym_reset",
+    "gym_observe",
+    "gym_close",
+    "batch_create_envs",
+    "batch_step",
+    "batch_reset",
+  ],
+  ecad: [
+    "create_schematic",
+    "place_components",
+    "route_nets",
+    "run_drc",
+    "run_erc",
+    "export_gerber",
+    "calc_impedance",
+  ],
+  // Mecheval self-grading oracle. The benchmark harness already excludes
+  // these during scored runs; hosts that don't want the benchmark
+  // vocabulary at all can drop the pack.
+  eval: ["verify_part", "list_eval_tasks"],
+};
+
+/** Tool names hidden by the `VCAD_MCP_PACKS` env var (empty = none). */
+function disabledToolNames(): Set<string> {
+  const env = process.env.VCAD_MCP_PACKS?.trim();
+  if (!env) return new Set();
+  const enabled = new Set(
+    env.split(",").map((s) => s.trim().toLowerCase()).filter(Boolean),
+  );
+  const disabled = new Set<string>();
+  for (const [pack, tools] of Object.entries(TOOL_PACKS)) {
+    if (!enabled.has(pack)) for (const t of tools) disabled.add(t);
+  }
+  return disabled;
+}
+
 export async function createServer(existingEngine?: Engine): Promise<Server> {
   // Initialize the WASM engine (or reuse one provided by the caller)
   const engine = existingEngine ?? await Engine.init();
@@ -184,6 +247,9 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
   // set plus all registry-driven kernel tools (they all mutate a session
   // document, so a preview is always meaningful).
   const uiTools = new Set([...GEOMETRY_TOOLS, ...dispatchableTools]);
+
+  // Tools hidden by VCAD_MCP_PACKS (resolved once at server creation).
+  const disabledTools = disabledToolNames();
 
   const server = new Server(
     {
@@ -529,7 +595,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
           "Returns Z0, effective Er, and propagation delay.",
         inputSchema: calcImpedanceSchema,
       },
-    ],
+    ].filter((t) => !disabledTools.has(t.name)),
   }));
 
   // ── MCP Apps: List UI resources ──────────────────────────────
@@ -589,6 +655,18 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
+
+    if (disabledTools.has(name)) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Tool '${name}' belongs to a pack disabled by VCAD_MCP_PACKS. Enable its pack to use it.`,
+          },
+        ],
+        isError: true,
+      };
+    }
 
     try {
       let result: {

--- a/packages/mcp/src/tools/registry-dispatch.ts
+++ b/packages/mcp/src/tools/registry-dispatch.ts
@@ -53,6 +53,23 @@ const DEFERRED_TOOLS = new Set<string>([
   "place_part",
 ]);
 
+/**
+ * MCP-context description overrides. The kernel-authored descriptions
+ * assume the in-app chat surface, where a system prompt carries the type
+ * catalog and material list; over MCP that context lives in the server
+ * `instructions` instead, and agents choose between two authoring
+ * altitudes — whole-part `create_cad_loon` vs single-node CRUD — so the
+ * descriptions steer that choice explicitly.
+ */
+const MCP_DESCRIPTIONS: Record<string, string> = {
+  create:
+    "Add a single feature node to a session document: a primitive (cube/cylinder/sphere/cone), boolean (union/difference/intersection), transform (translate/rotate/scale), sketch-based feature (extrude/revolve/sweep/loft), pattern, or modifier (fillet/chamfer/shell). Per-type parameters are in the Type Catalog in this server's instructions. One node per call — for whole parts or multi-feature models prefer `create_cad_loon`.",
+  update:
+    "Update parameters on an existing node — pass only the fields to change. The surgical-edit tool: when geometry is misplaced or mis-sized, prefer this over delete + re-create. Use `read` to find node ids. The result reports a compact `changed` diff of affected parts.",
+  set_material:
+    "Set a part's material preset. Keys — metals: aluminum, steel, brass, copper, titanium, chrome, gold, silver; plastics: abs-white, abs-black, abs-red, abs-blue, pla, petg, nylon, resin, acrylic, rubber; organic: oak, walnut, leather, cork, bamboo; glass: glass, glass-tinted; composite: carbon-fiber, fiberglass, kevlar; other: concrete, ceramic, foam.",
+};
+
 /** All tool names this dispatcher will handle. */
 export function registryDispatchableNames(): Set<string> {
   const all = commandRegistry.toAnthropicTools().map((t) => t.name);
@@ -90,7 +107,7 @@ function withDocumentId(tool: AnthropicTool): {
     properties?: Record<string, unknown>;
     required?: string[];
   };
-  const properties = {
+  const properties: Record<string, unknown> = {
     document_id: {
       type: "string",
       description:
@@ -98,10 +115,19 @@ function withDocumentId(tool: AnthropicTool): {
     },
     ...(original.properties ?? {}),
   };
+  // The kernel-authored params description points at "the system prompt",
+  // which doesn't exist over MCP — redirect to the server instructions.
+  if (tool.name === "create" && properties.params) {
+    properties.params = {
+      ...(properties.params as Record<string, unknown>),
+      description:
+        "Parameters for the chosen `type` — see the Type Catalog in this server's instructions (e.g. cube: {size:{x,y,z}}, cylinder: {radius,height}).",
+    };
+  }
   const required = ["document_id", ...(original.required ?? [])];
   return {
     name: tool.name,
-    description: tool.description,
+    description: MCP_DESCRIPTIONS[tool.name] ?? tool.description,
     inputSchema: {
       ...original,
       properties,
@@ -110,10 +136,102 @@ function withDocumentId(tool: AnthropicTool): {
   };
 }
 
+/** One part's entry in a mutation diff. */
+interface PartDiffEntry {
+  part_id: string;
+  name?: string;
+}
+
+/** Compact before/after diff of a mutation, reported back to the agent. */
+interface PartsDiff {
+  added: PartDiffEntry[];
+  removed: PartDiffEntry[];
+  modified: PartDiffEntry[];
+}
+
+/**
+ * Structural snapshot of every part: id → name + a fingerprint of its
+ * subtree (node ops, names, and material). Cheap — one JSON.stringify
+ * pass over reachable nodes — and exact enough to attribute any
+ * mutation to the parts it touched.
+ */
+function snapshotParts(
+  doc: import("@vcad/ir").Document,
+): Map<string, { name?: string; fingerprint: string }> {
+  const map = new Map<string, { name?: string; fingerprint: string }>();
+  for (const root of doc.roots) {
+    const partId = String(root.root);
+    const pieces: string[] = [
+      `material:${String(root.material ?? "")}:${String(
+        (doc.part_materials as Record<string, unknown> | undefined)?.[partId] ?? "",
+      )}`,
+    ];
+    const stack = [root.root];
+    const seen = new Set<number>();
+    while (stack.length > 0) {
+      const id = stack.pop()!;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const node = doc.nodes[String(id)];
+      if (!node) continue;
+      pieces.push(`${id}:${node.name ?? ""}:${JSON.stringify(node.op)}`);
+      for (const child of childrenOf(node.op)) stack.push(child);
+    }
+    pieces.sort();
+    map.set(partId, {
+      name: doc.nodes[partId]?.name ?? undefined,
+      fingerprint: pieces.join("|"),
+    });
+  }
+  return map;
+}
+
+/** Diff two part snapshots. Returns null when nothing changed. */
+function diffParts(
+  before: ReturnType<typeof snapshotParts>,
+  after: ReturnType<typeof snapshotParts>,
+): PartsDiff | null {
+  const diff: PartsDiff = { added: [], removed: [], modified: [] };
+  for (const [id, b] of before) {
+    const a = after.get(id);
+    if (!a) diff.removed.push({ part_id: id, name: b.name });
+    else if (a.fingerprint !== b.fingerprint)
+      diff.modified.push({ part_id: id, name: a.name });
+  }
+  for (const [id, a] of after) {
+    if (!before.has(id)) diff.added.push({ part_id: id, name: a.name });
+  }
+  if (!diff.added.length && !diff.removed.length && !diff.modified.length) {
+    return null;
+  }
+  return diff;
+}
+
+/** Merge a `changed` diff into a single-JSON-text-block result. */
+function appendChanged(
+  result: { content: Array<{ type: "text"; text: string }> },
+  changed: PartsDiff,
+): void {
+  const block = result.content[0];
+  if (!block || block.type !== "text") return;
+  try {
+    const parsed = JSON.parse(block.text) as Record<string, unknown>;
+    parsed.changed = changed;
+    block.text = JSON.stringify(parsed);
+  } catch {
+    // Non-JSON result — leave it alone rather than corrupt it.
+  }
+}
+
 /**
  * Dispatch a registry-tier tool call against a session document. Returns
  * the MCP-shaped response. Throws if the tool isn't dispatchable, the
  * session doesn't exist, or the planner reports an error.
+ *
+ * Mutations close the edit feedback loop: the result carries a compact
+ * `changed: {added, removed, modified}` diff of the parts the call
+ * touched, so the agent sees what actually happened to the document
+ * without a follow-up `read`.
  */
 export function dispatchRegistryTool(
   toolName: string,
@@ -141,6 +259,20 @@ export function dispatchRegistryTool(
     return handleRead(doc, toolArgs);
   }
 
+  const before = snapshotParts(doc);
+  const result = runMutation(toolName, toolArgs, doc, documentId);
+  const changed = diffParts(before, snapshotParts(doc));
+  if (changed) appendChanged(result, changed);
+  return result;
+}
+
+/** Execute a mutating registry tool against an open session document. */
+function runMutation(
+  toolName: string,
+  toolArgs: Record<string, unknown>,
+  doc: import("@vcad/ir").Document,
+  documentId: string,
+): { content: Array<{ type: "text"; text: string }> } {
   // `delete` and `set_material` go directly to applyToolOutcome — the
   // Rust planner expects CRDT stable_ids, but the IR-direct MCP path
   // uses stringified NodeIds for part_id. The args are already

--- a/packages/mcp/viewer-app/index.html
+++ b/packages/mcp/viewer-app/index.html
@@ -3,49 +3,161 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>vcad 3D Viewer</title>
+<title>vcad</title>
 <style>
+  /* vcad design tokens — mirrors packages/app/src/index.css.
+     The viewer is vcad-branded chrome: host theme picks dark/light,
+     the palette itself is vcad's. */
+  :root {
+    --brand: #F92672;
+    --brand-hover: #d91e63;
+
+    --bg: #0E0E10;
+    --surface: #1A1A1D;
+    --border: #3A3A40;
+    --border-soft: #2F2F34;
+    --text: #F5F5F5;
+    --text-2: #D4D4D4;
+    --text-muted: #9C9CA3;
+    --text-tert: #6A6A70;
+    --hover: #26262B;
+    --fill: #232327;
+
+    --radius-sm: 6px;
+    --hairline: 0.5px;
+    --vignette: rgba(0, 0, 0, 0.15);
+
+    --font-ui: "Inter", -apple-system, "SF Pro Text", system-ui, "Segoe UI",
+      Roboto, "Helvetica Neue", Arial, sans-serif;
+    --font-mono: "Berkeley Mono", ui-monospace, "SF Mono", SFMono-Regular,
+      Menlo, Consolas, monospace;
+  }
+  .light {
+    --bg: #FFFFFF;
+    --surface: #FFFFFF;
+    --border: #D4D4D4;
+    --border-soft: #D4D4D4;
+    --text: #000000;
+    --text-2: #171717;
+    --text-muted: #666666;
+    --text-tert: #999999;
+    --hover: #F4F4F5;
+    --fill: #F4F4F5;
+    --vignette: rgba(0, 0, 0, 0.1);
+  }
+
   * { margin: 0; padding: 0; box-sizing: border-box; }
   html, body {
     width: 100%; height: 100%; min-height: 380px; overflow: hidden;
-    background: var(--color-background-secondary, #1a1a2e);
-    color: var(--color-text-primary, #ccccdd);
-    font-family: var(--font-sans, system-ui, sans-serif);
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-ui);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
-  canvas { display: block; width: 100%; height: 100%; }
+  .light body, body.light { -webkit-font-smoothing: auto; }
+
+  #frame { display: flex; flex-direction: column; width: 100%; height: 100%; }
+
+  /* ── Header chrome ─────────────────────────────────────────── */
+  #header {
+    flex: none; display: flex; align-items: center; gap: 10px;
+    height: 34px; padding: 0 10px;
+    background: var(--surface);
+    border-bottom: var(--hairline) solid var(--border);
+    user-select: none;
+  }
+  #wordmark {
+    font-size: 14px; font-weight: 600; letter-spacing: -0.01em;
+    color: var(--text);
+  }
+  #wordmark .dot { color: var(--brand); }
+  #doc-label {
+    font: 11px var(--font-mono);
+    color: var(--text-muted);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    flex: 1;
+  }
+  .btn {
+    flex: none; display: inline-flex; align-items: center; gap: 5px;
+    height: 22px; padding: 0 9px;
+    background: var(--fill);
+    color: var(--text-2);
+    border: var(--hairline) solid var(--border);
+    border-radius: var(--radius-sm);
+    font: 500 11px var(--font-ui);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    display: none;
+  }
+  .btn:hover { background: var(--hover); color: var(--text); }
+  .btn-brand { border-color: transparent; background: var(--brand); color: #fff; }
+  .btn-brand:hover { background: var(--brand-hover); color: #fff; }
+
+  /* ── Viewport ──────────────────────────────────────────────── */
+  #stage { position: relative; flex: 1; min-height: 0; background: var(--bg); }
+  #stage canvas { display: block; width: 100%; height: 100%; }
+  /* Post-processing stand-in: matches the app's Vignette pass
+     (darkness 0.15 dark / 0.1 light). */
+  #vignette {
+    position: absolute; inset: 0; pointer-events: none;
+    background: radial-gradient(ellipse at center, transparent 55%, var(--vignette) 100%);
+  }
   #loading {
     position: absolute; inset: 0;
     display: flex; align-items: center; justify-content: center;
-    font-size: var(--font-text-md-size, 15px);
     flex-direction: column; gap: 8px;
+    font-size: 12px; color: var(--text-muted);
+    pointer-events: none;
   }
   #loading.hidden { display: none; }
-  #error { color: #ff6666; font-size: 12px; white-space: pre-wrap; max-width: 80%; }
-  .corner-btn {
-    position: absolute; bottom: 12px;
-    background: color-mix(in srgb, var(--color-background-primary, #ffffff) 12%, transparent);
-    color: var(--color-text-secondary, #ddd);
-    border: 1px solid var(--color-border-primary, rgba(128,128,128,0.35));
-    border-radius: var(--border-radius-md, 6px);
-    padding: 6px 14px; font: 13px var(--font-sans, system-ui, sans-serif);
-    cursor: pointer; display: none; backdrop-filter: blur(4px);
-    transition: background 0.15s;
+  #error { color: var(--brand); font: 11px var(--font-mono); white-space: pre-wrap; max-width: 80%; }
+
+  /* ── Status bar ────────────────────────────────────────────── */
+  #statusbar {
+    flex: none; display: flex; align-items: center; gap: 8px;
+    height: 26px; padding: 0 10px;
+    background: var(--surface);
+    border-top: var(--hairline) solid var(--border);
+    font: 11px var(--font-mono);
+    color: var(--text-muted);
+    user-select: none;
+    overflow: hidden;
   }
-  .corner-btn:hover {
-    background: color-mix(in srgb, var(--color-background-primary, #ffffff) 22%, transparent);
-    color: var(--color-text-primary, #fff);
+  #pulse {
+    flex: none; width: 7px; height: 7px; border-radius: 999px;
+    background: var(--text-tert);
+    transition: background 0.3s;
   }
-  #open-btn { right: 12px; }
-  #fullscreen-btn { left: 12px; }
+  #pulse.busy { background: var(--brand); animation: pulse 1s ease-in-out infinite; }
+  #pulse.ready { background: #98c379; }
+  #pulse.error { background: var(--brand); }
+  @keyframes pulse { 50% { opacity: 0.35; } }
+  #ticker { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #stats { flex: none; color: var(--text-tert); white-space: nowrap; }
 </style>
 </head>
 <body>
-<div id="loading">
-  <div id="status">vcad 3D Viewer — connecting...</div>
-  <div id="error"></div>
+<div id="frame">
+  <div id="header">
+    <span id="wordmark">vcad<span class="dot">.</span></span>
+    <span id="doc-label"></span>
+    <button id="fullscreen-btn" class="btn">Fullscreen</button>
+    <button id="open-btn" class="btn btn-brand">Open in vcad.io</button>
+  </div>
+  <div id="stage">
+    <div id="loading">
+      <div id="status">connecting…</div>
+      <div id="error"></div>
+    </div>
+    <div id="vignette"></div>
+  </div>
+  <div id="statusbar">
+    <span id="pulse"></span>
+    <span id="ticker">connecting to host…</span>
+    <span id="stats"></span>
+  </div>
 </div>
-<button id="open-btn" class="corner-btn">Open in vcad.io</button>
-<button id="fullscreen-btn" class="corner-btn">Fullscreen</button>
 <script type="module" src="./main.ts"></script>
 </body>
 </html>

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -333,6 +333,20 @@ function updateStats(model: THREE.Object3D, size: THREE.Vector3): void {
     `${formatDim(size.x)} × ${formatDim(size.y)} × ${formatDim(size.z)} mm`;
 }
 
+function clearModel(): void {
+  if (!currentModel) return;
+  modelGroup.remove(currentModel);
+  currentModel.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (mesh.geometry) mesh.geometry.dispose();
+    if (mesh.material) {
+      if (Array.isArray(mesh.material)) mesh.material.forEach((m) => m.dispose());
+      else mesh.material.dispose();
+    }
+  });
+  currentModel = null;
+}
+
 function loadGlb(base64Data: string): void {
   const binary = atob(base64Data);
   const bytes = new Uint8Array(binary.length);
@@ -340,17 +354,7 @@ function loadGlb(base64Data: string): void {
     bytes[i] = binary.charCodeAt(i);
   }
 
-  if (currentModel) {
-    modelGroup.remove(currentModel);
-    currentModel.traverse((child) => {
-      const mesh = child as THREE.Mesh;
-      if (mesh.geometry) mesh.geometry.dispose();
-      if (mesh.material) {
-        if (Array.isArray(mesh.material)) mesh.material.forEach((m) => m.dispose());
-        else mesh.material.dispose();
-      }
-    });
-  }
+  clearModel();
 
   loader.parse(
     bytes.buffer,
@@ -400,6 +404,96 @@ function loadGlb(base64Data: string): void {
   );
 }
 
+// ── Flat pattern rendering (sheet_metal_unfold) ──────────────
+// Drafting-table view: the cut silhouette and dashed bend centerlines
+// drawn on the ground plane with a near-top-down camera. Colors match
+// the app's SheetMetalView: cut + bend-up red, bend-down blue.
+interface FlatPatternLike {
+  panel_outlines_2d?: [number, number][][];
+  panel_holes_2d?: [number, number][][][];
+  silhouette_2d?: [number, number][][];
+  creases?: Array<{
+    line: [[number, number], [number, number]];
+    direction?: string;
+  }>;
+  area_mm2?: number;
+  bbox?: [number, number, number, number];
+}
+
+// Kernel-space Z lift so the drawing sits just above the grid plane.
+const FLAT_LIFT = 0.05;
+
+function flatLoop(
+  ring: [number, number][],
+  material: THREE.LineBasicMaterial,
+): THREE.LineLoop {
+  const points = ring.map(([x, y]) => new THREE.Vector3(x, y, FLAT_LIFT));
+  const geom = new THREE.BufferGeometry().setFromPoints(points);
+  return new THREE.LineLoop(geom, material);
+}
+
+function renderFlatPattern(fp: FlatPatternLike): void {
+  clearModel();
+
+  const group = new THREE.Group();
+  const cutMaterial = new THREE.LineBasicMaterial({ color: 0xef4444 });
+
+  // Prefer the merged fab silhouette; fall back to per-panel outlines.
+  const rings = fp.silhouette_2d?.length
+    ? fp.silhouette_2d
+    : [
+        ...(fp.panel_outlines_2d ?? []),
+        ...(fp.panel_holes_2d ?? []).flat(),
+      ];
+  for (const ring of rings) {
+    if (ring.length >= 2) group.add(flatLoop(ring, cutMaterial));
+  }
+
+  const [minX, minY, maxX, maxY] = fp.bbox ?? [0, 0, 0, 0];
+  const span = Math.max(maxX - minX, maxY - minY, 1);
+
+  for (const crease of fp.creases ?? []) {
+    const up = crease.direction !== "Down";
+    const mat = new THREE.LineDashedMaterial({
+      color: up ? 0xef4444 : 0x3b82f6,
+      dashSize: span / 50,
+      gapSize: span / 80,
+    });
+    const [[x0, y0], [x1, y1]] = crease.line;
+    const geom = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(x0, y0, FLAT_LIFT),
+      new THREE.Vector3(x1, y1, FLAT_LIFT),
+    ]);
+    const line = new THREE.Line(geom, mat);
+    line.computeLineDistances();
+    group.add(line);
+  }
+
+  modelGroup.add(group);
+  currentModel = group;
+  hasModel = true;
+  updateAxesVisibility();
+  contactShadow.visible = false;
+
+  // Near-top-down camera over the pattern (kernel XY → display X/-Z).
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  controls.target.set(cx, 0, -cy);
+  camera.position.set(cx, span * 1.5, -cy + span * 0.3);
+  camera.updateProjectionMatrix();
+  controls.update();
+
+  const panels = fp.panel_outlines_2d?.length ?? 0;
+  const bends = fp.creases?.length ?? 0;
+  statsEl.textContent =
+    `${panels} ${panels === 1 ? "panel" : "panels"} · ` +
+    `${bends} ${bends === 1 ? "bend" : "bends"} · ` +
+    `${formatDim(maxX - minX)} × ${formatDim(maxY - minY)} mm flat`;
+  loadingEl.classList.add("hidden");
+  setTicker("flat pattern — red cut/bend-up, blue bend-down", "ready");
+  renderer.render(scene, camera);
+}
+
 // ── Result handling ──────────────────────────────────────────
 type ContentBlock = { type?: string; text?: string };
 type ToolResultLike = {
@@ -416,6 +510,20 @@ function findInlineGlb(result: ToolResultLike): string | null {
     try {
       const parsed = JSON.parse(block.text) as { _vcad_glb?: string };
       if (parsed._vcad_glb) return parsed._vcad_glb;
+    } catch {
+      // Not JSON — skip
+    }
+  }
+  return null;
+}
+
+/** Find a `flat_pattern` payload (sheet_metal_unfold) in the result. */
+function findFlatPattern(result: ToolResultLike): FlatPatternLike | null {
+  for (const block of result.content ?? []) {
+    if (block?.type !== "text" || !block.text) continue;
+    try {
+      const parsed = JSON.parse(block.text) as { flat_pattern?: FlatPatternLike };
+      if (parsed.flat_pattern) return parsed.flat_pattern;
     } catch {
       // Not JSON — skip
     }
@@ -486,6 +594,20 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
 
   if (result.isError) {
     setStatus("tool reported an error — nothing to preview", "error");
+    return;
+  }
+
+  // Flat pattern (sheet_metal_unfold): 2D drawing, no GLB fetch. Checked
+  // before the document_id path — unfold results carry both.
+  const flat = findFlatPattern(result);
+  if (flat) {
+    const docId = result.structuredContent?.document_id ?? findDocumentId(result);
+    if (typeof docId === "string") {
+      lastDocumentId = docId;
+      docLabelEl.textContent = docId;
+      openBtn.style.display = "inline-flex";
+    }
+    renderFlatPattern(flat);
     return;
   }
 
@@ -574,48 +696,70 @@ fullscreenBtn.addEventListener("click", async () => {
 // ── Dev harness ──────────────────────────────────────────────
 // `#dev` renders sample geometry without an MCP host so the rig
 // (chrome, grid, IBL, shadow, stats) can be eyeballed in a browser.
-// `#dev-light` does the same in the light theme.
+// `#dev-light` does the same in the light theme; `#dev-flat` renders a
+// sample sheet-metal flat pattern (U-channel with two holes).
 if (location.hash.startsWith("#dev")) {
   if (location.hash === "#dev-light") {
     isDark = false;
     applyTheme();
   }
-  const sample = new THREE.Group();
-  const steel = new THREE.MeshStandardMaterial({ color: 0x9da3ab, metalness: 0.9, roughness: 0.35 });
-  const plastic = new THREE.MeshStandardMaterial({ color: 0xf92672, metalness: 0.0, roughness: 0.55 });
-  // Kernel space is Z-up: flange disc + boss along Z, pink cap on top.
-  const flange = new THREE.Mesh(new THREE.CylinderGeometry(30, 30, 8, 64), steel);
-  flange.rotation.x = Math.PI / 2;
-  flange.position.z = 4;
-  const boss = new THREE.Mesh(new THREE.CylinderGeometry(12, 12, 30, 48), steel);
-  boss.rotation.x = Math.PI / 2;
-  boss.position.z = 23;
-  const cap = new THREE.Mesh(new THREE.CylinderGeometry(13, 13, 4, 48), plastic);
-  cap.rotation.x = Math.PI / 2;
-  cap.position.z = 40;
-  sample.add(flange, boss, cap);
-  modelGroup.add(sample);
-  currentModel = sample;
-  hasModel = true;
-  updateAxesVisibility();
+  if (location.hash === "#dev-flat") {
+    renderFlatPattern({
+      silhouette_2d: [
+        [[-60, -40], [60, -40], [60, 40], [-60, 40]],
+        [[-45, -10], [-35, -10], [-35, 10], [-45, 10]],
+        [[35, -10], [45, -10], [45, 10], [35, 10]],
+      ],
+      panel_outlines_2d: [
+        [[-60, -40], [-20, -40], [-20, 40], [-60, 40]],
+        [[-20, -40], [20, -40], [20, 40], [-20, 40]],
+        [[20, -40], [60, -40], [60, 40], [20, 40]],
+      ],
+      creases: [
+        { line: [[-20, -40], [-20, 40]], direction: "Up" },
+        { line: [[20, -40], [20, 40]], direction: "Down" },
+      ],
+      bbox: [-60, -40, 60, 40],
+    });
+    docLabelEl.textContent = "dev-flat";
+  } else {
+    const sample = new THREE.Group();
+    const steel = new THREE.MeshStandardMaterial({ color: 0x9da3ab, metalness: 0.9, roughness: 0.35 });
+    const plastic = new THREE.MeshStandardMaterial({ color: 0xf92672, metalness: 0.0, roughness: 0.55 });
+    // Kernel space is Z-up: flange disc + boss along Z, pink cap on top.
+    const flange = new THREE.Mesh(new THREE.CylinderGeometry(30, 30, 8, 64), steel);
+    flange.rotation.x = Math.PI / 2;
+    flange.position.z = 4;
+    const boss = new THREE.Mesh(new THREE.CylinderGeometry(12, 12, 30, 48), steel);
+    boss.rotation.x = Math.PI / 2;
+    boss.position.z = 23;
+    const cap = new THREE.Mesh(new THREE.CylinderGeometry(13, 13, 4, 48), plastic);
+    cap.rotation.x = Math.PI / 2;
+    cap.position.z = 40;
+    sample.add(flange, boss, cap);
+    modelGroup.add(sample);
+    currentModel = sample;
+    hasModel = true;
+    updateAxesVisibility();
 
-  const box = new THREE.Box3().setFromObject(modelGroup);
-  const size = new THREE.Box3().setFromObject(sample).getSize(new THREE.Vector3());
-  const worldSize = box.getSize(new THREE.Vector3());
-  const worldCenter = box.getCenter(new THREE.Vector3());
-  const footprint = Math.max(worldSize.x, worldSize.z) * 1.8;
-  contactShadow.scale.set(footprint, footprint, 1);
-  contactShadow.position.set(worldCenter.x, -0.01, worldCenter.z);
-  contactShadow.visible = true;
-  controls.target.set(0, 21, 0);
-  camera.position.set(85, 75, 85);
-  controls.update();
-  docLabelEl.textContent = "dev-sample";
+    const box = new THREE.Box3().setFromObject(modelGroup);
+    const size = new THREE.Box3().setFromObject(sample).getSize(new THREE.Vector3());
+    const worldSize = box.getSize(new THREE.Vector3());
+    const worldCenter = box.getCenter(new THREE.Vector3());
+    const footprint = Math.max(worldSize.x, worldSize.z) * 1.8;
+    contactShadow.scale.set(footprint, footprint, 1);
+    contactShadow.position.set(worldCenter.x, -0.01, worldCenter.z);
+    contactShadow.visible = true;
+    controls.target.set(0, 21, 0);
+    camera.position.set(85, 75, 85);
+    controls.update();
+    docLabelEl.textContent = "dev-sample";
+    updateStats(sample, size);
+    loadingEl.classList.add("hidden");
+    setTicker("ready", "ready");
+  }
   openBtn.style.display = "inline-flex";
   fullscreenBtn.style.display = "inline-flex";
-  updateStats(sample, size);
-  loadingEl.classList.add("hidden");
-  setTicker("ready", "ready");
   // Debug handle for poking the scene from the console.
   (window as unknown as Record<string, unknown>).__vcad = {
     scene, camera, controls, grid, gridUniforms, contactShadow, renderer,

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -5,6 +5,12 @@
  * imports at render time. Receives tool results from the host via the
  * official App class, then fetches the GLB preview through the app-only
  * `get_preview_glb` tool so geometry never rides in model-visible results.
+ *
+ * The render rig mirrors the main app's viewport (ViewportContent.tsx):
+ * same key/fill/rim directional lights, the same procedural studio IBL
+ * baked through PMREM, the same infinite grid, axis lines, contact
+ * shadow, and ACES tone mapping — so a part previewed here reads the
+ * same as it does on vcad.io.
  */
 
 import * as THREE from "three";
@@ -12,73 +18,283 @@ import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { GLTFLoader } from "three/examples/jsm/loaders/GLTFLoader.js";
 import {
   App,
-  applyDocumentTheme,
-  applyHostStyleVariables,
-  applyHostFonts,
   type McpUiHostContext,
 } from "@modelcontextprotocol/ext-apps";
 
 const statusEl = document.getElementById("status")!;
 const errEl = document.getElementById("error")!;
 const loadingEl = document.getElementById("loading")!;
+const stageEl = document.getElementById("stage")!;
+const docLabelEl = document.getElementById("doc-label")!;
+const tickerEl = document.getElementById("ticker")!;
+const statsEl = document.getElementById("stats")!;
+const pulseEl = document.getElementById("pulse")!;
 const openBtn = document.getElementById("open-btn") as HTMLButtonElement;
 const fullscreenBtn = document.getElementById("fullscreen-btn") as HTMLButtonElement;
 
-function setStatus(text: string): void {
+type PulseState = "idle" | "busy" | "ready" | "error";
+
+function setStatus(text: string, pulse: PulseState = "busy"): void {
   loadingEl.classList.remove("hidden");
   statusEl.textContent = text;
+  setTicker(text, pulse);
 }
 
+function setTicker(text: string, pulse: PulseState): void {
+  tickerEl.textContent = text;
+  pulseEl.className = pulse === "idle" ? "" : pulse;
+}
+
+// ── Theme ────────────────────────────────────────────────────
+// The viewer is vcad-branded: the host only chooses dark/light, the
+// palette is vcad's own (mirrors packages/app/src/index.css).
+let isDark = true;
+
 // ── Scene setup ──────────────────────────────────────────────
-// Alpha canvas: the page background comes from host CSS variables, so the
-// viewport follows the host theme without re-creating the scene.
+// Alpha canvas: the page background is the vcad stage color (--bg), so
+// theme switches don't require re-creating the scene.
 const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
 renderer.setPixelRatio(window.devicePixelRatio);
-renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.toneMappingExposure = 1.2;
-document.body.appendChild(renderer.domElement);
+renderer.toneMappingExposure = 1.0;
+stageEl.insertBefore(renderer.domElement, stageEl.firstChild);
 
 const scene = new THREE.Scene();
 
-const camera = new THREE.PerspectiveCamera(
-  50,
-  window.innerWidth / window.innerHeight,
-  0.1,
-  10000,
-);
-camera.position.set(80, 80, 80);
+const camera = new THREE.PerspectiveCamera(50, 1, 0.1, 10000);
+camera.position.set(50, 50, 50);
 
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 controls.dampingFactor = 0.1;
-controls.addEventListener("change", () => renderer.render(scene, camera));
 
-// ── Lighting ─────────────────────────────────────────────────
-scene.add(new THREE.AmbientLight(0xffffff, 0.4));
-
-const key = new THREE.DirectionalLight(0xffffff, 1.2);
-key.position.set(50, 80, 40);
+// ── Lighting — the app's default three-point rig ─────────────
+// Same directions, colors, and theme-aware intensities as
+// buildDefaultSceneSettings(): positions are -direction * 100.
+const key = new THREE.DirectionalLight(new THREE.Color(1, 0.98, 0.95), 1.4);
+key.position.set(-50, 80, -40);
 scene.add(key);
 
-const fill = new THREE.DirectionalLight(0xffffff, 0.4);
-fill.position.set(-30, 40, -20);
+const fill = new THREE.DirectionalLight(new THREE.Color(0.95, 0.97, 1.0), 0.5);
+fill.position.set(30, 40, 20);
 scene.add(fill);
 
-const rim = new THREE.DirectionalLight(0xffffff, 0.2);
-rim.position.set(-50, -20, 50);
+const rim = new THREE.DirectionalLight(new THREE.Color(1, 1, 1), 0.35);
+rim.position.set(50, 20, -50);
 scene.add(rim);
 
-// ── Grid ─────────────────────────────────────────────────────
-scene.add(new THREE.GridHelper(200, 20, 0x555577, 0x444466));
+function applyLightIntensities(): void {
+  key.intensity = isDark ? 1.4 : 1.2;
+  fill.intensity = isDark ? 0.5 : 0.4;
+  rim.intensity = isDark ? 0.35 : 0.2;
+}
+
+// ── Procedural studio IBL ────────────────────────────────────
+// Mirrors the app's default <Environment> Lightformer rig: cool-white
+// key softbox, warm + cool fills, bright rim strip, faint floor bounce,
+// baked into a PMREM cubemap so metallic reflections read like a
+// product shot. Numbers are lifted verbatim from ViewportContent.tsx.
+const pmrem = new THREE.PMREMGenerator(renderer);
+
+interface Former {
+  intensity: [number, number]; // [dark, light]
+  color: [number, number, number];
+  position: [number, number, number];
+  rotation: [number, number, number];
+  scale: [number, number];
+}
+
+const LIGHTFORMERS: Former[] = [
+  // Key — cool-white ceiling softbox, tilted camera-left.
+  { intensity: [3.2, 5.5], color: [1.0, 0.99, 0.97], position: [3, 9, 3], rotation: [-Math.PI / 2 + 0.25, 0, 0.2], scale: [18, 14] },
+  // Fill — warmer, camera-right, lower.
+  { intensity: [1.3, 2.2], color: [1.0, 0.94, 0.86], position: [10, 2, 4], rotation: [0, -Math.PI / 2, 0.1], scale: [12, 8] },
+  // Opposite-side fill — slightly cooler.
+  { intensity: [0.9, 1.6], color: [0.96, 0.98, 1.0], position: [-10, 2, 0], rotation: [0, Math.PI / 2, -0.1], scale: [12, 8] },
+  // Rim — bright narrow strip behind the camera.
+  { intensity: [2.2, 3.6], color: [0.98, 1.0, 1.0], position: [0, 4, -12], rotation: [0, 0, 0], scale: [14, 5] },
+  // Faint floor bounce.
+  { intensity: [0.25, 0.5], color: [0.92, 0.94, 0.96], position: [0, -8, 0], rotation: [Math.PI / 2, 0, 0], scale: [20, 20] },
+];
+
+function buildStudioEnvironment(): void {
+  const envScene = new THREE.Scene();
+  envScene.background = new THREE.Color(
+    ...(isDark ? [0.018, 0.02, 0.024] : [0.62, 0.6, 0.58]) as [number, number, number],
+  );
+  for (const f of LIGHTFORMERS) {
+    const mat = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide });
+    mat.color.setRGB(...f.color).multiplyScalar(f.intensity[isDark ? 0 : 1]);
+    const plane = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), mat);
+    plane.position.set(...f.position);
+    plane.rotation.set(...f.rotation);
+    plane.scale.set(f.scale[0], f.scale[1], 1);
+    envScene.add(plane);
+  }
+  const target = pmrem.fromScene(envScene, 0, 0.1, 1000);
+  scene.environment?.dispose();
+  scene.environment = target.texture;
+  envScene.traverse((o) => {
+    const mesh = o as THREE.Mesh;
+    if (mesh.geometry) mesh.geometry.dispose();
+    if (mesh.material) (mesh.material as THREE.Material).dispose();
+  });
+}
+
+// ── Grid — drei <Grid> port (GridPlane.tsx) ──────────────────
+// cellSize 10 / sectionSize 100, fadeDistance 500, theme-aware colors.
+// Plane follows the camera so the grid reads as infinite.
+const GRID_FADE = 500;
+
+const gridUniforms = {
+  uCellSize: { value: 10 },
+  uSectionSize: { value: 100 },
+  uCellColor: { value: new THREE.Color("#2a2a2a") },
+  uSectionColor: { value: new THREE.Color("#3a3a3a") },
+  uCellThickness: { value: 0.5 },
+  uSectionThickness: { value: 1.0 },
+  uFadeDistance: { value: GRID_FADE },
+};
+
+const gridMaterial = new THREE.ShaderMaterial({
+  uniforms: gridUniforms,
+  transparent: true,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+  vertexShader: /* glsl */ `
+    varying vec3 vWorldPos;
+    void main() {
+      vec4 wp = modelMatrix * vec4(position, 1.0);
+      vWorldPos = wp.xyz;
+      gl_Position = projectionMatrix * viewMatrix * wp;
+    }
+  `,
+  fragmentShader: /* glsl */ `
+    varying vec3 vWorldPos;
+    uniform float uCellSize, uSectionSize, uCellThickness, uSectionThickness, uFadeDistance;
+    uniform vec3 uCellColor, uSectionColor;
+
+    float gridLine(vec2 p, float size, float thickness) {
+      vec2 r = p / size;
+      vec2 grid = abs(fract(r - 0.5) - 0.5) / fwidth(r);
+      float line = min(grid.x, grid.y) + 1.0 - thickness;
+      return 1.0 - min(line, 1.0);
+    }
+
+    void main() {
+      float cell = gridLine(vWorldPos.xz, uCellSize, uCellThickness);
+      float section = gridLine(vWorldPos.xz, uSectionSize, uSectionThickness);
+      float dist = distance(vWorldPos.xz, cameraPosition.xz);
+      float fade = 1.0 - smoothstep(0.0, uFadeDistance, dist);
+      vec3 color = mix(uCellColor, uSectionColor, step(0.5, section));
+      float alpha = max(cell, section) * fade;
+      if (alpha < 0.003) discard;
+      gl_FragColor = vec4(color, alpha);
+      #include <tonemapping_fragment>
+      #include <colorspace_fragment>
+    }
+  `,
+});
+
+const grid = new THREE.Mesh(new THREE.PlaneGeometry(GRID_FADE * 4, GRID_FADE * 4), gridMaterial);
+grid.rotation.x = -Math.PI / 2;
+grid.renderOrder = -2;
+scene.add(grid);
+
+// ── Axis lines (GridPlane.tsx) ───────────────────────────────
+// RGB convention in Z-up labels: X red, Y green (ground), Z blue (up).
+// Shown while orbiting or when there's nothing loaded — same rule as
+// the app (`isOrbiting || !hasParts`).
+const axes = new THREE.Group();
+
+function axisLine(points: [number, number, number][], colorDark: string, colorLight: string): { line: THREE.Line; dark: string; light: string } {
+  const geom = new THREE.BufferGeometry().setFromPoints(points.map((p) => new THREE.Vector3(...p)));
+  const mat = new THREE.LineBasicMaterial({ color: colorDark, transparent: true, opacity: 0.7, depthWrite: false });
+  const line = new THREE.Line(geom, mat);
+  line.renderOrder = -1;
+  return { line, dark: colorDark, light: colorLight };
+}
+
+const axisDefs = [
+  axisLine([[-500, 0, 0], [500, 0, 0]], "#e06c75", "#c94f4f"), // X
+  axisLine([[0, 0, -500], [0, 0, 500]], "#98c379", "#5a9a4a"), // Y (ground)
+  axisLine([[0, 0, 0], [0, 500, 0]], "#61afef", "#4a7dc9"),    // Z (up)
+];
+for (const a of axisDefs) axes.add(a.line);
+scene.add(axes);
+
+let isOrbiting = false;
+let hasModel = false;
+
+function updateAxesVisibility(): void {
+  axes.visible = isOrbiting || !hasModel;
+}
+updateAxesVisibility();
+
+controls.addEventListener("start", () => {
+  isOrbiting = true;
+  updateAxesVisibility();
+});
+controls.addEventListener("end", () => {
+  isOrbiting = false;
+  updateAxesVisibility();
+});
+
+// ── Contact shadow ───────────────────────────────────────────
+// Cheap stand-in for the app's <ContactShadows>: a radial-gradient
+// sprite under the part, sized to the model footprint on load.
+const shadowTexture = (() => {
+  const size = 256;
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d")!;
+  const g = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, size / 2);
+  g.addColorStop(0, "rgba(0,0,0,1)");
+  g.addColorStop(0.5, "rgba(0,0,0,0.45)");
+  g.addColorStop(1, "rgba(0,0,0,0)");
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, size, size);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+})();
+
+const shadowMaterial = new THREE.MeshBasicMaterial({
+  map: shadowTexture,
+  transparent: true,
+  opacity: 0.4,
+  depthWrite: false,
+});
+const contactShadow = new THREE.Mesh(new THREE.PlaneGeometry(1, 1), shadowMaterial);
+contactShadow.rotation.x = -Math.PI / 2;
+contactShadow.position.y = -0.01;
+contactShadow.visible = false;
+scene.add(contactShadow);
+
+function applyTheme(): void {
+  document.documentElement.classList.toggle("light", !isDark);
+  document.body.classList.toggle("light", !isDark);
+  applyLightIntensities();
+  buildStudioEnvironment();
+  gridUniforms.uCellColor.value.set(isDark ? "#2a2a2a" : "#555555");
+  gridUniforms.uSectionColor.value.set(isDark ? "#3a3a3a" : "#333333");
+  for (const a of axisDefs) {
+    (a.line.material as THREE.LineBasicMaterial).color.set(isDark ? a.dark : a.light);
+  }
+  shadowMaterial.opacity = isDark ? 0.4 : 0.3;
+}
+applyTheme();
 
 // ── Resize handler ───────────────────────────────────────────
-window.addEventListener("resize", () => {
-  camera.aspect = window.innerWidth / window.innerHeight;
+function resize(): void {
+  const w = stageEl.clientWidth || window.innerWidth;
+  const h = stageEl.clientHeight || window.innerHeight;
+  camera.aspect = w / h;
   camera.updateProjectionMatrix();
-  renderer.setSize(window.innerWidth, window.innerHeight);
-  renderer.render(scene, camera);
-});
+  renderer.setSize(w, h);
+}
+new ResizeObserver(resize).observe(stageEl);
+resize();
 
 // ── Animation loop ───────────────────────────────────────────
 function animate(): void {
@@ -96,6 +312,26 @@ scene.add(modelGroup);
 // ── GLB loading ──────────────────────────────────────────────
 const loader = new GLTFLoader();
 let currentModel: THREE.Object3D | null = null;
+
+function formatDim(v: number): string {
+  return v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
+}
+
+function updateStats(model: THREE.Object3D, size: THREE.Vector3): void {
+  let meshes = 0;
+  let tris = 0;
+  model.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!mesh.isMesh || !mesh.geometry) return;
+    meshes++;
+    const g = mesh.geometry;
+    tris += (g.index ? g.index.count : g.attributes.position?.count ?? 0) / 3;
+  });
+  const triLabel = tris >= 10_000 ? `${(tris / 1000).toFixed(1)}k` : `${Math.round(tris)}`;
+  statsEl.textContent =
+    `${meshes} ${meshes === 1 ? "body" : "bodies"} · ${triLabel} tris · ` +
+    `${formatDim(size.x)} × ${formatDim(size.y)} × ${formatDim(size.z)} mm`;
+}
 
 function loadGlb(base64Data: string): void {
   const binary = atob(base64Data);
@@ -122,6 +358,8 @@ function loadGlb(base64Data: string): void {
     (gltf) => {
       currentModel = gltf.scene;
       modelGroup.add(currentModel);
+      hasModel = true;
+      updateAxesVisibility();
 
       // Fit camera to model
       const box = new THREE.Box3().setFromObject(currentModel);
@@ -140,12 +378,24 @@ function loadGlb(base64Data: string): void {
       camera.updateProjectionMatrix();
       controls.update();
 
+      // Contact shadow under the footprint (world Y-up space)
+      const worldBox = new THREE.Box3().setFromObject(modelGroup);
+      const worldSize = worldBox.getSize(new THREE.Vector3());
+      const worldCenter = worldBox.getCenter(new THREE.Vector3());
+      const footprint = Math.max(worldSize.x, worldSize.z) * 1.8;
+      contactShadow.scale.set(footprint, footprint, 1);
+      contactShadow.position.set(worldCenter.x, -0.01, worldCenter.z);
+      contactShadow.visible = true;
+
+      // Size is measured pre-rotation in kernel Z-up mm
+      updateStats(currentModel, size);
       loadingEl.classList.add("hidden");
+      setTicker("ready", "ready");
       renderer.render(scene, camera);
     },
     (error) => {
       console.error("GLB parse error:", error);
-      setStatus("Error loading model");
+      setStatus("error loading model", "error");
     },
   );
 }
@@ -192,7 +442,7 @@ function captureVcode(result: ToolResultLike): void {
   for (const block of result.content ?? []) {
     if (block?.type === "text" && block.text?.startsWith("# vcad")) {
       vcodeDoc = block.text;
-      openBtn.style.display = "block";
+      openBtn.style.display = "inline-flex";
       return;
     }
   }
@@ -200,21 +450,23 @@ function captureVcode(result: ToolResultLike): void {
 
 // ── MCP Apps protocol ────────────────────────────────────────
 const app = new App(
-  { name: "vcad-viewer", version: "2.0.0" },
+  { name: "vcad-viewer", version: "2.1.0" },
   { availableDisplayModes: ["inline", "fullscreen"] },
 );
 
 function applyHostContext(ctx: McpUiHostContext | undefined): void {
   if (!ctx) return;
-  if (ctx.theme) applyDocumentTheme(ctx.theme);
-  if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
-  if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+  // Host only picks dark/light — the palette stays vcad's own.
+  if (ctx.theme) {
+    isDark = ctx.theme !== "light";
+    applyTheme();
+  }
   if (ctx.safeAreaInsets) {
     const { top, right, bottom, left } = ctx.safeAreaInsets;
     document.body.style.padding = `${top}px ${right}px ${bottom}px ${left}px`;
   }
   if (ctx.availableDisplayModes?.includes("fullscreen")) {
-    fullscreenBtn.style.display = "block";
+    fullscreenBtn.style.display = "inline-flex";
   }
   if (ctx.displayMode) currentDisplayMode = ctx.displayMode;
 }
@@ -233,7 +485,7 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
   captureVcode(result);
 
   if (result.isError) {
-    setStatus("tool reported an error — nothing to preview");
+    setStatus("tool reported an error — nothing to preview", "error");
     return;
   }
 
@@ -250,10 +502,14 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
   // structuredContent to widgets.
   const docId = result.structuredContent?.document_id ?? findDocumentId(result);
   if (typeof docId !== "string") {
-    setStatus("no geometry to preview");
+    setStatus("no geometry to preview", "idle");
     return;
   }
   lastDocumentId = docId;
+  docLabelEl.textContent = docId;
+  // A session document exists, so the deep link can always lazily fetch
+  // the doc on click even when no VCode rode along in the result.
+  openBtn.style.display = "inline-flex";
   setStatus("fetching geometry…");
   try {
     const previewResult = (await app.callServerTool({
@@ -264,11 +520,11 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
     if (glb) {
       loadGlb(glb);
     } else {
-      setStatus("no geometry to preview");
+      setStatus("no geometry to preview", "idle");
     }
   } catch (e) {
     console.error("[vcad-viewer] preview fetch failed:", e);
-    setStatus("preview unavailable");
+    setStatus("preview unavailable", "error");
     errEl.textContent = e instanceof Error ? e.message : String(e);
   }
 }
@@ -315,8 +571,59 @@ fullscreenBtn.addEventListener("click", async () => {
   }
 });
 
-// ── Connect (handlers are all registered above) ──────────────
-setStatus("vcad 3D Viewer — waiting for model…");
-await app.connect();
-applyHostContext(app.getHostContext());
-console.log("[vcad-viewer] connected to host");
+// ── Dev harness ──────────────────────────────────────────────
+// `#dev` renders sample geometry without an MCP host so the rig
+// (chrome, grid, IBL, shadow, stats) can be eyeballed in a browser.
+// `#dev-light` does the same in the light theme.
+if (location.hash.startsWith("#dev")) {
+  if (location.hash === "#dev-light") {
+    isDark = false;
+    applyTheme();
+  }
+  const sample = new THREE.Group();
+  const steel = new THREE.MeshStandardMaterial({ color: 0x9da3ab, metalness: 0.9, roughness: 0.35 });
+  const plastic = new THREE.MeshStandardMaterial({ color: 0xf92672, metalness: 0.0, roughness: 0.55 });
+  // Kernel space is Z-up: flange disc + boss along Z, pink cap on top.
+  const flange = new THREE.Mesh(new THREE.CylinderGeometry(30, 30, 8, 64), steel);
+  flange.rotation.x = Math.PI / 2;
+  flange.position.z = 4;
+  const boss = new THREE.Mesh(new THREE.CylinderGeometry(12, 12, 30, 48), steel);
+  boss.rotation.x = Math.PI / 2;
+  boss.position.z = 23;
+  const cap = new THREE.Mesh(new THREE.CylinderGeometry(13, 13, 4, 48), plastic);
+  cap.rotation.x = Math.PI / 2;
+  cap.position.z = 40;
+  sample.add(flange, boss, cap);
+  modelGroup.add(sample);
+  currentModel = sample;
+  hasModel = true;
+  updateAxesVisibility();
+
+  const box = new THREE.Box3().setFromObject(modelGroup);
+  const size = new THREE.Box3().setFromObject(sample).getSize(new THREE.Vector3());
+  const worldSize = box.getSize(new THREE.Vector3());
+  const worldCenter = box.getCenter(new THREE.Vector3());
+  const footprint = Math.max(worldSize.x, worldSize.z) * 1.8;
+  contactShadow.scale.set(footprint, footprint, 1);
+  contactShadow.position.set(worldCenter.x, -0.01, worldCenter.z);
+  contactShadow.visible = true;
+  controls.target.set(0, 21, 0);
+  camera.position.set(85, 75, 85);
+  controls.update();
+  docLabelEl.textContent = "dev-sample";
+  openBtn.style.display = "inline-flex";
+  fullscreenBtn.style.display = "inline-flex";
+  updateStats(sample, size);
+  loadingEl.classList.add("hidden");
+  setTicker("ready", "ready");
+  // Debug handle for poking the scene from the console.
+  (window as unknown as Record<string, unknown>).__vcad = {
+    scene, camera, controls, grid, gridUniforms, contactShadow, renderer,
+  };
+} else {
+  // ── Connect (handlers are all registered above) ────────────
+  setStatus("waiting for model…");
+  await app.connect();
+  applyHostContext(app.getHostContext());
+  console.log("[vcad-viewer] connected to host");
+}


### PR DESCRIPTION
## What

Makes the MCP Apps inline viewer feel like vcad, ports the app's exact render rig into it, and reorganizes the tool surface around the agent loop (**make → see → measure → verify → ship**).

### vcad chrome
- `vcad.` wordmark, mono session label, brand-pink **Open in vcad.io** button, status bar with kernel-pulse dot and live stats (`3 bodies · 640 tris · 60.0 × 42.0 × 60.0 mm`)
- Real design tokens from the app's `index.css` (stage `#0E0E10`, surface `#1A1A1D`, brand `#F92672`, hairline borders, 6px radii); host picks dark/light, palette stays vcad's

### Renderer parity (ported verbatim from `ViewportContent.tsx`)
- Key/fill/rim lights, five-Lightformer studio IBL baked via PMREM, drei-style infinite grid, Z-up axis lines while orbiting, contact shadow, ACES @ 1.0, CSS vignette
- Fixed a real shader bug: grid wrote linear color to the sRGB framebuffer (crushed to ~1/255) — now includes `tonemapping/colorspace` chunks, verified by pixel readback
- `#dev` / `#dev-light` / `#dev-flat` hash harness for hostless visual verification

### Tool surface, from first principles
- **Tool packs**: `VCAD_MCP_PACKS` trims 48 tools to an 18-tool core + opt-in packs (`dfm`, `sheet_metal`, `physics`, `ecad`, `eval`). Unset = everything (backward compatible; mecheval unaffected)
- **Mutation diffs**: `create`/`update`/`delete`/`set_material` results report `changed: {added, removed, modified}` — closes the edit feedback loop without a follow-up `read`
- **Server instructions**: kernel type catalog, material keys, Z-up orientation rules, and world-origin rotation semantics now ship as protocol-native MCP instructions, extracted from the kernel chat prompt at boot (no drift)
- **Description steering**: `create_cad_loon` for whole parts, `create`/`update` for surgical edits; dead "system prompt" references redirected
- **Flat patterns**: `sheet_metal_unfold` renders in the viewer as a 2D drawing (red cut/bend-up, blue bend-down, drafting-table camera), exempt from result slimming

## Verification
- 56 tests pass (8 new: diffs, steering, pack gating)
- End-to-end through the call handler: create → diff, update → diff, no-op → no diff; unfold carries `flat_pattern` + `document_id`, bend allowance checks out (100mm + 30mm flange → 134.27mm flat)
- Visual: dark/light/flat dev-harness screenshots against the real app side by side

🤖 Generated with [Claude Code](https://claude.com/claude-code)