### PR TITLE
docs: expand MCP README with tool packs, session lifecycle, and full API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       },
       "bin": {
         "mecheval-leaderboard": "dist/leaderboard-cli.js",
+        "mecheval-matrix": "dist/matrix-cli.js",
         "mecheval-run": "dist/cli.js"
       },
       "devDependencies": {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,86 +14,167 @@ Or add to your MCP configuration directly:
 claude mcp add vcad --command "npx @vcad/mcp"
 ```
 
+## Tool packs
+
+The surface is a small always-on core — the make → see → measure → verify →
+ship loop (session lifecycle, Loon/CRUD authoring, parts library,
+`inspect_cad`, `render_view`, `export_cad`, `import_step`,
+`open_in_browser`, `get_changelog`) — plus opt-out domain packs:
+
+| Pack | Tools |
+|------|-------|
+| `dfm` | `dfm_check`, `dfm_explain`, `dfm_suggest_fix`, `dfm_apply_fix` |
+| `sheet_metal` | `sheet_metal_create/unfold/check/materials/bend_table/cost/suggest_fix/sequence/nest` |
+| `physics` | `create_robot_env`, `gym_*`, `batch_*` |
+| `ecad` | `create_schematic`, `place_components`, `route_nets`, `run_drc`, `run_erc`, `export_gerber`, `calc_impedance` |
+| `eval` | `verify_part`, `list_eval_tasks` (mecheval self-grading oracle) |
+
+Set `VCAD_MCP_PACKS` to a comma-separated list of packs to enable
+(e.g. `VCAD_MCP_PACKS=sheet_metal,dfm`), or `none` for core only.
+Unset, every pack is enabled. A smaller surface costs fewer schema
+tokens per request and measurably improves tool-selection accuracy for
+focused workflows.
+
+## Agent feedback loop
+
+- **Server instructions** — the kernel's type catalog, material preset
+  keys, Z-up orientation rules, and transform semantics are published as
+  MCP server `instructions` (extracted from the kernel registry at boot,
+  so they never drift). Hosts surface them to the agent automatically.
+- **Mutation diffs** — `create`/`update`/`delete`/`set_material` results
+  carry a compact `changed: {added, removed, modified}` part diff, so
+  agents see what a mutation actually did without a follow-up `read`.
+- **Inline viewer** — geometry tools render in an embedded vcad viewport
+  (MCP Apps hosts); `sheet_metal_unfold` draws its flat pattern as a 2D
+  drawing with cut and bend-line layers.
+
 ## Tools
 
-### `create_cad_document`
+Most tools operate on an **editing session**: `open_document` returns a
+`document_id` that mutation and inspection tools take as input. The typical
+loop is open → author (`create_cad_loon`, `create`, `place_part`) → look and
+measure (`render_view`, `inspect_cad`) → fix → `get_document` →
+`export_cad` / `open_in_browser`.
 
-Create a CAD document from structured geometry input.
+### Session lifecycle
 
-**Input:**
-```json
-{
-  "parts": [{
-    "name": "plate",
-    "primitive": { "type": "cube", "size": { "x": 100, "y": 50, "z": 5 } },
-    "operations": [
-      {
-        "type": "difference",
-        "primitive": { "type": "cylinder", "radius": 3, "height": 10 },
-        "at": { "x": 10, "y": 10, "z": 0 }
-      }
-    ]
-  }]
-}
-```
+- `open_document` — open an editing session; pass an `initial` IR document
+  to edit existing geometry or omit it for an empty one. Returns the
+  `document_id` used by every session-aware tool.
+- `get_document` — dump the session's full IR Document JSON, e.g. to feed
+  `export_cad` or `open_in_browser`.
+- `close_document` — close a session and free its memory (idempotent).
 
-**Primitives:**
-- `cube` - Box shape with `size: {x, y, z}`
-- `cylinder` - Cylinder with `radius`, `height`, optional `segments`
-- `sphere` - Sphere with `radius`, optional `segments`
-- `cone` - Cone with `radius_bottom`, `radius_top`, `height`
+### Document editing (kernel CRUD)
 
-**Operations:**
-- `union` - Add geometry
-- `difference` - Subtract geometry
-- `intersection` - Keep only overlapping geometry
-- `translate` - Move with `offset: {x, y, z}`
-- `rotate` - Rotate with `angles: {x, y, z}` in degrees
-- `scale` - Scale with `factor: {x, y, z}`
-- `linear_pattern` - Repeat along `direction` with `count` and `spacing`
-- `circular_pattern` - Repeat around axis with `axis_origin`, `axis_dir`, `count`, `angle_deg`
+`create`, `read`, `update`, `delete`, `set_material` — the kernel's
+registry-driven editing tools, exposed with the exact schemas the in-app
+chat uses (they come from the kernel WASM at boot, so they never drift).
+Each takes a `document_id`. `create` adds a feature by `type` + `params`;
+`read` lists parts or returns one part's feature tree; `update` patches
+node parameters; `delete` removes a part; `set_material` assigns a preset
+material. Use these for surgical edits, `create_cad_loon` for whole parts.
 
-### `export_cad`
+### Loon authoring
 
-Export a CAD document to a file.
+- `create_cad_loon` — create a document in one shot from Loon source, a
+  Lisp-like parametric CAD DSL. This is the *full* modeling vocabulary —
+  primitives, booleans, transforms, fillet/chamfer/shell, linear/circular
+  patterns, sketches with extrude/revolve/sweep/loft, and assemblies with
+  joints — even where no dedicated MCP tool exists. Returns the document
+  (compact VCode or JSON IR) plus a `document_id` for follow-up edits.
 
-**Input:**
-```json
-{
-  "ir": { /* document from create_cad_document */ },
-  "filename": "plate.stl"
-}
-```
+### Parts library
 
-**Supported formats:**
-- `.stl` - Binary STL for 3D printing
-- `.glb` - Binary glTF for visualization
+- `search_parts` — search the stdlib parts library (fasteners, bearings, …)
+  by name, category, synonym, or catalog number (McMaster / ISO / DIN).
+- `place_part` — insert a result into a session document by its `path`,
+  with optional `params` overrides. Placed parts stay parametric.
 
-### `inspect_cad`
+### Geometry I/O
 
-Get geometry properties from a CAD document.
+- `export_cad` — write an IR document (`ir` + `filename`) to `.stl`
+  (3D printing), `.glb` (visualization), or — for sheet-metal documents —
+  `.step`/`.stp` of the folded body with true cylindrical bend faces.
+- `import_step` — import a `.step`/`.stp` file (AP203/AP214, as exported by
+  Fusion 360, SolidWorks, Onshape, …) into an IR document with
+  ImportedMesh nodes.
+- `open_in_browser` — compress a document into a shareable vcad.io URL
+  (very large documents may exceed the ~2KB URL limit).
 
-**Input:**
-```json
-{
-  "ir": { /* document from create_cad_document */ }
-}
-```
+### Inspect & verify
 
-**Output:**
-```json
-{
-  "volume_mm3": 1000,
-  "surface_area_mm2": 600,
-  "bounding_box": {
-    "min": { "x": 0, "y": 0, "z": 0 },
-    "max": { "x": 10, "y": 10, "z": 10 }
-  },
-  "center_of_mass": { "x": 5, "y": 5, "z": 5 },
-  "triangles": 12,
-  "parts": 1
-}
-```
+- `inspect_cad` — aggregate geometry properties for a session document:
+  volume, surface area, bounding box, center of mass, triangle count, and
+  mass when material density is known.
+- `render_view` — render the session document to an isometric PNG
+  (drafting-style line art, Z-up) so the agent can *see* the geometry,
+  not just numbers.
+- `verify_part` / `list_eval_tasks` — grade a session document against a
+  mecheval benchmark task with the official deterministic graders, and
+  browse the available task ids. The benchmark harness excludes these
+  during scored runs.
+
+### DFM (Design for Manufacturing)
+
+- `dfm_check` — run process-specific manufacturability checks
+  (`cnc_3axis`, `fdm`, `sla`, `injection`, `sheet_metal`, `casting_sand`,
+  `casting_investment`) against a session document; thresholds come from
+  TOML rule packs at `lib/dfm/<process>.toml`.
+- `dfm_explain` / `dfm_suggest_fix` / `dfm_apply_fix` — long-form rationale
+  for an issue, a suggested patch, and (for `set_param` patches) applying
+  it to the document. Re-run `dfm_check` to confirm the issue cleared.
+
+### Sheet metal
+
+- `sheet_metal_create` — build a part from a base flange plus a chain of
+  edge flanges, hems, and jogs; supports `shop_profile` catalogs (e.g.
+  `"sendcutsend"`) and bend relief. Returns a `document_id` plus flat-bbox
+  and DFM summary.
+- `sheet_metal_unfold` — flat pattern (outlines, holes, creases) plus a
+  fab-ready single-silhouette DXF with bend centerlines.
+- `sheet_metal_check` / `sheet_metal_suggest_fix` — manufacturability
+  violations against a shop profile, and the concrete parameter changes
+  that resolve them (the create → check → fix → re-check loop).
+- `sheet_metal_materials` / `sheet_metal_bend_table` — the built-in
+  material registry and the K-factor bend table (or a fab catalog via
+  `shop_profile`).
+- `sheet_metal_cost` — line-itemed cost estimate (material, cut, pierces,
+  bends, setup, markup).
+- `sheet_metal_sequence` — a feasible press-brake bend order with
+  springback-compensated angles.
+- `sheet_metal_nest` — pack multiple parts onto stock sheets and report
+  placements and utilization.
+
+### Physics simulation
+
+- `create_robot_env` — build a phyz physics environment from a vcad
+  assembly; returns an environment id.
+- `gym_step` / `gym_reset` / `gym_observe` / `gym_close` — gym-style RL
+  interface: step with `torque`, `position`, or `velocity` actions, read
+  joint positions/velocities and end-effector poses, reset, clean up.
+- `batch_create_envs` / `batch_step` / `batch_reset` — the same loop across
+  N parallel environments for RL training.
+
+### ECAD
+
+- `create_schematic` — schematic from component and wire definitions.
+- `place_components` — board outline, stackup, and footprint placement
+  from schematic data.
+- `route_nets` — copper traces connecting pads on the same net.
+- `run_drc` / `run_erc` — design and electrical rule checks.
+- `export_gerber` — Gerber RS-274X fabrication files, drill file,
+  pick-and-place CSV, and BOM.
+- `calc_impedance` — IPC-2141 trace impedance (microstrip, stripline,
+  differential pairs).
+
+### Other
+
+- `get_changelog` — query the vcad changelog by version, category,
+  feature, or MCP tool.
+- `get_preview_glb` — app-only (`visibility: ["app"]`): fetches the GLB
+  payload for the inline 3D viewer. Hidden from agents on spec-compliant
+  hosts; use `export_cad` for geometry exports.
 
 ## Example Usage
 
@@ -102,9 +183,10 @@ In Claude Code or another MCP-compatible assistant:
 > "Create a 50x30x5mm plate with four 3mm mounting holes at the corners, spaced 5mm from each edge. Export to mounting_plate.stl"
 
 The assistant will:
-1. Use `create_cad_document` to build the geometry
-2. Use `inspect_cad` to verify dimensions
-3. Use `export_cad` to write the STL file
+1. Use `create_cad_loon` to build the geometry (or `open_document` +
+   `create` for incremental edits)
+2. Use `render_view` and `inspect_cad` to verify shape and dimensions
+3. Use `get_document` + `export_cad` to write the STL file
 
 ## Development
 


### PR DESCRIPTION
## Summary

Completely rewrote the MCP README to document the full tool surface, organized by feature area and workflow. Replaced the minimal `create_cad_document` / `export_cad` / `inspect_cad` examples with comprehensive coverage of all 50+ tools, including session lifecycle, Loon authoring, parts library, DFM, sheet metal, physics simulation, ECAD, and evaluation.

## Key Changes

- **Tool packs system:** Documented `VCAD_MCP_PACKS` environment variable for opt-out domain packs (`dfm`, `sheet_metal`, `physics`, `ecad`, `eval`) to reduce schema tokens and improve tool-selection accuracy.

- **Agent feedback loop:** Added section on server instructions (type catalog, material presets, Z-up rules), mutation diffs (compact `changed` part diffs), and inline viewer support (embedded vcad viewport, flat-pattern DXF for sheet metal).

- **Session lifecycle:** Documented `open_document`, `get_document`, `close_document` as the foundation for all stateful editing.

- **Kernel CRUD tools:** Explained `create`, `read`, `update`, `delete`, `set_material` as registry-driven editing with schemas from the kernel WASM.

- **Loon authoring:** Highlighted `create_cad_loon` as the full modeling vocabulary (primitives, booleans, transforms, fillet/chamfer/shell, patterns, sketches, assemblies).

- **Parts library:** Added `search_parts` and `place_part` for stdlib fasteners and bearings.

- **Geometry I/O:** Documented `export_cad` (STL, GLB, STEP for sheet metal), `import_step` (AP203/AP214), `open_in_browser` (shareable URLs).

- **Inspect & verify:** Expanded `inspect_cad` and `render_view` descriptions; added `verify_part` / `list_eval_tasks` for mecheval grading.

- **DFM, sheet metal, physics, ECAD:** Added full tool tables for each domain pack with brief descriptions of each tool's purpose.

- **Example usage:** Updated to reflect modern session-based workflow (`open_document` → `create_cad_loon` or incremental `create` → `render_view` + `inspect_cad` → `get_document` + `export_cad`).

## Implementation Details

- Organized tools into logical sections: Session lifecycle, Document editing, Loon authoring, Parts library, Geometry I/O, Inspect & verify, DFM, Sheet metal, Physics, ECAD, Other.
- Each section includes tool names, brief descriptions, and key parameters/outputs where relevant.
- Emphasized the compact `changed` diff in mutation results to avoid follow-up reads.
- Clarified that server instructions are extracted from the kernel registry at boot and published as MCP `instructions`.
- Noted that `get_preview_glb` is app-only (`visibility: ["app"]`) and hidden from spec-compliant hosts.

https://claude.ai/code/session_01CYso2dpq1E8h8j4Amoan8q