### PR TITLE
MCP viewer: click-to-select parts — "make this taller" resolves via ui/update-model-context

### DIFF
--- a/changelog/entries/2026-06-11-mcp-viewer-pointing.json
+++ b/changelog/entries/2026-06-11-mcp-viewer-pointing.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-11-mcp-viewer-pointing",
+  "version": "0.9.4",
+  "date": "2026-06-11",
+  "category": "feat",
+  "title": "Click-to-select parts in the MCP viewer — \"make this taller\"",
+  "summary": "Select a part in the inline viewer and the agent knows what \"this\" means via ui/update-model-context; an Ask button sends part-grounded messages into the chat via ui/message.",
+  "features": ["mcp", "viewer", "agents", "selection"],
+  "mcpTools": ["get_preview_glb"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -47,6 +47,14 @@ focused workflows.
 - **Inline viewer** — geometry tools render in an embedded vcad viewport
   (MCP Apps hosts); `sheet_metal_unfold` draws its flat pattern as a 2D
   drawing with cut and bend-line layers.
+- **Pointing** — click a part in the viewer to select it (brand-pink
+  highlight + a chip with name, id, and bbox). Selection is pushed
+  silently via `ui/update-model-context`, so typing "make this 5 mm
+  taller" in the chat resolves to the selected part; the chip's **Ask**
+  button sends a part-grounded `ui/message` into the conversation. Both
+  are capability-gated via `getHostCapabilities()` and degrade to a
+  local inspector on hosts without them. GLB nodes carry
+  `"<part_id>:<name>"` names (`buildPartLabels`) to make the mapping.
 
 ## Tools
 

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1443,3 +1443,27 @@ describe("tool packs (VCAD_MCP_PACKS)", () => {
     expect(disabled.has("run_drc")).toBe(true);
   });
 });
+
+describe("GLB part-identity node names", () => {
+  it("names glTF nodes <part_id>:<name> for the viewer's click-to-select", async () => {
+    const { generateGlbPreview } = await import("../tools/preview.js");
+    const engine = await Engine.init();
+    const b64 = generateGlbPreview(makeCubeDoc(), engine);
+    expect(b64).toBeTruthy();
+    const glb = Buffer.from(b64!, "base64");
+    expect(glb.subarray(0, 4).toString()).toBe("glTF");
+    const jsonLen = glb.readUInt32LE(12);
+    const json = JSON.parse(glb.subarray(20, 20 + jsonLen).toString());
+    expect(json.nodes[0].name).toBe("1:test_cube");
+  });
+
+  it("buildPartLabels skips hidden roots to stay aligned with scene.parts", async () => {
+    const { buildPartLabels } = await import("../export/glb.js");
+    const doc = makeCubeDoc();
+    doc.nodes["2"] = { id: 2, name: "hidden_cube", op: { type: "Cube", size: { x: 5, y: 5, z: 5 } } };
+    doc.roots.push({ root: 2, material: "default", visible: false });
+    doc.nodes["3"] = { id: 3, name: null, op: { type: "Cube", size: { x: 2, y: 2, z: 2 } } };
+    doc.roots.push({ root: 3, material: "default" });
+    expect(buildPartLabels(doc)).toEqual(["1:test_cube", "3:"]);
+  });
+});

--- a/packages/mcp/src/export/glb.ts
+++ b/packages/mcp/src/export/glb.ts
@@ -5,6 +5,23 @@
  */
 
 import type { EvaluatedScene, TriangleMesh } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+
+/**
+ * Build `"<part_id>:<name>"` labels for every visible root, index-aligned
+ * with `EvaluatedScene.parts` (the evaluator maps visible roots 1:1 onto
+ * parts, padding failures with empty meshes — so the alignment holds even
+ * when a root fails to evaluate). The viewer parses these node names back
+ * into part identity for click-to-select.
+ */
+export function buildPartLabels(doc: Document): string[] {
+  return doc.roots
+    .filter((entry) => entry.visible !== false)
+    .map((entry) => {
+      const name = doc.nodes[String(entry.root)]?.name;
+      return `${entry.root}:${name ?? ""}`;
+    });
+}
 
 /** Default material for parts without material assignment. */
 const DEFAULT_MATERIAL = {
@@ -14,8 +31,17 @@ const DEFAULT_MATERIAL = {
   roughness: 0.5,
 };
 
-/** Convert evaluated scene to binary GLB bytes. */
-export function toGlbBytes(scene: EvaluatedScene, name: string): Uint8Array {
+/** Convert evaluated scene to binary GLB bytes.
+ *
+ * `partLabels` (index-aligned with `scene.parts`) become glTF node names —
+ * the viewer parses them back into part identity for click-to-select, so
+ * they follow the `"<part_id>:<name>"` convention from
+ * {@link buildPartLabels}. Omitted entries fall back to `part_<idx>`. */
+export function toGlbBytes(
+  scene: EvaluatedScene,
+  name: string,
+  partLabels?: string[],
+): Uint8Array {
   // Collect unique materials
   const materialMap = new Map<string, number>();
   const materials: Array<{
@@ -148,10 +174,10 @@ export function toGlbBytes(scene: EvaluatedScene, name: string): Uint8Array {
       ],
     });
 
-    // Node
+    // Node — named with part identity when the caller provides it.
     nodes.push({
       mesh: meshIdx,
-      name: `part_${meshIdx}`,
+      name: partLabels?.[meshIdx] ?? `part_${meshIdx}`,
     });
   }
 

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -7,7 +7,7 @@
 
 import type { Document } from "@vcad/ir";
 import type { Engine } from "@vcad/engine";
-import { toGlbBytes } from "../export/glb.js";
+import { buildPartLabels, toGlbBytes } from "../export/glb.js";
 
 /**
  * Generate a base64-encoded GLB preview from an IR document.
@@ -21,7 +21,9 @@ export function generateGlbPreview(
     const scene = engine.evaluate(doc);
     if (!scene || scene.parts.length === 0) return null;
 
-    const glbBytes = toGlbBytes(scene, "preview");
+    // Part-identity node names let the viewer map a click back to a
+    // part_id for selection context and "ask about this part".
+    const glbBytes = toGlbBytes(scene, "preview", buildPartLabels(doc));
     return uint8ArrayToBase64(glbBytes);
   } catch {
     // Evaluation failures should not break tool responses

--- a/packages/mcp/viewer-app/index.html
+++ b/packages/mcp/viewer-app/index.html
@@ -135,6 +135,55 @@
   @keyframes pulse { 50% { opacity: 0.35; } }
   #ticker { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   #stats { flex: none; color: var(--text-tert); white-space: nowrap; }
+
+  /* ── Selection chip ────────────────────────────────────────── */
+  #sel-chip {
+    flex: none; display: none; align-items: center; gap: 6px;
+    height: 18px; padding: 0 4px 0 8px;
+    background: color-mix(in srgb, var(--brand) 12%, transparent);
+    border: var(--hairline) solid color-mix(in srgb, var(--brand) 45%, transparent);
+    border-radius: 999px;
+    color: var(--text-2);
+    white-space: nowrap;
+    max-width: 45%;
+  }
+  #sel-chip.visible { display: inline-flex; }
+  #sel-label { overflow: hidden; text-overflow: ellipsis; }
+  #sel-label b { color: var(--text); font-weight: 600; }
+  .chip-btn {
+    flex: none; display: inline-flex; align-items: center; justify-content: center;
+    height: 14px; padding: 0 5px;
+    background: transparent; border: none; border-radius: 999px;
+    font: 500 10px var(--font-ui);
+    color: var(--text-muted); cursor: pointer;
+  }
+  .chip-btn:hover { color: var(--text); background: color-mix(in srgb, var(--brand) 25%, transparent); }
+  #ask-btn { color: var(--brand); display: none; }
+  #ask-btn.visible { display: inline-flex; }
+  #ask-btn:hover { color: #fff; background: var(--brand); }
+
+  /* ── Ask bar (sendMessage composer) ────────────────────────── */
+  #ask-bar {
+    position: absolute; left: 10px; right: 10px; bottom: 10px;
+    display: none; align-items: center; gap: 6px;
+    height: 32px; padding: 0 4px 0 10px;
+    background: var(--surface);
+    border: var(--hairline) solid var(--border);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  }
+  #ask-bar.visible { display: flex; }
+  #ask-prefix {
+    flex: none; font: 11px var(--font-mono); color: var(--brand);
+    max-width: 35%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  #ask-input {
+    flex: 1; height: 100%; min-width: 0;
+    background: transparent; border: none; outline: none;
+    font: 12px var(--font-ui); color: var(--text);
+  }
+  #ask-input::placeholder { color: var(--text-tert); }
+  #ask-send { display: inline-flex; }
 </style>
 </head>
 <body>
@@ -151,10 +200,20 @@
       <div id="error"></div>
     </div>
     <div id="vignette"></div>
+    <div id="ask-bar">
+      <span id="ask-prefix"></span>
+      <input id="ask-input" type="text" placeholder="ask about this part…" />
+      <button id="ask-send" class="btn btn-brand">Send</button>
+    </div>
   </div>
   <div id="statusbar">
     <span id="pulse"></span>
     <span id="ticker">connecting to host…</span>
+    <span id="sel-chip">
+      <span id="sel-label"></span>
+      <button id="ask-btn" class="chip-btn" title="Send a message about this part">Ask</button>
+      <button id="sel-clear" class="chip-btn" title="Clear selection (Esc)">✕</button>
+    </span>
     <span id="stats"></span>
   </div>
 </div>

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -31,6 +31,18 @@ const statsEl = document.getElementById("stats")!;
 const pulseEl = document.getElementById("pulse")!;
 const openBtn = document.getElementById("open-btn") as HTMLButtonElement;
 const fullscreenBtn = document.getElementById("fullscreen-btn") as HTMLButtonElement;
+const selChipEl = document.getElementById("sel-chip")!;
+const selLabelEl = document.getElementById("sel-label")!;
+const selClearBtn = document.getElementById("sel-clear") as HTMLButtonElement;
+const askBtn = document.getElementById("ask-btn") as HTMLButtonElement;
+const askBarEl = document.getElementById("ask-bar")!;
+const askPrefixEl = document.getElementById("ask-prefix")!;
+const askInput = document.getElementById("ask-input") as HTMLInputElement;
+const askSendBtn = document.getElementById("ask-send") as HTMLButtonElement;
+
+// Hostless dev harness (`#dev*`): selection affordances stay active but
+// protocol calls are logged instead of sent.
+const devMode = location.hash.startsWith("#dev");
 
 type PulseState = "idle" | "busy" | "ready" | "error";
 
@@ -335,6 +347,9 @@ function updateStats(model: THREE.Object3D, size: THREE.Vector3): void {
 
 function clearModel(): void {
   if (!currentModel) return;
+  // Restore selection highlights before disposal so we never dispose a
+  // clone while the original is detached.
+  select(null);
   modelGroup.remove(currentModel);
   currentModel.traverse((child) => {
     const mesh = child as THREE.Mesh;
@@ -403,6 +418,228 @@ function loadGlb(base64Data: string): void {
     },
   );
 }
+
+// ── Part selection — pointing for CAD ────────────────────────
+// GLB nodes are named "<part_id>:<name>" by the server (buildPartLabels),
+// so a raycast hit maps back to real part identity. Selection drives:
+//  1. a local inspector chip (name, id, dims) — works on every host
+//  2. ui/update-model-context — silent deixis, so "make this taller"
+//     typed in the host chat resolves to the selected part
+//  3. an "Ask" composer that sends a part-grounded ui/message
+// Both protocol calls are capability-gated via getHostCapabilities().
+
+interface SelectedPart {
+  partId: string;
+  name: string;
+  object: THREE.Object3D;
+}
+
+let selected: SelectedPart | null = null;
+let lastPushedContext = "";
+const SELECT_EMISSIVE = 0xf92672; // --brand
+
+/** Walk up from a raycast hit to the nearest part-labeled ancestor. */
+function partInfoFor(object: THREE.Object3D): SelectedPart | null {
+  let o: THREE.Object3D | null = object;
+  while (o) {
+    const m = /^(\d+):(.*)$/.exec(o.name);
+    if (m) {
+      return { partId: m[1], name: m[2] || `part ${m[1]}`, object: o };
+    }
+    o = o.parent;
+  }
+  return null;
+}
+
+/** Brand-pink emissive highlight. Materials are cloned per-mesh on
+ *  select (GLB materials are shared between same-material parts) and
+ *  restored + disposed on deselect. */
+function setHighlight(root: THREE.Object3D, on: boolean): void {
+  root.traverse((child) => {
+    const mesh = child as THREE.Mesh;
+    if (!mesh.isMesh) return;
+    if (on) {
+      const orig = mesh.material as THREE.MeshStandardMaterial;
+      if (!orig?.clone) return;
+      const highlighted = orig.clone();
+      highlighted.emissive = new THREE.Color(SELECT_EMISSIVE);
+      highlighted.emissiveIntensity = 0.28;
+      mesh.userData.origMaterial = orig;
+      mesh.material = highlighted;
+    } else if (mesh.userData.origMaterial) {
+      (mesh.material as THREE.Material).dispose();
+      mesh.material = mesh.userData.origMaterial as THREE.Material;
+      delete mesh.userData.origMaterial;
+    }
+  });
+}
+
+/** Selected part's bbox in kernel Z-up mm (world Y-up → kernel swap). */
+function selectedDims(): { x: number; y: number; z: number } | null {
+  if (!selected) return null;
+  const size = new THREE.Box3().setFromObject(selected.object).getSize(new THREE.Vector3());
+  return { x: size.x, y: size.z, z: size.y };
+}
+
+function select(info: SelectedPart | null): void {
+  if (selected?.object === info?.object) return;
+  if (selected) setHighlight(selected.object, false);
+  selected = info;
+  if (selected) {
+    setHighlight(selected.object, true);
+    const d = selectedDims();
+    const dims = d ? ` · ${formatDim(d.x)} × ${formatDim(d.y)} × ${formatDim(d.z)}` : "";
+    selLabelEl.innerHTML = "";
+    const b = document.createElement("b");
+    b.textContent = selected.name;
+    selLabelEl.append(b, ` #${selected.partId}${dims}`);
+    selChipEl.classList.add("visible");
+  } else {
+    selChipEl.classList.remove("visible");
+    askBarEl.classList.remove("visible");
+  }
+  void pushSelectionContext();
+}
+
+/** Silent ui/update-model-context push: the host delivers the latest
+ *  snapshot alongside the user's next chat message, so bare "this"
+ *  references resolve to the selected part. Overwrite semantics mean
+ *  deselection must push too (clears the stale pointer). */
+async function pushSelectionContext(): Promise<void> {
+  const d = selectedDims();
+  const payload = {
+    document_id: lastDocumentId,
+    viewer_selection: selected
+      ? {
+          part_id: selected.partId,
+          name: selected.name,
+          bbox_mm: d ? { x: +d.x.toFixed(2), y: +d.y.toFixed(2), z: +d.z.toFixed(2) } : undefined,
+        }
+      : null,
+  };
+  const serialized = JSON.stringify(payload);
+  if (serialized === lastPushedContext) return;
+  lastPushedContext = serialized;
+
+  const sentence = selected
+    ? `The user has selected part "${selected.name}" (part_id ${selected.partId})` +
+      `${lastDocumentId ? ` of document ${lastDocumentId}` : ""} in the vcad 3D viewer` +
+      `${d ? `; its bounding box is ${formatDim(d.x)} × ${formatDim(d.y)} × ${formatDim(d.z)} mm` : ""}. ` +
+      `Unqualified references like "this part" mean this selection.`
+    : "The user has cleared the part selection in the vcad 3D viewer.";
+
+  if (devMode) {
+    console.log("[vcad-viewer:dev] updateModelContext:", payload, sentence);
+    return;
+  }
+  const caps = app.getHostCapabilities();
+  if (!caps?.updateModelContext) return;
+  try {
+    await app.updateModelContext({
+      content: [{ type: "text", text: sentence }],
+      ...(caps.updateModelContext.structuredContent
+        ? { structuredContent: payload }
+        : {}),
+    });
+  } catch (e) {
+    console.warn("[vcad-viewer] updateModelContext failed:", e);
+  }
+}
+
+/** Show capability-gated affordances. Called after connect (and in dev). */
+function updateAffordances(): void {
+  const caps = devMode ? null : app.getHostCapabilities();
+  askBtn.classList.toggle("visible", devMode || Boolean(caps?.message));
+}
+
+// Click-to-pick: distinguish a click from an orbit via pointer travel.
+const raycaster = new THREE.Raycaster();
+const pointerNdc = new THREE.Vector2();
+let pointerDown: { x: number; y: number } | null = null;
+
+renderer.domElement.addEventListener("pointerdown", (e) => {
+  if (e.button === 0) pointerDown = { x: e.clientX, y: e.clientY };
+});
+
+renderer.domElement.addEventListener("pointerup", (e) => {
+  if (!pointerDown || e.button !== 0) return;
+  const travel = Math.hypot(e.clientX - pointerDown.x, e.clientY - pointerDown.y);
+  pointerDown = null;
+  if (travel > 5) return; // it was an orbit, not a click
+
+  const rect = renderer.domElement.getBoundingClientRect();
+  pointerNdc.set(
+    ((e.clientX - rect.left) / rect.width) * 2 - 1,
+    -((e.clientY - rect.top) / rect.height) * 2 + 1,
+  );
+  raycaster.setFromCamera(pointerNdc, camera);
+  for (const hit of raycaster.intersectObject(modelGroup, true)) {
+    const info = partInfoFor(hit.object);
+    if (info) {
+      select(info);
+      return;
+    }
+  }
+  select(null);
+});
+
+window.addEventListener("keydown", (e) => {
+  if (e.key !== "Escape") return;
+  if (askBarEl.classList.contains("visible")) {
+    askBarEl.classList.remove("visible");
+  } else {
+    select(null);
+  }
+});
+
+selClearBtn.addEventListener("click", () => select(null));
+
+// ── Ask composer — part-grounded ui/message ──────────────────
+askBtn.addEventListener("click", () => {
+  if (!selected) return;
+  askPrefixEl.textContent = `${selected.name} ▸`;
+  askBarEl.classList.add("visible");
+  askInput.focus();
+});
+
+async function sendAsk(): Promise<void> {
+  if (!selected) return;
+  const text = askInput.value.trim();
+  if (!text) return;
+  const grounded =
+    `About part "${selected.name}" (part_id ${selected.partId}` +
+    `${lastDocumentId ? `, document ${lastDocumentId}` : ""}) in the vcad viewer: ${text}`;
+  askSendBtn.disabled = true;
+  try {
+    if (devMode) {
+      console.log("[vcad-viewer:dev] sendMessage:", grounded);
+    } else {
+      const result = await app.sendMessage({
+        role: "user",
+        content: [{ type: "text", text: grounded }],
+      });
+      if (result.isError) {
+        setTicker("host declined the message", "error");
+        return;
+      }
+    }
+    askInput.value = "";
+    askBarEl.classList.remove("visible");
+    setTicker("sent to chat", "ready");
+  } catch (e) {
+    console.warn("[vcad-viewer] sendMessage failed:", e);
+    setTicker("message failed", "error");
+  } finally {
+    askSendBtn.disabled = false;
+  }
+}
+
+askSendBtn.addEventListener("click", () => void sendAsk());
+askInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") void sendAsk();
+  if (e.key === "Escape") askBarEl.classList.remove("visible");
+  e.stopPropagation(); // keep Escape-in-input from also clearing the selection
+});
 
 // ── Flat pattern rendering (sheet_metal_unfold) ──────────────
 // Drafting-table view: the cut silhouette and dashed bend centerlines
@@ -727,13 +964,18 @@ if (location.hash.startsWith("#dev")) {
     const steel = new THREE.MeshStandardMaterial({ color: 0x9da3ab, metalness: 0.9, roughness: 0.35 });
     const plastic = new THREE.MeshStandardMaterial({ color: 0xf92672, metalness: 0.0, roughness: 0.55 });
     // Kernel space is Z-up: flange disc + boss along Z, pink cap on top.
+    // Names follow the server's "<part_id>:<name>" GLB convention so
+    // click-to-select can be exercised hostless.
     const flange = new THREE.Mesh(new THREE.CylinderGeometry(30, 30, 8, 64), steel);
+    flange.name = "1:Flange";
     flange.rotation.x = Math.PI / 2;
     flange.position.z = 4;
     const boss = new THREE.Mesh(new THREE.CylinderGeometry(12, 12, 30, 48), steel);
+    boss.name = "2:Boss";
     boss.rotation.x = Math.PI / 2;
     boss.position.z = 23;
     const cap = new THREE.Mesh(new THREE.CylinderGeometry(13, 13, 4, 48), plastic);
+    cap.name = "3:Cap";
     cap.rotation.x = Math.PI / 2;
     cap.position.z = 40;
     sample.add(flange, boss, cap);
@@ -760,14 +1002,21 @@ if (location.hash.startsWith("#dev")) {
   }
   openBtn.style.display = "inline-flex";
   fullscreenBtn.style.display = "inline-flex";
+  lastDocumentId = "doc_dev";
+  updateAffordances();
   // Debug handle for poking the scene from the console.
   (window as unknown as Record<string, unknown>).__vcad = {
     scene, camera, controls, grid, gridUniforms, contactShadow, renderer,
+    select, partInfoFor, modelGroup,
   };
 } else {
   // ── Connect (handlers are all registered above) ────────────
   setStatus("waiting for model…");
   await app.connect();
   applyHostContext(app.getHostContext());
-  console.log("[vcad-viewer] connected to host");
+  updateAffordances();
+  console.log(
+    "[vcad-viewer] connected to host; capabilities:",
+    JSON.stringify(app.getHostCapabilities() ?? {}),
+  );
 }


### PR DESCRIPTION
## What

Closes the human side of the co-editing loop: **pointing**. Click a part in the inline MCP Apps viewer and the agent knows what "this" means.

### How it works

- **Part identity in the GLB** — `get_preview_glb` now names glTF nodes `"<part_id>:<name>"` (`buildPartLabels`, index-aligned with `scene.parts` — the evaluator pads failed roots with empty meshes, so alignment holds). A raycast hit walks up to the nearest labeled ancestor.
- **Selection** — brand-pink emissive highlight (materials are cloned per mesh since GLB shares materials across same-material parts, restored + disposed on deselect) and a status-bar chip: `Boss #2 · 24.0 × 24.0 × 30.0` with Ask / clear.
- **Silent deixis via `ui/update-model-context`** — every selection change pushes a sentence + `structuredContent` snapshot (`{document_id, viewer_selection: {part_id, name, bbox_mm}}`). The host delivers the latest snapshot with the user's next chat message, so *"make this 5mm taller"* typed in the normal chat box resolves to the selected part. Deselection pushes a cleared pointer; identical payloads dedupe (overwrite semantics).
- **`ui/message` Ask composer** — the chip's Ask button opens an inline composer; sending produces a part-grounded `user`-role message: `About part "Boss" (part_id 2, document doc_…) in the vcad viewer: make this 5mm taller`.
- **Capability-gated** — both calls check `getHostCapabilities()` (`updateModelContext` / `message` with per-modality granularity). Hosts without them keep a useful local inspector chip; the Ask button hides. `#dev` harness logs protocol calls instead of sending.

### Verification

- 58 tests pass (2 new: end-to-end GLB node naming through `generateGlbPreview`, hidden-root label alignment)
- Hostless dev-harness run: synthetic pointer events on the Boss → chip + highlight verified by screenshot; console shows the exact `updateModelContext` and `sendMessage` payloads; empty-space click clears chip + pushes cleared context; Esc closes/clears; orbit-vs-click discrimination via 5px pointer travel

🤖 Generated with [Claude Code](https://claude.com/claude-code)