### PR TITLE
ci: type-check @vcad/mcp in CI without breaking Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,16 @@ jobs:
       - run: npm run build -- --filter=!@vcad/docs
         env:
           VCAD_WASM_SKIP: '1'
+      # @vcad/mcp builds with `tsc --noCheck` (Vercel SDK-subpath compat,
+      # commit 2ae3b0cb), so its `build` task does NOT type-check — a real
+      # type error in packages/mcp/src would otherwise merge undetected.
+      # The `typecheck` task runs `tsc --noEmit` for every package that
+      # defines it (mcp + auth). mcp's script first regenerates its gitignored
+      # viewer module via build:viewer; upstream `dist` is reused from the
+      # build step above via `^build`.
+      - run: npm run typecheck
+        env:
+          VCAD_WASM_SKIP: '1'
       - run: npm test --workspaces --if-present
 
   # Dependency CVE gate. Informational for now so an unpatched upstream

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "postinstall": "node scripts/build-changelog.mjs",
     "build": "turbo build",
     "test": "turbo test",
+    "typecheck": "turbo typecheck",
     "dev": "turbo dev",
     "build:mecheval": "npm run build -w @mecheval/harness && npm run build -w @mecheval/leaderboard",
     "changelog:build": "node scripts/build-changelog.mjs",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "build:viewer": "vite build --config vite.viewer.config.ts && node scripts/wrap-viewer.mjs",
     "build": "npm run build:viewer && tsc --noCheck",
+    "typecheck": "npm run build:viewer && tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,10 @@
       "dependsOn": ["build"],
       "inputs": ["src/**", "**/*.test.ts"]
     },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "package.json", "tsconfig.json"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## What

Adds a dedicated `typecheck` task so CI type-checks `@vcad/mcp`, closing a blind spot where a real type error in `packages/mcp/src` could merge undetected.

## Why

`@vcad/mcp` builds with `tsc --noCheck` ([2ae3b0cb](https://github.com/ecto/vcad/commit/2ae3b0cb) — the MCP SDK subpath exports don't resolve under Vercel's `tsc`). That commit's message claimed *"types still checked in IDE/CI"*, but that was **false**: CI's TypeScript job runs `turbo build`, which runs each package's own build script — so mcp's build never type-checked. A genuinely broken `packages/mcp/src` could merge and ship a crash-on-boot dist.

mcp is the **only** workspace package whose build skips type-checking — every other TS package already type-checks via its plain `tsc` build. So this targets mcp specifically rather than reworking the whole build.

## What changed (4 files)

- **`turbo.json`** — new `typecheck` task (`dependsOn: ["^build"]` for upstream `.d.ts`).
- **`package.json`** — root `typecheck` script → `turbo typecheck`.
- **`packages/mcp/package.json`** — `typecheck` → `npm run build:viewer && tsc --noEmit`.
- **`.github/workflows/ci.yml`** — run `npm run typecheck` after the build step in the TypeScript job.

The mcp `build` script (`tsc --noCheck`) is **untouched**, so the Vercel build path is unaffected.

## Reviewer notes

- **Why `build:viewer` in the typecheck script?** `src/viewer.ts` imports `./viewer-html.generated.js`, a **gitignored** file (`src/viewer-html.generated.ts`) produced by `build:viewer`. It lives in `src/`, not the build `outputs` glob, so turbo's cache can't restore it — a bare `tsc --noEmit` fails `TS2307` on a clean checkout. Regenerating it first makes the gate robust to fresh trees and cache hits.
- **`@vcad/auth`** already had a dormant `typecheck` script that was never wired into CI; it's now enforced too (it passes clean).

## Verification

- ✅ Positive (cold): deleted the generated viewer module, ran `npm run typecheck --force` → regenerated + **9/9 tasks green**; plain `npm run typecheck` → exit 0.
- ✅ Negative: injected `const x: number = "..."` into `src/index.ts` → **exit 2**, `TS2322`, `Failed: @vcad/mcp#typecheck` → reverted clean.
- CI flow (`build` → `typecheck`) is strictly easier than the cold case above, so CI passes on green code and fails on type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)