### PR TITLE
fix(mcp): report real version in hosted server_info, not 0.0.0

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -155,11 +155,23 @@ import {
 /** Tools that produce or modify geometry and should show the 3D viewer.
  *  Registry-driven kernel tools (create, update, delete, …) are added
  *  dynamically in `createServer` once their names are known. */
+/** Build-time injected version. esbuild's `--define:__VCAD_VERSION__` (see
+ *  services/mcp/build.sh) replaces this with the package.json version literal
+ *  when bundling the hosted server, where the flattened layout breaks the
+ *  source-relative `../package.json` require below. Undefined in the normal
+ *  tsc `dist/` build — `typeof` guards against the ReferenceError. */
+declare const __VCAD_VERSION__: string | undefined;
+
 /** Server version + build identity, read from package.json at load time so the
  *  advertised version always matches the running build (no hardcoded literal to
  *  drift). VCAD_BUILD_SHA, if injected at build/deploy time, fingerprints the
  *  exact commit so a stale deploy is detectable via `server_info`. */
 const PKG_VERSION: string = (() => {
+  // Bundled hosted build: the version is baked in via esbuild define, since the
+  // require path below resolves to a nonexistent sibling of the single bundle.
+  if (typeof __VCAD_VERSION__ === "string" && __VCAD_VERSION__) {
+    return __VCAD_VERSION__;
+  }
   try {
     const req = createRequire(import.meta.url);
     return (req("../package.json") as { version?: string }).version ?? "0.0.0";

--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -32,12 +32,20 @@ echo "[vcad-mcp] Bundling with esbuild..."
 # "node:module"` that bundled sources (server.ts, wasm/ecad-diff.ts) emit —
 # two unaliased `createRequire` bindings would throw
 # `SyntaxError: Identifier 'createRequire' has already been declared` at load.
+#
+# __VCAD_VERSION__ is baked in from @vcad/mcp's package.json: the bundle flattens
+# server.ts away from its sibling package.json, so its source-relative require
+# resolves to nothing and server_info would otherwise report 0.0.0.
+MCP_VERSION="$(node -p "require('$REPO_ROOT/packages/mcp/package.json').version")"
+echo "[vcad-mcp] Baking version $MCP_VERSION into bundle"
+
 npx esbuild@latest entry.ts \
   --bundle \
   --platform=node \
   --target=node20 \
   --format=esm \
   --external:@resvg/resvg-js \
+  --define:__VCAD_VERSION__="\"$MCP_VERSION\"" \
   --outfile="$OUT/functions/mcp.func/index.mjs" \
   --banner:js="import { createRequire as __vcadCreateRequire } from 'module'; const require = __vcadCreateRequire(import.meta.url);"
 


### PR DESCRIPTION
## What

`server_info` on the hosted MCP server reported `version: 0.0.0` instead of the real package version.

## Why

The hosted server (`services/mcp/build.sh`) bundles everything into a single `mcp.func/index.mjs` via esbuild. At runtime `PKG_VERSION` in `server.ts` did `createRequire(import.meta.url)` → `require("../package.json")`. In the flattened bundle `import.meta.url` is `.../mcp.func/index.mjs`, so `../package.json` resolves to a path that doesn't exist and the `catch` fell back to `"0.0.0"`.

The normal `dist/` build (stdio / dev / desktop) was never affected — there `dist/server.js`'s `../package.json` is a real sibling — so this only ever surfaced on the hosted deploy.

## How

Bake the version in at bundle time rather than reading it from disk:

- **`services/mcp/build.sh`** — reads `@vcad/mcp`'s `package.json` version with `node -p` and passes `--define:__VCAD_VERSION__="\"$MCP_VERSION\""` to esbuild. Not a hardcoded literal — it tracks `package.json`.
- **`packages/mcp/src/server.ts`** — `PKG_VERSION` prefers the injected `__VCAD_VERSION__`, guarded by `typeof` so the undefined-at-runtime case in the normal `dist/` build (no define) safely falls through to the existing `require("../package.json")` path. Behavior there is unchanged.

## Verification

Reproduced the exact bundle + define with the real esbuild and identical bash quoting:
- **With define** → reports `0.9.4`; esbuild constant-folds the guard to `if ("0.9.4")`.
- **Without define** → `typeof` yields `"undefined"` (no `ReferenceError`), falls through to the require path.

## Notes for reviewers

- Takes effect on the next hosted deploy (rerun `services/mcp/build.sh`); the currently-live server keeps reporting `0.0.0` until redeployed.
- No changelog entry — this is deploy/bundler infra, not a product behavior change (per CLAUDE.md changelog policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)