### PR TITLE
feat(mcp): PCB floorplan, copper pours, design rules & ampacity tools

### DIFF
--- a/changelog/entries/2026-06-15-pcb-floorplan-pour-rules-tools.json
+++ b/changelog/entries/2026-06-15-pcb-floorplan-pour-rules-tools.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-pcb-floorplan-pour-rules-tools",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "feat",
+  "title": "PCB floorplan, copper pours, rules & ampacity MCP tools",
+  "summary": "Five new ECAD tools: set_placement (explicit per-component floorplan), add_zone (ground/power-plane copper pours), set_design_rules (configurable DRC + net classes), size_trace_for_current (IPC-2221 ampacity), and add_via_array (thermal/stitching via grids).",
+  "features": ["mcp", "pcb", "ecad"],
+  "mcpTools": ["set_placement", "add_zone", "set_design_rules", "size_trace_for_current", "add_via_array"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -20,6 +20,11 @@ import {
   addTrace,
   addVia,
   setStackup,
+  setPlacement,
+  addZone,
+  setDesignRules,
+  sizeTraceForCurrent,
+  addViaArray,
   addMotorWinding,
   aggregateDrc,
   parseNetPair,
@@ -1607,5 +1612,268 @@ describe("ecad pipeline behaviors (session flow)", () => {
     expect(pcbNodes).toHaveLength(1);
     const w = Math.max(...getPcbBoard(doc).outline.vertices.map((v) => v.x));
     expect(w).toBe(50);
+  });
+});
+
+// A board with two placed resistors (refs R1, R2) on a 50×50 outline.
+async function boardWithTwoResistors(): Promise<string> {
+  const created = out(
+    await createSchematic({
+      components: [resistor("R1", 0), resistor("R2", 20)],
+      nets: { MID: ["R1.2", "R2.1"] },
+    }),
+  );
+  const id = created.document_id as string;
+  out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+  return id;
+}
+
+/** True when a tool returned an error result (text isn't JSON — don't out() it). */
+const isErr = (r: unknown): boolean => (r as { isError?: boolean }).isError === true;
+
+describe("set_placement", () => {
+  it("places by ref with rotation + side and reports counts", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await setPlacement({
+        document_id: id,
+        placements: [
+          { ref: "R1", x: 10, y: 12, rotation: 90, side: "bottom" },
+          { ref: "R2", x: 30, y: 30 },
+        ],
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.moved).toBe(2);
+    expect(res.rotated).toBe(1);
+    expect(res.flipped).toBe(1);
+
+    const fp = (ref: string) => getPcbBoard(getSession(id)).footprints.find((f) => f.ref === ref)!;
+    expect(fp("R1").position).toEqual({ x: 10, y: 12 });
+    expect(fp("R1").rotation).toBe(90);
+    expect(fp("R1").front).toBe(false);
+    expect(fp("R2").position).toEqual({ x: 30, y: 30 });
+  });
+
+  it("collects unknown refs and warns on off-board landings", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await setPlacement({
+        document_id: id,
+        placements: [
+          { ref: "R1", x: 200, y: 200 },
+          { ref: "NOPE", x: 5, y: 5 },
+        ],
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.unknown_refs).toEqual(["NOPE"]);
+    expect(res.warnings.join(" ")).toContain("outside the board outline");
+  });
+
+  it("flags two footprints stacked at the same point", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await setPlacement({
+        document_id: id,
+        placements: [
+          { ref: "R1", x: 25, y: 25 },
+          { ref: "R2", x: 25, y: 25 },
+        ],
+      }),
+    );
+    expect(res.warnings.join(" ")).toContain("likely overlap");
+  });
+
+  it("errors when every ref is unknown", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await setPlacement({ document_id: id, placements: [{ ref: "X", x: 1, y: 1 }] });
+    expect(isErr(res)).toBe(true);
+  });
+});
+
+describe("add_zone", () => {
+  it("fills the whole board outline on a new net", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(await addZone({ document_id: id, net: "GND", fill_board: true }));
+    expect(res.success).toBe(true);
+    expect(res.fill).toBe("board");
+    expect(res.thermal_relief).toBe("Relief");
+
+    const board = getPcbBoard(getSession(id));
+    expect(board.zones).toHaveLength(1);
+    expect(board.zones[0].net).toBe("GND");
+    expect(board.zones[0].layer).toBe("FCu");
+    expect(board.zones[0].fillType).toBe("Solid");
+    expect(board.zones[0].outline.length).toBeGreaterThanOrEqual(3);
+    // The net was auto-created.
+    expect(board.nets.some((n) => n.id === "GND")).toBe(true);
+  });
+
+  it("accepts an explicit polygon and rejects a degenerate one", async () => {
+    const id = await boardWithTwoResistors();
+    const ok = out(
+      await addZone({
+        document_id: id,
+        net: "VBAT",
+        layer: "BCu",
+        outline: [
+          { x: 5, y: 5 },
+          { x: 20, y: 5 },
+          { x: 20, y: 20 },
+          { x: 5, y: 20 },
+        ],
+        thermal_relief: "Direct",
+      }),
+    );
+    expect(ok.success).toBe(true);
+    expect(ok.fill).toBe("polygon");
+    expect(getPcbBoard(getSession(id)).zones[0].thermalRelief).toBe("Direct");
+
+    const bad = await addZone({ document_id: id, net: "X", outline: [{ x: 0, y: 0 }] });
+    expect(isErr(bad)).toBe(true);
+  });
+});
+
+describe("set_design_rules", () => {
+  it("writes default rules and a net class that DRC then reads", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await setDesignRules({
+        document_id: id,
+        clearance: 0.3,
+        track_width: 0.4,
+        classes: [{ name: "power", nets: ["MID"], clearance: 0.6, track_width: 1.0 }],
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.rules.clearance).toBe(0.3);
+    expect(res.rules.track_width).toBe(0.4);
+    expect(res.classes).toEqual(["power"]);
+
+    const board = getPcbBoard(getSession(id));
+    expect(board.rules.defaultRules.clearance).toBe(0.3);
+    expect(board.rules.defaultRules.traceWidth).toBe(0.4);
+    expect(board.rules.classRules?.[0]).toMatchObject({ name: "power", clearance: 0.6, traceWidth: 1.0 });
+    expect(board.rules.netClassAssignments).toEqual({ power: ["MID"] });
+
+    // DRC still runs against the updated rules.
+    const drc = out(await runDrc({ document_id: id }));
+    expect(drc.success).toBe(true);
+  });
+
+  it("warns on unknown class nets and errors with no fields", async () => {
+    const id = await boardWithTwoResistors();
+    const warn = out(
+      await setDesignRules({ document_id: id, classes: [{ name: "hv", nets: ["GHOST"] }] }),
+    );
+    expect(warn.success).toBe(true);
+    expect(warn.warnings.join(" ")).toContain("GHOST");
+
+    const empty = await setDesignRules({ document_id: id });
+    expect(isErr(empty)).toBe(true);
+  });
+});
+
+describe("size_trace_for_current", () => {
+  it("solves a plausible width and derates inner layers", async () => {
+    const outer = out(sizeTraceForCurrent({ current_a: 10, copper_oz: 1, temp_rise_c: 10 }));
+    expect(outer.standard).toBe("IPC-2221");
+    expect(outer.current_a).toBe(10);
+    // 10A / 10°C / 1oz external lands around 7mm by the closed form.
+    expect(outer.width_mm).toBeGreaterThan(5);
+    expect(outer.width_mm).toBeLessThan(9);
+
+    const inner = out(
+      sizeTraceForCurrent({ current_a: 10, copper_oz: 1, temp_rise_c: 10, layer: "inner" }),
+    );
+    expect(inner.layer).toBe("inner");
+    // Inner traces shed heat poorly → must be wider for the same current.
+    expect(inner.width_mm).toBeGreaterThan(outer.width_mm);
+
+    // Heavier copper → narrower trace for the same current.
+    const heavy = out(sizeTraceForCurrent({ current_a: 10, copper_oz: 2, temp_rise_c: 10 }));
+    expect(heavy.width_mm).toBeLessThan(outer.width_mm);
+  });
+
+  it("snaps the width up to the fab grid and rejects bad current", async () => {
+    const r = out(sizeTraceForCurrent({ current_a: 3, fab_grid_mm: 0.5 }));
+    // Snapped up to the next grid step, never below the raw solve.
+    expect(r.width_mm).toBeGreaterThanOrEqual(r.width_mm_raw);
+    expect(r.width_mm - r.width_mm_raw).toBeLessThan(0.5);
+    const ratio = r.width_mm / 0.5;
+    expect(Math.abs(ratio - Math.round(ratio))).toBeLessThan(1e-9);
+
+    const bad = sizeTraceForCurrent({ current_a: 0 });
+    expect(isErr(bad)).toBe(true);
+  });
+});
+
+describe("add_via_array", () => {
+  it("fills a region with a clipped via grid", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await addViaArray({ document_id: id, net: "GND", region: { x: 10, y: 10, w: 5, h: 5 }, pitch: 1 }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.mode).toBe("region");
+    // 6×6 grid (0..5 inclusive at pitch 1), all inside the 50×50 board.
+    expect(res.vias_added).toBe(36);
+    const board = getPcbBoard(getSession(id));
+    expect(board.vias).toHaveLength(36);
+    expect(board.vias.every((v) => v.net === "GND")).toBe(true);
+  });
+
+  it("clips grid vias that fall outside the board", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await addViaArray({ document_id: id, net: "GND", region: { x: 48, y: 48, w: 6, h: 6 }, pitch: 1 }),
+    );
+    // Part of this region is off the 50×50 board → some vias dropped.
+    expect(res.skipped_outside_board).toBeGreaterThan(0);
+  });
+
+  it("places explicit points and refuses an empty request", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await addViaArray({
+        document_id: id,
+        net: "SIG",
+        points: [
+          { x: 5, y: 5 },
+          { x: 6, y: 6 },
+        ],
+      }),
+    );
+    expect(res.mode).toBe("points");
+    expect(res.vias_added).toBe(2);
+
+    const bad = await addViaArray({ document_id: id, net: "SIG" });
+    expect(isErr(bad)).toBe(true);
+  });
+});
+
+describe("new PCB tools survive the kernel pipeline", () => {
+  it("a pour, a via field, and tightened rules pass DRC + Gerber", async () => {
+    const id = await boardWithTwoResistors();
+    out(await setDesignRules({ document_id: id, clearance: 0.25, track_width: 0.3 }));
+    out(await addZone({ document_id: id, net: "GND", fill_board: true }));
+    out(
+      await addViaArray({
+        document_id: id,
+        net: "GND",
+        region: { x: 15, y: 15, w: 4, h: 4 },
+        pitch: 1,
+      }),
+    );
+    out(await routeNets({ document_id: id }));
+
+    // The kernel computes zone fills + DRC against the mutated rules; both must
+    // accept the board, and Gerber must render the new copper.
+    const drc = out(await runDrc({ document_id: id }));
+    expect(drc.success).toBe(true);
+    const gerber = out(await exportGerber({ document_id: id }));
+    expect(gerber.success).toBe(true);
+    expect(gerber.files.length).toBeGreaterThan(0);
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -108,6 +108,16 @@ import {
   addViaSchema,
   setStackup,
   setStackupSchema,
+  setPlacement,
+  setPlacementSchema,
+  addZone,
+  addZoneSchema,
+  setDesignRules,
+  setDesignRulesSchema,
+  sizeTraceForCurrent,
+  sizeTraceForCurrentSchema,
+  addViaArray,
+  addViaArraySchema,
   addMotorWinding,
   addMotorWindingSchema,
   calcMotor,
@@ -829,6 +839,55 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         inputSchema: setStackupSchema,
       },
       {
+        name: "set_placement",
+        description:
+          "Place footprints at explicit board-frame coordinates by ref — the " +
+          "floorplan realizer the auto-placer (grid/force_directed/radial) can't " +
+          "express: thermal rings, a quiet IMU corner, rim connectors. Batch; " +
+          "sets position/rotation/side and warns on off-board, in-cutout, or " +
+          "stacked landings. Mutates the session document.",
+        inputSchema: setPlacementSchema,
+        _meta: UI_META,
+      },
+      {
+        name: "add_zone",
+        description:
+          "Add a copper pour (ground/power plane) on a net+layer — fills are not " +
+          "traces. `fill_board:true` pours the whole outline (cutouts become " +
+          "voids); or give an explicit polygon for a partial plane. Mutates the " +
+          "session document.",
+        inputSchema: addZoneSchema,
+        _meta: UI_META,
+      },
+      {
+        name: "set_design_rules",
+        description:
+          "Set the board design rules run_drc enforces (clearance, track width, " +
+          "via, edge/hole/annular) and net classes — the way to give a power or " +
+          "high-voltage class wider clearance than signal nets. run_drc already " +
+          "reads pcb.rules; this writes them. Mutates the session document.",
+        inputSchema: setDesignRulesSchema,
+      },
+      {
+        name: "size_trace_for_current",
+        description:
+          "IPC-2221 conductor ampacity solved for trace width: given current, " +
+          "copper weight, allowed temp rise, and layer (outer/inner), returns the " +
+          "minimum width. The ampacity sibling of size_impedance/size_pdn — pure " +
+          "calc, no document.",
+        inputSchema: sizeTraceForCurrentSchema,
+      },
+      {
+        name: "add_via_array",
+        description:
+          "Place many vias at once — a grid over a rectangular `region` (thermal " +
+          "vias under FETs, GND-plane stitching) or an explicit `points` list. " +
+          "Grid vias are clipped to the board outline by default. Mutates the " +
+          "session document.",
+        inputSchema: addViaArraySchema,
+        _meta: UI_META,
+      },
+      {
         name: "add_motor_winding",
         description:
           "One-shot motor winding realizer: plans a balanced slots/poles/" +
@@ -1216,6 +1275,26 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
 
         case "set_stackup":
           result = setStackup(args);
+          break;
+
+        case "set_placement":
+          result = setPlacement(args);
+          break;
+
+        case "add_zone":
+          result = addZone(args);
+          break;
+
+        case "set_design_rules":
+          result = setDesignRules(args);
+          break;
+
+        case "size_trace_for_current":
+          result = sizeTraceForCurrent(args);
+          break;
+
+        case "add_via_array":
+          result = addViaArray(args);
           break;
 
         case "add_motor_winding":

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -26,6 +26,7 @@ import type {
   PcbLayer,
   Trace,
   Via,
+  Zone,
   Vec2,
 } from "@vcad/ir";
 import { createDocument } from "@vcad/ir";
@@ -3706,6 +3707,752 @@ export function setStackup(args: Record<string, unknown>) {
         text: JSON.stringify({
           success: true,
           stackup: pcb.stackup.layers,
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// set_placement — explicit per-component placement (the floorplan primitive)
+// ============================================================================
+
+/** JSON Schema for set_placement tool. */
+export const setPlacementSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    placements: {
+      type: "array" as const,
+      description:
+        "Absolute per-component placements in the board-local frame (mm). Each " +
+        "entry targets a placed footprint by `ref`. Realizes a deliberate " +
+        "floorplan the auto-placer (grid/force_directed/radial) can't — thermal " +
+        "rings, a quiet IMU corner, rim connectors. Off-board, in-cutout, and " +
+        "stacked positions are reported as warnings, not silently accepted.",
+      items: {
+        type: "object" as const,
+        properties: {
+          ref: { type: "string" as const, description: "Reference designator, e.g. 'U1', 'Q3', 'J2'" },
+          x: { type: "number" as const, description: "Absolute X in the board frame, mm" },
+          y: { type: "number" as const, description: "Absolute Y in the board frame, mm" },
+          rotation: { type: "number" as const, description: "Absolute rotation, degrees CCW" },
+          side: {
+            type: "string" as const,
+            description: "'top' (default) or 'bottom' — 'bottom' mirrors the footprint to the back copper",
+          },
+        },
+        required: ["ref"],
+      },
+    },
+  },
+  required: ["document_id", "placements"],
+};
+
+/**
+ * Place footprints at explicit board-frame coordinates — the realize step for a
+ * hand-authored floorplan. Looks each component up by `ref`, sets position /
+ * rotation / side, and validates each landing against the board outline
+ * (off-board, inside-a-cutout, and stacked-on-another-footprint become
+ * warnings). Mutates the session document.
+ */
+export function setPlacement(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  });
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+  const placements = Array.isArray(args.placements)
+    ? (args.placements as Array<Record<string, unknown>>)
+    : undefined;
+  if (!placements || placements.length === 0) {
+    return fail("placements must be a non-empty array of {ref, x?, y?, rotation?, side?}");
+  }
+
+  const byRef = new Map<string, Footprint>(
+    pcb.footprints.map((f) => [f.ref, f] as [string, Footprint]),
+  );
+  const outline = pcb.outline.vertices ?? [];
+  const cutouts = pcb.outline.cutouts ?? [];
+
+  const moved: string[] = [];
+  const rotated: string[] = [];
+  const flipped: string[] = [];
+  const unknownRefs: string[] = [];
+  const warnings: string[] = [];
+
+  for (const p of placements) {
+    const ref = String(p.ref ?? "");
+    if (!ref) {
+      warnings.push("skipped a placement with no `ref`");
+      continue;
+    }
+    const fp = byRef.get(ref);
+    if (!fp) {
+      unknownRefs.push(ref);
+      continue;
+    }
+    const hasX = typeof p.x === "number";
+    const hasY = typeof p.y === "number";
+    if (hasX !== hasY) {
+      warnings.push(`${ref}: give both x and y (or neither) — ignoring partial position`);
+    } else if (hasX && hasY) {
+      const pos = { x: round3(p.x as number), y: round3(p.y as number) };
+      fp.position = pos;
+      moved.push(ref);
+      if (outline.length >= 3) {
+        if (!pointInPolygon(pos, outline)) {
+          warnings.push(`${ref} at (${pos.x}, ${pos.y}) is outside the board outline`);
+        } else if (cutouts.some((c) => c.length >= 3 && pointInPolygon(pos, c))) {
+          warnings.push(`${ref} at (${pos.x}, ${pos.y}) sits inside a board cutout`);
+        }
+      }
+    }
+    if (typeof p.rotation === "number") {
+      fp.rotation = p.rotation as number;
+      rotated.push(ref);
+    }
+    const side = p.side != null ? String(p.side).toLowerCase() : undefined;
+    if (side === "bottom" || side === "top") {
+      const front = side === "top";
+      if (fp.front !== front) {
+        fp.front = front;
+        flipped.push(ref);
+      }
+    } else if (side != null) {
+      warnings.push(`${ref}: side "${String(p.side)}" — use 'top' or 'bottom'`);
+    }
+  }
+
+  // Two footprints at the same rounded point is almost always a mistake — the
+  // auto-placer never does it, so it's worth surfacing.
+  const seen = new Map<string, string>();
+  for (const ref of moved) {
+    const fp = byRef.get(ref)!;
+    const key = `${fp.position.x},${fp.position.y}`;
+    const prev = seen.get(key);
+    if (prev) warnings.push(`${ref} and ${prev} share the exact position ${key} — likely overlap`);
+    else seen.set(key, ref);
+  }
+
+  if (unknownRefs.length > 0) {
+    warnings.push(
+      `unknown refs (not on this board): ${unknownRefs.join(", ")} — ` +
+        `refs come from the schematic via place_components`,
+    );
+  }
+  if (moved.length === 0 && rotated.length === 0 && flipped.length === 0) {
+    return fail(
+      `no footprints updated${unknownRefs.length ? ` — all refs unknown: ${unknownRefs.join(", ")}` : ""}`,
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          moved: moved.length,
+          rotated: rotated.length,
+          flipped: flipped.length,
+          ...(unknownRefs.length > 0 ? { unknown_refs: unknownRefs } : {}),
+          ...(warnings.length > 0 ? { warnings } : {}),
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// add_zone — copper pour (ground / power plane) on a net
+// ============================================================================
+
+/** JSON Schema for add_zone tool. */
+export const addZoneSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    net: { type: "string" as const, description: "Net the pour belongs to (e.g. 'GND', 'VBAT')" },
+    layer: { type: "string" as const, description: "Copper layer (default 'FCu')" },
+    fill_board: {
+      type: "boolean" as const,
+      description:
+        "Pour the whole board outline (a full plane), treating board cutouts as " +
+        "voids. The usual ground/power-plane shortcut. Ignores `outline`.",
+    },
+    outline: {
+      type: "array" as const,
+      items: { ...vec2Schema },
+      description:
+        "Explicit pour polygon, board-local mm (>= 3 points) — for a partial " +
+        "plane (e.g. a VBAT pour over the FET drains). Omit with fill_board:true " +
+        "for a board-spanning plane.",
+    },
+    clearance: {
+      type: "number" as const,
+      description: "Copper-to-copper gap around the pour, mm (default: design-rule clearance)",
+    },
+    thermal_relief: {
+      type: "string" as const,
+      description:
+        "Pour-to-same-net-pad connection: 'Relief' (default, spoke thermals — " +
+        "solderable), 'Direct' (solid copper), or 'None'.",
+    },
+    thermal_gap: { type: "number" as const, description: "Relief gap around a connected pad, mm" },
+    thermal_spoke_width: { type: "number" as const, description: "Relief spoke width, mm" },
+    fill_type: { type: "string" as const, description: "'Solid' (default) or 'Hatched'" },
+    min_area: {
+      type: "number" as const,
+      description: "Discard isolated copper islands smaller than this, mm²",
+    },
+    priority: {
+      type: "number" as const,
+      description: "Higher-priority pours fill first and win overlaps (default 0)",
+    },
+  },
+  required: ["document_id", "net"],
+};
+
+/**
+ * Add a copper zone (pour) — the primitive for ground and power planes, which
+ * are fills on a net+layer, not traces. The stored zone is an outline + rules;
+ * the fab/DRC pipeline computes the actual filled copper. `fill_board` uses the
+ * board outline and treats its cutouts as voids. Mutates the session document.
+ */
+export function addZone(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  });
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+
+  const net = String(args.net ?? "");
+  const layer = ((args.layer as string) || "FCu") as PcbLayer;
+  if (!net) return fail("net is required — a pour must belong to a net");
+  if (!/Cu$/.test(layer)) {
+    return fail(`layer "${layer}" is not a copper layer (use FCu, BCu, In1Cu, ...)`);
+  }
+
+  const reliefArg = (args.thermal_relief as string) || "Relief";
+  if (!["Direct", "Relief", "None"].includes(reliefArg)) {
+    return fail("thermal_relief must be 'Direct', 'Relief', or 'None'");
+  }
+  const fillArg = (args.fill_type as string) || "Solid";
+  if (!["Solid", "Hatched"].includes(fillArg)) {
+    return fail("fill_type must be 'Solid' or 'Hatched'");
+  }
+
+  const fillBoard = args.fill_board === true;
+  const explicit = Array.isArray(args.outline)
+    ? (args.outline as Array<Record<string, unknown>>)
+    : undefined;
+
+  let rawOutline: Vec2[];
+  let holes: Vec2[][] | undefined;
+  let fillMode: "board" | "polygon";
+  if (explicit && !fillBoard) {
+    if (explicit.length < 3) return fail("outline needs >= 3 points");
+    for (const v of explicit) {
+      if (!v || typeof v.x !== "number" || typeof v.y !== "number") {
+        return fail("every outline point must be {x, y} in mm");
+      }
+    }
+    rawOutline = explicit.map((v) => ({ x: v.x as number, y: v.y as number }));
+    fillMode = "polygon";
+  } else {
+    const verts = pcb.outline.vertices ?? [];
+    if (verts.length < 3) {
+      return fail("board has no outline to fill — pass an explicit `outline` polygon");
+    }
+    rawOutline = verts.map((v) => ({ x: v.x, y: v.y }));
+    const cuts = pcb.outline.cutouts ?? [];
+    if (cuts.length > 0) {
+      holes = cuts.map((c) => c.map((v) => ({ x: round3(v.x), y: round3(v.y) })));
+    }
+    fillMode = "board";
+  }
+
+  const outline = ensureCcw(rawOutline).map((v) => ({ x: round3(v.x), y: round3(v.y) }));
+  const clearance = (args.clearance as number) ?? pcb.rules.defaultRules.clearance;
+
+  if (!pcb.nets.some((n) => n.id === net)) pcb.nets.push({ id: net, name: net });
+
+  const zone: Zone = {
+    outline,
+    net,
+    layer,
+    clearance,
+    fillType: fillArg as NonNullable<Zone["fillType"]>,
+    thermalRelief: reliefArg as NonNullable<Zone["thermalRelief"]>,
+    priority: typeof args.priority === "number" ? (args.priority as number) : 0,
+    ...(holes ? { holes } : {}),
+    ...(typeof args.min_area === "number" ? { minArea: args.min_area as number } : {}),
+    ...(typeof args.thermal_gap === "number" ? { thermalGap: args.thermal_gap as number } : {}),
+    ...(typeof args.thermal_spoke_width === "number"
+      ? { thermalSpokeWidth: args.thermal_spoke_width as number }
+      : {}),
+  };
+  pcb.zones.push(zone);
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          net,
+          layer,
+          fill: fillMode,
+          vertices: outline.length,
+          ...(holes ? { holes: holes.length } : {}),
+          clearance,
+          thermal_relief: reliefArg,
+          zones_total: pcb.zones.length,
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// set_design_rules — configurable DRC rules + net classes
+// ============================================================================
+
+/** JSON Schema for set_design_rules tool. */
+export const setDesignRulesSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    clearance: { type: "number" as const, description: "Default copper-to-copper clearance, mm" },
+    track_width: { type: "number" as const, description: "Default minimum trace width, mm" },
+    via_diameter: { type: "number" as const, description: "Default via pad diameter, mm" },
+    via_drill: { type: "number" as const, description: "Default via drill diameter, mm" },
+    diff_pair_gap: { type: "number" as const, description: "Default differential-pair gap, mm" },
+    diff_pair_width: { type: "number" as const, description: "Default differential-pair trace width, mm" },
+    edge_clearance: { type: "number" as const, description: "Copper-to-board-edge clearance, mm" },
+    hole_to_hole: { type: "number" as const, description: "Minimum hole-to-hole spacing, mm" },
+    min_annular_ring: { type: "number" as const, description: "Minimum via annular ring, mm" },
+    min_drill: { type: "number" as const, description: "Minimum drill diameter, mm" },
+    classes: {
+      type: "array" as const,
+      description:
+        "Net classes, each overriding the default clearance/width for its nets — " +
+        "DRC honors per-class clearance and trace width. This is how to enforce a " +
+        "high-voltage / power class (give VBAT and the phase nets a wide " +
+        "clearance) separate from signal nets. NOTE: creepage is not yet a " +
+        "distinct rule — model HV spacing as a high-clearance class here.",
+      items: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string" as const, description: "Class name, e.g. 'power', 'hv'" },
+          nets: {
+            type: "array" as const,
+            items: { type: "string" as const },
+            description: "Net ids assigned to this class",
+          },
+          clearance: { type: "number" as const },
+          track_width: { type: "number" as const },
+          via_diameter: { type: "number" as const },
+          via_drill: { type: "number" as const },
+          diff_pair_gap: { type: "number" as const },
+          diff_pair_width: { type: "number" as const },
+        },
+        required: ["name", "nets"],
+      },
+    },
+  },
+  required: ["document_id"],
+};
+
+/**
+ * Mutate the board design rules consumed by run_drc (and used as defaults by
+ * route_nets / add_coil). Sets default clearances/widths and/or net classes so a
+ * power or high-voltage class can carry wider clearance than signal nets. run_drc
+ * already reads pcb.rules — this is the writer for it. Mutates the session
+ * document.
+ */
+export function setDesignRules(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  });
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+
+  const rules = pcb.rules;
+  const dr = rules.defaultRules;
+  const warnings: string[] = [];
+  let touched = false;
+
+  const num = (k: string) => (typeof args[k] === "number" ? (args[k] as number) : undefined);
+  const requirePos = (k: string, v: number | undefined): boolean => {
+    if (v === undefined) return false;
+    if (!(v > 0)) {
+      warnings.push(`${k} must be > 0 — ignored`);
+      return false;
+    }
+    return true;
+  };
+
+  const clearance = num("clearance");
+  if (requirePos("clearance", clearance)) { dr.clearance = clearance!; touched = true; }
+  const trackWidth = num("track_width");
+  if (requirePos("track_width", trackWidth)) { dr.traceWidth = trackWidth!; touched = true; }
+  const viaDiameter = num("via_diameter");
+  if (requirePos("via_diameter", viaDiameter)) { dr.viaDiameter = viaDiameter!; touched = true; }
+  const viaDrill = num("via_drill");
+  if (requirePos("via_drill", viaDrill)) { dr.viaDrill = viaDrill!; touched = true; }
+  const dpg = num("diff_pair_gap");
+  if (requirePos("diff_pair_gap", dpg)) { dr.diffPairGap = dpg!; touched = true; }
+  const dpw = num("diff_pair_width");
+  if (requirePos("diff_pair_width", dpw)) { dr.diffPairWidth = dpw!; touched = true; }
+
+  const edgeClr = num("edge_clearance");
+  if (requirePos("edge_clearance", edgeClr)) { rules.edgeClearance = edgeClr!; touched = true; }
+  const h2h = num("hole_to_hole");
+  if (requirePos("hole_to_hole", h2h)) { rules.holeToHole = h2h!; touched = true; }
+  const minAnnular = num("min_annular_ring");
+  if (requirePos("min_annular_ring", minAnnular)) { rules.minAnnularRing = minAnnular!; touched = true; }
+  const minDrill = num("min_drill");
+  if (requirePos("min_drill", minDrill)) { rules.minDrill = minDrill!; touched = true; }
+
+  let classNames: string[] | undefined;
+  if (Array.isArray(args.classes)) {
+    const classesIn = args.classes as Array<Record<string, unknown>>;
+    const classRules: NetClassRules[] = [];
+    const assignments: Record<string, string[]> = {};
+    const knownNets = new Set(pcb.nets.map((n) => n.id));
+    for (const c of classesIn) {
+      const name = String(c.name ?? "");
+      const nets = Array.isArray(c.nets) ? (c.nets as unknown[]).map(String) : [];
+      if (!name) return fail("each class needs a `name`");
+      if (nets.length === 0) return fail(`class "${name}" needs a non-empty nets array`);
+      const unknown = nets.filter((id) => !knownNets.has(id));
+      if (unknown.length > 0) {
+        warnings.push(`class "${name}" references nets not on the board: ${unknown.join(", ")}`);
+      }
+      classRules.push({
+        name,
+        traceWidth: typeof c.track_width === "number" ? (c.track_width as number) : dr.traceWidth,
+        clearance: typeof c.clearance === "number" ? (c.clearance as number) : dr.clearance,
+        viaDiameter: typeof c.via_diameter === "number" ? (c.via_diameter as number) : dr.viaDiameter,
+        viaDrill: typeof c.via_drill === "number" ? (c.via_drill as number) : dr.viaDrill,
+        ...(typeof c.diff_pair_gap === "number" ? { diffPairGap: c.diff_pair_gap as number } : {}),
+        ...(typeof c.diff_pair_width === "number" ? { diffPairWidth: c.diff_pair_width as number } : {}),
+      });
+      assignments[name] = nets;
+    }
+    rules.classRules = classRules;
+    rules.netClassAssignments = assignments;
+    classNames = classRules.map((c) => c.name);
+    touched = true;
+  }
+
+  if (!touched) {
+    return fail("provide at least one rule field (clearance, track_width, …) or `classes`");
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          rules: {
+            clearance: dr.clearance,
+            track_width: dr.traceWidth,
+            via_diameter: dr.viaDiameter,
+            via_drill: dr.viaDrill,
+            edge_clearance: rules.edgeClearance,
+            hole_to_hole: rules.holeToHole,
+            min_annular_ring: rules.minAnnularRing,
+            min_drill: rules.minDrill,
+          },
+          ...(classNames ? { classes: classNames } : {}),
+          ...(warnings.length > 0 ? { warnings } : {}),
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// size_trace_for_current — IPC-2221 ampacity → trace width
+// ============================================================================
+
+/** JSON Schema for size_trace_for_current tool. */
+export const sizeTraceForCurrentSchema = {
+  type: "object" as const,
+  properties: {
+    current_a: { type: "number" as const, description: "Continuous current the trace must carry, A" },
+    copper_oz: {
+      type: "number" as const,
+      description: "Copper weight, oz/ft² (default 1; 1 oz ≈ 0.0348 mm). Match set_stackup.",
+    },
+    temp_rise_c: {
+      type: "number" as const,
+      description: "Allowed conductor temperature rise above ambient, °C (default 10)",
+    },
+    layer: {
+      type: "string" as const,
+      description:
+        "'outer' (default, in free air) or 'inner' (buried; derated ~2× because " +
+        "it sheds heat poorly, so it needs much more width for the same current).",
+    },
+    fab_grid_mm: {
+      type: "number" as const,
+      description: "Snap the solved width UP to this manufacturing grid, mm (default 0.0254 = 1 mil)",
+    },
+  },
+  required: ["current_a"],
+};
+
+/**
+ * IPC-2221 closed-form conductor ampacity, solved for width:
+ *   I = k · ΔT^0.44 · A^0.725   (A = cross-section in mil², k = 0.048 outer / 0.024 inner)
+ * Pure calc, no document — the ampacity sibling of size_impedance/size_pdn.
+ * Conservative vs IPC-2152 chart data (which credits board conduction and gives
+ * narrower traces) — the safe default for power nets.
+ */
+export function sizeTraceForCurrent(args: Record<string, unknown>) {
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  });
+  const current = args.current_a as number;
+  if (typeof current !== "number" || !(current > 0)) return fail("current_a must be > 0");
+  const copperOz = typeof args.copper_oz === "number" ? (args.copper_oz as number) : 1;
+  if (!(copperOz > 0)) return fail("copper_oz must be > 0");
+  const dT = typeof args.temp_rise_c === "number" ? (args.temp_rise_c as number) : 10;
+  if (!(dT > 0)) return fail("temp_rise_c must be > 0");
+  const layer = String(args.layer ?? "outer").toLowerCase() === "inner" ? "inner" : "outer";
+  const grid =
+    typeof args.fab_grid_mm === "number" && (args.fab_grid_mm as number) > 0
+      ? (args.fab_grid_mm as number)
+      : 0.0254;
+
+  const k = layer === "inner" ? 0.024 : 0.048;
+  const MIL_PER_MM = 1 / 0.0254;
+  const thicknessMm = copperOz * OZ_TO_MM;
+  const thicknessMil = thicknessMm * MIL_PER_MM;
+
+  // A_mil2 = (I / (k·ΔT^0.44))^(1/0.725)
+  const areaMil2 = Math.pow(current / (k * Math.pow(dT, 0.44)), 1 / 0.725);
+  const widthMil = areaMil2 / thicknessMil;
+  const widthMmRaw = widthMil / MIL_PER_MM;
+  const widthMm = Math.ceil(widthMmRaw / grid) * grid;
+  const crossMm2 = widthMm * thicknessMm;
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          standard: "IPC-2221",
+          current_a: current,
+          temp_rise_c: dT,
+          copper_oz: copperOz,
+          copper_thickness_mm: round3(thicknessMm),
+          layer,
+          width_mm: round3(widthMm),
+          width_mm_raw: round3(widthMmRaw),
+          cross_section_mm2: round3(crossMm2),
+          cross_section_mil2: Math.round(areaMil2 * 100) / 100,
+          note:
+            `IPC-2221 closed form (k=${k}). Conservative vs IPC-2152; inner ` +
+            `layers derate ~2×. Width snapped up to a ${grid}mm grid.`,
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// add_via_array — grid / batch of vias (thermal field, plane stitching)
+// ============================================================================
+
+/** JSON Schema for add_via_array tool. */
+export const addViaArraySchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    net: { type: "string" as const, description: "Net for every via in the array (e.g. 'GND')" },
+    region: {
+      type: "object" as const,
+      description:
+        "Rectangular region (board-local mm) filled with a via grid at `pitch` " +
+        "spacing — thermal-via fields under FETs, GND-plane stitching.",
+      properties: {
+        x: { type: "number" as const },
+        y: { type: "number" as const },
+        w: { type: "number" as const },
+        h: { type: "number" as const },
+      },
+      required: ["x", "y", "w", "h"],
+    },
+    points: {
+      type: "array" as const,
+      items: { ...vec2Schema },
+      description: "Explicit via centers (board-local mm) — alternative to `region` for hand stitching.",
+    },
+    pitch: { type: "number" as const, description: "Grid spacing for region mode, mm (default 1.0)" },
+    start_layer: { type: "string" as const, description: "Span start layer (default 'FCu')" },
+    end_layer: { type: "string" as const, description: "Span end layer (default 'BCu')" },
+    diameter: { type: "number" as const, description: "Via pad diameter, mm (default: design-rule viaDiameter)" },
+    drill: { type: "number" as const, description: "Via drill, mm (default: design-rule viaDrill)" },
+    clip_to_board: {
+      type: "boolean" as const,
+      description: "Drop grid vias outside the board outline / inside a cutout (default true)",
+    },
+  },
+  required: ["document_id", "net"],
+};
+
+/** Max vias one call will place — a guard against a fine pitch over a big region. */
+const MAX_VIA_ARRAY = 2000;
+
+/**
+ * Place many vias at once: a regular grid over a rectangular `region` (thermal
+ * vias, plane stitching) or an explicit list of `points`. Grid vias are clipped
+ * to the board outline by default. Mutates the session document.
+ */
+export function addViaArray(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = (text: string) => ({
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  });
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+
+  const net = String(args.net ?? "");
+  const startLayer = ((args.start_layer as string) || "FCu") as PcbLayer;
+  const endLayer = ((args.end_layer as string) || "BCu") as PcbLayer;
+  const diameter = (args.diameter as number) ?? pcb.rules.defaultRules.viaDiameter;
+  const drill = (args.drill as number) ?? pcb.rules.defaultRules.viaDrill;
+  if (!net) return fail("net is required — a via must belong to a net");
+  if (!/Cu$/.test(startLayer)) return fail(`start_layer "${startLayer}" is not a copper layer`);
+  if (!/Cu$/.test(endLayer)) return fail(`end_layer "${endLayer}" is not a copper layer`);
+
+  const explicitPoints = Array.isArray(args.points)
+    ? (args.points as Array<Record<string, unknown>>)
+    : undefined;
+  const region = args.region as { x?: unknown; y?: unknown; w?: unknown; h?: unknown } | undefined;
+
+  const candidates: Vec2[] = [];
+  let mode: "region" | "points";
+  if (explicitPoints && explicitPoints.length > 0) {
+    for (const p of explicitPoints) {
+      if (!p || typeof p.x !== "number" || typeof p.y !== "number") {
+        return fail("every point must be {x, y} in mm");
+      }
+      candidates.push({ x: p.x as number, y: p.y as number });
+    }
+    mode = "points";
+  } else if (
+    region &&
+    typeof region.x === "number" &&
+    typeof region.y === "number" &&
+    typeof region.w === "number" &&
+    typeof region.h === "number"
+  ) {
+    const x0 = region.x as number;
+    const y0 = region.y as number;
+    const w = region.w as number;
+    const h = region.h as number;
+    if (!(w > 0) || !(h > 0)) return fail("region.w and region.h must be > 0");
+    const pitch =
+      typeof args.pitch === "number" && (args.pitch as number) > 0 ? (args.pitch as number) : 1.0;
+    const cols = Math.floor(w / pitch) + 1;
+    const rows = Math.floor(h / pitch) + 1;
+    if (cols * rows > MAX_VIA_ARRAY) {
+      return fail(
+        `grid would be ${cols * rows} vias (> ${MAX_VIA_ARRAY}) — increase pitch or shrink region`,
+      );
+    }
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        candidates.push({ x: x0 + c * pitch, y: y0 + r * pitch });
+      }
+    }
+    mode = "region";
+  } else {
+    return fail("provide either `region` {x,y,w,h} or a non-empty `points` array");
+  }
+
+  // Clip grid vias to the board (default on). Points mode is taken as authored.
+  const clip = args.clip_to_board !== false && mode === "region";
+  const outline = pcb.outline.vertices ?? [];
+  const cutouts = pcb.outline.cutouts ?? [];
+  let skipped = 0;
+  const kept: Vec2[] = [];
+  for (const p of candidates) {
+    if (clip && outline.length >= 3) {
+      if (!pointInPolygon(p, outline)) { skipped++; continue; }
+      if (cutouts.some((cc) => cc.length >= 3 && pointInPolygon(p, cc))) { skipped++; continue; }
+    }
+    kept.push(p);
+  }
+
+  if (kept.length === 0) {
+    return fail(
+      mode === "region"
+        ? "no vias landed inside the board outline — check region coordinates"
+        : "no via points given",
+    );
+  }
+
+  if (!pcb.nets.some((n) => n.id === net)) pcb.nets.push({ id: net, name: net });
+
+  for (const p of kept) {
+    pcb.vias.push({
+      position: { x: round3(p.x), y: round3(p.y) },
+      diameter,
+      drill,
+      startLayer,
+      endLayer,
+      net,
+    });
+  }
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          net,
+          mode,
+          vias_added: kept.length,
+          ...(skipped > 0 ? { skipped_outside_board: skipped } : {}),
+          start_layer: startLayer,
+          end_layer: endLayer,
           ...docResultPayload(ctx),
         }),
       },


### PR DESCRIPTION
## What

Adds five ECAD MCP tools that take the PCB workflow from "describe a board" to "realize one." A flight-controller design session stalled because the MCP surface only exposed auto-placement (`grid`/`force_directed`/`radial`) and had no way to pour copper, configure design rules, or size power traces.

| tool | what it does |
|---|---|
| **set_placement** | Batch per-component placement by `ref` (x/y/rotation/side) — the floorplan realizer. Validates each landing against the outline: off-board, in-cutout, and stacked-footprint **warnings**. |
| **add_zone** | Copper pours (ground/power planes). `fill_board:true` pours the whole outline with cutouts as voids; or pass an explicit polygon. Writes `pcb.zones`; the fab/DRC pipeline computes the actual fill. |
| **set_design_rules** | Writes `pcb.rules` — default clearances/widths + net classes. `run_drc` already reads `pcb.rules`, so DRC honors these immediately. HV creepage is modeled as a high-clearance class (noted in the schema). |
| **size_trace_for_current** | IPC-2221 closed-form conductor ampacity solved for trace width. Pure calc — the ampacity sibling of `size_impedance`/`size_pdn`. Outer/inner derating, copper-weight aware, grid-snapped. |
| **add_via_array** | Via grids over a `region` (thermal fields, plane stitching) or explicit `points`, clipped to the outline, capped at 2000. |

## Why this was cheap

Most of the underlying infrastructure already existed and was simply unexposed at the MCP layer:
- `Footprint.position/rotation/front`, the `Zone` type, and `DesignRules`/`NetClassRules` are all first-class in the IR (TS + Rust).
- Copper-pour fill (`copper_pour.rs` / `fill_zones`) and rules-aware DRC (`check_drc(pcb)` reads `pcb.rules`) were already built.

So four of the five are thin wrappers over plumbing that was already in place; only `size_trace_for_current` is genuinely new logic (a pure closed-form calculator). All five are pure TS — **no WASM rebuild**. They're registered as always-on authoring primitives alongside `add_via`/`add_trace`/`set_stackup`.

## Notes for reviewers

- `run_drc` already consumed `pcb.rules` (both kernel and scalar-fallback paths); `set_design_rules` is just the writer for it — no DRC rewiring needed.
- `size_trace_for_current` uses the **IPC-2221** closed form, which is conservative vs IPC-2152 chart data (credits less board conduction → wider traces). Documented in the tool's schema/output `note`. Inner layers derate ~2×.
- HV **creepage** is not yet a distinct DRC rule; the schema steers users to model it as a high-clearance net class rather than implying a capability that doesn't exist (would need a new Rust `DrcRuleType` variant + WASM rebuild).

## Tests

- 14 new `ecad.test.ts` tests covering each tool's happy path, validation/error paths, and a **kernel-pipeline integration check**: a `fill_board` pour + via field + tightened rules → `route_nets` → `run_drc` → `export_gerber` all succeed (confirms the mutated board survives the Rust DRC/fill/Gerber path).
- Full `@vcad/mcp` suite: **142 pass / 2 skip**.
- `tsc --noEmit` clean (the mcp `build` uses `--noCheck`, so strict typecheck was run explicitly).
- Changelog entry added and validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)