### PR TITLE
feat(render): drafting-plate renders — HLR, smooth shading, AO, materials

### DIFF
--- a/changelog/entries/2026-06-15-render-occlusion-quality.json
+++ b/changelog/entries/2026-06-15-render-occlusion-quality.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-render-occlusion-quality",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "feat",
+  "title": "Drafting-plate renders: HLR, smooth shading, AO, materials",
+  "summary": "render_view is now a measured-ink drafting plate: hidden-line removal with dashed occluded edges, Gouraud smooth shading, baked ambient occlusion in cavities and concave seams, material-tinted ramps, studio rim light on a vellum ground with contact shadow, and a fix for cones rendering inside-out.",
+  "features": ["render", "visualization", "materials"],
+  "mcpTools": ["render_view"]
+}

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -1,15 +1,23 @@
 //! `vcad-render` — project a `.vcad` to static line art.
 //!
-//! Drafting-style rendering: low-poly painter's-algorithm shading with
-//! proper edge classification so tessellated flat faces don't look like
-//! a fan of slivers. Each triangulation edge is emitted as one of:
+//! Drafting-style rendering: painter's-algorithm flat shading under a bold,
+//! hidden-line-removed outline. The mesh is canonicalized (welded by
+//! position), each shell oriented outward by signed volume (winding alone is
+//! not reliably outward — cone laterals wind inward), then each triangle
+//! edge is classified as one of:
 //!
-//!   - boundary  (1 triangle)                   → drawn as silhouette
-//!   - crease    (2 tris, non-parallel normals) → drawn
-//!   - internal  (2 tris, parallel normals)     → hidden
+//!   - outline (boundary, or a silhouette between non-coplanar faces) → bold
+//!   - smooth  (silhouette of a curved surface: a cylinder/sphere profile) → bold,
+//!     but interior fragments (the stub off a bore's rim) are dropped
+//!   - crease  (two same-facing, non-coplanar faces)                  → fine
+//!   - internal (coplanar)                                            → hidden
 //!
-//! Filled polygons get no stroke; the edge lines get strokes. The result
-//! reads as drafting linework, not 3D rendering.
+//! Fills are stroked with their own colour at a hairline width so adjacent
+//! triangles overlap and the anti-alias seams that read as a fan across a
+//! flat tessellated face disappear. Kept edges are then clipped against an
+//! off-screen depth buffer so back faces, the far rims of bores, and
+//! occluded creases don't bleed through. The result reads as a clean
+//! drafting drawing, not a wireframe over fills.
 //!
 //! Two output paths share the same projection and edge classification:
 //!
@@ -44,13 +52,36 @@ use vcad_kernel::Solid;
 /// Default pixels-per-millimetre when no `--scale` is given.
 pub const DEFAULT_SCALE: f64 = 2.0;
 const PADDING_PX: f64 = 8.0;
-const STROKE_PX: f64 = 0.5;
-const TESSELLATION_SEGMENTS: u32 = 28;
+
+/// Interior crease stroke width (user units). Light, so tessellation and
+/// fillet rims read as fine linework rather than heavy outlines.
+const STROKE_CREASE_PX: f64 = 0.5;
+/// Silhouette / boundary stroke width (user units). Heavier than creases —
+/// the classic drafting convention of a bold outline over light interior
+/// lines, which makes the part pop and reads as deliberate, not noisy.
+const STROKE_OUTLINE_PX: f64 = 1.2;
+/// Hidden (occluded) edge stroke width — drawn dashed, the engineering
+/// convention that lets a single isometric reveal bores and pockets behind
+/// the front faces.
+const STROKE_HIDDEN_PX: f64 = 0.45;
+
+/// Curved primitives in the SVG path get a fine tessellation: at 64
+/// segments a cylinder facet spans ~5.6°, well under the crease threshold,
+/// so bores and fillets read as smooth surfaces instead of faceted barrels.
+const TESSELLATION_SEGMENTS: u32 = 64;
 
 /// Two triangles are considered coplanar when their unit normals' dot
 /// product exceeds this threshold. Tighter values reveal more creases;
-/// looser values hide more internal edges.
+/// looser values hide more internal edges. The SVG path uses
+/// [`COPLANAR_DOT_TOL_SVG`]; this tighter value is the historical knob kept
+/// for reference.
+#[allow(dead_code)]
 const COPLANAR_DOT_TOL: f64 = 0.997; // cos(~4.5°)
+
+/// Coplanar tolerance for the SVG path. At 64 segments adjacent curved
+/// facets differ by ~5.6°, so a ~10° threshold blends tessellation while
+/// still revealing real creases (chamfers, fillet rims, sharp edges).
+const COPLANAR_DOT_TOL_SVG: f64 = 0.985; // cos(~10°)
 
 /// Cull triangles whose normal points away from the camera by more than
 /// this margin. Anything just-barely-back-facing stays so silhouette
@@ -68,7 +99,43 @@ const LIGHT: [f64; 3] = [-0.6, -0.7, 0.8];
 
 const FILL_DARK: [u8; 3] = [14, 57, 96];
 const FILL_LIGHT: [u8; 3] = [200, 220, 235];
-const STROKE: &str = "#0e3960";
+
+/// Visible linework ink — a touch warmer and darker than the fill navy so
+/// lines read as ink laid on the wash, not the same hue as the fill.
+const INK: &str = "#0b2742";
+/// Warm off-white "vellum" the drafting plate sits on (matches the raster
+/// path's matte background). The signature ground behind every render.
+const PAPER: &str = "#f4f3f1";
+/// Contact-shadow tint (cool near-black) for the blurred ground ellipse.
+const SHADOW: &str = "#1a2b3a";
+
+/// The vcad-Blue tonal ramp: deep-shadow → core navy → mid → ice highlight.
+/// Sampled by the shading term so curved surfaces read as a graded wash
+/// instead of a two-colour lerp. The house colour system — one ramp, many
+/// renders.
+const RAMP: [[u8; 3]; 4] = [
+    [13, 44, 74],    // deep shadow
+    [30, 86, 130],   // core navy
+    [123, 160, 192], // mid
+    [205, 224, 238], // ice highlight
+];
+
+/// Long-side resolution of the off-screen depth buffer used for vector
+/// hidden-line removal in the SVG path. Decoupled from `scale` and the
+/// final raster size: a fixed budget keeps occlusion decisions crisp for
+/// tiny parts and bounded for huge ones. The final SVG is resolution-
+/// independent regardless; this only governs which edge spans survive.
+const OCC_BUFFER_LONG_SIDE: f64 = 1100.0;
+
+/// How much screen-space ambient occlusion darkens a fully-occluded corner
+/// (0 = off). Kept gentle — AO is a depth cue, not a stain. Concave
+/// creases, bore/pocket rims, and part-contact lines pick up a soft
+/// shadow; convex edges and open faces stay bright.
+const AO_STRENGTH: f64 = 0.7;
+/// AO below this fraction is treated as zero — it's the weak, noisy
+/// occlusion that coarse flat-face tessellation produces, which would
+/// otherwise band. Real cavities and contacts read well above it.
+const AO_FLOOR: f64 = 0.24;
 
 // ─── views ────────────────────────────────────────────────────────────────
 
@@ -154,7 +221,11 @@ impl std::str::FromStr for View {
 
 // ─── .vcad → solids ───────────────────────────────────────────────────────
 
-fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<Solid>, String> {
+/// A solid plus its material colour (linear RGB in `[0,1]`), if the
+/// document assigned one — used to tint the shading ramp.
+type TintedSolid = (Solid, Option<[f64; 3]>);
+
+fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<TintedSolid>, String> {
     let parsed = parse_vcad_file(raw_vcad).map_err(|e| format!("parse: {}", e))?;
     // NOTE: catch_unwind only works on native targets. On
     // wasm32-unknown-unknown a panic compiles to an `unreachable` trap —
@@ -168,7 +239,17 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<Solid>, String> {
     .map_err(|_| "eval panicked".to_string())?
     .map_err(|e| format!("eval: {}", e))?;
 
-    let solids: Vec<Solid> = scene.parts.iter().filter_map(|p| p.solid.clone()).collect();
+    let materials = &parsed.document.materials;
+    let solids: Vec<TintedSolid> = scene
+        .parts
+        .iter()
+        .filter_map(|p| {
+            p.solid.clone().map(|s| {
+                let color = materials.get(&p.material).map(|m| m.color);
+                (s, color)
+            })
+        })
+        .collect();
     Ok(solids)
 }
 
@@ -223,16 +304,140 @@ fn canonicalize(mesh: &vcad_kernel::vcad_kernel_tessellate::TriangleMesh) -> Can
     CanonMesh { verts, tris }
 }
 
+/// Orient per-triangle normals consistently outward, per connected shell.
+///
+/// Tessellation winding is not reliably outward across the kernel's
+/// primitives and booleans — cone laterals wind inward (so the raw winding
+/// normal points into the solid), while some boolean caps wind outward but
+/// carry inward *vertex* normals. Neither the winding nor the stored
+/// normals can be trusted alone. Geometry can: a closed shell whose
+/// triangle winding encloses negative signed volume is inside-out, so we
+/// flip that shell's normals. Shells are the connected components of the
+/// vertex-adjacency graph, so disjoint solids in one mesh are oriented
+/// independently.
+fn orient_normals(cm: &CanonMesh, normals: &mut [[f64; 3]]) {
+    let n = cm.verts.len();
+    if n == 0 {
+        return;
+    }
+    // Union-find over canonical vertices → connected shells.
+    let mut parent: Vec<usize> = (0..n).collect();
+    fn find(parent: &mut [usize], x: usize) -> usize {
+        let mut root = x;
+        while parent[root] != root {
+            root = parent[root];
+        }
+        let mut cur = x;
+        while parent[cur] != cur {
+            let next = parent[cur];
+            parent[cur] = root;
+            cur = next;
+        }
+        root
+    }
+    for t in &cm.tris {
+        let a = find(&mut parent, t[0]);
+        let b = find(&mut parent, t[1]);
+        let c = find(&mut parent, t[2]);
+        parent[b] = a;
+        parent[c] = a;
+    }
+    // Signed volume per shell (6× actual; only the sign matters).
+    let mut vol6: HashMap<usize, f64> = HashMap::new();
+    for t in &cm.tris {
+        let root = find(&mut parent, t[0]);
+        let (v0, v1, v2) = (cm.verts[t[0]], cm.verts[t[1]], cm.verts[t[2]]);
+        *vol6.entry(root).or_default() += dot(v0, cross(v1, v2));
+    }
+    for (ti, t) in cm.tris.iter().enumerate() {
+        let root = find(&mut parent, t[0]);
+        if vol6.get(&root).copied().unwrap_or(0.0) < 0.0 {
+            normals[ti] = [-normals[ti][0], -normals[ti][1], -normals[ti][2]];
+        }
+    }
+}
+
 // ─── per-solid render artifacts (shared by SVG + raster paths) ────────────
+
+/// How a kept edge reads, and how hidden-line removal treats it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EdgeKind {
+    /// A hard model outline: a boundary (open) edge, or a silhouette
+    /// between two clearly non-coplanar faces (a box edge, a bore rim at
+    /// its tangent). Stroked heavy; always kept where visible.
+    Outline,
+    /// The silhouette of a smoothly curved surface — a cylinder/sphere
+    /// profile, or the generatrix of a bore. Stroked heavy, but kept only
+    /// where it runs over open background (a true exterior outline) or as a
+    /// long interior run; short interior fragments are tangent-point noise
+    /// (the stub hanging off a hole's rim) and are dropped.
+    Smooth,
+    /// Interior crease between two same-facing, non-coplanar faces (a
+    /// chamfer rim, a sharp fold). Stroked light.
+    Crease,
+}
 
 struct SolidArtifacts {
     verts: Vec<[f64; 3]>,
     tris: Vec<[usize; 3]>,
     normals: Vec<[f64; 3]>,
+    /// Per-triangle, per-corner smoothed normals (angle-grouped: averaged
+    /// only across facets within the smoothing tolerance, so curved
+    /// surfaces interpolate smoothly while hard edges stay crisp). Drives
+    /// Gouraud shading in the SVG path.
+    corner_normals: Vec<[[f64; 3]; 3]>,
+    /// The shading ramp for this solid — the base navy ramp, tinted toward
+    /// the part's material colour when one is known.
+    ramp: [[u8; 3]; 4],
     visible: Vec<bool>,
     /// Kept edges (boundary, crease, or silhouette, with ≥1 visible
-    /// adjacent triangle) as canonical-vertex index pairs.
-    edges: Vec<(usize, usize)>,
+    /// adjacent triangle) as canonical-vertex index pairs plus their kind.
+    edges: Vec<(usize, usize, EdgeKind)>,
+}
+
+/// Per-triangle, per-corner smoothed normals. A corner's normal is the
+/// average of the face normals of all triangles incident to that vertex
+/// whose normal lies within `tol` of *this* triangle's normal — i.e. the
+/// same smooth surface. This rounds curved tessellation (cylinders,
+/// fillets, spheres) while leaving hard edges (a cube corner, a bore rim)
+/// crisp, because across a hard edge the neighbour's normal falls outside
+/// `tol` and is excluded.
+fn smoothed_corner_normals(
+    verts: &[[f64; 3]],
+    tris: &[[usize; 3]],
+    normals: &[[f64; 3]],
+    tol: f64,
+) -> Vec<[[f64; 3]; 3]> {
+    // Vertex → incident triangles.
+    let mut vtris: Vec<Vec<usize>> = vec![Vec::new(); verts.len()];
+    for (ti, t) in tris.iter().enumerate() {
+        for &v in t {
+            vtris[v].push(ti);
+        }
+    }
+    tris.iter()
+        .enumerate()
+        .map(|(ti, t)| {
+            let fn_ti = normals[ti];
+            let mut corners = [[0.0; 3]; 3];
+            for (c, &v) in t.iter().enumerate() {
+                let mut acc = [0.0; 3];
+                for &tj in &vtris[v] {
+                    if dot(fn_ti, normals[tj]) >= tol {
+                        acc = [
+                            acc[0] + normals[tj][0],
+                            acc[1] + normals[tj][1],
+                            acc[2] + normals[tj][2],
+                        ];
+                    }
+                }
+                let n = normalize(acc);
+                // Degenerate fallback: keep the flat face normal.
+                corners[c] = if n == [0.0; 3] { fn_ti } else { n };
+            }
+            corners
+        })
+        .collect()
 }
 
 /// How `build_artifacts` decides which mesh edges to keep as linework.
@@ -245,26 +450,43 @@ struct EdgeRules {
     /// path needs this because its loose `coplanar_dot_tol` would
     /// otherwise swallow the outline of finely tessellated cylinders.
     mark_silhouette: bool,
+    /// Keep hard edges (boundary/crease/silhouette) even when *both*
+    /// adjacent faces point away from the camera. The SVG path sets this so
+    /// fully-occluded model edges — the far side of a box, the near arc of a
+    /// through-bore's hidden rim — survive to be drawn as dashed hidden
+    /// lines; their occlusion is resolved by the depth buffer afterward.
+    /// (Coplanar tessellation facets are still dropped regardless.)
+    keep_occluded: bool,
 }
 
 impl EdgeRules {
-    /// The historical SVG behaviour.
+    /// The SVG path: silhouette-aware (vector hidden-line removal needs
+    /// explicit outlines) with the curved-facet-blending coplanar tol, and
+    /// keeps occluded hard edges so they can be dashed.
     fn svg() -> Self {
         EdgeRules {
-            coplanar_dot_tol: COPLANAR_DOT_TOL,
-            mark_silhouette: false,
+            coplanar_dot_tol: COPLANAR_DOT_TOL_SVG,
+            mark_silhouette: true,
+            keep_occluded: true,
         }
     }
 }
 
 fn build_artifacts(
     solids: &[Solid],
+    tints: &[Option<[f64; 3]>],
     cam: [f64; 3],
     segments: u32,
     rules: &EdgeRules,
 ) -> Vec<SolidArtifacts> {
     let mut out = Vec::new();
-    for solid in solids {
+    for (si, solid) in solids.iter().enumerate() {
+        let ramp = tints
+            .get(si)
+            .copied()
+            .flatten()
+            .map(tint_ramp)
+            .unwrap_or(RAMP);
         let mesh = catch_unwind(AssertUnwindSafe(|| solid.to_mesh(segments)));
         let Ok(mesh) = mesh else { continue };
         if mesh.indices.is_empty() {
@@ -275,12 +497,16 @@ fn build_artifacts(
             continue;
         }
 
-        // Per-triangle normal + back-face visibility.
-        let normals: Vec<[f64; 3]> = cm
+        // Per-triangle winding normal, then oriented outward per shell so
+        // back-face culling and silhouette tests use a consistent "out".
+        let mut normals: Vec<[f64; 3]> = cm
             .tris
             .iter()
             .map(|t| face_normal([cm.verts[t[0]], cm.verts[t[1]], cm.verts[t[2]]]))
             .collect();
+        orient_normals(&cm, &mut normals);
+        let corner_normals =
+            smoothed_corner_normals(&cm.verts, &cm.tris, &normals, rules.coplanar_dot_tol);
         let visible: Vec<bool> = normals
             .iter()
             .map(|n| dot(*n, cam) >= BACKFACE_DOT_MIN)
@@ -298,28 +524,42 @@ fn build_artifacts(
         }
 
         // Keep boundary + crease edges. Skip internal ones.
-        let mut edges: Vec<(usize, usize)> = Vec::new();
+        let mut edges: Vec<(usize, usize, EdgeKind)> = Vec::new();
         for (edge, adj_tris) in &edge_to_tris {
-            // Visibility: at least one adjacent triangle must be visible,
-            // otherwise we'd be drawing a hidden edge over the silhouette.
-            let any_visible = adj_tris.iter().any(|&ti| visible[ti]);
-            if !any_visible {
+            // Unless the caller wants occluded edges (for dashed hidden
+            // lines), drop edges with no front-facing adjacent triangle —
+            // without a depth buffer they'd be drawn over the silhouette.
+            // With one (the SVG path), keep them and let HLR dash them.
+            if !rules.keep_occluded && !adj_tris.iter().any(|&ti| visible[ti]) {
                 continue;
             }
-            let keep = match adj_tris.len() {
-                1 => true, // boundary / silhouette
+            let kind = match adj_tris.len() {
+                1 => Some(EdgeKind::Outline), // boundary
                 2 => {
                     let (t0, t1) = (adj_tris[0], adj_tris[1]);
                     let silhouette = rules.mark_silhouette
                         && (dot(normals[t0], cam) >= 0.0) != (dot(normals[t1], cam) >= 0.0);
-                    // Crease: only if normals are not coplanar.
                     let cosang = dot(normals[t0], normals[t1]).abs();
-                    silhouette || cosang < rules.coplanar_dot_tol
+                    let coplanar = cosang >= rules.coplanar_dot_tol;
+                    if silhouette {
+                        // A silhouette between near-coplanar facets is the
+                        // smooth outline of a curved surface; between
+                        // distinct faces it's a hard model edge.
+                        Some(if coplanar {
+                            EdgeKind::Smooth
+                        } else {
+                            EdgeKind::Outline
+                        })
+                    } else if !coplanar {
+                        Some(EdgeKind::Crease)
+                    } else {
+                        None // coplanar internal edge — hidden
+                    }
                 }
-                _ => true, // weird (non-manifold); render conservatively
+                _ => Some(EdgeKind::Outline), // weird (non-manifold); render conservatively
             };
-            if keep {
-                edges.push(*edge);
+            if let Some(kind) = kind {
+                edges.push((edge.0, edge.1, kind));
             }
         }
 
@@ -327,6 +567,8 @@ fn build_artifacts(
             verts: cm.verts,
             tris: cm.tris,
             normals,
+            corner_normals,
+            ramp,
             visible,
             edges,
         });
@@ -372,30 +614,408 @@ fn lambertian(n: [f64; 3], light: [f64; 3]) -> f64 {
     (d * 0.5 + 0.5).powf(0.85)
 }
 
+/// Studio shading term in `[0, 1]` for the SVG path: an upper-left key
+/// light over a soft ambient floor (no facet crushes to pure shadow) plus
+/// a grazing-angle "rim" lift that puts a bright lip on curved silhouettes
+/// — the cue that reads as a lit, three-dimensional surface rather than a
+/// flat fill.
+fn shade(n: [f64; 3], cam: [f64; 3], light: [f64; 3]) -> f64 {
+    let key = (dot(n, light) * 0.5 + 0.5).powf(0.85);
+    // Rim: strongest where the facet grazes the camera and is at least
+    // partially lit, so the lift lands on the lit side of a silhouette.
+    let graze = (1.0 - dot(n, cam).abs()).clamp(0.0, 1.0);
+    let rim = graze.powi(3) * (dot(n, light) * 0.5 + 0.5);
+    (key * 0.86 + 0.1 + rim * 0.26).clamp(0.0, 1.0)
+}
+
+/// Sample a 4-stop tonal `ramp` at `t ∈ [0, 1]` with linear interpolation.
+fn ramp_sample(ramp: &[[u8; 3]; 4], t: f64) -> [u8; 3] {
+    let t = t.clamp(0.0, 1.0) * 3.0;
+    let i = (t.floor() as usize).min(2);
+    mix_rgb(ramp[i], ramp[i + 1], t - i as f64)
+}
+
+fn luma(c: [f64; 3]) -> f64 {
+    0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2]
+}
+
+/// Tint the base [`RAMP`] toward a material colour while staying in the navy
+/// tonal family. Every stop is blended toward the material colour
+/// *rescaled to that stop's own luminance*, so the hue shift is coherent
+/// from shadow to highlight (no two-tone navy-body / warm-cap split) and
+/// the lighting tone is preserved. The blend strength scales with the
+/// material's saturation, so achromatic materials (aluminium, steel, the
+/// default) leave the navy essentially untouched while chromatic ones
+/// (copper, brass, gold, wood) warm or cool the whole ramp — one
+/// disciplined tint per part, never an arbitrary rainbow.
+fn tint_ramp(color: [f64; 3]) -> [[u8; 3]; 4] {
+    let mx = color[0].max(color[1]).max(color[2]).max(1e-3);
+    let mn = color[0].min(color[1]).min(color[2]);
+    let sat = (mx - mn) / mx; // HSV saturation
+                              // Restrained: navy is the brand, so the tint is a gentle hue nudge that
+                              // differentiates materials in an assembly without muddying into grey
+                              // (navy and warm metals are near-complementary, so a heavy blend would).
+    let k = (sat * 0.3).clamp(0.0, 0.2); // tint strength
+    let ml = luma(color).max(1e-3);
+    let mut out = RAMP;
+    for stop in out.iter_mut() {
+        let sl = luma([stop[0] as f64, stop[1] as f64, stop[2] as f64]) / 255.0;
+        let scale = sl / ml; // material rescaled to this stop's luminance
+        for c in 0..3 {
+            let base = stop[c] as f64;
+            let mat_at = (color[c] * scale * 255.0).clamp(0.0, 255.0);
+            stop[c] = (base * (1.0 - k) + mat_at * k).round() as u8;
+        }
+    }
+    out
+}
+
+fn hex(c: [u8; 3]) -> String {
+    format!("#{:02x}{:02x}{:02x}", c[0], c[1], c[2])
+}
+
 fn mix_rgb(a: [u8; 3], b: [u8; 3], t: f64) -> [u8; 3] {
     let mix = |x: u8, y: u8| ((x as f64) * (1.0 - t) + (y as f64) * t).round() as u8;
     [mix(a[0], b[0]), mix(a[1], b[1]), mix(a[2], b[2])]
 }
 
-fn mix_color(a: [u8; 3], b: [u8; 3], t: f64) -> String {
-    let [r, g, bl] = mix_rgb(a, b, t);
-    format!("#{:02x}{:02x}{:02x}", r, g, bl)
-}
-
 // ─── output buffers ───────────────────────────────────────────────────────
 
+/// A 2D line segment in final SVG coordinates.
+type Seg = ((f64, f64), (f64, f64));
+
+/// A projected, shaded triangle ready to emit. Screen coords are in final
+/// SVG user units (padding already applied); `depth` is the centroid depth
+/// for painter sorting. `fill` is a solid colour or a `url(#gN)` gradient
+/// ref; `stroke` is a solid colour that closes anti-alias seams without
+/// fighting the gradient.
 #[derive(Clone)]
 struct ProjPoly {
     s: [(f64, f64); 3],
     fill: String,
+    stroke: String,
     depth: f64,
 }
 
+/// An SVG `linearGradient` reproducing a triangle's Gouraud shade: the
+/// vector `(x1,y1)→(x2,y2)` and the colours at its two ends.
+struct GouraudGrad {
+    x1: f64,
+    y1: f64,
+    x2: f64,
+    y2: f64,
+    lo: [u8; 3],
+    hi: [u8; 3],
+}
+
+/// Build a per-triangle linear gradient that reproduces Gouraud (barycentric)
+/// shade interpolation. Shade is affine over the triangle, so its screen-space
+/// gradient is a single direction; we place an SVG `linearGradient` along it.
+/// Returns `None` when the shade range is negligible or the triangle is
+/// degenerate (the caller then flat-fills).
+fn gouraud_gradient(ps: [(f64, f64); 3], sh: [f64; 3], ramp: &[[u8; 3]; 4]) -> Option<GouraudGrad> {
+    let smin = sh[0].min(sh[1]).min(sh[2]);
+    let smax = sh[0].max(sh[1]).max(sh[2]);
+    if smax - smin < 0.012 {
+        return None;
+    }
+    let (e1x, e1y) = (ps[1].0 - ps[0].0, ps[1].1 - ps[0].1);
+    let (e2x, e2y) = (ps[2].0 - ps[0].0, ps[2].1 - ps[0].1);
+    let det = e1x * e2y - e1y * e2x;
+    if det.abs() < 1e-9 {
+        return None;
+    }
+    let (d1, d2) = (sh[1] - sh[0], sh[2] - sh[0]);
+    // ∇shade in screen space.
+    let bx = (e2y * d1 - e1y * d2) / det;
+    let by = (-e2x * d1 + e1x * d2) / det;
+    let blen = (bx * bx + by * by).sqrt();
+    if blen < 1e-9 {
+        return None;
+    }
+    let (ux, uy) = (bx / blen, by / blen);
+    // Project the corners onto the gradient direction; shade is monotonic
+    // along it, so min/max projection ↔ min/max shade.
+    let proj: [f64; 3] = [
+        ps[0].0 * ux + ps[0].1 * uy,
+        ps[1].0 * ux + ps[1].1 * uy,
+        ps[2].0 * ux + ps[2].1 * uy,
+    ];
+    let mut lo = 0;
+    let mut hi = 0;
+    for i in 1..3 {
+        if proj[i] < proj[lo] {
+            lo = i;
+        }
+        if proj[i] > proj[hi] {
+            hi = i;
+        }
+    }
+    let span = proj[hi] - proj[lo];
+    let (ax, ay) = ps[lo];
+    Some(GouraudGrad {
+        x1: ax,
+        y1: ay,
+        x2: ax + ux * span,
+        y2: ay + uy * span,
+        lo: ramp_sample(ramp, sh[lo]),
+        hi: ramp_sample(ramp, sh[hi]),
+    })
+}
+
+/// A projected edge in final SVG coords, with per-endpoint depth for the
+/// hidden-line-removal walk and a kind for stroke weighting.
 #[derive(Clone)]
 struct ProjEdge {
     a: (f64, f64),
+    da: f64,
     b: (f64, f64),
-    depth: f64,
+    db: f64,
+    kind: EdgeKind,
+}
+
+// ─── off-screen depth buffer (vector hidden-line removal) ──────────────────
+
+/// Fixed-budget depth buffer the SVG path rasterizes its triangles into so
+/// edges can be occlusion-tested before they're emitted as vector lines.
+struct DepthBuffer {
+    z: Vec<f64>,
+    bw: usize,
+    bh: usize,
+    /// Buffer cells per SVG user unit.
+    scale: f64,
+}
+
+impl DepthBuffer {
+    fn new(w: f64, h: f64) -> Self {
+        let s = (OCC_BUFFER_LONG_SIDE / w.max(h).max(1.0)).max(1.0);
+        let bw = ((w * s).ceil() as usize).clamp(1, 4096);
+        let bh = ((h * s).ceil() as usize).clamp(1, 4096);
+        DepthBuffer {
+            z: vec![f64::NEG_INFINITY; bw * bh],
+            bw,
+            bh,
+            scale: s,
+        }
+    }
+
+    #[inline]
+    fn at(&self, x: i64, y: i64) -> f64 {
+        if x < 0 || y < 0 || x >= self.bw as i64 || y >= self.bh as i64 {
+            f64::NEG_INFINITY
+        } else {
+            self.z[y as usize * self.bw + x as usize]
+        }
+    }
+
+    /// Rasterize a triangle (final SVG coords + per-vertex depth) into the
+    /// buffer, keeping the nearest (largest) depth per cell.
+    fn raster(&mut self, s: [(f64, f64); 3], vd: [f64; 3]) {
+        let p = [
+            (s[0].0 * self.scale, s[0].1 * self.scale, vd[0]),
+            (s[1].0 * self.scale, s[1].1 * self.scale, vd[1]),
+            (s[2].0 * self.scale, s[2].1 * self.scale, vd[2]),
+        ];
+        let area = edge_area(p[0], p[1], p[2].0, p[2].1);
+        if area.abs() < 1e-12 {
+            return;
+        }
+        let xs = [p[0].0, p[1].0, p[2].0];
+        let ys = [p[0].1, p[1].1, p[2].1];
+        let x0 = xs
+            .iter()
+            .cloned()
+            .fold(f64::INFINITY, f64::min)
+            .floor()
+            .max(0.0) as usize;
+        let y0 = ys
+            .iter()
+            .cloned()
+            .fold(f64::INFINITY, f64::min)
+            .floor()
+            .max(0.0) as usize;
+        let x1 = (xs.iter().cloned().fold(f64::NEG_INFINITY, f64::max).ceil())
+            .min((self.bw - 1) as f64) as usize;
+        let y1 = (ys.iter().cloned().fold(f64::NEG_INFINITY, f64::max).ceil())
+            .min((self.bh - 1) as f64) as usize;
+        if x0 > x1 || y0 > y1 {
+            return;
+        }
+        let sign = area.signum();
+        let inv = 1.0 / area.abs();
+        for py in y0..=y1 {
+            for px in x0..=x1 {
+                let cx = px as f64 + 0.5;
+                let cy = py as f64 + 0.5;
+                let w0 = edge_area(p[1], p[2], cx, cy) * sign;
+                let w1 = edge_area(p[2], p[0], cx, cy) * sign;
+                let w2 = edge_area(p[0], p[1], cx, cy) * sign;
+                if w0 < 0.0 || w1 < 0.0 || w2 < 0.0 {
+                    continue;
+                }
+                let depth = (w0 * p[0].2 + w1 * p[1].2 + w2 * p[2].2) * inv;
+                let idx = py * self.bw + px;
+                if depth > self.z[idx] {
+                    self.z[idx] = depth;
+                }
+            }
+        }
+    }
+
+    /// Screen-space ambient occlusion at a final-SVG point whose surface is
+    /// at camera depth `depth`. Samples rings of neighbours and counts those
+    /// significantly *nearer* than this point (geometry poking up in front,
+    /// i.e. blocking ambient light), with a distance falloff so only local
+    /// cavities contribute. Returns occlusion in `[0, 1]` (0 = open).
+    ///
+    /// `bias` ignores tiny depth differences (a surface's own screen slope);
+    /// `range` is the falloff distance — occluders nearer by more than this
+    /// don't count, so a foreground part doesn't shadow the whole background.
+    fn ao(&self, sx: f64, sy: f64, depth: f64, bias: f64, range: f64) -> f64 {
+        let bx = sx * self.scale;
+        let by = sy * self.scale;
+        // Two rings scaled to the buffer so the radius is resolution-stable.
+        let r0 = (self.bw.max(self.bh) as f64 * 0.006).clamp(2.0, 9.0);
+        let radii = [r0, r0 * 2.2, r0 * 4.0];
+        const ANG: usize = 8;
+        let mut occ = 0.0;
+        let mut total = 0.0;
+        for &r in &radii {
+            for a in 0..ANG {
+                let th = a as f64 / ANG as f64 * std::f64::consts::TAU;
+                let px = (bx + r * th.cos()).floor() as i64;
+                let py = (by + r * th.sin()).floor() as i64;
+                total += 1.0;
+                let z = self.at(px, py);
+                if z == f64::NEG_INFINITY {
+                    continue; // open sky — not an occluder
+                }
+                let diff = z - depth; // > 0 ⇒ neighbour is nearer (occludes)
+                if diff > bias {
+                    occ += (1.0 - diff / range).clamp(0.0, 1.0);
+                }
+            }
+        }
+        if total > 0.0 {
+            occ / total
+        } else {
+            0.0
+        }
+    }
+
+    /// Walk an edge (final SVG coords + endpoint depths) and split it into
+    /// its visible and hidden (occluded) sub-segments. Each [`VisSpan`]
+    /// carries its length in buffer cells and whether any of it ran over
+    /// open background, so the caller can apply per-kind keep rules and emit
+    /// the hidden parts as dashed convention lines. `bias` is an absolute
+    /// depth tolerance; the local depth gradient is added adaptively so
+    /// grazing/silhouette samples aren't self-occluded.
+    fn clip_edge(&self, a: (f64, f64), da: f64, b: (f64, f64), db: f64, bias: f64) -> EdgeClip {
+        let (ax, ay) = (a.0 * self.scale, a.1 * self.scale);
+        let (bx, by) = (b.0 * self.scale, b.1 * self.scale);
+        let len = ((bx - ax).powi(2) + (by - ay).powi(2)).sqrt();
+        let steps = len.ceil().max(1.0) as usize;
+        let scale = self.scale;
+        let mut clip = EdgeClip {
+            visible: Vec::new(),
+            hidden: Vec::new(),
+        };
+        // Current run state: visibility, start point, last point, bg flag.
+        let mut state: Option<bool> = None;
+        let mut run_start = (ax, ay);
+        let mut run_last = (ax, ay);
+        let mut run_over_bg = false;
+        let flush =
+            |vis: bool, start: (f64, f64), end: (f64, f64), over_bg: bool, c: &mut EdgeClip| {
+                let len_cells = ((end.0 - start.0).powi(2) + (end.1 - start.1).powi(2)).sqrt();
+                let span = VisSpan {
+                    a: (start.0 / scale, start.1 / scale),
+                    b: (end.0 / scale, end.1 / scale),
+                    len_cells,
+                    over_bg,
+                };
+                if vis {
+                    c.visible.push(span);
+                } else {
+                    c.hidden.push(span);
+                }
+            };
+        for i in 0..=steps {
+            let t = i as f64 / steps as f64;
+            let bxp = ax + (bx - ax) * t;
+            let byp = ay + (by - ay) * t;
+            let d = da + (db - da) * t;
+            let ix = bxp.floor() as i64;
+            let iy = byp.floor() as i64;
+            let z = self.at(ix, iy);
+            let mut over_bg = false;
+            let visible = if z == f64::NEG_INFINITY {
+                over_bg = true; // over background — nothing occludes it
+                true
+            } else {
+                let mut delta = 0.0f64;
+                for (nx, ny) in [(ix - 1, iy), (ix + 1, iy), (ix, iy - 1), (ix, iy + 1)] {
+                    let nz = self.at(nx, ny);
+                    if nz == f64::NEG_INFINITY {
+                        delta = f64::INFINITY; // silhouette pixel — always show
+                        over_bg = true;
+                    } else {
+                        delta = delta.max((z - nz).abs());
+                    }
+                }
+                d >= z - (bias + delta)
+            };
+            let pt = (bxp, byp);
+            match state {
+                Some(prev) if prev == visible => {
+                    run_last = pt;
+                    run_over_bg |= over_bg;
+                }
+                Some(prev) => {
+                    // Visibility flipped — close the previous run at this
+                    // boundary point so visible and hidden spans abut.
+                    flush(prev, run_start, pt, run_over_bg, &mut clip);
+                    run_start = pt;
+                    run_last = pt;
+                    run_over_bg = over_bg;
+                    state = Some(visible);
+                }
+                None => {
+                    run_start = pt;
+                    run_last = pt;
+                    run_over_bg = over_bg;
+                    state = Some(visible);
+                }
+            }
+        }
+        if let Some(vis) = state {
+            flush(vis, run_start, run_last, run_over_bg, &mut clip);
+        }
+        clip
+    }
+}
+
+/// The visible and hidden sub-segments of one edge after the depth-buffer walk.
+struct EdgeClip {
+    visible: Vec<VisSpan>,
+    hidden: Vec<VisSpan>,
+}
+
+/// One sub-segment of an edge after hidden-line removal.
+struct VisSpan {
+    a: (f64, f64),
+    b: (f64, f64),
+    /// Length in depth-buffer cells (resolution-independent measure).
+    len_cells: f64,
+    /// True if any sample ran over / beside open background.
+    over_bg: bool,
+}
+
+/// Twice the signed area of triangle (a, b, (px, py)) — the half-plane
+/// edge function shared by the depth rasterizer.
+#[inline]
+fn edge_area(a: (f64, f64, f64), b: (f64, f64, f64), px: f64, py: f64) -> f64 {
+    (b.0 - a.0) * (py - a.1) - (b.1 - a.1) * (px - a.0)
 }
 
 // ─── public API: SVG ──────────────────────────────────────────────────────
@@ -410,9 +1030,14 @@ pub fn render_svg_str(raw_vcad: &str, scale: f64) -> Result<String, String> {
 }
 
 /// Render raw `.vcad` document JSON to a self-contained SVG from `view`.
+///
+/// Unlike [`render_svg_solids_view`], this path knows each part's material
+/// and tints the shading ramp accordingly.
 pub fn render_svg_str_view(raw_vcad: &str, scale: f64, view: View) -> Result<String, String> {
-    let solids = evaluate_vcad(raw_vcad)?;
-    render_svg_solids_view(&solids, scale, view)
+    let tinted = evaluate_vcad(raw_vcad)?;
+    let solids: Vec<Solid> = tinted.iter().map(|(s, _)| s.clone()).collect();
+    let tints: Vec<Option<[f64; 3]>> = tinted.iter().map(|(_, t)| *t).collect();
+    render_svg_impl(&solids, &tints, scale, view)
 }
 
 /// Render pre-evaluated solids to a self-contained isometric SVG.
@@ -424,7 +1049,27 @@ pub fn render_svg_solids(solids: &[Solid], scale: f64) -> Result<String, String>
 }
 
 /// Render pre-evaluated solids to a self-contained SVG from `view`.
+///
+/// Pipeline: tessellate → back-face cull → project → shade (painter's
+/// algorithm, back-to-front) → rasterize a depth buffer → emit only the
+/// edge sub-segments that survive a z-test against it. The depth buffer
+/// gives true hidden-line removal in vector form, so back faces, the far
+/// rims of bores, and occluded creases no longer bleed through the fills.
+///
+/// This entry point has no material information, so every part uses the
+/// base navy ramp; use [`render_svg_str_view`] to honour document materials.
 pub fn render_svg_solids_view(solids: &[Solid], scale: f64, view: View) -> Result<String, String> {
+    let tints = vec![None; solids.len()];
+    render_svg_impl(solids, &tints, scale, view)
+}
+
+/// Shared SVG renderer; `tints[i]` optionally tints solid `i`'s ramp.
+fn render_svg_impl(
+    solids: &[Solid],
+    tints: &[Option<[f64; 3]>],
+    scale: f64,
+    view: View,
+) -> Result<String, String> {
     if solids.is_empty() {
         return Err("no solids produced".to_string());
     }
@@ -435,44 +1080,139 @@ pub fn render_svg_solids_view(solids: &[Solid], scale: f64, view: View) -> Resul
     let light = normalize(LIGHT);
     let project = |p: [f64; 3]| -> (f64, f64) { (dot(p, right) * scale, dot(p, down) * scale) };
 
-    let mut polys: Vec<ProjPoly> = Vec::new();
-    let mut edges: Vec<ProjEdge> = Vec::new();
+    let arts = build_artifacts(solids, tints, cam, TESSELLATION_SEGMENTS, &EdgeRules::svg());
 
-    for art in build_artifacts(solids, cam, TESSELLATION_SEGMENTS, &EdgeRules::svg()) {
-        // Project canonical vertices once.
-        let proj: Vec<(f64, f64)> = art.verts.iter().map(|v| project(*v)).collect();
+    // First pass: screen-space bbox + 3D bbox (for the depth-cue bias),
+    // over every projected vertex of every kept artifact.
+    let mut min_x = f64::INFINITY;
+    let mut min_y = f64::INFINITY;
+    let mut max_x = f64::NEG_INFINITY;
+    let mut max_y = f64::NEG_INFINITY;
+    let mut lo3 = [f64::INFINITY; 3];
+    let mut hi3 = [f64::NEG_INFINITY; 3];
+    let projected: Vec<Vec<(f64, f64)>> = arts
+        .iter()
+        .map(|art| {
+            art.verts
+                .iter()
+                .map(|v| {
+                    let (x, y) = project(*v);
+                    min_x = min_x.min(x);
+                    min_y = min_y.min(y);
+                    max_x = max_x.max(x);
+                    max_y = max_y.max(y);
+                    for i in 0..3 {
+                        lo3[i] = lo3[i].min(v[i]);
+                        hi3[i] = hi3[i].max(v[i]);
+                    }
+                    (x, y)
+                })
+                .collect()
+        })
+        .collect();
 
-        // Emit visible polygons.
+    if !min_x.is_finite() || !max_x.is_finite() {
+        return Err("no visible polygons after culling".to_string());
+    }
+    let w = (max_x - min_x) + 2.0 * PADDING_PX;
+    let h = (max_y - min_y) + 2.0 * PADDING_PX;
+    // Final SVG coordinate from a projected screen point.
+    let fin =
+        |(x, y): (f64, f64)| -> (f64, f64) { (x - min_x + PADDING_PX, y - min_y + PADDING_PX) };
+
+    // Depth buffer, built up front from every visible triangle. It serves
+    // two passes: ambient-occlusion sampling (below) and hidden-line removal
+    // (further down). Building it once, before shading, lets AO darken the
+    // corner shades that then drive the Gouraud gradients.
+    let diag =
+        ((hi3[0] - lo3[0]).powi(2) + (hi3[1] - lo3[1]).powi(2) + (hi3[2] - lo3[2]).powi(2)).sqrt();
+    let bias = 0.5 + 0.01 * diag;
+    let mut zbuf = DepthBuffer::new(w, h);
+    for (ai, art) in arts.iter().enumerate() {
+        let proj = &projected[ai];
         for (ti, t) in art.tris.iter().enumerate() {
             if !art.visible[ti] {
                 continue;
             }
-            let centroid = [
-                (art.verts[t[0]][0] + art.verts[t[1]][0] + art.verts[t[2]][0]) / 3.0,
-                (art.verts[t[0]][1] + art.verts[t[1]][1] + art.verts[t[2]][1]) / 3.0,
-                (art.verts[t[0]][2] + art.verts[t[1]][2] + art.verts[t[2]][2]) / 3.0,
+            zbuf.raster(
+                [fin(proj[t[0]]), fin(proj[t[1]]), fin(proj[t[2]])],
+                [
+                    dot(art.verts[t[0]], cam),
+                    dot(art.verts[t[1]], cam),
+                    dot(art.verts[t[2]], cam),
+                ],
+            );
+        }
+    }
+    // AO ignores a surface's own screen slope (larger than the HLR bias) and
+    // falls off over a fraction of the part so only local cavities darken.
+    let ao_bias = (0.02 * diag).max(bias);
+    let ao_range = (0.22 * diag).max(ao_bias * 3.0);
+
+    let mut polys: Vec<ProjPoly> = Vec::new();
+    let mut edges: Vec<ProjEdge> = Vec::new();
+    // Gradient defs for Gouraud-shaded (curved) facets, accumulated as we go.
+    let mut gradients = String::new();
+    let mut grad_id = 0usize;
+
+    for (ai, art) in arts.iter().enumerate() {
+        let proj = &projected[ai];
+        for (ti, t) in art.tris.iter().enumerate() {
+            if !art.visible[ti] {
+                continue;
+            }
+            let vd = [
+                dot(art.verts[t[0]], cam),
+                dot(art.verts[t[1]], cam),
+                dot(art.verts[t[2]], cam),
             ];
+            let ps = [fin(proj[t[0]]), fin(proj[t[1]]), fin(proj[t[2]])];
+            // Gouraud: shade each corner from its smoothed normal, darkened
+            // by screen-space ambient occlusion. Curved facets get a linear
+            // gradient; flat ones a single fill. Shared-vertex shades match
+            // across edges (same normal-group, same AO sample point), so
+            // curved surfaces stay continuous while hard edges stay crisp.
+            let cn = &art.corner_normals[ti];
+            // Floor weak AO to zero: a flat face triangulated as a coarse
+            // fan picks up tiny (~0.05) occlusion variation between corners
+            // that, amplified into the shade, would cross the gradient
+            // threshold and draw a fan of seams. Only meaningful occlusion
+            // (cavities, concave creases, part contact) survives the floor.
+            let ao = |p: (f64, f64), d: f64| {
+                ((zbuf.ao(p.0, p.1, d, ao_bias, ao_range) - AO_FLOOR) / (1.0 - AO_FLOOR)).max(0.0)
+            };
+            let sh = [
+                shade(cn[0], cam, light) * (1.0 - AO_STRENGTH * ao(ps[0], vd[0])),
+                shade(cn[1], cam, light) * (1.0 - AO_STRENGTH * ao(ps[1], vd[1])),
+                shade(cn[2], cam, light) * (1.0 - AO_STRENGTH * ao(ps[2], vd[2])),
+            ];
+            let avg = hex(ramp_sample(&art.ramp, (sh[0] + sh[1] + sh[2]) / 3.0));
+            let (fill, stroke) = match gouraud_gradient(ps, sh, &art.ramp) {
+                Some(g) => {
+                    let id = grad_id;
+                    grad_id += 1;
+                    gradients.push_str(&format!(
+                        r#"<linearGradient id="g{id}" gradientUnits="userSpaceOnUse" x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}"><stop offset="0" stop-color="{}"/><stop offset="1" stop-color="{}"/></linearGradient>"#,
+                        g.x1, g.y1, g.x2, g.y2, hex(g.lo), hex(g.hi),
+                    ));
+                    (format!("url(#g{id})"), avg)
+                }
+                None => (avg.clone(), avg),
+            };
             polys.push(ProjPoly {
-                s: [proj[t[0]], proj[t[1]], proj[t[2]]],
-                fill: mix_color(
-                    FILL_DARK,
-                    FILL_LIGHT,
-                    lambertian(art.normals[ti], light).clamp(0.0, 1.0),
-                ),
-                depth: dot(centroid, cam),
+                s: ps,
+                fill,
+                stroke,
+                depth: (vd[0] + vd[1] + vd[2]) / 3.0,
             });
         }
-
-        for &(a, b) in &art.edges {
-            let mid = [
-                (art.verts[a][0] + art.verts[b][0]) / 2.0,
-                (art.verts[a][1] + art.verts[b][1]) / 2.0,
-                (art.verts[a][2] + art.verts[b][2]) / 2.0,
-            ];
+        for &(a, b, kind) in &art.edges {
             edges.push(ProjEdge {
-                a: proj[a],
-                b: proj[b],
-                depth: dot(mid, cam),
+                a: fin(proj[a]),
+                da: dot(art.verts[a], cam),
+                b: fin(proj[b]),
+                db: dot(art.verts[b], cam),
+                kind,
             });
         }
     }
@@ -487,51 +1227,48 @@ pub fn render_svg_solids_view(solids: &[Solid], scale: f64, view: View) -> Resul
             .partial_cmp(&b.depth)
             .unwrap_or(std::cmp::Ordering::Equal)
     });
-    edges.sort_by(|a, b| {
-        a.depth
-            .partial_cmp(&b.depth)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
 
-    // BBox over polygons + edges.
-    let mut min_x = f64::INFINITY;
-    let mut min_y = f64::INFINITY;
-    let mut max_x = f64::NEG_INFINITY;
-    let mut max_y = f64::NEG_INFINITY;
-    for p in &polys {
-        for &(x, y) in &p.s {
-            if x < min_x {
-                min_x = x;
-            }
-            if y < min_y {
-                min_y = y;
-            }
-            if x > max_x {
-                max_x = x;
-            }
-            if y > max_y {
-                max_y = y;
-            }
-        }
-    }
+    // Hidden-line removal: clip every kept edge to its visible spans against
+    // the depth buffer built above. (`bias` already defined alongside it.)
+    // Minimum length (buffer cells) for an interior fragment of a smooth
+    // curved-surface silhouette to survive. Exterior outlines (over
+    // background) and long interior runs are kept; short interior stubs —
+    // the generatrix hanging off a bore's rim tangent — are dropped.
+    const SMOOTH_INTERIOR_MIN_CELLS: f64 = 18.0;
+    // A hidden (occluded) span must be at least this long to be drawn
+    // dashed — shorter ones are z-fighting noise, not real occluded edges.
+    const HIDDEN_MIN_CELLS: f64 = 6.0;
+    let mut crease_lines: Vec<Seg> = Vec::new();
+    let mut outline_lines: Vec<Seg> = Vec::new();
+    let mut hidden_lines: Vec<Seg> = Vec::new();
     for e in &edges {
-        for &(x, y) in &[e.a, e.b] {
-            if x < min_x {
-                min_x = x;
+        let clip = zbuf.clip_edge(e.a, e.da, e.b, e.db, bias);
+        let dst = match e.kind {
+            EdgeKind::Crease => &mut crease_lines,
+            EdgeKind::Outline | EdgeKind::Smooth => &mut outline_lines,
+        };
+        for span in &clip.visible {
+            let keep = match e.kind {
+                EdgeKind::Smooth => span.over_bg || span.len_cells >= SMOOTH_INTERIOR_MIN_CELLS,
+                // Hard edges and creases: keep everything visible.
+                EdgeKind::Outline | EdgeKind::Crease => true,
+            };
+            if keep {
+                dst.push((span.a, span.b));
             }
-            if y < min_y {
-                min_y = y;
-            }
-            if x > max_x {
-                max_x = x;
-            }
-            if y > max_y {
-                max_y = y;
+        }
+        // Hidden-line convention: occluded hard edges and creases become
+        // dashed lines (so a bore or pocket reads from a single view).
+        // Smooth curved-surface silhouettes are never dashed — their
+        // occluded fragments are tangent-point noise, not real edges.
+        if matches!(e.kind, EdgeKind::Outline | EdgeKind::Crease) {
+            for span in &clip.hidden {
+                if span.len_cells >= HIDDEN_MIN_CELLS {
+                    hidden_lines.push((span.a, span.b));
+                }
             }
         }
     }
-    let w = (max_x - min_x) + 2.0 * PADDING_PX;
-    let h = (max_y - min_y) + 2.0 * PADDING_PX;
 
     // Emit SVG.
     let mut out = String::new();
@@ -542,37 +1279,77 @@ pub fn render_svg_solids_view(solids: &[Solid], scale: f64, view: View) -> Resul
         r#"<svg xmlns="http://www.w3.org/2000/svg" width="{w:.2}" height="{h:.2}" viewBox="0 0 {w:.2} {h:.2}" role="img" aria-label="vcad render">"#
     ));
 
-    // Filled polygons — no stroke.
-    out.push_str(r#"<g shape-rendering="geometricPrecision">"#);
+    // Soft-shadow filter for the contact shadow + the Gouraud gradient defs.
+    let blur = ((w + h) * 0.008).clamp(1.0, 12.0);
+    out.push_str(&format!(
+        r#"<defs><filter id="sh" x="-50%" y="-50%" width="200%" height="200%"><feGaussianBlur stdDeviation="{blur:.2}"/></filter>{gradients}</defs>"#
+    ));
+
+    // Vellum ground — the warm paper the plate sits on.
+    out.push_str(&format!(
+        r#"<rect x="0" y="0" width="{w:.2}" height="{h:.2}" fill="{PAPER}"/>"#
+    ));
+
+    // Contact shadow: a blurred ellipse under the part's footprint, so it
+    // sits on the page instead of floating.
+    let foot_cx = (max_x - min_x) / 2.0 + PADDING_PX;
+    let foot_cy = (max_y - min_y) + PADDING_PX;
+    let foot_rx = ((max_x - min_x) / 2.0 * 0.94).max(1.0);
+    let foot_ry = (foot_rx * 0.13).max(1.0);
+    out.push_str(&format!(
+        r#"<ellipse cx="{foot_cx:.2}" cy="{foot_cy:.2}" rx="{foot_rx:.2}" ry="{foot_ry:.2}" fill="{SHADOW}" opacity="0.20" filter="url(#sh)"/>"#
+    ));
+
+    // Filled polygons. Each is stroked with its own fill colour at a
+    // hairline width so adjacent triangles overlap by a sub-pixel sliver —
+    // this closes the anti-alias seams that otherwise read as a faint fan
+    // of lines across coplanar tessellated faces.
+    out.push_str(r#"<g shape-rendering="geometricPrecision" stroke-linejoin="round">"#);
     for p in &polys {
         let pts = format!(
             "{:.2},{:.2} {:.2},{:.2} {:.2},{:.2}",
-            p.s[0].0 - min_x + PADDING_PX,
-            p.s[0].1 - min_y + PADDING_PX,
-            p.s[1].0 - min_x + PADDING_PX,
-            p.s[1].1 - min_y + PADDING_PX,
-            p.s[2].0 - min_x + PADDING_PX,
-            p.s[2].1 - min_y + PADDING_PX,
+            p.s[0].0, p.s[0].1, p.s[1].0, p.s[1].1, p.s[2].0, p.s[2].1,
         );
-        out.push_str(&format!(r#"<polygon points="{}" fill="{}"/>"#, pts, p.fill,));
+        out.push_str(&format!(
+            r#"<polygon points="{pts}" fill="{}" stroke="{}" stroke-width="0.75"/>"#,
+            p.fill, p.stroke,
+        ));
     }
     out.push_str("</g>");
 
-    // Boundary + crease edges on top.
-    out.push_str(&format!(
-        r#"<g stroke="{STROKE}" stroke-width="{STROKE_PX}" stroke-linecap="round" fill="none">"#
-    ));
-    for e in &edges {
+    // Linework, drawn over the fills. Hidden (occluded) edges first as fine
+    // dashed convention lines; then visible creases (light); then the bold
+    // outline (heavy) on top. Edges meet exactly at shared vertices (round
+    // caps) — no overshoot, so corners read precise rather than sketchy.
+    let dash = (blur * 0.6).clamp(2.0, 6.0);
+    let emit_lines = |out: &mut String,
+                      lines: &[Seg],
+                      width: f64,
+                      opacity: f64,
+                      dasharray: Option<f64>| {
+        if lines.is_empty() {
+            return;
+        }
+        let dash_attr = match dasharray {
+            Some(d) => format!(r#" stroke-dasharray="{d:.2} {:.2}""#, d * 0.6),
+            None => String::new(),
+        };
         out.push_str(&format!(
-            r#"<line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}"/>"#,
-            e.a.0 - min_x + PADDING_PX,
-            e.a.1 - min_y + PADDING_PX,
-            e.b.0 - min_x + PADDING_PX,
-            e.b.1 - min_y + PADDING_PX,
-        ));
-    }
-    out.push_str("</g></svg>");
+                r#"<g stroke="{INK}" stroke-width="{width}" stroke-linecap="round" fill="none" opacity="{opacity}"{dash_attr}>"#
+            ));
+        for &(a, b) in lines {
+            out.push_str(&format!(
+                r#"<line x1="{:.2}" y1="{:.2}" x2="{:.2}" y2="{:.2}"/>"#,
+                a.0, a.1, b.0, b.1,
+            ));
+        }
+        out.push_str("</g>");
+    };
+    emit_lines(&mut out, &hidden_lines, STROKE_HIDDEN_PX, 0.5, Some(dash));
+    emit_lines(&mut out, &crease_lines, STROKE_CREASE_PX, 1.0, None);
+    emit_lines(&mut out, &outline_lines, STROKE_OUTLINE_PX, 1.0, None);
 
+    out.push_str("</svg>");
     Ok(out)
 }
 
@@ -630,7 +1407,10 @@ mod raster {
     /// with the same edge classification as the SVG path drawn on top
     /// (hidden lines removed). Errors are human-readable strings.
     pub fn render_jpeg_str(raw_vcad: &str, opts: &RasterOptions) -> Result<Vec<u8>, String> {
-        let solids = evaluate_vcad(raw_vcad)?;
+        let solids: Vec<Solid> = evaluate_vcad(raw_vcad)?
+            .into_iter()
+            .map(|(s, _)| s)
+            .collect();
         render_jpeg_solids(&solids, opts)
     }
 
@@ -651,13 +1431,17 @@ mod raster {
         let down = normalize(opts.view.down());
         let light = normalize(LIGHT);
 
+        // The raster path is monochrome (mecheval reference images) — no tints.
+        let no_tints: Vec<Option<[f64; 3]>> = vec![None; solids.len()];
         let arts = build_artifacts(
             solids,
+            &no_tints,
             cam,
             RASTER_SEGMENTS,
             &EdgeRules {
                 coplanar_dot_tol: RASTER_COPLANAR_DOT_TOL,
                 mark_silhouette: true,
+                keep_occluded: false,
             },
         );
 
@@ -757,7 +1541,7 @@ mod raster {
         let bias_base = 0.5 + 0.005 * diag;
         for art in &arts {
             let proj: Vec<(f64, f64, f64)> = art.verts.iter().map(|v| to_px(*v)).collect();
-            for &(a, b) in &art.edges {
+            for &(a, b, _kind) in &art.edges {
                 draw_edge(&mut rgb, &zbuf, size, proj[a], proj[b], bias_base);
             }
         }
@@ -942,6 +1726,66 @@ mod tests {
   "roots": [{{ "root": 1, "material": "aluminum" }}]
 }}"#
         )
+    }
+
+    fn cone_vcad(radius_bottom: f64, radius_top: f64, height: f64) -> String {
+        format!(
+            r#"{{
+  "version": "0.1",
+  "nodes": {{
+    "1": {{
+      "id": 1,
+      "name": "Cone",
+      "op": {{ "type": "Cone", "radius_bottom": {radius_bottom}, "radius_top": {radius_top}, "height": {height}, "segments": 0 }}
+    }}
+  }},
+  "materials": {{
+    "aluminum": {{
+      "name": "aluminum",
+      "color": [0.91, 0.92, 0.93],
+      "metallic": 1.0,
+      "roughness": 0.4,
+      "density": 2700.0,
+      "friction": 0.6
+    }}
+  }},
+  "part_materials": {{}},
+  "roots": [{{ "root": 1, "material": "aluminum" }}]
+}}"#
+        )
+    }
+
+    /// Regression: the cone's lateral facets wind inward, so winding-only
+    /// orientation culled its front faces (you saw the concave inside) and
+    /// the top view culled everything ("no visible polygons"). Signed-volume
+    /// shell orientation must make every axis view produce visible fills.
+    #[test]
+    fn cone_renders_outward_in_all_views() {
+        for view in [View::Isometric, View::Front, View::Side, View::Top] {
+            let svg = render_svg_str_view(&cone_vcad(9.0, 0.0, 22.0), 4.0, view)
+                .unwrap_or_else(|e| panic!("cone {view:?} should render, got: {e}"));
+            assert!(
+                svg.matches("<polygon").count() > 4,
+                "cone {view:?} produced too few filled polygons — front faces likely culled"
+            );
+        }
+    }
+
+    /// The SVG path weights silhouettes/outlines heavier than interior
+    /// creases. A cube viewed isometrically shows both: its boundary
+    /// silhouette (outline) and the interior edges where visible faces meet
+    /// (crease).
+    #[test]
+    fn svg_emits_weighted_outline_and_crease_strokes() {
+        let svg = render_svg_str(&cube_vcad(20.0, 20.0, 20.0), 4.0).expect("cube should render");
+        assert!(
+            svg.contains(&format!(r#"stroke-width="{STROKE_OUTLINE_PX}""#)),
+            "expected a bold outline stroke group"
+        );
+        assert!(
+            svg.contains(&format!(r#"stroke-width="{STROKE_CREASE_PX}""#)),
+            "expected a fine crease stroke group"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Overhauls the **`vcad-render` SVG path** — what `render_view` (agent-eyes), the mecheval leaderboard, docs, and marketing all use — from a flat painter's render with wireframe bleed-through into a clean, measured-ink **drafting plate**.

## Why

`render_view` is how AI agents see their own CAD work, and the same renderer feeds the leaderboard and docs. The old output had a fan of seams on flat faces, vertical stripes inside bores, and every edge painted on top of the fills with no occlusion (back rims bled through). This makes the static render world-class and unmistakably vcad, while keeping it headless / CPU / vector (no GPU). Photoreal stays where it belongs — the in-app `vcad-kernel-raytrace` viewport toggle.

## What changed

- **True vector hidden-line removal** — rasterize a depth buffer, clip each edge to its visible spans. No more back faces / far bore rims bleeding through.
- **Dashed hidden lines** — occluded hard edges draw dashed (the engineering convention), so a single isometric reveals bores/pockets behind the front faces. A `keep_occluded` edge rule lets fully-occluded hard edges survive to be dashed (e.g. a through-bore's near rim arc completing the hidden circle); coplanar tessellation facets are still dropped.
- **Gouraud smooth shading** — per-corner angle-grouped smoothed normals drive a per-facet `linearGradient` reproducing barycentric shade interpolation. Curved surfaces read smooth, hard edges stay crisp; flat faces keep a single fill (bounded SVG size).
- **Baked ambient occlusion** — screen-space AO from the same depth buffer, folded into per-corner shade so cavities/bores/concave seams darken. An AO floor keeps flat faces clean.
- **Material-tinted ramps** — `evaluate_vcad` now carries each part's material colour; a restrained, luma-preserving, saturation-scaled tint nudges the navy ramp toward the material (aluminium/steel stay navy; copper/gold warm or cool). Differentiable in assemblies, never a rainbow.
- **Studio look** — key + ambient floor + grazing rim lip; multi-stop vcad-Blue ramp; warm ink linework with a weight hierarchy; vellum ground + soft contact shadow.
- **Correctness fix** — signed-volume per-shell normal orientation fixes cones (and any inverted-winding primitive) rendering inside-out, including the cone top view that previously culled to nothing.
- **Cleaner linework** — removed corner overshoot; edges meet exactly at shared vertices (precise, not sketchy).

## Reviewer notes

- **Raster JPEG path (mecheval reference images) is held byte-stable** except for the cone orientation correctness fix — it keeps the flat two-tone shading, its own tessellation, and `keep_occluded: false`.
- All changes are isolated to `crates/vcad-render/src/lib.rs` (+ a changelog entry). Public API signatures are unchanged; material tinting flows through the raw-`.vcad` path (`render_svg_str_view`), so the WASM `render_svg`/`render_svg_view` bindings need no changes.
- SVG size grows for fillet-/curve-dense parts (one gradient per curved facet), but `render_view` delivers the resvg-rasterized PNG, so the agent's payload is unaffected.
- Tests: 19 passing (added cone-orientation + weighted-stroke regression tests); `clippy -D warnings` clean; `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)