### PR TITLE
fix(mcp): get_document returns full IR, not a document_id stub

### DIFF
--- a/changelog/entries/2026-06-15-get-document-full-ir.json
+++ b/changelog/entries/2026-06-15-get-document-full-ir.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-get-document-full-ir",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "fix",
+  "title": "get_document returns the full IR again",
+  "summary": "On inline-viewer clients, get_document no longer collapses a large board's IR to a {document_id} stub, so callers can capture, serialize, and re-feed full session state.",
+  "features": ["mcp", "pcb"],
+  "mcpTools": ["get_document"]
+}

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -28,6 +28,7 @@ import {
   registryToolDescriptors,
   dispatchRegistryTool,
 } from "../tools/registry-dispatch.js";
+import { slimPreviewForInlineUi } from "../server.js";
 import {
   createRobotEnv,
   gymStep,
@@ -129,6 +130,74 @@ describe("session lifecycle", () => {
   it("close_document on unknown id reports closed: false", () => {
     const out = closeDocument({ document_id: "doc_missing" });
     expect(JSON.parse(out.content[0].text).closed).toBe(false);
+  });
+});
+
+describe("get_document body survives inline-UI slimming", () => {
+  // Regression: get_document is in GEOMETRY_TOOLS, so on a client that
+  // declared MCP Apps support, slimPreviewForInlineUi used to replace the
+  // full IR body with a {document_id} stub whenever it exceeded 8192 chars —
+  // which any real PCB does after place_components + route_nets. That broke
+  // get_document's contract ("return the full IR Document JSON").
+
+  /** A PCB session document whose serialized IR comfortably exceeds the
+   *  8192-char slim threshold, mirroring a routed board. */
+  function makeBigPcbDoc(): Document {
+    const components = Array.from({ length: 120 }, (_, i) => ({
+      ref: `R${i + 1}`,
+      footprint: "0805",
+      position: { x: i * 2.54, y: i * 1.27 },
+      pins: [
+        { number: "1", net: `NET_${i}` },
+        { number: "2", net: "GND" },
+      ],
+    }));
+    return {
+      version: "0.1",
+      nodes: {},
+      materials: {},
+      part_materials: {},
+      roots: [{ root: 1, material: "default" }],
+      pcb: {
+        outline: {
+          vertices: [
+            [0, 0],
+            [50, 0],
+            [50, 40],
+            [0, 40],
+          ],
+          thickness: 1.6,
+        },
+        components,
+        nets: { GND: components.map((c) => `${c.ref}.2`) },
+      },
+    } as unknown as Document;
+  }
+
+  it("get_document returns the full IR (pcb + roots), not a document_id stub", () => {
+    const text = JSON.stringify(makeBigPcbDoc());
+    expect(text.length).toBeGreaterThan(8192);
+
+    const result = { content: [{ type: "text", text }] };
+    // clientHasInlineUi=true is the case that triggered the bug.
+    slimPreviewForInlineUi(result, "doc_pcb", "get_document", true);
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.pcb).toBeDefined();
+    expect(parsed.pcb.components).toHaveLength(120);
+    expect(parsed.roots).toHaveLength(1);
+    // The regression collapsed the body to exactly { document_id }.
+    expect(Object.keys(parsed)).not.toEqual(["document_id"]);
+  });
+
+  it("still slims bulky mutation-tool results to a handle block", () => {
+    const result = { content: [{ type: "text", text: "x".repeat(9000) }] };
+    slimPreviewForInlineUi(result, "doc_pcb", "route_nets", true);
+    // summary line + { document_id } block
+    expect(result.content).toHaveLength(2);
+    expect(JSON.parse(result.content[1].text)).toEqual({
+      document_id: "doc_pcb",
+    });
   });
 });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1474,7 +1474,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
  * summary's "see the inline 3D viewer" points at nothing and the agent
  * loses the entire payload — it must keep the full text result.
  */
-function slimPreviewForInlineUi(
+export function slimPreviewForInlineUi(
   result: { content: Array<{ type: string; text: string }> },
   docId: string,
   toolName: string,
@@ -1484,6 +1484,13 @@ function slimPreviewForInlineUi(
   // The flat-pattern coordinates ARE the deliverable — the viewer draws
   // them, but the agent needs the numbers too. Never slim.
   if (toolName === "sheet_metal_unfold") return;
+  // get_document's contract is to RETURN the full IR Document body so the
+  // caller can capture / serialize / feed it back — the IR is the deliverable,
+  // not a side effect of a mutation. Slimming it to a {document_id} stub
+  // breaks that contract (and would be circular: the summary says "use
+  // get_document for the full IR"). Same set attachPreviewHandle already
+  // exempts from the handle-block append.
+  if (PURE_JSON_RESULT_TOOLS.has(toolName)) return;
   const alwaysSlim = toolName === "create_cad_loon";
   const totalChars = result.content.reduce(
     (n, c) => n + (c.type === "text" ? c.text.length : 0),


### PR DESCRIPTION
## What

`get_document` was returning only `{"document_id":"doc_..."}` instead of the full IR Document body, breaking its documented contract: *"Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into export_cad / open_in_browser."*

Reproduced first-hand against vcad 0.9.4 on a live PCB session created via `create_schematic` + `place_components` + `route_nets` — `get_document(document_id)` came back as an id-only stub.

## Why

The handler itself (`getDocumentTool`) was fine — it returns `JSON.stringify(doc)`. The corruption happened one layer up in the server dispatch.

`get_document` is in `GEOMETRY_TOOLS` → `uiTools`, so on any client that declared MCP Apps / inline-viewer support its result ran through `slimPreviewForInlineUi`. That function replaces the body with a summary + `{document_id}` block whenever the text exceeds 8192 chars — which **every real PCB does** after `place_components` + `route_nets`. The summary even said *"Use get_document for the full IR"* while being the slimmed output of `get_document`.

`attachPreviewHandle` already exempted `get_document` via `PURE_JSON_RESULT_TOOLS` (so it didn't append a handle block), but `slimPreviewForInlineUi` ignored that set and blew the body away.

This blocked: snapshotting full board state for an audit/receipt ledger, the legacy stateless re-run path (feeding the IR back via the inline `document` arg), and any "hand the board to another actor to re-verify" flow — which matters because PCB sessions are per-connection and ephemeral.

## The fix

`slimPreviewForInlineUi` now skips `PURE_JSON_RESULT_TOOLS` (which contains `get_document`), exactly the way it already skips `sheet_metal_unfold` whose payload is the deliverable. Exported the slimmer so it's directly testable.

## Test

New regression block in `tools.test.ts` exercising the actual slimming path (the existing unit tests on `getDocumentTool` can't catch this — slimming lives one layer up):
- A routed-PCB doc (>8192 chars, with `pcb` + `roots`) passed through the slimmer with `clientHasInlineUi=true` comes back with `pcb.components` and `roots` intact — asserts the body is **not** collapsed to `{ document_id }`.
- A contrast case confirming a bulky mutation tool (`route_nets`) *still* slims to a handle block, so the fix didn't over-broaden.

## Verification

- `npm test -w @vcad/mcp` → 159 passed / 2 skipped (incl. the 2 new tests)
- `tsc --noEmit` on `@vcad/mcp` → clean (the build uses `--noCheck`, so I ran a real typecheck)
- Changelog entry added (`fix`); `changelog:build` regenerates clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)