### PR TITLE
fix(mcp): make route_nets idempotent — re-routing no longer shorts

### DIFF
--- a/changelog/entries/2026-06-15-route-nets-idempotent.json
+++ b/changelog/entries/2026-06-15-route-nets-idempotent.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-route-nets-idempotent",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "fix",
+  "title": "route_nets is idempotent — re-routing no longer shorts",
+  "summary": "Re-running route_nets rips up the target nets' copper before routing, so a second pass replaces the route instead of stacking duplicate traces that crossed nets and created shorts.",
+  "features": ["pcb", "routing"],
+  "mcpTools": ["route_nets"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -259,6 +259,117 @@ describe("explicit netlist (nets as data)", () => {
   });
 });
 
+describe("route_nets idempotency", () => {
+  // The exact board from the field bug report. Before the fix, routing an
+  // already-routed board a second time stacked copper: the kernel ratsnest
+  // skips nets that already have a trace, so the second route_all came back
+  // empty, the no-kernel fallback in routeNets misfired, and it chained naive
+  // straight segments over the clean route — turning a handful of inherent
+  // violations into dozens of shorts. The fix rips up the target nets' copper
+  // before routing, so re-running replaces the route instead of adding to it.
+  const soic8 = (ref: string, x: number) => ({
+    ref,
+    value: "U",
+    footprint: "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+    x,
+    y: 0,
+    pins: Array.from({ length: 8 }, (_, i) => ({
+      number: `${i + 1}`,
+      name: "~",
+      type: "Passive",
+      x: i < 4 ? -5 : 5,
+      y: (i % 4) * 1.27,
+    })),
+  });
+  const cap = (ref: string, x: number) => ({
+    ref,
+    value: "100n",
+    footprint: "Capacitor_SMD:C_0805_2012Metric",
+    x,
+    y: 20,
+    pins: [
+      { number: "1", name: "~", type: "Passive", x: -2, y: 0 },
+      { number: "2", name: "~", type: "Passive", x: 2, y: 0 },
+    ],
+  });
+  const header = (ref: string, x: number) => ({
+    ref,
+    value: "Conn",
+    footprint: "Connector_PinHeader_2.54mm:PinHeader_1x04_P2.54mm_Vertical",
+    x,
+    y: 0,
+    pins: Array.from({ length: 4 }, (_, i) => ({
+      number: `${i + 1}`,
+      name: "~",
+      type: "Passive",
+      x: 0,
+      y: i * 2.54,
+    })),
+  });
+
+  const buildBoard = async () => {
+    const created = out(
+      await createSchematic({
+        components: [soic8("U1", 0), cap("C1", 20), cap("C2", 40), header("J1", 60)],
+        nets: {
+          VCC: ["U1.1", "C1.1", "J1.1"],
+          GND: ["U1.8", "C1.2", "C2.2", "J1.2"],
+          SIG1: ["U1.2", "C2.1"],
+          SIG2: ["U1.3", "J1.3"],
+          SIG3: ["U1.4", "J1.4"],
+        },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 35 }));
+    return id;
+  };
+
+  it("a second route_nets does not stack copper or add violations", async () => {
+    const id = await buildBoard();
+
+    // First route — establishes the clean baseline.
+    out(await routeNets({ document_id: id }));
+    const board1 = getPcbBoard(getSession(id));
+    const traces1 = board1.traces.length;
+    const vias1 = board1.vias.length;
+    const drc1 = out(await runDrc({ document_id: id }));
+    expect(traces1).toBeGreaterThan(0);
+
+    // Second route — must rip up and re-lay the same copper, not append a second
+    // set. After the rip-up the board is pads-only again, exactly as it was
+    // before the first route, so the deterministic router reproduces it byte
+    // for byte.
+    out(await routeNets({ document_id: id }));
+    const board2 = getPcbBoard(getSession(id));
+    const drc2 = out(await runDrc({ document_id: id }));
+
+    expect(board2.traces.length).toBe(traces1);
+    expect(board2.vias.length).toBe(vias1);
+    expect(drc2.violations).toBe(drc1.violations);
+    // The headline symptom: the re-route must never introduce shorts.
+    expect(drc2.byRule.Short ?? 0).toBe(0);
+  });
+
+  it("routing three times in a row stays flat — no monotonic copper growth", async () => {
+    const id = await buildBoard();
+
+    const snapshot = async () => {
+      out(await routeNets({ document_id: id }));
+      const b = getPcbBoard(getSession(id));
+      const drc = out(await runDrc({ document_id: id }));
+      return { traces: b.traces.length, vias: b.vias.length, violations: drc.violations };
+    };
+
+    const first = await snapshot();
+    const second = await snapshot();
+    const third = await snapshot();
+
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+  });
+});
+
 describe("schematic label diagnostics", () => {
   it("warns when a label touches neither a pin nor a wire endpoint", async () => {
     const created = out(

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -1629,6 +1629,28 @@ export async function routeNets(args: Record<string, unknown>) {
     nets: [...netConnections.entries()].map(([name, connections]) => ({ name, connections })),
   };
 
+  // Rip up existing copper on the nets we're about to (re)route. route_all is
+  // authoritative: it returns a *complete* fresh routing for every target net,
+  // so appending it on top of last run's copper would (a) stack duplicate
+  // traces at 0mm self-clearance and (b) let the recomputed solution cross the
+  // stale one and short other nets. Worse, the kernel's ratsnest skips nets that
+  // already have a trace, so a second route_all comes back empty and the
+  // no-kernel fallback below misfires — chaining naive straight segments over
+  // the clean route. Re-running route_nets must *replace* the prior route, not
+  // add to it. Scope the rip-up to exactly the nets route_all will route — nets
+  // with >=2 pads, intersected with `netsFilter` — so hand-routes on other nets
+  // (e.g. add_coil copper) survive.
+  const targetNets = new Set<string>();
+  for (const [net, conns] of netConnections) {
+    if (conns.length < 2) continue;
+    if (netsFilter.length > 0 && !netsFilter.includes(net)) continue;
+    targetNets.add(net);
+  }
+  if (targetNets.size > 0) {
+    pcb.traces = pcb.traces.filter((t) => !targetNets.has(t.net));
+    pcb.vias = pcb.vias.filter((v) => !targetNets.has(v.net));
+  }
+
   const rats = await computeRatsnest(pcb, netlist);
 
   const routedNets = new Set<string>();


### PR DESCRIPTION
## Problem

Running the vcad MCP `route_nets` tool on an already-routed board a second time stacked copper and created hard shorts. On the field-report board (U1 SOIC-8, C1/C2 0805 caps, J1 1x04 header, 5 nets) DRC went from **4 inherent violations → 72** (Clearance:61, HoleToHole:1, **Short:10**) on the second call — a second set of traces laid directly over the first. Both `route_nets` calls returned only `{document_id}`, so the destruction was invisible without a before/after `run_drc`.

## Root cause

Not the OHM Rust autorouter — its "never shorts" invariant holds, and `route_nets` *does* drive the whole-board `route_all` path. The bug was in the TS handler [`routeNets`](packages/mcp/src/tools/ecad.ts), and the mechanism was subtle:

1. On the second call every net already has a trace.
2. The kernel ratsnest ([`compute_ratsnest`](crates/vcad-ecad-pcb/src/ratsnest.rs)) **skips nets that already have a trace**, so `route_all` correctly returns *empty*.
3. The TS `computeRatsnest` (`rats`) is empty for the same reason → `routedSomething` is false → control falls into the `else if (rats.length === 0)` branch.
4. That branch is the **legacy no-kernel fallback** — it chains each net's pads with naive straight FCu segments, laid over the clean route. They cross other nets (shorts) and overlap same-net copper (0.000mm dupes).

The `rats.length === 0` condition conflated "no kernel available" with "already fully routed."

## Fix

Rip up the target nets' copper before routing — standard rip-up-and-reroute semantics, so re-running *replaces* the route instead of adding to it. Scoped to exactly the nets `route_all` will route (≥2 pads ∩ `netsFilter`) so hand-routes / `add_coil` copper on other nets survive. This also defuses the fallback misfire: after rip-up, a kernel-present board yields a fresh ratsnest, so `rats.length === 0` once again reliably means "no kernel."

## Tests

Two regression tests in `packages/mcp/src/__tests__/ecad.test.ts` using the field-report board:
- Route → route again: trace, via, and DRC violation counts stay **identical**, `byRule.Short` is 0.
- Route three times: snapshot stays flat (no monotonic growth).

Verified they **fail without the fix** (reproduce the exact 72 violations) and **pass with it**. Full ecad suite 90/90 green; `tsc --noEmit` clean.

## Note for reviewers

The rip-up is intentionally scoped to routable nets, so `add_coil` / hand-routed copper on other nets is preserved. Making `route_nets` also refresh hand-routes would be a separate, deliberate policy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)