### PR TITLE
feat(mcp): Discord activity rollups for tool usage

### DIFF
--- a/changelog/entries/2026-06-14-mcp-discord-alerts.json
+++ b/changelog/entries/2026-06-14-mcp-discord-alerts.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-14-mcp-discord-alerts",
+  "version": "0.9.4",
+  "date": "2026-06-14",
+  "category": "feat",
+  "title": "MCP: Discord activity rollups",
+  "summary": "Set a Discord webhook in notifyConfig to post a periodic summary of MCP tool usage (e.g. '23 tool calls across 4 sessions' every 15 min) — disabled by default, fire-and-forget, quiet when idle, and payload-safe (counts only, never arg values or IR).",
+  "features": ["mcp", "observability"],
+  "mcpTools": []
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,6 +35,30 @@ Unset, every pack is enabled. A smaller surface costs fewer schema
 tokens per request and measurably improves tool-selection accuracy for
 focused workflows.
 
+## Discord activity rollups
+
+The server can post a periodic activity summary to a Discord channel —
+handy for seeing that a deployed server is being used without a message
+per call. Every interval the notifier posts a rollup like:
+
+```
+📊 vcad activity · last 15m
+23 tool calls across 4 sessions · 1 error
+`create` ×9 · `update` ×6 · `export_cad` ×4 · `inspect_cad` ×3 · `render_view` ×1
+```
+
+It's disabled until you set a webhook, fire-and-forget (never blocks or
+fails a tool call), and stays quiet when idle (no "0 calls" pings). Only
+tool names, call counts, error counts, and the number of distinct sessions
+are sent — never argument values or document content.
+
+Configure it in `notifyConfig` at the top of [`src/notify.ts`](src/notify.ts) —
+paste your internal Discord webhook URL into `webhookUrl` (empty disables
+it). `rollupMs` (default 15 min) and `username` live there too. The repo is
+public, so a URL committed there lands in git history; treat it as a
+low-value secret (post-only, one channel) and rotate it from Discord if
+needed.
+
 ## Agent feedback loop
 
 - **Server instructions** — the kernel's type catalog, material preset

--- a/packages/mcp/src/__tests__/notify.test.ts
+++ b/packages/mcp/src/__tests__/notify.test.ts
@@ -1,0 +1,90 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { fireToolAlert, notifyConfig } from "../notify.js";
+
+const WEBHOOK = "https://discord.com/api/webhooks/test/token";
+// Tests run with a short rollup window so a single timer tick fires it.
+const INTERVAL_MS = 60_000;
+
+describe("fireToolAlert (rollup)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "" }));
+    vi.stubGlobal("fetch", fetchMock);
+    notifyConfig.webhookUrl = "";
+    notifyConfig.rollupMs = INTERVAL_MS;
+  });
+
+  afterEach(async () => {
+    // Drain any open window and let the follow-up idle tick clear the timer,
+    // so module-global state doesn't leak into the next test.
+    notifyConfig.webhookUrl = WEBHOOK;
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS * 2);
+    notifyConfig.webhookUrl = "";
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when no webhook URL is set", async () => {
+    fireToolAlert("inspect_cad", { document_id: "abc" }, {});
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts an aggregated rollup after the interval", async () => {
+    notifyConfig.webhookUrl = WEBHOOK;
+    // 5 calls across 2 sessions, one failure.
+    fireToolAlert("create", { document_id: "doc1" }, {});
+    fireToolAlert("create", { document_id: "doc1" }, {});
+    fireToolAlert("export_cad", { document_id: "doc1", format: "stl" }, {});
+    fireToolAlert("inspect_cad", { document_id: "doc2" }, {});
+    fireToolAlert("inspect_cad", { document_id: "doc2" }, { isError: true });
+
+    // Nothing fires before the interval elapses.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(WEBHOOK);
+    const payload = JSON.parse(init.body);
+    expect(payload.username).toBe("vcad mcp");
+    expect(payload.content).toContain("vcad activity");
+    expect(payload.content).toContain("5 tool calls");
+    expect(payload.content).toContain("across 2 sessions");
+    expect(payload.content).toContain("1 error");
+    // Per-tool counts, ranked by frequency.
+    expect(payload.content).toContain("`create` ×2");
+    expect(payload.content).toContain("`inspect_cad` ×2");
+    expect(payload.content).toContain("`export_cad` ×1");
+    expect(payload.allowed_mentions).toEqual({ parse: [] });
+  });
+
+  it("stays quiet on an idle window after reporting", async () => {
+    notifyConfig.webhookUrl = WEBHOOK;
+    fireToolAlert("create", { document_id: "doc1" }, {});
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // No calls in the next window — no second message.
+    await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never throws when the webhook POST fails", async () => {
+    notifyConfig.webhookUrl = WEBHOOK;
+    fetchMock.mockRejectedValue(new Error("network down"));
+    expect(() => fireToolAlert("create", {}, {})).not.toThrow();
+    await expect(
+      vi.advanceTimersByTimeAsync(INTERVAL_MS),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/mcp/src/notify.ts
+++ b/packages/mcp/src/notify.ts
@@ -1,0 +1,159 @@
+/**
+ * Discord activity rollups for MCP tool usage.
+ *
+ * Posts a periodic summary to a Discord channel so we can see at a glance that
+ * a deployed vcad MCP server is being used — e.g. "23 tool calls across 4
+ * sessions" every 15 minutes — rather than a line per call. Disabled until a
+ * webhook URL is set in `notifyConfig` below, so local/dev runs and the test
+ * suite stay silent and offline.
+ *
+ * Design constraints:
+ *   - Never block the tool response. Aggregation is in-memory and O(1); the
+ *     rollup POST is fire-and-forget on a background timer.
+ *   - Never throw into the caller. Every failure is swallowed to stderr.
+ *   - Stay quiet when idle. Empty windows are skipped (no "0 calls" pings),
+ *     and the timer stops itself until the next call arrives.
+ *   - Don't leak payloads. Only tool names, call counts, error counts, and the
+ *     number of distinct sessions are sent — never argument values or IR.
+ */
+
+/**
+ * Notifier configuration. No env vars — paste the internal Discord webhook
+ * URL here to enable rollups. NOTE: this repo is public, so a URL committed
+ * here lands in git history; treat it as a low-value secret (post-only, one
+ * channel) and rotate it from Discord if needed.
+ */
+export const notifyConfig = {
+  /** Internal Discord webhook URL. Empty = rollups disabled. */
+  webhookUrl: "",
+  /** Rollup interval in milliseconds (default 15 minutes). */
+  rollupMs: 15 * 60 * 1000,
+  /** Webhook display name. */
+  username: "vcad mcp",
+};
+
+/** Discord hard-caps message content at 2000 chars; stay comfortably below. */
+const MAX_CONTENT = 1800;
+/** Most tools to itemize in the rollup before collapsing into "+N more". */
+const MAX_TOOLS = 15;
+
+/** Mutable counters for the current rollup window. */
+interface Window {
+  total: number;
+  errors: number;
+  perTool: Map<string, number>;
+  sessions: Set<string>;
+  startedAt: number;
+}
+
+let win: Window | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
+
+/** Truncate a string to `n` chars with an ellipsis. */
+function clip(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function plural(n: number): string {
+  return n === 1 ? "" : "s";
+}
+
+function freshWindow(): Window {
+  return {
+    total: 0,
+    errors: 0,
+    perTool: new Map(),
+    sessions: new Set(),
+    startedAt: Date.now(),
+  };
+}
+
+/**
+ * Record a tool call toward the current rollup window. Fire-and-forget —
+ * returns immediately and never throws. A no-op when no webhook URL is set.
+ */
+export function fireToolAlert(
+  name: string,
+  args: Record<string, unknown>,
+  result: { isError?: boolean },
+): void {
+  if (!notifyConfig.webhookUrl) return;
+
+  if (!win) win = freshWindow();
+  win.total += 1;
+  if (result.isError) win.errors += 1;
+  win.perTool.set(name, (win.perTool.get(name) ?? 0) + 1);
+  const docId = args?.document_id;
+  if (typeof docId === "string" && docId) win.sessions.add(docId);
+
+  // Start ticking on the first call; the timer stops itself once idle.
+  if (!timer) {
+    timer = setInterval(rollup, notifyConfig.rollupMs);
+    // Don't keep the process alive just to deliver a rollup.
+    if (typeof timer.unref === "function") timer.unref();
+  }
+}
+
+/** Build the human-readable rollup message body for a window. */
+function formatRollup(w: Window): string {
+  const mins = Math.max(1, Math.round((Date.now() - w.startedAt) / 60_000));
+
+  const sessions = w.sessions.size > 0
+    ? ` across ${w.sessions.size} session${plural(w.sessions.size)}`
+    : "";
+  const errors = w.errors > 0 ? ` · ${w.errors} error${plural(w.errors)}` : "";
+
+  const ranked = [...w.perTool.entries()].sort((a, b) => b[1] - a[1]);
+  const shown = ranked.slice(0, MAX_TOOLS);
+  let tools = shown.map(([t, n]) => `\`${t}\` ×${n}`).join(" · ");
+  if (ranked.length > shown.length) {
+    tools += ` · +${ranked.length - shown.length} more`;
+  }
+
+  return clip(
+    `📊 **vcad activity** · last ${mins}m\n` +
+      `${w.total} tool call${plural(w.total)}${sessions}${errors}\n` +
+      tools,
+    MAX_CONTENT,
+  );
+}
+
+/** Timer tick: post the window's summary, or stop ticking if idle. */
+async function rollup(): Promise<void> {
+  const url = notifyConfig.webhookUrl;
+  const w = win;
+
+  // Idle window: nothing to report — stop the timer until the next call.
+  if (!w || w.total === 0 || !url) {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+    win = null;
+    return;
+  }
+
+  // Start a fresh window immediately so calls during the POST aren't lost.
+  win = null;
+
+  const body = JSON.stringify({
+    username: notifyConfig.username,
+    content: formatRollup(w),
+    allowed_mentions: { parse: [] },
+  });
+
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    if (!res.ok) {
+      console.error(
+        `[mcp] Discord rollup failed: ${res.status} ${res.statusText}`,
+      );
+    }
+  } catch (err) {
+    console.error("[mcp] Discord rollup error:", err);
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -136,6 +136,7 @@ import {
   VIEWER_CSP,
   MCP_APP_MIME_TYPE,
 } from "./viewer.js";
+import { fireToolAlert } from "./notify.js";
 
 /** Tools that produce or modify geometry and should show the 3D viewer.
  *  Registry-driven kernel tools (create, update, delete, …) are added
@@ -843,7 +844,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
     const { name, arguments: args = {} } = request.params;
 
     if (disabledTools.has(name)) {
-      return {
+      const disabledResult = {
         content: [
           {
             type: "text",
@@ -852,6 +853,8 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         ],
         isError: true,
       };
+      fireToolAlert(name, args, disabledResult);
+      return disabledResult;
     }
 
     try {
@@ -873,6 +876,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
           attachPreviewHandle(result, docId, name);
           slimPreviewForInlineUi(result, docId, name, clientHasInlineUi());
         }
+        fireToolAlert(name, args, result);
         return result;
       }
 
@@ -1087,11 +1091,14 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
           result = calcRf(args);
           break;
 
-        default:
-          return {
+        default: {
+          const unknownResult = {
             content: [{ type: "text", text: `Unknown tool: ${name}` }],
             isError: true,
           };
+          fireToolAlert(name, args, unknownResult);
+          return unknownResult;
+        }
       }
 
       // ── MCP Apps: attach preview handle for geometry tools ──────
@@ -1105,13 +1112,16 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         }
       }
 
+      fireToolAlert(name, args, result);
       return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return {
+      const errorResult = {
         content: [{ type: "text", text: `Error: ${message}` }],
         isError: true,
       };
+      fireToolAlert(name, args, errorResult);
+      return errorResult;
     }
   });
 


### PR DESCRIPTION
## What

Adds an opt-in Discord notifier to the vcad MCP server that posts a **periodic activity rollup** to an internal channel, so we can see at a glance that a deployed server is being used. Example message:

```
📊 vcad activity · last 15m
23 tool calls across 4 sessions · 1 error
`create` ×9 · `update` ×6 · `export_cad` ×4 · `inspect_cad` ×3 · `render_view` ×1
```

## Why

We wanted lightweight visibility into real usage of the deployed MCP server without a firehose — a rollup, not a line per call.

## How

- New `packages/mcp/src/notify.ts` aggregates calls in-memory (per-tool counts, error count, distinct sessions by `document_id`) and posts a summary on a background `setInterval` (default 15 min).
- Wired into the single `CallToolRequestSchema` dispatch chokepoint in `server.ts` — covers registry-driven tools, the static switch, disabled-pack rejections, unknown tools, and thrown errors.
- **Fire-and-forget**: never awaited in the request path, never throws — webhook failures are swallowed to stderr, so a flaky webhook can't break a tool call.
- **Quiet when idle**: empty windows are skipped (no "0 calls" pings) and the timer stops itself until the next call.
- **Payload-safe**: only tool names, counts, error count, and session count are sent — never argument values or IR.
- The aggregator is module-scoped, so in the long-lived HTTP server it accumulates process-wide across the per-request `Server` instances.

## Config

No env vars. Configured via the in-source `notifyConfig` object at the top of `src/notify.ts` (`webhookUrl`, `rollupMs`, `username`). **Disabled by default** — empty `webhookUrl` = off.

> ⚠️ This package is public. A webhook URL committed into `notifyConfig` lands in git history. It's a low-value secret (post-only, single channel) that can be rotated from Discord at any time, but reviewers should be aware.

## Testing

- New `notify.test.ts` (fake timers, mocked `fetch`): no-op when unset, aggregated rollup after the interval, quiet on idle windows, never throws on POST failure.
- Full `@vcad/mcp` suite green: **120 passed, 2 skipped**.
- Clean `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)