### PR TITLE
fix(mcp): durable per-user sessions — fix "Unknown document_id" on serverless

### DIFF
--- a/changelog/entries/2026-06-15-mcp-sessions-persist-to-account.json
+++ b/changelog/entries/2026-06-15-mcp-sessions-persist-to-account.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-mcp-sessions-persist-to-account",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "fix",
+  "title": "MCP agent work persists to your vcad account",
+  "summary": "Signed-in MCP sessions now save to your vcad.io account and survive across requests, fixing mid-build \"Unknown document_id\" errors on the hosted server.",
+  "features": ["mcp", "sync", "sessions"],
+  "mcpTools": ["open_document", "create_cad_loon", "import_step", "create_schematic", "route_nets", "close_document"]
+}

--- a/packages/mcp/src/__tests__/dispatch-persist.test.ts
+++ b/packages/mcp/src/__tests__/dispatch-persist.test.ts
@@ -1,0 +1,159 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { setSessionFetch } from "../session-store.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage of the dispatch persist/hydrate wrapper: drives the real
+ * CallTool handler in createServer through an in-memory MCP client, with a fake
+ * PostgREST backend, so the per-request session scope + persist gating are
+ * exercised exactly as in production. (The persist wrapper was previously only
+ * typecheck-verified.)
+ */
+
+interface Fake {
+  rows: Map<string, Record<string, unknown>>;
+  posts: number;
+  gets: number;
+}
+
+function installFake(): Fake {
+  const rows = new Map<string, Record<string, unknown>>();
+  const fake: Fake = { rows, posts: 0, gets: 0 };
+  const eq = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+  setSessionFetch((async (input: unknown, init: RequestInit = {}) => {
+    const url = new URL(String(input));
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST") {
+      fake.posts++;
+      const body = JSON.parse(String(init.body)) as Array<
+        Record<string, unknown>
+      >;
+      for (const r of body) rows.set(`${r.user_id}|${r.local_id}`, r);
+      return new Response(null, { status: 201 });
+    }
+    const key = `${eq(url.searchParams, "user_id")}|${eq(url.searchParams, "local_id")}`;
+    if (method === "GET") {
+      fake.gets++;
+      const row = rows.get(key);
+      if (!row) return new Response("", { status: 406 });
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(null, { status: 204 }); // DELETE
+  }) as unknown as typeof fetch);
+  return fake;
+}
+
+async function connect(
+  engine: Engine,
+  user: { sub: string; email: string } | null,
+) {
+  const server = await createServer(engine, { user });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function firstText(result: unknown): string {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return content[0].text;
+}
+
+describe("dispatch persist wrapper (end-to-end through createServer)", () => {
+  let engine: Engine;
+  let prevUrl: string | undefined;
+  let prevKey: string | undefined;
+
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  beforeEach(() => {
+    prevUrl = process.env.SUPABASE_URL;
+    prevKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    documents.clear();
+  });
+
+  afterEach(() => {
+    if (prevUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = prevUrl;
+    if (prevKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
+    setSessionFetch(((...a: Parameters<typeof fetch>) =>
+      fetch(...a)) as typeof fetch);
+  });
+
+  it("persists a creator, hydrates a reader from the store, and never persists a reader", async () => {
+    const fake = installFake();
+    const { client, server } = await connect(engine, {
+      sub: "user-1",
+      email: "u@x.test",
+    });
+
+    // Creator: open_document → persisted to the store on the way out.
+    const open = await client.callTool({ name: "open_document", arguments: {} });
+    const documentId = JSON.parse(firstText(open)).document_id as string;
+    expect(fake.posts).toBe(1);
+    expect(fake.rows.has(`user-1|mcp:${documentId}`)).toBe(true);
+
+    const postsAfterOpen = fake.posts;
+
+    // Reader: get_document runs in a fresh per-request scope, so it can only
+    // succeed by hydrating from the durable store — and it must NOT persist.
+    const got = await client.callTool({
+      name: "get_document",
+      arguments: { document_id: documentId },
+    });
+    expect(JSON.parse(firstText(got)).version).toBeDefined(); // IR round-tripped
+    expect(fake.gets).toBeGreaterThanOrEqual(1); // hydrate read happened
+    expect(fake.posts).toBe(postsAfterOpen); // reader did not write
+
+    await client.close();
+    await server.close();
+  });
+
+  it("persists a switch-path writer whose id is only in result text (create_schematic)", async () => {
+    const fake = installFake();
+    const { client, server } = await connect(engine, {
+      sub: "user-2",
+      email: "v@x.test",
+    });
+
+    // create_schematic is NOT a uiTool, so it never gets structuredContent —
+    // the persist site must fall back to scanning the result text for the id.
+    const res = await client.callTool({
+      name: "create_schematic",
+      arguments: {},
+    });
+    expect(res.isError ?? false).toBe(false);
+    const documentId = JSON.parse(firstText(res)).document_id as string;
+    expect(fake.posts).toBe(1);
+    expect(fake.rows.has(`user-2|mcp:${documentId}`)).toBe(true);
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/__tests__/session-store.test.ts
+++ b/packages/mcp/src/__tests__/session-store.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { Document } from "@vcad/ir";
+import {
+  SupabaseSessionStore,
+  InMemorySessionStore,
+  createSessionStore,
+  setSessionFetch,
+} from "../session-store.js";
+import {
+  documents,
+  hydrateSession,
+  persistSession,
+  getSession,
+  getDocumentTool,
+  runInSessionScope,
+} from "../tools/session.js";
+
+/** Minimal one-cube Document, same shape used across tools.test.ts. */
+function makeCubeDoc(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "test_cube",
+        op: { type: "Cube", size: { x: 10, y: 10, z: 10 } },
+      },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [{ root: 1, material: "default" }],
+  } as unknown as Document;
+}
+
+/**
+ * In-memory PostgREST stand-in for the `documents` table. Routes by method +
+ * `user_id` / `local_id` query filters, so it exercises the real
+ * SupabaseSessionStore request shaping (URLs, headers, body) without a network.
+ */
+function makePostgrestFake() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const seenUrls: string[] = [];
+  const key = (userId: string | null, localId: string | null) =>
+    `${userId}|${localId}`;
+  const eqParam = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+
+  const fetchImpl = (async (input: unknown, init: RequestInit = {}) => {
+    const urlStr = String(input);
+    seenUrls.push(urlStr);
+    const url = new URL(urlStr);
+    const sp = url.searchParams;
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST") {
+      const body = JSON.parse(String(init.body)) as Array<
+        Record<string, unknown>
+      >;
+      for (const r of body) {
+        rows.set(key(String(r.user_id), String(r.local_id)), r);
+      }
+      return new Response(null, { status: 201 });
+    }
+
+    const k = key(eqParam(sp, "user_id"), eqParam(sp, "local_id"));
+    if (method === "GET") {
+      const row = rows.get(k);
+      if (!row) return new Response("", { status: 406 }); // PostgREST: ≠1 row
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (method === "DELETE") {
+      rows.delete(k);
+      return new Response(null, { status: 204 });
+    }
+    return new Response("unexpected", { status: 400 });
+  }) as unknown as typeof fetch;
+
+  return { rows, seenUrls, fetchImpl };
+}
+
+const CFG = {
+  supabaseUrl: "https://supa.test",
+  serviceRoleKey: "service-role-key",
+  userId: "user-me",
+};
+
+afterEach(() => {
+  documents.clear();
+  setSessionFetch(((...args: Parameters<typeof fetch>) =>
+    fetch(...args)) as typeof fetch);
+});
+
+describe("SupabaseSessionStore", () => {
+  it("round-trips a document through save → load", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const store = new SupabaseSessionStore(CFG);
+
+    const doc = makeCubeDoc();
+    await store.save("doc_a", doc);
+    const loaded = await store.load("doc_a");
+
+    expect(loaded).toEqual(doc);
+    // Defensive copy — mutating the load result must not touch the backend.
+    (loaded as Document).roots.push({ root: 999, material: "x" } as never);
+    const again = await store.load("doc_a");
+    expect((again as Document).roots).toHaveLength(1);
+  });
+
+  it("returns null on a miss (never throws)", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const store = new SupabaseSessionStore(CFG);
+    expect(await store.load("doc_absent")).toBeNull();
+  });
+
+  it("scopes reads by user_id — no cross-user leak", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+
+    const mallory = new SupabaseSessionStore({ ...CFG, userId: "user-other" });
+    await mallory.save("doc_secret", makeCubeDoc());
+
+    // Same document_id, different caller → ownership filter excludes it.
+    const me = new SupabaseSessionStore(CFG);
+    expect(await me.load("doc_secret")).toBeNull();
+    // The owner can still read it.
+    expect(await mallory.load("doc_secret")).not.toBeNull();
+  });
+
+  it("keys rows by mcp:<documentId> and the caller's user_id", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    await new SupabaseSessionStore(CFG).save("doc_x", makeCubeDoc());
+
+    expect(fake.rows.has("user-me|mcp:doc_x")).toBe(true);
+    // Every request carries the ownership filter / conflict target.
+    expect(fake.seenUrls.some((u) => u.includes("on_conflict=user_id"))).toBe(
+      true,
+    );
+  });
+
+  it("drops a row by (user_id, local_id)", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const store = new SupabaseSessionStore(CFG);
+    await store.save("doc_d", makeCubeDoc());
+    expect(fake.rows.size).toBe(1);
+    await store.drop("doc_d");
+    expect(fake.rows.size).toBe(0);
+  });
+});
+
+describe("cold-instance recovery (hydrate on cache miss)", () => {
+  it("rehydrates a cleared cache from the durable store", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const store = new SupabaseSessionStore(CFG);
+
+    // Seed the durable store, then simulate a cold serverless instance: the
+    // warm cache is empty even though the row exists.
+    await store.save("doc_cold", makeCubeDoc());
+    documents.clear();
+    expect(documents.has("doc_cold")).toBe(false);
+
+    const hydrated = await hydrateSession(store, "doc_cold");
+    expect(hydrated).toBe(true);
+    expect(documents.has("doc_cold")).toBe(true);
+
+    // The reader path now succeeds instead of throwing "Unknown document_id".
+    const fetched = JSON.parse(
+      getDocumentTool({ document_id: "doc_cold" }).content[0].text,
+    ) as Document;
+    expect(fetched.roots).toHaveLength(1);
+    expect(Object.keys(fetched.nodes)).toContain("1");
+  });
+});
+
+describe("per-tenant cache isolation (runInSessionScope)", () => {
+  const userA = { sub: "user-A", email: "a@x.test" };
+  const userB = { sub: "user-B", email: "b@x.test" };
+
+  it("user B cannot read user A's warm-cached document by id", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const storeA = new SupabaseSessionStore({ ...CFG, userId: userA.sub });
+    const storeB = new SupabaseSessionStore({ ...CFG, userId: userB.sub });
+
+    // A, inside A's scope, creates + persists a session and can read it back.
+    await runInSessionScope(userA, async () => {
+      documents.set("doc_shared", makeCubeDoc());
+      await persistSession(storeA, "doc_shared");
+      expect(documents.has("doc_shared")).toBe(true);
+    });
+
+    // B, inside B's own (fresh, isolated) scope, must NOT see A's session —
+    // not from the cache (per-request Map is empty) and not via hydrate (B's
+    // store is scoped to B's user_id, so A's row is invisible).
+    await runInSessionScope(userB, async () => {
+      expect(documents.has("doc_shared")).toBe(false);
+      await hydrateSession(storeB, "doc_shared");
+      expect(documents.has("doc_shared")).toBe(false);
+      expect(() => getSession("doc_shared")).toThrow(/Unknown document_id/);
+    });
+
+    // And it never leaked into the process-wide fallback either.
+    expect(documents.has("doc_shared")).toBe(false);
+  });
+
+  it("the same user sees their session across requests via the durable store", async () => {
+    const fake = makePostgrestFake();
+    setSessionFetch(fake.fetchImpl);
+    const storeA = new SupabaseSessionStore({ ...CFG, userId: userA.sub });
+
+    await runInSessionScope(userA, async () => {
+      documents.set("doc_mine", makeCubeDoc());
+      await persistSession(storeA, "doc_mine");
+    });
+    // A later request: fresh empty scope, but hydrate pulls it from A's store.
+    await runInSessionScope(userA, async () => {
+      expect(documents.has("doc_mine")).toBe(false);
+      expect(await hydrateSession(storeA, "doc_mine")).toBe(true);
+      expect(getSession("doc_mine").roots).toHaveLength(1);
+    });
+  });
+});
+
+describe("in-memory fallback (no user / no service-role key)", () => {
+  it("load always misses and getSession still throws the pinned error", async () => {
+    const store = new InMemorySessionStore();
+    expect(await store.load()).toBeNull();
+    expect(await hydrateSession(store, "doc_missing")).toBe(false);
+    expect(() => getSession("doc_missing")).toThrow(/Unknown document_id/);
+  });
+});
+
+describe("createSessionStore factory", () => {
+  let prevUrl: string | undefined;
+  let prevKey: string | undefined;
+
+  beforeEach(() => {
+    prevUrl = process.env.SUPABASE_URL;
+    prevKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  });
+  afterEach(() => {
+    if (prevUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = prevUrl;
+    if (prevKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
+  });
+
+  it("returns in-memory without a user, even with keys set", () => {
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "k";
+    expect(createSessionStore(null)).toBeInstanceOf(InMemorySessionStore);
+  });
+
+  it("returns in-memory with a user but no service-role key", () => {
+    process.env.SUPABASE_URL = "https://supa.test";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(
+      createSessionStore({ sub: "user-me", email: "a@b.c" }),
+    ).toBeInstanceOf(InMemorySessionStore);
+  });
+
+  it("returns the Supabase store with a user + url + key", () => {
+    process.env.SUPABASE_URL = "https://supa.test/";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "k";
+    expect(
+      createSessionStore({ sub: "user-me", email: "a@b.c" }),
+    ).toBeInstanceOf(SupabaseSessionStore);
+  });
+});

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -21,6 +21,7 @@ import { createServer as createHttpServer } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { Engine } from "@vcad/engine";
 import { createServer } from "./server.js";
+import { verifyAccessToken } from "./oauth.js";
 import { getViewerHtml, MCP_APP_MIME_TYPE } from "./viewer.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
@@ -99,7 +100,8 @@ async function handleMcpRequest(
   res: import("node:http").ServerResponse,
 ): Promise<void> {
   const eng = await getEngine();
-  const server = await createServer(eng);
+  const user = verifyAccessToken(req);
+  const server = await createServer(eng, { user });
 
   const transport = new StreamableHTTPServerTransport({
     // Stateless: no session tracking

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -15,7 +15,10 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { createServer } from "./server.js";
 
 async function main() {
-  const server = await createServer();
+  // stdio is a single trusted local process — no HTTP request, no auth — so
+  // the session store stays in-memory (the documents Map is durable for the
+  // process lifetime).
+  const server = await createServer(undefined, { user: null });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -38,7 +38,20 @@ import {
   documents,
   registerSession,
   getSession,
+  hydrateSession,
+  persistSession,
+  dropSession,
+  runInSessionScope,
 } from "./tools/session.js";
+import { createSessionStore } from "./session-store.js";
+import type { AuthUser } from "./oauth.js";
+
+/** Per-connection context threaded from the transport entry point — the
+ *  authenticated user when the request carried a valid Bearer access token,
+ *  otherwise null (stdio, anonymous HTTP, or OAuth disabled). */
+export interface ServerContext {
+  user: AuthUser | null;
+}
 import {
   registryToolDescriptors,
   registryDispatchableNames,
@@ -230,6 +243,45 @@ const GEOMETRY_TOOLS = new Set([
   "load_document",
 ]);
 
+/**
+ * Switch-path tools that create or mutate a session Document, so the dispatch
+ * layer persists them to the durable store after they run. Registry-path
+ * mutators (create / update / delete / set_material) are detected separately
+ * via `dispatchableTools`. Readers, exporters, calculators, and planners
+ * (`read`, `inspect_cad`, `export_*`, `board_from_solid`, `winding_layout`,
+ * `calc_*` / `size_*`, `run_drc`, …) are intentionally absent — they never
+ * change the stored document.
+ */
+const SWITCH_DOC_WRITERS = new Set<string>([
+  // creators
+  "open_document",
+  "create_cad_loon",
+  "import_step",
+  "create_schematic",
+  "sheet_metal_create",
+  // load_document materializes a saved board into a live session; its
+  // local-disk read is a no-op on the serverless deploy, but on success
+  // persisting the loaded doc to the user's account is desirable.
+  "load_document",
+  // CAD / sheet-metal / DFM mutators
+  "place_part",
+  "dfm_apply_fix",
+  // PCB / ECAD mutators
+  "place_components",
+  "route_nets",
+  "route_diff_pair",
+  "add_coil",
+  "add_coil_array",
+  "add_motor_winding",
+  "add_trace",
+  "add_via",
+  "add_via_array",
+  "add_zone",
+  "set_stackup",
+  "set_placement",
+  "set_design_rules",
+]);
+
 /** MCP Apps UI metadata for geometry tools. */
 const UI_META = {
   ui: {
@@ -367,9 +419,21 @@ export function disabledToolNames(): Set<string> {
   return disabled;
 }
 
-export async function createServer(existingEngine?: Engine): Promise<Server> {
+export async function createServer(
+  existingEngine?: Engine,
+  context: ServerContext = { user: null },
+): Promise<Server> {
   // Initialize the WASM engine (or reuse one provided by the caller)
   const engine = existingEngine ?? await Engine.init();
+
+  // Durable session store for THIS connection's user. With a signed-in user +
+  // a Supabase service-role key it persists sessions to the cloud `documents`
+  // table — so a cold serverless instance rehydrates the board instead of
+  // throwing "Unknown document_id", and the work shows up at vcad.io.
+  // Otherwise an in-memory no-op store reproduces today's behavior. Held in a
+  // closure (not a module global) so concurrent connections on one warm
+  // instance can't clobber each other's binding.
+  const sessionStore = createSessionStore(context.user);
 
   // Wire the kernel WASM's chat helpers into the shared commandRegistry so
   // `toAnthropicTools` and `planCrud` work on the server too. Same bootstrap
@@ -413,6 +477,14 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
   // set plus all registry-driven kernel tools (they all mutate a session
   // document, so a preview is always meaningful).
   const uiTools = new Set([...GEOMETRY_TOOLS, ...dispatchableTools]);
+
+  // A tool call writes the session document when it's a switch-path creator/
+  // mutator OR a registry mutator (every dispatchable tool except `read`,
+  // which only inspects). Gates the post-dispatch durable persist so readers
+  // don't trigger a needless write-back.
+  const isDocWriter = (toolName: string): boolean =>
+    SWITCH_DOC_WRITERS.has(toolName) ||
+    (dispatchableTools.has(toolName) && toolName !== "read");
 
   // Tools hidden by VCAD_MCP_PACKS (resolved once at server creation).
   const disabledTools = disabledToolNames();
@@ -1095,6 +1167,12 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
     return Boolean(ext && ext["io.modelcontextprotocol/ui"]);
   };
 
+  type ToolResult = {
+    content: Array<{ type: string; text: string; annotations?: unknown }>;
+    structuredContent?: Record<string, unknown>;
+    isError?: boolean;
+  };
+
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args = {} } = request.params;
@@ -1111,12 +1189,32 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       };
     }
 
-    try {
-      let result: {
-        content: Array<{ type: string; text: string; annotations?: unknown }>;
-        structuredContent?: Record<string, unknown>;
-        isError?: boolean;
-      };
+    // Run the whole call in a per-connection session scope: a signed-in user
+    // gets an isolated per-request document cache (so a cache hit can't serve
+    // another tenant's doc), while anonymous/stdio callers share the
+    // process-wide fallback. Everything below — hydrate, dispatch, persist —
+    // must run inside it so the `documents` facade routes to the right cache.
+    return runInSessionScope(context.user, async (): Promise<ToolResult> => {
+    // ── Hydrate ───────────────────────────────────────────────────────────
+    // If the call names a session that isn't in the warm cache, rehydrate it
+    // from the durable store BEFORE the (synchronous) tool reads it via
+    // getSession. No-op under the in-memory store, so stdio/anonymous behavior
+    // is unchanged; the cold-serverless-instance fix lives here.
+    const incomingId =
+      typeof args.document_id === "string" ? args.document_id : null;
+    if (incomingId) {
+      try {
+        await hydrateSession(sessionStore, incomingId);
+      } catch {
+        // Durable load failed — fall back to cache (no worse than today).
+      }
+    }
+
+    // Inner dispatch. Encloses BOTH the registry path and the switch so the
+    // single persist site below covers every writer — the registry path used
+    // to early-return straight out of the handler, skipping post-processing.
+    const runTool = async (): Promise<ToolResult> => {
+      let result: ToolResult;
 
       // Registry-driven dispatch: any kernel tool from
       // `commandRegistry.toAnthropicTools()` (minus the browser-only and
@@ -1445,6 +1543,37 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
       }
 
       return result;
+    };
+
+    try {
+      const result = await runTool();
+
+      // ── Persist ─────────────────────────────────────────────────────────
+      // After a creator/mutator settles, write the (possibly newly-minted)
+      // session through to the durable store. Best-effort: the tool already
+      // succeeded, so a write failure must never turn it into an error.
+      // effectiveDocId reads the id already resolved into the result/args — it
+      // never re-runs resolvePreviewDocumentId, so minting tools
+      // (import_step / create_cad_loon) aren't double-registered.
+      if (!result.isError && isDocWriter(name)) {
+        const writtenId = effectiveDocId(result, args);
+        if (writtenId) {
+          try {
+            await persistSession(sessionStore, writtenId);
+          } catch {
+            // best-effort durable write
+          }
+        }
+      }
+      // close_document → also forget the durable row (flush-then-forget).
+      if (name === "close_document" && incomingId) {
+        try {
+          await dropSession(sessionStore, incomingId);
+        } catch {
+          // best-effort durable drop
+        }
+      }
+      return result;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return {
@@ -1452,6 +1581,7 @@ export async function createServer(existingEngine?: Engine): Promise<Server> {
         isError: true,
       };
     }
+    });
   });
 
   return server;
@@ -1594,4 +1724,48 @@ function resolvePreviewDocumentId(
   } catch {
     return null;
   }
+}
+
+/**
+ * The session id a just-finished writer tool touched — WITHOUT minting a new
+ * one. Prefers the explicit `document_id` arg, then the id the dispatch already
+ * attached to the result (`structuredContent.document_id` for uiTools, or a
+ * `{ "document_id": … }` text block, which is how switch-path ECAD tools that
+ * aren't uiTools — create_schematic, route_diff_pair, add_via_array, add_zone,
+ * set_placement, set_design_rules — surface theirs). Every candidate is guarded
+ * by `documents.has`, so only a live session is ever persisted. Deliberately
+ * does NOT call resolvePreviewDocumentId, which registers a fresh session for
+ * import_step / create_cad_loon and would double-mint here.
+ */
+function effectiveDocId(
+  result: {
+    content: Array<{ type: string; text: string }>;
+    structuredContent?: Record<string, unknown>;
+  },
+  args: Record<string, unknown>,
+): string | null {
+  const fromArgs =
+    typeof args.document_id === "string" ? args.document_id : null;
+  if (fromArgs && documents.has(fromArgs)) return fromArgs;
+
+  const fromStructured = result.structuredContent?.document_id;
+  if (typeof fromStructured === "string" && documents.has(fromStructured)) {
+    return fromStructured;
+  }
+
+  for (const block of result.content) {
+    if (block.type !== "text") continue;
+    try {
+      const parsed = JSON.parse(block.text) as { document_id?: unknown };
+      if (
+        typeof parsed.document_id === "string" &&
+        documents.has(parsed.document_id)
+      ) {
+        return parsed.document_id;
+      }
+    } catch {
+      // not JSON — skip
+    }
+  }
+  return null;
 }

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -1,0 +1,226 @@
+/**
+ * Durable backing store for MCP document sessions.
+ *
+ * WHY: the hosted MCP server runs as a Vercel serverless function, so the
+ * module-global `documents` Map in tools/session.ts is per-instance — a cold
+ * start, or a request routed to a different instance, loses every open session
+ * and surfaces as "Unknown document_id" mid-build. This store turns that Map
+ * into a warm-instance CACHE in front of a durable backend keyed by
+ * (user, document): the dispatch layer hydrates the cache on a miss and
+ * persists after a write, so a cold instance rehydrates the board instead of
+ * throwing.
+ *
+ * When a signed-in user AND a Supabase service-role key are present, sessions
+ * persist to the cloud `documents` table — the same table the web app syncs to,
+ * so an agent's work also shows up at vcad.io. Otherwise (local stdio, or an
+ * anonymous hosted call during the pre-MCP_REQUIRE_AUTH transition) the
+ * in-memory impl reproduces today's behavior exactly.
+ */
+import type { Document } from "@vcad/ir";
+import type { AuthUser } from "./oauth.js";
+
+export interface SessionStore {
+  /** Fetch a session's Document, or null on miss. Never throws for
+   *  not-found; transport/Supabase errors are logged and surfaced as null so
+   *  an outage degrades to "cache only", not a tool failure. */
+  load(documentId: string): Promise<Document | null>;
+  /** Create-or-update the durable row for this session. Idempotent on
+   *  (user_id, local_id). Best-effort: errors are logged, never thrown. */
+  save(documentId: string, doc: Document, name?: string): Promise<void>;
+  /** Forget the durable row (close_document). Best-effort. */
+  drop(documentId: string): Promise<void>;
+}
+
+/**
+ * No-op store = today's behavior: the `documents` cache is the source of truth,
+ * load always misses (so getSession throws "Unknown document_id" exactly as
+ * before), save/drop do nothing. Used for stdio and anonymous HTTP calls.
+ */
+export class InMemorySessionStore implements SessionStore {
+  async load(): Promise<Document | null> {
+    return null;
+  }
+  async save(): Promise<void> {
+    /* the in-memory cache is the source of truth */
+  }
+  async drop(): Promise<void> {
+    /* nothing durable to forget */
+  }
+}
+
+/**
+ * Low-level fetch seam, mirrors oauth.ts's injectable `supabaseExchange` so
+ * SupabaseSessionStore can be unit-tested without a network or
+ * @supabase/supabase-js.
+ */
+export let sessionFetch: typeof fetch = (...args) => fetch(...args);
+/** Test hook — mirrors setSupabaseExchange in oauth.ts. */
+export function setSessionFetch(fn: typeof fetch): void {
+  sessionFetch = fn;
+}
+
+export interface SupabaseStoreConfig {
+  /** SUPABASE_URL, trailing slash already stripped. */
+  supabaseUrl: string;
+  /** SUPABASE_SERVICE_ROLE_KEY — server-only; never reaches a client bundle. */
+  serviceRoleKey: string;
+  /** Caller's Supabase user id (access-token `sub` = auth.users.id). */
+  userId: string;
+}
+
+/**
+ * Cloud-backed store via raw PostgREST fetch with the service-role key.
+ *
+ * RLS is bypassed by the service role, so ownership is enforced in code: every
+ * query filters `user_id=eq.<caller>` and every write sets `user_id` to the
+ * caller — a caller can only ever touch their own MCP sessions.
+ *
+ * The `content` column holds the RAW Document IR. The web app's
+ * `cloudContentToVcadFile` recognizes `{ nodes, roots }` as a legacy IR
+ * document and renders it natively, so an MCP-authored board opens at
+ * vcad.io — it isn't just a dead row.
+ */
+export class SupabaseSessionStore implements SessionStore {
+  /**
+   * Per-session monotonic version. The `version` column is int4, so a
+   * timestamp can't be used (Date.now() overflows). A cold instance restarts
+   * the counter at 1; document_versions has no unique on version_number
+   * (migration 002), so a duplicate history number is cosmetic, not a fault.
+   */
+  private versions = new Map<string, number>();
+
+  constructor(private cfg: SupabaseStoreConfig) {}
+
+  /** `mcp:` prefix guarantees an MCP session can never collide with — or
+   *  upsert over — a web-app/IndexedDB row (those use bare UUIDs). */
+  private localId(documentId: string): string {
+    return `mcp:${documentId}`;
+  }
+
+  private rowsUrl(query = ""): string {
+    return `${this.cfg.supabaseUrl}/rest/v1/documents${query}`;
+  }
+
+  private headers(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      apikey: this.cfg.serviceRoleKey,
+      Authorization: `Bearer ${this.cfg.serviceRoleKey}`,
+      "Content-Type": "application/json",
+      ...extra,
+    };
+  }
+
+  /** `?user_id=eq.<caller>&local_id=eq.mcp:<id>` — the ownership-scoped key. */
+  private scope(documentId: string): string {
+    const uid = encodeURIComponent(this.cfg.userId);
+    const lid = encodeURIComponent(this.localId(documentId));
+    return `?user_id=eq.${uid}&local_id=eq.${lid}`;
+  }
+
+  async load(documentId: string): Promise<Document | null> {
+    try {
+      const res = await sessionFetch(
+        this.rowsUrl(`${this.scope(documentId)}&select=content&limit=1`),
+        {
+          method: "GET",
+          headers: this.headers({ Accept: "application/vnd.pgrst.object+json" }),
+        },
+      );
+      if (!res.ok) return null; // 406 = zero/≠1 rows → treat as a miss
+      const row = (await res.json()) as { content?: unknown };
+      const ir = unwrapDocument(row?.content);
+      // Defensive copy — match openDocument's discipline so a caller can't
+      // mutate the cached doc through a retained reference.
+      return ir ? (JSON.parse(JSON.stringify(ir)) as Document) : null;
+    } catch (err) {
+      console.error("[session-store] load failed:", err);
+      return null;
+    }
+  }
+
+  async save(documentId: string, doc: Document, name?: string): Promise<void> {
+    try {
+      const version = (this.versions.get(documentId) ?? 0) + 1;
+      this.versions.set(documentId, version);
+      const body = [
+        {
+          user_id: this.cfg.userId, // always the caller — never tool input
+          local_id: this.localId(documentId),
+          name: name ?? "MCP session",
+          content: doc, // raw IR → the app renders it as a legacy document
+          version,
+          device_modified_at: Date.now(),
+        },
+      ];
+      const res = await sessionFetch(
+        this.rowsUrl("?on_conflict=user_id,local_id"),
+        {
+          method: "POST",
+          headers: this.headers({
+            Prefer: "resolution=merge-duplicates,return=minimal",
+          }),
+          body: JSON.stringify(body),
+        },
+      );
+      if (!res.ok) {
+        console.error(
+          "[session-store] save failed:",
+          res.status,
+          await res.text().catch(() => ""),
+        );
+      }
+    } catch (err) {
+      console.error("[session-store] save failed:", err);
+    }
+  }
+
+  async drop(documentId: string): Promise<void> {
+    try {
+      await sessionFetch(this.rowsUrl(this.scope(documentId)), {
+        method: "DELETE",
+        headers: this.headers(),
+      });
+    } catch (err) {
+      console.error("[session-store] drop failed:", err);
+    }
+  }
+}
+
+/** True when `content` looks like a raw Document IR (has nodes + roots). */
+function looksLikeDocument(content: unknown): content is Document {
+  return (
+    !!content &&
+    typeof content === "object" &&
+    "nodes" in (content as object) &&
+    "roots" in (content as object)
+  );
+}
+
+/** Unwrap a stored `content` blob into a Document IR. Raw IR is stored
+ *  directly; tolerate a legacy `{ ir }` envelope defensively. */
+function unwrapDocument(content: unknown): Document | null {
+  if (looksLikeDocument(content)) return content;
+  const env = content as { ir?: unknown } | null;
+  if (env && looksLikeDocument(env.ir)) return env.ir;
+  return null;
+}
+
+/**
+ * Choose the store impl from env + the per-connection user. Returns the
+ * cloud-backed store only when ALL of: a signed-in user, SUPABASE_URL, and
+ * SUPABASE_SERVICE_ROLE_KEY are present; otherwise the in-memory no-op store
+ * (which preserves today's behavior). This single gate keeps the service-role
+ * key off any path that lacks an authenticated user.
+ */
+export function createSessionStore(user: AuthUser | null): SessionStore {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  if (user && url && key) {
+    return new SupabaseSessionStore({
+      supabaseUrl: url,
+      serviceRoleKey: key,
+      userId: user.sub,
+    });
+  }
+  return new InMemorySessionStore();
+}

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -11,16 +11,78 @@
 import { createDocument } from "@vcad/ir";
 import type { Document } from "@vcad/ir";
 import { writeFileSync, readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveWithinRoot } from "./safe-path.js";
+import type { SessionStore } from "../session-store.js";
+import type { AuthUser } from "../oauth.js";
 
-/** Session id → Document. Lives for the lifetime of the MCP server
- *  process, like `simulations` and `batchGroups` in tools/gym.ts. */
-export const documents = new Map<string, Document>();
+// ─── Session cache (per-connection isolated, or process-wide fallback) ────────
+//
+// The cache used to be a single process-global Map keyed by bare document_id,
+// shared across every connection on a warm serverless instance. Once sessions
+// became user-owned that was a cross-tenant leak: user B passing user A's id
+// would read A's warm-cached doc straight from the shared Map (getSession does
+// no ownership check). The fix: a signed-in connection runs inside an
+// AsyncLocalStorage scope with its OWN per-request Map, populated only from
+// that user's (user-scoped) durable store — so a cache hit can never serve
+// another tenant's document, and the per-request Map is GC'd after the request
+// (no unbounded growth). Anonymous / stdio callers have no tenant boundary and
+// keep the process-wide fallback (cross-request warm cache, today's behavior).
+
+/** Process-wide fallback cache: anonymous hosted calls, stdio, and any access
+ *  outside a per-connection scope (e.g. direct test calls). */
+const fallbackDocuments = new Map<string, Document>();
+
+const sessionScope = new AsyncLocalStorage<{
+  documents: Map<string, Document>;
+}>();
+
+/** The cache for the current connection: a signed-in user's isolated
+ *  per-request Map, or the process-wide fallback. */
+function activeDocuments(): Map<string, Document> {
+  return sessionScope.getStore()?.documents ?? fallbackDocuments;
+}
+
+/**
+ * Run `fn` with an isolated per-connection session cache when `user` is signed
+ * in, so concurrent users on one warm serverless instance never share mutable
+ * session state — a cache hit can't leak another tenant's document. Anonymous
+ * and stdio callers (`user === null`) keep the process-wide fallback: no tenant
+ * boundary to enforce, and their cross-request warm cache stays intact. The
+ * dispatch handler wraps every tool call in this.
+ */
+export function runInSessionScope<T>(user: AuthUser | null, fn: () => T): T {
+  if (!user) return fn();
+  return sessionScope.run({ documents: new Map() }, fn);
+}
+
+/**
+ * Session cache facade. Every read/write routes to the active cache
+ * (`activeDocuments`), so all existing `documents.has/get/set/delete/clear`
+ * call sites — here, in server.ts, in dfm.ts, and in tests — are transparently
+ * scope-aware with no change. Exported (in place of the raw Map) so tests can
+ * still clear/inspect it; outside any scope it is exactly the fallback Map. */
+export const documents = {
+  has: (id: string): boolean => activeDocuments().has(id),
+  get: (id: string): Document | undefined => activeDocuments().get(id),
+  set: (id: string, doc: Document): Map<string, Document> =>
+    activeDocuments().set(id, doc),
+  delete: (id: string): boolean => activeDocuments().delete(id),
+  clear: (): void => activeDocuments().clear(),
+  get size(): number {
+    return activeDocuments().size;
+  },
+};
 
 let nextId = 1;
 
 function nextSessionId(): string {
-  return `doc_${Date.now()}_${nextId++}`;
+  // The counter keeps intra-process uniqueness; the random suffix makes the id
+  // unguessable. Once a session persists to a user's account the id is a
+  // capability — sequential ids would let one caller enumerate another's
+  // warm-cache sessions.
+  return `doc_${nextId++}_${randomBytes(9).toString("base64url")}`;
 }
 
 /** Register a freshly-built document as a session and return its id.
@@ -33,7 +95,10 @@ export function registerSession(doc: Document): string {
   return id;
 }
 
-/** Get a session document by id, or throw a helpful error. */
+/** Get a session document by id, or throw a helpful error. Synchronous and
+ *  cache-only by design — the dispatch layer runs `hydrateSession` first, so a
+ *  durably-stored session is already resident here by the time a tool reads
+ *  it, and a genuine miss still throws the pinned error. */
 export function getSession(documentId: string): Document {
   const doc = documents.get(documentId);
   if (!doc) {
@@ -42,6 +107,49 @@ export function getSession(documentId: string): Document {
     );
   }
   return doc;
+}
+
+// ─── Durable cache ⇄ store bridge ─────────────────────────────────────────────
+//
+// The three helpers below are the ONLY async surface added for durability, and
+// they are called exclusively from the (already-async) dispatch handler — never
+// from a tool — so `getSession`, `registerSession`, `openDocument`, etc. keep
+// their synchronous signatures and no tool handler changes. The `store` is
+// passed in (not a module global) so concurrent connections on one warm
+// serverless instance can't clobber each other's binding.
+
+/** Cache-miss rehydrate: if `documentId` isn't resident, try the durable store
+ *  and populate the cache. Returns true if the doc is now cached. */
+export async function hydrateSession(
+  store: SessionStore,
+  documentId: string,
+): Promise<boolean> {
+  if (documents.has(documentId)) return true;
+  const doc = await store.load(documentId);
+  if (doc) {
+    documents.set(documentId, doc);
+    return true;
+  }
+  return false;
+}
+
+/** Best-effort durable persist of a session's current cache contents. */
+export async function persistSession(
+  store: SessionStore,
+  documentId: string,
+  name?: string,
+): Promise<void> {
+  const doc = documents.get(documentId);
+  if (doc) await store.save(documentId, doc, name);
+}
+
+/** Drop a session from both the cache and the durable store (close_document). */
+export async function dropSession(
+  store: SessionStore,
+  documentId: string,
+): Promise<void> {
+  documents.delete(documentId);
+  await store.drop(documentId);
 }
 
 // ─── open_document ────────────────────────────────────────────────────────

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -96,13 +96,19 @@ export default async function handler(
     return;
   }
 
+  // Identify the caller (null when OAuth is off or no Bearer token was sent).
+  // Computed unconditionally so an authenticated session persists to the
+  // user's account even while /mcp stays open during the MCP_REQUIRE_AUTH
+  // transition. verifyAccessToken is a local HMAC verify — no network.
+  const user = verifyAccessToken(req);
+
   // Optional hard gate on /mcp. Off by default so existing anonymous
   // clients keep working while the OAuth flow rolls out; set
   // MCP_REQUIRE_AUTH=1 (alongside MCP_OAUTH_SECRET) to require a valid
   // signed-in access token once every client has migrated.
   if (process.env.MCP_REQUIRE_AUTH && url.pathname === "/mcp") {
     const cfg = getOAuthConfig();
-    if (cfg && !verifyAccessToken(req)) {
+    if (cfg && !user) {
       res.writeHead(401, {
         "Content-Type": "text/plain",
         "WWW-Authenticate": wwwAuthenticate(cfg),
@@ -115,7 +121,7 @@ export default async function handler(
   // MCP endpoint — parse body for POST, then delegate to transport
   try {
     const engine = await getEngine();
-    const server = await createServer(engine);
+    const server = await createServer(engine, { user });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
       enableJsonResponse: true, // return JSON instead of SSE — Vercel buffers responses and adds Content-Length which breaks SSE streaming


### PR DESCRIPTION
## Why

The hosted MCP server (`mcp.vcad.io`) runs as a **Vercel serverless function**, so the module-global `documents` session map is **per-instance**. A cold start or a request routed to a different instance loses every open session and surfaces as **`Unknown document_id` mid-build** — exactly when an agent has placed components / added a coil and is about to export. It was never a TTL; the engine survived only because each cold instance rebuilds it from WASM, while nothing rebuilt the session map.

## What changed — session = document

The `documents` map becomes a **warm cache** in front of a durable, user-keyed store. The dispatch layer **hydrates on a cache miss** (a cold instance reloads the board) and **write-through-persists after a creator/mutator**, keyed by the OAuth user.

- **`packages/mcp/src/session-store.ts`** (new) — `SessionStore` interface; `InMemorySessionStore` (= today's behavior); `SupabaseSessionStore` (raw PostgREST + service-role key, ownership enforced in code since RLS is bypassed); `createSessionStore` factory (Supabase only when user + `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` are all present, else in-memory).
- **Content is stored as raw IR**, which the web app's `cloudContentToVcadFile` recognizes as a legacy doc and renders natively — an MCP-authored board **opens at vcad.io**, not as a dead row. `local_id = mcp:<id>` can't collide with app-origin UUID rows.
- **Identity** is threaded into `createServer` via `ServerContext` from the Vercel + standalone-HTTP entry points (`verifyAccessToken`, a local HMAC verify — no added latency); stdio stays anonymous.
- Persistence keys on the **already-resolved** document id, never re-running `resolvePreviewDocumentId`, so `import_step`/`create_cad_loon` aren't double-minted; **readers don't persist**.

## Per-tenant cache isolation

Once sessions are user-owned, the shared cache keyed by bare id was a cross-tenant leak (user B passing A's id reads A's warm doc; `getSession` does no ownership check).

- A signed-in connection runs inside an **`AsyncLocalStorage` scope** with its **own per-request cache**, populated only from that user's user-scoped store — a warm-cache hit can't serve another tenant's document, and the map is GC'd per request (no unbounded growth). Anonymous/stdio keep the process-wide fallback (today's behavior).
- The `documents` export is a **facade** routing to the active scope, so every existing call site (`server.ts`, `dfm.ts`, tests) is scope-aware with no edit — the only real change is wrapping the dispatch body in `runInSessionScope`.
- Session ids hardened to be **unguessable** (a session id is a capability once account-bound).

## Safety / rollout

- **Safe-degrades** to today's in-memory behavior until `SUPABASE_SERVICE_ROLE_KEY` is set on the hosted project — nothing breaks before activation.
- Flipping `MCP_REQUIRE_AUTH=1` to drop anonymous sessions entirely is a **separate ops step**, not part of this change.

## Verification

- `tsc --noEmit` clean; **171 mcp tests pass** (+4), 0 regressions.
- New tests: SupabaseSessionStore round-trip / ownership scoping, **cold-instance recovery**, **cross-user isolation** (B can't read A's warm-cached doc), and an **end-to-end** run through the real `createServer` dispatch handler (creator persists, reader hydrates from the store across a fresh per-request scope and does not persist, `create_schematic` persists via the content-text fallback).
- `services/mcp/build.sh` — the hosted esbuild bundle assembles with the new code (`AsyncLocalStorage` is available on Vercel node20).

## Activation (manual, dashboards)

Set `SUPABASE_SERVICE_ROLE_KEY` (server-only; **≠** the anon key) on the `vcad-mcp` Vercel project and redeploy.

## Follow-ups (out of scope)

Stricter `document_versions` history (read-then-PATCH); native CRDT-seed for richer in-app round-trip editing of MCP-origin docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)