### PR TITLE
mcp: ChatGPT Apps SDK + serverless-safe exports (Vercel-native rebase)

### DIFF
--- a/changelog/entries/2026-06-15-chatgpt-apps-serverless.json
+++ b/changelog/entries/2026-06-15-chatgpt-apps-serverless.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-15-chatgpt-apps-serverless",
+  "version": "0.9.4",
+  "date": "2026-06-15",
+  "category": "feat",
+  "title": "vcad 3D viewer in ChatGPT + serverless-safe exports",
+  "summary": "The inline 3D viewer now renders inside ChatGPT via the OpenAI Apps SDK, and export_cad / import_step / export_gerber return inline base64 on the hosted server instead of writing to its read-only disk.",
+  "features": ["mcp", "chatgpt", "apps-sdk", "viewer", "serverless"],
+  "mcpTools": ["export_cad", "import_step", "export_gerber", "get_preview_glb", "get_document"]
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -208,6 +208,65 @@ material. Use these for surgical edits, `create_cad_loon` for whole parts.
   payload for the inline 3D viewer. Hidden from agents on spec-compliant
   hosts; use `export_cad` for geometry exports.
 
+## Hosted server (mcp.vcad.io)
+
+The same server runs as a hosted Streamable-HTTP endpoint at
+`https://mcp.vcad.io/mcp`, deployed on **Vercel** from this repo:
+
+- `vercel.json` (repo root) builds vcad.io itself to `packages/app/dist`.
+- [`services/mcp/`](../../services/mcp) is a separate Vercel project that
+  esbuild-bundles [`entry.ts`](../../services/mcp/entry.ts) into a Build
+  Output API serverless function (`/mcp`, `/health`, `/oauth/*`,
+  `/.well-known/oauth-*`). `build.sh` ships the kernel WASM next to the
+  bundle and bakes in the package version.
+
+Two behaviors differ from a local stdio server, both because the function
+filesystem is read-only (`/var/task`) and invocations are isolated:
+
+- **Inline payloads.** `entry.ts` sets `VCAD_MCP_REMOTE=1`, so
+  `export_cad` returns base64 file contents (capped by
+  `MCP_MAX_INLINE_EXPORT_BYTES`, default 4 MiB) instead of writing to
+  disk; `import_step` takes `content_base64` instead of a path; and
+  `export_gerber` returns file contents inline. A `writeFileSync` on the
+  serverless FS would throw `EROFS` and be invisible to the caller
+  anyway.
+- **OAuth 2.1 + DCR.** Sign-in (Google/GitHub via Supabase) is handled by
+  [`oauth.ts`](src/oauth.ts) and wired in `entry.ts`; set
+  `MCP_OAUTH_SECRET` to enable it and `MCP_REQUIRE_AUTH=1` to require a
+  token on `/mcp`. See the
+  [overview docs](https://docs.vcad.io/reference/mcp/overview).
+
+Add it as a connector by URL: `https://mcp.vcad.io/mcp`.
+
+## ChatGPT (OpenAI Apps SDK)
+
+The hosted server doubles as a ChatGPT app: geometry tools carry
+`_meta["openai/outputTemplate"]` pointing at a second registration of the
+3D viewer (`text/html+skybridge`), and the viewer bundle detects
+ChatGPT's `window.openai` bridge at runtime
+([viewer-app/openai-shim.ts](viewer-app/openai-shim.ts)) — same HTML,
+both hosts. `get_preview_glb` and `get_document` are marked
+`openai/widgetAccessible` so the widget can fetch geometry and build
+"Open in vcad.io" deep links; the Ask button maps to
+`sendFollowUpMessage`. Part selection degrades to the local inspector
+(ChatGPT has no `ui/update-model-context` equivalent).
+
+To connect: ChatGPT → Settings → Apps & Connectors → developer mode →
+add `https://mcp.vcad.io/mcp`.
+
+## Codex CLI / IDE
+
+```bash
+# hosted (Streamable HTTP; OAuth via `codex mcp login vcad` when enabled)
+codex mcp add vcad --url https://mcp.vcad.io/mcp
+
+# or local stdio
+codex mcp add vcad -- npx -y @vcad/mcp
+```
+
+Both forms land in `~/.codex/config.toml` and are shared by the Codex
+IDE extension.
+
 ## Example Usage
 
 In Claude Code or another MCP-compatible assistant:

--- a/packages/mcp/src/__tests__/remote.test.ts
+++ b/packages/mcp/src/__tests__/remote.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { isRemoteDeployment, maxInlineExportBytes } from "../tools/remote.js";
+import { importStep } from "../tools/import.js";
+import { exportCad } from "../tools/export.js";
+import type { Engine } from "@vcad/engine";
+import { createDocument } from "@vcad/ir";
+
+afterEach(() => {
+  delete process.env.VCAD_MCP_REMOTE;
+  delete process.env.MCP_MAX_INLINE_EXPORT_BYTES;
+});
+
+describe("isRemoteDeployment / maxInlineExportBytes", () => {
+  it("is off by default, on when VCAD_MCP_REMOTE=1", () => {
+    expect(isRemoteDeployment()).toBe(false);
+    process.env.VCAD_MCP_REMOTE = "1";
+    expect(isRemoteDeployment()).toBe(true);
+  });
+
+  it("defaults the inline cap to 4 MiB and honors the override", () => {
+    expect(maxInlineExportBytes()).toBe(4 * 1024 * 1024);
+    process.env.MCP_MAX_INLINE_EXPORT_BYTES = "1024";
+    expect(maxInlineExportBytes()).toBe(1024);
+  });
+});
+
+describe("export_cad remote mode", () => {
+  // A minimal one-cube document via the loon-free IR builder would require
+  // the kernel; instead exercise the delivery branch through a tiny fake
+  // engine that returns a single-part scene with a trivial mesh.
+  const fakeEngine = {
+    evaluate: () => ({
+      parts: [
+        {
+          name: "p",
+          mesh: {
+            positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            indices: new Uint32Array([0, 1, 2]),
+            normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+          },
+          material: undefined,
+        },
+      ],
+    }),
+  } as unknown as Engine;
+
+  it("returns inline base64 (no path) when remote", () => {
+    process.env.VCAD_MCP_REMOTE = "1";
+    const res = exportCad({ ir: createDocument(), filename: "cube.stl" }, fakeEngine);
+    const out = JSON.parse(res.content[0].text);
+    expect(out.data_base64).toBeTruthy();
+    expect(out.path).toBeUndefined();
+    expect(out.filename).toBe("cube.stl");
+    // base64 decodes to the reported byte count
+    expect(Buffer.from(out.data_base64, "base64").length).toBe(out.bytes);
+  });
+
+  it("rejects exports over the inline cap when remote", () => {
+    process.env.VCAD_MCP_REMOTE = "1";
+    process.env.MCP_MAX_INLINE_EXPORT_BYTES = "10";
+    expect(() =>
+      exportCad({ ir: createDocument(), filename: "cube.stl" }, fakeEngine),
+    ).toThrow(/inline limit/);
+  });
+});
+
+describe("import_step remote mode", () => {
+  const fakeEngine = {} as Engine;
+
+  it("rejects a filesystem path on a hosted server", () => {
+    process.env.VCAD_MCP_REMOTE = "1";
+    expect(() => importStep({ filename: "part.step" }, fakeEngine)).toThrow(
+      /content_base64/,
+    );
+  });
+
+  it("requires filename or content_base64", () => {
+    expect(() => importStep({}, fakeEngine)).toThrow(
+      /filename.*content_base64|content_base64.*filename/,
+    );
+  });
+
+  it("rejects empty base64 content", () => {
+    expect(() => importStep({ content_base64: "" }, fakeEngine)).toThrow(
+      /filename|content_base64/,
+    );
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -177,6 +177,9 @@ import {
   VIEWER_RESOURCE_URI,
   VIEWER_CSP,
   MCP_APP_MIME_TYPE,
+  OPENAI_VIEWER_RESOURCE_URI,
+  OPENAI_APP_MIME_TYPE,
+  OPENAI_WIDGET_CSP,
 } from "./viewer.js";
 import { fireToolAlert } from "./notify.js";
 
@@ -283,13 +286,26 @@ const SWITCH_DOC_WRITERS = new Set<string>([
   "set_design_rules",
 ]);
 
-/** MCP Apps UI metadata for geometry tools. */
+/** UI metadata for geometry tools — both dialects, hosts read what they
+ *  understand: MCP Apps (`ui`/`ui/resourceUri`) for Claude/Cursor, and
+ *  OpenAI Apps SDK (`openai/outputTemplate`) for ChatGPT. */
 const UI_META = {
   ui: {
     resourceUri: VIEWER_RESOURCE_URI,
   },
   // Flat key format also required by Claude Desktop MCP Apps protocol
   "ui/resourceUri": VIEWER_RESOURCE_URI,
+  // ChatGPT Apps SDK: render results through the skybridge viewer.
+  "openai/outputTemplate": OPENAI_VIEWER_RESOURCE_URI,
+  "openai/toolInvocation/invoking": "Modeling geometry…",
+  "openai/toolInvocation/invoked": "Model updated",
+};
+
+/** Extra meta for tools the viewer iframe itself calls (GLB fetch, IR
+ *  fetch for the deep link). ChatGPT blocks widget-initiated tool calls
+ *  unless the tool is explicitly marked widget-accessible. */
+const WIDGET_CALLABLE_META = {
+  "openai/widgetAccessible": true,
 };
 
 /**
@@ -552,7 +568,9 @@ export async function createServer(
         description:
           "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`.",
         inputSchema: getDocumentSchema,
-        _meta: UI_META,
+        // Widget-callable: the viewer's "Open in vcad.io" button fetches
+        // the IR through this tool to build the deep link.
+        _meta: { ...UI_META, ...WIDGET_CALLABLE_META },
       },
       {
         name: "close_document",
@@ -623,6 +641,7 @@ export async function createServer(
             resourceUri: VIEWER_RESOURCE_URI,
             visibility: ["app"],
           },
+          ...WIDGET_CALLABLE_META,
         },
       },
       // ── Loon DSL one-shot ──────────────────────────────────────
@@ -1115,6 +1134,9 @@ export async function createServer(
   }));
 
   // ── MCP Apps: List UI resources ──────────────────────────────
+  // The same self-contained HTML is registered twice: once with the MCP
+  // Apps profile MIME (Claude, Cursor) and once with ChatGPT's skybridge
+  // MIME. The bundle detects which bridge the host injected at runtime.
   server.setRequestHandler(ListResourcesRequestSchema, async () => ({
     resources: [
       {
@@ -1127,6 +1149,16 @@ export async function createServer(
             csp: VIEWER_CSP,
             prefersBorder: false,
           },
+        },
+      },
+      {
+        uri: OPENAI_VIEWER_RESOURCE_URI,
+        name: "vcad 3D Viewer (ChatGPT)",
+        description: "Interactive 3D viewport for viewing CAD models",
+        mimeType: OPENAI_APP_MIME_TYPE,
+        _meta: {
+          "openai/widgetCSP": OPENAI_WIDGET_CSP,
+          "openai/widgetPrefersBorder": false,
         },
       },
     ],
@@ -1148,6 +1180,22 @@ export async function createServer(
                 csp: VIEWER_CSP,
                 prefersBorder: false,
               },
+            },
+          },
+        ],
+      };
+    }
+
+    if (uri === OPENAI_VIEWER_RESOURCE_URI) {
+      return {
+        contents: [
+          {
+            uri: OPENAI_VIEWER_RESOURCE_URI,
+            mimeType: OPENAI_APP_MIME_TYPE,
+            text: getViewerHtml(),
+            _meta: {
+              "openai/widgetCSP": OPENAI_WIDGET_CSP,
+              "openai/widgetPrefersBorder": false,
             },
           },
         ],

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -2192,10 +2192,13 @@ export async function exportGerber(args: Record<string, unknown>) {
     // module stays loadable in browser bundles (e.g. the HTTP MCP frontend).
     try {
       const fs = await import("node:fs/promises");
-      const path = await import("node:path");
-      await fs.mkdir(outputDir, { recursive: true });
+      const { resolveWithinRoot } = await import("./safe-path.js");
+      // Validate both the directory and each filename against cwd so a
+      // crafted output_dir or file name can't escape the workspace.
+      const dir = resolveWithinRoot(outputDir);
+      await fs.mkdir(dir, { recursive: true });
       for (const f of files) {
-        await fs.writeFile(path.join(outputDir, f.name), f.content, "utf8");
+        await fs.writeFile(resolveWithinRoot(f.name, dir), f.content, "utf8");
       }
       return {
         content: [

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -8,10 +8,55 @@ import { writeFileSync } from "node:fs";
 import { toStlBytes } from "../export/stl.js";
 import { toGlbBytes } from "../export/glb.js";
 import { resolveWithinRoot } from "./safe-path.js";
+import { isRemoteDeployment, maxInlineExportBytes } from "./remote.js";
 
 interface ExportInput {
   ir: Document;
   filename: string;
+}
+
+/**
+ * Deliver export bytes: write to disk on local servers, return base64
+ * inline on remote deployments. On serverless hosts (Vercel) the
+ * function filesystem is read-only — a writeFileSync there throws EROFS
+ * and the bytes would be invisible to the caller anyway — so the bytes
+ * ride back in the tool result instead.
+ */
+function deliver(
+  filename: string,
+  bytes: Uint8Array,
+  extra: Record<string, unknown>,
+): { content: Array<{ type: "text"; text: string }> } {
+  let payload: Record<string, unknown>;
+  if (isRemoteDeployment()) {
+    const cap = maxInlineExportBytes();
+    if (bytes.length > cap) {
+      throw new Error(
+        `Export is ${bytes.length} bytes — over the ${cap} byte inline limit for this hosted server. ` +
+          "Use open_in_browser to hand the document to vcad.io and export from there.",
+      );
+    }
+    payload = {
+      filename,
+      bytes: bytes.length,
+      data_base64: Buffer.from(bytes).toString("base64"),
+      note_delivery:
+        "Hosted server: file contents returned inline as base64 (this server has no access to your disk).",
+      ...extra,
+    };
+  } else {
+    // Resolve against the export dir (VCAD_MCP_EXPORT_DIR or cwd) and
+    // reject any path that escapes it.
+    const path = resolveWithinRoot(
+      filename,
+      process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd(),
+    );
+    writeFileSync(path, bytes);
+    payload = { path, bytes: bytes.length, ...extra };
+  }
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+  };
 }
 
 export const exportCadSchema = {
@@ -55,23 +100,12 @@ export function exportCad(
           "body needs B-rep bend geometry). Use .stl or .glb for mesh exports.",
       );
     }
-    const path = resolveWithinRoot(filename, process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd());
     const bytes = new TextEncoder().encode(step);
-    writeFileSync(path, bytes);
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            path,
-            bytes: bytes.length,
-            format: stepExt,
-            parts: 1,
-            note: "Folded sheet-metal body (AP214) with cylindrical bend faces — bends/angles/directions auto-detect in 3D fab pipelines.",
-          }),
-        },
-      ],
-    };
+    return deliver(filename, bytes, {
+      format: stepExt,
+      parts: 1,
+      note: "Folded sheet-metal body (AP214) with cylindrical bend faces — bends/angles/directions auto-detect in 3D fab pipelines.",
+    });
   }
 
   // Evaluate the document to get meshes
@@ -96,22 +130,8 @@ export function exportCad(
       throw new Error(`Unsupported format: .${ext}. Use .stl, .glb, or .step (sheet-metal only)`);
   }
 
-  // Resolve against the export dir (VCAD_MCP_EXPORT_DIR or cwd) and reject any
-  // path that escapes it.
-  const path = resolveWithinRoot(filename, process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd());
-  writeFileSync(path, bytes);
-
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({
-          path,
-          bytes: bytes.length,
-          format: ext,
-          parts: scene.parts.length,
-        }),
-      },
-    ],
-  };
+  return deliver(filename, bytes, {
+    format: ext,
+    parts: scene.parts.length,
+  });
 }

--- a/packages/mcp/src/tools/import.ts
+++ b/packages/mcp/src/tools/import.ts
@@ -8,12 +8,14 @@ import type { Engine, TriangleMesh } from "@vcad/engine";
 import { readFileSync, existsSync, statSync } from "node:fs";
 import { basename } from "node:path";
 import { resolveWithinRoot } from "./safe-path.js";
+import { isRemoteDeployment } from "./remote.js";
 
 // Cap STEP imports at 100 MB to prevent a remote caller from pinning memory.
 const MAX_STEP_BYTES = 100 * 1024 * 1024;
 
 interface ImportStepInput {
-  filename: string;
+  filename?: string;
+  content_base64?: string;
   name?: string;
   material?: string;
 }
@@ -24,8 +26,15 @@ export const importStepSchema = {
     filename: {
       type: "string" as const,
       description:
-        "Path to the STEP file (.step or .stp), relative to the server working directory " +
-        "(or VCAD_MCP_EXPORT_DIR if set).",
+        "Path to the STEP file (.step or .stp) on the server filesystem, relative to the " +
+        "server working directory (or VCAD_MCP_EXPORT_DIR if set). On hosted servers pass " +
+        "content_base64 instead.",
+    },
+    content_base64: {
+      type: "string" as const,
+      description:
+        "Base64-encoded STEP file contents. Use instead of `filename` when the " +
+        "server has no access to your filesystem (hosted/remote deployments).",
     },
     name: {
       type: "string" as const,
@@ -36,37 +45,58 @@ export const importStepSchema = {
       description: "Material key (default: 'steel')",
     },
   },
-  required: ["filename"],
 };
 
 export function importStep(
   input: unknown,
   engine: Engine,
 ): { content: Array<{ type: "text"; text: string }> } {
-  const { filename, name, material } = input as ImportStepInput;
+  const { filename, content_base64, name, material } = input as ImportStepInput;
 
-  // Resolve against the export dir (VCAD_MCP_EXPORT_DIR or cwd) and reject any
-  // path that escapes it.
-  const filepath = resolveWithinRoot(filename, process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd());
+  let fileBuffer: Buffer;
+  if (content_base64) {
+    fileBuffer = Buffer.from(content_base64, "base64");
+    if (fileBuffer.length === 0) {
+      throw new Error("content_base64 decoded to zero bytes");
+    }
+    if (fileBuffer.length > MAX_STEP_BYTES) {
+      throw new Error(`STEP content exceeds ${MAX_STEP_BYTES} byte limit`);
+    }
+  } else if (filename) {
+    if (isRemoteDeployment()) {
+      throw new Error(
+        "This hosted server has no access to your filesystem — pass the STEP " +
+          "file contents as `content_base64` instead of `filename`.",
+      );
+    }
+    // Resolve against the export dir (VCAD_MCP_EXPORT_DIR or cwd) and reject
+    // any path that escapes it.
+    const filepath = resolveWithinRoot(
+      filename,
+      process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd(),
+    );
 
-  if (!existsSync(filepath)) {
-    throw new Error("STEP file not found");
+    if (!existsSync(filepath)) {
+      throw new Error("STEP file not found");
+    }
+
+    const stat = statSync(filepath);
+    if (!stat.isFile()) {
+      throw new Error("STEP path is not a regular file");
+    }
+    if (stat.size > MAX_STEP_BYTES) {
+      throw new Error(`STEP file exceeds ${MAX_STEP_BYTES} byte limit`);
+    }
+
+    fileBuffer = readFileSync(filepath);
+  } else {
+    throw new Error("Provide either `filename` or `content_base64`");
   }
 
-  const stat = statSync(filepath);
-  if (!stat.isFile()) {
-    throw new Error("STEP path is not a regular file");
-  }
-  if (stat.size > MAX_STEP_BYTES) {
-    throw new Error(`STEP file exceeds ${MAX_STEP_BYTES} byte limit`);
-  }
-
-  // Read the file
-  const fileBuffer = readFileSync(filepath);
-  const arrayBuffer = fileBuffer.buffer.slice(
-    fileBuffer.byteOffset,
-    fileBuffer.byteOffset + fileBuffer.byteLength,
-  );
+  // Copy into a plain ArrayBuffer (Buffer.buffer may be a pooled
+  // SharedArrayBuffer slice; the engine API takes ArrayBuffer).
+  const arrayBuffer = new ArrayBuffer(fileBuffer.byteLength);
+  new Uint8Array(arrayBuffer).set(fileBuffer);
 
   // Import using the engine
   const meshes = engine.importStep(arrayBuffer);
@@ -77,7 +107,13 @@ export function importStep(
 
   // Create a document with ImportedMesh nodes
   const doc = createDocument();
-  const partName = name ?? basename(filename, /\.(step|stp)$/i.test(filename) ? filename.slice(-5) : "");
+  const sourceLabel = filename ?? "step-import";
+  const partName =
+    name ??
+    basename(
+      sourceLabel,
+      /\.(step|stp)$/i.test(sourceLabel) ? sourceLabel.slice(-5) : "",
+    );
   const partMaterial = material ?? "steel";
 
   let nextId = 1;
@@ -91,7 +127,7 @@ export function importStep(
       positions: Array.from(mesh.positions),
       indices: Array.from(mesh.indices),
       normals: mesh.normals ? Array.from(mesh.normals) : undefined,
-      source: filename,
+      source: sourceLabel,
     };
 
     const nodeId = nextId++;

--- a/packages/mcp/src/tools/remote.ts
+++ b/packages/mcp/src/tools/remote.ts
@@ -1,0 +1,25 @@
+/**
+ * Remote-deployment mode for filesystem-touching tools.
+ *
+ * On a local stdio server, "write the export to ./part.stl" means the
+ * user's own disk — useful. On a shared HTTP deployment (e.g. a
+ * claude.ai connector), the process cwd is the *server's* disk: writes
+ * are invisible to the caller and reads can't see the caller's files.
+ *
+ * The HTTP entry point sets VCAD_MCP_REMOTE=1; tools check this at call
+ * time and switch to inline payloads (base64 out, base64 in) instead of
+ * touching the filesystem.
+ */
+
+/** True when running as a shared/remote deployment (HTTP entry point). */
+export function isRemoteDeployment(): boolean {
+  return process.env.VCAD_MCP_REMOTE === "1";
+}
+
+/** Cap on raw bytes returned inline as base64 from export tools.
+ *  Tool results land in the model's context — keep them bounded. */
+export function maxInlineExportBytes(): number {
+  const raw = process.env.MCP_MAX_INLINE_EXPORT_BYTES;
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : 4 * 1024 * 1024;
+}

--- a/packages/mcp/src/viewer.ts
+++ b/packages/mcp/src/viewer.ts
@@ -27,6 +27,23 @@ export const VIEWER_RESOURCE_URI = "ui://vcad/viewer";
 /** MIME type for MCP App HTML resources. */
 export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
 
+/** Second registration of the same HTML for ChatGPT (OpenAI Apps SDK):
+ *  referenced from tools via `_meta["openai/outputTemplate"]` and served
+ *  with the skybridge MIME type so ChatGPT injects its widget bridge
+ *  (the viewer detects `window.openai` and adapts — see
+ *  viewer-app/openai-shim.ts). */
+export const OPENAI_VIEWER_RESOURCE_URI = "ui://vcad/viewer-openai.html";
+
+/** MIME type marking a resource as a ChatGPT Apps SDK widget. */
+export const OPENAI_APP_MIME_TYPE = "text/html+skybridge";
+
+/** ChatGPT widget CSP: the bundle is fully inlined; blob: is needed for
+ *  GLTFLoader's createObjectURL textures. */
+export const OPENAI_WIDGET_CSP = {
+  connect_domains: [] as string[],
+  resource_domains: ["blob:"],
+};
+
 /** Return the self-contained viewer HTML. */
 export function getViewerHtml(): string {
   return VIEWER_HTML;

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -20,6 +20,7 @@ import {
   App,
   type McpUiHostContext,
 } from "@modelcontextprotocol/ext-apps";
+import { isOpenAiHost, createOpenAiShim } from "./openai-shim";
 
 const statusEl = document.getElementById("status")!;
 const errEl = document.getElementById("error")!;
@@ -793,11 +794,16 @@ function captureVcode(result: ToolResultLike): void {
   }
 }
 
-// ── MCP Apps protocol ────────────────────────────────────────
-const app = new App(
-  { name: "vcad-viewer", version: "2.1.0" },
-  { availableDisplayModes: ["inline", "fullscreen"] },
-);
+// ── Host protocol ────────────────────────────────────────────
+// MCP Apps hosts (Claude, Cursor) speak the SEP-1865 postMessage
+// protocol via the App class; ChatGPT injects `window.openai` instead —
+// the shim adapts it to the same surface.
+const app = isOpenAiHost()
+  ? (createOpenAiShim() as unknown as App)
+  : new App(
+      { name: "vcad-viewer", version: "2.1.0" },
+      { availableDisplayModes: ["inline", "fullscreen"] },
+    );
 
 function applyHostContext(ctx: McpUiHostContext | undefined): void {
   if (!ctx) return;

--- a/packages/mcp/viewer-app/openai-shim.ts
+++ b/packages/mcp/viewer-app/openai-shim.ts
@@ -1,0 +1,167 @@
+/**
+ * ChatGPT Apps SDK host adapter.
+ *
+ * ChatGPT injects a `window.openai` bridge into widget iframes instead of
+ * speaking the MCP Apps postMessage protocol. This shim exposes the
+ * subset of the `App` class surface that main.ts uses, backed by
+ * `window.openai`, so the same viewer bundle runs on both hosts:
+ *
+ *   MCP Apps host (Claude, Cursor) → `new App(...)` (ext-apps)
+ *   ChatGPT                        → `createOpenAiShim()`
+ *
+ * Mapping:
+ *   ontoolresult        ← openai.toolOutput (the tool's structuredContent),
+ *                         synthesized into a ToolResultLike; refreshed on
+ *                         `openai:set_globals`
+ *   callServerTool      ← openai.callTool(name, args)  (tools must carry
+ *                         `_meta["openai/widgetAccessible"]: true`)
+ *   sendMessage         ← openai.sendFollowUpMessage({ prompt })
+ *   openLink            ← openai.openExternal({ href })
+ *   requestDisplayMode  ← openai.requestDisplayMode({ mode })
+ *   host context        ← openai.theme / openai.displayMode
+ *   updateModelContext  → unavailable (capability stays unset; the viewer
+ *                         degrades to its local selection inspector)
+ */
+
+/** The slice of `window.openai` this shim consumes (Apps SDK). */
+interface OpenAiBridge {
+  toolInput?: unknown;
+  toolOutput?: unknown;
+  widgetState?: unknown;
+  theme?: string;
+  displayMode?: string;
+  callTool?: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+  sendFollowUpMessage?: (opts: { prompt: string }) => Promise<unknown>;
+  openExternal?: (opts: { href: string }) => unknown;
+  requestDisplayMode?: (opts: { mode: string }) => Promise<{ mode?: string } | undefined>;
+  setWidgetState?: (state: unknown) => Promise<unknown>;
+}
+
+declare global {
+  interface Window {
+    openai?: OpenAiBridge;
+  }
+}
+
+/** True when running inside a ChatGPT widget iframe. */
+export function isOpenAiHost(): boolean {
+  return typeof window !== "undefined" && Boolean(window.openai);
+}
+
+interface ToolResultShape {
+  content: Array<{ type: string; text?: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+/** Wrap a toolOutput global as the ToolResultLike main.ts consumes. */
+function synthesizeResult(toolOutput: unknown): ToolResultShape {
+  return {
+    content: [],
+    structuredContent:
+      toolOutput && typeof toolOutput === "object"
+        ? (toolOutput as Record<string, unknown>)
+        : undefined,
+    isError: false,
+  };
+}
+
+/** Normalize callTool's return shape to a tool result. */
+function normalizeToolResult(raw: unknown): unknown {
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    if (Array.isArray(obj.content)) return obj;
+    const inner = obj.result as Record<string, unknown> | undefined;
+    if (inner && Array.isArray(inner.content)) return inner;
+  }
+  return raw ?? {};
+}
+
+export function createOpenAiShim() {
+  const oai = window.openai!;
+  let lastToolOutput: unknown;
+
+  const shim = {
+    // Handlers main.ts assigns — same contract as the App class.
+    onhostcontextchanged: undefined as
+      | ((params: { hostContext: Record<string, unknown> }) => void)
+      | undefined,
+    ontoolinput: undefined as (() => void) | undefined,
+    ontoolresult: undefined as ((result: unknown) => void) | undefined,
+
+    getHostContext(): Record<string, unknown> {
+      return {
+        theme: oai.theme === "light" ? "light" : "dark",
+        displayMode: oai.displayMode ?? "inline",
+        availableDisplayModes: ["inline", "fullscreen"],
+      };
+    },
+
+    getHostCapabilities(): Record<string, unknown> {
+      return {
+        // Ask button (ui/message ↔ sendFollowUpMessage)
+        ...(oai.sendFollowUpMessage ? { message: {} } : {}),
+        // No ChatGPT equivalent of ui/update-model-context — leave unset
+        // so selection degrades to the local inspector.
+      };
+    },
+
+    async connect(): Promise<void> {
+      window.addEventListener("openai:set_globals", () => {
+        shim.onhostcontextchanged?.({ hostContext: shim.getHostContext() });
+        if (oai.toolOutput !== lastToolOutput && oai.toolOutput != null) {
+          lastToolOutput = oai.toolOutput;
+          shim.ontoolresult?.(synthesizeResult(oai.toolOutput));
+        }
+      });
+      // Tool output may already be set when the widget hydrates.
+      if (oai.toolOutput != null) {
+        lastToolOutput = oai.toolOutput;
+        queueMicrotask(() => shim.ontoolresult?.(synthesizeResult(oai.toolOutput)));
+      }
+    },
+
+    async callServerTool(opts: {
+      name: string;
+      arguments: Record<string, unknown>;
+    }): Promise<unknown> {
+      if (!oai.callTool) {
+        throw new Error("host does not allow widget tool calls");
+      }
+      return normalizeToolResult(await oai.callTool(opts.name, opts.arguments));
+    },
+
+    async sendMessage(opts: {
+      role: string;
+      content: Array<{ type: string; text: string }>;
+    }): Promise<{ isError?: boolean }> {
+      if (!oai.sendFollowUpMessage) return { isError: true };
+      const prompt = opts.content
+        .map((c) => (c.type === "text" ? c.text : ""))
+        .join("\n")
+        .trim();
+      await oai.sendFollowUpMessage({ prompt });
+      return {};
+    },
+
+    async updateModelContext(): Promise<void> {
+      // Unreachable: getHostCapabilities never advertises it here.
+    },
+
+    async openLink(opts: { url: string }): Promise<void> {
+      if (oai.openExternal) {
+        oai.openExternal({ href: opts.url });
+        return;
+      }
+      throw new Error("openExternal unavailable");
+    },
+
+    async requestDisplayMode(opts: { mode: string }): Promise<{ mode: string }> {
+      if (!oai.requestDisplayMode) return { mode: "inline" };
+      const granted = await oai.requestDisplayMode({ mode: opts.mode });
+      return { mode: granted?.mode ?? "inline" };
+    },
+  };
+
+  return shim;
+}

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -24,6 +24,16 @@ import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
 
+// The serverless function filesystem is read-only (/var/task), so the
+// filesystem-touching tools (export_cad, import_step, export_gerber)
+// must return inline base64 payloads instead of writing to disk — a
+// writeFileSync there throws EROFS and the bytes would be invisible to
+// the caller anyway. The tools read this flag at call time
+// (isRemoteDeployment()), so setting it at module scope is sufficient.
+if (process.env.VCAD_MCP_REMOTE === undefined) {
+  process.env.VCAD_MCP_REMOTE = "1";
+}
+
 // Locate WASM file next to this bundle
 const __bundleDir = dirname(fileURLToPath(import.meta.url));
 const WASM_PATH = join(__bundleDir, "vcad_kernel_wasm_bg.wasm");


### PR DESCRIPTION
Rebases the claude.ai / ChatGPT connector work onto current `main`, which has independently shipped an **identical** OAuth 2.1 + DCR server and a Vercel serverless MCP deployment (`services/mcp/`). The branch was reset to `origin/main` and re-landed as **one additive commit** — no Fly, no duplicate OAuth, no in-memory session rework.

## Why

The original branch targeted a Fly.io deployment and carried its own OAuth implementation. Since then `main` converged on the same OAuth design (byte-for-byte identical `oauth.ts`) and a Vercel serverless function as the production MCP host. So most of the branch was redundant or built on the wrong (process-warm) assumptions. This reconciles down to only what's unique and correct for serverless.

## Dropped (redundant or wrong model for serverless)

- The branch's own `oauth.ts` + `oauth.test.ts` — byte-identical to `main`'s.
- The in-memory `SessionMap` / TTL / LRU / per-user-namespace rework — meaningless on stateless Vercel (a fresh server is built per invocation). `main`'s plain `session.ts` (Map + filesystem `save`/`load_document`) is kept as-is.
- All Fly artifacts (`Dockerfile.mcp`, `fly.mcp.toml`, `.dockerignore`).

## Re-landed (unique + serverless-correct)

**ChatGPT Apps SDK** — the hosted server now doubles as a ChatGPT app:
- `viewer-app/openai-shim.ts` detects `window.openai` and adapts it to the same surface the MCP Apps `App` class exposes (`toolOutput` → structuredContent, `callTool`, `sendFollowUpMessage`, display modes). Same self-contained viewer HTML serves Claude/Cursor **and** ChatGPT.
- Geometry tools carry `openai/outputTemplate` + invocation strings; `get_preview_glb` / `get_document` are marked `openai/widgetAccessible`; a second `text/html+skybridge` resource is registered alongside the MCP Apps one.

**Serverless export crash fix** — `main`'s `export_cad` did `writeFileSync` to `cwd()`, which is read-only `/var/task` on Vercel → **EROFS**:
- `export_cad` now returns inline base64 (cap `MCP_MAX_INLINE_EXPORT_BYTES`, default 4 MiB) when remote; `import_step` accepts `content_base64`; `export_gerber`'s output path is sandboxed via `resolveWithinRoot`.
- **Critical wiring:** `VCAD_MCP_REMOTE=1` is set at the top of `services/mcp/entry.ts` — without it the fix never activates in production.

Deploy docs now describe Vercel (`services/mcp` esbuild bundle + root `vercel.json`), not Fly.

## Verification

- `tsc --noEmit` clean; **172 mcp tests pass** (including `main`'s OAuth suite + a new `remote.test.ts` covering the inline-vs-disk branch).
- ChatGPT widget verified end-to-end in a browser harness that injects a `window.openai` bridge the way ChatGPT does: geometry renders, capability gating correct, zero console errors.
- Remote-mode `export_cad` verified over the wire: returns base64, no path, no EROFS; `import_step` rejects filesystem paths pointing callers at `content_base64`.

## Reviewer notes

- Purely additive on `main` — no changes to `session.ts`, `gym.ts`, `http.ts`, or `oauth.ts`.
- Known follow-up (not in this PR): `nextSessionId()` in `session.ts` still uses guessable `doc_${Date.now()}_${n}` ids; these are bearer capabilities on the now-public endpoint and should move to `randomBytes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)