### PR TITLE
fix(mcp): use crypto-random session/sim/batch ids

### DIFF
--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -7,6 +7,7 @@
  * Uses the phyz physics engine via WASM bindings.
  */
 
+import { randomBytes } from "node:crypto";
 import type { Document } from "@vcad/ir";
 import {
   PhysicsEnv,
@@ -38,9 +39,6 @@ interface BatchGroup {
   };
 }
 const batchGroups = new Map<string, BatchGroup>();
-
-let nextSimId = 1;
-let nextBatchId = 1;
 
 /** JSON Schema for create_robot_env input */
 export const createRobotEnvSchema = {
@@ -158,7 +156,7 @@ export async function createRobotEnv(input: unknown): Promise<{
   }
 
   try {
-    const envId = `sim_${nextSimId++}`;
+    const envId = `sim_${randomBytes(12).toString("base64url")}`;
 
     const env = await PhysicsEnv.create(args.document, {
       endEffectorIds: args.end_effector_ids,
@@ -401,7 +399,7 @@ export async function batchCreateEnvs(input: unknown): Promise<{
   }
 
   try {
-    const batchId = `batch_${nextBatchId++}`;
+    const batchId = `batch_${randomBytes(12).toString("base64url")}`;
     const envOptions = {
       endEffectorIds: args.end_effector_ids,
       dt: args.dt,

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -11,16 +11,20 @@
 import { createDocument } from "@vcad/ir";
 import type { Document } from "@vcad/ir";
 import { writeFileSync, readFileSync } from "node:fs";
+import { randomBytes } from "node:crypto";
 import { resolveWithinRoot } from "./safe-path.js";
 
 /** Session id → Document. Lives for the lifetime of the MCP server
  *  process, like `simulations` and `batchGroups` in tools/gym.ts. */
 export const documents = new Map<string, Document>();
 
-let nextId = 1;
-
 function nextSessionId(): string {
-  return `doc_${Date.now()}_${nextId++}`;
+  // Crypto-random, unguessable session id. Session ids are bearer
+  // capabilities (anyone holding a document_id can read/mutate that
+  // session), so a sequential timestamp+counter scheme would let a caller
+  // enumerate another user's recent document_id within a warm instance's
+  // lifetime. Nothing parses the id — it's only a Map key / opaque handle.
+  return `doc_${randomBytes(12).toString("base64url")}`;
 }
 
 /** Register a freshly-built document as a session and return its id.


### PR DESCRIPTION
## What

Replace the guessable, sequential MCP session-id scheme with crypto-random ids.

- `packages/mcp/src/tools/session.ts` — `nextSessionId()` now returns `doc_${randomBytes(12).toString("base64url")}` (96 bits of entropy). Dropped the `nextId` counter; added `import { randomBytes } from "node:crypto"`.
- `packages/mcp/src/tools/gym.ts` — same treatment for `sim_` and `batch_` ids; removed the `nextSimId`/`nextBatchId` counters.

## Why

Session ids are **bearer capabilities** — anyone holding a `document_id` can read or mutate that session via `get_document` / `update` / etc. The old scheme, `doc_${Date.now()}_${counter}`, was a sequential timestamp + counter. Now that the MCP server is deployed publicly on Vercel (`services/mcp`), that made it possible to **enumerate another user's recent `document_id`** within a warm serverless instance's lifetime and hijack their session.

96 bits of CSPRNG entropy makes ids unguessable.

## Notes for reviewers

- Nothing parses these ids — they're only used as `Map` keys and opaque handles in `save_document`/`load_document`/etc. — so the format change is fully isolated.
- `npm test -w @vcad/mcp` → **165 passed, 2 skipped**. The session and gym-tool suites both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)