### PR TITLE
fix(ecad/router): iterative rip-up + corridor blockers finish congested boards

### DIFF
--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -61,6 +61,11 @@ pub struct RouteAllResult {
 /// Copper layers tried per connection, in order (front first, then back).
 const LAYERS: [PcbLayer; 2] = [PcbLayer::FCu, PcbLayer::BCu];
 
+/// Maximum rip-up-and-reroute rounds before accepting the still-unrouted set.
+/// The loop also stops the instant a round places nothing new, so this only
+/// bounds worst-case work on a genuinely over-constrained board.
+const MAX_RIPUP_ROUNDS: usize = 8;
+
 /// A connection that has been routed, plus the session spans it occupies —
 /// enough to rip it back out and re-route it.
 struct Placed {
@@ -116,9 +121,23 @@ pub fn route_all(pcb: &Pcb, width: f64, nets_filter: &[String]) -> RouteAllResul
         }
     }
 
-    // Rip-up pass: for each connection that couldn't route, rip the other-net
-    // copper directly blocking it, route it, then re-route the ripped victims.
-    let still_unrouted = ripup_pass(&mut session, pcb, width, &mut placed, unrouted_conns);
+    // Rip-up passes: iterate to convergence (bounded). One pass rips the copper
+    // blocking a failed connection, routes it, then re-routes the victims;
+    // repeating lets short nets reclaim space from long ones and lets a victim
+    // that failed in one round find a path once the board settles. Stop the
+    // instant a round places nothing new, so a stuck board exits immediately.
+    let mut pending = unrouted_conns;
+    for _ in 0..MAX_RIPUP_ROUNDS {
+        if pending.is_empty() {
+            break;
+        }
+        let placed_before = placed.len();
+        pending = ripup_pass(&mut session, pcb, width, &mut placed, pending);
+        if placed.len() <= placed_before {
+            break;
+        }
+    }
+    let still_unrouted = pending;
 
     // Flatten the placed connections into the result.
     let mut traces = Vec::new();
@@ -275,13 +294,19 @@ fn ripup_pass(
     let mut still: Vec<(String, Vec2, Vec2)> = Vec::new();
 
     for (net, from, to) in unrouted {
-        // Spans of other-net copper crossing the direct path, on either layer.
+        // Other-net copper crossing a CORRIDOR around the direct path — not the
+        // hairline segment. The maze router detours around copper, so the
+        // connections worth ripping are everything in the band a detour would
+        // thread; a hairline probe finds only what sits exactly on the straight
+        // line and leaves congested-but-offset nets with an empty victim set
+        // (abandoned without trying). A few-trace-wide corridor surfaces them.
+        let clearance = session.clearance_for(&net);
+        let corridor_hw = hw + clearance + width * 3.0;
         let seg = CopperGeom::Segment {
             a: from,
             b: to,
-            half_w: hw,
+            half_w: corridor_hw,
         };
-        let clearance = session.clearance_for(&net);
         let mut blocker_spans: HashSet<SpanId> = HashSet::new();
         for &layer in &LAYERS {
             for b in session.probe(&seg, layer, &net, clearance).blockers {
@@ -538,6 +563,53 @@ mod tests {
             })
             .count();
         assert_eq!(bad, 0, "must never emit shorting copper");
+    }
+
+    #[test]
+    fn congested_crossing_nets_all_route() {
+        // N nets whose connections all cross through the board center — a
+        // rip-up stress test. The greedy pass plus a single rip-up round leaves
+        // several unrouted; iterative rip-up with corridor blocker detection
+        // should place them all, DRC-clean.
+        let n = 16usize;
+        let mut fps = Vec::new();
+        for i in 0..n {
+            let net = format!("N{i}");
+            // Top row left→right, bottom row right→left: every net crosses center.
+            fps.push(fp(
+                &format!("T{i}"),
+                4.0 + 2.8 * i as f64,
+                24.0,
+                vec![pad("1", 0.0, 0.0, &net)],
+            ));
+            fps.push(fp(
+                &format!("B{i}"),
+                4.0 + 2.8 * (n - 1 - i) as f64,
+                6.0,
+                vec![pad("1", 0.0, 0.0, &net)],
+            ));
+        }
+        let pcb0 = board(fps);
+        let r = route_all(&pcb0, 0.25, &[]);
+        let mut pcb = pcb0.clone();
+        apply(&mut pcb, &r);
+
+        let bad = check_drc(&pcb)
+            .into_iter()
+            .filter(|v| {
+                matches!(
+                    v.rule,
+                    crate::drc::DrcRuleType::Short | crate::drc::DrcRuleType::Clearance
+                )
+            })
+            .count();
+        assert_eq!(bad, 0, "router output must be short/clearance clean");
+        assert_eq!(
+            r.routed_nets.len(),
+            n,
+            "expected all {n} nets routed, unrouted: {:?}",
+            r.unrouted_nets
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`route_all` leaves roughly half the nets unrouted on congested boards (verified on a real 12-component flight-controller board: 14 of 27 nets, and reproduced here as a unit test that gets 8 of 16). The per-net maze A* router is sound — the weakness is in the orchestration:

1. **The rip-up pass ran exactly once.** A victim that failed to re-route in that single pass was abandoned permanently.
2. **Rip-up candidates were found only on the hairline pad-to-pad straight line.** Since the maze router *detours* around copper, the real blockers usually sit off that line — so congested-but-offset nets came back with an empty victim set and were dropped without a genuine attempt.

## Fix

Two contained changes to `route_all` / `ripup_pass`:

- **Iterate rip-up to convergence** — `MAX_RIPUP_ROUNDS = 8`, stopping the instant a round places nothing new (so a genuinely stuck board exits immediately). This lets short nets reclaim space from long ones and gives a once-failed victim another shot as the board settles.
- **Widen blocker detection to a corridor** — `hw + clearance + width*3` instead of the hairline segment — so the connections a detour would actually have to thread become rip candidates.

## Verification

New test `congested_crossing_nets_all_route` (16 nets all crossing the board center):

| | before | after |
|---|---|---|
| nets routed | **8 / 16** | **16 / 16** |
| short/clearance DRC | clean | clean |
| full `vcad-ecad-pcb` suite | — | **122 / 122 pass** |

The **DRC-clean-by-construction invariant is preserved**: every (re)route still goes through `try_route`, which probes copper before committing, so the router never emits a short.

## Scope / not in this PR

This addresses the **congestion/ordering** failure that dominates real boards. Two deeper limitations remain (tracked separately):

- **Fine-pitch QFP escape** — at 0.5 mm pitch with 0.2 mm trace + clearance you can't fit a trace between adjacent pads; inner pins need **fan-out vias**, which the router doesn't generate yet.
- **No pad-to-inner-plane via stitching** — on a 4-layer board, SMD pads are never via'd down to inner GND/VCC planes, so those planes stay electrically dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
