### PR TITLE
feat(mcp): surface build identity in handshake, server_info, and /health

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -3,6 +3,7 @@
  */
 
 import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -203,10 +204,16 @@ import { fireToolAlert } from "./notify.js";
  *  tsc `dist/` build — `typeof` guards against the ReferenceError. */
 declare const __VCAD_VERSION__: string | undefined;
 
+/** Build-time injected commit + timestamp. esbuild's `--define:__VCAD_BUILD_SHA__`
+ *  / `__VCAD_BUILD_TIME__` (see services/mcp/build.sh) replace these with the
+ *  string literals from VERCEL_GIT_COMMIT_SHA at bundle time. Undefined in the
+ *  normal tsc `dist/` build — `typeof` guards against the ReferenceError. */
+declare const __VCAD_BUILD_SHA__: string | undefined;
+declare const __VCAD_BUILD_TIME__: string | undefined;
+
 /** Server version + build identity, read from package.json at load time so the
  *  advertised version always matches the running build (no hardcoded literal to
- *  drift). VCAD_BUILD_SHA, if injected at build/deploy time, fingerprints the
- *  exact commit so a stale deploy is detectable via `server_info`. */
+ *  drift). */
 const PKG_VERSION: string = (() => {
   // Bundled hosted build: the version is baked in via esbuild define, since the
   // require path below resolves to a nonexistent sibling of the single bundle.
@@ -220,7 +227,56 @@ const PKG_VERSION: string = (() => {
     return "0.0.0";
   }
 })();
-const BUILD_SHA: string = process.env.VCAD_BUILD_SHA ?? "unknown";
+
+/** Exact commit, baked at build time. The runtime env fallbacks
+ *  (VERCEL_GIT_COMMIT_SHA, then the legacy VCAD_BUILD_SHA) only fire for
+ *  non-bundled runs; on the hosted serverless build the define wins. "unknown"
+ *  means neither was available — itself a useful signal. */
+const BUILD_SHA: string =
+  (typeof __VCAD_BUILD_SHA__ === "string" && __VCAD_BUILD_SHA__) ||
+  process.env.VERCEL_GIT_COMMIT_SHA ||
+  process.env.VCAD_BUILD_SHA ||
+  "unknown";
+const BUILD_TIME: string =
+  (typeof __VCAD_BUILD_TIME__ === "string" && __VCAD_BUILD_TIME__) || "unknown";
+const SHORT_SHA: string = BUILD_SHA === "unknown" ? "unknown" : BUILD_SHA.slice(0, 7);
+
+/** Version advertised in the MCP `initialize` handshake. Semver build-metadata
+ *  (`0.9.4+1a2b3c4`) is the protocol-native place to surface which commit a
+ *  client is connected to — every MCP client sees it at connect time without
+ *  calling a tool. Build metadata is ignored in semver precedence, so this stays
+ *  a valid version string. */
+const VERSION_WITH_BUILD: string =
+  SHORT_SHA === "unknown" ? PKG_VERSION : `${PKG_VERSION}+${SHORT_SHA}`;
+
+/** Per-process identity, fresh at every cold start. On serverless this is the
+ *  difference between "the deployment is wrong" and "I'm pinned to one stale
+ *  instance": two calls reporting different instance_id / build_sha means old
+ *  instances are still draining behind a correct deployment. */
+const INSTANCE_ID: string = randomUUID().slice(0, 8);
+const PROCESS_STARTED_AT: number = Date.now();
+
+/** Single source of truth for build/runtime identity, shared by the
+ *  `server_info` tool, the `initialize` handshake, and the /health endpoint. */
+export function getBuildInfo(): {
+  name: string;
+  version: string;
+  version_full: string;
+  build_sha: string;
+  build_time: string;
+  instance_id: string;
+  uptime_s: number;
+} {
+  return {
+    name: "vcad",
+    version: PKG_VERSION,
+    version_full: VERSION_WITH_BUILD,
+    build_sha: BUILD_SHA,
+    build_time: BUILD_TIME,
+    instance_id: INSTANCE_ID,
+    uptime_s: Math.round((Date.now() - PROCESS_STARTED_AT) / 1000),
+  };
+}
 
 /** Kernel WASM exports this server depends on; checked at startup so a stale or
  *  incomplete dist surfaces as a clear boot error rather than an opaque
@@ -544,13 +600,15 @@ export async function createServer(
     );
   }
   console.error(
-    `[mcp] vcad ${PKG_VERSION} (build ${BUILD_SHA}) — ${dispatchableTools.size} kernel tools; kernel WASM ${kernelWasmLoaded ? "ok" : "UNAVAILABLE"}`,
+    `[mcp] vcad ${VERSION_WITH_BUILD} (instance ${INSTANCE_ID}) — ${dispatchableTools.size} kernel tools; kernel WASM ${kernelWasmLoaded ? "ok" : "UNAVAILABLE"}`,
   );
 
   const server = new Server(
     {
       name: "vcad",
-      version: PKG_VERSION,
+      // Build-tagged (`0.9.4+1a2b3c4`) so the commit is visible in the MCP
+      // `initialize` handshake — no tool call needed to tell builds apart.
+      version: VERSION_WITH_BUILD,
     },
     {
       capabilities: {
@@ -1575,9 +1633,7 @@ export async function createServer(
               {
                 type: "text",
                 text: JSON.stringify({
-                  name: "vcad",
-                  version: PKG_VERSION,
-                  build_sha: BUILD_SHA,
+                  ...getBuildInfo(),
                   kernel_wasm: kernelWasmLoaded ? "ok" : "unavailable",
                   ...(kernelWasmMissing.length > 0
                     ? { kernel_wasm_missing_exports: kernelWasmMissing }

--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -37,7 +37,17 @@ echo "[vcad-mcp] Bundling with esbuild..."
 # server.ts away from its sibling package.json, so its source-relative require
 # resolves to nothing and server_info would otherwise report 0.0.0.
 MCP_VERSION="$(node -p "require('$REPO_ROOT/packages/mcp/package.json').version")"
-echo "[vcad-mcp] Baking version $MCP_VERSION into bundle"
+
+# Build identity baked at build time so server_info, the MCP `initialize`
+# handshake, and /health can fingerprint the exact running commit. On Vercel
+# VERCEL_GIT_COMMIT_SHA is set during the build; fall back to git, then a
+# sentinel. Baking (vs reading process.env at runtime) is deterministic — it
+# doesn't depend on the project's "expose system env vars at runtime" setting,
+# whose absence is what made a stale serverless instance indistinguishable
+# from a fresh one.
+BUILD_SHA="${VERCEL_GIT_COMMIT_SHA:-$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)}"
+BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "[vcad-mcp] Baking version $MCP_VERSION build ${BUILD_SHA:0:7} ($BUILD_TIME) into bundle"
 
 npx esbuild@latest entry.ts \
   --bundle \
@@ -46,6 +56,8 @@ npx esbuild@latest entry.ts \
   --format=esm \
   --external:@resvg/resvg-js \
   --define:__VCAD_VERSION__="\"$MCP_VERSION\"" \
+  --define:__VCAD_BUILD_SHA__="\"$BUILD_SHA\"" \
+  --define:__VCAD_BUILD_TIME__="\"$BUILD_TIME\"" \
   --outfile="$OUT/functions/mcp.func/index.mjs" \
   --banner:js="import { createRequire as __vcadCreateRequire } from 'module'; const require = __vcadCreateRequire(import.meta.url);"
 

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -12,7 +12,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createServer } from "@vcad/mcp/server";
+import { createServer, getBuildInfo } from "@vcad/mcp/server";
 import {
   getOAuthConfig,
   handleOAuthRoute,
@@ -88,12 +88,16 @@ export default async function handler(
     return;
   }
 
-  // Health check
-  if (req.method === "GET" && req.url === "/health") {
+  // Health check — public, no auth. Carries full build identity so prod can be
+  // verified with a plain `curl https://mcp.vcad.io/health` (no MCP handshake):
+  // diff build_sha against `git rev-parse HEAD`, and watch instance_id to see
+  // stale serverless instances draining behind a fresh deployment.
+  if (req.method === "GET" && url.pathname === "/health") {
     try {
       const engine = await getEngine();
       sendJson(res, 200, {
         status: "ok",
+        ...getBuildInfo(),
         engine: !!engine,
         timestamp: new Date().toISOString(),
       });


### PR DESCRIPTION
## Why

A correct production deploy (#291) was indistinguishable from a stale serverless instance because **nothing reported which commit was running**:

- `server_info.build_sha` was `"unknown"` — `VCAD_BUILD_SHA` was never injected at build/deploy.
- The MCP `initialize` handshake advertised a bare `0.9.4`.
- The hosted `/health` returned only `{status, engine, timestamp}`.

So answering *"is the fix actually live?"* meant hand-cross-referencing Vercel deployment metadata. (In practice the deploy was correct and the symptom was a pre-fix lambda still serving one sticky session — exactly the case this makes visible.)

## What

Surface build identity the idiomatic-MCP way, from a single source of truth (`getBuildInfo()` in `packages/mcp/src/server.ts`):

1. **`initialize` handshake** — `serverInfo.version` is now `0.9.4+<sha>` (valid semver build-metadata). Every MCP client sees the exact commit at connect time, no tool call. This is the protocol-native channel for "which build am I talking to?".
2. **`server_info` tool** — spreads `getBuildInfo()`: `build_sha`, `build_time`, `version_full`, plus a per-cold-start `instance_id` and `uptime_s`, alongside the existing kernel-WASM fields.
3. **`/health`** (`services/mcp/entry.ts`) — public, no-auth JSON carrying the same identity. `curl https://mcp.vcad.io/health` → diff `build_sha` against `git rev-parse HEAD`, no handshake needed. Match switched from `req.url` to `url.pathname` for robustness.

**SHA baked at build time** (`services/mcp/build.sh`): `--define:__VCAD_BUILD_SHA__` / `__VCAD_BUILD_TIME__` from `VERCEL_GIT_COMMIT_SHA`, mirroring the existing `__VCAD_VERSION__`. Baking is deterministic — it doesn't depend on the project's "expose system env vars at runtime" setting. A runtime `process.env` fallback (`VERCEL_GIT_COMMIT_SHA`, then legacy `VCAD_BUILD_SHA`) covers non-bundled runs.

The sleeper feature is **`instance_id`** (fresh per cold start): the failure mode that prompted this was *one* stale instance behind a *correct* deployment. Two calls returning different `instance_id`/`build_sha` now visibly means old instances are draining.

## Design note

Used the version-string + tool + `/health` surfaces rather than `_meta` on the `initialize` result — `serverInfo.version` is universally surfaced by clients, `_meta` isn't. Easy to add `_meta` later if a client wants structured handshake data.

## Verification

- Ran the real `services/mcp/build.sh` with a fake `VERCEL_GIT_COMMIT_SHA` → baked SHA + `version_full` confirmed present in the output `mcp.func/index.mjs` bundle.
- `tsc --noEmit -p packages/mcp` clean (the package's normal build uses `tsc --noCheck`, so this is the real typecheck).
- `entry.ts` typechecks against the built `@vcad/mcp/server` `.d.ts`.
- MCP suite: **197 passed / 2 skipped** (incl. #291's `kernel-trap-recovery` tests).

No changelog entry: this is deploy/observability infra, not a product behavior change.

## Not in this PR

- Doesn't evict currently-stale lambdas — a Redeploy / instance drain is still the operational step to recycle pre-#291 instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)