### PR TITLE
fix(loon): let-bound subjects no longer drop their cuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,6 +6926,7 @@ dependencies = [
  "vcad-kernel-sweep",
  "vcad-kernel-tessellate",
  "vcad-kernel-text",
+ "vcad-loon",
 ]
 
 [[package]]

--- a/changelog/entries/2026-06-17-loon-let-body.json
+++ b/changelog/entries/2026-06-17-loon-let-body.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-17-loon-let-body",
+  "version": "0.9.4",
+  "date": "2026-06-17",
+  "category": "fix",
+  "title": "Loon let-bound parts no longer drop their cuts",
+  "summary": "[let name value body] in create_cad_loon now evaluates and returns the body; previously the trailing body was silently dropped, so a let-bound base solid rendered un-cut with every boolean lost.",
+  "features": ["loon", "create_cad_loon", "booleans"],
+  "mcpTools": ["create_cad_loon"]
+}

--- a/crates/vcad-eval/Cargo.toml
+++ b/crates/vcad-eval/Cargo.toml
@@ -20,3 +20,6 @@ vcad-kernel-geom.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+
+[dev-dependencies]
+vcad-loon.workspace = true

--- a/crates/vcad-eval/tests/loon_boolean_composition.rs
+++ b/crates/vcad-eval/tests/loon_boolean_composition.rs
@@ -1,0 +1,83 @@
+//! End-to-end regression: loon source with chained / nested / `let`-bound
+//! `difference` operations must evaluate to geometry with every cut applied.
+//!
+//! Uses clean axis-aligned cubes (no curved surfaces) so `volume()` is a
+//! reliable oracle — the BRep boolean kernel is exact for these. This isolates
+//! the *evaluator + loon* composition from any kernel curved-surface robustness
+//! concerns: the point under test is that nesting/`let` do not drop cuts.
+
+use vcad_eval::{evaluate_document, EvalOptions};
+use vcad_loon::eval_vcad;
+
+fn volume(src: &str) -> f64 {
+    let doc = eval_vcad(src, None).expect("eval_vcad");
+    let scene = evaluate_document(
+        &doc,
+        &EvalOptions {
+            skip_clash_detection: true,
+            clock: None,
+        },
+    )
+    .expect("evaluate_document");
+    scene.parts[0].solid.as_ref().expect("root solid").volume()
+}
+
+/// 100³ body (1_000_000) minus three disjoint 10³ cubes (−3_000) = 997_000.
+const EXPECTED: f64 = 997_000.0;
+
+#[test]
+fn chained_nested_difference_applies_all_cuts() {
+    // Outer difference's subject is itself a difference, three deep.
+    let v = volume(
+        "[difference [translate 80 80 80 [cube 10 10 10]] \
+           [difference [translate 50 50 50 [cube 10 10 10]] \
+             [difference [translate 10 10 10 [cube 10 10 10]] \
+               [cube 100 100 100]]]]",
+    );
+    assert!(
+        (v - EXPECTED).abs() < 1.0,
+        "chained diff vol={v}, want {EXPECTED}"
+    );
+}
+
+#[test]
+fn pipe_chained_difference_applies_all_cuts() {
+    // The documented `pipe` authoring form threads the body through each cut —
+    // it lowers to the same nested-subject Difference chain.
+    let v = volume(
+        "[pipe [cube 100 100 100] \
+           [difference [translate 10 10 10 [cube 10 10 10]]] \
+           [difference [translate 50 50 50 [cube 10 10 10]]] \
+           [difference [translate 80 80 80 [cube 10 10 10]]]]",
+    );
+    assert!(
+        (v - EXPECTED).abs() < 1.0,
+        "pipe diff vol={v}, want {EXPECTED}"
+    );
+}
+
+#[test]
+fn let_bound_chained_difference_applies_all_cuts() {
+    // Regression: `[let b BODY expr]` used to drop the body expression and
+    // return the bare body (vol == 1_000_000, no cuts). It must now apply all.
+    let v = volume(
+        "[let b [cube 100 100 100] \
+           [difference [translate 80 80 80 [cube 10 10 10]] \
+             [difference [translate 50 50 50 [cube 10 10 10]] \
+               [difference [translate 10 10 10 [cube 10 10 10]] b]]]]",
+    );
+    assert!(
+        (v - EXPECTED).abs() < 1.0,
+        "let-bound chained diff vol={v}, want {EXPECTED} (1_000_000 == cuts dropped)"
+    );
+}
+
+#[test]
+fn single_difference_applies_cut() {
+    // Baseline: a single cut works (matches reported case 1).
+    let v = volume("[difference [translate 10 10 10 [cube 10 10 10]] [cube 100 100 100]]");
+    assert!(
+        (v - 999_000.0).abs() < 1.0,
+        "single diff vol={v}, want 999000"
+    );
+}

--- a/crates/vcad-kernel/tests/chained_curved_boolean_regression.rs
+++ b/crates/vcad-kernel/tests/chained_curved_boolean_regression.rs
@@ -1,0 +1,79 @@
+//! Tracked regression for a BRep boolean robustness bug exposed by chained
+//! booleans over curved surfaces.
+//!
+//! Minimal trigger (all three required — removing any one makes it pass):
+//!   1. a *filleted* body (curved blend faces),
+//!   2. a *sphere* subtracted from it (leaves a concave spherical face), then
+//!   3. a *cylinder* subtracted from that result (a curved tool).
+//!
+//! Expected: `(filleted_cube − sphere) − cylinder` is the body with a spherical
+//! dish and a small cylindrical notch — its bounding box stays within the body
+//! (z ≈ 0..28). Observed: the second difference produces invalid topology in
+//! which the subtracted sphere *resurfaces as positive geometry*, ballooning the
+//! bounding box to the sphere's extent (z ≈ 94).
+//!
+//! This is NOT a loon / IR / evaluator bug — the IR is a correct Difference
+//! chain and the node evaluator composes it correctly (see
+//! `vcad-eval/tests/loon_boolean_composition.rs`, which passes on planar
+//! geometry). The fault is in the curved-surface SSI / classification path of
+//! `vcad-kernel-booleans`. The companion tests
+//! `chained_planar_boolean_is_robust` and `single_curved_difference_is_robust`
+//! below are NOT ignored and guard the working cases.
+//!
+//! When the kernel is fixed, drop the `#[ignore]` from
+//! `chained_curved_boolean_resurfaces_sphere`.
+
+use vcad_kernel::Solid;
+
+fn zmax(s: &Solid) -> f64 {
+    s.bounding_box().1[2]
+}
+
+/// The exact reported failing geometry. Ignored until the boolean kernel is
+/// fixed; flips from `z≈94` (sphere resurfaced) to `z≈28` when correct.
+#[test]
+#[ignore = "known kernel boolean bug: chained curved difference resurfaces the subtracted sphere"]
+fn chained_curved_boolean_resurfaces_sphere() {
+    let body = Solid::cube(90.0, 60.0, 28.0).fillet(14.0);
+    let sphere = Solid::sphere(36.0, 0).translate(45.0, 30.0, 58.0);
+    let cyl = Solid::cylinder(5.0, 4.0, 0).translate(45.0, 42.0, 25.0);
+
+    let dished = body.difference(&sphere); // works alone (z stays ~28)
+    let result = dished.difference(&cyl); // bug: sphere comes back
+
+    let z = zmax(&result);
+    assert!(
+        z <= 30.0,
+        "subtracted sphere resurfaced: result z-max = {z:.1} (body is ~28; sphere would push to ~94)"
+    );
+}
+
+/// Guard: the same chain over planar tools is robust — proves nesting itself is
+/// fine and pins the failure to curved surfaces.
+#[test]
+fn chained_planar_boolean_is_robust() {
+    let body = Solid::cube(100.0, 100.0, 100.0);
+    let h1 = Solid::cube(10.0, 10.0, 10.0).translate(10.0, 10.0, 10.0);
+    let h2 = Solid::cube(10.0, 10.0, 10.0).translate(50.0, 50.0, 50.0);
+    let h3 = Solid::cube(10.0, 10.0, 10.0).translate(80.0, 80.0, 80.0);
+
+    let result = body.difference(&h1).difference(&h2).difference(&h3);
+    let v = result.volume();
+    assert!(
+        (v - 997_000.0).abs() < 1.0,
+        "planar chained difference vol={v}, want 997000"
+    );
+}
+
+/// Guard: a single curved difference (sphere out of a filleted cube) is robust —
+/// pins the failure to *chaining* a further curved cut, not the first one.
+#[test]
+fn single_curved_difference_is_robust() {
+    let body = Solid::cube(90.0, 60.0, 28.0).fillet(14.0);
+    let sphere = Solid::sphere(36.0, 0).translate(45.0, 30.0, 58.0);
+    let z = zmax(&body.difference(&sphere));
+    assert!(
+        z <= 30.0,
+        "single curved difference z-max={z:.1} (want ~28)"
+    );
+}

--- a/crates/vcad-loon/tests/chained_booleans.rs
+++ b/crates/vcad-loon/tests/chained_booleans.rs
@@ -1,0 +1,144 @@
+//! Regression tests for chained / nested boolean composition in the loon
+//! evaluator.
+//!
+//! Booleans are subject-last: `[difference tool subject]` → `subject − tool`.
+//! The cases below mirror real bug reports where multi-feature parts authored
+//! by nesting `difference` (the recommended `create_cad_loon` path) lost their
+//! cuts:
+//!
+//!   * the SUBJECT of an outer `difference` is itself a `difference` result, and
+//!   * the body is referenced through a `[let name value body]` binding, whose
+//!     trailing body used to be silently dropped (returning the bound value).
+//!
+//! Both reduce to the same IR shape, so we assert the evaluator emits a proper
+//! chain of `Difference` nodes with every cut still referenced.
+
+use vcad_ir::{CsgOp, Document, NodeId};
+use vcad_loon::eval_vcad;
+
+/// Walk the (single) root and return the chain of `Difference` nodes from the
+/// root inward, following the `left` (subject) edge — i.e. the order cuts are
+/// composed. Each entry is `(left, right)`.
+fn difference_chain(doc: &Document) -> Vec<(NodeId, NodeId)> {
+    assert_eq!(doc.roots.len(), 1, "expected exactly one root");
+    let mut chain = Vec::new();
+    let mut cur = doc.roots[0].root;
+    while let Some(node) = doc.nodes.get(&cur) {
+        match &node.op {
+            CsgOp::Difference { left, right } => {
+                chain.push((*left, *right));
+                cur = *left;
+            }
+            _ => break,
+        }
+    }
+    chain
+}
+
+fn op_of(doc: &Document, id: NodeId) -> &CsgOp {
+    &doc.nodes[&id].op
+}
+
+/// The terminal subject of the chain (follow `left` past every Difference) must
+/// be the filleted cube body — proof no cut was dropped and the body survives.
+fn assert_body_is_filleted_cube(doc: &Document, mut id: NodeId) {
+    while let CsgOp::Difference { left, .. } = op_of(doc, id) {
+        id = *left;
+    }
+    match op_of(doc, id) {
+        CsgOp::Fillet { child, .. } => {
+            assert!(
+                matches!(op_of(doc, *child), CsgOp::Cube { .. }),
+                "fillet child should be the cube body"
+            );
+        }
+        other => panic!("expected filleted-cube body at chain tail, got {other:?}"),
+    }
+}
+
+const CASE_3: &str = "[difference [translate 45 42 25 [cylinder 5 4]] \
+   [difference [translate 39 -5 6 [fillet 1.5 [cube 12 10 5]]] \
+     [difference [translate 45 30 58 [sphere 36]] \
+       [fillet 14 [cube 90 60 28]]]]]";
+
+const CASE_4: &str = "[let b [fillet 14 [cube 90 60 28]] \
+   [difference [translate 45 42 25 [cylinder 5 4]] \
+     [difference [translate 39 -5 6 [fillet 1.5 [cube 12 10 5]]] \
+       [difference [translate 45 30 58 [sphere 36]] b]]]]";
+
+/// Case 3: chained differences where each outer `difference`'s subject is the
+/// previous `difference` result. All three cuts must compose into a 3-deep
+/// Difference chain ending at the body.
+#[test]
+fn chained_difference_keeps_every_cut() {
+    let doc = eval_vcad(CASE_3, None).unwrap();
+    let chain = difference_chain(&doc);
+    assert_eq!(chain.len(), 3, "expected 3 chained Difference nodes");
+
+    // Each `right` (tool) is, in order: cylinder, small filleted cube, sphere.
+    let tool_ops: Vec<&CsgOp> = chain
+        .iter()
+        .map(|(_, right)| {
+            // tools are wrapped in Translate — peel one transform
+            match op_of(&doc, *right) {
+                CsgOp::Translate { child, .. } => op_of(&doc, *child),
+                other => other,
+            }
+        })
+        .collect();
+    assert!(
+        matches!(tool_ops[0], CsgOp::Cylinder { .. }),
+        "outer cut = cylinder"
+    );
+    assert!(
+        matches!(tool_ops[1], CsgOp::Fillet { .. }),
+        "middle cut = filleted small cube"
+    );
+    assert!(
+        matches!(tool_ops[2], CsgOp::Sphere { .. }),
+        "inner cut = sphere"
+    );
+
+    assert_body_is_filleted_cube(&doc, doc.roots[0].root);
+}
+
+/// Case 4: the same chain, but the body is bound with `[let b … expr]`. Before
+/// the fix the `let` returned `b` (the bare body) and every cut vanished. Now
+/// it must produce the identical chain to case 3.
+#[test]
+fn let_bound_subject_keeps_every_cut() {
+    let doc = eval_vcad(CASE_4, None).unwrap();
+    let chain = difference_chain(&doc);
+    assert_eq!(
+        chain.len(),
+        3,
+        "let-bound body must still compose into 3 Difference nodes (was 0 — cuts dropped)"
+    );
+    assert_body_is_filleted_cube(&doc, doc.roots[0].root);
+
+    // Case 3 and case 4 are the same part expressed two ways → identical node count.
+    let doc3 = eval_vcad(CASE_3, None).unwrap();
+    assert_eq!(
+        doc.nodes.len(),
+        doc3.nodes.len(),
+        "let-bound and inline chains must yield the same graph size"
+    );
+}
+
+/// The `let` body must actually be evaluated and returned. A `let`-bound body
+/// with no further use still produces the bare body; with a `difference` around
+/// it the difference must win.
+#[test]
+fn let_body_is_not_dropped() {
+    // Plain binding then a cut applied to it via the body expression.
+    let doc = eval_vcad(
+        "[let body [cube 20 20 20] [difference [translate 5 5 5 [cube 5 5 5]] body]]",
+        None,
+    )
+    .unwrap();
+    assert_eq!(doc.roots.len(), 1);
+    assert!(
+        matches!(op_of(&doc, doc.roots[0].root), CsgOp::Difference { .. }),
+        "let body (a difference) must be the root, not the bare bound cube"
+    );
+}


### PR DESCRIPTION
## What

Fixes the reported bug where multi-feature parts authored via nested / `let`-bound `difference` in `create_cad_loon` lost their cuts. Investigation turned up **two distinct bugs**, not one.

### Bug 1 — loon `let` dropped its body ✅ fixed
`[let name value body]` evaluated the value, bound it, and returned **the bound value** — silently ignoring the trailing body. So `[let b BODY expr]` returned the un-cut `b`, dropping every boolean. (Case 4 produced 2 nodes instead of the 12-node chain.)

The behavioral fix is in **loon-lang's `eval_let`** (`ecto/loon`, consumed by vcad as a path dependency): the 2-arg statement form `[let x v]` is unchanged (still binds into the current scope so top-level / `[do …]` sequencing observes it); `[let x v body…]` now pushes a scope, binds, evaluates the body, and returns its last value.

> ⚠️ **Cross-repo:** the `eval_let` change lives in `ecto/loon` (branch `pr8-fix`), committed there as `41a3112`. It must be pushed/landed in `ecto/loon` for vcad CI/prod (which builds loon via path dep) to pick up the fix. This vcad PR contains the tests + tracking only.

### Bug 2 — kernel chained curved boolean ⚠️ tracked, not fixed → ecto/vcad#298
Case 3's render failure is **not** the loon evaluator — the loon→IR conversion and the `vcad-eval` node evaluator compose nested/chained differences correctly (verified on planar geometry, `997000` vol). The fault is in `vcad-kernel-booleans`: subtracting a **curved tool from a solid that already has a concave curved face** resurfaces the subtracted geometry. Razor-thin trigger requiring all three of: filleted body + sphere cut + cylinder cut. Minimal repro `(filleted_cube − sphere) − cylinder` balloons the bbox z from ~28 to ~94.

Captured as an `#[ignore]`d regression test plus two passing guards, and filed as **#298**.

## Tests
- `vcad-loon/tests/chained_booleans.rs` — IR-structure tests for reported cases 3 & 4 (every cut present; case 4 now matches case 3).
- `vcad-eval/tests/loon_boolean_composition.rs` — end-to-end geometry on clean manifolds (reliable `volume()`): nested / `pipe` / `let`-bound chains all apply every cut.
- `vcad-kernel/tests/chained_curved_boolean_regression.rs` — ignored kernel-bug tracker (#298) + planar/single-curved guards.
- loon-lang: `let_with_body_*` regression tests.

All green (437 loon tests, vcad-loon, vcad-eval, vcad-kernel guards). rustfmt clean; no new clippy beyond the codebase baseline.

## Reviewer notes
- `vcad-loon` added as a **dev-dependency** of `vcad-eval` (no cycle — vcad-loon doesn't depend on vcad-eval) to enable the end-to-end loon→geometry test.
- Changelog entry added (`fix`, user-facing via `create_cad_loon`).
- Case status against the original repro: cases 1 & 2 correct; case 4's evaluator bug fixed; cases 3 & 4 on the exact filleted+sphere+cylinder geometry still render wrong pending the kernel fix (#298). Authoring with a single union-of-tools (`A − (B ∪ C ∪ D)`) is a working workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
