### PR TITLE
feat(mcp): vcad Fabricate Phase 0 — quote custom manufacturing via MCP

### DIFF
--- a/changelog/entries/2026-06-18-fabricate-quote-manufacturing.json
+++ b/changelog/entries/2026-06-18-fabricate-quote-manufacturing.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-18-fabricate-quote-manufacturing",
+  "version": "0.9.4",
+  "date": "2026-06-18",
+  "category": "feat",
+  "title": "Quote custom manufacturing from a design via MCP",
+  "summary": "New quote_manufacturing / get_order_status / list_orders MCP tools quote a part (PCB, CNC, 3D-print, sheet-metal, cast-metal) from a live session through a fab broker (JLCPCB, Digital Metal) and persist a quote + order. Quote-only for now — no payment.",
+  "features": ["fabricate", "ordering", "manufacturing", "jlcpcb", "digital-metal"],
+  "mcpTools": ["quote_manufacturing", "get_order_status", "list_orders"]
+}

--- a/packages/mcp/src/__tests__/fabricate.test.ts
+++ b/packages/mcp/src/__tests__/fabricate.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { openDocument, documents } from "../tools/session.js";
+import {
+  quoteManufacturing,
+  getOrderStatus,
+  listOrders,
+} from "../tools/order.js";
+import { InMemoryFabricateStore } from "../fabricate/store.js";
+import { FulfillmentBroker } from "../fabricate/broker.js";
+import { applyMargin, MARGIN_RATE } from "../fabricate/pricing.js";
+import { digitalMetalAdapter } from "../fabricate/adapters/digitalmetal.js";
+import type { GeometryMetrics } from "../fabricate/types.js";
+
+function metrics(over: Partial<GeometryMetrics> = {}): GeometryMetrics {
+  return {
+    ok: true,
+    parts: 1,
+    volume_mm3: 1000,
+    surface_area_mm2: 600,
+    footprint_mm2: 100,
+    max_dim_mm: 10,
+    bbox: { min: [0, 0, 0], max: [10, 10, 10] },
+    ...over,
+  };
+}
+
+function cubeDoc(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": { id: 1, name: "blank", op: { type: "Cube", size: { x: 10, y: 10, z: 10 } } },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [{ root: 1, material: "default" }],
+  } as unknown as Document;
+}
+
+describe("fabricate pricing + broker (no engine)", () => {
+  it("applies the cost-plus margin", () => {
+    expect(applyMargin(1000)).toBe(Math.round(1000 * (1 + MARGIN_RATE)));
+    expect(applyMargin(1000)).toBe(1250);
+  });
+
+  it("quotes cast_metal, keeps fab cost server-only, and is not orderable in Phase 0", async () => {
+    const broker = new FulfillmentBroker();
+    const r = await broker.quote({ process: "cast_metal", quantity: 2, metrics: metrics() });
+
+    expect(r.recommended).not.toBeNull();
+    expect(r.options.length).toBeGreaterThan(0);
+    // Server-only economics are returned to the BROKER caller (the tool), but
+    // every customer-facing option is margin-inclusive and not orderable yet.
+    expect(r.fab_cost_minor).toBeGreaterThan(0);
+    expect(r.margin_minor).toBeGreaterThan(0);
+    for (const o of r.options) {
+      expect(o.total_minor).toBeGreaterThan(0);
+      expect(o.pricing_basis).toBe("estimate");
+      expect(o.orderable).toBe(false); // Phase 0: estimate, never orderable
+    }
+    // Marked-up total is strictly above the raw fab cost.
+    expect(r.recommended!.total_minor).toBeGreaterThan(r.fab_cost_minor);
+  });
+
+  it("flags an oversize cast_metal part as out of spec", async () => {
+    const q = await digitalMetalAdapter.quote({
+      process: "cast_metal",
+      quantity: 1,
+      metrics: metrics({ max_dim_mm: 400 }), // > 350 mm envelope
+    });
+    expect(q).not.toBeNull();
+    expect(q!.in_spec).toBe(false);
+  });
+
+  it("PCB quote uses board area + layers and stays in spec", async () => {
+    const broker = new FulfillmentBroker();
+    const r = await broker.quote({
+      process: "pcb",
+      quantity: 5,
+      metrics: metrics({ ok: false, parts: 0, footprint_mm2: 0, max_dim_mm: 0, bbox: null }),
+      boardAreaMm2: 2500, // 50x50mm
+      layers: 4,
+    });
+    const jlc = r.options.find((o) => o.fab === "jlcpcb");
+    expect(jlc).toBeDefined();
+    expect(jlc!.in_spec).toBe(true);
+    expect(jlc!.total_minor).toBeGreaterThan(0);
+  });
+
+  it("CNC has no contracted fab → only a non-orderable estimate", async () => {
+    const broker = new FulfillmentBroker();
+    const r = await broker.quote({ process: "cnc", quantity: 1, metrics: metrics() });
+    expect(r.options.length).toBeGreaterThan(0);
+    expect(r.options.every((o) => o.orderable === false)).toBe(true);
+    expect(r.options.some((o) => o.fab === "vcad_estimate")).toBe(true);
+  });
+
+  it("uses the shared kernel estimate when provided, so MCP agrees with the app", async () => {
+    const broker = new FulfillmentBroker();
+    const base = 10000; // $100 total fab cost from the shared estimator
+    const r = await broker.quote({
+      process: "cast_metal",
+      quantity: 1,
+      metrics: metrics(),
+      baseCostMinor: base,
+    });
+    expect(r.recommended).not.toBeNull();
+    // The adapter used the shared estimate, NOT its local coefficients.
+    expect(r.fab_cost_minor).toBe(base);
+    // Customer total = marked-up base + landed (Digital Metal = US, $8, no duty).
+    expect(r.recommended!.fab).toBe("digitalmetal");
+    expect(r.recommended!.total_minor).toBe(applyMargin(base) + 800);
+  });
+});
+
+describe("fabricate quote loop (engine)", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+  beforeEach(() => {
+    documents.clear();
+  });
+
+  it("quotes a real cube, hides fab cost, persists a QUOTED order, and reads it back", async () => {
+    const open = openDocument({ initial: cubeDoc() });
+    const { document_id } = JSON.parse(open.content[0].text);
+
+    const store = new InMemoryFabricateStore();
+    const quoteRes = await quoteManufacturing(
+      { document_id, process: "cast_metal", quantity: 2, material: "stainless" },
+      engine,
+      store,
+      null,
+    );
+    expect(quoteRes.isError).toBeFalsy();
+    const quote = JSON.parse(quoteRes.content[0].text);
+
+    // Measured real geometry off the cube.
+    expect(quote.geometry.parts).toBe(1);
+    expect(quote.geometry.volume_mm3).toBeGreaterThan(0);
+    expect(quote.quote_id).toBeTruthy();
+    expect(quote.order_id).toBeTruthy();
+    expect(quote.total_amount_usd).toBeGreaterThan(0);
+    expect(quote.fab_options.length).toBeGreaterThan(0);
+    expect(quote.margin_hidden).toBe(true);
+
+    // Consistency: a volume-based process is priced by the SAME kernel cost
+    // model the app's Build quote uses (not ad-hoc coefficients).
+    expect(quote.material_catalog).toBeTruthy();
+    expect(quote.cost_model).toContain("kernel");
+
+    // The marked-up cost / margin must NEVER leak into the agent-facing result.
+    expect(quoteRes.content[0].text).not.toContain("fab_cost");
+    expect(quoteRes.content[0].text).not.toContain("margin_minor");
+
+    // The order was persisted at QUOTED and is readable + listable.
+    const statusRes = await getOrderStatus({ order_id: quote.order_id }, store, null);
+    const status = JSON.parse(statusRes.content[0].text);
+    expect(status.state).toBe("QUOTED");
+    expect(status.events[0].state).toBe("QUOTED");
+    expect(status.tracking).toBeNull();
+
+    const listRes = await listOrders({ status: "QUOTED" }, store, null);
+    const list = JSON.parse(listRes.content[0].text);
+    expect(list.orders.some((o: { order_id: string }) => o.order_id === quote.order_id)).toBe(true);
+  });
+
+  it("rejects an unknown process", async () => {
+    const open = openDocument({ initial: cubeDoc() });
+    const { document_id } = JSON.parse(open.content[0].text);
+    const res = await quoteManufacturing(
+      { document_id, process: "frobnicate", quantity: 1 },
+      engine,
+      new InMemoryFabricateStore(),
+      null,
+    );
+    expect(res.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/fabricate/adapters/digitalmetal.ts
+++ b/packages/mcp/src/fabricate/adapters/digitalmetal.ts
@@ -1,0 +1,68 @@
+/**
+ * Digital Metal (digitalmetal.io) adapter — instant-quote CAST METAL parts.
+ *
+ * A strong adapter fit: their flow is STEP upload → instant quote + DFM →
+ * configure (alloy / qty / finish) → online checkout, and vcad exports STEP
+ * natively (export_cad on a sheet-metal/solid document). US-based (SF + ATX),
+ * 1-piece minimum, 5-10 business-day lead, max part 350 × 350 × 200 mm,
+ * tolerance ±0.1 mm / 10 mm. Casts stainless, steel, zinc, zamak.
+ *
+ * Phase 0 is QUOTE-ONLY with a LOCAL estimate (pricing_basis: "estimate"). A
+ * live quote/order integration is a roadmap item once their /docs API surface
+ * is confirmed; until then this is an estimate, not orderable.
+ */
+
+import type { AdapterQuote, ManufacturerAdapter, QuoteRequest } from "../types.js";
+
+// Build envelope (mm) and supported alloys per digitalmetal.io.
+const MAX_DIM_MM = 350;
+const ALLOYS = ["stainless", "steel", "zinc", "zamak"];
+
+export const digitalMetalAdapter: ManufacturerAdapter = {
+  key: "digitalmetal",
+  label: "Digital Metal",
+  region: "US",
+  processes: ["cast_metal"],
+  supportsDdp: true, // US domestic — no import duty.
+  async quote(req: QuoteRequest): Promise<AdapterQuote | null> {
+    if (req.process !== "cast_metal") return null;
+
+    const volCm3 = Math.max(0.1, req.metrics.volume_mm3 / 1000);
+    // Cast-metal cost driver: prefer the shared kernel cost model (consistent
+    // with the in-app quote); fall back to local coefficients.
+    const unitMinor = Math.round(volCm3 * 90 + 1200);
+    const fabCostMinor = req.baseCostMinor ?? unitMinor * req.quantity;
+
+    const notes: string[] = [
+      `Local estimate (pricing_basis=estimate): ~${volCm3.toFixed(1)} cm³ cast metal, qty ${req.quantity}.`,
+      "Digital Metal: US-based, 1-piece min, 5-10 business-day lead, ±0.1 mm/10 mm. Live API is a roadmap item.",
+    ];
+    if (req.baseCostMinor != null) {
+      notes.push("Priced via the shared kernel cost model — agrees with the in-app Build quote.");
+    }
+
+    let inSpec = true;
+    if (req.metrics.ok && req.metrics.max_dim_mm > MAX_DIM_MM) {
+      inSpec = false;
+      notes.push(
+        `Part max dimension ${req.metrics.max_dim_mm.toFixed(0)} mm exceeds the ${MAX_DIM_MM} mm build envelope.`,
+      );
+    }
+    if (req.material && !ALLOYS.includes(req.material.toLowerCase())) {
+      notes.push(
+        `Material "${req.material}" not in Digital Metal's catalog (${ALLOYS.join(", ")}); estimate uses a default alloy.`,
+      );
+    }
+    if (!req.metrics.ok) {
+      notes.push("No solid geometry measured — estimate is a floor only.");
+    }
+
+    return {
+      fab_cost_minor: fabCostMinor,
+      lead_time_days: 8,
+      in_spec: inSpec,
+      pricing_basis: "estimate",
+      notes,
+    };
+  },
+};

--- a/packages/mcp/src/fabricate/adapters/generic.ts
+++ b/packages/mcp/src/fabricate/adapters/generic.ts
@@ -1,0 +1,63 @@
+/**
+ * Generic vcad estimator — a fallback adapter for processes with no contracted
+ * fab yet (CNC, sheet_metal, and a floor for pcb/3dprint/cast_metal). It always
+ * returns pricing_basis: "estimate" and is flagged NOT orderable by the broker,
+ * so an agent can see a ballpark for any process while we stand up real fab
+ * partners. Coefficients are deliberate placeholders.
+ *
+ * Honesty over theater: this exists so quote_manufacturing works end-to-end for
+ * every process, NOT to imply we can fulfill CNC/sheet-metal today.
+ */
+
+import type { AdapterQuote, ManufacturerAdapter, Process, QuoteRequest } from "../types.js";
+
+// Per-process cost driver + envelope (placeholder).
+const MODELS: Record<
+  Process,
+  { perCm3: number; perCm2: number; base: number; lead: number; maxDimMm: number }
+> = {
+  pcb: { perCm3: 0, perCm2: 8, base: 200, lead: 8, maxDimMm: 500 },
+  cnc: { perCm3: 120, perCm2: 0, base: 1500, lead: 10, maxDimMm: 500 },
+  "3dprint": { perCm3: 35, perCm2: 0, base: 250, lead: 7, maxDimMm: 256 },
+  sheet_metal: { perCm3: 0, perCm2: 12, base: 900, lead: 9, maxDimMm: 1000 },
+  cast_metal: { perCm3: 90, perCm2: 0, base: 1200, lead: 10, maxDimMm: 350 },
+};
+
+export const genericEstimateAdapter: ManufacturerAdapter = {
+  key: "vcad_estimate",
+  label: "vcad estimate (no contracted fab yet)",
+  region: "n/a",
+  processes: ["pcb", "cnc", "3dprint", "sheet_metal", "cast_metal"],
+  supportsDdp: false,
+  async quote(req: QuoteRequest): Promise<AdapterQuote | null> {
+    const m = MODELS[req.process];
+    if (!m) return null;
+
+    const volCm3 = Math.max(0.1, req.metrics.volume_mm3 / 1000);
+    const areaCm2 = Math.max(1, (req.boardAreaMm2 ?? req.metrics.footprint_mm2) / 100);
+    const unitMinor = Math.round(m.base + volCm3 * m.perCm3 + areaCm2 * m.perCm2);
+    // Prefer the shared kernel cost model (consistent with the in-app quote);
+    // fall back to local coefficients when it's unavailable.
+    const fabCostMinor = req.baseCostMinor ?? unitMinor * req.quantity;
+
+    const inSpec = !req.metrics.ok || req.metrics.max_dim_mm <= m.maxDimMm;
+    const notes = [
+      `Ballpark estimate — no contracted ${req.process} fab yet, NOT orderable.`,
+    ];
+    if (req.baseCostMinor != null) {
+      notes.push("Priced via the shared kernel cost model — agrees with the in-app Build quote.");
+    }
+    if (!inSpec) {
+      notes.push(
+        `Part max dimension ${req.metrics.max_dim_mm.toFixed(0)} mm exceeds the ~${m.maxDimMm} mm envelope.`,
+      );
+    }
+    return {
+      fab_cost_minor: fabCostMinor,
+      lead_time_days: m.lead,
+      in_spec: inSpec,
+      pricing_basis: "estimate",
+      notes,
+    };
+  },
+};

--- a/packages/mcp/src/fabricate/adapters/jlcpcb.ts
+++ b/packages/mcp/src/fabricate/adapters/jlcpcb.ts
@@ -1,0 +1,113 @@
+/**
+ * JLCPCB adapter — PCB fabrication + 3D printing.
+ *
+ * Phase 0 is QUOTE-ONLY and computes a LOCAL estimate (pricing_basis:
+ * "estimate"). The live JLCPCB Partner API quote is gated behind credentials
+ * AND is deliberately NOT wired yet: the binding quote + ordering endpoints
+ * require an approval-gated ACCESS_KEY + SECRET_KEY (HMAC-signed requests) we
+ * don't hold, and shipping an unverifiable HTTP integration is worse than a
+ * labeled estimate. The credential seam is here so Phase 1 only has to fill in
+ * `quoteViaApi`.
+ *
+ * The APP_ID is a public identifier read from JLCPCB_APP_ID (env, not source).
+ * The cost coefficients below are deliberately conservative PLACEHOLDERS — they
+ * produce sane positive numbers for the end-to-end loop, not real JLCPCB prices.
+ */
+
+import type { AdapterQuote, ManufacturerAdapter, QuoteRequest } from "../types.js";
+
+function appConfigured(): boolean {
+  return Boolean(process.env.JLCPCB_APP_ID);
+}
+
+/** True once the approval-gated signing secrets are present (Phase 1). */
+function credentialed(): boolean {
+  return Boolean(
+    process.env.JLCPCB_APP_ID &&
+      process.env.JLCPCB_ACCESS_KEY &&
+      process.env.JLCPCB_SECRET_KEY,
+  );
+}
+
+/** Local PCB cost estimate from board area, layer count, and quantity. */
+function estimatePcb(req: QuoteRequest): AdapterQuote {
+  const layers = Math.max(1, Math.round(req.layers ?? 2));
+  const areaMm2 = req.boardAreaMm2 ?? req.metrics.footprint_mm2;
+  const areaCm2 = Math.max(1, areaMm2 / 100);
+
+  // Layer factor: 2L = 1.0, +0.4 per extra layer (placeholder).
+  const layerFactor = 1 + Math.max(0, layers - 2) * 0.4;
+
+  // Per-unit fab cost (minor units): area-driven + per-board handling.
+  const unitMinor = Math.round(areaCm2 * 6 * layerFactor + 30);
+  // Amortized panelization/setup, in minor units.
+  const setupMinor = 200;
+  const fabCostMinor = setupMinor + unitMinor * req.quantity;
+
+  const notes = [
+    `Local estimate (pricing_basis=estimate): ${layers}-layer, ~${areaCm2.toFixed(1)} cm² board, qty ${req.quantity}.`,
+    appConfigured()
+      ? "JLCPCB_APP_ID configured; binding Partner-API quote wired in Phase 1 (needs ACCESS_KEY + SECRET_KEY)."
+      : "JLCPCB credentials not set — estimate only. Set JLCPCB_APP_ID/ACCESS_KEY/SECRET_KEY for binding quotes.",
+  ];
+  if (!req.boardAreaMm2 && !req.metrics.ok) {
+    notes.push(
+      "Board area defaulted: pass board_area_mm2 (and layers) for a sharper PCB estimate.",
+    );
+  }
+  return {
+    fab_cost_minor: fabCostMinor,
+    lead_time_days: 7,
+    in_spec: true,
+    pricing_basis: "estimate",
+    notes,
+  };
+}
+
+/** Local 3D-print cost estimate from part volume and quantity. */
+function estimate3dPrint(req: QuoteRequest): AdapterQuote {
+  const volCm3 = Math.max(0.1, req.metrics.volume_mm3 / 1000);
+  // Prefer the shared kernel cost model (consistent with the in-app quote);
+  // fall back to local coefficients.
+  const unitMinor = Math.round(volCm3 * 35 + 250);
+  const fabCostMinor = req.baseCostMinor ?? unitMinor * req.quantity;
+  const inSpec = req.metrics.max_dim_mm <= 256; // typical resin/FDM envelope
+  const notes = [
+    `Local estimate (pricing_basis=estimate): ~${volCm3.toFixed(1)} cm³, qty ${req.quantity}.`,
+  ];
+  if (req.baseCostMinor != null) {
+    notes.push("Priced via the shared kernel cost model — agrees with the in-app Build quote.");
+  }
+  if (!inSpec) {
+    notes.push(
+      `Part max dimension ${req.metrics.max_dim_mm.toFixed(0)} mm exceeds the ~256 mm build envelope.`,
+    );
+  }
+  if (!req.metrics.ok) {
+    notes.push("No solid geometry measured — estimate is a floor only.");
+  }
+  return {
+    fab_cost_minor: fabCostMinor,
+    lead_time_days: 6,
+    in_spec: inSpec,
+    pricing_basis: "estimate",
+    notes,
+  };
+}
+
+export const jlcpcbAdapter: ManufacturerAdapter = {
+  key: "jlcpcb",
+  label: "JLCPCB",
+  region: "CN",
+  processes: ["pcb", "3dprint"],
+  supportsDdp: true,
+  async quote(req: QuoteRequest): Promise<AdapterQuote | null> {
+    // Phase 1 seam: when credentialed, call the live Partner API for a binding
+    // quote here (HMAC-SHA256 signed; APP_ID + ACCESS_KEY + SECRET_KEY).
+    void credentialed; // referenced to document the seam; live call is Phase 1.
+
+    if (req.process === "pcb") return estimatePcb(req);
+    if (req.process === "3dprint") return estimate3dPrint(req);
+    return null;
+  },
+};

--- a/packages/mcp/src/fabricate/broker.ts
+++ b/packages/mcp/src/fabricate/broker.ts
@@ -1,0 +1,123 @@
+/**
+ * Fulfillment Broker — vendor-neutral routing core.
+ *
+ * Takes a normalized QuoteRequest, fans out to every adapter that serves the
+ * process, applies the hidden cost-plus margin + landed cost, normalizes to
+ * margin-INCLUSIVE FabOptions, and picks the recommended option (cheapest
+ * in-spec, preferring orderable). The per-fab cost and margin never leave this
+ * module in the agent-facing options — only in the server-only economics it
+ * returns alongside.
+ *
+ * Phase 0 is quote-only: adapters return estimates, so `orderable` is false for
+ * every option (you can quote, not yet order). place_order + binding quotes
+ * land in Phase 1.
+ */
+
+import { jlcpcbAdapter } from "./adapters/jlcpcb.js";
+import { digitalMetalAdapter } from "./adapters/digitalmetal.js";
+import { genericEstimateAdapter } from "./adapters/generic.js";
+import { applyMargin, estimateLandedCost, marginOf } from "./pricing.js";
+import type {
+  FabOption,
+  LandedCost,
+  ManufacturerAdapter,
+  QuoteRequest,
+} from "./types.js";
+
+/** Fabs with a real (eventual) contract — eligible to be orderable. The
+ *  generic estimator never is. Still requires a BINDING quote to flip
+ *  orderable true, which Phase 0 never produces. */
+const CONTRACTED_FABS = new Set(["jlcpcb", "digitalmetal"]);
+
+export const DEFAULT_ADAPTERS: readonly ManufacturerAdapter[] = [
+  jlcpcbAdapter,
+  digitalMetalAdapter,
+  genericEstimateAdapter,
+];
+
+export interface BrokerResult {
+  options: FabOption[];
+  /** Recommended option (first after sort), or null if nothing quoted. */
+  recommended: FabOption | null;
+  landed_cost: LandedCost;
+  /** Server-only economics for the recommended option. */
+  fab_cost_minor: number;
+  margin_minor: number;
+}
+
+export class FulfillmentBroker {
+  constructor(
+    private adapters: readonly ManufacturerAdapter[] = DEFAULT_ADAPTERS,
+  ) {}
+
+  async quote(req: QuoteRequest): Promise<BrokerResult> {
+    const eligible = this.adapters.filter((a) =>
+      a.processes.includes(req.process),
+    );
+
+    const built: Array<{ option: FabOption; fabCost: number }> = [];
+    for (const adapter of eligible) {
+      let q;
+      try {
+        q = await adapter.quote(req);
+      } catch {
+        q = null; // a failing adapter drops out, never breaks the quote.
+      }
+      if (!q) continue;
+
+      const landed = estimateLandedCost({
+        region: adapter.region,
+        supportsDdp: adapter.supportsDdp,
+      });
+      const markedUp = applyMargin(q.fab_cost_minor);
+      const totalMinor = markedUp + landed.shipping_minor + landed.duty_minor;
+      const orderable =
+        CONTRACTED_FABS.has(adapter.key) && q.pricing_basis === "binding";
+
+      built.push({
+        fabCost: q.fab_cost_minor,
+        option: {
+          fab: adapter.key,
+          fab_label: adapter.label,
+          region: adapter.region,
+          unit_price_minor: Math.round(totalMinor / req.quantity),
+          total_minor: totalMinor,
+          lead_time_days: q.lead_time_days,
+          in_spec: q.in_spec,
+          pricing_basis: q.pricing_basis,
+          supports_ddp: adapter.supportsDdp,
+          orderable,
+          notes: q.notes,
+        },
+      });
+    }
+
+    // Sort: in-spec first, then orderable, then cheapest total.
+    built.sort((a, b) => {
+      if (a.option.in_spec !== b.option.in_spec) return a.option.in_spec ? -1 : 1;
+      if (a.option.orderable !== b.option.orderable)
+        return a.option.orderable ? -1 : 1;
+      return a.option.total_minor - b.option.total_minor;
+    });
+
+    const top = built[0] ?? null;
+    const landed = top
+      ? estimateLandedCost({
+          region: this.adapterRegion(top.option.fab),
+          supportsDdp: top.option.supports_ddp,
+        })
+      : { shipping_minor: 0, duty_minor: 0, basis: "none" };
+
+    return {
+      options: built.map((b) => b.option),
+      recommended: top ? top.option : null,
+      landed_cost: landed,
+      fab_cost_minor: top ? top.fabCost : 0,
+      margin_minor: top ? marginOf(top.fabCost) : 0,
+    };
+  }
+
+  private adapterRegion(key: string): string {
+    return this.adapters.find((a) => a.key === key)?.region ?? "n/a";
+  }
+}

--- a/packages/mcp/src/fabricate/geometry.ts
+++ b/packages/mcp/src/fabricate/geometry.ts
@@ -1,0 +1,112 @@
+/**
+ * vcad Fabricate — lean geometry measurement for cost models.
+ *
+ * A trimmed-down cousin of the inspect_cad math: evaluates the document and
+ * aggregates volume / surface area / bounding box across all parts. Cost
+ * models only need volume, footprint, and the max bounding dimension, so this
+ * intentionally skips per-part mass / center-of-mass.
+ *
+ * Tolerant by design: a PCB/ecad document (or any doc the kernel can't mesh
+ * into solids) yields ok:false with zeroed metrics, and the caller falls back
+ * to caller-supplied dimensions (e.g. boardAreaMm2 for PCBs).
+ */
+
+import type { Document } from "@vcad/ir";
+import type { Engine, TriangleMesh } from "@vcad/engine";
+import type { GeometryMetrics } from "./types.js";
+
+function vertex(mesh: TriangleMesh, index: number): [number, number, number] {
+  const i = index * 3;
+  return [mesh.positions[i], mesh.positions[i + 1], mesh.positions[i + 2]];
+}
+
+/** Signed volume of the tetrahedron (origin, p1, p2, p3). */
+function signedTetVolume(
+  p1: [number, number, number],
+  p2: [number, number, number],
+  p3: [number, number, number],
+): number {
+  return (
+    (p1[0] * (p2[1] * p3[2] - p3[1] * p2[2]) -
+      p2[0] * (p1[1] * p3[2] - p3[1] * p1[2]) +
+      p3[0] * (p1[1] * p2[2] - p2[1] * p1[2])) /
+    6.0
+  );
+}
+
+function triArea(
+  p1: [number, number, number],
+  p2: [number, number, number],
+  p3: [number, number, number],
+): number {
+  const ax = p2[0] - p1[0],
+    ay = p2[1] - p1[1],
+    az = p2[2] - p1[2];
+  const bx = p3[0] - p1[0],
+    by = p3[1] - p1[1],
+    bz = p3[2] - p1[2];
+  const cx = ay * bz - az * by;
+  const cy = az * bx - ax * bz;
+  const cz = ax * by - ay * bx;
+  return Math.sqrt(cx * cx + cy * cy + cz * cz) / 2.0;
+}
+
+const EMPTY: GeometryMetrics = {
+  ok: false,
+  parts: 0,
+  volume_mm3: 0,
+  surface_area_mm2: 0,
+  footprint_mm2: 0,
+  max_dim_mm: 0,
+  bbox: null,
+};
+
+/** Evaluate `ir` and aggregate geometry metrics across all parts. */
+export function measureDocument(ir: Document, engine: Engine): GeometryMetrics {
+  let scene: { parts: Array<{ mesh: TriangleMesh }> };
+  try {
+    scene = engine.evaluate(ir) as { parts: Array<{ mesh: TriangleMesh }> };
+  } catch {
+    return { ...EMPTY };
+  }
+  if (!scene.parts || scene.parts.length === 0) return { ...EMPTY };
+
+  let volume = 0;
+  let area = 0;
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+
+  for (const part of scene.parts) {
+    const mesh = part.mesh;
+    const numTris = mesh.indices.length / 3;
+    for (let t = 0; t < numTris; t++) {
+      const p1 = vertex(mesh, mesh.indices[t * 3]);
+      const p2 = vertex(mesh, mesh.indices[t * 3 + 1]);
+      const p3 = vertex(mesh, mesh.indices[t * 3 + 2]);
+      volume += signedTetVolume(p1, p2, p3);
+      area += triArea(p1, p2, p3);
+      for (const p of [p1, p2, p3]) {
+        for (let k = 0; k < 3; k++) {
+          if (p[k] < min[k]) min[k] = p[k];
+          if (p[k] > max[k]) max[k] = p[k];
+        }
+      }
+    }
+  }
+
+  if (!Number.isFinite(min[0])) return { ...EMPTY };
+
+  const dx = max[0] - min[0];
+  const dy = max[1] - min[1];
+  const dz = max[2] - min[2];
+
+  return {
+    ok: true,
+    parts: scene.parts.length,
+    volume_mm3: Math.abs(volume),
+    surface_area_mm2: area,
+    footprint_mm2: dx * dy,
+    max_dim_mm: Math.max(dx, dy, dz),
+    bbox: { min, max },
+  };
+}

--- a/packages/mcp/src/fabricate/pricing.ts
+++ b/packages/mcp/src/fabricate/pricing.ts
@@ -1,0 +1,56 @@
+/**
+ * vcad Fabricate — margin + landed-cost model.
+ *
+ * Monetization (decided): cost-plus markup, folded into the line total and
+ * NEVER exposed as a separate fee. No agentic-payment protocol carries a
+ * take-rate field, so the margin lives in the price, not the protocol.
+ *
+ * All money is integer MINOR units (USD cents).
+ */
+
+import type { LandedCost } from "./types.js";
+
+/**
+ * Gross margin rate. ~25% — anchored below Xometry's ~35% marketplace gross so
+ * it survives ~5-7% MoR/processing fees yet stays low enough to deter
+ * disintermediation once a buyer can price-check fabs directly.
+ *
+ * Treat Xometry's ~35% as their VERTICALLY-INTEGRATED margin, not a markup
+ * ceiling a pure reseller can copy — hence the conservative default.
+ */
+export const MARGIN_RATE = 0.25;
+
+/** Mark a per-fab cost up to the customer-facing price (minor units). */
+export function applyMargin(fabCostMinor: number): number {
+  return Math.round(fabCostMinor * (1 + MARGIN_RATE));
+}
+
+/** The margin portion of a marked-up price (server-only). */
+export function marginOf(fabCostMinor: number): number {
+  return applyMargin(fabCostMinor) - fabCostMinor;
+}
+
+/**
+ * Phase 0 landed-cost estimate. Deliberately simple and HONEST:
+ *  - domestic (US) fab → flat domestic shipping, no duty.
+ *  - offshore fab → DDP estimate: the fab is importer-of-record and bears duty
+ *    volatility, so duty to the buyer is 0 and we say so. (Phase 1 makes DDP a
+ *    hard requirement rather than an assumption — a 20-30% margin can't absorb
+ *    a Section 301 tariff swing.)
+ *
+ * Never cached across quotes; the duty regime is volatile.
+ */
+export function estimateLandedCost(opts: {
+  region: string;
+  supportsDdp: boolean;
+}): LandedCost {
+  const offshore = opts.region.toUpperCase() !== "US";
+  if (!offshore) {
+    return { shipping_minor: 800, duty_minor: 0, basis: "domestic_estimate" };
+  }
+  return {
+    shipping_minor: 2500,
+    duty_minor: 0,
+    basis: opts.supportsDdp ? "ddp_estimate" : "duty_unbundled_estimate",
+  };
+}

--- a/packages/mcp/src/fabricate/process-map.ts
+++ b/packages/mcp/src/fabricate/process-map.ts
@@ -1,0 +1,92 @@
+/**
+ * Bridge between the Fabricate ordering vocabulary (Process) and the shared
+ * kernel cost model (vcad-kernel-cost, exposed as DfmProcess + estimateCost in
+ * @vcad/engine). This is the SAME estimator the app's "Build" → QuotePanel uses,
+ * so a quote agrees whether it comes from the app UI or an agent over MCP.
+ *
+ * PCB has no volume×material cost model in the kernel, so it maps to null and
+ * keeps its bespoke area/layers estimate in the JLCPCB adapter.
+ */
+
+import type { DfmProcess } from "@vcad/engine";
+import type { Process } from "./types.js";
+
+/** Map a Fabricate process to the kernel cost model's process, or null when
+ *  the kernel has no estimator for it (PCB). */
+export function toDfmProcess(p: Process): DfmProcess | null {
+  switch (p) {
+    case "cnc":
+      return "cnc_3axis";
+    case "3dprint":
+      return "fdm";
+    case "sheet_metal":
+      return "sheet_metal";
+    case "cast_metal":
+      return "casting_sand"; // Digital Metal casts (gravity-fed sand).
+    case "pcb":
+      return null;
+    default:
+      return null;
+  }
+}
+
+// Exact catalog names from vcad-kernel-cost::Material::catalog().
+const CATALOG = [
+  "PLA",
+  "PETG",
+  "ABS",
+  "TPU",
+  "SLA Resin",
+  "Aluminum 6061",
+  "Steel 1018",
+  "Brass C360",
+  "Polycarbonate",
+  "Cast Aluminum A356",
+  "Cast Iron",
+];
+
+// Friendly aliases → catalog names. Materials with no catalog entry (e.g.
+// stainless, zinc, zamak) map to the nearest priced stand-in for the estimate.
+const ALIASES: Record<string, string> = {
+  pla: "PLA",
+  petg: "PETG",
+  abs: "ABS",
+  tpu: "TPU",
+  resin: "SLA Resin",
+  "sla resin": "SLA Resin",
+  aluminum: "Aluminum 6061",
+  aluminium: "Aluminum 6061",
+  al: "Aluminum 6061",
+  steel: "Steel 1018",
+  stainless: "Steel 1018",
+  "stainless steel": "Steel 1018",
+  brass: "Brass C360",
+  polycarbonate: "Polycarbonate",
+  pc: "Polycarbonate",
+  "cast aluminum": "Cast Aluminum A356",
+  zinc: "Cast Aluminum A356",
+  zamak: "Cast Aluminum A356",
+  "cast iron": "Cast Iron",
+  iron: "Cast Iron",
+};
+
+// Default catalog material per process when the caller doesn't specify one.
+// Mirrors the app QuotePanel's MATERIAL_MAPPINGS picks.
+const DEFAULTS: Record<Process, string> = {
+  pcb: "",
+  "3dprint": "PLA",
+  cnc: "Aluminum 6061",
+  sheet_metal: "Aluminum 6061",
+  cast_metal: "Cast Aluminum A356",
+};
+
+/** Resolve a (process, free-form material) pair to a kernel-cost catalog name. */
+export function catalogMaterial(p: Process, material?: string): string {
+  if (material) {
+    const key = material.trim().toLowerCase();
+    const exact = CATALOG.find((c) => c.toLowerCase() === key);
+    if (exact) return exact;
+    if (ALIASES[key]) return ALIASES[key];
+  }
+  return DEFAULTS[p];
+}

--- a/packages/mcp/src/fabricate/store.ts
+++ b/packages/mcp/src/fabricate/store.ts
@@ -1,0 +1,224 @@
+/**
+ * vcad Fabricate — durable store for quotes + orders.
+ *
+ * Mirrors session-store.ts: an in-memory impl (local stdio / anonymous — the
+ * source of truth in-process, perfect for running the loop locally) and a
+ * cloud impl over raw PostgREST with the service-role key (hosted + signed-in
+ * user). RLS is bypassed by the service role, so ownership is enforced in code:
+ * every query filters user_id and every write sets it to the caller.
+ */
+
+import type { AuthUser } from "../oauth.js";
+import type { Order, OrderState, Quote, QuoteEconomics } from "./types.js";
+
+export interface OrderFilter {
+  status?: OrderState;
+  limit?: number;
+}
+
+export interface FabricateStore {
+  saveQuote(quote: Quote, econ: QuoteEconomics, userId: string): Promise<void>;
+  saveOrder(order: Order, fabCostMinor: number, userId: string): Promise<void>;
+  getOrder(orderId: string, userId: string): Promise<Order | null>;
+  listOrders(userId: string, filter: OrderFilter): Promise<Order[]>;
+}
+
+// ── In-memory (module-global so it survives across calls in one process) ──
+
+const memQuotes = new Map<string, { quote: Quote; econ: QuoteEconomics }>();
+const memOrders = new Map<string, { order: Order; fabCostMinor: number }>();
+
+const memKey = (userId: string, id: string): string => `${userId}::${id}`;
+
+export class InMemoryFabricateStore implements FabricateStore {
+  async saveQuote(quote: Quote, econ: QuoteEconomics, userId: string): Promise<void> {
+    memQuotes.set(memKey(userId, quote.quote_id), { quote, econ });
+  }
+  async saveOrder(order: Order, fabCostMinor: number, userId: string): Promise<void> {
+    memOrders.set(memKey(userId, order.order_id), { order, fabCostMinor });
+  }
+  async getOrder(orderId: string, userId: string): Promise<Order | null> {
+    return memOrders.get(memKey(userId, orderId))?.order ?? null;
+  }
+  async listOrders(userId: string, filter: OrderFilter): Promise<Order[]> {
+    const prefix = `${userId}::`;
+    const out: Order[] = [];
+    for (const [key, val] of memOrders) {
+      if (!key.startsWith(prefix)) continue;
+      if (filter.status && val.order.state !== filter.status) continue;
+      out.push(val.order);
+    }
+    out.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+    return typeof filter.limit === "number" ? out.slice(0, filter.limit) : out;
+  }
+}
+
+// ── Supabase (raw PostgREST + service role) ──
+
+/** Injectable fetch seam (mirrors session-store's sessionFetch) for tests. */
+export let fabricateFetch: typeof fetch = (...args) => fetch(...args);
+export function setFabricateFetch(fn: typeof fetch): void {
+  fabricateFetch = fn;
+}
+
+interface SupabaseCfg {
+  supabaseUrl: string;
+  serviceRoleKey: string;
+}
+
+export class SupabaseFabricateStore implements FabricateStore {
+  constructor(private cfg: SupabaseCfg) {}
+
+  private headers(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      apikey: this.cfg.serviceRoleKey,
+      Authorization: `Bearer ${this.cfg.serviceRoleKey}`,
+      "Content-Type": "application/json",
+      ...extra,
+    };
+  }
+
+  private url(table: string, query = ""): string {
+    return `${this.cfg.supabaseUrl}/rest/v1/${table}${query}`;
+  }
+
+  async saveQuote(quote: Quote, econ: QuoteEconomics, userId: string): Promise<void> {
+    const row = {
+      id: quote.quote_id,
+      user_id: userId,
+      document_id: quote.document_id,
+      doc_hash: quote.doc_hash,
+      process: quote.process,
+      material: quote.material,
+      quantity: quote.quantity,
+      fab_options: quote.fab_options,
+      dfm: quote.dfm,
+      fab_cost_minor: econ.fab_cost_minor,
+      margin_minor: econ.margin_minor,
+      landed_cost: quote.landed_cost,
+      total_amount_minor: quote.total_amount_minor,
+      currency: quote.currency,
+      expires_at: quote.expires_at,
+    };
+    await this.insert("quotes", row);
+  }
+
+  async saveOrder(order: Order, fabCostMinor: number, userId: string): Promise<void> {
+    const row = {
+      id: order.order_id,
+      user_id: userId,
+      document_id: order.document_id,
+      quote_id: order.quote_id,
+      state: order.state,
+      fab: order.fab,
+      fab_order_ref: order.fab_order_ref,
+      amount_total_minor: order.amount_total_minor,
+      fab_cost_minor: fabCostMinor,
+      currency: order.currency,
+      ship_to: order.ship_to,
+      events: order.events,
+    };
+    await this.insert("orders", row, "id");
+  }
+
+  async getOrder(orderId: string, userId: string): Promise<Order | null> {
+    try {
+      const res = await fabricateFetch(
+        this.url(
+          "orders",
+          `?id=eq.${encodeURIComponent(orderId)}&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
+        ),
+        { method: "GET", headers: this.headers({ Accept: "application/vnd.pgrst.object+json" }) },
+      );
+      if (!res.ok) return null;
+      return rowToOrder(await res.json());
+    } catch (err) {
+      console.error("[fabricate-store] getOrder failed:", err);
+      return null;
+    }
+  }
+
+  async listOrders(userId: string, filter: OrderFilter): Promise<Order[]> {
+    try {
+      const limit = typeof filter.limit === "number" ? filter.limit : 50;
+      let q = `?user_id=eq.${encodeURIComponent(userId)}&order=created_at.desc&limit=${limit}`;
+      if (filter.status) q += `&state=eq.${encodeURIComponent(filter.status)}`;
+      const res = await fabricateFetch(this.url("orders", q), {
+        method: "GET",
+        headers: this.headers(),
+      });
+      if (!res.ok) return [];
+      const rows = (await res.json()) as unknown[];
+      return rows.map(rowToOrder);
+    } catch (err) {
+      console.error("[fabricate-store] listOrders failed:", err);
+      return [];
+    }
+  }
+
+  private async insert(
+    table: string,
+    row: Record<string, unknown>,
+    onConflict?: string,
+  ): Promise<void> {
+    try {
+      const q = onConflict ? `?on_conflict=${onConflict}` : "";
+      const res = await fabricateFetch(this.url(table, q), {
+        method: "POST",
+        headers: this.headers({
+          Prefer: onConflict
+            ? "resolution=merge-duplicates,return=minimal"
+            : "return=minimal",
+        }),
+        body: JSON.stringify([row]),
+      });
+      if (!res.ok) {
+        console.error(
+          `[fabricate-store] insert ${table} failed:`,
+          res.status,
+          await res.text().catch(() => ""),
+        );
+      }
+    } catch (err) {
+      console.error(`[fabricate-store] insert ${table} failed:`, err);
+    }
+  }
+}
+
+/** Map a PostgREST orders row to an Order. */
+function rowToOrder(row: unknown): Order {
+  const r = (row ?? {}) as Record<string, unknown>;
+  return {
+    order_id: String(r.id ?? ""),
+    document_id: String(r.document_id ?? ""),
+    quote_id: String(r.quote_id ?? ""),
+    state: (r.state as OrderState) ?? "QUOTED",
+    fab: (r.fab as string) ?? null,
+    fab_order_ref: (r.fab_order_ref as string) ?? null,
+    amount_total_minor: Number(r.amount_total_minor ?? 0),
+    currency: String(r.currency ?? "USD"),
+    ship_to: r.ship_to ?? null,
+    events: Array.isArray(r.events) ? (r.events as Order["events"]) : [],
+    created_at: String(r.created_at ?? ""),
+    updated_at: String(r.updated_at ?? ""),
+  };
+}
+
+/**
+ * Choose the store impl: cloud-backed when a signed-in user AND Supabase
+ * service-role env are present, else in-memory (preserves local/stdio behavior
+ * and keeps the loop fully runnable offline).
+ */
+export function createFabricateStore(user: AuthUser | null): FabricateStore {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  if (user && url && key) {
+    return new SupabaseFabricateStore({ supabaseUrl: url, serviceRoleKey: key });
+  }
+  return new InMemoryFabricateStore();
+}
+
+/** The owner id used for store scoping — the authenticated user, or "local". */
+export function ownerId(user: AuthUser | null): string {
+  return user?.sub ?? "local";
+}

--- a/packages/mcp/src/fabricate/types.ts
+++ b/packages/mcp/src/fabricate/types.ts
@@ -1,0 +1,176 @@
+/**
+ * vcad Fabricate — shared types for the design-to-doorstep ordering layer.
+ *
+ * Phase 0 (the spine): quote a custom-manufactured part from a live session,
+ * persist the quote + a QUOTED order. No money moves.
+ *
+ * Money is integer MINOR units (USD cents) everywhere — never floats. The
+ * per-fab cost is server-only and never crosses into a tool result; the agent
+ * sees only the margin-inclusive total.
+ */
+
+/** Manufacturing processes vcad can quote. */
+export type Process = "pcb" | "cnc" | "3dprint" | "sheet_metal" | "cast_metal";
+
+export const PROCESSES: readonly Process[] = [
+  "pcb",
+  "cnc",
+  "3dprint",
+  "sheet_metal",
+  "cast_metal",
+];
+
+/** Full order lifecycle (mirrors the orders.state check constraint). */
+export type OrderState =
+  | "DRAFT"
+  | "QUOTED"
+  | "EXPIRED"
+  | "AUTHORIZED"
+  | "PENDING_PAYMENT"
+  | "PAYMENT_FAILED"
+  | "PAID"
+  | "SUBMITTED"
+  | "SUBMIT_FAILED"
+  | "RECONCILING"
+  | "IN_PRODUCTION"
+  | "SHIPPED"
+  | "DELIVERED"
+  | "CANCELED"
+  | "CANCELED_BY_FAB"
+  | "REFUNDED";
+
+/** Whether a price is a vcad local estimate or a binding fab quote. */
+export type PricingBasis = "estimate" | "binding";
+
+/** Normalized request a broker hands to each adapter. */
+export interface QuoteRequest {
+  process: Process;
+  material?: string;
+  quantity: number;
+  finish?: string;
+  /** Geometry measured from the live session document. */
+  metrics: GeometryMetrics;
+  /** PCB-only overrides (geometry can't always recover these in Phase 0). */
+  layers?: number;
+  boardAreaMm2?: number;
+  /**
+   * Total fab cost (minor units) from the SHARED kernel cost model
+   * (estimateCost / vcad-kernel-cost) — the same estimator the app's Build
+   * quote uses, so adapters agree with the in-app QuotePanel. Undefined for PCB
+   * (no kernel model) or when the estimate is unavailable; adapters then fall
+   * back to their local coefficient estimate.
+   */
+  baseCostMinor?: number;
+  /** Resolved kernel-cost catalog material name (e.g. "Aluminum 6061"). */
+  materialCatalog?: string;
+}
+
+/** Lean geometry summary used by the cost models. */
+export interface GeometryMetrics {
+  ok: boolean;
+  parts: number;
+  volume_mm3: number;
+  surface_area_mm2: number;
+  /** Bounding-box footprint (x * y) — a board-area proxy for PCBs. */
+  footprint_mm2: number;
+  /** Largest bounding-box dimension — the build-envelope gate. */
+  max_dim_mm: number;
+  bbox: { min: [number, number, number]; max: [number, number, number] } | null;
+}
+
+/** Raw, pre-margin quote from a single manufacturer adapter. */
+export interface AdapterQuote {
+  /** Per-fab cost in minor units BEFORE vcad margin — server-only. */
+  fab_cost_minor: number;
+  lead_time_days: number;
+  in_spec: boolean;
+  pricing_basis: PricingBasis;
+  /** Human-readable notes (DFM flags, envelope, min-order, etc.). */
+  notes: string[];
+}
+
+/** A manufacturer adapter: quote-only in Phase 0 (no createOrder yet). */
+export interface ManufacturerAdapter {
+  key: string;
+  label: string;
+  region: string;
+  processes: readonly Process[];
+  supportsDdp: boolean;
+  /** Returns null if this adapter can't serve the request at all. */
+  quote(req: QuoteRequest): Promise<AdapterQuote | null>;
+}
+
+/** A margin-INCLUSIVE option as shown to the agent. Fab cost is never here. */
+export interface FabOption {
+  fab: string;
+  fab_label: string;
+  region: string;
+  /** Margin-inclusive, landed, per-unit price (minor units). */
+  unit_price_minor: number;
+  /** Margin-inclusive, landed, total for the requested quantity (minor units). */
+  total_minor: number;
+  lead_time_days: number;
+  in_spec: boolean;
+  pricing_basis: PricingBasis;
+  supports_ddp: boolean;
+  /** True when this option is orderable today (real contracted fab + binding). */
+  orderable: boolean;
+  notes: string[];
+}
+
+/** Landed-cost breakdown surfaced before the agent commits. */
+export interface LandedCost {
+  shipping_minor: number;
+  duty_minor: number;
+  /** "ddp_estimate" → fab is importer-of-record and bears duty volatility. */
+  basis: string;
+}
+
+/** A lightweight DFM summary attached to a quote. */
+export interface DfmSummary {
+  checked: boolean;
+  passed: boolean;
+  violations: string[];
+}
+
+/** The persisted quote (and the shape returned to the agent, minus internals). */
+export interface Quote {
+  quote_id: string;
+  document_id: string;
+  doc_hash: string | null;
+  process: Process;
+  material: string | null;
+  quantity: number;
+  dfm: DfmSummary;
+  fab_options: FabOption[];
+  landed_cost: LandedCost;
+  /** Recommended (cheapest in-spec orderable, else cheapest in-spec) total. */
+  total_amount_minor: number;
+  currency: string;
+  /** Always true — fab cost / margin are never in the returned object. */
+  margin_hidden: true;
+  expires_at: string;
+  created_at: string;
+}
+
+/** Server-only economics persisted alongside a quote, never returned. */
+export interface QuoteEconomics {
+  fab_cost_minor: number;
+  margin_minor: number;
+}
+
+/** The persisted order lifecycle row. */
+export interface Order {
+  order_id: string;
+  document_id: string;
+  quote_id: string;
+  state: OrderState;
+  fab: string | null;
+  fab_order_ref: string | null;
+  amount_total_minor: number;
+  currency: string;
+  ship_to: unknown | null;
+  events: Array<{ state: OrderState; at: string; note?: string }>;
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -45,6 +45,15 @@ import {
   runInSessionScope,
 } from "./tools/session.js";
 import { createSessionStore } from "./session-store.js";
+import { createFabricateStore } from "./fabricate/store.js";
+import {
+  quoteManufacturing,
+  quoteManufacturingSchema,
+  getOrderStatus,
+  getOrderStatusSchema,
+  listOrders,
+  listOrdersSchema,
+} from "./tools/order.js";
 import type { AuthUser } from "./oauth.js";
 
 /** Per-connection context threaded from the transport entry point — the
@@ -386,6 +395,7 @@ const WIDGET_CALLABLE_META = {
  * tool in a disabled pack return an error pointing at the env var.
  */
 const TOOL_PACKS: Record<string, readonly string[]> = {
+  fabricate: ["quote_manufacturing", "get_order_status", "list_orders"],
   dfm: ["dfm_check", "dfm_explain", "dfm_suggest_fix", "dfm_apply_fix"],
   sheet_metal: [
     "sheet_metal_create",
@@ -522,6 +532,12 @@ export async function createServer(
   // closure (not a module global) so concurrent connections on one warm
   // instance can't clobber each other's binding.
   const sessionStore = createSessionStore(context.user);
+
+  // vcad Fabricate store (quotes + orders). Cloud-backed for a signed-in user
+  // with the Supabase service-role key, else in-memory (local stdio). Held in
+  // the connection closure like sessionStore so concurrent connections can't
+  // clobber each other.
+  const fabricateStore = createFabricateStore(context.user);
 
   // Wire the kernel WASM's chat helpers into the shared commandRegistry so
   // `toAnthropicTools` and `planCrud` work on the server too. Same bootstrap
@@ -676,6 +692,25 @@ export async function createServer(
           "this to confirm a tool exists in THIS build before assuming a stale " +
           "or version-skewed deploy.",
         inputSchema: serverInfoSchema,
+      },
+      // ── vcad Fabricate: order custom-manufactured parts ───────
+      {
+        name: "quote_manufacturing",
+        description:
+          "Quote manufacturing a part from a live session: measures the design, runs light DFM, and returns margin-inclusive price options per fab (pcb/cnc/3dprint/sheet_metal/cast_metal). Persists a quote + a QUOTED order. Phase 0 is quote-only — prices are estimates and ordering/payment ship next; no money moves.",
+        inputSchema: quoteManufacturingSchema,
+      },
+      {
+        name: "get_order_status",
+        description:
+          "Return the lifecycle row for a Fabricate order (state, fab, totals, event timeline). Read-only.",
+        inputSchema: getOrderStatusSchema,
+      },
+      {
+        name: "list_orders",
+        description:
+          "List the caller's Fabricate orders, newest first. Optional status filter and limit. Read-only.",
+        inputSchema: listOrdersSchema,
       },
       // ── Stdlib parts library (session-aware) ──────────────────
       {
@@ -1435,6 +1470,18 @@ export async function createServer(
 
         case "inspect_cad":
           result = inspectCad(args, engine);
+          break;
+
+        case "quote_manufacturing":
+          result = await quoteManufacturing(args, engine, fabricateStore, context.user);
+          break;
+
+        case "get_order_status":
+          result = await getOrderStatus(args, fabricateStore, context.user);
+          break;
+
+        case "list_orders":
+          result = await listOrders(args, fabricateStore, context.user);
           break;
 
         case "render_view":

--- a/packages/mcp/src/tools/order.ts
+++ b/packages/mcp/src/tools/order.ts
@@ -1,0 +1,317 @@
+/**
+ * vcad Fabricate MCP tools — Phase 0 (the spine, zero money).
+ *
+ *   quote_manufacturing — measure a live design, run light DFM, fan out to fab
+ *                         adapters, return a margin-inclusive quote, and persist
+ *                         it + a QUOTED order. NO money moves.
+ *   get_order_status    — read an order's lifecycle row.
+ *   list_orders         — list the caller's orders.
+ *
+ * place_order / authorize_spend / wallet tools (the money plane) are Phase 1,
+ * gated on the three critical fixes (DB-backed revocable authz, idempotent
+ * outbox worker, atomic debit RPC). Nothing here can spend.
+ */
+
+import { randomUUID, createHash } from "node:crypto";
+import { estimateCost, type Engine } from "@vcad/engine";
+import type { AuthUser } from "../oauth.js";
+import { getSession } from "./session.js";
+import { measureDocument } from "../fabricate/geometry.js";
+import { FulfillmentBroker } from "../fabricate/broker.js";
+import { toDfmProcess, catalogMaterial } from "../fabricate/process-map.js";
+import { ownerId, type FabricateStore } from "../fabricate/store.js";
+import {
+  PROCESSES,
+  type DfmSummary,
+  type GeometryMetrics,
+  type Order,
+  type OrderState,
+  type Process,
+  type Quote,
+} from "../fabricate/types.js";
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+const QUOTE_TTL_MS = 24 * 60 * 60 * 1000; // 24h. Phase 1 shortens this for duty volatility.
+
+function ok(payload: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+function err(message: string): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify({ error: message }) }], isError: true };
+}
+
+// ── quote_manufacturing ────────────────────────────────────────────────────
+
+export const quoteManufacturingSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: { type: "string" as const, description: "Session id from open_document." },
+    process: {
+      type: "string" as const,
+      enum: [...PROCESSES],
+      description: "Manufacturing process: pcb | cnc | 3dprint | sheet_metal | cast_metal.",
+    },
+    quantity: { type: "integer" as const, minimum: 1, description: "Number of parts. Default 1." },
+    material: { type: "string" as const, description: "Optional material (e.g. aluminum, stainless, resin)." },
+    finish: { type: "string" as const, description: "Optional finish (e.g. anodized, sandblasted)." },
+    ship_to: {
+      type: "object" as const,
+      description: "Optional ship-to address (stored on the order; not validated in Phase 0).",
+    },
+    layers: { type: "integer" as const, minimum: 1, description: "PCB only: copper layer count (default 2)." },
+    board_area_mm2: {
+      type: "number" as const,
+      description: "PCB only: board area override when geometry can't recover it.",
+    },
+  },
+  required: ["document_id", "process", "quantity"],
+};
+
+/** Lightweight Phase-0 DFM. Deep checks (dfm_check / run_drc /
+ *  sheet_metal_check) are wired into this path in Phase 1. */
+function quoteDfm(process: Process, metrics: GeometryMetrics): DfmSummary {
+  const violations: string[] = [];
+  if (process !== "pcb" && !metrics.ok) {
+    violations.push(
+      "No solid geometry could be measured from the document — quote is a floor estimate only.",
+    );
+  }
+  return { checked: true, passed: violations.length === 0, violations };
+}
+
+function docHash(ir: unknown): string {
+  return createHash("sha256").update(JSON.stringify(ir)).digest("hex").slice(0, 16);
+}
+
+const toUsd = (minor: number): number => Math.round(minor) / 100;
+
+export async function quoteManufacturing(
+  input: unknown,
+  engine: Engine,
+  store: FabricateStore,
+  user: AuthUser | null,
+): Promise<ToolResult> {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const documentId = String(args.document_id ?? "");
+  const process = String(args.process ?? "") as Process;
+  const quantity = Math.max(1, Math.round(Number(args.quantity ?? 1)));
+
+  if (!documentId) return err("document_id is required.");
+  if (!PROCESSES.includes(process)) {
+    return err(`Unknown process "${process}". Use one of: ${PROCESSES.join(", ")}.`);
+  }
+
+  const ir = getSession(documentId); // throws "Unknown document_id" if absent
+  const metrics = measureDocument(ir, engine);
+  const dfm = quoteDfm(process, metrics);
+
+  // Price via the SHARED kernel cost model (estimateCost / vcad-kernel-cost) —
+  // the same estimator the app's Build → QuotePanel uses — so an agent's quote
+  // agrees with the in-app quote. PCB has no kernel model (maps to null) and
+  // keeps the JLCPCB area/layers estimate. Mirror the app's call (no qty) for
+  // exact per-unit agreement, then scale to the requested quantity.
+  const requestedMaterial = typeof args.material === "string" ? args.material : undefined;
+  const dfmProcess = toDfmProcess(process);
+  const materialCatalog = dfmProcess ? catalogMaterial(process, requestedMaterial) : undefined;
+  let baseCostMinor: number | undefined;
+  if (dfmProcess && materialCatalog && metrics.ok && metrics.volume_mm3 > 0) {
+    try {
+      const est = await estimateCost({
+        process: dfmProcess,
+        material: materialCatalog,
+        partVolumeMm3: metrics.volume_mm3,
+      });
+      if (est && est.total_usd > 0) {
+        baseCostMinor = Math.round(est.total_usd * 100) * quantity;
+      }
+    } catch {
+      // estimateCost unavailable (e.g. unknown material) — adapters fall back
+      // to their local coefficient estimate.
+    }
+  }
+
+  const broker = new FulfillmentBroker();
+  const result = await broker.quote({
+    process,
+    quantity,
+    material: requestedMaterial,
+    finish: typeof args.finish === "string" ? args.finish : undefined,
+    metrics,
+    layers: typeof args.layers === "number" ? args.layers : undefined,
+    boardAreaMm2: typeof args.board_area_mm2 === "number" ? args.board_area_mm2 : undefined,
+    baseCostMinor,
+    materialCatalog,
+  });
+
+  if (!result.recommended) {
+    return err(`No fab adapter could quote process "${process}".`);
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + QUOTE_TTL_MS).toISOString();
+  const quoteId = randomUUID();
+  const orderId = randomUUID();
+  const owner = ownerId(user);
+
+  const quote: Quote = {
+    quote_id: quoteId,
+    document_id: documentId,
+    doc_hash: docHash(ir),
+    process,
+    material: typeof args.material === "string" ? args.material : null,
+    quantity,
+    dfm,
+    fab_options: result.options,
+    landed_cost: result.landed_cost,
+    total_amount_minor: result.recommended.total_minor,
+    currency: "USD",
+    margin_hidden: true,
+    expires_at: expiresAt,
+    created_at: now.toISOString(),
+  };
+
+  const order: Order = {
+    order_id: orderId,
+    document_id: documentId,
+    quote_id: quoteId,
+    state: "QUOTED",
+    fab: result.recommended.fab,
+    fab_order_ref: null,
+    amount_total_minor: result.recommended.total_minor,
+    currency: "USD",
+    ship_to: (args.ship_to as unknown) ?? null,
+    events: [{ state: "QUOTED", at: now.toISOString(), note: "quote_manufacturing" }],
+    created_at: now.toISOString(),
+    updated_at: now.toISOString(),
+  };
+
+  // Best-effort persistence — a store outage must never fail a quote.
+  try {
+    await store.saveQuote(quote, { fab_cost_minor: result.fab_cost_minor, margin_minor: result.margin_minor }, owner);
+    await store.saveOrder(order, result.fab_cost_minor, owner);
+  } catch {
+    /* in-memory never throws; cloud logs internally */
+  }
+
+  // Agent-facing payload: margin-inclusive prices only; fab cost / margin never appear.
+  return ok({
+    quote_id: quoteId,
+    order_id: orderId,
+    process,
+    quantity,
+    material: quote.material,
+    material_catalog: materialCatalog ?? null,
+    cost_model:
+      baseCostMinor != null
+        ? "vcad kernel cost model (consistent with the in-app Build quote)"
+        : "adapter-local estimate",
+    geometry: metrics.ok
+      ? {
+          parts: metrics.parts,
+          volume_mm3: Math.round(metrics.volume_mm3),
+          max_dim_mm: Math.round(metrics.max_dim_mm),
+          footprint_mm2: Math.round(metrics.footprint_mm2),
+        }
+      : { measured: false },
+    dfm,
+    fab_options: result.options.map((o) => ({
+      fab: o.fab,
+      fab_label: o.fab_label,
+      region: o.region,
+      unit_price_usd: toUsd(o.unit_price_minor),
+      total_usd: toUsd(o.total_minor),
+      lead_time_days: o.lead_time_days,
+      in_spec: o.in_spec,
+      pricing_basis: o.pricing_basis,
+      orderable: o.orderable,
+      notes: o.notes,
+    })),
+    recommended_fab: result.recommended.fab,
+    total_amount_usd: toUsd(quote.total_amount_minor),
+    total_amount_minor: quote.total_amount_minor,
+    currency: "USD",
+    landed_cost: {
+      shipping_usd: toUsd(result.landed_cost.shipping_minor),
+      duty_usd: toUsd(result.landed_cost.duty_minor),
+      basis: result.landed_cost.basis,
+    },
+    margin_hidden: true,
+    orderable: result.recommended.orderable,
+    expires_at: expiresAt,
+    note:
+      "Phase 0: quote-only. Prices are local ESTIMATES (no binding fab quote yet) and ordering/payment ships in Phase 1. " +
+      "An order row was created at state QUOTED — see it with get_order_status / list_orders.",
+  });
+}
+
+// ── get_order_status ─────────────────────────────────────────────────────────
+
+export const getOrderStatusSchema = {
+  type: "object" as const,
+  properties: {
+    order_id: { type: "string" as const, description: "Order id from quote_manufacturing." },
+  },
+  required: ["order_id"],
+};
+
+export async function getOrderStatus(
+  input: unknown,
+  store: FabricateStore,
+  user: AuthUser | null,
+): Promise<ToolResult> {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const orderId = String(args.order_id ?? "");
+  if (!orderId) return err("order_id is required.");
+
+  const order = await store.getOrder(orderId, ownerId(user));
+  if (!order) return err(`Unknown order_id: ${orderId}`);
+
+  return ok({
+    order_id: order.order_id,
+    document_id: order.document_id,
+    quote_id: order.quote_id,
+    state: order.state,
+    fab: order.fab,
+    fab_order_ref: order.fab_order_ref,
+    total_amount_usd: toUsd(order.amount_total_minor),
+    currency: order.currency,
+    tracking: null,
+    events: order.events,
+  });
+}
+
+// ── list_orders ───────────────────────────────────────────────────────────────
+
+export const listOrdersSchema = {
+  type: "object" as const,
+  properties: {
+    status: { type: "string" as const, description: "Optional order state filter (e.g. QUOTED)." },
+    limit: { type: "integer" as const, minimum: 1, maximum: 200, description: "Max rows (default 50)." },
+  },
+  required: [],
+};
+
+export async function listOrders(
+  input: unknown,
+  store: FabricateStore,
+  user: AuthUser | null,
+): Promise<ToolResult> {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const status = typeof args.status === "string" ? (args.status as OrderState) : undefined;
+  const limit = typeof args.limit === "number" ? args.limit : undefined;
+
+  const orders = await store.listOrders(ownerId(user), { status, limit });
+  return ok({
+    count: orders.length,
+    orders: orders.map((o) => ({
+      order_id: o.order_id,
+      document_id: o.document_id,
+      state: o.state,
+      fab: o.fab,
+      total_amount_usd: toUsd(o.amount_total_minor),
+      currency: o.currency,
+      created_at: o.created_at,
+    })),
+  });
+}

--- a/supabase/migrations/024_fabricate_orders.sql
+++ b/supabase/migrations/024_fabricate_orders.sql
@@ -1,0 +1,165 @@
+-- vcad Fabricate — Phase 0 (the spine, zero money).
+--
+-- Lets an agent quote a custom-manufactured part from a live CAD/PCB session
+-- and persists the quote + a nascent order so the design→DFM→binding-quote
+-- loop is visible end-to-end. NO money moves in Phase 0: the money plane
+-- (spend_authorizations, wallets, wallet_ledger, processed_events) and the
+-- ordering/payment transitions land in the Phase 1 migration, gated on the
+-- three critical fixes (DB-backed revocable authz, idempotent outbox worker,
+-- atomic debit RPC).
+--
+-- Tables:
+--   fab_partners — per-fab catalog + due-diligence row (the routing source).
+--   quotes       — a priced, DFM-checked cart for one design at a point in time.
+--   orders       — the lifecycle row; in Phase 0 it starts (and stays) at
+--                  QUOTED. place_order (Phase 1) advances it past AUTHORIZED.
+--
+-- Money is stored in integer MINOR units (USD cents) — never floats. The
+-- per-fab cost (fab_cost_minor) is server-only and NEVER returned to the agent;
+-- the agent sees only the margin-inclusive total. Two ledgers the fab can't
+-- bridge.
+
+-- ---------------------------------------------------------------------------
+-- fab_partners — manufacturer catalog + per-seller due diligence
+-- ---------------------------------------------------------------------------
+
+create table if not exists fab_partners (
+  id uuid primary key default gen_random_uuid(),
+  -- Stable adapter key (matches ManufacturerAdapter.key in code).
+  key text not null unique,
+  name text not null,
+  -- Processes this fab serves: pcb | cnc | 3dprint | sheet_metal | cast_metal.
+  processes text[] not null default '{}',
+  region text,
+  supports_ddp boolean not null default false,
+  -- US-only lane flag — controlled/sensitive parts route only to is_us_only fabs.
+  is_us_only boolean not null default false,
+  -- Per-seller due-diligence (the Paddle/FTC lesson): track dispute rate +
+  -- require an insurance cert before a fab is order-eligible (Phase 1 gate).
+  dispute_rate numeric not null default 0,
+  insurance_cert_url text,
+  -- active = advertised for quoting. order_eligible (Phase 1) is a stricter gate.
+  active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+-- ---------------------------------------------------------------------------
+-- quotes — a priced, DFM-checked cart for one design at one moment
+-- ---------------------------------------------------------------------------
+
+create table if not exists quotes (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  -- Client/session document id (text — MCP session ids aren't all uuids).
+  document_id text not null,
+  -- Hash of the design at quote time. Phase 1 binds this into the spend
+  -- authorization so the receipt proves WHAT was ordered.
+  doc_hash text,
+  process text not null check (
+    process in ('pcb', 'cnc', '3dprint', 'sheet_metal', 'cast_metal')
+  ),
+  material text,
+  quantity integer not null check (quantity > 0),
+  -- Normalized, margin-INCLUSIVE options shown to the agent (fab cost hidden).
+  fab_options jsonb not null default '[]'::jsonb,
+  dfm jsonb,
+  -- Server-only economics. fab_cost_minor + margin_minor never leave the server.
+  fab_cost_minor bigint,
+  margin_minor bigint,
+  landed_cost jsonb,
+  total_amount_minor bigint not null,
+  currency text not null default 'USD',
+  expires_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists quotes_user_created_idx
+  on quotes (user_id, created_at desc);
+
+-- ---------------------------------------------------------------------------
+-- orders — the lifecycle row (Phase 0: QUOTED only)
+-- ---------------------------------------------------------------------------
+
+create table if not exists orders (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  document_id text not null,
+  quote_id uuid references quotes(id) on delete set null,
+  -- Full lifecycle enumerated now so Phase 1 needs no state migration.
+  state text not null default 'QUOTED' check (
+    state in (
+      'DRAFT', 'QUOTED', 'EXPIRED', 'AUTHORIZED', 'PENDING_PAYMENT',
+      'PAYMENT_FAILED', 'PAID', 'SUBMITTED', 'SUBMIT_FAILED', 'RECONCILING',
+      'IN_PRODUCTION', 'SHIPPED', 'DELIVERED', 'CANCELED', 'CANCELED_BY_FAB',
+      'REFUNDED'
+    )
+  ),
+  fab text,
+  fab_order_ref text,
+  amount_total_minor bigint,
+  -- Server-only; never returned to the agent.
+  fab_cost_minor bigint,
+  currency text not null default 'USD',
+  ship_to jsonb,
+  -- Append-only lifecycle timeline: [{state, at, note}].
+  events jsonb not null default '[]'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists orders_user_created_idx
+  on orders (user_id, created_at desc);
+
+create index if not exists orders_quote_idx
+  on orders (quote_id);
+
+-- ---------------------------------------------------------------------------
+-- Triggers — touch updated_at (touch_updated_at() defined in migration 014)
+-- ---------------------------------------------------------------------------
+
+create trigger orders_touch_updated_at
+  before update on orders
+  for each row execute function touch_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- RLS — users own their quotes/orders; fab_partners is a read-only catalog
+-- ---------------------------------------------------------------------------
+
+alter table fab_partners enable row level security;
+alter table quotes       enable row level security;
+alter table orders       enable row level security;
+
+-- Catalog: any authenticated user may read active partners; only service_role
+-- writes (vetting a partner is an operator action, never a client one).
+create policy "Anyone reads fab partners"
+  on fab_partners for select
+  using (true);
+
+create policy "Users manage own quotes"
+  on quotes for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users manage own orders"
+  on orders for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+grant all on fab_partners, quotes, orders to service_role;
+grant usage, select on all sequences in schema public to service_role;
+
+-- ---------------------------------------------------------------------------
+-- Seed the launch fab catalog (idempotent)
+-- ---------------------------------------------------------------------------
+
+insert into fab_partners (key, name, processes, region, supports_ddp, is_us_only, active)
+values
+  ('jlcpcb',      'JLCPCB',       array['pcb','3dprint'], 'CN', true,  false, true),
+  ('digitalmetal','Digital Metal', array['cast_metal'],    'US', true,  true,  true)
+on conflict (key) do update set
+  name = excluded.name,
+  processes = excluded.processes,
+  region = excluded.region,
+  supports_ddp = excluded.supports_ddp,
+  is_us_only = excluded.is_us_only,
+  active = excluded.active;


### PR DESCRIPTION
## What

The zero-money **spine** of *vcad Fabricate* — the design-to-doorstep ordering layer. An agent can now quote a custom-manufactured part from a live CAD/PCB session and persist the quote + a `QUOTED` order, so the **design → DFM → binding-quote** loop runs end-to-end via MCP.

**No money moves.** The money plane (spend authorizations, prepaid wallet, payments, `place_order`) is Phase 1, deliberately gated on the three critical fixes surfaced by the adversarial design review.

## Why

Every shipped agentic-commerce rail assumes a fixed-price catalog SKU. Custom manufacturing has none — price is computed from geometry. vcad already holds the parametric design + DFM + cost model, so it can price what no catalog can. This PR lays the foundation: a vendor-neutral broker over manufacturer adapters, quote/order persistence, and an MCP tool surface, all built to fit the existing server.

## What landed

- **Migration `024_fabricate_orders.sql`** — `quotes`, `orders` (full lifecycle enum incl. `RECONCILING`/`EXPIRED`), `fab_partners` (catalog + per-seller due-diligence: dispute rate, insurance cert, US-only lane). RLS user-owned, money in integer **minor units**, `fab_cost`/`margin` columns **server-only**. Seeds JLCPCB + Digital Metal. **Not yet pushed** (targets the prod project — run `supabase db push` when ready).
- **`packages/mcp/src/fabricate/`** — vendor-neutral `FulfillmentBroker` + `ManufacturerAdapter` (JLCPCB, Digital Metal, generic estimator), lean geometry measurement, cost-plus `pricing` (25%, **margin folded into the line total**), and a `store` (in-memory for local stdio + Supabase PostgREST for hosted, mirroring `session-store`).
- **MCP tools** `quote_manufacturing` / `get_order_status` / `list_orders`, wired into `server.ts` (new `fabricate` pack, per-connection store, descriptors + dispatch). `place_order` is intentionally **absent** (Phase 1).
- **App consistency** — the MCP quote uses the **same Rust `estimateCost`** (`vcad-kernel-cost`) the app's **Build → QuotePanel** uses, via a `Process` ↔ `DfmProcess` + catalog-material map, so an agent's quote agrees **per-unit** with the in-app quote. PCB keeps its bespoke area/layers model (the kernel has no PCB cost model).

## Reviewer notes

- **Quote-only by design**: every option is labeled `pricing_basis: "estimate"` with `orderable: false`. Nothing can spend.
- **JLCPCB** `APP_ID` is read from `JLCPCB_APP_ID` (env, not source). Binding quotes still need the approval-gated `ACCESS_KEY`/`SECRET_KEY`, so the live Partner-API call is a **documented seam**, not wired — we don't ship an unverifiable HTTP integration.
- **Digital Metal** (`digitalmetal.io`) added as a `cast_metal` adapter — STEP-native, US-based, a strong early fit.
- `fab_cost`/`margin` never appear in a tool result (a test asserts this).
- Forward item (Phase 1): wire the QuotePanel's waitlist to the real order pipeline once the money plane lands.

## Testing

- New `fabricate.test.ts` — 8 tests: unit coverage of the broker/pricing/adapters + a **real cube quoted through the engine** (geometry measured, fab cost confirmed hidden, order persisted + listed) + a shared-estimator consistency check.
- Full `@vcad/mcp` suite: **205 passed / 2 skipped**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)