### PR TITLE
fix(mcp/fabricate): keep the generic estimator a fallback, not a competitor

### DIFF
--- a/changelog/entries/2026-06-18-fabricate-fallback-fix.json
+++ b/changelog/entries/2026-06-18-fabricate-fallback-fix.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-18-fabricate-fallback-fix",
+  "version": "0.9.4",
+  "date": "2026-06-18",
+  "category": "fix",
+  "title": "Manufacturing quotes prefer real fabs over the estimate",
+  "summary": "quote_manufacturing no longer lets the generic 'no contracted fab' estimate duplicate or out-rank a real fab (e.g. undercutting JLCPCB on a 4-layer board); the estimate now appears only for processes with no contracted fab yet.",
+  "features": ["fabricate", "ordering", "manufacturing"],
+  "mcpTools": ["quote_manufacturing"]
+}

--- a/packages/mcp/src/__tests__/fabricate.test.ts
+++ b/packages/mcp/src/__tests__/fabricate.test.ts
@@ -112,6 +112,35 @@ describe("fabricate pricing + broker (no engine)", () => {
     expect(r.recommended!.fab).toBe("digitalmetal");
     expect(r.recommended!.total_minor).toBe(applyMargin(base) + 800);
   });
+
+  it("drops the generic estimator when a contracted fab serves the process", async () => {
+    const broker = new FulfillmentBroker();
+
+    // PCB: JLCPCB is contracted → the non-orderable generic must not appear or
+    // out-rank it (regression: it used to undercut JLCPCB on a 4-layer board).
+    const pcb = await broker.quote({
+      process: "pcb",
+      quantity: 10,
+      metrics: metrics({ ok: false, parts: 0, footprint_mm2: 0, max_dim_mm: 0, bbox: null }),
+      boardAreaMm2: 10000,
+      layers: 4,
+    });
+    expect(pcb.options.some((o) => o.fab === "vcad_estimate")).toBe(false);
+    expect(pcb.recommended?.fab).toBe("jlcpcb");
+
+    // cast_metal: Digital Metal contracted → generic dropped.
+    const cast = await broker.quote({
+      process: "cast_metal",
+      quantity: 1,
+      metrics: metrics(),
+      baseCostMinor: 5000,
+    });
+    expect(cast.options.every((o) => o.fab !== "vcad_estimate")).toBe(true);
+
+    // CNC: no contracted fab → the generic estimator remains (as the fallback).
+    const cnc = await broker.quote({ process: "cnc", quantity: 1, metrics: metrics() });
+    expect(cnc.options.some((o) => o.fab === "vcad_estimate")).toBe(true);
+  });
 });
 
 describe("fabricate quote loop (engine)", () => {

--- a/packages/mcp/src/fabricate/broker.ts
+++ b/packages/mcp/src/fabricate/broker.ts
@@ -92,15 +92,25 @@ export class FulfillmentBroker {
       });
     }
 
+    // The generic estimator is a FALLBACK, not a competitor: drop it whenever a
+    // contracted fab already quoted this process, so a non-orderable ballpark
+    // can't out-rank or duplicate a real fab (e.g. vcad_estimate undercutting
+    // JLCPCB on a 4-layer board). It only stands alone for processes with no
+    // contracted fab yet (CNC, sheet metal).
+    const hasContracted = built.some((b) => CONTRACTED_FABS.has(b.option.fab));
+    const pool = hasContracted
+      ? built.filter((b) => CONTRACTED_FABS.has(b.option.fab))
+      : built;
+
     // Sort: in-spec first, then orderable, then cheapest total.
-    built.sort((a, b) => {
+    pool.sort((a, b) => {
       if (a.option.in_spec !== b.option.in_spec) return a.option.in_spec ? -1 : 1;
       if (a.option.orderable !== b.option.orderable)
         return a.option.orderable ? -1 : 1;
       return a.option.total_minor - b.option.total_minor;
     });
 
-    const top = built[0] ?? null;
+    const top = pool[0] ?? null;
     const landed = top
       ? estimateLandedCost({
           region: this.adapterRegion(top.option.fab),
@@ -109,7 +119,7 @@ export class FulfillmentBroker {
       : { shipping_minor: 0, duty_minor: 0, basis: "none" };
 
     return {
-      options: built.map((b) => b.option),
+      options: pool.map((b) => b.option),
       recommended: top ? top.option : null,
       landed_cost: landed,
       fab_cost_minor: top ? top.fabCost : 0,


### PR DESCRIPTION
## What

`quote_manufacturing` fanned the generic **"no contracted fab yet"** estimator across *every* process. For processes that already have a contracted fab, that produced a duplicate option that could even **out-rank the real fab**.

Found while testing quotes across a matrix of models on the **live** server: on a 4-layer PCB the non-orderable `vcad_estimate` ($150) undercut and was *recommended over* JLCPCB ($166.25); on a 3D-print it returned a duplicate identical price to JLCPCB.

## Fix

The broker now drops the generic estimator whenever a contracted fab already quoted the process — it only stands alone for processes with **no** contracted fab yet (CNC, sheet metal).

Result:
- `pcb`, `3dprint` → **JLCPCB** only
- `cast_metal` → **Digital Metal** only
- `cnc`, `sheet_metal` → `vcad_estimate` only (true fallback)

## Testing

- New regression test asserting the generic estimator is dropped for `pcb`/`cast_metal` (contracted) and retained for `cnc` (no contract).
- Full `@vcad/mcp` suite: **208 passed**. `tsc --noEmit` clean (after rebuilding workspace dists).

## Notes

Phase 0 remains quote-only (`orderable: false`); this only changes *which* option is surfaced/recommended, not ordering. Follow-up to #302.

🤖 Generated with [Claude Code](https://claude.com/claude-code)