### PR TITLE
feat(mcp/fabricate): stateless quote_manufacturing via inline IR

### DIFF
--- a/changelog/entries/2026-06-18-quote-inline-ir.json
+++ b/changelog/entries/2026-06-18-quote-inline-ir.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-18-quote-inline-ir",
+  "version": "0.9.4",
+  "date": "2026-06-18",
+  "category": "feat",
+  "title": "Stateless manufacturing quotes via inline IR",
+  "summary": "quote_manufacturing now accepts an inline `ir` Document as an alternative to document_id — no open_document needed, no session held, immune to serverless cold-start/cross-instance session loss, and safe to call in parallel.",
+  "features": ["fabricate", "ordering", "manufacturing", "mcp"],
+  "mcpTools": ["quote_manufacturing"]
+}

--- a/packages/mcp/src/__tests__/fabricate.test.ts
+++ b/packages/mcp/src/__tests__/fabricate.test.ts
@@ -207,4 +207,32 @@ describe("fabricate quote loop (engine)", () => {
     );
     expect(res.isError).toBe(true);
   });
+
+  it("quotes from inline IR with no open_document (stateless, serverless-safe)", async () => {
+    // The serverless fix: no session is created, so this can't hit the
+    // cross-instance "Unknown document_id" failure and is safe to parallelize.
+    const res = await quoteManufacturing(
+      { ir: cubeDoc(), process: "cnc", quantity: 1, material: "aluminum" },
+      engine,
+      new InMemoryFabricateStore(),
+      null,
+    );
+    expect(res.isError).toBeFalsy();
+    const quote = JSON.parse(res.content[0].text);
+    expect(quote.geometry.parts).toBe(1);
+    expect(quote.total_amount_usd).toBeGreaterThan(0);
+    expect(quote.cost_model).toContain("kernel");
+    expect(quote.quote_id).toBeTruthy();
+    expect(quote.order_id).toBeTruthy();
+  });
+
+  it("requires either ir or document_id", async () => {
+    const res = await quoteManufacturing(
+      { process: "cnc", quantity: 1 },
+      engine,
+      new InMemoryFabricateStore(),
+      null,
+    );
+    expect(res.isError).toBe(true);
+  });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -697,7 +697,7 @@ export async function createServer(
       {
         name: "quote_manufacturing",
         description:
-          "Quote manufacturing a part from a live session: measures the design, runs light DFM, and returns margin-inclusive price options per fab (pcb/cnc/3dprint/sheet_metal/cast_metal). Persists a quote + a QUOTED order. Phase 0 is quote-only — prices are estimates and ordering/payment ship next; no money moves.",
+          "Quote manufacturing a part: measures the design, runs light DFM, and returns margin-inclusive price options per fab (pcb/cnc/3dprint/sheet_metal/cast_metal). Pass `ir` (inline Document — stateless, no open_document needed, serverless-safe, parallel-safe) OR a `document_id` from an open session. Persists a quote + a QUOTED order. Phase 0 is quote-only — prices are estimates and ordering/payment ship next; no money moves.",
         inputSchema: quoteManufacturingSchema,
       },
       {

--- a/packages/mcp/src/tools/order.ts
+++ b/packages/mcp/src/tools/order.ts
@@ -14,6 +14,7 @@
 
 import { randomUUID, createHash } from "node:crypto";
 import { estimateCost, type Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
 import type { AuthUser } from "../oauth.js";
 import { getSession } from "./session.js";
 import { measureDocument } from "../fabricate/geometry.js";
@@ -46,7 +47,15 @@ function err(message: string): ToolResult {
 export const quoteManufacturingSchema = {
   type: "object" as const,
   properties: {
-    document_id: { type: "string" as const, description: "Session id from open_document." },
+    ir: {
+      type: "object" as const,
+      description:
+        "Inline Document IR to quote directly — a STATELESS alternative to document_id. Needs no open_document, holds no session, and is immune to the serverless cold-start/instance issue, so it's the robust choice for one-shot or parallel quotes. Provide this OR document_id.",
+    },
+    document_id: {
+      type: "string" as const,
+      description: "Session id from open_document. Provide this OR `ir`.",
+    },
     process: {
       type: "string" as const,
       enum: [...PROCESSES],
@@ -65,7 +74,7 @@ export const quoteManufacturingSchema = {
       description: "PCB only: board area override when geometry can't recover it.",
     },
   },
-  required: ["document_id", "process", "quantity"],
+  required: ["process", "quantity"],
 };
 
 /** Lightweight Phase-0 DFM. Deep checks (dfm_check / run_drc /
@@ -94,15 +103,27 @@ export async function quoteManufacturing(
 ): Promise<ToolResult> {
   const args = (input ?? {}) as Record<string, unknown>;
   const documentId = String(args.document_id ?? "");
+  const inlineIr =
+    args.ir && typeof args.ir === "object" ? (args.ir as Document) : null;
   const process = String(args.process ?? "") as Process;
   const quantity = Math.max(1, Math.round(Number(args.quantity ?? 1)));
 
-  if (!documentId) return err("document_id is required.");
   if (!PROCESSES.includes(process)) {
     return err(`Unknown process "${process}". Use one of: ${PROCESSES.join(", ")}.`);
   }
+  if (!inlineIr && !documentId) {
+    return err(
+      "Provide either `ir` (inline Document — stateless, serverless-safe) or `document_id` (an open session).",
+    );
+  }
 
-  const ir = getSession(documentId); // throws "Unknown document_id" if absent
+  // Stateless when `ir` is supplied: no session lookup, so it's immune to the
+  // serverless cold-start/cross-instance session loss and safe to call in
+  // parallel. Otherwise resolve from the live session (throws if absent).
+  const ir = inlineIr ?? getSession(documentId);
+  const hash = docHash(ir);
+  // Traceability ref for the persisted quote/order when there's no session id.
+  const documentRef = documentId || `inline:${hash}`;
   const metrics = measureDocument(ir, engine);
   const dfm = quoteDfm(process, metrics);
 
@@ -156,8 +177,8 @@ export async function quoteManufacturing(
 
   const quote: Quote = {
     quote_id: quoteId,
-    document_id: documentId,
-    doc_hash: docHash(ir),
+    document_id: documentRef,
+    doc_hash: hash,
     process,
     material: typeof args.material === "string" ? args.material : null,
     quantity,
@@ -173,7 +194,7 @@ export async function quoteManufacturing(
 
   const order: Order = {
     order_id: orderId,
-    document_id: documentId,
+    document_id: documentRef,
     quote_id: quoteId,
     state: "QUOTED",
     fab: result.recommended.fab,


### PR DESCRIPTION
## The serverless problem

The hosted MCP runs as Vercel serverless functions. In `runInSessionScope` (session.ts), an **authenticated** request gets a brand-new empty session map every call, so a session survives across requests **only** by rehydrating from the durable Supabase store. When that store is dormant (the `SUPABASE_SERVICE_ROLE_KEY` isn't set in prod) or the caller is anonymous (no durable path at all), `open_document` → `quote_manufacturing` loses the session and returns **"Unknown document_id"** — confirmed on prod **even for a sequential call**, and always under parallelism (parallel calls scatter across instances).

## This PR — the stateless keystone

`quote_manufacturing` now accepts an inline **`ir`** Document as an alternative to `document_id`:

- With `ir`, there's **no session lookup** — the quote is computed directly from the passed geometry. It cannot hit cross-instance session loss and is **safe to call in parallel**. This is the robust path for one-shot agent quotes.
- `document_id` still works for the stateful editing flow (open → mutate → quote).
- Persisted quote/order get an `inline:<hash>` ref when there's no session id.

```jsonc
// before: two calls, fragile across instances
open_document({ initial: ir }) -> document_id
quote_manufacturing({ document_id, process, quantity })   // may 404 on a cold instance

// after: one stateless call, bulletproof + parallelizable
quote_manufacturing({ ir, process, quantity })
```

## Testing

- New tests: inline-IR quote with **no** `open_document`; `ir`-or-`document_id` required.
- Full `@vcad/mcp` suite: **210 passed**. `tsc --noEmit` clean.

## Follow-up (the rest of the world-class fix — not in this PR)

This fixes the stateless/compute path. The **stateful** tool surface (`create`, `update`, `place_part`, `route_nets`, …) still needs durable sessions to survive cold starts:
1. **Set `SUPABASE_SERVICE_ROLE_KEY` in the `vcad-mcp` prod env** — the durable `SessionStore` + `FabricateStore` are gated on it; without it, authed sessions are lost every request. *(Ops action — biggest single win, near-zero code.)*
2. **Make sessions durable for anonymous too** — capability-keyed by the unguessable document id (a dedicated `mcp_sessions` table), so the stateful flow works across instances without requiring auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)