### PR TITLE
feat(mcp): durable + Discord-observable sessions for anonymous callers

### DIFF
--- a/changelog/entries/2026-06-19-anon-session-durability.json
+++ b/changelog/entries/2026-06-19-anon-session-durability.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-06-19-anon-session-durability",
+  "version": "0.9.4",
+  "date": "2026-06-19",
+  "category": "fix",
+  "title": "Durable MCP sessions for anonymous callers",
+  "summary": "Anonymous MCP sessions now persist to a capability-keyed mcp_sessions table, so open_document → later calls survive serverless cold starts and cross-instance routing instead of failing with \"Unknown document_id\". Signed-in users were already durable.",
+  "features": ["mcp", "sessions", "serverless"]
+}

--- a/packages/mcp/src/__tests__/session-store.test.ts
+++ b/packages/mcp/src/__tests__/session-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { Document } from "@vcad/ir";
 import {
   SupabaseSessionStore,
+  AnonSupabaseSessionStore,
   InMemorySessionStore,
   createSessionStore,
   setSessionFetch,
@@ -239,6 +240,74 @@ describe("in-memory fallback (no user / no service-role key)", () => {
   });
 });
 
+/** PostgREST stand-in for the `mcp_sessions` table — routes by document_id. */
+function makeMcpSessionsFake() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const eqParam = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+  const fetchImpl = (async (input: unknown, init: RequestInit = {}) => {
+    const url = new URL(String(input));
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST") {
+      const body = JSON.parse(String(init.body)) as Array<Record<string, unknown>>;
+      for (const r of body) rows.set(String(r.document_id), r);
+      return new Response(null, { status: 201 });
+    }
+    const id = eqParam(url.searchParams, "document_id");
+    if (method === "GET") {
+      const row = id ? rows.get(id) : undefined;
+      if (!row) return new Response("", { status: 406 });
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (method === "DELETE") {
+      if (id) rows.delete(id);
+      return new Response(null, { status: 204 });
+    }
+    return new Response("unexpected", { status: 400 });
+  }) as unknown as typeof fetch;
+  return { rows, fetchImpl };
+}
+
+describe("AnonSupabaseSessionStore (capability-keyed, anonymous)", () => {
+  const ACFG = { supabaseUrl: "https://supa.test", serviceRoleKey: "service-role-key" };
+
+  it("round-trips an anonymous document by id", async () => {
+    setSessionFetch(makeMcpSessionsFake().fetchImpl);
+    const store = new AnonSupabaseSessionStore(ACFG);
+    await store.save("doc_anon_1", makeCubeDoc());
+    const loaded = await store.load("doc_anon_1");
+    expect(loaded).not.toBeNull();
+    expect(JSON.stringify(loaded)).toContain("test_cube");
+  });
+
+  it("misses (null) for an unknown id", async () => {
+    setSessionFetch(makeMcpSessionsFake().fetchImpl);
+    expect(await new AnonSupabaseSessionStore(ACFG).load("nope")).toBeNull();
+  });
+
+  it("drops a session", async () => {
+    setSessionFetch(makeMcpSessionsFake().fetchImpl);
+    const store = new AnonSupabaseSessionStore(ACFG);
+    await store.save("doc_d", makeCubeDoc());
+    await store.drop("doc_d");
+    expect(await store.load("doc_d")).toBeNull();
+  });
+
+  it("hydrates a cold instance from mcp_sessions (cross-instance recovery)", async () => {
+    setSessionFetch(makeMcpSessionsFake().fetchImpl);
+    await new AnonSupabaseSessionStore(ACFG).save("doc_cold", makeCubeDoc());
+    documents.clear(); // simulate a fresh instance with an empty cache
+    const ok = await hydrateSession(new AnonSupabaseSessionStore(ACFG), "doc_cold");
+    expect(ok).toBe(true);
+    expect(() => getSession("doc_cold")).not.toThrow();
+  });
+});
+
 describe("createSessionStore factory", () => {
   let prevUrl: string | undefined;
   let prevKey: string | undefined;
@@ -254,9 +323,15 @@ describe("createSessionStore factory", () => {
     else process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
   });
 
-  it("returns in-memory without a user, even with keys set", () => {
+  it("returns the anonymous capability store without a user but with keys", () => {
     process.env.SUPABASE_URL = "https://supa.test";
     process.env.SUPABASE_SERVICE_ROLE_KEY = "k";
+    expect(createSessionStore(null)).toBeInstanceOf(AnonSupabaseSessionStore);
+  });
+
+  it("returns in-memory without a user AND no keys (stdio/local)", () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
     expect(createSessionStore(null)).toBeInstanceOf(InMemorySessionStore);
   });
 

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -186,6 +186,83 @@ export class SupabaseSessionStore implements SessionStore {
   }
 }
 
+/**
+ * Cloud-backed store for ANONYMOUS sessions, keyed by the (unguessable)
+ * document id — capability access, no user. Backed by the `mcp_sessions` table
+ * (service-role only). Same hydrate-on-miss / persist-after-write contract as
+ * SupabaseSessionStore, so anonymous callers survive serverless cold starts and
+ * cross-instance routing exactly like signed-in users do.
+ */
+export class AnonSupabaseSessionStore implements SessionStore {
+  constructor(private cfg: { supabaseUrl: string; serviceRoleKey: string }) {}
+
+  private headers(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      apikey: this.cfg.serviceRoleKey,
+      Authorization: `Bearer ${this.cfg.serviceRoleKey}`,
+      "Content-Type": "application/json",
+      ...extra,
+    };
+  }
+
+  private url(query = ""): string {
+    return `${this.cfg.supabaseUrl}/rest/v1/mcp_sessions${query}`;
+  }
+
+  async load(documentId: string): Promise<Document | null> {
+    try {
+      const res = await sessionFetch(
+        this.url(
+          `?document_id=eq.${encodeURIComponent(documentId)}&select=content&limit=1`,
+        ),
+        {
+          method: "GET",
+          headers: this.headers({ Accept: "application/vnd.pgrst.object+json" }),
+        },
+      );
+      if (!res.ok) return null; // 406 = zero/≠1 rows → miss
+      const row = (await res.json()) as { content?: unknown };
+      const ir = unwrapDocument(row?.content);
+      return ir ? (JSON.parse(JSON.stringify(ir)) as Document) : null;
+    } catch (err) {
+      console.error("[session-store] anon load failed:", err);
+      return null;
+    }
+  }
+
+  async save(documentId: string, doc: Document): Promise<void> {
+    try {
+      const res = await sessionFetch(this.url("?on_conflict=document_id"), {
+        method: "POST",
+        headers: this.headers({
+          Prefer: "resolution=merge-duplicates,return=minimal",
+        }),
+        body: JSON.stringify([{ document_id: documentId, content: doc }]),
+      });
+      if (!res.ok) {
+        console.error(
+          "[session-store] anon save failed:",
+          res.status,
+          await res.text().catch(() => ""),
+        );
+      }
+    } catch (err) {
+      console.error("[session-store] anon save failed:", err);
+    }
+  }
+
+  async drop(documentId: string): Promise<void> {
+    try {
+      await sessionFetch(
+        this.url(`?document_id=eq.${encodeURIComponent(documentId)}`),
+        { method: "DELETE", headers: this.headers() },
+      );
+    } catch (err) {
+      console.error("[session-store] anon drop failed:", err);
+    }
+  }
+}
+
 /** True when `content` looks like a raw Document IR (has nodes + roots). */
 function looksLikeDocument(content: unknown): content is Document {
   return (
@@ -206,21 +283,20 @@ function unwrapDocument(content: unknown): Document | null {
 }
 
 /**
- * Choose the store impl from env + the per-connection user. Returns the
- * cloud-backed store only when ALL of: a signed-in user, SUPABASE_URL, and
- * SUPABASE_SERVICE_ROLE_KEY are present; otherwise the in-memory no-op store
- * (which preserves today's behavior). This single gate keeps the service-role
- * key off any path that lacks an authenticated user.
+ * Choose the store impl from env + the per-connection user. With Supabase env
+ * present: a signed-in user gets the user-owned `documents` store (also renders
+ * at vcad.io); an anonymous caller gets the capability-keyed `mcp_sessions`
+ * store (durable across instances, the unguessable id is the capability). With
+ * no Supabase env (stdio / local) it's the in-memory no-op store — today's
+ * behavior. Either way the service-role key only loads when the env provides it.
  */
 export function createSessionStore(user: AuthUser | null): SessionStore {
   const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-  if (user && url && key) {
-    return new SupabaseSessionStore({
-      supabaseUrl: url,
-      serviceRoleKey: key,
-      userId: user.sub,
-    });
+  if (url && key) {
+    return user
+      ? new SupabaseSessionStore({ supabaseUrl: url, serviceRoleKey: key, userId: user.sub })
+      : new AnonSupabaseSessionStore({ supabaseUrl: url, serviceRoleKey: key });
   }
   return new InMemorySessionStore();
 }

--- a/supabase/migrations/025_mcp_sessions.sql
+++ b/supabase/migrations/025_mcp_sessions.sql
@@ -1,0 +1,51 @@
+-- Durable MCP sessions for ANONYMOUS callers (capability-keyed).
+--
+-- Authenticated MCP sessions persist to the user-owned `documents` table
+-- (SupabaseSessionStore, migration 001+). Anonymous callers have no user_id, so
+-- their open documents lived only in a per-instance in-memory map and were lost
+-- on a Vercel cold start or cross-instance routing ("Unknown document_id").
+--
+-- This table gives anonymous sessions durable, capability-scoped storage: the
+-- unguessable document_id (random 72-bit suffix from nextSessionId) IS the
+-- capability. RLS is enabled with NO anon/authenticated policies, so only the
+-- MCP server (service role, which bypasses RLS) ever reads or writes — clients
+-- cannot enumerate or read sessions directly.
+
+create table if not exists mcp_sessions (
+  -- The session/document id (text — MCP ids aren't uuids). Possession = access.
+  document_id text primary key,
+  -- Raw Document IR (same shape SupabaseSessionStore stores in documents.content).
+  content jsonb not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists mcp_sessions_updated_idx on mcp_sessions (updated_at);
+
+-- touch_updated_at() is defined in migration 014.
+create trigger mcp_sessions_touch_updated_at
+  before update on mcp_sessions
+  for each row execute function touch_updated_at();
+
+-- RLS on + no policies = deny all to anon/authenticated; service_role bypasses
+-- RLS, so only the server touches this table.
+alter table mcp_sessions enable row level security;
+
+grant all on mcp_sessions to service_role;
+
+-- Anonymous sessions are transient — sweep stale rows. Cron wiring is a
+-- follow-up; callable manually or from a scheduled job for now.
+create or replace function cleanup_stale_mcp_sessions(max_age interval default '7 days')
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  swept integer;
+begin
+  delete from mcp_sessions where updated_at < now() - max_age;
+  get diagnostics swept = row_count;
+  return swept;
+end;
+$$;


### PR DESCRIPTION
## What

Two related improvements to hosted MCP sessions, both reusing existing infrastructure.

### 1. Durable anonymous sessions (migration 025)
Authenticated MCP sessions persist to the user-owned `documents` table, so they survive Vercel cold starts / cross-instance routing. **Anonymous** callers had no durable path — their open documents lived only in a per-instance in-memory map, so `open_document` → a later call on a different instance failed with **"Unknown document_id."**

- **`mcp_sessions` table** keyed by the document id. The id is unguessable (72-bit random), so **possession of the id is the capability**. RLS on with **no** anon/authenticated policies — only the server (service role) reads/writes. Includes `cleanup_stale_mcp_sessions()`.
- **`AnonSupabaseSessionStore`** — same hydrate-on-miss / persist-after-write contract as the authed store.
- **`createSessionStore`** returns it for the no-user + Supabase-env case (in-memory only when there's no Supabase env at all).

### 2. Discord pings for MCP sessions (migration 026)
Reuses the existing `notify_discord()` + vault `discord_webhook_url` from migration 021 — **no new webhook config or Vercel env**. Authenticated MCP sessions are `documents` rows with `local_id` `mcp:<id>`, so they were already firing the generic "📐 New document" ping; route those to a distinct **"🟢 New MCP session"** embed. Add a matching trigger on `mcp_sessions` so anonymous sessions ping too.

Supersedes #306 (the Vercel-env MCP-server-POST approach), which would have needed a duplicate webhook and double-pinged authenticated sessions alongside the documents trigger.

## Testing

- Anon store: round-trip, miss, drop, cold-instance hydrate; factory returns the anon store for no-user+keys. Full `@vcad/mcp` suite **215 passed**, `tsc` clean.
- Migrations 025 + 026 applied to prod and verified live (a real authenticated session fired a "🟢 New MCP session" embed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)