### PR TITLE
feat(mcp): Discord ping on each new MCP session

### DIFF
--- a/packages/mcp/src/__tests__/notify.test.ts
+++ b/packages/mcp/src/__tests__/notify.test.ts
@@ -6,7 +6,7 @@ import {
   afterEach,
   vi,
 } from "vitest";
-import { fireToolAlert, notifyConfig } from "../notify.js";
+import { fireToolAlert, fireSessionAlert, notifyConfig } from "../notify.js";
 
 const WEBHOOK = "https://discord.com/api/webhooks/test/token";
 // Tests run with a short rollup window so a single timer tick fires it.
@@ -86,5 +86,101 @@ describe("fireToolAlert (rollup)", () => {
     await expect(
       vi.advanceTimersByTimeAsync(INTERVAL_MS),
     ).resolves.not.toThrow();
+  });
+});
+
+describe("fireSessionAlert (new-session ping)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const ENVS = [
+    "VERCEL_ENV",
+    "DISCORD_FORCE",
+    "DISCORD_WEBHOOK_URL",
+    "DISCORD_WEBHOOK_URL_SESSION",
+    "VCAD_BUILD_SHA",
+  ];
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true, status: 204, statusText: "" }));
+    vi.stubGlobal("fetch", fetchMock);
+    for (const k of ENVS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    notifyConfig.webhookUrl = "";
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    vi.unstubAllGlobals();
+  });
+
+  it("no-ops when no webhook is configured (even if forced)", async () => {
+    process.env.DISCORD_FORCE = "1";
+    await fireSessionAlert("doc_1", "open_document", null);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops outside production unless forced", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    process.env.VERCEL_ENV = "preview";
+    await fireSessionAlert("doc_1", "open_document", null);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts an embed for a new session (forced), masking the caller", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    process.env.DISCORD_FORCE = "1";
+    process.env.VCAD_BUILD_SHA = "abcdef1234";
+    await fireSessionAlert("doc_xyz", "create_cad_loon", {
+      email: "alex@example.com",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(WEBHOOK);
+    const payload = JSON.parse(init.body);
+    const embed = payload.embeds[0];
+    expect(embed.title).toContain("New MCP session");
+    const fields = Object.fromEntries(
+      embed.fields.map((f: { name: string; value: string }) => [f.name, f.value]),
+    );
+    expect(fields.session).toContain("doc_xyz");
+    expect(fields.via).toContain("create_cad_loon");
+    expect(fields.who).toBe("a***@example.com");
+    expect(fields.build).toContain("abcdef1");
+    expect(payload.allowed_mentions).toEqual({ parse: [] });
+  });
+
+  it("labels an anonymous caller as 'anonymous'", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    process.env.DISCORD_FORCE = "1";
+    await fireSessionAlert("doc_1", "open_document", null);
+    const embed = JSON.parse(fetchMock.mock.calls[0][1].body).embeds[0];
+    const who = embed.fields.find(
+      (f: { name: string }) => f.name === "who",
+    ).value;
+    expect(who).toBe("anonymous");
+  });
+
+  it("prefers the session-specific webhook override", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    process.env.DISCORD_WEBHOOK_URL_SESSION = "https://discord.com/api/webhooks/sess/tok";
+    process.env.DISCORD_FORCE = "1";
+    await fireSessionAlert("doc_1", "open_document", null);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://discord.com/api/webhooks/sess/tok",
+    );
+  });
+
+  it("never throws when the webhook POST fails", async () => {
+    process.env.DISCORD_WEBHOOK_URL = WEBHOOK;
+    process.env.DISCORD_FORCE = "1";
+    fetchMock.mockRejectedValue(new Error("network down"));
+    await expect(
+      fireSessionAlert("doc_1", "open_document", null),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/mcp/src/notify.ts
+++ b/packages/mcp/src/notify.ts
@@ -157,3 +157,87 @@ async function rollup(): Promise<void> {
     console.error("[mcp] Discord rollup error:", err);
   }
 }
+
+// ── New-session ping ─────────────────────────────────────────────────────────
+
+/** Resolve the webhook for session pings: a session-specific override, then the
+ *  shared `DISCORD_WEBHOOK_URL` (same convention as the app), then the hardcoded
+ *  rollup config (usually empty). */
+function resolveSessionWebhook(): string | null {
+  return (
+    process.env.DISCORD_WEBHOOK_URL_SESSION ||
+    process.env.DISCORD_WEBHOOK_URL ||
+    notifyConfig.webhookUrl ||
+    null
+  );
+}
+
+/** "alex@example.com" → "a****@example.com"; null/empty → "anonymous". */
+function maskEmail(email: string | null | undefined): string {
+  if (!email) return "anonymous";
+  const at = email.indexOf("@");
+  if (at < 1) return "signed-in";
+  return `${email[0]}${"*".repeat(Math.max(1, at - 1))}${email.slice(at)}`;
+}
+
+/**
+ * Post a one-off Discord embed when a NEW MCP session is created (open_document
+ * and the other session creators). Awaited by the dispatch layer but bounded by
+ * a 2.5s timeout and never throws — a Discord outage can't break or hang a tool
+ * call. Gated to production (mirrors packages/app/api/_lib/discord.ts); set
+ * DISCORD_FORCE=1 to fire from preview/dev. No webhook configured → silent no-op.
+ *
+ * Privacy: sends only the session id, the creating tool, a masked `who`, and the
+ * build sha — never argument values or IR.
+ */
+export async function fireSessionAlert(
+  documentId: string,
+  toolName: string,
+  user: { email?: string | null } | null,
+): Promise<void> {
+  if (
+    process.env.VERCEL_ENV !== "production" &&
+    process.env.DISCORD_FORCE !== "1"
+  ) {
+    return;
+  }
+  const webhook = resolveSessionWebhook();
+  if (!webhook) return;
+
+  const sha = (process.env.VCAD_BUILD_SHA ?? "").slice(0, 7);
+  const embed: Record<string, unknown> = {
+    title: "🟢 New MCP session",
+    color: 0xf92672, // vcad pink
+    timestamp: new Date().toISOString(),
+    fields: [
+      { name: "session", value: `\`${clip(documentId, 64)}\``, inline: true },
+      { name: "via", value: `\`${clip(toolName, 48)}\``, inline: true },
+      { name: "who", value: maskEmail(user?.email ?? null), inline: true },
+      ...(sha ? [{ name: "build", value: `\`${sha}\``, inline: true }] : []),
+    ],
+  };
+
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), 2500);
+  try {
+    const res = await fetch(webhook, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: notifyConfig.username,
+        embeds: [embed],
+        allowed_mentions: { parse: [] },
+      }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) {
+      console.error(
+        `[mcp] Discord session ping failed: ${res.status} ${res.statusText}`,
+      );
+    }
+  } catch (err) {
+    console.error("[mcp] Discord session ping error:", err);
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -201,7 +201,7 @@ import {
   OPENAI_APP_MIME_TYPE,
   OPENAI_WIDGET_CSP,
 } from "./viewer.js";
-import { fireToolAlert } from "./notify.js";
+import { fireToolAlert, fireSessionAlert } from "./notify.js";
 
 /** Tools that produce or modify geometry and should show the 3D viewer.
  *  Registry-driven kernel tools (create, update, delete, …) are added
@@ -1800,6 +1800,12 @@ export async function createServer(
             await persistSession(sessionStore, writtenId);
           } catch {
             // best-effort durable write
+          }
+          // A creator mints an id with NO incoming document_id → a brand-new
+          // session. Ping Discord once (no-op unless a webhook is configured;
+          // never throws, bounded by its own timeout).
+          if (!incomingId) {
+            await fireSessionAlert(writtenId, name, context.user);
           }
         }
       }


### PR DESCRIPTION
## What

Posts a one-off Discord embed whenever a **new MCP session** is created — so we can see in real time when someone (or some agent) starts using the hosted MCP, alongside the existing 15-minute activity rollup.

Fires from the dispatch layer exactly when a tool mints a `document_id` with **no incoming `document_id`** — i.e. a session *creator* (`open_document`, `create_cad_loon`, `import_step`, `create_schematic`, `sheet_metal_create`, `load_document`). Mutators on existing sessions don't trigger it.

## Behavior

- **Env-driven webhook**, same convention as `packages/app/api/_lib/discord.ts`: `DISCORD_WEBHOOK_URL` (with an optional `DISCORD_WEBHOOK_URL_SESSION` override).
- **Production-gated** (`VERCEL_ENV=production`); set `DISCORD_FORCE=1` to test from preview/dev. No webhook configured → **silent no-op**, so local/stdio runs and the test suite stay offline.
- **Awaited but bounded** by a 2.5s `AbortController` timeout and never throws — a Discord outage can't break or stall a tool call.
- **Privacy**: sends only the session id, the creating tool, a masked `who` (e.g. `a***@example.com` / `anonymous`), and the build sha — never argument values or IR.

## Testing

- 6 new tests: no-op gating (no webhook / non-prod), embed shape + caller masking, session-webhook override, never-throws on POST failure.
- Full `@vcad/mcp` suite: **216 passed**. `tsc --noEmit` clean.
- No changelog entry — internal ops observability, not user-facing product behavior.

## To enable in prod

Set `DISCORD_WEBHOOK_URL` (or `DISCORD_WEBHOOK_URL_SESSION`) on the `vcad-mcp` Vercel project. Until then it's a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)