### PR TITLE
feat(mcp): Discord pings for MCP sessions (migration 026)

### DIFF
--- a/supabase/migrations/026_discord_mcp_sessions.sql
+++ b/supabase/migrations/026_discord_mcp_sessions.sql
@@ -1,0 +1,78 @@
+-- Discord pings for MCP sessions — reuses notify_discord() + the vault webhook
+-- (migration 021); no new webhook config or env var.
+--
+-- Two cases:
+--   * Authenticated MCP sessions persist to `documents` with local_id
+--     'mcp:<id>' (SupabaseSessionStore), so they currently fire the generic
+--     "📐 New document" ping. Route those to a distinct "🟢 New MCP session"
+--     embed instead, so MCP usage is separable from real web-app documents.
+--   * Anonymous MCP sessions live in `mcp_sessions` (migration 025) and had no
+--     ping at all — add one.
+
+-- ─── documents: route MCP rows to an MCP-session embed ───────────────────────
+create or replace function notify_discord_on_document_create()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  owner_username text;
+  owner_label text;
+begin
+  select username into owner_username from profiles where id = new.user_id;
+  owner_label := coalesce(owner_username, 'user:' || substr(new.user_id::text, 1, 8));
+
+  -- MCP-authored sessions (local_id 'mcp:<id>') → MCP-session embed, not a doc.
+  if new.local_id like 'mcp:%' then
+    perform notify_discord(jsonb_build_object(
+      'title', '🟢 New MCP session',
+      'color', 3066993, -- #2ecc71
+      'timestamp', new.created_at,
+      'fields', jsonb_build_array(
+        jsonb_build_object('name', 'session', 'value', substr(new.local_id, 5), 'inline', true),
+        jsonb_build_object('name', 'who',     'value', owner_label,             'inline', true)
+      )
+    ));
+    return new;
+  end if;
+
+  -- Real web-app document (unchanged from migration 021).
+  perform notify_discord(jsonb_build_object(
+    'title', '📐 New document',
+    'color', 16328818, -- #f92672
+    'timestamp', new.created_at,
+    'fields', jsonb_build_array(
+      jsonb_build_object('name', 'name',  'value', coalesce(new.name, 'untitled'), 'inline', true),
+      jsonb_build_object('name', 'owner', 'value', owner_label,                    'inline', true)
+    )
+  ));
+  return new;
+end;
+$$;
+
+-- ─── mcp_sessions: anonymous MCP-session pings ───────────────────────────────
+create or replace function notify_discord_on_mcp_session_create()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  perform notify_discord(jsonb_build_object(
+    'title', '🟢 New MCP session',
+    'color', 3066993, -- #2ecc71
+    'timestamp', new.created_at,
+    'fields', jsonb_build_array(
+      jsonb_build_object('name', 'session', 'value', new.document_id, 'inline', true),
+      jsonb_build_object('name', 'who',     'value', 'anonymous',     'inline', true)
+    )
+  ));
+  return new;
+end;
+$$;
+
+drop trigger if exists discord_notify_mcp_session_create on public.mcp_sessions;
+create trigger discord_notify_mcp_session_create
+  after insert on public.mcp_sessions
+  for each row execute function notify_discord_on_mcp_session_create();


### PR DESCRIPTION
## What

Migration 026 — Discord pings for MCP sessions, reusing the existing `notify_discord()` + Supabase Vault `discord_webhook_url` from migration 021 (**no new webhook config or Vercel env**).

- Authenticated MCP sessions are `documents` rows with `local_id` `mcp:<id>`, so they were already firing the generic "📐 New document" ping — route those to a distinct **"🟢 New MCP session"** embed.
- Add a matching trigger on `mcp_sessions` (migration 025) so anonymous sessions ping too.

## Why a separate PR

This commit was pushed to the #305 branch *after* #305 had already merged, so the migration file never made it onto `main`. The triggers are **already applied to prod** (verified live — a real "🟢 New MCP session" embed landed in Discord), so this PR just catches `main`'s migration history up to prod, keeping `supabase db reset` reproducible.

Supersedes the closed #306 (Vercel-env approach — would have duplicated the webhook and double-pinged).

## Risk

Low — additive trigger/function changes only; `notify_discord()` swallows its own errors so a Discord outage can't roll back a write. Already running in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)