### PR TITLE
feat(fabricate): Phase 1 money-plane schema + atomic wallet/authz primitives

### DIFF
--- a/scripts/money-plane/stub.sql
+++ b/scripts/money-plane/stub.sql
@@ -1,0 +1,12 @@
+-- Minimal Supabase-ish deps so migration 027 applies in a plain Postgres.
+create role service_role;
+create role authenticated;
+create role anon;
+create schema if not exists auth;
+create table auth.users (id uuid primary key default gen_random_uuid(), email text, is_anonymous boolean default false);
+create or replace function auth.uid() returns uuid language sql stable as $$ select nullif(current_setting('test.uid', true),'')::uuid $$;
+create table profiles (id uuid primary key references auth.users(id), username text);
+create or replace function touch_updated_at() returns trigger language plpgsql as $$ begin new.updated_at = now(); return new; end $$;
+-- subset of migration 024 columns that 027 references
+create table quotes (id uuid primary key default gen_random_uuid(), user_id uuid, doc_hash text, process text, total_amount_minor bigint, created_at timestamptz default now());
+create table orders (id uuid primary key default gen_random_uuid(), user_id uuid, quote_id uuid references quotes(id), state text default 'QUOTED', fab text, created_at timestamptz default now());

--- a/scripts/money-plane/tests.sql
+++ b/scripts/money-plane/tests.sql
@@ -1,0 +1,101 @@
+\set ON_ERROR_STOP on
+-- ── seed ──
+insert into auth.users (id, email) values ('11111111-1111-1111-1111-111111111111','a@x.test');
+insert into profiles (id, username) values ('11111111-1111-1111-1111-111111111111','alice');
+insert into quotes (id, user_id, doc_hash, process, total_amount_minor)
+  values ('22222222-2222-2222-2222-222222222222','11111111-1111-1111-1111-111111111111','hash_abc','pcb',30000);
+insert into orders (id, user_id, quote_id, fab)
+  values ('33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','22222222-2222-2222-2222-222222222222','jlcpcb');
+
+do $$
+declare u uuid := '11111111-1111-1111-1111-111111111111';
+        o uuid := '33333333-3333-3333-3333-333333333333';
+        q uuid := '22222222-2222-2222-2222-222222222222';
+        a uuid; r jsonb; n int;
+begin
+  -- topup
+  r := credit_wallet(u, 1000, 'topup', 'topup-1'); assert (r->>'ok')='true' and (r->>'balance_minor')='1000', 'topup '||r::text;
+  -- idempotent topup
+  r := credit_wallet(u, 1000, 'topup', 'topup-1'); assert (r->>'idempotent')='true' and (r->>'balance_minor')='1000', 'topup-replay '||r::text;
+  -- reused key, different amount
+  r := credit_wallet(u, 5, 'topup', 'topup-1'); assert (r->>'reason')='idempotency_key_reused', 'reuse '||r::text;
+
+  -- one_time authz: authorized, matches quote, fab+process allow, hash match, max 500
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,process_allowlist,fab_allowlist,doc_hash,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,array['pcb'],array['jlcpcb'],'hash_abc','authorized', now()+interval '1 day')
+    returning id into a;
+  -- happy debit 300
+  r := debit_wallet(u,300,o,a,'deb-1'); assert (r->>'ok')='true' and (r->>'balance_minor')='700', 'debit '||r::text;
+  -- idempotent debit replay
+  r := debit_wallet(u,300,o,a,'deb-1'); assert (r->>'idempotent')='true' and (r->>'balance_minor')='700', 'debit-replay '||r::text;
+  -- authz now consumed
+  assert (select status from spend_authorizations where id=a)='consumed', 'authz not consumed';
+  -- reusing consumed authz (new key) fails
+  r := debit_wallet(u,100,o,a,'deb-2'); assert (r->>'reason')='authz_not_authorized', 'consumed-reuse '||r::text;
+
+  -- insufficient funds
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,doc_hash,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',999999,'hash_abc','authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet(u,5000,o,a,'deb-3'); assert (r->>'reason')='insufficient_funds' and (r->>'balance_minor')='700','insufficient '||r::text;
+
+  -- amount exceeds authz
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',50,'authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet(u,100,o,a,'deb-4'); assert (r->>'reason')='amount_exceeds_authz','exceeds '||r::text;
+
+  -- expired authz
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,'authorized',now()-interval '1 minute') returning id into a;
+  r := debit_wallet(u,100,o,a,'deb-5'); assert (r->>'reason')='authz_expired','expired '||r::text;
+
+  -- revoked via kill switch
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,'authorized',now()+interval '1 day') returning id into a;
+  n := revoke_user_authorizations(u); assert n>=1, 'revoke count';
+  r := debit_wallet(u,100,o,a,'deb-6'); assert (r->>'reason')='authz_revoked','revoked '||r::text;
+
+  -- wrong user
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,'authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet('44444444-4444-4444-4444-444444444444',100,o,a,'deb-7'); assert (r->>'reason')='authz_not_found','wronguser '||r::text;
+
+  -- fab not allowed
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,fab_allowlist,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,array['pcbway'],'authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet(u,100,o,a,'deb-8'); assert (r->>'reason')='fab_not_allowed','fab '||r::text;
+
+  -- doc_hash mismatch
+  insert into spend_authorizations (id,user_id,quote_id,kind,max_amount_minor,doc_hash,status,expires_at)
+    values (gen_random_uuid(),u,q,'one_time',500,'WRONG','authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet(u,100,o,a,'deb-9'); assert (r->>'reason')='doc_hash_mismatch','hash '||r::text;
+
+  -- standing authz + daily cap: balance 700, cap 250
+  insert into spend_authorizations (id,user_id,kind,max_amount_minor,daily_cap_minor,status,expires_at)
+    values (gen_random_uuid(),u,'standing',500,250,'authorized',now()+interval '1 day') returning id into a;
+  r := debit_wallet(u,200,o,a,'deb-10'); assert (r->>'ok')='true' and (r->>'balance_minor')='500','standing1 '||r::text;
+  assert (select status from spend_authorizations where id=a)='authorized','standing stays authorized'; -- not consumed
+  r := debit_wallet(u,100,o,a,'deb-11'); assert (r->>'reason')='daily_cap_exceeded','dailycap '||r::text; -- 200+100>250
+
+  -- refund requires order
+  r := credit_wallet(u,50,'refund','ref-1'); assert (r->>'reason')='refund_requires_order','refund-noorder '||r::text;
+  r := credit_wallet(u,50,'refund','ref-2',o); assert (r->>'ok')='true' and (r->>'balance_minor')='550','refund-ok '||r::text;
+
+  -- reconciliation: no drift
+  assert (select count(*) from fn_wallet_drift())=0, 'drift detected';
+
+  raise notice 'ALL LOGIC TESTS PASSED';
+end $$;
+
+-- service-role guard: an authenticated caller must be rejected
+set request.jwt.claims = '{"role":"authenticated"}';
+do $$
+declare ok boolean := false;
+begin
+  begin
+    perform credit_wallet('11111111-1111-1111-1111-111111111111', 1, 'topup', 'should-fail');
+  exception when others then ok := true;
+  end;
+  assert ok, 'service-role guard did NOT block authenticated caller';
+  raise notice 'SERVICE-ROLE GUARD PASSED';
+end $$;
+reset request.jwt.claims;

--- a/scripts/money-plane/validate.sh
+++ b/scripts/money-plane/validate.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Validate the Fabricate money-plane migration (027) against an ephemeral
+# Postgres: applies it twice (re-runnability) and runs the behavior matrix
+# (idempotency, every authz-failure mode, daily cap, allowlists, drift,
+# service-role guard). Requires docker + psql. No effect on any real DB.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MIG="$HERE/../../supabase/migrations/027_fabricate_money_plane.sql"
+PORT="${PORT:-55440}"
+CID=$(docker run -d --rm -e POSTGRES_PASSWORD=pw -p "$PORT:5432" postgres:16-alpine)
+trap 'docker stop "$CID" >/dev/null 2>&1 || true' EXIT
+export PGPASSWORD=pw
+URL="postgresql://postgres@localhost:$PORT/postgres"
+for _ in $(seq 1 30); do psql "$URL" -c "select 1" >/dev/null 2>&1 && break; sleep 1; done
+psql "$URL" -q -f "$HERE/stub.sql"
+psql "$URL" -v ON_ERROR_STOP=1 -q -f "$MIG" >/dev/null   # apply
+psql "$URL" -v ON_ERROR_STOP=1 -q -f "$MIG" >/dev/null   # re-apply (idempotency)
+psql "$URL" -q -f "$HERE/tests.sql" 2>&1 | grep -iE "NOTICE:|ERROR|FAIL"

--- a/supabase/migrations/027_fabricate_money_plane.sql
+++ b/supabase/migrations/027_fabricate_money_plane.sql
@@ -1,0 +1,405 @@
+-- vcad Fabricate — Phase 1 money plane (schema + atomic primitives only).
+--
+-- Lands the DURABLE, REVOCABLE money primitives the adversarial review flagged
+-- as must-fix, with NO tool yet wired to spend. Nothing here charges anyone —
+-- place_order / authorize_spend / Stripe land in a later slice (test-mode +
+-- flag-gated first).
+--
+-- Guardrails encoded here:
+--   1. Spend authorizations are DB rows with a real lifecycle
+--      (pending_human → authorized → consumed/revoked/expired) + a kill switch.
+--      A signed JWT (app-side) is only a pointer; this table is the truth, and
+--      EVERY field (max_amount, daily_cap, process/fab allowlist, doc_hash,
+--      quote binding, expiry, ownership) is enforced in debit_wallet().
+--   2. wallet_ledger is the append-only source of truth; wallets.balance is a
+--      cached mirror. Wallet writes happen ONLY inside the SECURITY DEFINER
+--      RPCs — service_role gets SELECT only on wallets/ledger.
+--   3. debit_wallet() is one atomic, balance-floored, per-user-idempotent txn
+--      (advisory-lock serialized on (user, key)) that also consumes a one_time
+--      authorization — no double-spend, no replay double-charge, no cross-user
+--      key collision.
+--
+-- Isolation: correctness assumes the default READ COMMITTED (FOR UPDATE
+-- re-reads the latest committed row). A caller that bumps to REPEATABLE READ /
+-- SERIALIZABLE must treat SQLSTATE 40001 as a retry, not a debit failure.
+--
+-- Money is integer MINOR units (USD cents) everywhere.
+
+-- ─── wallets — cached balance mirror (source of truth is wallet_ledger) ───────
+create table if not exists wallets (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  credit_balance_minor bigint not null default 0 check (credit_balance_minor >= 0),
+  currency text not null default 'USD',
+  updated_at timestamptz not null default now()
+);
+
+-- ─── wallet_ledger — append-only; balance = sum(delta_minor) ──────────────────
+create table if not exists wallet_ledger (
+  id bigserial primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  -- Signed: +topup / +refund, -order_debit / -metered_api.
+  delta_minor bigint not null,
+  reason text not null check (
+    reason in ('topup', 'order_debit', 'refund', 'metered_api', 'adjustment')
+  ),
+  order_id uuid references orders(id) on delete set null,
+  -- Idempotency key, namespaced PER USER (not global) so one tenant's key can
+  -- never collide with another's.
+  idempotency_key text not null,
+  -- Snapshot of the resulting balance for audit / reconciliation / replay.
+  balance_after_minor bigint not null,
+  created_at timestamptz not null default now(),
+  unique (user_id, idempotency_key)
+);
+
+create index if not exists wallet_ledger_user_idx
+  on wallet_ledger (user_id, created_at desc);
+
+-- ─── spend_authorizations — DB-backed, revocable (NOT a stateless JWT) ────────
+create table if not exists spend_authorizations (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  -- null for a standing budget; required for a one_time quote authorization.
+  quote_id uuid references quotes(id) on delete cascade,
+  kind text not null check (kind in ('one_time', 'standing')),
+  max_amount_minor bigint not null check (max_amount_minor > 0),
+  daily_cap_minor bigint check (daily_cap_minor is null or daily_cap_minor > 0),
+  process_allowlist text[],
+  fab_allowlist text[],
+  doc_hash text,
+  status text not null default 'pending_human' check (
+    status in ('pending_human', 'authorized', 'consumed', 'revoked', 'expired')
+  ),
+  approved_by uuid references auth.users(id),
+  approved_at timestamptz,
+  revoked_at timestamptz,
+  consumed_at timestamptz,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  -- A one_time authorization must bind to a specific quote.
+  check (kind <> 'one_time' or quote_id is not null)
+);
+
+create index if not exists spend_authorizations_user_idx
+  on spend_authorizations (user_id, created_at desc);
+
+-- ledger ← authorization link (added after spend_authorizations exists so the
+-- FK resolves regardless of table order). Enables per-authorization daily-cap
+-- accounting + audit (which authz funded which debit).
+alter table wallet_ledger
+  add column if not exists authorization_id uuid references spend_authorizations(id) on delete set null;
+
+-- ─── processed_events — durable webhook idempotency (NOT an in-memory Map) ────
+create table if not exists processed_events (
+  event_id text primary key,
+  source text not null default 'stripe',
+  created_at timestamptz not null default now()
+);
+
+-- ─── orders: money-plane columns (table from migration 024) ──────────────────
+alter table orders add column if not exists authorization_id uuid references spend_authorizations(id);
+alter table orders add column if not exists idempotency_key text;
+alter table orders add column if not exists stripe_payment_intent_id text;
+-- One order per quote — server-derivable double-order guard. Phase-0 already
+-- writes exactly one order per (fresh) quote_id, so this builds cleanly.
+create unique index if not exists orders_quote_unique on orders (quote_id) where quote_id is not null;
+
+-- ─── touch_updated_at (defined in migration 014); re-runnable ────────────────
+drop trigger if exists wallets_touch_updated_at on wallets;
+create trigger wallets_touch_updated_at
+  before update on wallets
+  for each row execute function touch_updated_at();
+
+-- ─── guard: money RPCs are server-only, even if a future migration re-grants ─
+-- Blocks a PostgREST 'authenticated'/'anon' caller; allows service_role and
+-- internal (no-JWT) contexts like migrations / pg_cron.
+create or replace function assert_money_caller()
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_claims text := current_setting('request.jwt.claims', true);
+begin
+  if v_claims is not null
+     and (v_claims::jsonb ->> 'role') in ('authenticated', 'anon') then
+    raise exception 'forbidden: money functions are service-role only';
+  end if;
+end;
+$$;
+
+-- Per-call sanity ceiling so a fat-fingered/abusive amount can't move $millions.
+-- ($1,000,000 in minor units.)
+
+-- ─── debit_wallet() — atomic, balance-floored, idempotent, authz-consuming ───
+-- The ONLY way credits leave a wallet. Returns jsonb:
+--   { ok:true,  balance_minor, idempotent? }   on success / replay
+--   { ok:false, reason, balance_minor? }        on a guarded failure (no raise)
+-- Signature verification of the authorization JWT happens APP-SIDE; here we
+-- enforce DB-state truth and every authz field.
+create or replace function debit_wallet(
+  p_user uuid,
+  p_amount_minor bigint,
+  p_order_id uuid,
+  p_authorization_id uuid,
+  p_idempotency_key text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  c_max_minor constant bigint := 100000000; -- $1M ceiling
+  v_authz spend_authorizations%rowtype;
+  v_existing wallet_ledger%rowtype;
+  v_balance bigint;
+  v_spent_today bigint;
+  v_fab text;
+  v_process text;
+  v_order_quote uuid;
+  v_quote_hash text;
+begin
+  perform assert_money_caller();
+
+  if p_amount_minor is null or p_amount_minor <= 0 then
+    return jsonb_build_object('ok', false, 'reason', 'invalid_amount');
+  end if;
+  if p_amount_minor > c_max_minor then
+    return jsonb_build_object('ok', false, 'reason', 'amount_over_ceiling');
+  end if;
+  if p_idempotency_key is null or length(p_idempotency_key) = 0 then
+    return jsonb_build_object('ok', false, 'reason', 'missing_idempotency_key');
+  end if;
+
+  -- Serialize same-(user,key) calls so the idempotency check-then-insert is
+  -- race-free (the loser sees the winner's committed row, not a unique error).
+  perform pg_advisory_xact_lock(hashtext(p_user::text || ':' || p_idempotency_key));
+
+  -- Idempotent replay (per-user key). Must match the original request.
+  select * into v_existing
+    from wallet_ledger
+    where user_id = p_user and idempotency_key = p_idempotency_key;
+  if found then
+    if v_existing.reason <> 'order_debit'
+       or v_existing.order_id is distinct from p_order_id
+       or v_existing.authorization_id is distinct from p_authorization_id
+       or v_existing.delta_minor <> -p_amount_minor then
+      return jsonb_build_object('ok', false, 'reason', 'idempotency_key_reused');
+    end if;
+    return jsonb_build_object('ok', true, 'idempotent', true,
+                             'balance_minor', v_existing.balance_after_minor);
+  end if;
+
+  -- Lock + validate the authorization against DB truth.
+  select * into v_authz from spend_authorizations where id = p_authorization_id for update;
+  if not found or v_authz.user_id <> p_user then
+    return jsonb_build_object('ok', false, 'reason', 'authz_not_found');
+  end if;
+  if v_authz.revoked_at is not null or v_authz.status = 'revoked' then
+    return jsonb_build_object('ok', false, 'reason', 'authz_revoked');
+  end if;
+  if v_authz.expires_at <= now() then
+    return jsonb_build_object('ok', false, 'reason', 'authz_expired');
+  end if;
+  if v_authz.status <> 'authorized' then
+    return jsonb_build_object('ok', false, 'reason', 'authz_not_authorized');
+  end if;
+  if p_amount_minor > v_authz.max_amount_minor then
+    return jsonb_build_object('ok', false, 'reason', 'amount_exceeds_authz');
+  end if;
+
+  -- Fetch the order (ownership-scoped) + its quote for binding/allowlist checks.
+  select o.fab, o.quote_id, q.process, q.doc_hash
+    into v_fab, v_order_quote, v_process, v_quote_hash
+    from orders o
+    left join quotes q on q.id = o.quote_id
+    where o.id = p_order_id and o.user_id = p_user;
+  if not found then
+    return jsonb_build_object('ok', false, 'reason', 'order_not_found');
+  end if;
+
+  if v_authz.kind = 'one_time' and v_order_quote is distinct from v_authz.quote_id then
+    return jsonb_build_object('ok', false, 'reason', 'authz_quote_mismatch');
+  end if;
+  if v_authz.doc_hash is not null and v_quote_hash is distinct from v_authz.doc_hash then
+    return jsonb_build_object('ok', false, 'reason', 'doc_hash_mismatch');
+  end if;
+  if v_authz.fab_allowlist is not null
+     and not (v_fab = any(v_authz.fab_allowlist)) then
+    return jsonb_build_object('ok', false, 'reason', 'fab_not_allowed');
+  end if;
+  if v_authz.process_allowlist is not null
+     and not (v_process = any(v_authz.process_allowlist)) then
+    return jsonb_build_object('ok', false, 'reason', 'process_not_allowed');
+  end if;
+
+  -- Daily cumulative cap (standing budgets).
+  if v_authz.daily_cap_minor is not null then
+    select coalesce(sum(-delta_minor), 0) into v_spent_today
+      from wallet_ledger
+      where authorization_id = v_authz.id and reason = 'order_debit'
+        and created_at >= date_trunc('day', now() at time zone 'UTC');
+    if v_spent_today + p_amount_minor > v_authz.daily_cap_minor then
+      return jsonb_build_object('ok', false, 'reason', 'daily_cap_exceeded');
+    end if;
+  end if;
+
+  -- Lock the wallet and enforce the balance floor.
+  select credit_balance_minor into v_balance from wallets where user_id = p_user for update;
+  if not found then
+    v_balance := 0;
+  end if;
+  if v_balance < p_amount_minor then
+    return jsonb_build_object('ok', false, 'reason', 'insufficient_funds', 'balance_minor', v_balance);
+  end if;
+
+  v_balance := v_balance - p_amount_minor;
+
+  insert into wallet_ledger (user_id, delta_minor, reason, order_id, authorization_id, idempotency_key, balance_after_minor)
+    values (p_user, -p_amount_minor, 'order_debit', p_order_id, p_authorization_id, p_idempotency_key, v_balance);
+
+  update wallets set credit_balance_minor = v_balance where user_id = p_user;
+
+  -- Consume one_time authorizations; standing budgets stay 'authorized' and are
+  -- bounded by daily_cap + expiry.
+  if v_authz.kind = 'one_time' then
+    update spend_authorizations set status = 'consumed', consumed_at = now() where id = v_authz.id;
+  end if;
+
+  return jsonb_build_object('ok', true, 'balance_minor', v_balance);
+end;
+$$;
+
+-- ─── credit_wallet() — top-ups + refunds (per-user idempotent) ───────────────
+create or replace function credit_wallet(
+  p_user uuid,
+  p_amount_minor bigint,
+  p_reason text,
+  p_idempotency_key text,
+  p_order_id uuid default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  c_max_minor constant bigint := 100000000; -- $1M ceiling
+  v_existing wallet_ledger%rowtype;
+  v_balance bigint;
+begin
+  perform assert_money_caller();
+
+  if p_amount_minor is null or p_amount_minor <= 0 then
+    return jsonb_build_object('ok', false, 'reason', 'invalid_amount');
+  end if;
+  if p_amount_minor > c_max_minor then
+    return jsonb_build_object('ok', false, 'reason', 'amount_over_ceiling');
+  end if;
+  if p_reason not in ('topup', 'refund', 'adjustment') then
+    return jsonb_build_object('ok', false, 'reason', 'invalid_reason');
+  end if;
+  if p_reason = 'refund' and p_order_id is null then
+    return jsonb_build_object('ok', false, 'reason', 'refund_requires_order');
+  end if;
+  if p_idempotency_key is null or length(p_idempotency_key) = 0 then
+    return jsonb_build_object('ok', false, 'reason', 'missing_idempotency_key');
+  end if;
+
+  perform pg_advisory_xact_lock(hashtext(p_user::text || ':' || p_idempotency_key));
+
+  select * into v_existing
+    from wallet_ledger
+    where user_id = p_user and idempotency_key = p_idempotency_key;
+  if found then
+    if v_existing.reason <> p_reason
+       or v_existing.order_id is distinct from p_order_id
+       or v_existing.delta_minor <> p_amount_minor then
+      return jsonb_build_object('ok', false, 'reason', 'idempotency_key_reused');
+    end if;
+    return jsonb_build_object('ok', true, 'idempotent', true,
+                             'balance_minor', v_existing.balance_after_minor);
+  end if;
+
+  insert into wallets (user_id, credit_balance_minor) values (p_user, 0)
+    on conflict (user_id) do nothing;
+
+  select credit_balance_minor into v_balance from wallets where user_id = p_user for update;
+  v_balance := coalesce(v_balance, 0) + p_amount_minor;
+
+  insert into wallet_ledger (user_id, delta_minor, reason, order_id, idempotency_key, balance_after_minor)
+    values (p_user, p_amount_minor, p_reason, p_order_id, p_idempotency_key, v_balance);
+
+  update wallets set credit_balance_minor = v_balance where user_id = p_user;
+
+  return jsonb_build_object('ok', true, 'balance_minor', v_balance);
+end;
+$$;
+
+-- ─── revoke_user_authorizations() — kill switch ──────────────────────────────
+create or replace function revoke_user_authorizations(p_user uuid)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  n integer;
+begin
+  perform assert_money_caller();
+  update spend_authorizations
+    set status = 'revoked', revoked_at = now()
+    where user_id = p_user and status in ('pending_human', 'authorized');
+  get diagnostics n = row_count;
+  return n;
+end;
+$$;
+
+-- ─── fn_wallet_drift() — reconciliation: cached balance vs ledger sum ─────────
+create or replace function fn_wallet_drift()
+returns table (user_id uuid, cached_minor bigint, ledger_minor bigint)
+language sql
+security definer
+set search_path = public
+as $$
+  select w.user_id,
+         w.credit_balance_minor,
+         coalesce((select sum(l.delta_minor) from wallet_ledger l where l.user_id = w.user_id), 0)
+  from wallets w
+  where w.credit_balance_minor
+        <> coalesce((select sum(l.delta_minor) from wallet_ledger l where l.user_id = w.user_id), 0);
+$$;
+
+-- ─── RLS — users read their own money rows; ALL writes via the RPCs ───────────
+alter table wallets               enable row level security;
+alter table wallet_ledger         enable row level security;
+alter table spend_authorizations  enable row level security;
+alter table processed_events      enable row level security;
+
+drop policy if exists "Users read own wallet" on wallets;
+drop policy if exists "Users read own ledger" on wallet_ledger;
+drop policy if exists "Users read own authorizations" on spend_authorizations;
+create policy "Users read own wallet"         on wallets              for select using (auth.uid() = user_id);
+create policy "Users read own ledger"         on wallet_ledger        for select using (auth.uid() = user_id);
+create policy "Users read own authorizations" on spend_authorizations for select using (auth.uid() = user_id);
+-- processed_events: no policies → only service_role (bypasses RLS) touches it.
+
+-- wallets + ledger: service_role gets SELECT only — the SECURITY DEFINER RPCs
+-- (running as owner) are the SOLE writers, so even a leaked service key can't
+-- rewrite a balance outside the audited RPC path.
+grant select on wallets, wallet_ledger to service_role;
+-- authorizations + events are server-managed directly (mint/approve/dedupe).
+grant all on spend_authorizations, processed_events to service_role;
+grant usage, select on all sequences in schema public to service_role;
+
+-- Money-moving RPCs are server-only. Never grant execute to authenticated/anon.
+revoke all on function debit_wallet(uuid, bigint, uuid, uuid, text) from public;
+revoke all on function credit_wallet(uuid, bigint, text, text, uuid) from public;
+revoke all on function revoke_user_authorizations(uuid) from public;
+revoke all on function fn_wallet_drift() from public;
+grant execute on function debit_wallet(uuid, bigint, uuid, uuid, text) to service_role;
+grant execute on function credit_wallet(uuid, bigint, text, text, uuid) to service_role;
+grant execute on function revoke_user_authorizations(uuid) to service_role;
+grant execute on function fn_wallet_drift() to service_role;


### PR DESCRIPTION
## What

The first slice of the post-quote **money plane** — durable, revocable primitives only. **Nothing spends yet**: `place_order` / `authorize_spend` / Stripe land in the next slice (test-mode + flag-gated). This migration encodes the three guardrails the adversarial review flagged as non-negotiable.

### Migration 027
- **`wallets`** (cached balance mirror) · **`wallet_ledger`** (append-only source of truth; per-user idempotency key) · **`spend_authorizations`** (DB-backed, full lifecycle `pending_human → authorized → consumed/revoked/expired` + kill switch) · **`processed_events`** (durable webhook idempotency — replaces the in-memory Map).
- `orders` gains `authorization_id` / `idempotency_key` / `stripe_payment_intent_id` + a one-order-per-quote unique index.
- **`debit_wallet()`** — one atomic, balance-floored txn, **advisory-lock serialized on (user, key)** so concurrent same-key retries replay cleanly instead of raising `unique_violation`. Enforces **every** authz field: max amount, **per-authz** daily cap, process/fab allowlist, `doc_hash` binding, quote binding, expiry, ownership. Consumes `one_time` authzs; standing budgets persist.
- **`credit_wallet()`** (top-ups/refunds; refund requires an order), **`revoke_user_authorizations()`** (kill switch), **`fn_wallet_drift()`** (reconciliation: cached vs `sum(ledger)`).
- Defense in depth: **`assert_money_caller()`** rejects `authenticated`/`anon` callers; `wallets`+`wallet_ledger` grant **SELECT-only** to `service_role` so the SECURITY DEFINER RPCs are the *sole* writers; a per-call $1M ceiling.

## Adversarial review → fixes

A 5-lens review (double-spend, replay, authz-bypass, balance-integrity, Postgres-correctness) found the core sound but flagged: concurrent-same-key `unique_violation`, globally-unique key + cross-user replay, **dead** authz fields (`daily_cap`/allowlists/`doc_hash`), missing `o.user_id` check, non-re-runnable DDL, no reconciliation. **All addressed.**

## Validation

`scripts/money-plane/validate.sh` spins an ephemeral Postgres 16, applies 027 **twice** (re-runnability), and runs the behavior matrix:
- idempotent replay (debit + credit), reused-key-different-amount rejection
- one-time consume; consumed/expired/revoked/wrong-user/over-max rejections
- insufficient funds, **per-authz** daily cap, fab + process allowlists, doc-hash binding
- refund-requires-order, **zero reconciliation drift**, service-role guard blocks an authenticated caller

→ `ALL LOGIC TESTS PASSED` · `SERVICE-ROLE GUARD PASSED`.

## Deploy

**Not applied to prod.** Unlike 024–026, this is money infra — it stays unapplied until the full Phase-1 slice (`authorize_spend`, `place_order`, Stripe test-mode) is built, reviewed, and flag-gated. No changelog entry (no user-facing behavior yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)