### PR TITLE
feat(mcp): emit per-tool-call events to PostHog

### DIFF
--- a/packages/mcp/src/__tests__/notify.test.ts
+++ b/packages/mcp/src/__tests__/notify.test.ts
@@ -7,6 +7,7 @@ import {
   vi,
 } from "vitest";
 import { fireToolAlert, notifyConfig } from "../notify.js";
+import { telemetryConfig } from "../telemetry.js";
 
 const WEBHOOK = "https://discord.com/api/webhooks/test/token";
 // Tests run with a short rollup window so a single timer tick fires it.
@@ -21,6 +22,9 @@ describe("fireToolAlert (rollup)", () => {
     vi.stubGlobal("fetch", fetchMock);
     notifyConfig.webhookUrl = "";
     notifyConfig.rollupMs = INTERVAL_MS;
+    // Keep the PostHog sink off so fetch-call counts reflect only Discord,
+    // regardless of any POSTHOG_API_KEY in the ambient environment.
+    telemetryConfig.apiKey = "";
   });
 
   afterEach(async () => {

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  captureToolCall,
+  configureTelemetry,
+  flushTelemetry,
+  telemetryConfig,
+} from "../telemetry.js";
+
+const KEY = "phc_test_key";
+
+describe("captureToolCall (PostHog)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200, statusText: "OK" }));
+    vi.stubGlobal("fetch", fetchMock);
+    telemetryConfig.apiKey = "";
+    telemetryConfig.host = "https://us.i.posthog.com";
+    configureTelemetry({
+      version: "1.2.3",
+      build_sha: "abc1234",
+      instance_id: "inst-1",
+    });
+  });
+
+  afterEach(async () => {
+    await flushTelemetry();
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when no API key is set", async () => {
+    captureToolCall("inspect_cad", { document_id: "abc" }, {});
+    await flushTelemetry();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("posts a mcp_tool_call event with build identity to /capture/", async () => {
+    telemetryConfig.apiKey = KEY;
+    captureToolCall("create", { document_id: "doc1" }, {});
+    await flushTelemetry();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://us.i.posthog.com/capture/");
+    const payload = JSON.parse(init.body);
+    expect(payload.api_key).toBe(KEY);
+    expect(payload.event).toBe("mcp_tool_call");
+    expect(payload.properties.tool).toBe("create");
+    expect(payload.properties.is_error).toBe(false);
+    expect(payload.properties.mcp_version).toBe("1.2.3");
+    expect(payload.properties.build_sha).toBe("abc1234");
+    expect(payload.properties.instance_id).toBe("inst-1");
+  });
+
+  it("keys anonymous events by session and suppresses person profiles", async () => {
+    telemetryConfig.apiKey = KEY;
+    captureToolCall("export_cad", { document_id: "doc2", format: "stl" }, {});
+    await flushTelemetry();
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.distinct_id).toBe("doc2");
+    expect(payload.properties.authenticated).toBe(false);
+    expect(payload.properties.$process_person_profile).toBe(false);
+    expect(payload.properties.document_id).toBe("doc2");
+    // No arg values beyond the session id leak into the event.
+    expect(payload.properties.format).toBeUndefined();
+    expect(payload.properties.$set).toBeUndefined();
+  });
+
+  it("flags the error result", async () => {
+    telemetryConfig.apiKey = KEY;
+    captureToolCall("run_drc", { document_id: "d" }, { isError: true });
+    await flushTelemetry();
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.properties.is_error).toBe(true);
+  });
+
+  it("never throws when the capture POST fails", async () => {
+    telemetryConfig.apiKey = KEY;
+    fetchMock.mockRejectedValue(new Error("network down"));
+    expect(() => captureToolCall("create", {}, {})).not.toThrow();
+    await expect(flushTelemetry()).resolves.not.toThrow();
+  });
+});

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -23,6 +23,7 @@ import { Engine } from "@vcad/engine";
 import { createServer } from "./server.js";
 import { verifyAccessToken } from "./oauth.js";
 import { getViewerHtml, MCP_APP_MIME_TYPE } from "./viewer.js";
+import { flushTelemetry } from "./telemetry.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
 
@@ -211,6 +212,7 @@ const httpServer = createHttpServer(async (req, res) => {
         return;
       }
       await handleMcpRequest(req, res);
+      await flushTelemetry();
       return;
     }
 

--- a/packages/mcp/src/notify.ts
+++ b/packages/mcp/src/notify.ts
@@ -1,3 +1,5 @@
+import { captureToolCall } from "./telemetry.js";
+
 /**
  * Discord activity rollups for MCP tool usage.
  *
@@ -77,6 +79,9 @@ export function fireToolAlert(
   args: Record<string, unknown>,
   result: { isError?: boolean },
 ): void {
+  // PostHog telemetry is gated independently of the Discord webhook below.
+  captureToolCall(name, args, result);
+
   if (!notifyConfig.webhookUrl) return;
 
   if (!win) win = freshWindow();

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -202,6 +202,11 @@ import {
   OPENAI_WIDGET_CSP,
 } from "./viewer.js";
 import { fireToolAlert } from "./notify.js";
+import { configureTelemetry, flushTelemetry } from "./telemetry.js";
+
+// Re-exported so the Vercel transport entry can drain in-flight PostHog
+// captures before a serverless instance freezes (see services/mcp/entry.ts).
+export { flushTelemetry };
 
 /** Tools that produce or modify geometry and should show the 3D viewer.
  *  Registry-driven kernel tools (create, update, delete, …) are added
@@ -286,6 +291,10 @@ export function getBuildInfo(): {
     uptime_s: Math.round((Date.now() - PROCESS_STARTED_AT) / 1000),
   };
 }
+
+// Stamp every telemetry event with the running build identity (version, commit,
+// instance) — set once at module load.
+configureTelemetry(getBuildInfo());
 
 /** Kernel WASM exports this server depends on; checked at startup so a stale or
  *  incomplete dist surfaces as a clear boot error rather than an opaque

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -1,0 +1,132 @@
+/**
+ * PostHog telemetry for MCP tool usage.
+ *
+ * Emits one `mcp_tool_call` event per tool invocation so we can see which tools
+ * agents actually use, error rates, and signed-in vs anonymous traffic — the
+ * event-level companion to notify.ts's Discord rollups, fed from the same single
+ * chokepoint (`fireToolAlert`). Disabled until POSTHOG_API_KEY is set, so local
+ * stdio installs, dev, and the test suite stay silent and offline.
+ *
+ * Design constraints (mirroring notify.ts):
+ *   - Never block the tool response. capture() starts a fetch and returns.
+ *   - Never throw into the caller. Every failure is swallowed to stderr.
+ *   - Don't leak payloads. Only the tool name, error flag, session id, signed-in
+ *     flag, and build identity are sent — never argument values or IR.
+ *
+ * Serverless delivery: a Vercel function can freeze the instant it returns,
+ * killing an in-flight fetch. So capture() registers its promise in `pending`
+ * and the transport entry awaits flushTelemetry() after handling each request.
+ */
+
+import { currentUser } from "./tools/session.js";
+
+/**
+ * Notifier configuration. The PostHog project key (the public `phc_…` write
+ * key) and host come from the environment, so they're set on the hosted server
+ * (Vercel) without enabling telemetry for every local install. Empty key =
+ * disabled. Tests/dev override these fields directly.
+ */
+export const telemetryConfig = {
+  /** PostHog project API key (public `phc_…` write key). Empty = disabled. */
+  apiKey: process.env.POSTHOG_API_KEY || "",
+  /** PostHog ingestion host. */
+  host: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
+};
+
+/** Static build identity, set once by the server module at load. */
+let buildContext: Record<string, string> = {};
+
+/** Called once from server.ts so events carry the running version/commit. */
+export function configureTelemetry(info: {
+  version: string;
+  build_sha: string;
+  instance_id: string;
+}): void {
+  buildContext = {
+    mcp_version: info.version,
+    build_sha: info.build_sha,
+    instance_id: info.instance_id,
+  };
+}
+
+/** In-flight capture POSTs, drained by flushTelemetry(). */
+const pending = new Set<Promise<void>>();
+
+/**
+ * Capture one tool call to PostHog. Fire-and-forget — returns immediately and
+ * never throws. A no-op when no API key is set.
+ */
+export function captureToolCall(
+  name: string,
+  args: Record<string, unknown>,
+  result: { isError?: boolean },
+): void {
+  const key = telemetryConfig.apiKey;
+  if (!key) return;
+
+  const user = currentUser();
+  const docId =
+    typeof args?.document_id === "string" && args.document_id
+      ? args.document_id
+      : undefined;
+
+  // Signed-in → attribute to the user (matches the web app's posthog.identify).
+  // Anonymous → key by session (document) so events still group meaningfully,
+  // but suppress person-profile creation to avoid a person per anon document
+  // (matches the web app's `person_profiles: 'identified_only'`).
+  const distinctId = user?.sub ?? docId ?? "mcp-anonymous";
+
+  const properties: Record<string, unknown> = {
+    tool: name,
+    is_error: !!result.isError,
+    authenticated: !!user,
+    ...buildContext,
+    $process_person_profile: !!user,
+  };
+  if (docId) properties.document_id = docId;
+  if (user?.email) properties.$set = { email: user.email };
+
+  const body = JSON.stringify({
+    api_key: key,
+    event: "mcp_tool_call",
+    distinct_id: distinctId,
+    properties,
+    timestamp: new Date().toISOString(),
+  });
+
+  const url = `${telemetryConfig.host.replace(/\/$/, "")}/capture/`;
+  const p = fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+  })
+    .then((res) => {
+      if (!res.ok) {
+        console.error(
+          `[mcp] PostHog capture failed: ${res.status} ${res.statusText}`,
+        );
+      }
+    })
+    .catch((err) => {
+      console.error("[mcp] PostHog capture error:", err);
+    })
+    .finally(() => {
+      pending.delete(p);
+    });
+  pending.add(p);
+}
+
+/**
+ * Await all in-flight captures, with a hard timeout so a slow PostHog can never
+ * hold a response open. Call after handling each MCP request so events flush
+ * before a serverless instance freezes. Never throws.
+ */
+export async function flushTelemetry(timeoutMs = 2000): Promise<void> {
+  if (pending.size === 0) return;
+  const inflight = Promise.allSettled([...pending]);
+  const timeout = new Promise<void>((resolve) => {
+    const t = setTimeout(resolve, timeoutMs);
+    if (typeof t.unref === "function") t.unref();
+  });
+  await Promise.race([inflight, timeout]);
+}

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -36,6 +36,7 @@ const fallbackDocuments = new Map<string, Document>();
 
 const sessionScope = new AsyncLocalStorage<{
   documents: Map<string, Document>;
+  user: AuthUser | null;
 }>();
 
 /** The cache for the current connection: a signed-in user's isolated
@@ -54,7 +55,13 @@ function activeDocuments(): Map<string, Document> {
  */
 export function runInSessionScope<T>(user: AuthUser | null, fn: () => T): T {
   if (!user) return fn();
-  return sessionScope.run({ documents: new Map() }, fn);
+  return sessionScope.run({ documents: new Map(), user }, fn);
+}
+
+/** The signed-in user for the current tool call, or null (anonymous/stdio).
+ *  Read by telemetry to attribute events; outside any scope returns null. */
+export function currentUser(): AuthUser | null {
+  return sessionScope.getStore()?.user ?? null;
 }
 
 /**

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -12,7 +12,7 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createServer, getBuildInfo } from "@vcad/mcp/server";
+import { createServer, getBuildInfo, flushTelemetry } from "@vcad/mcp/server";
 import {
   getOAuthConfig,
   handleOAuthRoute,
@@ -146,6 +146,9 @@ export default async function handler(
     try {
       await transport.handleRequest(req, res);
     } finally {
+      // Drain PostHog captures before the serverless instance can freeze —
+      // an in-flight fetch is killed the instant the function returns.
+      await flushTelemetry();
       await transport.close();
       await server.close();
     }


### PR DESCRIPTION
## What

Wires MCP tool usage into PostHog. Before this, the MCP server had **no PostHog telemetry** — `posthog-js` ran only in the web app and docs. The server's sole metrics chokepoint was `fireToolAlert` (15-min Discord rollups, off by default). This adds an event-level PostHog sink fed from that same single chokepoint.

## Why

We want visibility into which MCP tools agents actually use, error rates, and signed-in vs anonymous traffic — the agent surface was a blind spot in analytics.

## How

- **New `packages/mcp/src/telemetry.ts`** — raw `fetch` to PostHog `/capture/` (no new npm dependency; mirrors the existing Discord webhook pattern). Emits one `mcp_tool_call` event per tool call with `tool`, `is_error`, `authenticated`, `document_id`, and build identity (`mcp_version`/`build_sha`/`instance_id`). **No arg payloads leak** — only `document_id` is taken from args, never values/IR.
- **`notify.ts`** — `fireToolAlert` now also calls `captureToolCall`, so all 4 chokepoint sites feed both sinks. PostHog is gated **independently** on `POSTHOG_API_KEY` (empty = disabled, so local/stdio/tests stay silent and offline).
- **`tools/session.ts`** — the session `AsyncLocalStorage` scope now carries the user; new `currentUser()` lets signed-in calls attribute to `user.sub` (with `$set` email), else key by session id with `$process_person_profile: false` (matches the web app's `person_profiles: 'identified_only'`).
- **Serverless-safe flush** — `flushTelemetry()` (re-exported from `server.ts`) awaits in-flight captures with a 2s cap, called after `handleRequest` in `services/mcp/entry.ts` (Vercel) and `http.ts`. A Vercel function freezes the instant it returns, which would otherwise kill an in-flight fetch.
- **Tests** — new `telemetry.test.ts` (envelope, build identity, anon person-profile suppression, no-payload-leak, error flag, never-throws); `notify.test.ts` hardened to keep the PostHog sink off regardless of ambient env.

## Verification

- `npx vitest run` in `@vcad/mcp`: **218 passed / 2 skipped**.
- Typecheck clean (`npm run typecheck`); the Vercel esbuild bundle (`services/mcp/build.sh`) assembles.
- Local runtime smoke test (outside vitest mocks): both calls POST to `/capture/` with the correct envelope and no payload leak.
- **Live end-to-end**: fired a real `mcp_tool_call` through the actual code path and queried it back via HogQL in the **vcad.io** PostHog project (id 299864) — landed intact.

## Reviewer notes / rollout

- `POSTHOG_API_KEY` is already set on the **`vcad-mcp`** Vercel project (Production env, municipal-robotics team) → the public `phc_…` key for the vcad.io project. It's a **no-op until this merges and deploys**; events start flowing on the git-connected production deploy.
- Optional `POSTHOG_HOST` defaults to `https://us.i.posthog.com`.
- No changelog entry: internal observability, not a user-facing product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)