### PR TITLE
fix(mcp): serve the live window from the Vercel entry point

### DIFF
--- a/packages/mcp/src/__tests__/live-route.test.ts
+++ b/packages/mcp/src/__tests__/live-route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Readable } from "node:stream";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { handleLiveRequest } from "../live-route.js";
+
+function makeReq(method: string, path: string, body?: string): IncomingMessage {
+  const req = body != null ? Readable.from([Buffer.from(body)]) : Readable.from([]);
+  Object.assign(req, {
+    method,
+    url: path,
+    headers: { host: "mcp.vcad.io" },
+    socket: { remoteAddress: "127.0.0.1" },
+  });
+  return req as unknown as IncomingMessage;
+}
+
+interface CapRes {
+  statusCode: number;
+  body: string;
+  ended: boolean;
+  writeHead(s: number, h?: unknown): CapRes;
+  end(b?: string): void;
+}
+function makeRes(): CapRes {
+  return {
+    statusCode: 0,
+    body: "",
+    ended: false,
+    writeHead(s) {
+      this.statusCode = s;
+      return this;
+    },
+    end(b) {
+      this.body = b ?? "";
+      this.ended = true;
+    },
+  };
+}
+const res = () => makeRes() as unknown as ServerResponse & CapRes;
+
+// No Supabase env → createSessionEventStore returns the no-op store, so reads
+// are [] and appends are accepted but discarded — enough to test routing.
+let saved: Record<string, string | undefined>;
+beforeEach(() => {
+  saved = {
+    url: process.env.SUPABASE_URL,
+    key: process.env.SUPABASE_SERVICE_ROLE_KEY,
+    flag: process.env.VCAD_LIVE_WINDOW,
+  };
+  delete process.env.SUPABASE_URL;
+  delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+});
+afterEach(() => {
+  for (const [k, v] of [
+    ["SUPABASE_URL", saved.url],
+    ["SUPABASE_SERVICE_ROLE_KEY", saved.key],
+    ["VCAD_LIVE_WINDOW", saved.flag],
+  ] as const) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
+
+describe("handleLiveRequest routing", () => {
+  it("returns false for a non-/live path (caller continues routing)", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    const handled = await handleLiveRequest(makeReq("GET", "/mcp"), r, { user: null });
+    expect(handled).toBe(false);
+    expect(r.ended).toBe(false);
+  });
+
+  it("404s every /live path when the flag is off", async () => {
+    delete process.env.VCAD_LIVE_WINDOW;
+    const r = res();
+    const handled = await handleLiveRequest(
+      makeReq("GET", "/live/doc_x/events"),
+      r,
+      { user: null },
+    );
+    expect(handled).toBe(true);
+    expect(r.statusCode).toBe(404);
+  });
+
+  it("serves events as JSON when the flag is on", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    await handleLiveRequest(makeReq("GET", "/live/doc_x/events"), r, { user: null });
+    expect(r.statusCode).toBe(200);
+    const parsed = JSON.parse(r.body) as { session_id: string; events: unknown[] };
+    expect(parsed.session_id).toBe("doc_x");
+    expect(Array.isArray(parsed.events)).toBe(true);
+  });
+
+  it("accepts a valid annotation (200 ok)", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    await handleLiveRequest(
+      makeReq("POST", "/live/doc_x/annotate", JSON.stringify({ type: "pin", payload: { text: "hi" } })),
+      r,
+      { user: null },
+    );
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).ok).toBe(true);
+  });
+
+  it("rejects an invalid overlay type (400)", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    await handleLiveRequest(
+      makeReq("POST", "/live/doc_x/annotate", JSON.stringify({ type: "mutation", payload: {} })),
+      r,
+      { user: null },
+    );
+    expect(r.statusCode).toBe(400);
+    expect(JSON.parse(r.body).ok).toBe(false);
+  });
+
+  it("400s a missing session id", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    await handleLiveRequest(makeReq("GET", "/live/"), r, { user: null });
+    expect(r.statusCode).toBe(400);
+  });
+
+  it("404s an unknown /live action", async () => {
+    process.env.VCAD_LIVE_WINDOW = "1";
+    const r = res();
+    await handleLiveRequest(makeReq("GET", "/live/doc_x/bogus"), r, { user: null });
+    expect(r.statusCode).toBe(404);
+  });
+});

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -24,8 +24,7 @@ import { createServer } from "./server.js";
 import { verifyAccessToken } from "./oauth.js";
 import { getViewerHtml, MCP_APP_MIME_TYPE } from "./viewer.js";
 import { flushTelemetry } from "./telemetry.js";
-import { createSessionEventStore } from "./session-store.js";
-import { appendOverlay, listEvents } from "./tools/live.js";
+import { handleLiveRequest } from "./live-route.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
 
@@ -126,99 +125,6 @@ async function handleMcpRequest(
     await transport.close();
     await server.close();
   }
-}
-
-/**
- * Handle a live-review-window request. Capability-keyed by the session id in the
- * path (`/live/<id>/<action>`) — possession of the unguessable id is the grant,
- * same model as mcp_sessions. Reads/appends go through the service-role event
- * store, so they work for both anon and signed-in sessions by session id alone.
- *
- *   GET  /live/<id>/events[?since=N]  → the session's spine events (replay)
- *   POST /live/<id>/annotate          → append a viewer overlay (pin/flag/…)
- *
- * The geometry stream (GLB / fold) and the browser viewer app are a separate,
- * env-gated slice — this is the data backbone the broadcast trigger feeds.
- */
-async function handleLiveRequest(
-  req: import("node:http").IncomingMessage,
-  res: import("node:http").ServerResponse,
-): Promise<void> {
-  const url = new URL(req.url ?? "/", `http://${req.headers.host}`);
-  const parts = url.pathname.split("/").filter(Boolean); // ["live", id, action]
-  const sessionId = parts[1] ? decodeURIComponent(parts[1]) : "";
-  const action = parts[2] ?? "";
-  if (!sessionId) {
-    res.writeHead(400, { "Content-Type": "text/plain" });
-    res.end("missing session id");
-    return;
-  }
-
-  // Viewers are usually anonymous (the link is the capability); a Bearer token,
-  // if present, just attributes the actor. The event store reads/writes by
-  // session id via the service role regardless.
-  const user = verifyAccessToken(req);
-  const eventStore = createSessionEventStore(user);
-
-  if (req.method === "GET" && action === "events") {
-    // Each call does a per-session fetch; throttle this public read like annotate.
-    if (rateLimitExceeded(clientIp(req))) {
-      res.writeHead(429, { "Content-Type": "text/plain" });
-      res.end("Too Many Requests");
-      return;
-    }
-    const sinceRaw = url.searchParams.get("since");
-    const since = sinceRaw != null && sinceRaw !== "" ? Number(sinceRaw) : undefined;
-    const events = await listEvents(
-      eventStore,
-      sessionId,
-      Number.isFinite(since) ? since : undefined,
-    );
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ session_id: sessionId, events }));
-    return;
-  }
-
-  if (req.method === "POST" && action === "annotate") {
-    if (rateLimitExceeded(clientIp(req))) {
-      res.writeHead(429, { "Content-Type": "text/plain" });
-      res.end("Too Many Requests");
-      return;
-    }
-    let parsed: unknown;
-    try {
-      // An overlay is tiny — a far smaller cap than the 10 MiB /mcp default.
-      parsed = JSON.parse(await readBody(req, 16 * 1024));
-    } catch {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "invalid or oversized json body" }));
-      return;
-    }
-    // Tolerate null / array / scalar bodies — appendOverlay rejects the empty
-    // overlay with a clean 400 instead of throwing a 500.
-    const body =
-      parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {};
-    const result = await appendOverlay(
-      eventStore,
-      sessionId,
-      {
-        type: typeof body.type === "string" ? body.type : "",
-        payload: body.payload,
-        author: typeof body.author === "string" ? body.author : undefined,
-      },
-      // The verified token identity is authoritative; a body author is only ever
-      // honored (namespaced) for genuinely anonymous viewers.
-      { trustedAuthor: user?.email || undefined },
-    );
-    res.writeHead(result.ok ? 200 : 400, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(result));
-    return;
-  }
-
-  res.writeHead(404, { "Content-Type": "text/plain" });
-  res.end("Not Found");
 }
 
 /** Read request body as string, enforcing a max size (default MAX_BODY_BYTES;
@@ -325,15 +231,9 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
 
-    // Live review window — capability-keyed by the (unguessable) session id.
-    // Flag-gated: a new public read/append surface, off until VCAD_LIVE_WINDOW=1.
-    if (path.startsWith("/live/")) {
-      if (process.env.VCAD_LIVE_WINDOW !== "1") {
-        res.writeHead(404, { "Content-Type": "text/plain" });
-        res.end("Not Found");
-        return;
-      }
-      await handleLiveRequest(req, res);
+    // Live review window (/live/*) — shared, flag-gated handler. Returns true
+    // once it has written a response.
+    if (await handleLiveRequest(req, res, { user: verifyAccessToken(req) })) {
       return;
     }
 

--- a/packages/mcp/src/live-route.ts
+++ b/packages/mcp/src/live-route.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared HTTP handler for the live review window (`/live/*`).
+ *
+ * Both deployment entry points use it, so the routes behave identically:
+ *   - services/mcp/entry.ts  → the Vercel serverless function (mcp.vcad.io)
+ *   - packages/mcp/src/http.ts → the standalone Node server (Fly.io / local)
+ *
+ * Capability-keyed by the session id in the path — possession of the
+ * unguessable id is the grant, same model as mcp_sessions. Reads/appends go
+ * through the service-role event store, so they work for both anon and
+ * signed-in sessions by session id alone. FLAG-GATED behind VCAD_LIVE_WINDOW
+ * (default OFF → 404).
+ *
+ *   GET  /live/<id>/events[?since=N]  → the session's spine events (replay)
+ *   POST /live/<id>/annotate          → append a viewer overlay (pin/flag/…)
+ *
+ * The geometry stream (GLB / fold) and the browser viewer app are a separate,
+ * env-gated slice — this is the data backbone the broadcast trigger feeds.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AuthUser } from "./oauth.js";
+import { createSessionEventStore } from "./session-store.js";
+import { appendOverlay, listEvents } from "./tools/live.js";
+
+/** An overlay body is tiny — a far smaller cap than the 10 MiB /mcp default. */
+const LIVE_BODY_MAX_BYTES = 16 * 1024;
+
+// ── Per-IP rate limiter (per-instance; weak on serverless but a real brake on
+//    the standalone server, and a cheap floor everywhere). ──
+const RATE_LIMIT_PER_MINUTE = parseInt(
+  process.env.MCP_RATE_LIMIT_PER_MINUTE || "60",
+  10,
+);
+const RATE_WINDOW_MS = 60_000;
+const rateMap = new Map<string, { windowStart: number; count: number }>();
+
+function clientIp(req: IncomingMessage): string {
+  const fwd = req.headers["x-forwarded-for"];
+  if (typeof fwd === "string" && fwd.length > 0) return fwd.split(",")[0].trim();
+  return req.socket?.remoteAddress ?? "unknown";
+}
+
+function rateLimited(ip: string): boolean {
+  if (RATE_LIMIT_PER_MINUTE <= 0) return false;
+  const now = Date.now();
+  const entry = rateMap.get(ip);
+  if (!entry || now - entry.windowStart >= RATE_WINDOW_MS) {
+    rateMap.set(ip, { windowStart: now, count: 1 });
+    return false;
+  }
+  entry.count += 1;
+  return entry.count > RATE_LIMIT_PER_MINUTE;
+}
+
+function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        reject(new Error("body too large"));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+const text = (res: ServerResponse, status: number, body: string): void => {
+  res.writeHead(status, { "Content-Type": "text/plain" });
+  res.end(body);
+};
+const json = (res: ServerResponse, status: number, body: unknown): void => {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+};
+
+/**
+ * Handle a `/live/*` request. Returns `true` once it has written a response —
+ * callers do `if (await handleLiveRequest(req, res, { user })) return;`. Returns
+ * `false` for any non-`/live` path so the caller continues its own routing.
+ */
+export async function handleLiveRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: { user: AuthUser | null } = { user: null },
+): Promise<boolean> {
+  const url = new URL(req.url ?? "/", `https://${req.headers.host ?? "localhost"}`);
+  if (!url.pathname.startsWith("/live/")) return false;
+
+  // A new public read/append surface — off unless explicitly enabled.
+  if (process.env.VCAD_LIVE_WINDOW !== "1") {
+    text(res, 404, "Not Found");
+    return true;
+  }
+
+  const parts = url.pathname.split("/").filter(Boolean); // ["live", id, action]
+  const sessionId = parts[1] ? decodeURIComponent(parts[1]) : "";
+  const action = parts[2] ?? "";
+  if (!sessionId) {
+    text(res, 400, "missing session id");
+    return true;
+  }
+
+  const eventStore = createSessionEventStore(opts.user);
+
+  if (req.method === "GET" && action === "events") {
+    if (rateLimited(clientIp(req))) {
+      text(res, 429, "Too Many Requests");
+      return true;
+    }
+    const sinceRaw = url.searchParams.get("since");
+    const since = sinceRaw != null && sinceRaw !== "" ? Number(sinceRaw) : undefined;
+    const events = await listEvents(
+      eventStore,
+      sessionId,
+      Number.isFinite(since) ? since : undefined,
+    );
+    json(res, 200, { session_id: sessionId, events });
+    return true;
+  }
+
+  if (req.method === "POST" && action === "annotate") {
+    if (rateLimited(clientIp(req))) {
+      text(res, 429, "Too Many Requests");
+      return true;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readBody(req, LIVE_BODY_MAX_BYTES));
+    } catch {
+      json(res, 400, { ok: false, error: "invalid or oversized json body" });
+      return true;
+    }
+    // Tolerate null / array / scalar bodies — appendOverlay rejects the empty
+    // overlay with a clean 400 instead of throwing a 500.
+    const body =
+      parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {};
+    const result = await appendOverlay(
+      eventStore,
+      sessionId,
+      {
+        type: typeof body.type === "string" ? body.type : "",
+        payload: body.payload,
+        author: typeof body.author === "string" ? body.author : undefined,
+      },
+      // The verified token identity is authoritative; a body author is only ever
+      // honored (namespaced) for genuinely anonymous viewers.
+      { trustedAuthor: opts.user?.email || undefined },
+    );
+    json(res, result.ok ? 200 : 400, result);
+    return true;
+  }
+
+  text(res, 404, "Not Found");
+  return true;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -74,6 +74,9 @@ import {
   dispatchRegistryTool,
 } from "./tools/registry-dispatch.js";
 import { buildErrorResult, enrichErrorResult } from "./tools/next-actions.js";
+// Re-exported so the Vercel entry point (services/mcp/entry.ts) serves the live
+// window through the same handler as the standalone server (http.ts).
+export { handleLiveRequest } from "./live-route.js";
 import {
   createRobotEnv,
   createRobotEnvSchema,

--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -107,6 +107,11 @@ cat > "$OUT/config.json" << 'EOF'
       "dest": "/mcp"
     },
     {
+      "src": "/live/(.*)",
+      "methods": ["GET", "POST", "OPTIONS"],
+      "dest": "/mcp"
+    },
+    {
       "src": "/oauth/(register|authorize|start|callback|token)",
       "methods": ["GET", "POST", "OPTIONS"],
       "dest": "/mcp"

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -12,7 +12,12 @@
 
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { createServer, getBuildInfo, flushTelemetry } from "@vcad/mcp/server";
+import {
+  createServer,
+  getBuildInfo,
+  flushTelemetry,
+  handleLiveRequest,
+} from "@vcad/mcp/server";
 import {
   getOAuthConfig,
   handleOAuthRoute,
@@ -115,6 +120,12 @@ export default async function handler(
   // user's account even while /mcp stays open during the MCP_REQUIRE_AUTH
   // transition. verifyAccessToken is a local HMAC verify — no network.
   const user = verifyAccessToken(req);
+
+  // Live review window (/live/*) — shared, flag-gated handler (VCAD_LIVE_WINDOW).
+  // Returns true once it has written a response; falls through otherwise.
+  if (await handleLiveRequest(req, res, { user })) {
+    return;
+  }
 
   // Optional hard gate on /mcp. Off by default so existing anonymous
   // clients keep working while the OAuth flow rolls out; set


### PR DESCRIPTION
## What & why

The live-window backbone from #310 was wired into the **wrong entry point** for production. The Vercel function bundles `services/mcp/entry.ts` and routes only an allowlist of paths (`/mcp`, `/health`, `/oauth/*`, `/.well-known/*`) via the Build Output API. My `/live` routes lived in `packages/mcp/src/http.ts` — the **Fly.io/local** server — so in production `/live/*` 404'd at the platform layer and `VCAD_LIVE_WINDOW` gated code that wasn't in the deployed function.

Caught while turning the flag on: `GET https://mcp.vcad.io/live/<id>/events` returned the Vercel platform `NOT_FOUND`, not the app's response.

## Changes

- **`packages/mcp/src/live-route.ts`** (new) — a shared, self-contained `handleLiveRequest`: flag gate (`VCAD_LIVE_WINDOW`), path routing, per-IP rate limit, 16 KB body cap. Both entry points call it, so the routes behave identically on Vercel and the standalone server.
- **`server.ts`** re-exports it; **`services/mcp/entry.ts`** imports it via `@vcad/mcp/server` and calls it after identifying the caller, before the `/mcp` transport.
- **`services/mcp/build.sh`** adds `/live/(.*)` to the route allowlist.
- **`http.ts`** now delegates to the shared handler (removes the duplicate inline copy).

## Verification

- `tsc --noEmit` clean; **281 mcp tests pass** (7 new `live-route` routing tests: flag-off 404, events JSON, annotate accept/reject, missing-id, unknown-action).
- Confirmed the production build path: `@vcad/mcp` builds with the re-export in `dist/server.{js,d.ts}`, and **`entry.ts` bundles cleanly with `esbuild@latest`** (the exact bundler `build.sh` uses), with `handleLiveRequest` resolved and inlined.

## After merge

`VCAD_LIVE_WINDOW=1` is already set on the `vcad-mcp` project, so the git deploy this merge triggers will both serve `/live` **and** pick up the flag (a git deploy reads current env, unlike `vercel redeploy`). Then `GET /live/<id>/events` and `POST /live/<id>/annotate` go live at mcp.vcad.io.

Security posture is unchanged from #310's review: capability-keyed by the unguessable session id, rate-limited, verified-identity-authoritative author with `viewer:` namespacing for anon, payload-capped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)