### PR TITLE
Continue in Claude: one-click web→MCP part handoff

### DIFF
--- a/changelog/entries/2026-06-23-continue-in-claude.json
+++ b/changelog/entries/2026-06-23-continue-in-claude.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-23-continue-in-claude",
+  "version": "0.9.4",
+  "date": "2026-06-23",
+  "category": "feat",
+  "title": "Continue in Claude",
+  "summary": "Hand the part you're looking at to Claude, ChatGPT, or your editor in one click — it loads your exact geometry and picks up where you left off.",
+  "details": "## What's New\n\n- **One-click handoff** - A \"Continue in Claude…\" item in the File menu opens an AI host with your current part already loaded — no blank slate, no copy-paste.\n- **Host matrix** - Claude Desktop and ChatGPT open with the part prefilled; Cursor and VS Code get one-click connector install; Claude Code gets a copyable command. Remembers your last-used host.\n- **Token-based, not geometry-in-URL** - The link carries only a short share token; the new `continue_document` MCP tool resolves it server-side and materializes the geometry, so even large parts hand off cleanly.",
+  "features": [
+    "mcp",
+    "ai",
+    "handoff",
+    "sharing"
+  ],
+  "mcpTools": [
+    "continue_document"
+  ]
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -45,6 +45,7 @@ const AboutModal = lazyWithRetry(() => import("@/components/AboutModal").then(m 
 const RecentFilesModal = lazyWithRetry(() => import("@/components/RecentFilesModal").then(m => ({ default: m.RecentFilesModal })), "RecentFilesModal");
 const ProductModal = lazyWithRetry(() => import("@/components/ProductModal").then(m => ({ default: m.ProductModal })), "ProductModal");
 const ShareDialog = lazyWithRetry(() => import("@/components/ShareDialog").then(m => ({ default: m.ShareDialog })), "ShareDialog");
+const ContinueDialog = lazyWithRetry(() => import("@/components/ContinueDialog").then(m => ({ default: m.ContinueDialog })), "ContinueDialog");
 const VersionHistoryModal = lazyWithRetry(() => import("@/components/VersionHistoryModal").then(m => ({ default: m.VersionHistoryModal })), "VersionHistoryModal");
 const ForkPromptModal = lazyWithRetry(() => import("@/components/ForkPromptModal").then(m => ({ default: m.ForkPromptModal })), "ForkPromptModal");
 const ReadOnlyBanner = lazyWithRetry(() => import("@/components/ReadOnlyBanner").then(m => ({ default: m.ReadOnlyBanner })), "ReadOnlyBanner");
@@ -249,6 +250,7 @@ export function App() {
   const [aboutOpen, setAboutOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const [continueOpen, setContinueOpen] = useState(false);
   const [versionHistoryOpen, setVersionHistoryOpen] = useState(false);
   const [documentPickerOpen, setDocumentPickerOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -1144,6 +1146,7 @@ export function App() {
                 onSave={handleSave}
                 onOpen={handleOpen}
                 onShareOpen={() => setShareOpen(true)}
+                onContinueOpen={() => setContinueOpen(true)}
                 onVersionHistoryOpen={() => setVersionHistoryOpen(true)}
               >
                 <ToolPalette />
@@ -1179,6 +1182,7 @@ export function App() {
           <AboutModal open={aboutOpen} onOpenChange={setAboutOpen} />
           <ProductModal open={productOpen} onOpenChange={setProductOpen} />
           <ShareDialog open={shareOpen} onOpenChange={setShareOpen} />
+          <ContinueDialog open={continueOpen} onOpenChange={setContinueOpen} />
           <VersionHistoryModal
             open={versionHistoryOpen}
             onOpenChange={setVersionHistoryOpen}

--- a/packages/app/src/components/ContinueDialog.tsx
+++ b/packages/app/src/components/ContinueDialog.tsx
@@ -1,0 +1,255 @@
+import { useState, useEffect, useCallback } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "@phosphor-icons/react/dist/ssr/X";
+import { Sparkle } from "@phosphor-icons/react/dist/ssr/Sparkle";
+import { ArrowSquareOut } from "@phosphor-icons/react/dist/ssr/ArrowSquareOut";
+import { Copy } from "@phosphor-icons/react/dist/ssr/Copy";
+import {
+  useAuthStore,
+  createShare,
+  listSharesForDocument,
+} from "@vcad/auth";
+import { useDocumentStore } from "@vcad/core";
+import { useNotificationStore } from "@/stores/notification-store";
+import { loadDocument as loadStoredDocument } from "@/lib/storage";
+import {
+  buildContinueTargets,
+  type ContinueTarget,
+  type ContinueHost,
+} from "@/lib/continue-links";
+import { cn } from "@/lib/utils";
+
+interface ContinueDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const LAST_HOST_KEY = "vcad.continue.lastHost";
+
+/** Trigger a deep link: a new tab for http(s), the OS protocol handler for
+ *  custom schemes (claude:// / cursor:// / vscode:). An anchor click fires the
+ *  custom scheme without navigating the app away. */
+function openLink(url: string): void {
+  const a = document.createElement("a");
+  a.href = url;
+  a.target = /^https?:/i.test(url) ? "_blank" : "_self";
+  a.rel = "noopener noreferrer";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
+  const user = useAuthStore((s) => s.user);
+  const isAnonymous = useAuthStore((s) => s.isAnonymous);
+  const isSignedIn = !!user && !isAnonymous;
+  const documentId = useDocumentStore((s) => s.documentId);
+  const documentName = useDocumentStore((s) => s.documentName);
+
+  const [cloudId, setCloudId] = useState<string | null>(null);
+  const [cloudLookupDone, setCloudLookupDone] = useState(false);
+  const [token, setToken] = useState<string | null>(null);
+  const [minting, setMinting] = useState(false);
+  const [lastHost, setLastHost] = useState<ContinueHost | null>(null);
+  const [copiedHost, setCopiedHost] = useState<ContinueHost | null>(null);
+
+  // Resolve cloudId + an existing-or-fresh share token when the dialog opens.
+  // The token is the capability the model resolves via `continue_document` —
+  // minting it here is what makes the first turn operate on the real part.
+  useEffect(() => {
+    if (!open || !documentId || !isSignedIn) {
+      setCloudLookupDone(false);
+      setCloudId(null);
+      setToken(null);
+      return;
+    }
+    try {
+      const stored = localStorage.getItem(LAST_HOST_KEY);
+      if (stored) setLastHost(stored as ContinueHost);
+    } catch {
+      /* private mode — no last-host memory */
+    }
+    let cancelled = false;
+    (async () => {
+      setMinting(true);
+      try {
+        const stored = await loadStoredDocument(documentId);
+        if (cancelled) return;
+        const cid = stored?.cloudId ?? null;
+        setCloudId(cid);
+        setCloudLookupDone(true);
+        if (!cid) return;
+        // Reuse an existing share token if one exists, else mint one. Continue
+        // only needs the token (the capability) — it deliberately does NOT
+        // publish to the public /@user/slug profile, so there's no username
+        // picker in this flow.
+        const existing = await listSharesForDocument(cid);
+        if (cancelled) return;
+        if (existing.length > 0 && existing[0]) {
+          setToken(existing[0].token);
+        } else {
+          const share = await createShare(cid);
+          if (!cancelled) setToken(share.token);
+        }
+      } catch (err) {
+        console.error("[continue-dialog] mint failed:", err);
+        if (!cancelled) {
+          setCloudLookupDone(true);
+          useNotificationStore
+            .getState()
+            .toast.error(`Couldn't prepare the handoff: ${(err as Error).message}`);
+        }
+      } finally {
+        if (!cancelled) setMinting(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, documentId, isSignedIn]);
+
+  const remember = useCallback((host: ContinueHost) => {
+    setLastHost(host);
+    try {
+      localStorage.setItem(LAST_HOST_KEY, host);
+    } catch {
+      /* private mode */
+    }
+  }, []);
+
+  const runTarget = useCallback(
+    async (target: ContinueTarget) => {
+      // Copy the seed first when the host can't prefill it (web) or has no URL
+      // (Claude Code), so the clipboard is ready by the time the host opens.
+      const needsCopy = !!target.clipboard && (target.copyWithOpen || !target.url);
+      if (needsCopy && target.clipboard) {
+        try {
+          await navigator.clipboard.writeText(target.clipboard);
+          setCopiedHost(target.host);
+          setTimeout(() => setCopiedHost(null), 1500);
+        } catch {
+          useNotificationStore
+            .getState()
+            .toast.error("Couldn't copy the starter prompt to the clipboard.");
+        }
+      }
+      if (target.url) openLink(target.url);
+      remember(target.host);
+
+      const msg = target.url
+        ? needsCopy
+          ? `Opening ${target.label} — paste the copied prompt to start.`
+          : `Opening ${target.label} with your part.`
+        : `Copied the install command + prompt for ${target.label}.`;
+      useNotificationStore.getState().toast.success(msg);
+    },
+    [remember],
+  );
+
+  const blocker: string | null = !isSignedIn
+    ? "Sign in to continue this part in Claude."
+    : cloudLookupDone && !cloudId
+      ? "Save this document to the cloud before continuing."
+      : null;
+
+  const targets = token
+    ? buildContinueTargets({ token, docName: documentName || undefined })
+    : [];
+  // Surface the last-used host first; Claude Desktop leads otherwise.
+  const ordered = [...targets].sort((a, b) => {
+    if (a.host === lastHost) return -1;
+    if (b.host === lastHost) return 1;
+    return 0;
+  });
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content
+          data-tauri-drag-region=""
+          className={cn(
+            "fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2",
+            "rounded-xl border border-border bg-surface p-6 shadow-xl select-none",
+            "focus:outline-none",
+          )}
+        >
+          <Dialog.Close className="absolute right-3 top-3 p-1.5 text-text-muted hover:text-text transition-colors cursor-pointer">
+            <X size={14} />
+          </Dialog.Close>
+
+          <div className="flex items-center gap-2 mb-1">
+            <Sparkle size={14} className="text-brand" weight="fill" />
+            <Dialog.Title className="text-sm font-semibold text-text truncate">
+              Continue {documentName || "this part"} in Claude
+            </Dialog.Title>
+          </div>
+          <p className="text-[11px] text-text-muted leading-relaxed mb-4">
+            Hand this part to an AI you can talk to — it loads your exact
+            geometry and picks up where you left off.
+          </p>
+
+          {blocker && (
+            <div className="text-xs text-text-muted py-4">{blocker}</div>
+          )}
+
+          {!blocker && (
+            <div className="space-y-1.5">
+              {minting && !token && (
+                <div className="text-[11px] text-text-muted py-3">
+                  Preparing your handoff…
+                </div>
+              )}
+              {ordered.map((target) => {
+                const isCopyOnly = !target.url;
+                return (
+                  <button
+                    key={target.host}
+                    type="button"
+                    disabled={!token}
+                    onClick={() => runTarget(target)}
+                    className={cn(
+                      "w-full flex items-center gap-3 px-3 py-2 text-left",
+                      "border border-border bg-bg hover:border-brand hover:bg-hover",
+                      "transition-colors disabled:opacity-50 disabled:cursor-wait",
+                    )}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs font-medium text-text">
+                          {target.label}
+                        </span>
+                        {target.host === lastHost && (
+                          <span className="text-[9px] uppercase tracking-wide text-brand">
+                            Last used
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-[10px] text-text-muted/80 leading-snug mt-0.5">
+                        {target.hint}
+                      </div>
+                    </div>
+                    {copiedHost === target.host ? (
+                      <span className="text-[10px] text-brand">Copied</span>
+                    ) : isCopyOnly ? (
+                      <Copy size={13} className="text-text-muted shrink-0" />
+                    ) : (
+                      <ArrowSquareOut
+                        size={13}
+                        className="text-text-muted shrink-0"
+                      />
+                    )}
+                  </button>
+                );
+              })}
+              <p className="text-[10px] text-text-muted/70 leading-relaxed pt-2">
+                Adding the vcad connector is a one-time step. After that, every
+                handoff is one click.
+              </p>
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/app/src/components/ContinueDialog.tsx
+++ b/packages/app/src/components/ContinueDialog.tsx
@@ -14,9 +14,11 @@ import { useNotificationStore } from "@/stores/notification-store";
 import { loadDocument as loadStoredDocument } from "@/lib/storage";
 import {
   buildContinueTargets,
+  encodeDocForSeed,
   type ContinueTarget,
   type ContinueHost,
 } from "@/lib/continue-links";
+import { analytics } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 interface ContinueDialogProps {
@@ -46,21 +48,22 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
   const documentId = useDocumentStore((s) => s.documentId);
   const documentName = useDocumentStore((s) => s.documentName);
 
-  const [cloudId, setCloudId] = useState<string | null>(null);
-  const [cloudLookupDone, setCloudLookupDone] = useState(false);
   const [token, setToken] = useState<string | null>(null);
-  const [minting, setMinting] = useState(false);
+  const [inlineBlob, setInlineBlob] = useState<string | null>(null);
+  const [prepError, setPrepError] = useState<string | null>(null);
+  const [preparing, setPreparing] = useState(false);
   const [lastHost, setLastHost] = useState<ContinueHost | null>(null);
   const [copiedHost, setCopiedHost] = useState<ContinueHost | null>(null);
 
-  // Resolve cloudId + an existing-or-fresh share token when the dialog opens.
-  // The token is the capability the model resolves via `continue_document` —
-  // minting it here is what makes the first turn operate on the real part.
+  // Prepare the handoff when the dialog opens. Preferred path: a signed-in,
+  // cloud-synced doc → a durable share token the model resolves server-side (no
+  // size limit, persists at vcad.io). Fallback: an accountless inline handoff
+  // that compresses the live geometry into the seed itself.
   useEffect(() => {
-    if (!open || !documentId || !isSignedIn) {
-      setCloudLookupDone(false);
-      setCloudId(null);
+    if (!open || !documentId) {
       setToken(null);
+      setInlineBlob(null);
+      setPrepError(null);
       return;
     }
     try {
@@ -71,36 +74,48 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
     }
     let cancelled = false;
     (async () => {
-      setMinting(true);
+      setPreparing(true);
+      setPrepError(null);
       try {
-        const stored = await loadStoredDocument(documentId);
+        if (isSignedIn) {
+          const stored = await loadStoredDocument(documentId);
+          const cid = stored?.cloudId ?? null;
+          if (cid && !cancelled) {
+            // Reuse an existing share token, else mint one. Continue needs only
+            // the token (the capability) — it deliberately does NOT publish to
+            // the public /@user/slug profile, so there's no username picker.
+            const existing = await listSharesForDocument(cid);
+            if (cancelled) return;
+            const tok = existing[0]?.token ?? (await createShare(cid)).token;
+            if (!cancelled) {
+              setToken(tok);
+              setInlineBlob(null);
+            }
+            return;
+          }
+        }
+        // Accountless (or not-yet-synced) → inline handoff from the live IR.
+        const doc = useDocumentStore.getState().document;
+        const blob = await encodeDocForSeed(doc);
         if (cancelled) return;
-        const cid = stored?.cloudId ?? null;
-        setCloudId(cid);
-        setCloudLookupDone(true);
-        if (!cid) return;
-        // Reuse an existing share token if one exists, else mint one. Continue
-        // only needs the token (the capability) — it deliberately does NOT
-        // publish to the public /@user/slug profile, so there's no username
-        // picker in this flow.
-        const existing = await listSharesForDocument(cid);
-        if (cancelled) return;
-        if (existing.length > 0 && existing[0]) {
-          setToken(existing[0].token);
+        if (blob) {
+          setInlineBlob(blob);
+          setToken(null);
         } else {
-          const share = await createShare(cid);
-          if (!cancelled) setToken(share.token);
+          setPrepError(
+            "This part is too large for an accountless handoff. Sign in to " +
+              "continue it in Claude.",
+          );
         }
       } catch (err) {
-        console.error("[continue-dialog] mint failed:", err);
+        console.error("[continue-dialog] prepare failed:", err);
         if (!cancelled) {
-          setCloudLookupDone(true);
-          useNotificationStore
-            .getState()
-            .toast.error(`Couldn't prepare the handoff: ${(err as Error).message}`);
+          setPrepError(
+            `Couldn't prepare the handoff: ${(err as Error).message}`,
+          );
         }
       } finally {
-        if (!cancelled) setMinting(false);
+        if (!cancelled) setPreparing(false);
       }
     })();
     return () => {
@@ -135,6 +150,7 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
       }
       if (target.url) openLink(target.url);
       remember(target.host);
+      analytics.continueHandoff(target.host, token ? "token" : "inline");
 
       const msg = target.url
         ? needsCopy
@@ -143,18 +159,20 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
         : `Copied the install command + prompt for ${target.label}.`;
       useNotificationStore.getState().toast.success(msg);
     },
-    [remember],
+    [remember, token],
   );
 
-  const blocker: string | null = !isSignedIn
-    ? "Sign in to continue this part in Claude."
-    : cloudLookupDone && !cloudId
-      ? "Save this document to the cloud before continuing."
+  const mode: "token" | "inline" | null = token
+    ? "token"
+    : inlineBlob
+      ? "inline"
       : null;
 
   const targets = token
     ? buildContinueTargets({ token, docName: documentName || undefined })
-    : [];
+    : inlineBlob
+      ? buildContinueTargets({ inlineDoc: inlineBlob, docName: documentName || undefined })
+      : [];
   // Surface the last-used host first; Claude Desktop leads otherwise.
   const ordered = [...targets].sort((a, b) => {
     if (a.host === lastHost) return -1;
@@ -189,13 +207,13 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
             geometry and picks up where you left off.
           </p>
 
-          {blocker && (
-            <div className="text-xs text-text-muted py-4">{blocker}</div>
+          {prepError && (
+            <div className="text-xs text-text-muted py-4">{prepError}</div>
           )}
 
-          {!blocker && (
+          {!prepError && (
             <div className="space-y-1.5">
-              {minting && !token && (
+              {preparing && !mode && (
                 <div className="text-[11px] text-text-muted py-3">
                   Preparing your handoff…
                 </div>
@@ -242,6 +260,15 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
                   </button>
                 );
               })}
+              {mode === "inline" && (
+                <p className="text-[10px] text-text-muted/70 leading-relaxed pt-1">
+                  Handing off without an account.{" "}
+                  <span className="text-text-muted">
+                    Sign in to hand off larger parts and keep them in your
+                    account.
+                  </span>
+                </p>
+              )}
               <p className="text-[10px] text-text-muted/70 leading-relaxed pt-2">
                 Adding the vcad connector is a one-time step. After that, every
                 handoff is one click.

--- a/packages/app/src/components/ContinueDialog.tsx
+++ b/packages/app/src/components/ContinueDialog.tsx
@@ -19,6 +19,7 @@ import {
   type ContinueHost,
 } from "@/lib/continue-links";
 import { analytics } from "@/lib/analytics";
+import { useClaudeLiveStatus } from "@/hooks/useClaudeLiveStatus";
 import { cn } from "@/lib/utils";
 
 interface ContinueDialogProps {
@@ -54,6 +55,11 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
   const [preparing, setPreparing] = useState(false);
   const [lastHost, setLastHost] = useState<ContinueHost | null>(null);
   const [copiedHost, setCopiedHost] = useState<ContinueHost | null>(null);
+  const [launched, setLaunched] = useState(false);
+
+  // Once a signed-in (token) handoff is launched, reflect the model's edits to
+  // the continued session back into this tab — the "alive in both surfaces" beat.
+  const live = useClaudeLiveStatus(launched && token ? token : null);
 
   // Prepare the handoff when the dialog opens. Preferred path: a signed-in,
   // cloud-synced doc → a durable share token the model resolves server-side (no
@@ -64,8 +70,10 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
       setToken(null);
       setInlineBlob(null);
       setPrepError(null);
+      setLaunched(false);
       return;
     }
+    setLaunched(false);
     try {
       const stored = localStorage.getItem(LAST_HOST_KEY);
       if (stored) setLastHost(stored as ContinueHost);
@@ -151,6 +159,8 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
       if (target.url) openLink(target.url);
       remember(target.host);
       analytics.continueHandoff(target.host, token ? "token" : "inline");
+      // A token handoff has a durable row to watch — start reflecting edits.
+      if (token) setLaunched(true);
 
       const msg = target.url
         ? needsCopy
@@ -206,6 +216,22 @@ export function ContinueDialog({ open, onOpenChange }: ContinueDialogProps) {
             Hand this part to an AI you can talk to — it loads your exact
             geometry and picks up where you left off.
           </p>
+
+          {launched && mode === "token" && (
+            <div className="flex items-center gap-2 mb-4 px-2.5 py-1.5 rounded-md border border-brand/30 bg-brand/5">
+              <span
+                className={cn(
+                  "h-1.5 w-1.5 rounded-full shrink-0",
+                  live.live ? "bg-brand animate-pulse" : "bg-text-muted/50",
+                )}
+              />
+              <span className="text-[11px] text-text">
+                {live.live
+                  ? `Live in Claude · ${live.edits} edit${live.edits === 1 ? "" : "s"}`
+                  : "Waiting for Claude to pick it up…"}
+              </span>
+            </div>
+          )}
 
           {prepError && (
             <div className="text-xs text-text-muted py-4">{prepError}</div>

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -60,6 +60,9 @@ interface HeaderProps {
   onOpen: () => void;
   /** Opens the ShareDialog. Enabled only when signed in + cloud-synced. */
   onShareOpen: () => void;
+  /** Opens the ContinueDialog (hand off this part to Claude/ChatGPT/an editor).
+   *  Enabled only when signed in + cloud-synced. */
+  onContinueOpen: () => void;
   /** Opens the VersionHistoryModal. Enabled only when signed in. */
   onVersionHistoryOpen: () => void;
   /** Tool palette (tab strip + icon row) docked directly under the menu bar. */
@@ -357,7 +360,7 @@ function XRMenuItems() {
   );
 }
 
-export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen, onVersionHistoryOpen, children }: HeaderProps) {
+export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen, onContinueOpen, onVersionHistoryOpen, children }: HeaderProps) {
   const user = useAuthStore((s) => s.user);
   const isAnonymous = useAuthStore((s) => s.isAnonymous);
   // "Has a permanent identity" — false for anon Supabase sessions.
@@ -534,6 +537,14 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
                   disabled={!isSignedIn}
                 >
                   {t("menu.file.share_link")}
+                </MenuItem>
+                <MenuItem
+                  onSelect={onContinueOpen}
+                  icon={Sparkle}
+                  iconClassName="text-brand"
+                  disabled={!isSignedIn}
+                >
+                  {t("menu.file.continue_in_claude")}
                 </MenuItem>
                 <MenuItem
                   onSelect={onVersionHistoryOpen}

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -542,7 +542,6 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
                   onSelect={onContinueOpen}
                   icon={Sparkle}
                   iconClassName="text-brand"
-                  disabled={!isSignedIn}
                 >
                   {t("menu.file.continue_in_claude")}
                 </MenuItem>

--- a/packages/app/src/hooks/useClaudeLiveStatus.ts
+++ b/packages/app/src/hooks/useClaudeLiveStatus.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { getSupabase } from "@vcad/auth";
+import { continueSessionRowKey } from "@/lib/continue-links";
+
+export interface ClaudeLiveStatus {
+  /** True once the model's first edit to the continued session lands. */
+  live: boolean;
+  /** Number of edits observed since the handoff. */
+  edits: number;
+  /** Wall-clock ms of the most recent edit, or null. */
+  lastAt: number | null;
+}
+
+const IDLE: ClaudeLiveStatus = { live: false, edits: 0, lastAt: null };
+
+/**
+ * Reflect a signed-in "Continue in Claude" handoff back into the vcad.io tab.
+ *
+ * The model's continued session persists to the user's own `documents` row
+ * (`local_id = mcp:cont_<token>`); subscribing to Realtime changes on that row
+ * lets us show the part coming alive in Claude — each edit bumps the counter and
+ * pulses the badge. Owner RLS means we only ever see our own row.
+ *
+ * Pass `null` to disable (the inline/anon handoff has no durable row, and we
+ * only subscribe once the user actually launches a host). Requires `documents`
+ * in the supabase_realtime publication (migration 031).
+ */
+export function useClaudeLiveStatus(token: string | null): ClaudeLiveStatus {
+  const [status, setStatus] = useState<ClaudeLiveStatus>(IDLE);
+
+  useEffect(() => {
+    setStatus(IDLE);
+    if (!token) return;
+    const supabase = getSupabase();
+    if (!supabase) return;
+
+    const channel = supabase.channel(`continue-${token}`);
+    channel.on(
+      "postgres_changes" as never,
+      {
+        event: "*",
+        schema: "public",
+        table: "documents",
+        filter: `local_id=eq.${continueSessionRowKey(token)}`,
+      },
+      () => {
+        setStatus((s) => ({
+          live: true,
+          edits: s.edits + 1,
+          lastAt: Date.now(),
+        }));
+      },
+    );
+    channel.subscribe();
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [token]);
+
+  return status;
+}

--- a/packages/app/src/lib/analytics.ts
+++ b/packages/app/src/lib/analytics.ts
@@ -39,6 +39,11 @@ export const analytics = {
   printPanelOpened: () => ph?.capture("print_panel_opened"),
   quotePanelOpened: () => ph?.capture("quote_panel_opened"),
 
+  // "Continue in Claude" handoff — which host, and whether it was a signed-in
+  // (token) or accountless (inline) handoff.
+  continueHandoff: (host: string, mode: "token" | "inline") =>
+    ph?.capture("continue_handoff", { host, mode }),
+
   // Command registry — fired for every action triggered through
   // useAppCommands, regardless of which surface invoked it. Lets us see
   // which commands are actually used and whether users prefer the mobile

--- a/packages/app/src/lib/continue-links.ts
+++ b/packages/app/src/lib/continue-links.ts
@@ -1,0 +1,155 @@
+/**
+ * "Continue in Claude" host links.
+ *
+ * Pure builders for the deep links / commands that hand the user's current part
+ * off to an AI host. The part's geometry never rides the URL — only an opaque
+ * vcad.io share token (a UUID) does, which the model resolves server-side with
+ * the `continue_document` MCP tool.
+ *
+ * Host reality (verified June 2026 — keep this honest, it drives the UX):
+ *  - Claude Desktop: `claude://claude.ai/new?q=…` prefills a new chat (~14k cap).
+ *  - claude.ai web:  NO prompt-prefill URL (the `?q=` param was removed Oct 2025
+ *                    over a prompt-injection exploit) → open + copy-to-clipboard.
+ *  - ChatGPT:        `https://chatgpt.com/?q=…` prefills (and submits) a prompt.
+ *  - Cursor / VS Code: one-click MCP *install* deep links (no prompt) — the seed
+ *                    is copied for the user to paste once the connector is added.
+ *  - Claude Code:    a copyable `claude mcp add …` one-liner + the seed.
+ *
+ * No host installs the connector AND seeds a prompt in a single link, so the
+ * dialog pairs an action (open/install) with a copyable seed where needed.
+ */
+
+/** Canonical hosted MCP endpoint. Overridable for staging/self-host. */
+export const DEFAULT_MCP_URL = "https://mcp.vcad.io/mcp";
+
+export type ContinueHost =
+  | "claude-desktop"
+  | "claude-web"
+  | "chatgpt"
+  | "cursor"
+  | "vscode"
+  | "claude-code";
+
+export interface ContinueTarget {
+  host: ContinueHost;
+  /** Short label for the menu/button. */
+  label: string;
+  /** One-line hint shown under the option. */
+  hint: string;
+  /** A deep link / URL to open (custom scheme or https). Absent for copy-only. */
+  url?: string;
+  /** Text to put on the clipboard (seed prompt, or a CLI command). */
+  clipboard?: string;
+  /** When true, the URL should be opened AND the clipboard copied (the host
+   *  can't prefill, so the user pastes the seed after it opens). */
+  copyWithOpen?: boolean;
+}
+
+export interface ContinueLinksInput {
+  /** The vcad.io share token (UUID) the model will resolve. */
+  token: string;
+  /** Document name, woven into the seed for a friendlier first turn. */
+  docName?: string;
+  /** MCP endpoint to install; defaults to {@link DEFAULT_MCP_URL}. */
+  mcpUrl?: string;
+}
+
+/** Base64-encode a UTF-8 string. `btoa` is global in the browser and in the
+ *  Node ≥16 test runner; we route bytes through it via a binary string so
+ *  non-ASCII doc names survive. */
+function toBase64(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+/**
+ * The natural-language seed handed to a prompt host. Short by design — it
+ * carries the token, not the geometry, and tells the model exactly which tool
+ * to call so the user's first turn operates on their real part.
+ */
+export function buildSeedPrompt(token: string, docName?: string): string {
+  const subject = docName ? `my vcad part "${docName}"` : "my vcad part";
+  return (
+    `Continue ${subject}. Call the vcad \`continue_document\` tool with token ` +
+    `"${token}" to load it, then render it and tell me what you see. If the ` +
+    `vcad tool isn't available, walk me through adding the vcad connector.`
+  );
+}
+
+/** The MCP server config object a host's install link encodes. */
+function serverConfig(mcpUrl: string): { type: "http"; url: string } {
+  return { type: "http", url: mcpUrl };
+}
+
+/**
+ * Build every host target for a handoff. The dialog renders these; the caller
+ * decides which to surface (e.g. remembers the user's last pick).
+ */
+export function buildContinueTargets(
+  input: ContinueLinksInput,
+): ContinueTarget[] {
+  const mcpUrl = input.mcpUrl ?? DEFAULT_MCP_URL;
+  const seed = buildSeedPrompt(input.token, input.docName);
+  const q = encodeURIComponent(seed);
+
+  // Cursor: base64 server config + separate name param.
+  const cursorConfig = toBase64(JSON.stringify(serverConfig(mcpUrl)));
+  const cursorUrl =
+    `cursor://anysphere.cursor-deeplink/mcp/install?name=vcad&config=${cursorConfig}`;
+
+  // VS Code: URL-encoded JSON with the name inline (NOT base64 — different
+  // encoder from Cursor; a shared encoder would silently corrupt one of them).
+  const vscodeConfig = encodeURIComponent(
+    JSON.stringify({ name: "vcad", ...serverConfig(mcpUrl) }),
+  );
+  const vscodeUrl = `vscode:mcp/install?${vscodeConfig}`;
+
+  return [
+    {
+      host: "claude-desktop",
+      label: "Claude Desktop",
+      hint: "Opens a new chat with your part loaded.",
+      url: `claude://claude.ai/new?q=${q}`,
+    },
+    {
+      host: "claude-web",
+      label: "Claude (web)",
+      hint: "Opens claude.ai and copies the starter prompt to paste.",
+      url: "https://claude.ai/new",
+      clipboard: seed,
+      copyWithOpen: true,
+    },
+    {
+      host: "chatgpt",
+      label: "ChatGPT",
+      hint: "Opens ChatGPT with the starter prompt.",
+      url: `https://chatgpt.com/?q=${q}`,
+    },
+    {
+      host: "cursor",
+      label: "Cursor",
+      hint: "Installs the vcad connector; paste the copied prompt to start.",
+      url: cursorUrl,
+      clipboard: seed,
+      copyWithOpen: true,
+    },
+    {
+      host: "vscode",
+      label: "VS Code",
+      hint: "Installs the vcad connector; paste the copied prompt to start.",
+      url: vscodeUrl,
+      clipboard: seed,
+      copyWithOpen: true,
+    },
+    {
+      host: "claude-code",
+      label: "Claude Code",
+      hint: "Copies a one-line install command + starter prompt.",
+      clipboard:
+        `claude mcp add --transport http vcad ${mcpUrl}\n` +
+        `# then:\nclaude "${seed}"`,
+    },
+  ];
+}

--- a/packages/app/src/lib/continue-links.ts
+++ b/packages/app/src/lib/continue-links.ts
@@ -62,6 +62,17 @@ export interface ContinueLinksInput {
  *  fall back to a sign-in handoff. */
 export const MAX_INLINE_BLOB = 8000;
 
+/**
+ * The Supabase `documents.local_id` a signed-in token handoff persists under —
+ * the `mcp:` prefix plus the deterministic `cont_<token>` session id the server
+ * keys it by (see continue_document). The vcad.io tab watches this row over
+ * Realtime to reflect the model's edits live; must stay in lockstep with the
+ * server's keying.
+ */
+export function continueSessionRowKey(token: string): string {
+  return `mcp:cont_${token}`;
+}
+
 /** Base64-encode a UTF-8 string. `btoa` is global in the browser and in the
  *  Node ≥16 test runner; we route bytes through it via a binary string so
  *  non-ASCII doc names survive. */

--- a/packages/app/src/lib/continue-links.ts
+++ b/packages/app/src/lib/continue-links.ts
@@ -60,7 +60,7 @@ export interface ContinueLinksInput {
 function toBase64(s: string): string {
   const bytes = new TextEncoder().encode(s);
   let bin = "";
-  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  for (const b of bytes) bin += String.fromCharCode(b);
   return btoa(bin);
 }
 

--- a/packages/app/src/lib/continue-links.ts
+++ b/packages/app/src/lib/continue-links.ts
@@ -46,13 +46,21 @@ export interface ContinueTarget {
 }
 
 export interface ContinueLinksInput {
-  /** The vcad.io share token (UUID) the model will resolve. */
-  token: string;
+  /** The vcad.io share token (UUID) the model resolves (signed-in handoff). */
+  token?: string;
+  /** A compressed inline IR blob (from {@link encodeDocForSeed}) for an
+   *  accountless handoff. Supply this OR `token`. */
+  inlineDoc?: string;
   /** Document name, woven into the seed for a friendlier first turn. */
   docName?: string;
   /** MCP endpoint to install; defaults to {@link DEFAULT_MCP_URL}. */
   mcpUrl?: string;
 }
+
+/** Max compressed-IR blob we'll inline into a seed. Keeps a prefilled host URL
+ *  under the tightest cap (Claude Desktop ~14k, ChatGPT unknown). Larger parts
+ *  fall back to a sign-in handoff. */
+export const MAX_INLINE_BLOB = 8000;
 
 /** Base64-encode a UTF-8 string. `btoa` is global in the browser and in the
  *  Node ≥16 test runner; we route bytes through it via a binary string so
@@ -78,6 +86,37 @@ export function buildSeedPrompt(token: string, docName?: string): string {
   );
 }
 
+/**
+ * The inline-doc seed for an accountless handoff — the same shape as
+ * {@link buildSeedPrompt} but carrying the compressed geometry instead of a
+ * token (the model passes it to `continue_document` as `doc`).
+ */
+function buildInlineSeed(blob: string, docName?: string): string {
+  const subject = docName ? `my vcad part "${docName}"` : "my vcad part";
+  return (
+    `Continue ${subject}. Call the vcad \`continue_document\` tool with this ` +
+    `inline doc to load it, then render it and tell me what you see. If the ` +
+    `vcad tool isn't available, walk me through adding the vcad connector.\n\n` +
+    `doc="${blob}"`
+  );
+}
+
+/** Compress an IR document for an accountless inline handoff (gzip + base64url,
+ *  matching what `continue_document` decodes). Returns null when the result is
+ *  too large to ride a host URL safely — the caller falls back to sign-in. */
+export async function encodeDocForSeed(doc: unknown): Promise<string | null> {
+  const cs = new CompressionStream("gzip");
+  const stream = new Blob([JSON.stringify(doc)]).stream().pipeThrough(cs);
+  const buf = new Uint8Array(await new Response(stream).arrayBuffer());
+  let bin = "";
+  for (const b of buf) bin += String.fromCharCode(b);
+  const blob = btoa(bin)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  return blob.length > MAX_INLINE_BLOB ? null : blob;
+}
+
 /** The MCP server config object a host's install link encodes. */
 function serverConfig(mcpUrl: string): { type: "http"; url: string } {
   return { type: "http", url: mcpUrl };
@@ -91,7 +130,9 @@ export function buildContinueTargets(
   input: ContinueLinksInput,
 ): ContinueTarget[] {
   const mcpUrl = input.mcpUrl ?? DEFAULT_MCP_URL;
-  const seed = buildSeedPrompt(input.token, input.docName);
+  const seed = input.inlineDoc
+    ? buildInlineSeed(input.inlineDoc, input.docName)
+    : buildSeedPrompt(input.token ?? "", input.docName);
   const q = encodeURIComponent(seed);
 
   // Cursor: base64 server config + separate name param.

--- a/packages/app/src/test/continue-links.test.ts
+++ b/packages/app/src/test/continue-links.test.ts
@@ -62,7 +62,7 @@ describe("buildContinueTargets", () => {
         "cursor://anysphere.cursor-deeplink/mcp/install?name=vcad&config=",
       ),
     ).toBe(true);
-    const b64 = t.url!.split("config=")[1];
+    const b64 = t.url!.split("config=")[1]!;
     const cfg = JSON.parse(atob(b64));
     expect(cfg).toEqual({ type: "http", url: DEFAULT_MCP_URL });
   });
@@ -89,7 +89,7 @@ describe("buildContinueTargets", () => {
       token: TOKEN,
       mcpUrl: "https://staging.vcad.io/mcp",
     }).find((x) => x.host === "cursor")!;
-    const cfg = JSON.parse(atob(t.url!.split("config=")[1]));
+    const cfg = JSON.parse(atob(t.url!.split("config=")[1]!));
     expect(cfg.url).toBe("https://staging.vcad.io/mcp");
   });
 });

--- a/packages/app/src/test/continue-links.test.ts
+++ b/packages/app/src/test/continue-links.test.ts
@@ -3,6 +3,7 @@ import {
   buildContinueTargets,
   buildSeedPrompt,
   encodeDocForSeed,
+  continueSessionRowKey,
   MAX_INLINE_BLOB,
   DEFAULT_MCP_URL,
   type ContinueHost,
@@ -112,6 +113,12 @@ describe("buildContinueTargets", () => {
     }).find((x) => x.host === "cursor")!;
     const cfg = JSON.parse(atob(t.url!.split("config=")[1]!));
     expect(cfg.url).toBe("https://staging.vcad.io/mcp");
+  });
+});
+
+describe("continueSessionRowKey", () => {
+  it("matches the server's mcp:cont_<token> keying (rendezvous contract)", () => {
+    expect(continueSessionRowKey(TOKEN)).toBe(`mcp:cont_${TOKEN}`);
   });
 });
 

--- a/packages/app/src/test/continue-links.test.ts
+++ b/packages/app/src/test/continue-links.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildContinueTargets,
+  buildSeedPrompt,
+  DEFAULT_MCP_URL,
+  type ContinueHost,
+} from "../lib/continue-links";
+
+const TOKEN = "11111111-2222-3333-4444-555555555555";
+
+const byHost = (host: ContinueHost) => {
+  const t = buildContinueTargets({ token: TOKEN, docName: "Bracket" }).find(
+    (x) => x.host === host,
+  );
+  if (!t) throw new Error(`no target for ${host}`);
+  return t;
+};
+
+const qOf = (url: string) =>
+  decodeURIComponent(url.slice(url.indexOf("q=") + 2));
+
+describe("buildSeedPrompt", () => {
+  it("carries the token + tool name + doc name, never geometry", () => {
+    const seed = buildSeedPrompt(TOKEN, "Bracket");
+    expect(seed).toContain(TOKEN);
+    expect(seed).toContain("continue_document");
+    expect(seed).toContain("Bracket");
+    expect(seed.length).toBeLessThan(600); // stays well under any URL cap
+  });
+
+  it("degrades gracefully without a doc name", () => {
+    expect(buildSeedPrompt(TOKEN)).toContain("my vcad part");
+  });
+});
+
+describe("buildContinueTargets", () => {
+  it("Claude Desktop uses the claude:// scheme and prefills the seed", () => {
+    const t = byHost("claude-desktop");
+    expect(t.url?.startsWith("claude://claude.ai/new?q=")).toBe(true);
+    expect(qOf(t.url!)).toBe(buildSeedPrompt(TOKEN, "Bracket"));
+    expect(t.copyWithOpen).toBeFalsy();
+  });
+
+  it("claude.ai web has no prefill — opens + copies the seed", () => {
+    const t = byHost("claude-web");
+    expect(t.url).toBe("https://claude.ai/new");
+    expect(t.url).not.toContain("q=");
+    expect(t.clipboard).toBe(buildSeedPrompt(TOKEN, "Bracket"));
+    expect(t.copyWithOpen).toBe(true);
+  });
+
+  it("ChatGPT prefills via chatgpt.com/?q=", () => {
+    const t = byHost("chatgpt");
+    expect(t.url?.startsWith("https://chatgpt.com/?q=")).toBe(true);
+    expect(qOf(t.url!)).toBe(buildSeedPrompt(TOKEN, "Bracket"));
+  });
+
+  it("Cursor encodes a base64 server config + name param", () => {
+    const t = byHost("cursor");
+    expect(
+      t.url?.startsWith(
+        "cursor://anysphere.cursor-deeplink/mcp/install?name=vcad&config=",
+      ),
+    ).toBe(true);
+    const b64 = t.url!.split("config=")[1];
+    const cfg = JSON.parse(atob(b64));
+    expect(cfg).toEqual({ type: "http", url: DEFAULT_MCP_URL });
+  });
+
+  it("VS Code URL-encodes JSON with name inline (not base64)", () => {
+    const t = byHost("vscode");
+    expect(t.url?.startsWith("vscode:mcp/install?")).toBe(true);
+    const cfg = JSON.parse(
+      decodeURIComponent(t.url!.slice("vscode:mcp/install?".length)),
+    );
+    expect(cfg).toEqual({ name: "vcad", type: "http", url: DEFAULT_MCP_URL });
+  });
+
+  it("Claude Code is a copyable install command + seed (no url)", () => {
+    const t = byHost("claude-code");
+    expect(t.url).toBeUndefined();
+    expect(t.clipboard).toContain("claude mcp add --transport http vcad");
+    expect(t.clipboard).toContain(DEFAULT_MCP_URL);
+    expect(t.clipboard).toContain(TOKEN);
+  });
+
+  it("honors a custom mcpUrl override", () => {
+    const t = buildContinueTargets({
+      token: TOKEN,
+      mcpUrl: "https://staging.vcad.io/mcp",
+    }).find((x) => x.host === "cursor")!;
+    const cfg = JSON.parse(atob(t.url!.split("config=")[1]));
+    expect(cfg.url).toBe("https://staging.vcad.io/mcp");
+  });
+});

--- a/packages/app/src/test/continue-links.test.ts
+++ b/packages/app/src/test/continue-links.test.ts
@@ -2,11 +2,22 @@ import { describe, it, expect } from "vitest";
 import {
   buildContinueTargets,
   buildSeedPrompt,
+  encodeDocForSeed,
+  MAX_INLINE_BLOB,
   DEFAULT_MCP_URL,
   type ContinueHost,
 } from "../lib/continue-links";
 
 const TOKEN = "11111111-2222-3333-4444-555555555555";
+
+/** Decode a base64url gzip blob using only Web APIs (no node deps). */
+async function decodeBlob(blob: string): Promise<string> {
+  const b64 = blob.replace(/-/g, "+").replace(/_/g, "/");
+  const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+  const ds = new DecompressionStream("gzip");
+  const stream = new Blob([bytes]).stream().pipeThrough(ds);
+  return new Response(stream).text();
+}
 
 const byHost = (host: ContinueHost) => {
   const t = buildContinueTargets({ token: TOKEN, docName: "Bracket" }).find(
@@ -84,6 +95,16 @@ describe("buildContinueTargets", () => {
     expect(t.clipboard).toContain(TOKEN);
   });
 
+  it("inlineDoc builds a seed embedding the blob, with no token", () => {
+    const t = buildContinueTargets({
+      inlineDoc: "BLOB123",
+      docName: "Bracket",
+    }).find((x) => x.host === "claude-desktop")!;
+    const seed = decodeURIComponent(t.url!.slice(t.url!.indexOf("q=") + 2));
+    expect(seed).toContain('doc="BLOB123"');
+    expect(seed).not.toContain(TOKEN);
+  });
+
   it("honors a custom mcpUrl override", () => {
     const t = buildContinueTargets({
       token: TOKEN,
@@ -91,5 +112,30 @@ describe("buildContinueTargets", () => {
     }).find((x) => x.host === "cursor")!;
     const cfg = JSON.parse(atob(t.url!.split("config=")[1]!));
     expect(cfg.url).toBe("https://staging.vcad.io/mcp");
+  });
+});
+
+describe("encodeDocForSeed", () => {
+  it("round-trips an IR doc through gzip + base64url", async () => {
+    const doc = { version: 1, nodes: {}, roots: ["n1"] };
+    const blob = await encodeDocForSeed(doc);
+    expect(blob).toBeTruthy();
+    expect(blob).toMatch(/^[A-Za-z0-9_-]+$/); // base64url, no padding
+    expect(JSON.parse(await decodeBlob(blob!))).toEqual(doc);
+  });
+
+  it("returns null when the part is too large to inline", async () => {
+    // A doc whose compressed form blows past MAX_INLINE_BLOB. Random-ish keys
+    // resist gzip so the blob actually exceeds the cap.
+    const nodes: Record<string, unknown> = {};
+    for (let i = 0; i < 4000; i++) {
+      nodes[`node_${i}_${(i * 2654435761) % 1e9}`] = {
+        op: "cube",
+        size: [i % 97, (i * 7) % 89, (i * 13) % 83],
+      };
+    }
+    const blob = await encodeDocForSeed({ version: 1, nodes, roots: [] });
+    expect(blob).toBeNull();
+    expect(MAX_INLINE_BLOB).toBeGreaterThan(0);
   });
 });

--- a/packages/core/src/i18n/translations.ts
+++ b/packages/core/src/i18n/translations.ts
@@ -778,6 +778,7 @@ export const translations = {
     "menu.file.open": "Open…",
     "menu.file.save": "Save",
     "menu.file.share_link": "Share link…",
+    "menu.file.continue_in_claude": "Continue in Claude…",
     "menu.file.version_history": "Version history…",
     "menu.file.export": "Export",
     "menu.file.export_stl": "Export STL",

--- a/packages/mcp/src/__tests__/continue-doc.test.ts
+++ b/packages/mcp/src/__tests__/continue-doc.test.ts
@@ -121,4 +121,43 @@ describe("continueDocument", () => {
     expect(r.isError).toBe(true);
     expect(r.content[0].text).toMatch(/Continue in Claude/);
   });
+
+  it("is idempotent on the token: re-open reuses the same session (one fetch)", async () => {
+    let fetches = 0;
+    setSessionFetch((async () => {
+      fetches++;
+      return jsonResp([
+        { name: "Bracket", content: { version: 1, nodes: {}, roots: ["n1"] } },
+      ]);
+    }) as unknown as typeof fetch);
+    const r1 = await continueDocument({ token: UUID });
+    const r2 = await continueDocument({ token: UUID });
+    const id1 = json(r1).document_id;
+    const id2 = json(r2).document_id;
+    expect(id1).toBe(`cont_${UUID}`); // deterministic rendezvous key
+    expect(id2).toBe(id1);
+    expect(fetches).toBe(1); // the re-open is served from the warm cache
+  });
+
+  it("rehydrates a durable session before re-fetching the share (cold instance)", async () => {
+    let fetched = false;
+    setSessionFetch((() => {
+      fetched = true;
+      throw new Error("cold re-open must prefer the durable session");
+    }) as unknown as typeof fetch);
+    const store = {
+      load: async (id: string) =>
+        id === `cont_${UUID}`
+          ? ({ version: 1, nodes: {}, roots: ["a", "b", "c"] } as never)
+          : null,
+      save: async () => {},
+      drop: async () => {},
+    };
+    const r = await continueDocument({ token: UUID }, store);
+    expect(r.isError).toBeFalsy();
+    const out = json(r);
+    expect(out.document_id).toBe(`cont_${UUID}`);
+    expect(out.parts).toBe(3); // came from the durable session, not the share
+    expect(fetched).toBe(false);
+  });
 });

--- a/packages/mcp/src/__tests__/continue-doc.test.ts
+++ b/packages/mcp/src/__tests__/continue-doc.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { resolveShareToken, setSessionFetch } from "../session-store.js";
+import { continueDocument } from "../tools/continue-doc.js";
+import { documents } from "../tools/session.js";
+
+const UUID = "11111111-2222-3333-4444-555555555555";
+const json = (r: { content: Array<{ text: string }> }) =>
+  JSON.parse(r.content[0].text);
+const jsonResp = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+const origUrl = process.env.SUPABASE_URL;
+const origKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = "https://supa.test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+  documents.clear();
+});
+
+afterEach(() => {
+  setSessionFetch(((...a: Parameters<typeof fetch>) => fetch(...a)) as typeof fetch);
+  if (origUrl === undefined) delete process.env.SUPABASE_URL;
+  else process.env.SUPABASE_URL = origUrl;
+  if (origKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  else process.env.SUPABASE_SERVICE_ROLE_KEY = origKey;
+});
+
+describe("resolveShareToken", () => {
+  it("returns null without Supabase env", async () => {
+    delete process.env.SUPABASE_URL;
+    expect(await resolveShareToken(UUID)).toBeNull();
+  });
+
+  it("returns null for a non-uuid token (never hits the network)", async () => {
+    let called = false;
+    setSessionFetch((() => {
+      called = true;
+      throw new Error("should not fetch");
+    }) as unknown as typeof fetch);
+    expect(await resolveShareToken("not-a-uuid")).toBeNull();
+    expect(called).toBe(false);
+  });
+
+  it("parses the get_shared_document RPC row", async () => {
+    setSessionFetch((async (input: unknown, init: RequestInit = {}) => {
+      expect(String(input)).toContain("/rest/v1/rpc/get_shared_document");
+      expect(JSON.parse(String(init.body))).toEqual({ p_token: UUID });
+      return jsonResp([{ name: "Bracket", content: { nodes: {}, roots: ["n1"] } }]);
+    }) as unknown as typeof fetch);
+    const r = await resolveShareToken(UUID);
+    expect(r?.name).toBe("Bracket");
+    expect(r?.content).toEqual({ nodes: {}, roots: ["n1"] });
+  });
+
+  it("returns null when the token resolves to no rows", async () => {
+    setSessionFetch((async () => jsonResp([])) as unknown as typeof fetch);
+    expect(await resolveShareToken(UUID)).toBeNull();
+  });
+});
+
+describe("continueDocument", () => {
+  it("errors on a missing token", async () => {
+    const r = await continueDocument({});
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/requires a `token`/);
+  });
+
+  it("errors with a re-share hint on an unknown token", async () => {
+    setSessionFetch((async () => jsonResp([])) as unknown as typeof fetch);
+    const r = await continueDocument({ token: UUID });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/Continue in Claude/);
+  });
+
+  it("opens a session from raw-IR share content (no WASM needed)", async () => {
+    setSessionFetch((async () =>
+      jsonResp([
+        { name: "Bracket", content: { version: 1, nodes: {}, roots: ["n1"] } },
+      ])) as unknown as typeof fetch);
+    const r = await continueDocument({ token: UUID });
+    expect(r.isError).toBeFalsy();
+    const out = json(r);
+    expect(typeof out.document_id).toBe("string");
+    expect(out.parts).toBe(1);
+    expect(out.name).toBe("Bracket");
+    // The session is registered and resolvable for subsequent tool calls.
+    expect(documents.has(out.document_id)).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/continue-doc.test.ts
+++ b/packages/mcp/src/__tests__/continue-doc.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { gzipSync } from "node:zlib";
 import { resolveShareToken, setSessionFetch } from "../session-store.js";
 import { continueDocument } from "../tools/continue-doc.js";
 import { documents } from "../tools/session.js";
+
+/** gzip + base64url, mirroring the web app's inline-doc encoder. */
+function encodeInline(obj: unknown): string {
+  return gzipSync(Buffer.from(JSON.stringify(obj), "utf-8"))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
 
 const UUID = "11111111-2222-3333-4444-555555555555";
 const json = (r: { content: Array<{ text: string }> }) =>
@@ -89,5 +99,26 @@ describe("continueDocument", () => {
     expect(out.name).toBe("Bracket");
     // The session is registered and resolvable for subsequent tool calls.
     expect(documents.has(out.document_id)).toBe(true);
+  });
+
+  it("opens a session from an inline `doc` handoff (anon path, no network)", async () => {
+    let fetched = false;
+    setSessionFetch((() => {
+      fetched = true;
+      throw new Error("inline path must not hit the network");
+    }) as unknown as typeof fetch);
+    const blob = encodeInline({ version: 1, nodes: {}, roots: ["a", "b"] });
+    const r = await continueDocument({ doc: blob });
+    expect(r.isError).toBeFalsy();
+    const out = json(r);
+    expect(out.parts).toBe(2);
+    expect(documents.has(out.document_id)).toBe(true);
+    expect(fetched).toBe(false);
+  });
+
+  it("errors with a re-share hint on a corrupt inline `doc`", async () => {
+    const r = await continueDocument({ doc: "not-valid-gzip-base64" });
+    expect(r.isError).toBe(true);
+    expect(r.content[0].text).toMatch(/Continue in Claude/);
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1804,7 +1804,7 @@ export async function createServer(
           break;
 
         case "continue_document":
-          result = await continueDocument(args);
+          result = await continueDocument(args, sessionStore);
           break;
 
         case "server_info":

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -745,11 +745,21 @@ export async function createServer(
         name: "continue_document",
         description:
           "Open the user's vcad.io part as an editing session from a 'Continue " +
-          "in Claude' handoff token. The web app hands you this token in the " +
-          "starter prompt; call this first, then render_view it and continue the " +
-          "user's work. Returns a `document_id` for subsequent tool calls. The " +
-          "geometry is fetched server-side from the share token — never paste it.",
+          "in Claude' handoff (a share `token`, or an inline `doc` for accountless " +
+          "handoffs). The web app hands you this in the starter prompt; call this " +
+          "first, then render_view it and continue the user's work. Returns a " +
+          "`document_id` for subsequent tool calls. The geometry is fetched " +
+          "server-side — never paste it.",
         inputSchema: continueDocumentSchema,
+        // Directory-ready hints: read-only intent (it opens, never mutates the
+        // source doc), and it reaches the network to resolve the handoff.
+        annotations: {
+          title: "Continue from vcad.io",
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: false,
+          openWorldHint: true,
+        },
         _meta: UI_META,
       },
       {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -45,6 +45,10 @@ import {
   runInSessionScope,
 } from "./tools/session.js";
 import {
+  continueDocument,
+  continueDocumentSchema,
+} from "./tools/continue-doc.js";
+import {
   createSessionStore,
   createSessionEventStore,
   createShareStore,
@@ -333,6 +337,9 @@ const GEOMETRY_TOOLS = new Set([
   "import_step",
   "open_document",
   "get_document",
+  // Opens a web doc (from a "Continue in Claude" share token) as a live session
+  // seeded with its geometry — render it like open_document/load_document.
+  "continue_document",
   "place_part",
   "set_material",
   "dfm_apply_fix",
@@ -369,6 +376,9 @@ const SWITCH_DOC_WRITERS = new Set<string>([
   "import_step",
   "create_schematic",
   "sheet_metal_create",
+  // Seeds a new session from a web doc's geometry — persist it to the user's
+  // account so the continued part survives a cold instance and shows at vcad.io.
+  "continue_document",
   // load_document materializes a saved board into a live session; its
   // local-disk read is a no-op on the serverless deploy, but on success
   // persisting the loaded doc to the user's account is desirable.
@@ -729,6 +739,17 @@ export async function createServer(
           "its new document_id. The cheap way to resume a board/part across runs " +
           "instead of rebuilding it.",
         inputSchema: loadDocumentSchema,
+        _meta: UI_META,
+      },
+      {
+        name: "continue_document",
+        description:
+          "Open the user's vcad.io part as an editing session from a 'Continue " +
+          "in Claude' handoff token. The web app hands you this token in the " +
+          "starter prompt; call this first, then render_view it and continue the " +
+          "user's work. Returns a `document_id` for subsequent tool calls. The " +
+          "geometry is fetched server-side from the share token — never paste it.",
+        inputSchema: continueDocumentSchema,
         _meta: UI_META,
       },
       {
@@ -1770,6 +1791,10 @@ export async function createServer(
 
         case "load_document":
           result = loadDocument(args);
+          break;
+
+        case "continue_document":
+          result = await continueDocument(args);
           break;
 
         case "server_info":

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -264,6 +264,59 @@ export class AnonSupabaseSessionStore implements SessionStore {
   }
 }
 
+/**
+ * Resolve a public share token (`document_shares.token`) to its cloud document
+ * content + name, via the `get_shared_document` SECURITY DEFINER RPC — the same
+ * path the web app's `fetchSharedDocument` uses. This is the server side of the
+ * "Continue in Claude" handoff: the browser mints a share token for the part the
+ * user is looking at, and `continue_document` resolves it here. Service-role
+ * keyed (the RPC is granted to anon/authenticated, but we already hold the key
+ * and it avoids spinning a second client). Returns null on miss / invalid token
+ * / no env.
+ *
+ * `content` is the RAW stored content — a CRDT state blob (`{replica_id, ops}`),
+ * a raw IR Document (`{nodes, roots}`), or a loon envelope — so the caller
+ * materializes it to IR (CRDT needs the kernel engine).
+ */
+export async function resolveShareToken(
+  token: string,
+): Promise<{ content: unknown; name: string } | null> {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  if (!url || !key) return null;
+  // The RPC param is typed `uuid`; a non-uuid token 400s. Cheap guard so a
+  // malformed handoff degrades to a clean miss, not a logged PostgREST error.
+  if (
+    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(token)
+  ) {
+    return null;
+  }
+  try {
+    const res = await sessionFetch(`${url}/rest/v1/rpc/get_shared_document`, {
+      method: "POST",
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ p_token: token }),
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as
+      | Array<{ name?: string; content?: unknown }>
+      | { name?: string; content?: unknown };
+    const row = Array.isArray(body) ? body[0] : body;
+    if (!row || row.content == null) return null;
+    return {
+      content: row.content,
+      name: typeof row.name === "string" ? row.name : "Shared document",
+    };
+  } catch (err) {
+    console.error("[session-store] resolveShareToken failed:", err);
+    return null;
+  }
+}
+
 /** True when `content` looks like a raw Document IR (has nodes + roots). */
 function looksLikeDocument(content: unknown): content is Document {
   return (

--- a/packages/mcp/src/tools/continue-doc.ts
+++ b/packages/mcp/src/tools/continue-doc.ts
@@ -20,8 +20,9 @@ import { getKernelWasm } from "@vcad/engine";
 import { fromVCode } from "@vcad/ir";
 import type { Document } from "@vcad/ir";
 import { gunzipSync } from "node:zlib";
+import type { SessionStore } from "../session-store.js";
 import { resolveShareToken } from "../session-store.js";
-import { registerSession } from "./session.js";
+import { documents, registerSession } from "./session.js";
 
 export const continueDocumentSchema = {
   type: "object" as const,
@@ -50,6 +51,26 @@ type ToolText = {
 
 function err(text: string): ToolText {
   return { isError: true, content: [{ type: "text", text }] };
+}
+
+/** The success payload: the session handle plus a nudge toward the verify loop
+ *  (render it, then leave a re-runnable Receipt for any claim). */
+function ok(id: string, doc: Document, name: string): ToolText {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          document_id: id,
+          parts: doc.roots?.length ?? 0,
+          name,
+          hint:
+            "Render with render_view, then continue the user's work. Leave a " +
+            "re-runnable proof of any claim with verify_part / build_receipt.",
+        }),
+      },
+    ],
+  };
 }
 
 function looksLikeIr(c: unknown): c is Document {
@@ -108,6 +129,7 @@ async function materialize(content: unknown): Promise<Document | null> {
 
 export async function continueDocument(
   args: Record<string, unknown>,
+  store?: SessionStore,
 ): Promise<ToolText> {
   const token = String(args.token ?? "").trim();
   const inlineDoc = String(args.doc ?? "").trim();
@@ -118,10 +140,27 @@ export async function continueDocument(
     );
   }
 
-  // Resolve the raw content + a display name from whichever source was given.
-  let content: unknown;
-  let name = "Shared part";
+  // ── Signed-in handoff: a deterministic, idempotent session keyed off the
+  // token. A re-click — or a re-open on a cold serverless instance — reuses the
+  // SAME session, so the Living Viewport accretes in place, any in-progress
+  // edits survive, and the vcad.io tab can subscribe to this session's durable
+  // row (`mcp:cont_<token>`) by a key it already knows. The token is an
+  // unguessable UUID, so the derived id stays capability-safe.
   if (token) {
+    const id = `cont_${token}`;
+    // Warm cache → reuse as-is (preserves the model's edits this session).
+    const cached = documents.get(id);
+    if (cached) return ok(id, cached, "Shared part");
+    // Cold instance → rehydrate the durable session before falling back to the
+    // (older) shared snapshot, so edits aren't lost across an instance flip.
+    if (store) {
+      const existing = await store.load(id);
+      if (existing) {
+        documents.set(id, existing);
+        return ok(id, existing, "Shared part");
+      }
+    }
+    // First open → materialize from the share snapshot.
     const resolved = await resolveShareToken(token);
     if (!resolved) {
       return err(
@@ -129,19 +168,35 @@ export async function continueDocument(
           `"Continue in Claude" again from vcad.io to mint a fresh handoff link.`,
       );
     }
-    content = resolved.content;
-    name = resolved.name;
-  } else {
+    let doc: Document | null;
     try {
-      content = decodeInlineDoc(inlineDoc);
+      doc = await materialize(resolved.content);
     } catch (e) {
       return err(
-        `Couldn't read the inline handoff: ${(e as Error).message}. ` +
-          `Ask the user to click "Continue in Claude" again from vcad.io.`,
+        `Could not open the shared document: ${(e as Error).message}. ` +
+          `Ask the user to re-share from vcad.io.`,
       );
     }
+    if (!doc) {
+      return err(
+        "The shared document is in a format this build can't open yet " +
+          "(expected CRDT or IR content).",
+      );
+    }
+    documents.set(id, doc);
+    return ok(id, doc, resolved.name);
   }
 
+  // ── Accountless inline handoff: no stable key, so a fresh session id.
+  let content: unknown;
+  try {
+    content = decodeInlineDoc(inlineDoc);
+  } catch (e) {
+    return err(
+      `Couldn't read the inline handoff: ${(e as Error).message}. ` +
+        `Ask the user to click "Continue in Claude" again from vcad.io.`,
+    );
+  }
   let doc: Document | null;
   try {
     doc = await materialize(content);
@@ -157,18 +212,5 @@ export async function continueDocument(
         "(expected CRDT or IR content).",
     );
   }
-
-  const id = registerSession(doc);
-  return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({
-          document_id: id,
-          parts: doc.roots?.length ?? 0,
-          name,
-        }),
-      },
-    ],
-  };
+  return ok(registerSession(doc), doc, "Shared part");
 }

--- a/packages/mcp/src/tools/continue-doc.ts
+++ b/packages/mcp/src/tools/continue-doc.ts
@@ -17,7 +17,9 @@
  * separate live-mitosis path.)
  */
 import { getKernelWasm } from "@vcad/engine";
+import { fromVCode } from "@vcad/ir";
 import type { Document } from "@vcad/ir";
+import { gunzipSync } from "node:zlib";
 import { resolveShareToken } from "../session-store.js";
 import { registerSession } from "./session.js";
 
@@ -28,11 +30,17 @@ export const continueDocumentSchema = {
       type: "string" as const,
       description:
         "The vcad.io share token from a 'Continue in Claude' handoff (a UUID). " +
-        "Opens the user's current part as an editing session you can render, " +
-        "measure, and continue.",
+        "Opens the signed-in user's current part as an editing session you can " +
+        "render, measure, and continue.",
+    },
+    doc: {
+      type: "string" as const,
+      description:
+        "An inline, compressed document handoff (gzip + base64url of the IR), " +
+        "used when the part was handed off without a cloud account. Supply " +
+        "either `token` or `doc`.",
     },
   },
-  required: ["token"],
 };
 
 type ToolText = {
@@ -60,6 +68,18 @@ function looksLikeCrdt(c: unknown): boolean {
     "replica_id" in (c as object) &&
     Array.isArray((c as { ops?: unknown }).ops)
   );
+}
+
+/** Decode an inline `doc` handoff (gzip + base64url of VCode or IR JSON) into
+ *  raw content for {@link materialize}. Mirrors the encoding open_in_browser /
+ *  the web app produce. Throws on a corrupt blob — the caller turns that into a
+ *  re-share hint. */
+function decodeInlineDoc(blob: string): unknown {
+  const b64 = blob.replace(/-/g, "+").replace(/_/g, "/");
+  const buf = Buffer.from(b64, "base64");
+  const text = gunzipSync(buf).toString("utf-8").trim();
+  // The web app gzips raw IR JSON; open_in_browser may emit VCode (`#…`).
+  return text.startsWith("#") ? fromVCode(text) : JSON.parse(text);
 }
 
 /** Materialize raw cloud `content` into an IR Document. Returns null for shapes
@@ -90,24 +110,41 @@ export async function continueDocument(
   args: Record<string, unknown>,
 ): Promise<ToolText> {
   const token = String(args.token ?? "").trim();
-  if (!token) {
+  const inlineDoc = String(args.doc ?? "").trim();
+  if (!token && !inlineDoc) {
     return err(
-      "continue_document requires a `token` — the vcad.io share token from the " +
-        "Continue in Claude handoff.",
+      "continue_document requires a `token` (a vcad.io share token) or an " +
+        "inline `doc` from the Continue in Claude handoff.",
     );
   }
 
-  const resolved = await resolveShareToken(token);
-  if (!resolved) {
-    return err(
-      `No shared document for token "${token}". Ask the user to click ` +
-        `"Continue in Claude" again from vcad.io to mint a fresh handoff link.`,
-    );
+  // Resolve the raw content + a display name from whichever source was given.
+  let content: unknown;
+  let name = "Shared part";
+  if (token) {
+    const resolved = await resolveShareToken(token);
+    if (!resolved) {
+      return err(
+        `No shared document for token "${token}". Ask the user to click ` +
+          `"Continue in Claude" again from vcad.io to mint a fresh handoff link.`,
+      );
+    }
+    content = resolved.content;
+    name = resolved.name;
+  } else {
+    try {
+      content = decodeInlineDoc(inlineDoc);
+    } catch (e) {
+      return err(
+        `Couldn't read the inline handoff: ${(e as Error).message}. ` +
+          `Ask the user to click "Continue in Claude" again from vcad.io.`,
+      );
+    }
   }
 
   let doc: Document | null;
   try {
-    doc = await materialize(resolved.content);
+    doc = await materialize(content);
   } catch (e) {
     return err(
       `Could not open the shared document: ${(e as Error).message}. ` +
@@ -129,7 +166,7 @@ export async function continueDocument(
         text: JSON.stringify({
           document_id: id,
           parts: doc.roots?.length ?? 0,
-          name: resolved.name,
+          name,
         }),
       },
     ],

--- a/packages/mcp/src/tools/continue-doc.ts
+++ b/packages/mcp/src/tools/continue-doc.ts
@@ -1,0 +1,137 @@
+/**
+ * continue_document — open an MCP editing session from a vcad.io web document's
+ * public share token. The server side of the web app's "Continue in Claude"
+ * handoff: the browser mints a share token for the part the user is looking at,
+ * hands it to the model in the seed prompt, and the model calls this tool. The
+ * geometry never rides the URL — only the opaque token does.
+ *
+ * The web doc's canonical stored content is CRDT state (`{replica_id, ops}`),
+ * which has no pre-materialized IR, so we materialize it through the kernel
+ * engine's `WasmDocumentEngine.load()` — the same engine `render_view` already
+ * boots. Raw-IR content (an MCP-authored or legacy doc) is passed through.
+ *
+ * The opened session is a NEW `mcp:`-keyed session seeded from the web doc's
+ * geometry — continuation in Claude is its own session, exactly like every other
+ * MCP-authored document, so it renders at vcad.io without colliding with the
+ * original web row. (Streaming edits back into the *same* open web tab is the
+ * separate live-mitosis path.)
+ */
+import { getKernelWasm } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { resolveShareToken } from "../session-store.js";
+import { registerSession } from "./session.js";
+
+export const continueDocumentSchema = {
+  type: "object" as const,
+  properties: {
+    token: {
+      type: "string" as const,
+      description:
+        "The vcad.io share token from a 'Continue in Claude' handoff (a UUID). " +
+        "Opens the user's current part as an editing session you can render, " +
+        "measure, and continue.",
+    },
+  },
+  required: ["token"],
+};
+
+type ToolText = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function err(text: string): ToolText {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
+function looksLikeIr(c: unknown): c is Document {
+  return (
+    !!c &&
+    typeof c === "object" &&
+    "nodes" in (c as object) &&
+    "roots" in (c as object)
+  );
+}
+
+function looksLikeCrdt(c: unknown): boolean {
+  return (
+    !!c &&
+    typeof c === "object" &&
+    "replica_id" in (c as object) &&
+    Array.isArray((c as { ops?: unknown }).ops)
+  );
+}
+
+/** Materialize raw cloud `content` into an IR Document. Returns null for shapes
+ *  this build can't open (e.g. loon-only, or CRDT when the engine is absent). */
+async function materialize(content: unknown): Promise<Document | null> {
+  // Already IR — defensive copy so the caller can't mutate a shared reference.
+  if (looksLikeIr(content)) {
+    return JSON.parse(JSON.stringify(content)) as Document;
+  }
+  if (looksLikeCrdt(content)) {
+    const wasm = (await getKernelWasm()) as unknown as {
+      WasmDocumentEngine?: {
+        load(bytes: Uint8Array): { get_document_json(): string };
+      };
+    };
+    const Engine = wasm?.WasmDocumentEngine;
+    if (!Engine) return null;
+    // The web app stores CRDT as JSON; `crdtBytes` is its UTF-8 encoding
+    // (see cloudContentToVcadFile). Mirror that so `load()` accepts it.
+    const bytes = new TextEncoder().encode(JSON.stringify(content));
+    const engine = Engine.load(bytes);
+    return JSON.parse(engine.get_document_json()) as Document;
+  }
+  return null;
+}
+
+export async function continueDocument(
+  args: Record<string, unknown>,
+): Promise<ToolText> {
+  const token = String(args.token ?? "").trim();
+  if (!token) {
+    return err(
+      "continue_document requires a `token` — the vcad.io share token from the " +
+        "Continue in Claude handoff.",
+    );
+  }
+
+  const resolved = await resolveShareToken(token);
+  if (!resolved) {
+    return err(
+      `No shared document for token "${token}". Ask the user to click ` +
+        `"Continue in Claude" again from vcad.io to mint a fresh handoff link.`,
+    );
+  }
+
+  let doc: Document | null;
+  try {
+    doc = await materialize(resolved.content);
+  } catch (e) {
+    return err(
+      `Could not open the shared document: ${(e as Error).message}. ` +
+        `Ask the user to re-share from vcad.io.`,
+    );
+  }
+  if (!doc) {
+    return err(
+      "The shared document is in a format this build can't open yet " +
+        "(expected CRDT or IR content).",
+    );
+  }
+
+  const id = registerSession(doc);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          document_id: id,
+          parts: doc.roots?.length ?? 0,
+          name: resolved.name,
+        }),
+      },
+    ],
+  };
+}

--- a/supabase/migrations/031_documents_realtime.sql
+++ b/supabase/migrations/031_documents_realtime.sql
@@ -1,0 +1,27 @@
+-- Live "Continue in Claude" reflection.
+--
+-- When a signed-in user hands a part off to Claude, the model's continued
+-- session persists to the `documents` table under local_id = mcp:cont_<token>
+-- (same owner / user_id as the web user). Publishing `documents` to Realtime
+-- lets the vcad.io tab subscribe to that row and reflect the model's edits live
+-- — the "alive in both surfaces" beat.
+--
+-- Security: `documents` RLS already restricts every row to its owner
+-- (auth.uid() = user_id, migration 001), and Realtime enforces RLS per
+-- subscriber using their JWT, so a user only ever receives changes to their OWN
+-- documents — never anyone else's. Default replica identity (the primary key)
+-- is sufficient: subscribers get the new row on INSERT/UPDATE, which is all the
+-- reflection needs.
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'documents'
+  ) then
+    alter publication supabase_realtime add table documents;
+  end if;
+end $$;


### PR DESCRIPTION
## Continue in Claude

A signed-in user looking at their part on vcad.io clicks **File → Continue in Claude…** and lands in Claude (or ChatGPT, or their editor) with their *exact geometry already loaded and being edited* — no blank slate, no copy-paste. The install is plumbing; the part teleports.

The geometry never rides the URL: the link carries a short share token, and a new `continue_document` MCP tool resolves it server-side and materializes the geometry.

### What's in here (7 commits)

**V1 — the core**
- `continue_document` MCP tool: resolves a share token via the `get_shared_document` RPC, materializes **raw CRDT** content through the kernel engine (`WasmDocumentEngine.load().get_document_json()` — the engine `render_view` already boots), opens a live session that renders inline + persists to the user's account.
- `continue-links.ts`: the verified per-host deep-link matrix — Claude Desktop `claude://claude.ai/new?q=` (prefill), ChatGPT `chatgpt.com/?q=`, Cursor/VS Code one-click MCP install, Claude Code one-liner. (claude.ai **web** `?q=` was removed Oct 2025, so it's open-and-copy.)
- `ContinueDialog` + File-menu item: mints/reuses a share token (no public profile publish → no username picker), host picker, remembers last host.

**V2 — reach + readiness**
- Accountless inline handoff: compresses live IR into the seed (`encodeDocForSeed`, length-guarded), falling back to a sign-in nudge for large parts.
- `continue_handoff` telemetry; `continue_document` MCP tool annotations for Anthropic Directory readiness.

**V3 — alive in both surfaces**
- Idempotent `cont_<token>` rendezvous key: re-clicks reattach to the same session (Living Viewport accretes in place, edits survive), and it's the durable row key the tab can watch.
- Live reflection: migration 031 publishes `documents` to Realtime; the dialog shows a **"Live in Claude"** pill that pulses as the model edits (owner-RLS scopes it to the user's own row).

### Verification
- MCP: `continue_document` 11 tests + full suite **306 pass**; typecheck clean.
- App: 13 `continue-links` tests; whole-app `tsc -b` clean; app boots with no errors.
- Migration 031: `supabase db push --dry-run` OK (**not applied** — see below).

### ⚠️ Before merge / deploy
1. **Migration 031 publishes the whole `documents` table to Supabase Realtime** — a deliberate prod fan-out decision. RLS still scopes every event to its owner. Apply with `supabase db push` when ready.
2. **Manual end-to-end pass** (can't be driven headless): from a signed-in vcad.io session, Continue → Claude Desktop, confirm the part loads and the "Live in Claude" pill pulses as you edit. Confirm the exact `claude://claude.ai/new?q=` scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
