### PR TITLE
ci(mcp): redeploy vcad-mcp when workspace packages change

### DIFF
--- a/services/mcp/vercel.json
+++ b/services/mcp/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "cd ../.. && npm ci --ignore-scripts",
   "buildCommand": "bash build.sh",
+  "ignoreCommand": "cd ../.. && git diff --quiet HEAD^ HEAD -- services/mcp packages/ir packages/core packages/engine packages/mcp packages/kernel-wasm",
   "framework": null
 }


### PR DESCRIPTION
## Why

The `vcad-mcp` Vercel project builds from `services/mcp`, so Vercel's monorepo change-detection only redeploys when files under `services/mcp` change. The photoreal PCB rendering work ([#323](https://github.com/ecto/vcad/pull/323)) lived entirely in `packages/*` + `crates/*`, so the merge to `main` was **ignored** — prod kept serving the old renderer (verified: live `get_preview_glb` still emitted the purple-IC / single-green-slab materials with `extensionsUsed: null`).

## What

Adds an `ignoreCommand` to `services/mcp/vercel.json` that proceeds with the build whenever `services/mcp` **or** any workspace package bundled by `build.sh` (`@vcad/ir`, `@vcad/core`, `@vcad/engine`, `@vcad/mcp`, `kernel-wasm`) changed since the last commit, and skips otherwise.

`git diff --quiet` exits 0 (skip) when none of those paths changed and 1 (build) when they did — matching Vercel's ignored-build-step convention.

## Effect

Merging this commit itself touches `services/mcp`, so it triggers a build — which rebuilds the workspace and bundles the already-merged #323 changes + the new kernel WASM, bringing the photoreal renderer live. Future `packages/**` merges will auto-deploy instead of silently skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)