### PR TITLE
Add video recording for physics simulations

### DIFF
--- a/changelog/entries/2026-06-25-physics-sim-video-export.json
+++ b/changelog/entries/2026-06-25-physics-sim-video-export.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-25-physics-sim-video-export",
+  "version": "0.9.4",
+  "date": "2026-06-25",
+  "category": "feat",
+  "title": "Record physics simulations to video",
+  "summary": "New Record button on the simulate toolbar captures the viewport to MP4 (or WebM where MP4 isn't supported) while the sim runs, including in raytraced mode. AI agents can request the same via the new `record_simulation` MCP tool, which returns an animated GIF of any active physics env.",
+  "features": ["physics", "simulation", "recording", "raytrace"],
+  "mcpTools": ["record_simulation"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15322,6 +15322,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/gifenc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gifenc/-/gifenc-1.0.3.tgz",
+      "integrity": "sha512-xdr6AdrfGBcfzncONUOlXMBuc5wJDtOueE3c5rdG0oNgtINLD+f2iFZltrBRZYzACRbKr+mSVU/x98zv2u3jmw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
@@ -27283,7 +27290,8 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@vcad/core": "*",
         "@vcad/engine": "*",
-        "@vcad/ir": "*"
+        "@vcad/ir": "*",
+        "gifenc": "^1.0.3"
       },
       "bin": {
         "vcad-mcp": "dist/index.js",
@@ -27291,6 +27299,7 @@
       },
       "devDependencies": {
         "@modelcontextprotocol/ext-apps": "^1.7.4",
+        "@supabase/supabase-js": "^2.45.0",
         "@types/node": "^22",
         "@types/three": "^0.184.1",
         "three": "^0.184.0",
@@ -27300,7 +27309,8 @@
         "vitest": "^3.0"
       },
       "optionalDependencies": {
-        "@resvg/resvg-js": "^2.6.2"
+        "@resvg/resvg-js": "^2.6.2",
+        "gifenc": "^1.0.3"
       }
     },
     "packages/mcp/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27290,8 +27290,7 @@
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@vcad/core": "*",
         "@vcad/engine": "*",
-        "@vcad/ir": "*",
-        "gifenc": "^1.0.3"
+        "@vcad/ir": "*"
       },
       "bin": {
         "vcad-mcp": "dist/index.js",

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -34,6 +34,7 @@ import { examples } from "@/data/examples";
 import { SignInButton, UserMenu, triggerSync, useAuthStore } from "@vcad/auth";
 import { useChangelogStore } from "@/stores/changelog-store";
 import { useNotificationStore } from "@/stores/notification-store";
+import { ensureNotRecording } from "@/lib/recording-guard";
 import { useDfmStore } from "@/stores/dfm-store";
 import { useAppCommands } from "@/hooks/useAppCommands";
 import { COMMAND_ICONS } from "@/lib/command-icons";
@@ -295,7 +296,10 @@ function RayTracingSubmenu() {
       }
     >
       <MenuItem
-        onSelect={() => { if (renderMode === "raytrace") toggleRenderMode(); }}
+        onSelect={() => {
+          if (!ensureNotRecording()) return;
+          if (renderMode === "raytrace") toggleRenderMode();
+        }}
       >
         <span className={renderMode === "standard" ? "text-brand" : "text-text"}>
           {t("menu.view.ray_tracing.off")}
@@ -305,6 +309,7 @@ function RayTracingSubmenu() {
         <MenuItem
           key={q}
           onSelect={() => {
+            if (renderMode !== "raytrace" && !ensureNotRecording()) return;
             if (renderMode !== "raytrace") toggleRenderMode();
             setRaytraceQuality(q);
           }}

--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -31,6 +31,34 @@ let latestCameraState: CameraState | null = null;
  */
 let invalidateFromSync: (() => void) | null = null;
 
+/**
+ * The mounted overlay canvas. Exposed so the video recorder can call
+ * `captureStream` on it directly — the overlay sits on top of the R3F WebGL
+ * canvas and is the only surface that shows raytraced pixels.
+ */
+let overlayCanvasEl: HTMLCanvasElement | null = null;
+
+/**
+ * Forces a single raytrace render at the standard tier, bypassing the
+ * draft→standard→high refinement scheduler. The recorder calls this once per
+ * captured video frame so animation is visible in the recording (the normal
+ * scheduler only fires renders on camera change).
+ */
+let forceRenderFn: (() => void) | null = null;
+
+/** Returns the live raytrace overlay canvas, or null when not mounted. */
+export function getRayTracedOverlayCanvas(): HTMLCanvasElement | null {
+  return overlayCanvasEl;
+}
+
+/**
+ * Trigger a single immediate raytrace render at the standard tier.
+ * No-op if the overlay isn't mounted. Safe to call from outside React.
+ */
+export function triggerRaytraceRender(): void {
+  forceRenderFn?.();
+}
+
 function setCameraStateCallback(cb: ((state: CameraState) => void) | null) {
   cameraStateCallback = cb;
 }
@@ -542,6 +570,31 @@ export function RayTracedViewportOverlay() {
 
   // Backwards-compat alias used by the camera-state callback below.
   const doRender = runRefinement;
+
+  // Expose the overlay canvas so the video recorder can captureStream it.
+  // (Module-level pointer because the recorder hook lives inside the R3F
+  // Canvas tree and the overlay does not — sharing through context would
+  // require lifting state up past the Canvas boundary.)
+  useEffect(() => {
+    overlayCanvasEl = canvasRef.current;
+    return () => {
+      if (overlayCanvasEl === canvasRef.current) overlayCanvasEl = null;
+    };
+  });
+
+  // Expose a one-shot render hook for the recorder. Each call renders the
+  // current camera state at the standard tier (no refinement chain) so a
+  // single recorder tick produces a single fresh frame — animation is
+  // visible without waiting for the draft→standard→high pyramid.
+  useEffect(() => {
+    forceRenderFn = () => {
+      const state = lastCameraStateRef.current;
+      if (state) doRenderAtTier(state, "standard");
+    };
+    return () => {
+      forceRenderFn = null;
+    };
+  }, [doRenderAtTier]);
 
   // Register callback for camera updates. Each new camera state cancels
   // the in-progress refinement and starts a new one — the user gets an

--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -580,7 +580,7 @@ export function RayTracedViewportOverlay() {
     return () => {
       if (overlayCanvasEl === canvasRef.current) overlayCanvasEl = null;
     };
-  });
+  }, []);
 
   // Expose a one-shot render hook for the recorder. Each call renders the
   // current camera state at the standard tier (no refinement chain) so a
@@ -642,34 +642,19 @@ export function RayTracedViewportOverlay() {
 
   // Apply debug mode changes to raytracer
   useEffect(() => {
-    console.log(`[DEBUG] Debug mode effect running: mode=${raytraceDebugMode}, lastMode=${lastDebugModeRef.current}, hasRayTracer=${!!rayTracer}`);
-
-    if (!rayTracer) {
-      console.log("[DEBUG] No rayTracer available");
-      return;
-    }
-    if (raytraceDebugMode === lastDebugModeRef.current) {
-      console.log("[DEBUG] Debug mode unchanged, skipping");
-      return;
-    }
+    if (!rayTracer) return;
+    if (raytraceDebugMode === lastDebugModeRef.current) return;
 
     lastDebugModeRef.current = raytraceDebugMode;
     const modeNumber = DEBUG_MODE_MAP[raytraceDebugMode] ?? 0;
 
-    console.log(`[DEBUG] Setting debug mode: ${raytraceDebugMode} -> ${modeNumber}`);
-
-    // Check if method exists
     const rt = rayTracer as { setDebugMode?: (mode: number) => void };
-    const hasMethod = typeof rt.setDebugMode === "function";
-    console.log(`[DEBUG] setDebugMode method exists: ${hasMethod}`);
-
-    if (!hasMethod) {
-      console.log("[DEBUG] WARNING: setDebugMode not available - WASM may need rebuild");
+    if (typeof rt.setDebugMode !== "function") {
+      logger.debug("gpu", "setDebugMode not available - WASM may need rebuild");
       return;
     }
 
-    rt.setDebugMode!(modeNumber);
-    console.log(`[DEBUG] Called setDebugMode(${modeNumber})`);
+    rt.setDebugMode(modeNumber);
 
     // Re-render to see the change
     if (lastCameraStateRef.current) {

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -58,6 +58,7 @@ import { useWebGLContextLost } from "@/hooks/useWebGLContextLost";
 import { useTheme } from "@/hooks/useTheme";
 import { useInputDeviceDetection } from "@/hooks/useInputDeviceDetection";
 import { usePhysicsSimulation } from "@/hooks/usePhysicsSimulation";
+import { useCanvasRecorder } from "@/hooks/useCanvasRecorder";
 import {
   useCameraSettingsStore,
   getEffectiveInputDevice,
@@ -308,6 +309,7 @@ export function ViewportContent({
   useCameraControls();
   useInputDeviceDetection();
   usePhysicsSimulation();
+  useCanvasRecorder();
 
   const isPcbMode = mode === "pcb";
 

--- a/packages/app/src/components/footer/RaytraceChip.tsx
+++ b/packages/app/src/components/footer/RaytraceChip.tsx
@@ -5,6 +5,7 @@ import { useUiStore, type RaytraceQuality } from "@vcad/core";
 import { FooterChipButton } from "@/components/footer/FooterChip";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { ensureNotRecording } from "@/lib/recording-guard";
 import { useCallback } from "react";
 
 const QUALITY_OPTIONS: Array<{
@@ -364,7 +365,9 @@ export function RaytraceChip({ className }: { className?: string }) {
 
           <button
             type="button"
-            onClick={toggleRenderMode}
+            onClick={() => {
+              if (ensureNotRecording()) toggleRenderMode();
+            }}
             className={cn(
               "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left",
               "transition-colors",

--- a/packages/app/src/hooks/useCanvasRecorder.ts
+++ b/packages/app/src/hooks/useCanvasRecorder.ts
@@ -1,0 +1,316 @@
+/**
+ * Records the viewport to a video file via MediaRecorder.
+ *
+ * Capture target depends on render mode:
+ *   - standard mode  → R3F's WebGL canvas (via `useThree().gl.domElement`)
+ *   - raytrace mode  → the raytrace overlay canvas (sits on top of WebGL)
+ *
+ * In raytrace mode the recorder also drives a per-animation-frame raytrace
+ * render via `triggerRaytraceRender()`. The normal scheduler in
+ * `RayTracedViewport` only re-renders on camera change, so animation would
+ * otherwise produce a frozen file.
+ *
+ * Lifecycle is driven by `useRecordingStore` — the toolbar calls `start()`
+ * and `stop()`, this hook spins MediaRecorder up and down accordingly. Sim
+ * mode is observed so pause/resume mirror the sim state and the sim Stop
+ * button auto-finalizes the recording.
+ */
+
+import { useEffect, useRef } from "react";
+import { useThree } from "@react-three/fiber";
+import {
+  useDocumentStore,
+  useRecordingStore,
+  useSimulationStore,
+  useUiStore,
+  logger,
+} from "@vcad/core";
+import {
+  getRayTracedOverlayCanvas,
+  triggerRaytraceRender,
+} from "@/components/RayTracedViewport";
+import { downloadBlob } from "@/lib/download";
+
+const MIME_PREFERENCES = [
+  "video/mp4;codecs=avc1.640028",
+  "video/mp4;codecs=avc1.42E01E",
+  "video/mp4",
+  "video/webm;codecs=vp9",
+  "video/webm;codecs=vp8",
+  "video/webm",
+];
+
+const VIDEO_BITRATE = 12_000_000;
+const CAPTURE_FPS = 60;
+const CHUNK_MS = 250;
+
+function pickMimeType(): string | null {
+  if (typeof MediaRecorder === "undefined") return null;
+  for (const mime of MIME_PREFERENCES) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime;
+  }
+  return null;
+}
+
+function extensionFor(mimeType: string): string {
+  if (mimeType.startsWith("video/mp4")) return "mp4";
+  if (mimeType.startsWith("video/webm")) return "webm";
+  return "bin";
+}
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 60) || "untitled"
+  );
+}
+
+function timestampForFilename(): string {
+  // 2026-06-25T18-04-12 — colon-free so all OSes accept it.
+  return new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+}
+
+interface RecorderRefs {
+  recorder: MediaRecorder | null;
+  chunks: Blob[];
+  mimeType: string | null;
+  rafId: number | null;
+  raytraceDriving: boolean;
+}
+
+/**
+ * Hook to manage video recording lifecycle. Must be called inside the R3F
+ * Canvas tree (uses `useThree` to get the WebGL canvas).
+ */
+export function useCanvasRecorder() {
+  const { gl } = useThree();
+  const status = useRecordingStore((s) => s.status);
+  const renderMode = useUiStore((s) => s.renderMode);
+  const simMode = useSimulationStore((s) => s.mode);
+
+  const refs = useRef<RecorderRefs>({
+    recorder: null,
+    chunks: [],
+    mimeType: null,
+    rafId: null,
+    raytraceDriving: false,
+  });
+
+  // React to recording status intents from the store.
+  useEffect(() => {
+    const store = useRecordingStore.getState();
+    const cur = refs.current;
+
+    // Intent: start. Store has flipped to "recording" but we haven't built
+    // a MediaRecorder yet — do that now.
+    if (status === "recording" && !cur.recorder) {
+      const mimeType = pickMimeType();
+      if (!mimeType) {
+        store.setError("MediaRecorder is not supported in this browser.");
+        return;
+      }
+
+      const overlay = getRayTracedOverlayCanvas();
+      const useOverlay = renderMode === "raytrace" && overlay !== null;
+      if (renderMode === "raytrace" && !useOverlay) {
+        logger.warn(
+          "app",
+          "Raytrace overlay not mounted at record start; falling back to WebGL canvas.",
+        );
+      }
+      const canvas = useOverlay ? overlay! : gl.domElement;
+
+      const captureSource = canvas as HTMLCanvasElement & {
+        captureStream?: (fps?: number) => MediaStream;
+      };
+      if (typeof captureSource.captureStream !== "function") {
+        store.setError("Canvas.captureStream is not supported in this browser.");
+        return;
+      }
+      const stream = captureSource.captureStream(CAPTURE_FPS);
+
+      let recorder: MediaRecorder;
+      try {
+        recorder = new MediaRecorder(stream, {
+          mimeType,
+          videoBitsPerSecond: VIDEO_BITRATE,
+        });
+      } catch (err) {
+        store.setError(
+          err instanceof Error
+            ? err.message
+            : "Failed to create MediaRecorder.",
+        );
+        return;
+      }
+
+      cur.chunks = [];
+      cur.recorder = recorder;
+      cur.mimeType = mimeType;
+      cur.raytraceDriving = useOverlay;
+
+      recorder.ondataavailable = (ev) => {
+        if (ev.data && ev.data.size > 0) {
+          cur.chunks.push(ev.data);
+          useRecordingStore.getState().addBytes(ev.data.size);
+        }
+      };
+
+      recorder.onerror = (ev) => {
+        const error = (ev as { error?: { message?: string } }).error;
+        const msg = error?.message ?? "MediaRecorder error";
+        logger.warn("app", `Recorder error: ${msg}`);
+        useRecordingStore.getState().setError(msg);
+      };
+
+      recorder.onstop = () => {
+        const chunks = cur.chunks;
+        const mime = cur.mimeType ?? "video/webm";
+        cur.chunks = [];
+        cur.recorder = null;
+        cur.mimeType = null;
+        cur.raytraceDriving = false;
+        if (cur.rafId !== null) {
+          cancelAnimationFrame(cur.rafId);
+          cur.rafId = null;
+        }
+
+        if (chunks.length === 0) {
+          useRecordingStore.getState().reset();
+          return;
+        }
+
+        const blob = new Blob(chunks, { type: mime });
+        const docName =
+          useDocumentStore.getState().documentName ?? "untitled";
+        const filename = `vcad-sim-${slugify(docName)}-${timestampForFilename()}.${extensionFor(mime)}`;
+        downloadBlob(blob, filename);
+        useRecordingStore.getState().reset();
+      };
+
+      try {
+        recorder.start(CHUNK_MS);
+        useRecordingStore.getState().setMimeType(mimeType);
+      } catch (err) {
+        cur.recorder = null;
+        cur.mimeType = null;
+        cur.raytraceDriving = false;
+        store.setError(
+          err instanceof Error ? err.message : "Failed to start recording.",
+        );
+        return;
+      }
+
+      if (cur.raytraceDriving) {
+        const tick = () => {
+          if (!refs.current.raytraceDriving) return;
+          triggerRaytraceRender();
+          refs.current.rafId = requestAnimationFrame(tick);
+        };
+        refs.current.rafId = requestAnimationFrame(tick);
+      }
+      return;
+    }
+
+    // Intent: finalize. Store has flipped to "saving" — stop the recorder so
+    // onstop fires, the file gets written, and the store moves back to idle.
+    if (status === "saving" && cur.recorder) {
+      try {
+        if (cur.recorder.state !== "inactive") cur.recorder.stop();
+      } catch (err) {
+        logger.warn("app", `Recorder stop failed: ${err}`);
+        useRecordingStore.getState().reset();
+      }
+      return;
+    }
+
+    // Intent: store reset to idle while a recorder was live — discard.
+    if (status === "idle" && cur.recorder) {
+      cur.chunks = [];
+      try {
+        cur.recorder.ondataavailable = null;
+        cur.recorder.onstop = null;
+        cur.recorder.onerror = null;
+        if (cur.recorder.state !== "inactive") cur.recorder.stop();
+      } catch {
+        // best-effort
+      }
+      cur.recorder = null;
+      cur.mimeType = null;
+      cur.raytraceDriving = false;
+      if (cur.rafId !== null) {
+        cancelAnimationFrame(cur.rafId);
+        cur.rafId = null;
+      }
+    }
+  }, [status, renderMode, gl]);
+
+  // Mirror sim play/pause into recorder pause/resume so the captured timeline
+  // matches what the user sees. Sim Stop auto-finalizes the recording.
+  useEffect(() => {
+    const cur = refs.current;
+    const rec = cur.recorder;
+    if (!rec) return;
+
+    if (simMode === "paused" && rec.state === "recording") {
+      try {
+        rec.pause();
+        useRecordingStore.getState().pause();
+        if (cur.rafId !== null) {
+          cancelAnimationFrame(cur.rafId);
+          cur.rafId = null;
+        }
+      } catch (err) {
+        logger.warn("app", `Recorder pause failed: ${err}`);
+      }
+    } else if (simMode === "running" && rec.state === "paused") {
+      try {
+        rec.resume();
+        useRecordingStore.getState().resume();
+        if (cur.raytraceDriving && cur.rafId === null) {
+          const tick = () => {
+            if (!refs.current.raytraceDriving) return;
+            triggerRaytraceRender();
+            refs.current.rafId = requestAnimationFrame(tick);
+          };
+          cur.rafId = requestAnimationFrame(tick);
+        }
+      } catch (err) {
+        logger.warn("app", `Recorder resume failed: ${err}`);
+      }
+    } else if (simMode === "off" && rec.state !== "inactive") {
+      // Sim stopped while recording: finalize via the store so the same
+      // save path runs.
+      useRecordingStore.getState().stop();
+    }
+  }, [simMode]);
+
+  // Clean up on unmount.
+  useEffect(() => {
+    return () => {
+      const cur = refs.current;
+      if (cur.rafId !== null) {
+        cancelAnimationFrame(cur.rafId);
+        cur.rafId = null;
+      }
+      const rec = cur.recorder;
+      if (rec && rec.state !== "inactive") {
+        try {
+          rec.ondataavailable = null;
+          rec.onstop = null;
+          rec.onerror = null;
+          rec.stop();
+        } catch {
+          // best-effort
+        }
+      }
+      cur.recorder = null;
+      cur.chunks = [];
+      cur.mimeType = null;
+      cur.raytraceDriving = false;
+    };
+  }, []);
+}

--- a/packages/app/src/hooks/useCanvasRecorder.ts
+++ b/packages/app/src/hooks/useCanvasRecorder.ts
@@ -217,7 +217,15 @@ export function useCanvasRecorder() {
 
     // Intent: finalize. Store has flipped to "saving" — stop the recorder so
     // onstop fires, the file gets written, and the store moves back to idle.
+    // Synchronously cancel the raytrace-driver rAF here too: onstop is
+    // dispatched async, so without this we'd kick off one or two pointless
+    // renders during the gap between stop() and onstop.
     if (status === "saving" && cur.recorder) {
+      cur.raytraceDriving = false;
+      if (cur.rafId !== null) {
+        cancelAnimationFrame(cur.rafId);
+        cur.rafId = null;
+      }
       try {
         if (cur.recorder.state !== "inactive") cur.recorder.stop();
       } catch (err) {
@@ -286,7 +294,11 @@ export function useCanvasRecorder() {
       // save path runs.
       useRecordingStore.getState().stop();
     }
-  }, [simMode]);
+    // `status` is in the deps so this also fires right after the recorder
+    // is created — without it, a recorder started while simMode was already
+    // "paused" would remain in the "recording" MediaRecorder state and
+    // capture frozen frames.
+  }, [simMode, status]);
 
   // Clean up on unmount.
   useEffect(() => {

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,7 @@ import { useElectronicsStore } from "../stores/electronics-store";
 import { useNotificationStore } from "../stores/notification-store";
 import { useLogStore } from "../stores/log-store";
 import { useChangelogStore } from "../stores/changelog-store";
+import { ensureNotRecording } from "@/lib/recording-guard";
 
 // Track last Escape time for double-tap emergency exit
 let lastEscapeTime = 0;
@@ -330,7 +331,7 @@ export function useKeyboardShortcuts() {
       if (e.altKey && (e.key === "r" || e.key === "R")) {
         e.preventDefault();
         const { raytraceAvailable, toggleRenderMode } = useUiStore.getState();
-        if (raytraceAvailable) {
+        if (raytraceAvailable && ensureNotRecording()) {
           toggleRenderMode();
         }
         return;

--- a/packages/app/src/hooks/useToolDefinitions.tsx
+++ b/packages/app/src/hooks/useToolDefinitions.tsx
@@ -49,6 +49,7 @@ import {
   useSketchStore,
   useEngineStore,
   useSimulationStore,
+  useRecordingStore,
   exportStlBlob,
   exportGltfBlob,
   exportStepBlob,
@@ -221,6 +222,11 @@ export function useToolDefinitions(): {
   const stopSim = useSimulationStore((s) => s.stop);
   const stepSim = useSimulationStore((s) => s.step);
   const setPlaybackSpeed = useSimulationStore((s) => s.setPlaybackSpeed);
+
+  // Recording
+  const recordingStatus = useRecordingStore((s) => s.status);
+  const startRecording = useRecordingStore((s) => s.start);
+  const stopRecording = useRecordingStore((s) => s.stop);
 
   // Onboarding (guided flow pulses)
   const guidedFlowActive = useOnboardingStore((s) => s.guidedFlowActive);
@@ -564,6 +570,49 @@ export function useToolDefinitions(): {
           hasJoints && simMode !== "running" && physicsAvailable && !sketchActive,
         iconColor: color("simulate"),
         onClick: stepSim,
+      },
+      {
+        id: "simulate-record",
+        tab: "simulate",
+        label:
+          recordingStatus === "recording" || recordingStatus === "paused"
+            ? "Stop Recording"
+            : recordingStatus === "saving"
+              ? "Saving…"
+              : "Record",
+        tooltip: !hasJoints
+          ? "Record (add joints to simulate)"
+          : !physicsAvailable
+            ? "Record (physics unavailable)"
+            : recordingStatus === "recording" || recordingStatus === "paused"
+              ? "Stop recording and save video"
+              : recordingStatus === "saving"
+                ? "Saving recording…"
+                : "Record simulation to video file",
+        icon: Circle,
+        enabled:
+          hasJoints &&
+          physicsAvailable &&
+          !sketchActive &&
+          recordingStatus !== "saving",
+        active:
+          recordingStatus === "recording" || recordingStatus === "paused",
+        pulse: recordingStatus === "recording",
+        iconColor:
+          recordingStatus === "recording" || recordingStatus === "paused"
+            ? "text-red-500"
+            : color("simulate"),
+        onClick: () => {
+          if (recordingStatus === "recording" || recordingStatus === "paused") {
+            stopRecording();
+          } else if (recordingStatus === "idle") {
+            startRecording();
+            if (simMode !== "running") {
+              analytics.physicsSimulationRun();
+              playSim();
+            }
+          }
+        },
       },
     ];
 

--- a/packages/app/src/lib/recording-guard.ts
+++ b/packages/app/src/lib/recording-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * Guard against actions that would corrupt an in-flight recording.
+ *
+ * Centralized so every renderMode toggle gates the same way — a per-call-site
+ * inline check is easy to miss, and the MediaRecorder will silently capture
+ * a now-detached canvas if the user changes render mode mid-recording (the
+ * stream is bound to one HTMLCanvasElement at start and can't be swapped).
+ */
+
+import { useRecordingStore } from "@vcad/core";
+import { useNotificationStore } from "@/stores/notification-store";
+
+/**
+ * Returns true when the action can proceed. If a recording is in flight,
+ * surfaces a toast and returns false.
+ */
+export function ensureNotRecording(
+  action = "Switch render mode",
+): boolean {
+  const status = useRecordingStore.getState().status;
+  if (status === "idle") return true;
+  useNotificationStore
+    .getState()
+    .addToast(`${action} disabled while recording — stop recording first.`, "info");
+  return false;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -123,6 +123,9 @@ export type {
   SimulationObservation,
 } from "./stores/simulation-store.js";
 
+export { useRecordingStore } from "./stores/recording-store.js";
+export type { RecordingState, RecordingStatus } from "./stores/recording-store.js";
+
 export { useChatStore } from "./stores/chat-store.js";
 export type {
   ChatState,

--- a/packages/core/src/stores/recording-store.ts
+++ b/packages/core/src/stores/recording-store.ts
@@ -1,0 +1,103 @@
+/**
+ * Recording store for capturing the viewport canvas to video.
+ *
+ * Drives the simulate-toolbar Record button and the `useCanvasRecorder` hook.
+ * The hook owns the `MediaRecorder` instance and the captured Blob chunks —
+ * this store only tracks lifecycle state so the UI can reflect it and so the
+ * hook can react to start/stop intents from anywhere in the app.
+ */
+
+import { create } from "zustand";
+
+/**
+ * Recording lifecycle:
+ *   idle     → no recording, no recorder.
+ *   recording → toolbar requested start; hook spins up MediaRecorder.
+ *   paused   → MediaRecorder.pause() called (sim is paused).
+ *   saving   → toolbar (or sim-stop) requested finalize; hook flushes and
+ *              calls reset() once the file is written.
+ */
+export type RecordingStatus = "idle" | "recording" | "paused" | "saving";
+
+export interface RecordingState {
+  status: RecordingStatus;
+  /** ms since epoch when recording started; null when idle */
+  startedAt: number | null;
+  /** Negotiated MIME container (hook reports back after starting MediaRecorder) */
+  mimeType: string | null;
+  /** Bytes received from MediaRecorder dataavailable chunks so far */
+  bytesRecorded: number;
+  /** User-visible error message from the last attempt, if any */
+  error: string | null;
+
+  /** Toolbar intent: begin recording. Hook reacts and starts MediaRecorder. */
+  start: () => void;
+  /** Toolbar intent: finalize. Hook stops MediaRecorder and saves the file. */
+  stop: () => void;
+  /** Hook callback: MediaRecorder has paused. */
+  pause: () => void;
+  /** Hook callback: MediaRecorder has resumed. */
+  resume: () => void;
+  /** Hook callback: MediaRecorder started successfully. */
+  setMimeType: (mime: string) => void;
+  /** Hook callback: dataavailable produced a chunk. */
+  addBytes: (n: number) => void;
+  /** Reset to idle (hook calls this after the file is written). */
+  reset: () => void;
+  /** Hook reports failure; status returns to idle. */
+  setError: (message: string) => void;
+}
+
+export const useRecordingStore = create<RecordingState>((set) => ({
+  status: "idle",
+  startedAt: null,
+  mimeType: null,
+  bytesRecorded: 0,
+  error: null,
+
+  start: () =>
+    set((s) =>
+      s.status === "idle"
+        ? {
+            status: "recording",
+            startedAt: Date.now(),
+            mimeType: null,
+            bytesRecorded: 0,
+            error: null,
+          }
+        : s,
+    ),
+
+  stop: () =>
+    set((s) =>
+      s.status === "recording" || s.status === "paused"
+        ? { status: "saving" }
+        : s,
+    ),
+
+  pause: () =>
+    set((s) => (s.status === "recording" ? { status: "paused" } : s)),
+
+  resume: () =>
+    set((s) => (s.status === "paused" ? { status: "recording" } : s)),
+
+  setMimeType: (mimeType) => set({ mimeType }),
+
+  addBytes: (n) => set((s) => ({ bytesRecorded: s.bytesRecorded + n })),
+
+  reset: () =>
+    set({
+      status: "idle",
+      startedAt: null,
+      mimeType: null,
+      bytesRecorded: 0,
+    }),
+
+  setError: (message) =>
+    set({
+      status: "idle",
+      startedAt: null,
+      mimeType: null,
+      error: message,
+    }),
+}));

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,7 +31,8 @@
     "@vcad/ir": "*"
   },
   "optionalDependencies": {
-    "@resvg/resvg-js": "^2.6.2"
+    "@resvg/resvg-js": "^2.6.2",
+    "gifenc": "^1.0.3"
   },
   "devDependencies": {
     "@modelcontextprotocol/ext-apps": "^1.7.4",

--- a/packages/mcp/src/gifenc.d.ts
+++ b/packages/mcp/src/gifenc.d.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal ambient typings for the `gifenc` package, which ships without
+ * its own type declarations. We only describe the surface used by
+ * `tools/record.ts`; full API coverage isn't worth the maintenance.
+ */
+declare module "gifenc" {
+  export function GIFEncoder(): {
+    writeFrame: (
+      indexed: Uint8Array,
+      width: number,
+      height: number,
+      opts: { palette: number[][]; delay: number },
+    ) => void;
+    finish: () => void;
+    bytes: () => Uint8Array;
+  };
+  export function quantize(rgba: Uint8Array, maxColors: number): number[][];
+  export function applyPalette(rgba: Uint8Array, palette: number[][]): Uint8Array;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,6 +17,7 @@ import type { Document } from "@vcad/ir";
 import { exportCad, exportCadSchema } from "./tools/export.js";
 import { inspectCad, inspectCadSchema } from "./tools/inspect.js";
 import { renderView, renderViewSchema, renderPcb, renderPcbSchema } from "./tools/render.js";
+import { recordSimulation, recordSimulationSchema } from "./tools/record.js";
 import {
   verifyPart,
   verifyPartSchema,
@@ -461,6 +462,7 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "gym_reset",
     "gym_observe",
     "gym_close",
+    "record_simulation",
     "batch_create_envs",
     "batch_step",
     "batch_reset",
@@ -1038,6 +1040,17 @@ export async function createServer(
         name: "gym_close",
         description: "Close and clean up a simulation environment.",
         inputSchema: gymCloseSchema,
+      },
+      {
+        name: "record_simulation",
+        description:
+          "Step an open physics env N times and return an animated GIF of the run — your eyes on the simulation. " +
+          "Drives the env created via create_robot_env, mutates the paired session document's joint states each step, " +
+          "and re-renders through the same kernel SVG pipeline as render_view. " +
+          "Defaults to passive playback (zero torque) under gravity; pass `action` (constant) or `actions[steps][action_dim]` (per-step) for active control. " +
+          "Hard caps: steps ≤ 600, width_px ≤ 1024. " +
+          "Requires the optional `@resvg/resvg-js` rasterizer and `gifenc` encoder; degrades to a JSON joint-trajectory dump when either is missing.",
+        inputSchema: recordSimulationSchema,
       },
       {
         name: "batch_create_envs",
@@ -1705,6 +1718,10 @@ export async function createServer(
 
         case "gym_close":
           result = gymClose(args);
+          break;
+
+        case "record_simulation":
+          result = (await recordSimulation(args)) as unknown as typeof result;
           break;
 
         case "batch_create_envs":

--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -26,6 +26,13 @@ export type StepResult = PhysicsStepResult;
 /** In-memory storage for active simulations */
 const simulations = new Map<string, PhysicsEnv>();
 
+/** Look up an active env by id. Returns null if not found.
+ *  Exposed for sibling tools (e.g. record_simulation) that need to drive
+ *  an already-created env without re-creating it. */
+export function getSimulation(envId: string): PhysicsEnv | null {
+  return simulations.get(envId) ?? null;
+}
+
 /** In-memory storage for batch simulation groups */
 interface BatchGroup {
   envs: PhysicsEnv[];

--- a/packages/mcp/src/tools/record.ts
+++ b/packages/mcp/src/tools/record.ts
@@ -424,7 +424,9 @@ function resolveActions(
           error: `'actions[${i}]' must be an array of length ${actionDim} (got ${Array.isArray(row) ? `length ${row.length}` : typeof row}).`,
         };
       }
-      out.push(row.map(Number));
+      const checked = coerceFiniteVector(row, `actions[${i}]`);
+      if ("error" in checked) return checked;
+      out.push(checked.values);
     }
     return { values: out };
   }
@@ -436,13 +438,35 @@ function resolveActions(
         error: `'action' length ${constant.length} does not match action_dim=${actionDim}.`,
       };
     }
-    vec = constant.map(Number);
+    const checked = coerceFiniteVector(constant, "action");
+    if ("error" in checked) return checked;
+    vec = checked.values;
   } else {
     vec = new Array(actionDim).fill(0);
   }
   const values: number[][] = new Array(steps);
   for (let i = 0; i < steps; i++) values[i] = vec;
   return { values };
+}
+
+/** Validate that every element coerces to a finite number. NaN and ±Infinity
+ *  silently propagate through the phyz solver and surface as corrupted joint
+ *  states downstream, so we reject them at the boundary. */
+function coerceFiniteVector(
+  row: unknown[],
+  label: string,
+): { values: number[] } | { error: string } {
+  const out = new Array<number>(row.length);
+  for (let j = 0; j < row.length; j++) {
+    const n = Number(row[j]);
+    if (!Number.isFinite(n)) {
+      return {
+        error: `'${label}[${j}]' must be a finite number (got ${JSON.stringify(row[j])}).`,
+      };
+    }
+    out[j] = n;
+  }
+  return { values: out };
 }
 
 function errorResult(text: string): RecordResult {

--- a/packages/mcp/src/tools/record.ts
+++ b/packages/mcp/src/tools/record.ts
@@ -1,0 +1,458 @@
+/**
+ * record_simulation — server-side physics-to-video for AI agents.
+ *
+ * Pairs an open session document with an active PhysicsEnv (from
+ * create_robot_env), steps the env N times, mutates the cached document's
+ * joint state values to match each observation, then re-renders the document
+ * through the same kernel SVG path that powers `render_view`. Frames are
+ * rasterized to PNG via the optional `@resvg/resvg-js` rasterizer and muxed
+ * into an animated GIF via the optional `gifenc` encoder.
+ *
+ * Returns inline `image/gif` so the agent can SEE the run (same content
+ * shape as render_view's PNG). When either optional dep is missing, the
+ * tool degrades to a JSON summary listing the per-frame joint trajectory —
+ * never a silent failure.
+ */
+
+import { getKernelWasm, resetKernelWasm } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { getSession } from "./session.js";
+import { getSimulation } from "./gym.js";
+import type { PhysicsActionType } from "@vcad/engine";
+
+export const recordSimulationSchema = {
+  type: "object" as const,
+  properties: {
+    env_id: {
+      type: "string" as const,
+      description: "Environment id from create_robot_env.",
+    },
+    document_id: {
+      type: "string" as const,
+      description:
+        "Session document id from open_document. Must describe the same assembly the env was created from (same joint order).",
+    },
+    steps: {
+      type: "number" as const,
+      description: "Number of simulation steps to record (1–600).",
+    },
+    action_type: {
+      type: "string" as const,
+      enum: ["torque", "position", "velocity"],
+      description:
+        "Action mode used for every recorded step. Defaults to 'torque' with all-zeros (passive playback under gravity).",
+    },
+    action: {
+      type: "array" as const,
+      items: { type: "number" as const },
+      description:
+        "Constant action vector applied every step (length = action_dim from create_robot_env). Mutually exclusive with `actions`.",
+    },
+    actions: {
+      type: "array" as const,
+      items: { type: "array" as const, items: { type: "number" as const } },
+      description:
+        "Per-step action vectors (length = steps; each inner array length = action_dim). Mutually exclusive with `action`.",
+    },
+    fps: {
+      type: "number" as const,
+      description: "Playback frame rate of the encoded GIF (1–60, default 30).",
+    },
+    view: {
+      type: "string" as const,
+      enum: ["iso", "isometric", "top", "front", "side"],
+      description: "Camera view; defaults to 'iso'.",
+    },
+    width_px: {
+      type: "number" as const,
+      description: "Raster width per frame (64–1024, default 480).",
+    },
+  },
+  required: ["env_id", "document_id", "steps"],
+};
+
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+interface RecordResult {
+  content: ContentBlock[];
+  isError?: boolean;
+}
+
+/** px-per-mm passed to the kernel renderer; the raster step handles
+ *  final sizing, so this only controls SVG coordinate precision. */
+const SVG_SCALE = 2.0;
+
+/** Per-frame hard cap. Each frame holds the WASM instance synchronously and
+ *  buffers a PNG in Node heap, so the budget is multiplicative. */
+const MAX_STEPS = 600;
+const MIN_STEPS = 1;
+const DEFAULT_WIDTH_PX = 480;
+const MIN_WIDTH_PX = 64;
+const MAX_WIDTH_PX = 1024;
+const DEFAULT_FPS = 30;
+const MIN_FPS = 1;
+const MAX_FPS = 60;
+
+type RasterOutcome =
+  | { rgba: Uint8Array; width: number; height: number }
+  | { rgba: null; reason: "module-missing" | string };
+
+/** Rasterize one SVG frame to RGBA pixels via the optional resvg dep. */
+async function rasterize(
+  svg: string,
+  widthPx: number,
+): Promise<RasterOutcome> {
+  let ResvgCtor: typeof import("@resvg/resvg-js").Resvg;
+  try {
+    ({ Resvg: ResvgCtor } = await import("@resvg/resvg-js"));
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
+      return { rgba: null, reason: "module-missing" };
+    }
+    return {
+      rgba: null,
+      reason: `resvg import failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+  try {
+    const resvg = new ResvgCtor(svg, {
+      fitTo: { mode: "width", value: widthPx },
+      background: "white",
+    });
+    const rendered = resvg.render();
+    const pixels = rendered.pixels;
+    return {
+      rgba: new Uint8Array(
+        pixels.buffer,
+        pixels.byteOffset,
+        pixels.byteLength,
+      ),
+      width: rendered.width,
+      height: rendered.height,
+    };
+  } catch (e) {
+    return {
+      rgba: null,
+      reason: `rasterization failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+type GifencModule = typeof import("gifenc");
+
+/** Lazy-load the optional `gifenc` encoder. Returns null with a reason
+ *  when the module is missing or import-time fails. */
+async function loadGifenc(): Promise<
+  { mod: GifencModule } | { mod: null; reason: string }
+> {
+  try {
+    const mod = (await import("gifenc")) as unknown as GifencModule;
+    return { mod };
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
+      return { mod: null, reason: "module-missing" };
+    }
+    return {
+      mod: null,
+      reason: `gifenc import failed: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+}
+
+export async function recordSimulation(
+  args: Record<string, unknown>,
+): Promise<RecordResult> {
+  const envId = String(args.env_id ?? "");
+  const documentId = String(args.document_id ?? "");
+
+  const stepsRaw = Number(args.steps ?? 0);
+  if (!Number.isFinite(stepsRaw)) {
+    return errorResult(
+      `record_simulation refused: 'steps' must be a finite number`,
+    );
+  }
+  const steps = Math.min(
+    MAX_STEPS,
+    Math.max(MIN_STEPS, Math.round(stepsRaw)),
+  );
+
+  const widthRaw = Number(args.width_px ?? DEFAULT_WIDTH_PX);
+  const widthPx = Math.min(
+    MAX_WIDTH_PX,
+    Math.max(
+      MIN_WIDTH_PX,
+      Number.isFinite(widthRaw) ? Math.round(widthRaw) : DEFAULT_WIDTH_PX,
+    ),
+  );
+
+  const fpsRaw = Number(args.fps ?? DEFAULT_FPS);
+  const fps = Math.min(
+    MAX_FPS,
+    Math.max(MIN_FPS, Number.isFinite(fpsRaw) ? Math.round(fpsRaw) : DEFAULT_FPS),
+  );
+
+  const viewRaw = String(args.view ?? "iso").toLowerCase();
+  const view = (
+    viewRaw === "isometric"
+      ? "iso"
+      : ["iso", "top", "front", "side"].includes(viewRaw)
+        ? viewRaw
+        : "iso"
+  ) as "iso" | "top" | "front" | "side";
+  const viewLabel = view === "iso" ? "isometric" : view;
+
+  const actionType = (args.action_type ?? "torque") as PhysicsActionType;
+  if (!["torque", "position", "velocity"].includes(actionType)) {
+    return errorResult(
+      `record_simulation refused: action_type '${actionType}' is not one of torque|position|velocity`,
+    );
+  }
+
+  // Look up the env and document. Both must already exist; this tool does
+  // not create either, by design — the agent's expected flow is
+  //   open_document → create_robot_env → record_simulation
+  // so failures here mean a typo, an expired session, or a closed env.
+  const env = getSimulation(envId);
+  if (!env) {
+    return errorResult(`Unknown env_id: ${envId}`);
+  }
+
+  let doc: Document;
+  try {
+    doc = getSession(documentId);
+  } catch (e) {
+    return errorResult(
+      `Unknown document_id: ${documentId} (${e instanceof Error ? e.message : String(e)})`,
+    );
+  }
+
+  if (!doc.joints || doc.joints.length === 0) {
+    return errorResult(
+      `document_id ${documentId} has no joints — nothing to animate.`,
+    );
+  }
+  if (doc.joints.length !== env.numJoints) {
+    return errorResult(
+      `joint-count mismatch: env_id has ${env.numJoints} joints, document_id has ${doc.joints.length}. The env must have been created from a different assembly.`,
+    );
+  }
+
+  // Resolve the action vector(s). `actions` (per-step) wins over `action`
+  // (constant); falling back to all-zeros means "passive playback".
+  const perStepActions = resolveActions(args, env.actionDim, steps);
+  if ("error" in perStepActions) {
+    return errorResult(perStepActions.error);
+  }
+
+  const wasm = (await getKernelWasm()) as unknown as {
+    render_svg: (vcadJson: string, scale: number) => string;
+    render_svg_view?: (vcadJson: string, scale: number, view: string) => string;
+  };
+  if (typeof wasm.render_svg !== "function") {
+    return errorResult(
+      "record_simulation unavailable: kernel WASM build predates render_svg — rebuild @vcad/kernel-wasm.",
+    );
+  }
+
+  // Pre-flight: load the GIF encoder so we can degrade early if it's
+  // missing, instead of stepping the env first and discarding the work.
+  const gifLoad = await loadGifenc();
+
+  // Deep-copy the document for stepping. The session doc is shared mutable
+  // state — if a second tool call lands while we're iterating, our restore
+  // would clobber their writes. Operating on a clone keeps the session doc
+  // untouched throughout, and the agent can always inspect the env via
+  // gym_observe afterward to see the final pose.
+  const docClone: Document = JSON.parse(JSON.stringify(doc));
+
+  const jointTrajectory: number[][] = [];
+  const delayMs = Math.max(1, Math.round(1000 / fps));
+
+  let rasterDegraded: string | null = null;
+  let firstFrameSize: { width: number; height: number } | null = null;
+  let encoder: ReturnType<GifencModule["GIFEncoder"]> | null = null;
+  if (gifLoad.mod) encoder = gifLoad.mod.GIFEncoder();
+
+  let framesEncoded = 0;
+  for (let s = 0; s < steps; s++) {
+    const result = env.step(actionType, perStepActions.values[s]!);
+    const obs = result.observation;
+
+    for (let j = 0; j < docClone.joints!.length; j++) {
+      const pos = obs.joint_positions[j];
+      if (typeof pos === "number") docClone.joints![j]!.state = pos;
+    }
+    jointTrajectory.push([...obs.joint_positions]);
+
+    let svg: string;
+    try {
+      svg =
+        view !== "iso" && typeof wasm.render_svg_view === "function"
+          ? wasm.render_svg_view(JSON.stringify(docClone), SVG_SCALE, view)
+          : wasm.render_svg(JSON.stringify(docClone), SVG_SCALE);
+    } catch (e) {
+      if (e instanceof WebAssembly.RuntimeError) {
+        resetKernelWasm(`render_svg trapped during record_simulation: ${e.message}`);
+        return errorResult(
+          `kernel trap during frame ${s + 1}/${steps}: ${e.message}`,
+        );
+      }
+      return errorResult(
+        `render failed at frame ${s + 1}/${steps}: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+
+    const raster = await rasterize(svg, widthPx);
+    if (!raster.rgba) {
+      rasterDegraded =
+        raster.reason === "module-missing"
+          ? "Install @resvg/resvg-js for rasterization."
+          : `Rasterization failed: ${raster.reason}.`;
+      break;
+    }
+    if (!firstFrameSize) {
+      firstFrameSize = { width: raster.width, height: raster.height };
+    }
+
+    // Stream the frame into the encoder so we never hold more than one
+    // decoded RGBA buffer + the indexed bytes at once. Without this the
+    // peak memory at MAX_STEPS×MAX_WIDTH_PX would be in the gigabytes.
+    if (encoder && gifLoad.mod) {
+      const palette = gifLoad.mod.quantize(raster.rgba, 256);
+      const indexed = gifLoad.mod.applyPalette(raster.rgba, palette);
+      encoder.writeFrame(indexed, raster.width, raster.height, {
+        palette,
+        delay: delayMs,
+      });
+      framesEncoded++;
+    }
+  }
+
+  if (rasterDegraded || !encoder) {
+    const note =
+      rasterDegraded ??
+      ("reason" in gifLoad && gifLoad.reason === "module-missing"
+        ? "Install `gifenc` to receive an animated GIF; returning joint trajectory only."
+        : "reason" in gifLoad
+          ? `GIF ${gifLoad.reason}; returning joint trajectory only.`
+          : "No frames captured.");
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              env_id: envId,
+              document_id: documentId,
+              steps: jointTrajectory.length,
+              fps,
+              view: viewLabel,
+              format: "json",
+              note,
+              joint_trajectory: jointTrajectory,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+      isError: rasterDegraded !== null,
+    };
+  }
+
+  encoder.finish();
+  const gif = encoder.bytes();
+
+  return {
+    content: [
+      {
+        type: "image",
+        data: Buffer.from(gif).toString("base64"),
+        mimeType: "image/gif",
+      },
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            env_id: envId,
+            document_id: documentId,
+            steps: framesEncoded,
+            fps,
+            view: viewLabel,
+            width_px: firstFrameSize?.width ?? widthPx,
+            height_px: firstFrameSize?.height ?? null,
+            format: "gif",
+            duration_s: Math.round((framesEncoded / fps) * 100) / 100,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+function resolveActions(
+  args: Record<string, unknown>,
+  actionDim: number,
+  steps: number,
+): { values: number[][] } | { error: string } {
+  const perStep = args.actions;
+  const constant = args.action;
+
+  if (perStep !== undefined && constant !== undefined) {
+    return {
+      error: "Pass either `action` or `actions`, not both.",
+    };
+  }
+
+  if (Array.isArray(perStep)) {
+    if (perStep.length !== steps) {
+      return {
+        error: `'actions' length ${perStep.length} does not match steps=${steps}.`,
+      };
+    }
+    const out: number[][] = [];
+    for (let i = 0; i < perStep.length; i++) {
+      const row = perStep[i];
+      if (!Array.isArray(row) || row.length !== actionDim) {
+        return {
+          error: `'actions[${i}]' must be an array of length ${actionDim} (got ${Array.isArray(row) ? `length ${row.length}` : typeof row}).`,
+        };
+      }
+      out.push(row.map(Number));
+    }
+    return { values: out };
+  }
+
+  let vec: number[];
+  if (Array.isArray(constant)) {
+    if (constant.length !== actionDim) {
+      return {
+        error: `'action' length ${constant.length} does not match action_dim=${actionDim}.`,
+      };
+    }
+    vec = constant.map(Number);
+  } else {
+    vec = new Array(actionDim).fill(0);
+  }
+  const values: number[][] = new Array(steps);
+  for (let i = 0; i < steps; i++) values[i] = vec;
+  return { values };
+}
+
+function errorResult(text: string): RecordResult {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ error: text }),
+      },
+    ],
+    isError: true,
+  };
+}


### PR DESCRIPTION
## Summary

Adds the ability to record physics simulations to video files (MP4/WebM) from both the web app viewport and the MCP server. Users can now capture animated simulations running in the UI, and AI agents can programmatically record simulation runs to GIF via the new `record_simulation` MCP tool.

## Key Changes

### Web App Recording (`packages/app`)
- **`useCanvasRecorder` hook** — Manages MediaRecorder lifecycle, capturing either the WebGL canvas (standard mode) or raytrace overlay canvas (raytrace mode). Mirrors sim play/pause into recorder pause/resume, and auto-finalizes when sim stops.
- **`recording-store`** — Zustand store tracking recording status (idle/recording/paused/saving), bytes recorded, MIME type, and errors. Drives the Record button state and lifecycle.
- **Record button** — Added to simulate toolbar; shows recording status (pulsing red when active), disabled during sketch mode or when physics unavailable.
- **Render mode guard** — `recording-guard.ts` prevents switching render modes mid-recording (MediaRecorder stream is bound to one canvas at start).
- **RayTracedViewport integration** — Exposes overlay canvas and `triggerRaytraceRender()` so recorder can drive per-frame raytrace renders during animation (normal scheduler only fires on camera change).

### MCP Server Recording (`packages/mcp`)
- **`record_simulation` tool** — Server-side physics-to-video: pairs a session document with an active PhysicsEnv, steps the env N times, mutates the document's joint state to match observations, re-renders via kernel SVG, rasterizes frames to PNG via optional `@resvg/resvg-js`, and muxes into animated GIF via optional `gifenc`.
- **Graceful degradation** — When optional deps are missing, tool returns JSON trajectory summary instead of silent failure.
- **Action resolution** — Supports constant action vector or per-step action arrays; defaults to all-zeros (passive playback under gravity).
- **Configurable output** — FPS (1–60), view (iso/top/front/side), width (64–1024px), step count (1–600).
- **Type definitions** — Added `gifenc.d.ts` ambient types for the encoder module.

### Core Store Export
- **`useRecordingStore`** exported from `@vcad/core` so app components can subscribe to recording state.

### Dependencies
- Added optional `gifenc@^1.0.3` to `packages/mcp` for GIF encoding.

## Implementation Details

- **Memory efficiency** — Frames are streamed into the GIF encoder one at a time so peak memory stays bounded even at 600 steps × 1024px.
- **WASM safety** — Kernel traps during rendering are caught, the WASM instance is reset, and a clear error is returned.
- **Canvas capture** — Uses `HTMLCanvasElement.captureStream()` for zero-copy frame delivery to MediaRecorder.
- **Raytrace animation** — Recorder drives a per-frame raytrace render loop via `requestAnimationFrame` so animation is visible in the recording (bypasses the normal draft→standard→high refinement scheduler).
- **Sim pause/resume mirroring** — MediaRecorder pause/resume is synchronized with sim state so the captured timeline matches what the user sees.
- **File naming** — Recorded videos are saved with timestamp and slugified document name (e.g., `vcad-sim-my-robot-2026-06-25T18-04-12.mp4`).

## Testing Notes

- Web app: Start a simulation, click Record, watch the red pulsing button, stop to save the file.
- MCP: Call `record_simulation` with an active env and document; returns GIF or JSON trajectory depending on optional dep availability.
- Render mode switching is blocked while recording; attempting it shows a toast notification.

https://claude.ai/code/session_01KtBp4K2pM1p2ANbWj5SypM