### PR TITLE
feat(mcp): place_components reports board utilization + suggested outline

### DIFF
--- a/changelog/entries/2026-06-24-place-components-utilization.json
+++ b/changelog/entries/2026-06-24-place-components-utilization.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-24-place-components-utilization",
+  "version": "0.9.4",
+  "date": "2026-06-24",
+  "category": "feat",
+  "title": "place_components reports board utilization",
+  "summary": "place_components now returns a utilization report — board vs occupied area, % used, component bounding box, and an advisory right-sized outline — so over-large boards can be tightened in one step.",
+  "features": ["mcp", "ecad", "agents"],
+  "mcpTools": ["place_components"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -737,6 +737,98 @@ describe("board shapes and radial placement", () => {
   });
 });
 
+describe("place_components utilization", () => {
+  it("reports board utilization and a tighter rectangular outline", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+      }),
+    );
+    const placed = out(
+      await placeComponents({
+        document_id: created.document_id,
+        board_width: 50,
+        board_height: 40,
+      }),
+    );
+
+    const u = placed.utilization;
+    expect(u).toBeDefined();
+    // Board area is exact from the rectangle outline.
+    expect(u.board_area_mm2).toBeCloseTo(2000, 1);
+    expect(u.component_area_mm2).toBeGreaterThan(0);
+    expect(u.component_area_mm2).toBeLessThan(u.board_area_mm2);
+    // % used is internally consistent and a small fraction (two 0805 parts).
+    expect(u.utilization_pct).toBeCloseTo(
+      Math.round((u.component_area_mm2 / u.board_area_mm2) * 1000) / 10,
+      1,
+    );
+    expect(u.utilization_pct).toBeGreaterThan(0);
+    expect(u.utilization_pct).toBeLessThan(100);
+
+    // Bounding box is positive and fits inside the board.
+    expect(u.bounding_box.w).toBeGreaterThan(0);
+    expect(u.bounding_box.h).toBeGreaterThan(0);
+    expect(u.bounding_box.x).toBeGreaterThanOrEqual(0);
+
+    // Suggested outline keeps the rect shape, encloses the parts, and is
+    // tighter than the over-large 50×40 board.
+    expect(u.suggested_outline.type).toBe("rect");
+    expect(u.suggested_outline.width).toBeGreaterThanOrEqual(u.bounding_box.w);
+    expect(u.suggested_outline.height).toBeGreaterThanOrEqual(u.bounding_box.h);
+    expect(u.suggested_outline.width).toBeLessThan(50);
+    expect(u.suggested_outline.note).toContain("edge clearance");
+  });
+
+  it("suggests an enclosing circle for a circular board", async () => {
+    const created = out(
+      await createSchematic({
+        components: Array.from({ length: 4 }, (_, i) => resistor(`R${i + 1}`, i * 8)),
+      }),
+    );
+    const placed = out(
+      await placeComponents({
+        document_id: created.document_id,
+        board_shape: { type: "circle", outer_diameter: 40 },
+      }),
+    );
+
+    const u = placed.utilization;
+    expect(u).toBeDefined();
+    // 64-gon inscribed in r=20 ≈ π·20² = 1257 mm².
+    expect(u.board_area_mm2).toBeGreaterThan(1200);
+    expect(u.board_area_mm2).toBeLessThan(1300);
+    expect(u.suggested_outline.type).toBe("circle");
+    expect(u.suggested_outline.outer_diameter).toBeGreaterThan(0);
+    expect(u.suggested_outline.outer_diameter).toBeLessThanOrEqual(40);
+    expect(u.suggested_outline.center).toBeDefined();
+  });
+
+  it("honors edge_margin when sizing the suggested outline", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+      }),
+    );
+    const id = created.document_id;
+
+    // Zero margin → suggested width hugs the bounding box (rounded up to 0.5mm).
+    const tight = out(
+      await placeComponents({ document_id: id, board_width: 50, board_height: 40, edge_margin: 0 }),
+    ).utilization;
+    expect(tight.suggested_outline.width - tight.bounding_box.w).toBeGreaterThanOrEqual(0);
+    expect(tight.suggested_outline.width - tight.bounding_box.w).toBeLessThan(0.5);
+    expect(tight.suggested_outline.note).toContain("0mm");
+
+    // 5mm margin → ~10mm wider than the bounding box (both sides).
+    const loose = out(
+      await placeComponents({ document_id: id, board_width: 50, board_height: 40, edge_margin: 5 }),
+    ).utilization;
+    expect(loose.suggested_outline.width - loose.bounding_box.w).toBeGreaterThanOrEqual(10);
+    expect(loose.suggested_outline.width - loose.bounding_box.w).toBeLessThan(10.5);
+  });
+});
+
 describe("add_coil", () => {
   async function circleBoardSession(): Promise<string> {
     const created = out(await createSchematic({ components: [resistor("R1", 0)] }));

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1088,7 +1088,10 @@ export async function createServer(
           "(board_width/height), circle with optional center bore " +
           "(board_shape — e.g. a motor stator), or any polygon (outline, e.g. " +
           "from board_from_solid). strategy=radial rings components for " +
-          "annular boards.",
+          "annular boards. Returns a `utilization` report (board vs occupied " +
+          "area, % used, component bounding box, and an advisory " +
+          "suggested_outline) so you can right-size an over-large board in one " +
+          "step instead of guessing.",
         inputSchema: placeComponentsSchema,
       },
       {

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -576,6 +576,14 @@ export const placeComponentsSchema = {
       type: "number" as const,
       description: "Angle of the first component for strategy=radial (default 0 = +X).",
     },
+    edge_margin: {
+      type: "number" as const,
+      description:
+        "Edge clearance in mm used when computing the advisory " +
+        "`utilization.suggested_outline` (default: max of the design-rule edge " +
+        "clearance and 2mm). Does not affect placement — only the suggested " +
+        "right-sized outline reported back.",
+    },
   },
   required: [],
 };
@@ -1702,6 +1710,22 @@ export async function placeComponents(args: Record<string, unknown>) {
   const netsSummary: Record<string, string[]> = {};
   for (const [name, pins] of derived.nets) netsSummary[name] = pins;
 
+  // --- Board utilization + suggested outline (advisory) -----------------
+  // Force-directed/grid placement can leave a generous board mostly empty
+  // copper. Report how much area the parts actually occupy, plus the tightest
+  // same-shape outline that still holds them, so cost-sensitive callers (and
+  // agents) can right-size in one step instead of trial-and-error. Strictly
+  // advisory — the caller decides whether to act on it.
+  const utilization = computeUtilization(
+    footprints,
+    vertices,
+    cutouts,
+    outlineArg ? "polygon" : shapeArg ? "circle" : "rect",
+    circleInnerR,
+    args.edge_margin as number | undefined,
+    rules.edgeClearance,
+  );
+
   return {
     content: [
       {
@@ -1725,11 +1749,139 @@ export async function placeComponents(args: Record<string, unknown>) {
             shape: outlineArg ? "polygon" : shapeArg ? "circle" : "rect",
             ...(cutouts && cutouts.length > 0 ? { cutouts: cutouts.length } : {}),
           },
+          ...(utilization ? { utilization } : {}),
           nets: netsSummary,
           ...docResultPayload(ctx),
         }),
       },
     ],
+  };
+}
+
+/**
+ * Axis-aligned half-extents (mm) of a single pad in footprint-local coords.
+ * Mirrors the placer's keep-out sizing but keeps x/y separate for a tight
+ * bounding box. Pad rotation is ignored (consistent with the placer).
+ */
+function padHalfExtents(shape: Pad["shape"]): { hx: number; hy: number } {
+  switch (shape.type) {
+    case "Circle":
+      return { hx: shape.diameter / 2, hy: shape.diameter / 2 };
+    case "Rect":
+    case "Oval":
+    case "RoundRect":
+      return { hx: shape.width / 2, hy: shape.height / 2 };
+    case "Custom": {
+      let hx = 0;
+      let hy = 0;
+      for (const v of shape.vertices) {
+        hx = Math.max(hx, Math.abs(v.x));
+        hy = Math.max(hy, Math.abs(v.y));
+      }
+      return { hx: hx || 0.5, hy: hy || 0.5 };
+    }
+    default:
+      return { hx: 0.5, hy: 0.5 };
+  }
+}
+
+/**
+ * Board-area utilization plus an advisory right-sized outline, from the final
+ * placed footprints. Component area is courtyard-approximate — summed pad
+ * bounding boxes, the geometry we reliably have for every footprint (inline,
+ * engine-resolved, or generic placeholder). The suggested outline keeps the
+ * board's current shape and honors `edge_margin`. Returns undefined when
+ * there's nothing to measure (no pads, or a degenerate board area).
+ */
+function computeUtilization(
+  footprints: Footprint[],
+  vertices: Vec2[],
+  cutouts: Vec2[][] | undefined,
+  shape: "polygon" | "circle" | "rect",
+  innerRadius: number,
+  edgeMarginArg: number | undefined,
+  edgeClearance: number,
+):
+  | {
+      board_area_mm2: number;
+      component_area_mm2: number;
+      utilization_pct: number;
+      bounding_box: { x: number; y: number; w: number; h: number };
+      suggested_outline: Record<string, unknown>;
+    }
+  | undefined {
+  // World-space AABB of every placed footprint; sum of the boxes is the
+  // occupied (courtyard-approximate) area.
+  let occMinX = Infinity;
+  let occMinY = Infinity;
+  let occMaxX = -Infinity;
+  let occMaxY = -Infinity;
+  let componentArea = 0;
+  for (const fp of footprints) {
+    let lMinX = Infinity;
+    let lMinY = Infinity;
+    let lMaxX = -Infinity;
+    let lMaxY = -Infinity;
+    for (const pad of fp.pads) {
+      const { hx, hy } = padHalfExtents(pad.shape);
+      lMinX = Math.min(lMinX, pad.position.x - hx);
+      lMaxX = Math.max(lMaxX, pad.position.x + hx);
+      lMinY = Math.min(lMinY, pad.position.y - hy);
+      lMaxY = Math.max(lMaxY, pad.position.y + hy);
+    }
+    if (!Number.isFinite(lMinX)) continue; // padless footprint — skip
+    componentArea += (lMaxX - lMinX) * (lMaxY - lMinY);
+    occMinX = Math.min(occMinX, fp.position.x + lMinX);
+    occMaxX = Math.max(occMaxX, fp.position.x + lMaxX);
+    occMinY = Math.min(occMinY, fp.position.y + lMinY);
+    occMaxY = Math.max(occMaxY, fp.position.y + lMaxY);
+  }
+
+  // Usable board area = outer polygon minus cutouts (shoelace, sign-agnostic).
+  const boardArea =
+    Math.abs(loopSignedArea(vertices)) -
+    (cutouts ?? []).reduce((s, c) => s + Math.abs(loopSignedArea(c)), 0);
+
+  if (!Number.isFinite(occMinX) || boardArea <= 0) return undefined;
+
+  const round2 = (v: number) => Math.round(v * 100) / 100;
+  const ceilHalf = (v: number) => Math.ceil(v * 2) / 2; // round up to 0.5mm
+  const bbW = occMaxX - occMinX;
+  const bbH = occMaxY - occMinY;
+  // Default keeps the suggestion DRC-safe: never tighter than the board's own
+  // edge clearance, and at least 2mm so a fab edge router has room.
+  const margin = Math.max(0, edgeMarginArg ?? Math.max(edgeClearance, 2));
+
+  // Suggest the board's current shape — that's the in-place right-size.
+  let suggested: Record<string, unknown>;
+  if (shape === "circle") {
+    // Enclosing circle of the component AABBs, recentered on the cluster.
+    const cx = (occMinX + occMaxX) / 2;
+    const cy = (occMinY + occMaxY) / 2;
+    const od = ceilHalf(2 * (Math.hypot(bbW / 2, bbH / 2) + margin));
+    suggested = {
+      type: "circle",
+      outer_diameter: od,
+      center: { x: round2(cx), y: round2(cy) },
+      ...(innerRadius > 0 ? { inner_diameter: round2(2 * innerRadius) } : {}),
+      note: `Minimum enclosing circle with ${margin}mm edge clearance`,
+    };
+  } else {
+    suggested = {
+      type: "rect",
+      width: ceilHalf(bbW + 2 * margin),
+      height: ceilHalf(bbH + 2 * margin),
+      origin: { x: round2(occMinX - margin), y: round2(occMinY - margin) },
+      note: `Minimum enclosing rectangle with ${margin}mm edge clearance`,
+    };
+  }
+
+  return {
+    board_area_mm2: round2(boardArea),
+    component_area_mm2: round2(componentArea),
+    utilization_pct: Math.round((componentArea / boardArea) * 1000) / 10,
+    bounding_box: { x: round2(occMinX), y: round2(occMinY), w: round2(bbW), h: round2(bbH) },
+    suggested_outline: suggested,
   };
 }
 


### PR DESCRIPTION
## What

`place_components` now returns a `utilization` block alongside the placed board, so callers (and agents) get an immediate read on spatial efficiency instead of discovering an over-large board the hard way.

New fields in the return payload:
- **`board_area_mm2`** — outer outline area minus cutouts (shoelace)
- **`component_area_mm2`** — summed footprint pad bounding boxes (courtyard-approximate; works for inline, engine-resolved, *and* generic-placeholder footprints)
- **`utilization_pct`** — component area ÷ board area
- **`bounding_box`** — tight `{x, y, w, h}` around all placed parts
- **`suggested_outline`** — the tightest *same-shape* outline that still holds the parts, recentered on the cluster:
  - circle → `{outer_diameter, center, inner_diameter?, note}`
  - rect / polygon → `{width, height, origin, note}`

New optional **`edge_margin`** param (default `max(design-rule edge clearance, 2mm)`) controls the suggested outline's clearance. It affects the suggestion only — placement is unchanged.

## Why

On a generous board with a few clustered components, the placer gave no signal that ~70% of the copper was empty. PCB fab cost scales with panel area, so knowing you're at ~9% utilization on a 25mm board — and that a 16mm board would hold the same parts — saves an iteration cycle. It also lets an LLM agent close the loop: place → read utilization → re-place tighter, with no human in the middle.

The suggestion is **strictly advisory** — the caller decides whether to act on it.

## Proof

Real-kernel run of the reported scenario (25mm circle, SOIC-8 + 7 0402/0805 passives):

| strategy | utilization | bounding box | suggested |
|---|---|---|---|
| `grid` | 9.2% | 17.2 × 15.3 | ⌀27.5mm |
| `force_directed` | 9.2% | 7.7 × 9.2 | **⌀16mm** |

The force-directed case is the exact complaint: a 25mm board at ~9% utilization → suggest a 16mm board (~41% of the area), recentered on the cluster. `board_area_mm2` = 490.09 matches π·12.5² (64-gon approximation).

## Reviewer notes

- Component area is **courtyard-approximate** — summed pad AABBs, the geometry reliably available for every footprint path. It under-counts IC bodies between pad rows slightly; the headline number is `utilization_pct`, which is what callers act on.
- The suggested outline keeps the board's current shape (in-place right-size); for annular circle boards the existing `inner_diameter` is preserved.
- Default margin is `max(edgeClearance, 2)` so the suggestion is never tighter than the board's own edge-clearance DRC.
- Returns nothing (field omitted) when there's nothing to measure — no pads or degenerate board area.

## Tests

3 new cases in `ecad.test.ts` (rect utilization + consistency, circle suggestion, `edge_margin` scaling). Full MCP suite: **307 passed**, 2 skipped. `tsc --noEmit` clean. Changelog entry added (`feat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)