### PR TITLE
fix(pcb): force-directed placement no longer bakes in cross-net pad shorts

### DIFF
--- a/changelog/entries/2026-06-24-placer-cross-net-clearance.json
+++ b/changelog/entries/2026-06-24-placer-cross-net-clearance.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-24-placer-cross-net-clearance",
+  "version": "0.9.4",
+  "date": "2026-06-24",
+  "category": "fix",
+  "title": "Force-directed placement no longer bakes in cross-net shorts",
+  "summary": "place_components with strategy:force_directed now legalizes different-net pad overlaps to clearance instead of settling components on top of each other, and reports placement_conflicts with success:false when a board is too tight to separate them.",
+  "features": ["pcb", "placement", "drc"],
+  "mcpTools": ["place_components"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -293,6 +293,123 @@ describe("ecad session flow", () => {
     expect(d).toBeGreaterThan(8);
   });
 
+  it("force_directed never bakes a cross-net pad short into the board", async () => {
+    // A tightly-netted NE555-style cluster: the net-attraction can pull
+    // different-net pads on top of each other (a VCC/GND short) before any
+    // routing. Placement must legalize that away, not ship success with a short.
+    const r = (ref: string) => ({
+      ref,
+      value: "1k",
+      footprint: "Resistor_SMD:R_0805",
+      x: 0,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive" },
+        { number: "2", name: "~", type: "Passive" },
+      ],
+    });
+    const twoPin = (ref: string, value: string, footprint: string) => ({
+      ref,
+      value,
+      footprint,
+      x: 0,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive" },
+        { number: "2", name: "~", type: "Passive" },
+      ],
+    });
+    const created = out(
+      await createSchematic({
+        components: [
+          {
+            ref: "U1",
+            value: "NE555",
+            footprint: "Package_SO:SOIC-8_3.9x4.9mm_P1.27mm",
+            x: 0,
+            y: 0,
+            pins: Array.from({ length: 8 }, (_, i) => ({
+              number: String(i + 1),
+              name: ["GND", "TRIG", "OUT", "RESET", "CTRL", "THR", "DIS", "VCC"][i],
+              type: "Passive",
+            })),
+          },
+          r("R1"),
+          r("R2"),
+          r("R3"),
+          twoPin("C1", "10uF", "Capacitor_SMD:C_1206"),
+          twoPin("C2", "10nF", "Capacitor_SMD:C_0805"),
+          twoPin("D1", "LED", "LED_SMD:LED_0805"),
+          twoPin("J1", "PWR", "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm"),
+        ],
+        nets: {
+          VCC: ["J1.1", "U1.8", "U1.4", "R1.1"],
+          GND: ["J1.2", "U1.1", "C1.2", "C2.2", "R3.2"],
+          DIS: ["U1.7", "R1.2", "R2.1"],
+          THR: ["U1.6", "U1.2", "R2.2", "C1.1"],
+          CTRL: ["U1.5", "C2.1"],
+          OUT: ["U1.3", "D1.1"],
+          LEDK: ["D1.2", "R3.1"],
+        },
+      }),
+    );
+    const id = created.document_id;
+    const placed = out(
+      await placeComponents({
+        document_id: id,
+        board_shape: { outer_diameter: 25, type: "circle" },
+        strategy: "force_directed",
+      }),
+    );
+    expect(placed.success).toBe(true);
+    expect(placed.placement_conflicts).toBeUndefined();
+
+    // The DRC oracle: before any routing, no copper-to-copper clearance or short
+    // violations may exist (the only legal violations are unrouted ratsnest).
+    const drc = out(await runDrc({ document_id: id, detail: "full" }));
+    const shorts = (drc.details ?? []).filter((v: { rule: string }) => v.rule === "Short");
+    expect(shorts).toHaveLength(0);
+    expect(drc.categories.clearance).toBe(0);
+  });
+
+  it("force_directed reports cross-net conflicts it can't fit (no false success)", async () => {
+    // Four 1x02 headers (~4.5mm wide) sharing a common net on a 5mm board:
+    // there is physically no way to separate every different-net pad. The placer
+    // must report the unresolved pairs and refuse to claim success.
+    const hdr = (ref: string) => ({
+      ref,
+      value: "H",
+      footprint: "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm",
+      x: 0,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive" },
+        { number: "2", name: "~", type: "Passive" },
+      ],
+    });
+    const comps = ["J1", "J2", "J3", "J4"].map(hdr);
+    const nets: Record<string, string[]> = { COMMON: comps.map((c) => `${c.ref}.1`) };
+    comps.forEach((c) => (nets[`SIG_${c.ref}`] = [`${c.ref}.2`]));
+    const created = out(await createSchematic({ components: comps, nets }));
+    const placed = out(
+      await placeComponents({
+        document_id: created.document_id,
+        board_width: 5,
+        board_height: 5,
+        strategy: "force_directed",
+      }),
+    );
+    expect(placed.success).toBe(false);
+    expect(placed.placement_conflicts.length).toBeGreaterThan(0);
+    // Each reported conflict is a genuine sub-clearance gap (clearance is 0.2mm).
+    for (const c of placed.placement_conflicts) {
+      expect(c.gap).toBeLessThan(0.2);
+      expect(c.a).toBeTruthy();
+      expect(c.b).toBeTruthy();
+    }
+    expect(placed.warnings.some((w: string) => /cross-net pad overlap/i.test(w))).toBe(true);
+  });
+
   it("route_nets honors per-net-class width and reports realized widths", async () => {
     const created = out(
       await createSchematic({

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -561,8 +561,11 @@ export const placeComponentsSchema = {
       description:
         "Placement strategy: grid, force_directed, radial (default: grid). " +
         "force_directed pulls net-sharing parts together and pushes overlapping " +
-        "courtyards apart (size-aware) — prefer it for dense, multi-cluster " +
-        "boards (power stage + MCU + connectors) where routability matters. " +
+        "courtyards apart (size-aware), then legalizes any different-net pad " +
+        "overlap to clearance so it never bakes in a short — prefer it for " +
+        "dense, multi-cluster boards (power stage + MCU + connectors) where " +
+        "routability matters. If the board is too small to separate every " +
+        "cross-net pad it reports `placement_conflicts` and success:false. " +
         "radial places components evenly on a ring — natural for circular " +
         "boards like motor stators.",
     },
@@ -1308,6 +1311,114 @@ function forceDirectedRefine(
   }
 }
 
+/** A pad's copper, in component-local coordinates, for clearance legalization. */
+interface LocalPad {
+  x: number;
+  y: number;
+  /** Bounding-circle radius (over-approximates the copper, never misses an overlap). */
+  r: number;
+  net?: string;
+}
+
+/**
+ * Hard-separate components whose cross-net pads violate copper clearance.
+ *
+ * The force-directed pass balances net-attraction against courtyard repulsion,
+ * but that equilibrium can still settle with two components' pads — on
+ * *different* nets — overlapping, baking a short into the board before any
+ * routing (e.g. a VCC pad stacked on a GND pad). This pass mirrors the DRC
+ * pad-clearance rule (different-net pads must clear; same-net or unnetted pads
+ * may touch) and shoves the offending components apart along their
+ * center-to-center axis until every cross-net pad pair clears — or a pass cap
+ * is hit when the board is simply too tight. Each pad is modeled as its
+ * bounding circle (radius ≥ the real copper), so clearing the circles
+ * guarantees the true rectangular copper clears too.
+ *
+ * Returns the component pairs it could *not* separate, so the caller can refuse
+ * to report success on a board that still contains a short.
+ */
+function legalizeCrossNetClearance(
+  components: SchematicComponent[],
+  positions: Vec2[],
+  padLayout: LocalPad[][],
+  clearance: number,
+  bounds: { minX: number; minY: number; maxX: number; maxY: number },
+): Array<{ a: string; b: string; gap: number }> {
+  const n = positions.length;
+  const eps = 1e-3;
+  // Separate to a hair beyond clearance so the later 0.01mm position rounding
+  // (footprint build) can't nudge a just-cleared pair back under the limit.
+  const target = clearance + 0.05;
+
+  // Worst cross-net clearance deficit between components i and j at their
+  // current positions (>0 means a cross-net pad pair is closer than `goal`).
+  const deficit = (i: number, j: number, goal: number): number => {
+    let worst = 0;
+    for (const pa of padLayout[i]) {
+      if (!pa.net) continue;
+      for (const pb of padLayout[j]) {
+        if (!pb.net || pa.net === pb.net) continue;
+        const ax = positions[i].x + pa.x;
+        const ay = positions[i].y + pa.y;
+        const bx = positions[j].x + pb.x;
+        const by = positions[j].y + pb.y;
+        const gap = Math.hypot(ax - bx, ay - by) - pa.r - pb.r;
+        const d = goal - gap;
+        if (d > worst) worst = d;
+      }
+    }
+    return worst;
+  };
+
+  const maxPasses = 400;
+  for (let pass = 0; pass < maxPasses; pass++) {
+    let moved = false;
+    for (let i = 0; i < n; i++) {
+      for (let j = i + 1; j < n; j++) {
+        const d = deficit(i, j, target);
+        if (d <= eps) continue;
+        moved = true;
+        let dx = positions[j].x - positions[i].x;
+        let dy = positions[j].y - positions[i].y;
+        let len = Math.hypot(dx, dy);
+        if (len < 1e-6) {
+          // Coincident centers — pick a deterministic separation axis (no RNG,
+          // so placement stays reproducible) from the index pair.
+          const a = (((i + 1) * 73856093) ^ ((j + 1) * 19349663)) % 360;
+          dx = Math.cos((a * Math.PI) / 180);
+          dy = Math.sin((a * Math.PI) / 180);
+          len = 1;
+        }
+        const ux = dx / len;
+        const uy = dy / len;
+        const half = d / 2 + eps;
+        positions[i].x = Math.min(bounds.maxX, Math.max(bounds.minX, positions[i].x - ux * half));
+        positions[i].y = Math.min(bounds.maxY, Math.max(bounds.minY, positions[i].y - uy * half));
+        positions[j].x = Math.min(bounds.maxX, Math.max(bounds.minX, positions[j].x + ux * half));
+        positions[j].y = Math.min(bounds.maxY, Math.max(bounds.minY, positions[j].y + uy * half));
+      }
+    }
+    if (!moved) break;
+  }
+
+  // Report pairs that still breach the real clearance after the cap — the board
+  // couldn't fit them (e.g. too small, or clamped into the same corner).
+  const remaining: Array<{ a: string; b: string; gap: number }> = [];
+  for (let i = 0; i < n; i++) {
+    for (let j = i + 1; j < n; j++) {
+      const d = deficit(i, j, clearance);
+      if (d > eps) {
+        remaining.push({
+          a: components[i].ref,
+          b: components[j].ref,
+          gap: Math.round((clearance - d) * 1000) / 1000,
+        });
+      }
+    }
+  }
+  return remaining;
+}
+
 /** Return the polygon wound counter-clockwise (kernel extrusion convention). */
 function ensureCcw(poly: Vec2[]): Vec2[] {
   return loopSignedArea(poly) < 0 ? [...poly].reverse() : poly;
@@ -1519,6 +1630,21 @@ export async function placeComponents(args: Record<string, unknown>) {
         return 0.5; // Custom polygon — small default
     }
   };
+  // Bounding-circle radius of a pad's copper (half-diagonal for rects) — used by
+  // cross-net clearance legalization, where the circle must *contain* the copper
+  // so that separating circles guarantees the real pads can't short.
+  const padRadius = (shape: Pad["shape"]): number => {
+    switch (shape.type) {
+      case "Circle":
+        return shape.diameter / 2;
+      case "Rect":
+      case "Oval":
+      case "RoundRect":
+        return Math.hypot(shape.width, shape.height) / 2;
+      default:
+        return 0.5; // Custom polygon — small default
+    }
+  };
   const componentExtent = (pads: Pad[]): number => {
     let r = 0.8; // floor so a 1-pad part still claims some room
     for (const p of pads) {
@@ -1532,6 +1658,51 @@ export async function placeComponents(args: Record<string, unknown>) {
     const t = resolutions[i]?.template;
     return t ? componentExtent(t.pads) : 1.0;
   });
+
+  // Pad copper (local position + bounding radius + net) per component, mirroring
+  // the same precedence the footprint build below uses (inline > engine template
+  // > generic spread). Feeds cross-net clearance legalization. Net resolution
+  // matches netIdForPin but is side-effect free (doesn't populate the net list).
+  const padNetOf = (comp: SchematicComponent, padNumber: string): string | undefined => {
+    const pin = comp.pins.find((p) => p.number === padNumber);
+    if (!pin) return undefined;
+    return useConnectivity
+      ? netByPin.get(pinKey(comp.ref, pin.number))
+      : pin.name && pin.name !== "~"
+        ? pin.name
+        : undefined;
+  };
+  const padLayout: LocalPad[][] = components.map((comp, i) => {
+    if (comp.pads && comp.pads.length > 0) {
+      return comp.pads.map((p) => ({
+        x: p.position.x,
+        y: p.position.y,
+        r: padRadius(p.shape),
+        net: padNetOf(comp, p.number),
+      }));
+    }
+    const t = resolutions[i]?.template;
+    if (t) {
+      return t.pads.map((p) => ({
+        x: p.position.x,
+        y: p.position.y,
+        r: padRadius(p.shape),
+        net: padNetOf(comp, p.number),
+      }));
+    }
+    // Generic fallback — must match the spread used in the footprint build.
+    return comp.pins.map((pin, pi) => ({
+      x: (pi - (comp.pins.length - 1) / 2) * 2.54,
+      y: 0,
+      r: padRadius({ type: "Rect", width: 1.0, height: 1.2 }),
+      net: padNetOf(comp, pin.number),
+    }));
+  });
+
+  // Cross-net pad pairs the force-directed legalizer could not separate (board
+  // too tight). Non-empty means a short is baked in → the placer reports failure
+  // rather than silently shipping it.
+  let placementConflicts: Array<{ a: string; b: string; gap: number }> = [];
 
   let positions: Vec2[];
   if (strategy === "radial") {
@@ -1569,12 +1740,23 @@ export async function placeComponents(args: Record<string, unknown>) {
     }));
 
     if (strategy === "force_directed") {
-      forceDirectedRefine(components, positions, netByPin, useConnectivity, extents, {
+      const fdBounds = {
         minX: bboxMinX + margin,
         minY: bboxMinY + margin,
         maxX: bboxMaxX - margin,
         maxY: bboxMaxY - margin,
-      });
+      };
+      forceDirectedRefine(components, positions, netByPin, useConnectivity, extents, fdBounds);
+      // The force-directed equilibrium can leave different-net pads overlapping
+      // (a short). Shove them apart to clearance before the board is built; any
+      // pair that can't be separated on this board is surfaced to the caller.
+      placementConflicts = legalizeCrossNetClearance(
+        components,
+        positions,
+        padLayout,
+        defaultRules.clearance,
+        fdBounds,
+      );
     }
   }
 
@@ -1702,16 +1884,31 @@ export async function placeComponents(args: Record<string, unknown>) {
   const netsSummary: Record<string, string[]> = {};
   for (const [name, pins] of derived.nets) netsSummary[name] = pins;
 
+  // A cross-net pad overlap is a hard short — never report success with one.
+  if (placementConflicts.length > 0) {
+    const pairs = placementConflicts.map((c) => `${c.a}/${c.b}`).join(", ");
+    warnings.push(
+      `Cross-net pad overlap couldn't be resolved on this board (${pairs}) — a short ` +
+        `before any routing. Enlarge the board, or floorplan these parts with set_placement.`,
+    );
+  }
+
   return {
     content: [
       {
         type: "text" as const,
         text: JSON.stringify({
-          success: true,
+          success: placementConflicts.length === 0,
           footprints_placed: footprints.length,
           footprints_resolved: footprints.length - fallbackFootprints.length,
           strategy,
           ...(warnings.length > 0 ? { warnings } : {}),
+          // Cross-net pad pairs the placer could not separate — each is a short
+          // baked into the layout. `gap` is the residual copper-to-copper
+          // distance (mm); below the design clearance (0.2mm) it will fail DRC.
+          ...(placementConflicts.length > 0
+            ? { placement_conflicts: placementConflicts }
+            : {}),
           // Footprint ids that did NOT resolve to a real package family — these
           // got a generic placeholder, so their pads are approximate. Supply a
           // recognized KiCad id or inline `pads` to fix.


### PR DESCRIPTION
## Problem

`place_components` with `strategy: "force_directed"` could place two components so that pads on **different nets** physically overlap — a hard short (e.g. VCC/GND) baked into the layout before any routing — while still returning `success: true`.

Root cause is exactly as flagged in the bug report: `forceDirectedRefine` repels on **circular courtyard extents** but never checks **net-level pad clearance**, so the net-attraction force can pull cross-net pads on top of each other. DRC catches it afterward, but the placer never surfaces it.

Reproduced with an NE555 astable blinker on a 25mm circle: `run_drc` (before routing) reported **4 shorts + 8 pad-clearance violations**, with C1/J1-style pads at 0.000mm.

## Fix

Add a post-convergence **legalization pass** (`legalizeCrossNetClearance`) to the force-directed strategy:

- After force-directed settles, sweep every inter-component pad pair. For any **different-net** pair closer than the design clearance, shove the two components apart along their center-to-center axis, iterating until clean or a pass cap is hit.
- Mirrors the DRC rule exactly: **same-net and unnetted pads may touch** (courtyard overlap stays a warning); only **cross-net copper** is separated. Intra-footprint pad pairs are untouched (the pass is between distinct components).
- Pads are modeled as **bounding circles that contain the copper** (half-diagonal radius), so clearing the circles guarantees the real rectangular pads clear — it can never miss a short. A small cushion absorbs the later 0.01mm position rounding.
- Fully **deterministic** (no RNG; coincident centers get a hash-derived separation axis).

When the board is too tight to separate every cross-net pad, the placer now returns `success: false` with a `placement_conflicts` array (residual gaps) and a warning, instead of silently shipping a short. The board is still placed, so an agent can inspect it and enlarge.

## Verification

- **Before**: NE555 on 25mm circle → 4 shorts + 8 pad-clearance violations (min cross-net gap −1.03mm).
- **After**: 0 shorts, 0 clearance violations, `success: true`.
- Two regression tests added in `ecad.test.ts`:
  - happy path — asserts DRC-clean via the real oracle (`categories.clearance === 0`, no `Short`),
  - failure path — 4 headers on a 5mm board → `success: false` + `placement_conflicts`.
  - Confirmed both are sensitive (fail without the fix).
- All **306 MCP tests pass**; `tsc --noEmit` clean; changelog entry added.

## Reviewer notes

- Scoped to `force_directed` per the report; `grid`/`radial` behavior is unchanged.
- Deliberate trade-off: the conservative bounding-circle pad model can occasionally flag a `placement_conflict` on a genuinely cramped board that the exact rotated-rect DRC would pass. This errs toward "warn and enlarge the board," the right bias for a P0 short — it never claims success when a real short exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)