### PR TITLE
Native app: parametric document editor, sketch, real materials, transform gizmo & premium studio

### DIFF
--- a/apple/VcadApp/Package.swift
+++ b/apple/VcadApp/Package.swift
@@ -1,10 +1,15 @@
 // swift-tools-version: 6.0
 import PackageDescription
+import Foundation
 
-// Absolute path to the directory holding libvcad_ffi.a (built by
-// scripts/build-ffi.sh from crates/vcad-ffi). Hardcoded for local dev; a real
-// build would resolve this via an xcframework or an env var.
-let ffiLibDir = "/Users/cam/Developer/vcad/.claude/worktrees/elated-mclaren-925de7/apple/VcadApp/Libs"
+// Directory holding libvcad_ffi.a (built by build-ffi.sh from crates/vcad-ffi).
+// Derived from the manifest's own location so it stays correct across worktrees
+// instead of pinning to one checkout; a shipping build would resolve this via an
+// xcframework or an env var.
+let ffiLibDir = URL(fileURLWithPath: #filePath)
+    .deletingLastPathComponent()
+    .appendingPathComponent("Libs")
+    .path
 
 let package = Package(
     name: "VcadApp",

--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -426,6 +426,43 @@ enum DocEdit {
         }
     }
 
+    /// Wrap the part's root in a rotate-about-center sandwich
+    /// (Translate(C) · Rotate(0) · Translate(−C)) so a ring drag spins it in
+    /// place, not around the world origin. Returns the Rotate node id to drive.
+    static func wrapRotate(_ json: inout [String: Any], partIndex: Int,
+                           _ cx: Double, _ cy: Double, _ cz: Double) -> Int? {
+        guard let childId = rootNodeId(json, partIndex: partIndex),
+              var nodes = json["nodes"] as? [String: Any] else { return nil }
+        let base = nodes.values.compactMap { ($0 as? [String: Any])?["id"] as? NSNumber }
+            .map(\.intValue).max() ?? 0
+        let inId = base + 1, rotId = base + 2, outId = base + 3
+        nodes[String(inId)] = ["id": inId,
+                               "op": ["type": "Translate", "child": childId,
+                                      "offset": ["x": -cx, "y": -cy, "z": -cz]]]
+        nodes[String(rotId)] = ["id": rotId, "name": "Rotate",
+                                "op": ["type": "Rotate", "child": inId,
+                                       "angles": ["x": 0.0, "y": 0.0, "z": 0.0]]]
+        nodes[String(outId)] = ["id": outId,
+                                "op": ["type": "Translate", "child": rotId,
+                                       "offset": ["x": cx, "y": cy, "z": cz]]]
+        json["nodes"] = nodes
+        setRootNode(&json, partIndex: partIndex, nodeId: outId)
+        return rotId
+    }
+
+    /// Set one component (0=x,1=y,2=z, degrees) of a Rotate node's angles.
+    static func setRotateAngle(_ json: inout [String: Any], rotNodeId: Int, axisIndex: Int, degrees: Double) {
+        guard var nodes = json["nodes"] as? [String: Any],
+              var node = nodes[String(rotNodeId)] as? [String: Any],
+              var op = node["op"] as? [String: Any],
+              var ang = op["angles"] as? [String: Any] else { return }
+        ang[["x", "y", "z"][axisIndex]] = degrees
+        op["angles"] = ang
+        node["op"] = op
+        nodes[String(rotNodeId)] = node
+        json["nodes"] = nodes
+    }
+
     private static func rootNodeId(_ json: [String: Any], partIndex: Int) -> Int? {
         guard let roots = json["roots"] as? [[String: Any]] else { return nil }
         var vis = 0

--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -391,6 +391,59 @@ enum DocEdit {
         (json["nodes"] as? [String: Any])?[String(nodeId)].flatMap { $0 as? [String: Any] }?["op"] as? [String: Any]
     }
 
+    /// The `partIndex`-th visible root's translate offset, if its root node is a
+    /// Translate (else nil — the part sits at its authored position).
+    static func rootTranslateOffset(_ json: [String: Any], partIndex: Int) -> (Double, Double, Double)? {
+        guard let childId = rootNodeId(json, partIndex: partIndex),
+              let node = (json["nodes"] as? [String: Any])?[String(childId)] as? [String: Any],
+              let op = node["op"] as? [String: Any], (op["type"] as? String) == "Translate",
+              let o = op["offset"] as? [String: Any] else { return nil }
+        return ((o["x"] as? NSNumber)?.doubleValue ?? 0,
+                (o["y"] as? NSNumber)?.doubleValue ?? 0,
+                (o["z"] as? NSNumber)?.doubleValue ?? 0)
+    }
+
+    /// Set the part's world translation — updating its root Translate in place, or
+    /// wrapping the root in a fresh "Move" Translate the first time (so the gizmo
+    /// never nests Translates).
+    static func setRootTranslate(_ json: inout [String: Any], partIndex: Int,
+                                 _ x: Double, _ y: Double, _ z: Double) {
+        guard let childId = rootNodeId(json, partIndex: partIndex),
+              var nodes = json["nodes"] as? [String: Any] else { return }
+        let off: [String: Any] = ["x": x, "y": y, "z": z]
+        if var node = nodes[String(childId)] as? [String: Any],
+           var op = node["op"] as? [String: Any], (op["type"] as? String) == "Translate" {
+            op["offset"] = off
+            node["op"] = op
+            nodes[String(childId)] = node
+            json["nodes"] = nodes
+        } else {
+            let id = nextNodeId(json)
+            nodes[String(id)] = ["id": id, "name": "Move",
+                                 "op": ["type": "Translate", "child": childId, "offset": off]]
+            json["nodes"] = nodes
+            setRootNode(&json, partIndex: partIndex, nodeId: id)
+        }
+    }
+
+    private static func rootNodeId(_ json: [String: Any], partIndex: Int) -> Int? {
+        guard let roots = json["roots"] as? [[String: Any]] else { return nil }
+        var vis = 0
+        for r in roots where (r["visible"] as? Bool) ?? true {
+            if vis == partIndex { return (r["root"] as? NSNumber)?.intValue }
+            vis += 1
+        }
+        return nil
+    }
+    private static func setRootNode(_ json: inout [String: Any], partIndex: Int, nodeId: Int) {
+        guard var roots = json["roots"] as? [[String: Any]] else { return }
+        var vis = 0
+        for (i, r) in roots.enumerated() where (r["visible"] as? Bool) ?? true {
+            if vis == partIndex { roots[i]["root"] = nodeId; json["roots"] = roots; return }
+            vis += 1
+        }
+    }
+
     /// Assign a material to the `partIndex`-th visible root, and ensure the
     /// document carries a definition for the key (from the preset table) so it
     /// renders + survives save/reload.

--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -28,11 +28,20 @@ struct DocRoot {
     let visible: Bool
 }
 
+/// A material definition embedded in the document (color + PBR scalars).
+struct DocMaterial {
+    let color: (Double, Double, Double)
+    let metallic: Float
+    let roughness: Float
+    let transmission: Float
+}
+
 /// A parsed parametric document — just enough structure to render the tree and
 /// the inspector; geometry still comes from the kernel.
 struct DocumentGraph {
     let nodes: [Int: DocNode]
     let roots: [DocRoot]
+    let materials: [String: DocMaterial]
 
     /// Visible roots in order — index-aligned with the kernel scene's parts.
     var visibleRoots: [DocRoot] { roots.filter { $0.visible } }
@@ -71,8 +80,23 @@ struct DocumentGraph {
             }
         }
 
+        var materials: [String: DocMaterial] = [:]
+        if let raw = obj["materials"] as? [String: Any] {
+            for (k, v) in raw {
+                guard let m = v as? [String: Any], let c = m["color"] as? [Any], c.count >= 3,
+                      let r = (c[0] as? NSNumber)?.doubleValue,
+                      let g = (c[1] as? NSNumber)?.doubleValue,
+                      let b = (c[2] as? NSNumber)?.doubleValue else { continue }
+                materials[k] = DocMaterial(
+                    color: (r, g, b),
+                    metallic: Float((m["metallic"] as? NSNumber)?.doubleValue ?? 0.4),
+                    roughness: Float((m["roughness"] as? NSNumber)?.doubleValue ?? 0.5),
+                    transmission: Float((m["transmission"] as? NSNumber)?.doubleValue ?? 0))
+            }
+        }
+
         guard !nodes.isEmpty, !roots.isEmpty else { return nil }
-        return DocumentGraph(nodes: nodes, roots: roots)
+        return DocumentGraph(nodes: nodes, roots: roots, materials: materials)
     }
 
     // MARK: feature tree
@@ -365,6 +389,28 @@ enum DocEdit {
     /// Current op dict for a node (for populating the inspector's editors).
     static func op(_ json: [String: Any], nodeId: Int) -> [String: Any]? {
         (json["nodes"] as? [String: Any])?[String(nodeId)].flatMap { $0 as? [String: Any] }?["op"] as? [String: Any]
+    }
+
+    /// Assign a material to the `partIndex`-th visible root, and ensure the
+    /// document carries a definition for the key (from the preset table) so it
+    /// renders + survives save/reload.
+    static func setRootMaterial(_ json: inout [String: Any], partIndex: Int, key: String) {
+        guard var roots = json["roots"] as? [[String: Any]] else { return }
+        var vis = 0
+        for (i, r) in roots.enumerated() where (r["visible"] as? Bool) ?? true {
+            if vis == partIndex { roots[i]["material"] = key; json["roots"] = roots; break }
+            vis += 1
+        }
+        var mats = json["materials"] as? [String: Any] ?? [:]
+        if mats[key] == nil, let p = MaterialPreset.byKey(key) {
+            mats[key] = ["name": key,
+                         "color": [p.color.0, p.color.1, p.color.2],
+                         "metallic": Double(p.metallic),
+                         "roughness": Double(p.roughness),
+                         "transmission": Double(p.transmission),
+                         "density": 1000.0, "friction": 0.5]
+            json["materials"] = mats
+        }
     }
 
     static func setName(_ json: inout [String: Any], nodeId: Int, name: String) {

--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -131,6 +131,7 @@ struct DocumentGraph {
     static func label(_ t: String) -> String {
         switch t {
         case "Cube": return "Box"
+        case "Sketch2D": return "Sketch"
         case "LinearPattern": return "Linear Pattern"
         case "CircularPattern": return "Circular Pattern"
         case "PcbBoard": return "PCB Board"
@@ -156,7 +157,7 @@ struct DocumentGraph {
         case "Translate": return "move.3d"
         case "Rotate": return "rotate.3d"
         case "Scale": return "scale.3d"
-        case "Sketch": return "scribble.variable"
+        case "Sketch", "Sketch2D": return "scribble.variable"
         case "Extrude": return "arrow.up.to.line"
         case "Revolve": return "arrow.trianglehead.2.clockwise.rotate.90"
         case "LinearPattern": return "rectangle.split.3x1"
@@ -279,6 +280,38 @@ enum DocEdit {
         json["nodes"] = nodes
         var roots = json["roots"] as? [[String: Any]] ?? []
         roots.append(["root": id, "material": anyMaterial(json)])
+        json["roots"] = roots
+    }
+
+    /// Author a Sketch2D (closed Line loop) + Extrude as a new part — the
+    /// sketch→solid workflow. `verts` are 2D plane coords (mm); the basis vectors
+    /// place the plane in 3D and `direction` is the extrude vector (length=depth).
+    static func addExtrudedProfile(_ json: inout [String: Any],
+                                   verts: [(Double, Double)],
+                                   origin: (Double, Double, Double),
+                                   xDir: (Double, Double, Double),
+                                   yDir: (Double, Double, Double),
+                                   direction: (Double, Double, Double)) {
+        guard verts.count >= 3 else { return }
+        func v3(_ t: (Double, Double, Double)) -> [String: Any] { ["x": t.0, "y": t.1, "z": t.2] }
+        let sid = nextNodeId(json)
+        let eid = sid + 1
+        var segs: [[String: Any]] = []
+        for i in 0..<verts.count {
+            let a = verts[i], b = verts[(i + 1) % verts.count]
+            segs.append(["type": "Line",
+                         "start": ["x": a.0, "y": a.1],
+                         "end": ["x": b.0, "y": b.1]])
+        }
+        var nodes = json["nodes"] as? [String: Any] ?? [:]
+        nodes[String(sid)] = ["id": sid, "name": "Sketch",
+                              "op": ["type": "Sketch2D", "origin": v3(origin),
+                                     "x_dir": v3(xDir), "y_dir": v3(yDir), "segments": segs]]
+        nodes[String(eid)] = ["id": eid, "name": "Extrude",
+                              "op": ["type": "Extrude", "sketch": sid, "direction": v3(direction)]]
+        json["nodes"] = nodes
+        var roots = json["roots"] as? [[String: Any]] ?? []
+        roots.append(["root": eid, "material": anyMaterial(json)])
         json["roots"] = roots
     }
 

--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -1,0 +1,399 @@
+import Foundation
+
+// Parses a `.vcad` parametric document (JSON: a node DAG + scene roots) into a
+// navigable feature tree — the native counterpart of the web app's FeatureTree.
+// The kernel evaluates the same file into renderable meshes; this layer recovers
+// the *operations* behind those meshes (types, parameters, parent/child
+// hierarchy) so the sidebar shows real modeling history instead of an anonymous
+// "Part 1, Part 2" list.
+//
+// Index contract: `evaluate_document` (crates/vcad-eval) builds one part per
+// scene root with `visible != false`, in array order. So the i-th VISIBLE root
+// maps to kernel scene part `i`. `visibleRoots` preserves exactly that mapping,
+// which is what lets a tree row drive a viewport entity (visibility, selection).
+
+/// One operation node in the DAG.
+struct DocNode {
+    let id: Int
+    let name: String?
+    let opType: String
+    /// Full op dict, kept for on-demand parameter readout.
+    let op: [String: Any]
+}
+
+/// A scene root. One visible root == one kernel scene part (in order).
+struct DocRoot {
+    let nodeId: Int
+    let material: String?
+    let visible: Bool
+}
+
+/// A parsed parametric document — just enough structure to render the tree and
+/// the inspector; geometry still comes from the kernel.
+struct DocumentGraph {
+    let nodes: [Int: DocNode]
+    let roots: [DocRoot]
+
+    /// Visible roots in order — index-aligned with the kernel scene's parts.
+    var visibleRoots: [DocRoot] { roots.filter { $0.visible } }
+
+    static func load(path: String) -> DocumentGraph? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else { return nil }
+        return parse(data)
+    }
+
+    static func parse(_ data: Data) -> DocumentGraph? {
+        guard let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return nil }
+        return parse(obj)
+    }
+
+    /// Build a graph from an already-parsed JSON object — the editable path,
+    /// where the model keeps a mutable doc dict and re-parses after each edit.
+    static func parse(_ obj: [String: Any]) -> DocumentGraph? {
+        guard let nodesRaw = obj["nodes"] as? [String: Any] else { return nil }
+
+        var nodes: [Int: DocNode] = [:]
+        for (_, v) in nodesRaw {
+            guard let n = v as? [String: Any],
+                  let id = (n["id"] as? NSNumber)?.intValue,
+                  let op = n["op"] as? [String: Any],
+                  let opType = op["type"] as? String else { continue }
+            nodes[id] = DocNode(id: id, name: n["name"] as? String, opType: opType, op: op)
+        }
+
+        var roots: [DocRoot] = []
+        if let rootsRaw = obj["roots"] as? [[String: Any]] {
+            for r in rootsRaw {
+                guard let nodeId = (r["root"] as? NSNumber)?.intValue else { continue }
+                roots.append(DocRoot(nodeId: nodeId,
+                                     material: r["material"] as? String,
+                                     visible: (r["visible"] as? Bool) ?? true))
+            }
+        }
+
+        guard !nodes.isEmpty, !roots.isEmpty else { return nil }
+        return DocumentGraph(nodes: nodes, roots: roots)
+    }
+
+    // MARK: feature tree
+
+    /// Top-level rows: one per VISIBLE root (so `partIndex` aligns with the
+    /// kernel scene), each expandable into its operation sub-tree.
+    func featureRoots() -> [FeatureNode] {
+        visibleRoots.enumerated().map { partIndex, root in
+            buildNode(root.nodeId, partIndex: partIndex, depth: 0, visited: [])
+        }
+    }
+
+    private func buildNode(_ id: Int, partIndex: Int?, depth: Int, visited: Set<Int>) -> FeatureNode {
+        guard let node = nodes[id] else {
+            return FeatureNode(id: "missing\(id)", nodeId: id, name: "Missing #\(id)",
+                               opType: "Empty", symbol: "questionmark.circle", detail: nil,
+                               partIndex: partIndex, children: [])
+        }
+        var seen = visited
+        seen.insert(id)
+        var kids: [FeatureNode] = []
+        if depth < 32 {   // cycle + runaway-depth guard
+            for ref in childRefs(of: node.op) where !seen.contains(ref) {
+                kids.append(buildNode(ref, partIndex: nil, depth: depth + 1, visited: seen))
+            }
+        }
+        return FeatureNode(
+            id: "n\(id)",
+            nodeId: id,
+            name: node.name?.isEmpty == false ? node.name! : Self.label(node.opType),
+            opType: node.opType,
+            symbol: Self.symbol(node.opType),
+            detail: Self.paramSummary(node),
+            partIndex: partIndex,
+            children: kids)
+    }
+
+    /// Child node ids an op references, in reading order (operands, then the
+    /// profile/parent it builds on). Only true node-ref keys are pulled, so
+    /// scalar fields like `count`/`radius` are never mistaken for children.
+    private func childRefs(of op: [String: Any]) -> [Int] {
+        var out: [Int] = []
+        for key in ["left", "right", "child", "children", "base",
+                    "sketch", "sketches", "profile", "profiles", "parent"] {
+            if let n = (op[key] as? NSNumber)?.intValue {
+                out.append(n)
+            } else if let arr = op[key] as? [Any] {
+                for e in arr { if let n = (e as? NSNumber)?.intValue { out.append(n) } }
+            }
+        }
+        return out
+    }
+
+    // MARK: op presentation (matches the web FeatureTree vocabulary)
+
+    static func label(_ t: String) -> String {
+        switch t {
+        case "Cube": return "Box"
+        case "LinearPattern": return "Linear Pattern"
+        case "CircularPattern": return "Circular Pattern"
+        case "PcbBoard": return "PCB Board"
+        case "StepImport", "MeshImport", "ImportedMesh": return "Imported"
+        case "EmbroideryPattern": return "Embroidery"
+        case "PartInstance": return "Instance"
+        case let s where s.hasPrefix("SheetMetal"):
+            return "Sheet Metal " + s.dropFirst("SheetMetal".count)
+        default: return t
+        }
+    }
+
+    static func symbol(_ t: String) -> String {
+        switch t {
+        case "Cube": return "cube"
+        case "Cylinder": return "cylinder"
+        case "Sphere": return "circle.circle"
+        case "Cone": return "cone"
+        case "Empty": return "circle.dashed"
+        case "Union": return "plus.square.on.square"
+        case "Difference": return "minus.square"
+        case "Intersection": return "square.on.square.dashed"
+        case "Translate": return "move.3d"
+        case "Rotate": return "rotate.3d"
+        case "Scale": return "scale.3d"
+        case "Sketch": return "scribble.variable"
+        case "Extrude": return "arrow.up.to.line"
+        case "Revolve": return "arrow.trianglehead.2.clockwise.rotate.90"
+        case "LinearPattern": return "rectangle.split.3x1"
+        case "CircularPattern": return "circle.grid.cross"
+        case "Shell": return "cube.transparent"
+        case "Fillet": return "square.on.circle"
+        case "Chamfer": return "triangle"
+        case "Text": return "textformat"
+        case "Sweep": return "scribble"
+        case "Loft": return "square.stack.3d.up"
+        case "PcbBoard": return "cpu"
+        case "EmbroideryPattern": return "scribble.variable"
+        case "PartInstance": return "shippingbox"
+        case "StepImport", "MeshImport", "ImportedMesh": return "square.and.arrow.down"
+        case let s where s.hasPrefix("SheetMetal"): return "angle"
+        default: return "cube.transparent"
+        }
+    }
+
+    /// A short, correct parameter readout for the common ops. nil when the op
+    /// has no concise scalar summary worth showing inline.
+    static func paramSummary(_ node: DocNode) -> String? {
+        let op = node.op
+        func num(_ k: String) -> Double? { (op[k] as? NSNumber)?.doubleValue }
+        func intv(_ k: String) -> Int? { (op[k] as? NSNumber)?.intValue }
+        func vec(_ k: String) -> (Double, Double, Double)? {
+            guard let v = op[k] as? [String: Any],
+                  let x = (v["x"] as? NSNumber)?.doubleValue,
+                  let y = (v["y"] as? NSNumber)?.doubleValue,
+                  let z = (v["z"] as? NSNumber)?.doubleValue else { return nil }
+            return (x, y, z)
+        }
+        func g(_ d: Double) -> String {
+            d == d.rounded() ? String(Int(d)) : String(format: "%.1f", d)
+        }
+        switch node.opType {
+        case "Cube":
+            if let s = vec("size") { return "\(g(s.0)) × \(g(s.1)) × \(g(s.2)) mm" }
+        case "Cylinder":
+            if let r = num("radius"), let h = num("height") { return "⌀\(g(r * 2)) × \(g(h)) mm" }
+        case "Sphere":
+            if let r = num("radius") { return "⌀\(g(r * 2)) mm" }
+        case "Cone":
+            let r = num("radius1") ?? num("radius") ?? 0
+            return "⌀\(g(r * 2)) × \(g(num("height") ?? 0)) mm"
+        case "Translate":
+            if let o = vec("offset") { return "(\(g(o.0)), \(g(o.1)), \(g(o.2)))" }
+        case "Rotate":
+            if let a = vec("angles") { return "\(g(a.0))°, \(g(a.1))°, \(g(a.2))°" }
+        case "Scale":
+            if let f = vec("factor") { return "×(\(g(f.0)), \(g(f.1)), \(g(f.2)))" }
+        case "Fillet":
+            if let r = num("radius") { return "r\(g(r)) mm" }
+        case "Chamfer":
+            if let d = num("distance") { return "\(g(d)) mm" }
+        case "Shell":
+            if let t = num("thickness") { return "t\(g(t)) mm" }
+        case "Extrude":
+            if let d = vec("direction") {
+                return "h\(g((d.0 * d.0 + d.1 * d.1 + d.2 * d.2).squareRoot())) mm"
+            }
+        case "Revolve":
+            if let a = num("angle_deg") { return "\(g(a))°" }
+        case "LinearPattern":
+            if let c = intv("count") { return "×\(c)" }
+        case "CircularPattern":
+            if let c = intv("count") {
+                if let a = num("angle_deg") { return "×\(c) over \(g(a))°" }
+                return "×\(c)"
+            }
+        default:
+            break
+        }
+        return nil
+    }
+}
+
+// MARK: in-place JSON edits
+// The kernel is a pure `JSON → meshes` evaluator, so editing a document is just
+// mutating its JSON dict and re-evaluating — no editable-doc FFI needed. These
+// operate on the model's live `documentJSON` and are deliberately total (a bad
+// path is a silent no-op, never a crash) since the UI only offers valid edits.
+// Node-map keys equal the node id stringified, which the .vcad format guarantees.
+
+enum DocEdit {
+    static func serialize(_ json: [String: Any]) -> Data? {
+        try? JSONSerialization.data(withJSONObject: json, options: [.sortedKeys])
+    }
+    /// Human-readable variant for writing back to disk.
+    static func serializePretty(_ json: [String: Any]) -> Data? {
+        try? JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+    }
+
+    private static func nextNodeId(_ json: [String: Any]) -> Int {
+        let nodes = json["nodes"] as? [String: Any] ?? [:]
+        let maxId = nodes.values
+            .compactMap { ($0 as? [String: Any])?["id"] as? NSNumber }
+            .map(\.intValue).max() ?? 0
+        return maxId + 1
+    }
+
+    private static func anyMaterial(_ json: [String: Any]) -> String {
+        if let m = (json["materials"] as? [String: Any])?.keys.sorted().first { return m }
+        if let r = (json["roots"] as? [[String: Any]])?.first?["material"] as? String { return r }
+        return "default"
+    }
+
+    /// Append a fresh primitive as a new scene root (the Create tools, on docs).
+    static func addPrimitiveRoot(_ json: inout [String: Any], shape: BaseShape) {
+        let id = nextNodeId(json)
+        var nodes = json["nodes"] as? [String: Any] ?? [:]
+        let op: [String: Any]
+        let name: String
+        switch shape {
+        case .cube: op = ["type": "Cube", "size": ["x": 30.0, "y": 30.0, "z": 30.0]]; name = "Box"
+        case .cylinder: op = ["type": "Cylinder", "radius": 15.0, "height": 30.0, "segments": 64]; name = "Cylinder"
+        case .sphere: op = ["type": "Sphere", "radius": 15.0, "segments": 48]; name = "Sphere"
+        }
+        nodes[String(id)] = ["id": id, "name": name, "op": op]
+        json["nodes"] = nodes
+        var roots = json["roots"] as? [[String: Any]] ?? []
+        roots.append(["root": id, "material": anyMaterial(json)])
+        json["roots"] = roots
+    }
+
+    /// Combine two visible parts (by part index, `a` first = base/left) into one
+    /// boolean root. The two source roots are removed and a single new root
+    /// referencing both their nodes is appended. `op` is "Union"/"Difference"/
+    /// "Intersection". Order matters for Difference (a − b).
+    static func combineRoots(_ json: inout [String: Any], _ a: Int, _ b: Int, op: String) {
+        guard a != b, var roots = json["roots"] as? [[String: Any]] else { return }
+        var visToRaw: [Int] = []
+        for (i, r) in roots.enumerated() where (r["visible"] as? Bool) ?? true { visToRaw.append(i) }
+        guard a < visToRaw.count, b < visToRaw.count else { return }
+        let ra = visToRaw[a], rb = visToRaw[b]
+        guard let nodeA = (roots[ra]["root"] as? NSNumber)?.intValue,
+              let nodeB = (roots[rb]["root"] as? NSNumber)?.intValue else { return }
+        let material = (roots[ra]["material"] as? String) ?? anyMaterial(json)
+        let id = nextNodeId(json)
+        var nodes = json["nodes"] as? [String: Any] ?? [:]
+        nodes[String(id)] = ["id": id, "name": op, "op": ["type": op, "left": nodeA, "right": nodeB]]
+        json["nodes"] = nodes
+        // Remove both source roots (higher raw index first), append the combined one.
+        roots.remove(at: max(ra, rb))
+        roots.remove(at: min(ra, rb))
+        roots.append(["root": id, "material": material])
+        json["roots"] = roots
+    }
+
+    /// Wrap the `partIndex`-th visible root's node in a Fillet/Chamfer (the
+    /// Modify tools, on docs). Re-points the root at the new modifier node.
+    static func wrapRootWithModifier(_ json: inout [String: Any], partIndex: Int, fillet: Bool) {
+        guard var roots = json["roots"] as? [[String: Any]] else { return }
+        var vis = 0
+        for (i, r) in roots.enumerated() where (r["visible"] as? Bool) ?? true {
+            if vis == partIndex {
+                guard let childId = (r["root"] as? NSNumber)?.intValue else { return }
+                let id = nextNodeId(json)
+                var nodes = json["nodes"] as? [String: Any] ?? [:]
+                let op: [String: Any] = fillet
+                    ? ["type": "Fillet", "child": childId, "radius": 2.0]
+                    : ["type": "Chamfer", "child": childId, "distance": 2.0]
+                nodes[String(id)] = ["id": id, "name": fillet ? "Fillet" : "Chamfer", "op": op]
+                json["nodes"] = nodes
+                roots[i]["root"] = id
+                json["roots"] = roots
+                return
+            }
+            vis += 1
+        }
+    }
+
+    /// Current op dict for a node (for populating the inspector's editors).
+    static func op(_ json: [String: Any], nodeId: Int) -> [String: Any]? {
+        (json["nodes"] as? [String: Any])?[String(nodeId)].flatMap { $0 as? [String: Any] }?["op"] as? [String: Any]
+    }
+
+    static func setName(_ json: inout [String: Any], nodeId: Int, name: String) {
+        guard var nodes = json["nodes"] as? [String: Any],
+              var node = nodes[String(nodeId)] as? [String: Any] else { return }
+        node["name"] = name
+        nodes[String(nodeId)] = node
+        json["nodes"] = nodes
+    }
+
+    static func setScalar(_ json: inout [String: Any], nodeId: Int, key: String, value: Double) {
+        mutateOp(&json, nodeId: nodeId) { $0[key] = value }
+    }
+
+    static func setInt(_ json: inout [String: Any], nodeId: Int, key: String, value: Int) {
+        mutateOp(&json, nodeId: nodeId) { $0[key] = value }
+    }
+
+    static func setVecComponent(_ json: inout [String: Any], nodeId: Int,
+                                key: String, axis: String, value: Double) {
+        mutateOp(&json, nodeId: nodeId) { op in
+            var v = (op[key] as? [String: Any]) ?? [:]
+            v[axis] = value
+            op[key] = v
+        }
+    }
+
+    /// Remove the `partIndex`-th VISIBLE root (mapping back into the raw roots
+    /// array, which may contain hidden entries). The orphaned subtree is left in
+    /// `nodes` — harmless, the evaluator only walks reachable roots.
+    static func removeRoot(_ json: inout [String: Any], partIndex: Int) {
+        guard var roots = json["roots"] as? [[String: Any]] else { return }
+        var vis = 0
+        for (i, r) in roots.enumerated() where (r["visible"] as? Bool) ?? true {
+            if vis == partIndex { roots.remove(at: i); json["roots"] = roots; return }
+            vis += 1
+        }
+    }
+
+    private static func mutateOp(_ json: inout [String: Any], nodeId: Int,
+                                 _ body: (inout [String: Any]) -> Void) {
+        guard var nodes = json["nodes"] as? [String: Any],
+              var node = nodes[String(nodeId)] as? [String: Any],
+              var op = node["op"] as? [String: Any] else { return }
+        body(&op)
+        node["op"] = op
+        nodes[String(nodeId)] = node
+        json["nodes"] = nodes
+    }
+}
+
+/// One row in the native feature tree — a node in the DAG, possibly with operand
+/// children. Root rows carry a `partIndex` that links them to a viewport entity
+/// (`part<i>`), driving visibility and selection sync.
+struct FeatureNode: Identifiable {
+    let id: String
+    let nodeId: Int
+    let name: String
+    let opType: String
+    let symbol: String
+    let detail: String?
+    let partIndex: Int?
+    let children: [FeatureNode]
+    var hasChildren: Bool { !children.isEmpty }
+}

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -6,7 +6,7 @@ import CVcadFFI
 
 // Model layer. The SwiftUI shell is in Shell.swift; kernel/streaming in Kernel.swift.
 
-private let kSamplesDir = "/Users/cam/Developer/vcad/.claude/worktrees/elated-mclaren-925de7"
+private let kSamplesDir = "/Users/cam/Developer/vcad/.claude/worktrees/great-bohr-4c355d"
 
 enum GeometrySource: Hashable, Identifiable {
     case sandbox
@@ -69,10 +69,44 @@ enum Modifier: String, CaseIterable {
 /// A tab in the tool palette (the native reinterpretation of the web app's
 /// Borland tool picker — same model, native skin).
 enum ToolTab: String, CaseIterable, Identifiable {
-    case create, modify
+    case create, modify, combine
     var id: String { rawValue }
     var label: String { rawValue.capitalized }
-    var symbol: String { self == .create ? "plus.square.on.square" : "wand.and.rays" }
+    var symbol: String {
+        switch self {
+        case .create: return "plus.square.on.square"
+        case .modify: return "wand.and.rays"
+        case .combine: return "square.on.square.dashed"
+        }
+    }
+}
+
+/// A boolean combine operation (the Combine tab — acts on two selected parts).
+enum BooleanOp: String, CaseIterable, Identifiable {
+    case union, difference, intersection
+    var id: String { rawValue }
+    var label: String {
+        switch self {
+        case .union: return "Union"
+        case .difference: return "Subtract"
+        case .intersection: return "Intersect"
+        }
+    }
+    /// The IR op tag emitted into the document.
+    var opType: String {
+        switch self {
+        case .union: return "Union"
+        case .difference: return "Difference"
+        case .intersection: return "Intersection"
+        }
+    }
+    var symbol: String {
+        switch self {
+        case .union: return "plus.circle"
+        case .difference: return "minus.circle"
+        case .intersection: return "circle.circle"
+        }
+    }
 }
 
 /// One tool button within a tab.
@@ -114,7 +148,9 @@ final class EditorModel {
     var source: GeometrySource = .sandbox {
         didSet {
             geometryDirty = true
-            selectedFeatureID = source.isSandbox ? "modifier" : "part0"
+            loadDocumentTree()                    // parse the DAG for a .vcad
+            if !availableTabs.contains(toolTab) { toolTab = .create }
+            selectedFeatureID = defaultSelection()
             resetCamera()        // frame the new part cleanly
         }
     }
@@ -136,7 +172,10 @@ final class EditorModel {
     // Selection binds tree -> inspector AND rolls history (selecting "base"
     // shows the modifier's input).
     var selectedFeatureID: String? = "modifier" {
-        didSet { if source.isSandbox { geometryDirty = true } }
+        didSet {
+            if source.isSandbox { geometryDirty = true }
+            else if selectedFeatureID != oldValue { selectionDirty = true }
+        }
     }
 
     // Live readouts.
@@ -160,6 +199,444 @@ final class EditorModel {
     var pinchBaseline: Float = 1.5
     var draggingHandle = false
     var handleBaseline: Double = 0
+
+    // MARK: document feature tree
+    // The parsed DAG behind a loaded .vcad — drives the hierarchical sidebar,
+    // per-part visibility, and selection ↔ viewport highlight. Geometry still
+    // comes from the kernel; this is the *operations* view of the same file.
+
+    var documentGraph: DocumentGraph?
+    var featureNodes: [FeatureNode] = []
+    var expandedFeatureIDs: Set<String> = []
+    /// Part indices hidden via the eye toggle (empty = all shown).
+    var hiddenParts: Set<Int> = []
+    /// Isolate: when set, only this part shows (supersedes `hiddenParts`).
+    var isolatedPart: Int?
+    /// Viewport needs to re-apply part visibility / re-highlight the selection.
+    var visibilityDirty = false
+    var selectionDirty = false
+    /// Parts ⌘-clicked for a multi-part action (booleans). Ordered: first = base.
+    var multiSelectedParts: [Int] = []
+    /// Per-part kernel-space AABBs, index-aligned with the rendered parts —
+    /// the cheap basis for picking a part in the viewport (tap → select row).
+    @ObservationIgnored var docPartBounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
+
+    var usesDocumentTree: Bool { documentGraph != nil && !featureNodes.isEmpty }
+
+    /// Parse the DAG when a `.vcad` document loads; clear it for every other
+    /// source. Resets visibility + expansion so each document opens clean.
+    private func loadDocumentTree() {
+        hiddenParts.removeAll()
+        isolatedPart = nil
+        multiSelectedParts = []
+        expandedFeatureIDs.removeAll()
+        docPartBounds = []
+        documentJSON = nil
+        undoStack.removeAll(); redoStack.removeAll()
+        renamingFeatureID = nil
+        documentDirty = false
+        if case let .document(path, _) = source,
+           let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+           let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+           let g = DocumentGraph.parse(dict) {
+            documentJSON = dict
+            documentGraph = g
+            featureNodes = g.featureRoots()
+            // Auto-expand a single-root doc so its history reads at a glance.
+            if featureNodes.count == 1, let only = featureNodes.first {
+                expandedFeatureIDs.insert(only.id)
+            }
+        } else {
+            documentGraph = nil
+            featureNodes = []
+        }
+    }
+
+    private func defaultSelection() -> String? {
+        switch source {
+        case .sandbox: return "modifier"
+        case .document: return featureNodes.first?.id
+        default: return "part0"
+        }
+    }
+
+    func toggleExpanded(_ id: String) {
+        if expandedFeatureIDs.contains(id) { expandedFeatureIDs.remove(id) }
+        else { expandedFeatureIDs.insert(id) }
+    }
+
+    // MARK: per-part visibility
+
+    func isPartVisible(_ i: Int) -> Bool {
+        if let iso = isolatedPart { return i == iso }
+        return !hiddenParts.contains(i)
+    }
+    var hasHiddenParts: Bool { isolatedPart != nil || !hiddenParts.isEmpty }
+
+    func toggleVisibility(part i: Int) {
+        isolatedPart = nil                       // an explicit toggle exits isolate
+        if hiddenParts.contains(i) { hiddenParts.remove(i) } else { hiddenParts.insert(i) }
+        visibilityDirty = true
+    }
+    func isolate(part i: Int) {
+        isolatedPart = (isolatedPart == i) ? nil : i
+        hiddenParts.removeAll()
+        visibilityDirty = true
+    }
+    func showAllParts() {
+        hiddenParts.removeAll()
+        isolatedPart = nil
+        visibilityDirty = true
+    }
+
+    // MARK: selection ↔ part mapping
+
+    /// The viewport part index implied by the current selection — the owning
+    /// root of the selected feature row, or nil (selecting deep operands still
+    /// highlights the part they build).
+    var selectedPartIndex: Int? {
+        guard let sel = selectedFeatureID else { return nil }
+        for node in featureNodes {
+            if let pi = node.partIndex, Self.subtree(node, contains: sel) { return pi }
+        }
+        return nil
+    }
+    private static func subtree(_ node: FeatureNode, contains id: String) -> Bool {
+        if node.id == id { return true }
+        return node.children.contains { subtree($0, contains: id) }
+    }
+
+    /// Single-select a row (clears any multi-selection).
+    func selectFeature(_ id: String) {
+        if !multiSelectedParts.isEmpty { multiSelectedParts = [] }
+        selectedFeatureID = id
+    }
+    /// ⌘-click: toggle a part in the multi-selection; the last click stays primary.
+    func toggleMultiSelect(part pi: Int, featureID id: String) {
+        if let idx = multiSelectedParts.firstIndex(of: pi) { multiSelectedParts.remove(at: idx) }
+        else { multiSelectedParts.append(pi) }
+        selectedFeatureID = id
+        selectionDirty = true
+    }
+    /// The parts to highlight: the multi-selection if any, else the primary part.
+    var highlightedParts: Set<Int> {
+        multiSelectedParts.isEmpty ? Set([selectedPartIndex].compactMap { $0 }) : Set(multiSelectedParts)
+    }
+
+    var selectedFeatureNode: FeatureNode? { Self.find(featureNodes, id: selectedFeatureID) }
+    private static func find(_ nodes: [FeatureNode], id: String?) -> FeatureNode? {
+        guard let id else { return nil }
+        for n in nodes {
+            if n.id == id { return n }
+            if let f = find(n.children, id: id) { return f }
+        }
+        return nil
+    }
+
+    /// Material key assigned to a rendered part (root order), if any.
+    func materialName(forPart i: Int) -> String? {
+        guard let g = documentGraph, i < g.visibleRoots.count else { return nil }
+        return g.visibleRoots[i].material
+    }
+
+    func documentBaseColor(_ i: Int) -> NSColor { Self.partColors[i % Self.partColors.count] }
+    static let brandPink = NSColor(srgbRed: 0.976, green: 0.149, blue: 0.447, alpha: 1.0)
+
+    /// Ray-pick a document part by its AABB (kernel coords) — nearest entry
+    /// wins. Coarse (box, not triangle) but robust and ample for selection.
+    func pickDocumentPart(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Int? {
+        var best: (i: Int, t: Float)?
+        for (i, b) in docPartBounds.enumerated() where isPartVisible(i) {
+            guard let t = Self.rayAABB(o: o, d: d, lo: b.min, hi: b.max) else { continue }
+            if best == nil || t < best!.t { best = (i, t) }
+        }
+        return best?.i
+    }
+
+    /// Slab test → entry distance along the ray, or nil if it misses.
+    private static func rayAABB(o: SIMD3<Float>, d: SIMD3<Float>,
+                                lo: SIMD3<Float>, hi: SIMD3<Float>) -> Float? {
+        var tmin: Float = -.greatestFiniteMagnitude
+        var tmax: Float = .greatestFiniteMagnitude
+        for a in 0..<3 {
+            let di = d[a]
+            if abs(di) < 1e-9 {
+                if o[a] < lo[a] || o[a] > hi[a] { return nil }
+            } else {
+                let inv = 1 / di
+                var t1 = (lo[a] - o[a]) * inv
+                var t2 = (hi[a] - o[a]) * inv
+                if t1 > t2 { swap(&t1, &t2) }
+                tmin = max(tmin, t1)
+                tmax = min(tmax, t2)
+                if tmin > tmax { return nil }
+            }
+        }
+        return tmax < 0 ? nil : max(tmin, 0)
+    }
+
+    // MARK: document editing
+    // The kernel is a pure JSON→meshes evaluator, so editing = mutate the live
+    // doc dict + re-evaluate. `documentJSON` is the source of truth; `featureNodes`
+    // / geometry are re-derived after each edit. Undo/redo are JSON snapshots.
+
+    @ObservationIgnored var documentJSON: [String: Any]?
+    var undoStack: [Data] = []
+    var redoStack: [Data] = []
+    var documentDirty = false
+    /// One scrub gesture = one undo entry; skip the materialize-pop on edits.
+    @ObservationIgnored var suppressMaterializePop = false
+    /// In-place re-eval of a parameter edit (mesh swap, no full rebuild / pop).
+    var docParamDirty = false
+    /// The feature row currently being renamed inline, if any.
+    var renamingFeatureID: String?
+
+    var canUndo: Bool { !undoStack.isEmpty }
+    var canRedo: Bool { !redoStack.isEmpty }
+    /// Export is available for anything with exportable geometry (not the gripper).
+    var canExport: Bool { if case .gripper = source { return false }; return true }
+
+    // MARK: authoring (Create/Modify tools on a loaded document)
+
+    /// Add a fresh primitive as a new part in the loaded document.
+    func addPrimitive(_ shape: BaseShape) {
+        guard documentJSON != nil else { return }
+        applyEdit(snapshot: true, reeval: .rebuild) { DocEdit.addPrimitiveRoot(&$0, shape: shape) }
+        selectedFeatureID = featureNodes.last?.id        // focus the new part
+    }
+
+    /// Combine the two ⌘-selected parts with a boolean op (first = base).
+    func combineSelected(_ op: BooleanOp) {
+        guard documentJSON != nil, multiSelectedParts.count == 2 else { return }
+        let a = multiSelectedParts[0], b = multiSelectedParts[1]
+        applyEdit(snapshot: true, reeval: .rebuild) { DocEdit.combineRoots(&$0, a, b, op: op.opType) }
+        multiSelectedParts = []
+        hiddenParts.removeAll(); isolatedPart = nil       // indices collapsed
+        selectedFeatureID = featureNodes.last?.id          // the new combined part
+    }
+
+    /// Tabs available in the tool palette — Combine only applies to documents.
+    var availableTabs: [ToolTab] { usesDocumentTree ? [.create, .modify, .combine] : [.create, .modify] }
+
+    /// Wrap the selected part with a fillet/chamfer over all its edges.
+    func applyModifierToSelected(_ mod: Modifier) {
+        guard documentJSON != nil, mod != .none, let pi = selectedPartIndex else { return }
+        let selBefore = selectedPartIndex
+        applyEdit(snapshot: true, reeval: .rebuild) {
+            DocEdit.wrapRootWithModifier(&$0, partIndex: pi, fillet: mod == .fillet)
+        }
+        // Keep the same part selected (its root node id changed → select its row).
+        if let pi = selBefore, pi < featureNodes.count { selectedFeatureID = featureNodes[pi].id }
+    }
+
+    // MARK: save
+
+    func saveDocument() {
+        guard case let .document(path, _) = source,
+              let json = documentJSON, let data = DocEdit.serializePretty(json) else { return }
+        if (try? data.write(to: URL(fileURLWithPath: path))) != nil { documentDirty = false }
+    }
+
+    func saveDocumentAs(_ url: URL) {
+        guard let json = documentJSON, let data = DocEdit.serializePretty(json) else { return }
+        guard (try? data.write(to: url)) != nil else { return }
+        openDocument(url)        // re-open from the saved file (resets dirty/undo)
+    }
+
+    /// Discard edits and reload the document from disk.
+    func revertDocument() {
+        guard case .document = source else { return }
+        loadDocumentTree()
+        geometryDirty = true; selectionDirty = true; visibilityDirty = true
+        selectedFeatureID = featureNodes.first?.id
+    }
+
+    private enum Reeval { case inPlace, rebuild, none }
+
+    private func pushUndo() {
+        guard let json = documentJSON, let data = DocEdit.serialize(json) else { return }
+        undoStack.append(data)
+        if undoStack.count > 64 { undoStack.removeFirst() }
+        redoStack.removeAll()
+    }
+
+    private func applyEdit(snapshot: Bool, reeval: Reeval, _ mutate: (inout [String: Any]) -> Void) {
+        guard var json = documentJSON else { return }
+        if snapshot { pushUndo() }
+        mutate(&json)
+        documentJSON = json
+        documentDirty = true
+        if let g = DocumentGraph.parse(json) {
+            documentGraph = g
+            featureNodes = g.featureRoots()
+        }
+        switch reeval {
+        case .inPlace:
+            docParamDirty = true
+        case .rebuild:
+            suppressMaterializePop = true
+            geometryDirty = true; selectionDirty = true; visibilityDirty = true
+        case .none:
+            break
+        }
+    }
+
+    /// Current op dict for a node — feeds the inspector's parameter editors.
+    func opDict(nodeId: Int) -> [String: Any]? {
+        documentJSON.flatMap { DocEdit.op($0, nodeId: nodeId) }
+    }
+
+    func editScalar(nodeId: Int, key: String, value: Double, snapshot: Bool) {
+        applyEdit(snapshot: snapshot, reeval: .inPlace) {
+            DocEdit.setScalar(&$0, nodeId: nodeId, key: key, value: value)
+        }
+    }
+    func editVec(nodeId: Int, key: String, axis: String, value: Double, snapshot: Bool) {
+        applyEdit(snapshot: snapshot, reeval: .inPlace) {
+            DocEdit.setVecComponent(&$0, nodeId: nodeId, key: key, axis: axis, value: value)
+        }
+    }
+    func editInt(nodeId: Int, key: String, value: Int, snapshot: Bool) {
+        applyEdit(snapshot: snapshot, reeval: .inPlace) {
+            DocEdit.setInt(&$0, nodeId: nodeId, key: key, value: value)
+        }
+    }
+    func renameFeature(_ nodeId: Int, to name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        applyEdit(snapshot: true, reeval: .none) {
+            DocEdit.setName(&$0, nodeId: nodeId, name: trimmed)
+        }
+    }
+    func deletePart(_ partIndex: Int) {
+        applyEdit(snapshot: true, reeval: .rebuild) {
+            DocEdit.removeRoot(&$0, partIndex: partIndex)
+        }
+        // Indices shifted; clear visibility/multi-select and re-anchor selection.
+        hiddenParts.removeAll(); isolatedPart = nil; multiSelectedParts = []
+        if selectedFeatureNode == nil { selectedFeatureID = featureNodes.first?.id }
+    }
+
+    func undo() {
+        guard let data = undoStack.popLast() else { return }
+        if let cur = documentJSON, let curData = DocEdit.serialize(cur) { redoStack.append(curData) }
+        restore(data)
+    }
+    func redo() {
+        guard let data = redoStack.popLast() else { return }
+        if let cur = documentJSON, let curData = DocEdit.serialize(cur) { undoStack.append(curData) }
+        restore(data)
+    }
+    private func restore(_ data: Data) {
+        guard let dict = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else { return }
+        documentJSON = dict
+        if let g = DocumentGraph.parse(dict) { documentGraph = g; featureNodes = g.featureRoots() }
+        hiddenParts.removeAll(); isolatedPart = nil
+        suppressMaterializePop = true
+        geometryDirty = true; selectionDirty = true; visibilityDirty = true
+        if selectedFeatureNode == nil { selectedFeatureID = featureNodes.first?.id }
+    }
+
+    /// Re-evaluate the edited doc and return fresh part meshes for an in-place
+    /// swap (no entity rebuild → smooth scrubbing). Keeps display scale/center
+    /// fixed so the part doesn't jump mid-edit; updates the live readouts +
+    /// pick bounds. Returns nil if the edit produced no geometry.
+    func reevalDocumentMeshes() -> [MeshResource]? {
+        guard let json = documentJSON, let data = DocEdit.serialize(json) else { return nil }
+        let start = Date()
+        let scene: OpaquePointer? = data.withUnsafeBytes {
+            vcad_scene_from_json($0.bindMemory(to: UInt8.self).baseAddress, data.count)
+        }
+        guard let scene else { return nil }
+        defer { vcad_scene_free(scene) }
+        let count = vcad_scene_part_count(scene)
+        var meshes: [MeshResource] = []
+        var bounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
+        var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        var tris = 0
+        for i in 0..<count {
+            let km = KernelMesh.fromView(vcad_scene_part_mesh(scene, i))
+            if km.isEmpty { continue }
+            lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
+            tris += km.triangleCount
+            meshes.append(km.resource(name: "part\(i)"))
+            bounds.append((km.minBound, km.maxBound))
+        }
+        guard !meshes.isEmpty else { return nil }
+        docPartBounds = bounds
+        solveMillis = Date().timeIntervalSince(start) * 1000
+        triangleCount = tris
+        partCount = meshes.count
+        sizeMM = hi - lo
+        return meshes
+    }
+
+    // MARK: export
+    // No export FFI today, so STL is written here from the current part meshes
+    // (binary STL = just triangles). Works for the sandbox + any loaded/edited doc.
+
+    /// Kernel meshes for whatever is on screen right now (sandbox primitive or
+    /// the evaluated document), for export.
+    private func currentKernelMeshes() -> [KernelMesh] {
+        switch source {
+        case .sandbox:
+            return sandboxKernelMesh().map { [$0] } ?? []
+        case .document, .generated:
+            let data: Data?
+            if let json = documentJSON { data = DocEdit.serialize(json) }
+            else if case let .document(path, _) = source { data = try? Data(contentsOf: URL(fileURLWithPath: path)) }
+            else if case let .generated(loon, _) = source { data = Data(loon.utf8) }
+            else { data = nil }
+            guard let data else { return [] }
+            let isLoon = { if case .generated = source { return true } else { return false } }()
+            let scene: OpaquePointer? = data.withUnsafeBytes { raw in
+                let base = raw.bindMemory(to: UInt8.self).baseAddress
+                return isLoon ? vcad_scene_from_loon(base, data.count) : vcad_scene_from_json(base, data.count)
+            }
+            guard let scene else { return [] }
+            defer { vcad_scene_free(scene) }
+            var out: [KernelMesh] = []
+            for i in 0..<vcad_scene_part_count(scene) {
+                let km = KernelMesh.fromView(vcad_scene_part_mesh(scene, i))
+                if !km.isEmpty { out.append(km) }
+            }
+            return out
+        case .gripper:
+            return []
+        }
+    }
+
+    @discardableResult
+    func exportSTL(to url: URL) -> Bool {
+        let meshes = currentKernelMeshes()
+        guard !meshes.isEmpty else { return false }
+        var triCount = 0
+        for m in meshes { triCount += m.triangleCount }
+
+        var data = Data()
+        data.append(Data(count: 80))                    // header
+        var n = UInt32(triCount).littleEndian
+        withUnsafeBytes(of: &n) { data.append(contentsOf: $0) }
+
+        func put(_ f: Float) { var v = f.bitPattern.littleEndian; withUnsafeBytes(of: &v) { data.append(contentsOf: $0) } }
+        for m in meshes {
+            var i = 0
+            while i + 2 < m.indices.count {
+                let a = m.positions[Int(m.indices[i])]
+                let b = m.positions[Int(m.indices[i + 1])]
+                let c = m.positions[Int(m.indices[i + 2])]
+                let nrm = normalize(cross(b - a, c - a))
+                put(nrm.x.isFinite ? nrm.x : 0); put(nrm.y.isFinite ? nrm.y : 0); put(nrm.z.isFinite ? nrm.z : 1)
+                put(a.x); put(a.y); put(a.z)
+                put(b.x); put(b.y); put(b.z)
+                put(c.x); put(c.y); put(c.z)
+                data.append(contentsOf: [0, 0])         // attribute byte count
+                i += 3
+            }
+        }
+        return (try? data.write(to: url)) != nil
+    }
 
     // Hover affordance for the draggable handles (cursor + a subtle scale pop).
     // The handles' live world positions are projected to screen to hit-test the
@@ -467,19 +944,41 @@ final class EditorModel {
     // MARK: tool palette
 
     func tools(for tab: ToolTab) -> [Tool] {
+        let docMode = usesDocumentTree
         switch tab {
         case .create:
             return BaseShape.allCases.map { shape in
-                Tool(id: "shape.\(shape.rawValue)", label: shape.label, symbol: shape.symbol,
-                     isActive: baseShape == shape) { [weak self] in self?.baseShape = shape }
+                // Sandbox: pick the primitive. Document: add a new part.
+                Tool(id: "shape.\(shape.rawValue)",
+                     label: docMode ? "Add \(shape.label)" : shape.label, symbol: shape.symbol,
+                     isActive: !docMode && baseShape == shape) { [weak self] in
+                    if docMode { self?.addPrimitive(shape) } else { self?.baseShape = shape }
+                }
             }
         case .modify:
-            return Modifier.allCases.map { mod in
+            return Modifier.allCases.compactMap { mod in
+                if docMode {
+                    guard mod != .none else { return nil }     // no "None" tool when authoring
+                    let ok = selectedPartIndex != nil
+                    return Tool(id: "mod.\(mod.rawValue)", label: mod.label, symbol: mod.symbol,
+                                isActive: false, enabled: ok,
+                                hint: ok ? "" : "Select a part first") { [weak self] in
+                        self?.applyModifierToSelected(mod)
+                    }
+                }
                 // Fillet/chamfer are no-ops on a sphere (no edges) — surface that.
                 let ok = mod == .none || baseShape != .sphere
                 return Tool(id: "mod.\(mod.rawValue)", label: mod.label, symbol: mod.symbol,
                             isActive: modifier == mod, enabled: ok,
                             hint: ok ? "" : "No edges on a sphere") { [weak self] in self?.modifier = mod }
+            }
+        case .combine:
+            guard docMode else { return [] }
+            let ready = multiSelectedParts.count == 2
+            return BooleanOp.allCases.map { b in
+                Tool(id: "bool.\(b.rawValue)", label: b.label, symbol: b.symbol,
+                     isActive: false, enabled: ready,
+                     hint: ready ? "" : "⌘-click 2 parts") { [weak self] in self?.combineSelected(b) }
             }
         }
     }
@@ -659,9 +1158,12 @@ final class EditorModel {
 
     private func documentScene(path: String) -> RenderScene {
         let start = Date()
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)), !data.isEmpty else {
-            return .empty
-        }
+        // Prefer the live (possibly edited) doc; fall back to the file on disk
+        // for formats the JSON parser couldn't load (legacy terse `.vcad`).
+        let data: Data?
+        if let json = documentJSON { data = DocEdit.serialize(json) }
+        else { data = try? Data(contentsOf: URL(fileURLWithPath: path)) }
+        guard let data, !data.isEmpty else { return .empty }
         let scene: OpaquePointer? = data.withUnsafeBytes { raw in
             vcad_scene_from_json(raw.bindMemory(to: UInt8.self).baseAddress, data.count)
         }
@@ -691,6 +1193,7 @@ final class EditorModel {
     private func sceneFromHandle(_ scene: OpaquePointer, start: Date) -> RenderScene {
         let count = vcad_scene_part_count(scene)
         var meshes: [(MeshResource, NSColor)] = []
+        var bounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
         var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
         var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
         var tris = 0
@@ -700,8 +1203,12 @@ final class EditorModel {
             lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
             tris += km.triangleCount
             meshes.append((km.resource(name: "part\(i)"), Self.partColors[i % Self.partColors.count]))
+            // Index-aligned with `meshes` (and thus the rendered part entities),
+            // so a viewport tap maps back to the right feature-tree row.
+            bounds.append((km.minBound, km.maxBound))
         }
         guard !meshes.isEmpty else { return .empty }
+        docPartBounds = bounds
 
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = tris

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -254,9 +254,16 @@ final class EditorModel {
     /// Part under the cursor (documents) — drives a subtle hover highlight.
     var hoveredPartIndex: Int?
     var hoverDirty = false
-    /// Per-part kernel-space AABBs, index-aligned with the rendered parts —
-    /// the cheap basis for picking a part in the viewport (tap → select row).
-    @ObservationIgnored var docPartBounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
+    /// Per-part kernel-space triangle meshes (+ AABB), index-aligned with the
+    /// rendered parts — the basis for precise ray-triangle hover/pick. The AABB
+    /// is a broadphase cull before the triangle test.
+    struct PickMesh {
+        var positions: [SIMD3<Float>]
+        var indices: [UInt32]
+        var lo: SIMD3<Float>
+        var hi: SIMD3<Float>
+    }
+    @ObservationIgnored var docPartMeshes: [PickMesh] = []
 
     var usesDocumentTree: Bool { documentGraph != nil && !featureNodes.isEmpty }
 
@@ -268,7 +275,7 @@ final class EditorModel {
         multiSelectedParts = []
         hoveredPartIndex = nil
         expandedFeatureIDs.removeAll()
-        docPartBounds = []
+        docPartMeshes = []
         documentJSON = nil
         undoStack.removeAll(); redoStack.removeAll()
         renamingFeatureID = nil
@@ -411,15 +418,44 @@ final class EditorModel {
     func documentBaseColor(_ i: Int) -> NSColor { Self.partColors[i % Self.partColors.count] }
     static let brandPink = NSColor(srgbRed: 0.976, green: 0.149, blue: 0.447, alpha: 1.0)
 
-    /// Ray-pick a document part by its AABB (kernel coords) — nearest entry
-    /// wins. Coarse (box, not triangle) but robust and ample for selection.
+    /// Ray-pick a document part by its actual triangles (kernel coords) — the
+    /// nearest surface hit wins. An AABB test culls parts the ray misses, and
+    /// skips parts whose box is already farther than the best surface hit.
     func pickDocumentPart(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Int? {
         var best: (i: Int, t: Float)?
-        for (i, b) in docPartBounds.enumerated() where isPartVisible(i) {
-            guard let t = Self.rayAABB(o: o, d: d, lo: b.min, hi: b.max) else { continue }
-            if best == nil || t < best!.t { best = (i, t) }
+        for (i, pm) in docPartMeshes.enumerated() where isPartVisible(i) {
+            guard let tBox = Self.rayAABB(o: o, d: d, lo: pm.lo, hi: pm.hi) else { continue }
+            if let b = best, tBox > b.t { continue }      // whole box is behind a closer hit
+            var localBest: Float?
+            let pos = pm.positions, ind = pm.indices
+            var k = 0
+            while k + 2 < ind.count {
+                let a = pos[Int(ind[k])], b2 = pos[Int(ind[k + 1])], c = pos[Int(ind[k + 2])]
+                if let t = Self.rayTriangle(o: o, d: d, a: a, b: b2, c: c),
+                   localBest == nil || t < localBest! { localBest = t }
+                k += 3
+            }
+            if let lt = localBest, best == nil || lt < best!.t { best = (i, lt) }
         }
         return best?.i
+    }
+
+    /// Möller–Trumbore ray-triangle intersection → hit distance, or nil.
+    private static func rayTriangle(o: SIMD3<Float>, d: SIMD3<Float>,
+                                    a: SIMD3<Float>, b: SIMD3<Float>, c: SIMD3<Float>) -> Float? {
+        let e1 = b - a, e2 = c - a
+        let p = cross(d, e2)
+        let det = simd_dot(e1, p)
+        if abs(det) < 1e-7 { return nil }
+        let inv = 1 / det
+        let tv = o - a
+        let u = simd_dot(tv, p) * inv
+        if u < -1e-5 || u > 1 + 1e-5 { return nil }
+        let q = cross(tv, e1)
+        let v = simd_dot(d, q) * inv
+        if v < -1e-5 || u + v > 1 + 1e-5 { return nil }
+        let t = simd_dot(e2, q) * inv
+        return t > 1e-5 ? t : nil
     }
 
     /// Slab test → entry distance along the ray, or nil if it misses.
@@ -754,7 +790,7 @@ final class EditorModel {
         defer { vcad_scene_free(scene) }
         let count = vcad_scene_part_count(scene)
         var meshes: [MeshResource] = []
-        var bounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
+        var picks: [PickMesh] = []
         var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
         var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
         var tris = 0
@@ -764,10 +800,11 @@ final class EditorModel {
             lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
             tris += km.triangleCount
             meshes.append(km.resource(name: "part\(i)"))
-            bounds.append((km.minBound, km.maxBound))
+            picks.append(PickMesh(positions: km.positions, indices: km.indices,
+                                  lo: km.minBound, hi: km.maxBound))
         }
         guard !meshes.isEmpty else { return nil }
-        docPartBounds = bounds
+        docPartMeshes = picks
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = tris
         partCount = meshes.count
@@ -1423,7 +1460,7 @@ final class EditorModel {
     private func sceneFromHandle(_ scene: OpaquePointer, start: Date) -> RenderScene {
         let count = vcad_scene_part_count(scene)
         var meshes: [(MeshResource, NSColor)] = []
-        var bounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
+        var picks: [PickMesh] = []
         var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
         var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
         var tris = 0
@@ -1434,11 +1471,12 @@ final class EditorModel {
             tris += km.triangleCount
             meshes.append((km.resource(name: "part\(i)"), Self.partColors[i % Self.partColors.count]))
             // Index-aligned with `meshes` (and thus the rendered part entities),
-            // so a viewport tap maps back to the right feature-tree row.
-            bounds.append((km.minBound, km.maxBound))
+            // so a viewport ray maps back to the right feature-tree row.
+            picks.append(PickMesh(positions: km.positions, indices: km.indices,
+                                  lo: km.minBound, hi: km.maxBound))
         }
         guard !meshes.isEmpty else { return .empty }
-        docPartBounds = bounds
+        docPartMeshes = picks
 
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = tris

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -109,6 +109,40 @@ enum BooleanOp: String, CaseIterable, Identifiable {
     }
 }
 
+/// A 2D sketch drawing tool (mirrors the web app's line/rectangle/circle tools).
+enum SketchTool: String, CaseIterable, Identifiable {
+    case line, rectangle, circle
+    var id: String { rawValue }
+    var label: String { rawValue.capitalized }
+    var symbol: String {
+        switch self {
+        case .line: return "line.diagonal"
+        case .rectangle: return "rectangle"
+        case .circle: return "circle"
+        }
+    }
+}
+
+/// An axis-aligned sketch plane (origin at world 0). Basis vectors place 2D
+/// sketch coords in 3D; `normal` is the extrude direction.
+enum SketchPlane: String, CaseIterable, Identifiable {
+    case xy, xz, yz
+    var id: String { rawValue }
+    var label: String { rawValue.uppercased() }
+    var xDir: (Double, Double, Double) {
+        switch self { case .xy: return (1, 0, 0); case .xz: return (1, 0, 0); case .yz: return (0, 1, 0) }
+    }
+    var yDir: (Double, Double, Double) {
+        switch self { case .xy: return (0, 1, 0); case .xz: return (0, 0, 1); case .yz: return (0, 0, 1) }
+    }
+    var normal: (Double, Double, Double) {
+        switch self { case .xy: return (0, 0, 1); case .xz: return (0, 1, 0); case .yz: return (1, 0, 0) }
+    }
+    var xDirF: SIMD3<Float> { SIMD3(Float(xDir.0), Float(xDir.1), Float(xDir.2)) }
+    var yDirF: SIMD3<Float> { SIMD3(Float(yDir.0), Float(yDir.1), Float(yDir.2)) }
+    var normalF: SIMD3<Float> { SIMD3(Float(normal.0), Float(normal.1), Float(normal.2)) }
+}
+
 /// One tool button within a tab.
 struct Tool: Identifiable {
     let id: String
@@ -437,6 +471,130 @@ final class EditorModel {
         if let pi = selBefore, pi < featureNodes.count { selectedFeatureID = featureNodes[pi].id }
     }
 
+    // MARK: sketch mode (draw a profile → extrude), a port of the web sketcher
+
+    var sketching = false
+    var sketchPlane: SketchPlane = .xy
+    var sketchTool: SketchTool = .rectangle
+    /// The profile polygon, in plane (2D mm) coords. Closed when `sketchClosed`.
+    var sketchVerts: [SIMD2<Float>] = []
+    /// First click for the rectangle/circle two-click tools.
+    var sketchAnchor: SIMD2<Float>?
+    /// True once a closed profile exists (ready to extrude).
+    var sketchClosed = false
+    /// Live cursor on the plane, for rubber-band preview.
+    var sketchCursor: SIMD2<Float>?
+    var sketchExtrudeDepth: Double = 10
+    /// Viewport needs to rebuild the sketch preview overlay.
+    var sketchDirty = false
+    private let sketchCircleSegments = 48
+    /// Click-to-close radius for the line tool (plane mm).
+    private let sketchCloseDist: Float = 2.5
+
+    var canFinishSketch: Bool { sketchClosed && sketchVerts.count >= 3 }
+
+    func enterSketch() {
+        guard usesDocumentTree else { return }
+        sketching = true
+        resetSketchShape()
+        // Frame the plane head-on so drawing maps 1:1 to the screen.
+        switch sketchPlane {
+        case .xy: azimuth = 0; elevation = 1.45
+        case .xz: azimuth = 0; elevation = 0
+        case .yz: azimuth = .pi / 2; elevation = 0
+        }
+        sketchDirty = true
+    }
+    func exitSketch() {
+        sketching = false
+        resetSketchShape()
+        sketchDirty = true
+    }
+    func setSketchTool(_ t: SketchTool) {
+        sketchTool = t
+        resetSketchShape()
+        sketchDirty = true
+    }
+    func setSketchPlane(_ p: SketchPlane) {
+        sketchPlane = p
+        resetSketchShape()
+        switch p {
+        case .xy: azimuth = 0; elevation = 1.45
+        case .xz: azimuth = 0; elevation = 0
+        case .yz: azimuth = .pi / 2; elevation = 0
+        }
+        sketchDirty = true
+    }
+    private func resetSketchShape() {
+        sketchVerts = []; sketchAnchor = nil; sketchClosed = false; sketchCursor = nil
+    }
+
+    /// A tap on the sketch plane (2D plane coords) — drives the active tool.
+    func sketchTap(_ p: SIMD2<Float>) {
+        switch sketchTool {
+        case .line:
+            if sketchClosed { break }
+            if sketchVerts.count >= 3, let f = sketchVerts.first, simd_distance(f, p) < sketchCloseDist {
+                sketchClosed = true
+            } else {
+                sketchVerts.append(p)
+            }
+        case .rectangle:
+            if let a = sketchAnchor {
+                sketchVerts = [a, SIMD2(p.x, a.y), p, SIMD2(a.x, p.y)]
+                sketchClosed = true; sketchAnchor = nil
+            } else {
+                sketchAnchor = p; sketchVerts = []
+            }
+        case .circle:
+            if let c = sketchAnchor {
+                sketchVerts = circlePoints(center: c, radius: simd_distance(c, p))
+                sketchClosed = true; sketchAnchor = nil
+            } else {
+                sketchAnchor = p; sketchVerts = []
+            }
+        }
+        sketchDirty = true
+    }
+
+    private func circlePoints(center c: SIMD2<Float>, radius r: Float) -> [SIMD2<Float>] {
+        (0..<sketchCircleSegments).map { i in
+            let a = 2 * Float.pi * Float(i) / Float(sketchCircleSegments)
+            return SIMD2(c.x + r * cos(a), c.y + r * sin(a))
+        }
+    }
+
+    /// Project a kernel-space ray onto the sketch plane → 2D plane coords.
+    func sketchPlanePoint(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> SIMD2<Float>? {
+        let n = sketchPlane.normalF
+        let denom = simd_dot(d, n)
+        guard abs(denom) > 1e-6 else { return nil }
+        let t = -simd_dot(o, n) / denom        // plane passes through origin
+        guard t > 0 else { return nil }
+        let pt = o + t * d
+        return SIMD2(simd_dot(pt, sketchPlane.xDirF), simd_dot(pt, sketchPlane.yDirF))
+    }
+
+    /// 2D plane coords → 3D kernel coords (for drawing the preview).
+    func sketchWorld(_ v: SIMD2<Float>) -> SIMD3<Float> {
+        v.x * sketchPlane.xDirF + v.y * sketchPlane.yDirF
+    }
+
+    /// Realize the closed profile as a Sketch2D + Extrude, then leave sketch mode.
+    func finishSketch() {
+        guard canFinishSketch, documentJSON != nil else { return }
+        let verts = sketchVerts.map { (Double($0.x), Double($0.y)) }
+        let n = sketchPlane.normal
+        let dir = (n.0 * sketchExtrudeDepth, n.1 * sketchExtrudeDepth, n.2 * sketchExtrudeDepth)
+        let plane = sketchPlane
+        applyEdit(snapshot: true, reeval: .rebuild) {
+            DocEdit.addExtrudedProfile(&$0, verts: verts, origin: (0, 0, 0),
+                                       xDir: plane.xDir, yDir: plane.yDir, direction: dir)
+        }
+        selectedFeatureID = featureNodes.last?.id
+        exitSketch()
+    }
+
     // MARK: save
 
     func saveDocument() {
@@ -680,9 +838,12 @@ final class EditorModel {
         keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             MainActor.assumeIsolated {
                 guard let self else { return }
-                if event.keyCode == 53, self.usesDocumentTree,
-                   self.renamingFeatureID == nil, self.hasSelection {
-                    self.deselectAll()
+                if event.keyCode == 53 {                       // Escape
+                    if self.sketching {
+                        self.exitSketch()
+                    } else if self.usesDocumentTree, self.renamingFeatureID == nil, self.hasSelection {
+                        self.deselectAll()
+                    }
                 }
             }
             return event
@@ -974,7 +1135,7 @@ final class EditorModel {
         let docMode = usesDocumentTree
         switch tab {
         case .create:
-            return BaseShape.allCases.map { shape in
+            var out = BaseShape.allCases.map { shape in
                 // Sandbox: pick the primitive. Document: add a new part.
                 Tool(id: "shape.\(shape.rawValue)",
                      label: docMode ? "Add \(shape.label)" : shape.label, symbol: shape.symbol,
@@ -982,6 +1143,11 @@ final class EditorModel {
                     if docMode { self?.addPrimitive(shape) } else { self?.baseShape = shape }
                 }
             }
+            if docMode {
+                out.append(Tool(id: "sketch", label: "Sketch", symbol: "scribble.variable",
+                                isActive: false) { [weak self] in self?.enterSketch() })
+            }
+            return out
         case .modify:
             return Modifier.allCases.compactMap { mod in
                 if docMode {

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -385,6 +385,29 @@ final class EditorModel {
         return g.visibleRoots[i].material
     }
 
+    /// Resolve a part's render material: the doc's own definition → a preset by
+    /// key → a neutral fallback (so unknown-material parts look as before).
+    func resolvedMaterial(forPart i: Int) -> ResolvedMaterial {
+        let key = materialName(forPart: i) ?? ""
+        if let d = documentGraph?.materials[key] {
+            return ResolvedMaterial(
+                color: NSColor(srgbRed: d.color.0, green: d.color.1, blue: d.color.2, alpha: 1),
+                metallic: d.metallic, roughness: d.roughness, transmission: d.transmission)
+        }
+        if let p = MaterialPreset.byKey(key) {
+            return ResolvedMaterial(color: p.nsColor, metallic: p.metallic,
+                                    roughness: p.roughness, transmission: p.transmission)
+        }
+        return ResolvedMaterial(color: documentBaseColor(i), metallic: 0.55, roughness: 0.34, transmission: 0)
+    }
+
+    /// Assign a material to a part — recolors live (no geometry rebuild).
+    func setPartMaterial(_ partIndex: Int, _ key: String) {
+        guard documentJSON != nil else { return }
+        applyEdit(snapshot: true, reeval: .none) { DocEdit.setRootMaterial(&$0, partIndex: partIndex, key: key) }
+        selectionDirty = true
+    }
+
     func documentBaseColor(_ i: Int) -> NSColor { Self.partColors[i % Self.partColors.count] }
     static let brandPink = NSColor(srgbRed: 0.976, green: 0.149, blue: 0.447, alpha: 1.0)
 

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -694,6 +694,96 @@ final class EditorModel {
         exitSketch()
     }
 
+    // MARK: transform gizmo (drag a part along an axis to translate it)
+
+    /// Last viewport size, so a targeted handle drag can rebuild the kernel ray.
+    @ObservationIgnored var viewSize: CGSize = .zero
+    /// Viewport should reposition the gizmo (selection changed / drag ended).
+    var gizmoDirty = false
+    @ObservationIgnored private var gizmoPart: Int?
+    @ObservationIgnored private var gizmoAxis: SIMD3<Float> = .zero
+    @ObservationIgnored private var gizmoBase: (Double, Double, Double) = (0, 0, 0)
+    @ObservationIgnored private var gizmoStartCenter: SIMD3<Float> = .zero
+    @ObservationIgnored private var gizmoT0: Float = 0
+
+    /// Show the gizmo for a single selected part (not while sketching/multi-select).
+    var showsGizmo: Bool {
+        usesDocumentTree && !sketching && multiSelectedParts.isEmpty && selectedPartIndex != nil
+    }
+    /// Selected part center in kernel coords (gizmo origin).
+    func gizmoCenterKernel() -> SIMD3<Float>? {
+        guard let pi = selectedPartIndex, pi < docPartMeshes.count else { return nil }
+        let m = docPartMeshes[pi]
+        return (m.lo + m.hi) / 2
+    }
+    /// Arm length scaled to the part.
+    func gizmoArmLength() -> Float {
+        guard let pi = selectedPartIndex, pi < docPartMeshes.count else { return 12 }
+        let d = docPartMeshes[pi].hi - docPartMeshes[pi].lo
+        return max(8, 0.55 * max(d.x, max(d.y, d.z)))
+    }
+
+    func beginGizmoDrag(axis: SIMD3<Float>, ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
+        guard let pi = selectedPartIndex, let json = documentJSON, let c = gizmoCenterKernel() else { return }
+        pushUndo()
+        gizmoPart = pi
+        gizmoAxis = axis
+        gizmoStartCenter = c
+        gizmoBase = DocEdit.rootTranslateOffset(json, partIndex: pi) ?? (0, 0, 0)
+        gizmoT0 = Self.axisParam(rayO: ray.o, rayD: ray.d, center: c, axis: axis)
+    }
+    func gizmoDragTo(ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
+        guard let pi = gizmoPart, var json = documentJSON else { return }
+        let t = Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: gizmoAxis)
+        let delta = t - gizmoT0
+        DocEdit.setRootTranslate(&json, partIndex: pi,
+                                 gizmoBase.0 + Double(gizmoAxis.x * delta),
+                                 gizmoBase.1 + Double(gizmoAxis.y * delta),
+                                 gizmoBase.2 + Double(gizmoAxis.z * delta))
+        documentJSON = json
+        documentDirty = true
+        if let g = DocumentGraph.parse(json) { documentGraph = g; featureNodes = g.featureRoots() }
+        docParamDirty = true        // in-place re-eval → smooth
+    }
+    func endGizmoDrag() {
+        gizmoPart = nil
+        gizmoDirty = true           // snap the gizmo to the part's new center
+    }
+    /// Whether a ray passes through the gizmo (so a tap on it doesn't deselect).
+    func rayHitsGizmo(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Bool {
+        guard showsGizmo, let c = gizmoCenterKernel() else { return false }
+        let len = gizmoArmLength()
+        let pad = max(0.6, len * 0.035) * 5
+        for ax in [SIMD3<Float>(1, 0, 0), SIMD3<Float>(0, 1, 0), SIMD3<Float>(0, 0, 1)] {
+            let lo = simd_min(c, c + ax * len) - SIMD3<Float>(repeating: pad)
+            let hi = simd_max(c, c + ax * len) + SIMD3<Float>(repeating: pad)
+            if Self.rayAABB(o: o, d: d, lo: lo, hi: hi) != nil { return true }
+        }
+        return false
+    }
+
+    func gizmoAxis(for name: String) -> SIMD3<Float>? {
+        switch name {
+        case "gizmoX": return SIMD3(1, 0, 0)
+        case "gizmoY": return SIMD3(0, 1, 0)
+        case "gizmoZ": return SIMD3(0, 0, 1)
+        default: return nil
+        }
+    }
+
+    /// Param `t` along the axis line (center + t·axis) closest to the ray — the
+    /// standard closest-point-between-two-lines solution (axis is a unit vector).
+    private static func axisParam(rayO: SIMD3<Float>, rayD: SIMD3<Float>,
+                                  center: SIMD3<Float>, axis: SIMD3<Float>) -> Float {
+        let w0 = rayO - center
+        let b = simd_dot(rayD, axis)
+        let d = simd_dot(rayD, w0)
+        let e = simd_dot(axis, w0)
+        let denom = 1 - b * b
+        if abs(denom) < 1e-5 { return e }       // ray ∥ axis → fall back to projection
+        return (e - b * d) / denom
+    }
+
     // MARK: save
 
     func saveDocument() {

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -694,20 +694,47 @@ final class EditorModel {
         exitSketch()
     }
 
-    // MARK: transform gizmo (drag a part along an axis to translate it)
+    // MARK: transform gizmo (drag a part to translate it — axis + plane handles)
 
     /// Last viewport size, so a targeted handle drag can rebuild the kernel ray.
     @ObservationIgnored var viewSize: CGSize = .zero
-    /// Viewport should reposition the gizmo (selection changed / drag ended).
+    /// Viewport should reposition / re-highlight the gizmo.
     var gizmoDirty = false
+    /// The handle under the cursor ("gizmoX" / "planeXY" / …), for hover + cursor.
+    var hoveredGizmoHandle: String?
     @ObservationIgnored private var gizmoPart: Int?
-    @ObservationIgnored private var gizmoAxis: SIMD3<Float> = .zero
+    @ObservationIgnored private var gizmoActive: GizmoHandle?
     @ObservationIgnored private var gizmoBase: (Double, Double, Double) = (0, 0, 0)
     @ObservationIgnored private var gizmoStartCenter: SIMD3<Float> = .zero
     @ObservationIgnored private var gizmoT0: Float = 0
-    /// Live displacement of the part during a gizmo drag, so the viewport can
-    /// slide the gizmo along with the part instead of leaving it at the start.
+    @ObservationIgnored private var gizmoStartPlane: SIMD3<Float> = .zero
+    /// Live displacement of the part during a drag, so the viewport can slide the
+    /// gizmo with it instead of leaving it at the grab point.
     @ObservationIgnored var gizmoLiveOffset: SIMD3<Float> = .zero
+
+    enum GizmoHandle {
+        case axis(SIMD3<Float>)
+        case plane(SIMD3<Float>, SIMD3<Float>)   // two in-plane unit axes
+    }
+    func gizmoHandle(for name: String) -> GizmoHandle? {
+        switch name {
+        case "gizmoX": return .axis(SIMD3(1, 0, 0))
+        case "gizmoY": return .axis(SIMD3(0, 1, 0))
+        case "gizmoZ": return .axis(SIMD3(0, 0, 1))
+        case "planeXY": return .plane(SIMD3(1, 0, 0), SIMD3(0, 1, 0))
+        case "planeYZ": return .plane(SIMD3(0, 1, 0), SIMD3(0, 0, 1))
+        case "planeXZ": return .plane(SIMD3(1, 0, 0), SIMD3(0, 0, 1))
+        default: return nil
+        }
+    }
+    static let gizmoAxisDefs: [(name: String, dir: SIMD3<Float>)] = [
+        ("gizmoX", SIMD3(1, 0, 0)), ("gizmoY", SIMD3(0, 1, 0)), ("gizmoZ", SIMD3(0, 0, 1)),
+    ]
+    static let gizmoPlaneDefs: [(name: String, a: SIMD3<Float>, b: SIMD3<Float>)] = [
+        ("planeXY", SIMD3(1, 0, 0), SIMD3(0, 1, 0)),
+        ("planeYZ", SIMD3(0, 1, 0), SIMD3(0, 0, 1)),
+        ("planeXZ", SIMD3(1, 0, 0), SIMD3(0, 0, 1)),
+    ]
 
     /// Show the gizmo for a single selected part (not while sketching/multi-select).
     var showsGizmo: Bool {
@@ -719,32 +746,48 @@ final class EditorModel {
         let m = docPartMeshes[pi]
         return (m.lo + m.hi) / 2
     }
-    /// Arm length scaled to the part.
+    /// Arm length — reaches past the part so the arrowheads clear the geometry.
     func gizmoArmLength() -> Float {
-        guard let pi = selectedPartIndex, pi < docPartMeshes.count else { return 12 }
+        guard let pi = selectedPartIndex, pi < docPartMeshes.count else { return 14 }
         let d = docPartMeshes[pi].hi - docPartMeshes[pi].lo
-        return max(8, 0.55 * max(d.x, max(d.y, d.z)))
+        return max(10, 0.5 * max(d.x, max(d.y, d.z)) + 0.22 * (d.x + d.y + d.z) / 3)
     }
+    var gizmoPlaneOffset: Float { gizmoArmLength() * 0.34 }
+    var gizmoPlaneSize: Float { gizmoArmLength() * 0.17 }
 
-    func beginGizmoDrag(axis: SIMD3<Float>, ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
-        guard let pi = selectedPartIndex, let json = documentJSON, let c = gizmoCenterKernel() else { return }
+    func beginGizmoDrag(handle name: String, ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
+        guard let pi = selectedPartIndex, let json = documentJSON,
+              let c = gizmoCenterKernel(), let h = gizmoHandle(for: name) else { return }
         pushUndo()
         gizmoPart = pi
-        gizmoAxis = axis
+        gizmoActive = h
         gizmoStartCenter = c
         gizmoBase = DocEdit.rootTranslateOffset(json, partIndex: pi) ?? (0, 0, 0)
-        gizmoT0 = Self.axisParam(rayO: ray.o, rayD: ray.d, center: c, axis: axis)
         gizmoLiveOffset = .zero
+        switch h {
+        case .axis(let ax):
+            gizmoT0 = Self.axisParam(rayO: ray.o, rayD: ray.d, center: c, axis: ax)
+        case .plane(let a, let b):
+            let n = simd_normalize(simd_cross(a, b))
+            gizmoStartPlane = Self.rayPlane(o: ray.o, d: ray.d, point: c, normal: n) ?? c
+        }
     }
     func gizmoDragTo(ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
-        guard let pi = gizmoPart, var json = documentJSON else { return }
-        let t = Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: gizmoAxis)
-        let delta = t - gizmoT0
-        gizmoLiveOffset = gizmoAxis * delta        // slide the gizmo with the part
+        guard let pi = gizmoPart, var json = documentJSON, let h = gizmoActive else { return }
+        var off = SIMD3<Float>.zero
+        switch h {
+        case .axis(let ax):
+            off = ax * (Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: ax) - gizmoT0)
+        case .plane(let a, let b):
+            let n = simd_normalize(simd_cross(a, b))
+            guard let p = Self.rayPlane(o: ray.o, d: ray.d, point: gizmoStartCenter, normal: n) else { return }
+            off = p - gizmoStartPlane
+        }
+        gizmoLiveOffset = off
         DocEdit.setRootTranslate(&json, partIndex: pi,
-                                 gizmoBase.0 + Double(gizmoAxis.x * delta),
-                                 gizmoBase.1 + Double(gizmoAxis.y * delta),
-                                 gizmoBase.2 + Double(gizmoAxis.z * delta))
+                                 gizmoBase.0 + Double(off.x),
+                                 gizmoBase.1 + Double(off.y),
+                                 gizmoBase.2 + Double(off.z))
         documentJSON = json
         documentDirty = true
         if let g = DocumentGraph.parse(json) { documentGraph = g; featureNodes = g.featureRoots() }
@@ -752,29 +795,34 @@ final class EditorModel {
     }
     func endGizmoDrag() {
         gizmoPart = nil
+        gizmoActive = nil
         gizmoLiveOffset = .zero
-        gizmoDirty = true           // rebuild the gizmo at the part's new center
-    }
-    /// Whether a ray passes through the gizmo (so a tap on it doesn't deselect).
-    func rayHitsGizmo(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Bool {
-        guard showsGizmo, let c = gizmoCenterKernel() else { return false }
-        let len = gizmoArmLength()
-        let pad = max(0.6, len * 0.035) * 5
-        for ax in [SIMD3<Float>(1, 0, 0), SIMD3<Float>(0, 1, 0), SIMD3<Float>(0, 0, 1)] {
-            let lo = simd_min(c, c + ax * len) - SIMD3<Float>(repeating: pad)
-            let hi = simd_max(c, c + ax * len) + SIMD3<Float>(repeating: pad)
-            if Self.rayAABB(o: o, d: d, lo: lo, hi: hi) != nil { return true }
-        }
-        return false
+        gizmoDirty = true
     }
 
-    func gizmoAxis(for name: String) -> SIMD3<Float>? {
-        switch name {
-        case "gizmoX": return SIMD3(1, 0, 0)
-        case "gizmoY": return SIMD3(0, 1, 0)
-        case "gizmoZ": return SIMD3(0, 0, 1)
-        default: return nil
+    /// Nearest gizmo handle the ray hits, or nil — drives hover + tap-protection.
+    func hitGizmoHandle(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> String? {
+        guard showsGizmo, let c = gizmoCenterKernel() else { return nil }
+        let len = gizmoArmLength()
+        let pad = max(0.6, len * 0.045)
+        var best: (name: String, t: Float)?
+        func consider(_ name: String, _ lo: SIMD3<Float>, _ hi: SIMD3<Float>) {
+            if let t = Self.rayAABB(o: o, d: d, lo: lo, hi: hi), best == nil || t < best!.t { best = (name, t) }
         }
+        for a in Self.gizmoAxisDefs {
+            consider(a.name, simd_min(c, c + a.dir * len) - SIMD3(repeating: pad),
+                     simd_max(c, c + a.dir * len) + SIMD3(repeating: pad))
+        }
+        let off = gizmoPlaneOffset, hs = gizmoPlaneSize / 2 + pad
+        for p in Self.gizmoPlaneDefs {
+            let pc = c + (p.a + p.b) * off
+            consider(p.name, pc - SIMD3(repeating: hs), pc + SIMD3(repeating: hs))
+        }
+        return best?.name
+    }
+    /// Whether a ray hits the gizmo (so a tap on it doesn't deselect).
+    func rayHitsGizmo(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Bool {
+        hitGizmoHandle(originKernel: o, dirKernel: d) != nil
     }
 
     /// Param `t` along the axis line (center + t·axis) closest to the ray — the
@@ -788,6 +836,14 @@ final class EditorModel {
         let denom = 1 - b * b
         if abs(denom) < 1e-5 { return e }       // ray ∥ axis → fall back to projection
         return (e - b * d) / denom
+    }
+
+    /// Ray ∩ plane (through `point`, with `normal`) → world point, or nil if ∥.
+    private static func rayPlane(o: SIMD3<Float>, d: SIMD3<Float>,
+                                 point: SIMD3<Float>, normal: SIMD3<Float>) -> SIMD3<Float>? {
+        let denom = simd_dot(d, normal)
+        if abs(denom) < 1e-6 { return nil }
+        return o + d * (simd_dot(point - o, normal) / denom)
     }
 
     // MARK: save

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -311,6 +311,14 @@ final class EditorModel {
         if !multiSelectedParts.isEmpty { multiSelectedParts = [] }
         selectedFeatureID = id
     }
+    /// Whether anything is selected (drives Escape/empty-click deselect).
+    var hasSelection: Bool { selectedFeatureID != nil || !multiSelectedParts.isEmpty }
+    /// Clear all selection — empty-space click or Escape (documents only).
+    func deselectAll() {
+        multiSelectedParts = []
+        selectedFeatureID = nil
+        selectionDirty = true
+    }
     /// ⌘-click: toggle a part in the multi-selection; the last click stays primary.
     func toggleMultiSelect(part pi: Int, featureID id: String) {
         if let idx = multiSelectedParts.firstIndex(of: pi) { multiSelectedParts.remove(at: idx) }
@@ -663,6 +671,24 @@ final class EditorModel {
         panOffset += (-dx * right + dy * up) * (distance * 0.0016)
     }
 
+    // Escape → deselect (documents only; never while renaming, so the rename
+    // field's own Esc-cancel still works). Returns the event so other handlers
+    // still see it.
+    nonisolated(unsafe) private var keyMonitor: Any?
+    func installKeyMonitor() {
+        guard keyMonitor == nil else { return }
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                if event.keyCode == 53, self.usesDocumentTree,
+                   self.renamingFeatureID == nil, self.hasSelection {
+                    self.deselectAll()
+                }
+            }
+            return event
+        }
+    }
+
     // Two-finger / wheel scroll → zoom. Installed once when the viewport appears.
     nonisolated(unsafe) private var scrollMonitor: Any?
     func installScrollZoom() {
@@ -693,6 +719,7 @@ final class EditorModel {
     deinit {
         if let d = gripperDoc { vcad_doc_free(d) }
         if let m = scrollMonitor { NSEvent.removeMonitor(m) }
+        if let m = keyMonitor { NSEvent.removeMonitor(m) }
     }
 
     /// Clearance from the connector cutout to the nearest enclosure side wall —

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -6,6 +6,19 @@ import CVcadFFI
 
 // Model layer. The SwiftUI shell is in Shell.swift; kernel/streaming in Kernel.swift.
 
+/// One motion vocabulary for the whole app, so every surface moves with the same
+/// personality. Reach for these instead of ad-hoc `.snappy`/`.smooth` literals.
+enum Motion {
+    /// Selection, tab swaps, small state flips — quick and crisp.
+    static let snappy = Animation.snappy(duration: 0.22, extraBounce: 0.04)
+    /// Panels appearing / docking — a soft settle.
+    static let panel = Animation.spring(response: 0.4, dampingFraction: 0.84)
+    /// Content morphs, value-driven layout shifts.
+    static let smooth = Animation.smooth(duration: 0.3)
+    /// A small confident "pop" for things that materialize.
+    static let pop = Animation.spring(response: 0.32, dampingFraction: 0.7)
+}
+
 private let kSamplesDir = "/Users/cam/Developer/vcad/.claude/worktrees/great-bohr-4c355d"
 
 enum GeometrySource: Hashable, Identifiable {
@@ -210,8 +223,8 @@ final class EditorModel {
     }
 
     var toolTab: ToolTab = .create
-    /// Header (Borland-style top strip) vs footer (below the composer).
-    var toolPlacement: ToolPlacement = .header
+    /// Footer (single-row shelf below the composer) vs a Borland-style header.
+    var toolPlacement: ToolPlacement = .footer
     func cycleToolPlacement() {
         toolPlacement = toolPlacement == .header ? .footer : .header
     }
@@ -916,6 +929,60 @@ final class EditorModel {
         panOffset += (-dx * right + dy * up) * (distance * 0.0016)
     }
 
+    // MARK: inertial orbit — flick to spin, momentum decays to rest
+    nonisolated(unsafe) private var spinTimer: Timer?
+    @ObservationIgnored private var azVel: Float = 0      // rad/s
+    @ObservationIgnored private var elVel: Float = 0
+    @ObservationIgnored private var lastOrbitTime: Date?
+
+    /// A drag started — kill any running momentum and reset velocity tracking.
+    func beginOrbit() {
+        stopSpin()
+        lastOrbitTime = Date()
+        azVel = 0; elVel = 0
+    }
+
+    /// Incremental orbit from a drag delta; tracks angular velocity (low-pass
+    /// filtered) so the flick at release carries momentum.
+    func orbitDrag(dx: Float, dy: Float) {
+        let now = Date()
+        let dt = Float(now.timeIntervalSince(lastOrbitTime ?? now))
+        lastOrbitTime = now
+        let daz = -dx * 0.01
+        let before = elevation
+        azimuth += daz
+        elevation = max(-1.45, min(1.45, elevation + dy * 0.01))
+        let del = elevation - before
+        if dt > 1e-4, dt < 0.1 {
+            azVel = 0.6 * azVel + 0.4 * (daz / dt)
+            elVel = 0.6 * elVel + 0.4 * (del / dt)
+        }
+    }
+
+    /// Release — coast if the flick was fast enough.
+    func endOrbit() {
+        if abs(azVel) > 0.2 || abs(elVel) > 0.2 { startSpin() }
+    }
+
+    private func startSpin() {
+        stopSpin()
+        let dt: Float = 1.0 / 120.0
+        spinTimer = Timer.scheduledTimer(withTimeInterval: TimeInterval(dt), repeats: true) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.azimuth += self.azVel * dt
+                let ne = max(-1.45, min(1.45, self.elevation + self.elVel * dt))
+                if ne != self.elevation { self.elevation = ne } else { self.elVel = 0 }
+                let decay: Float = 0.94
+                self.azVel *= decay; self.elVel *= decay
+                if abs(self.azVel) < 0.05, abs(self.elVel) < 0.05 { self.stopSpin() }
+            }
+        }
+    }
+
+    /// Stop coasting (also called when the user grabs / zooms / taps).
+    func stopSpin() { spinTimer?.invalidate(); spinTimer = nil }
+
     // Escape → deselect (documents only; never while renaming, so the rename
     // field's own Esc-cancel still works). Returns the event so other handlers
     // still see it.
@@ -944,6 +1011,7 @@ final class EditorModel {
         scrollMonitor = NSEvent.addLocalMonitorForEvents(matching: .scrollWheel) { [weak self] event in
             MainActor.assumeIsolated {
                 guard let self, !self.draggingHandle else { return }
+                self.stopSpin()                       // zooming interrupts coasting
                 let dy = Float(event.scrollingDeltaY)
                 let k = Float(event.hasPreciseScrollingDeltas ? 0.004 : 0.04)
                 self.distance = max(0.45, min(8.0, self.distance * (1 - dy * k)))
@@ -968,6 +1036,7 @@ final class EditorModel {
         if let d = gripperDoc { vcad_doc_free(d) }
         if let m = scrollMonitor { NSEvent.removeMonitor(m) }
         if let m = keyMonitor { NSEvent.removeMonitor(m) }
+        spinTimer?.invalidate()
     }
 
     /// Clearance from the connector cutout to the nearest enclosure side wall —

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -705,6 +705,9 @@ final class EditorModel {
     @ObservationIgnored private var gizmoBase: (Double, Double, Double) = (0, 0, 0)
     @ObservationIgnored private var gizmoStartCenter: SIMD3<Float> = .zero
     @ObservationIgnored private var gizmoT0: Float = 0
+    /// Live displacement of the part during a gizmo drag, so the viewport can
+    /// slide the gizmo along with the part instead of leaving it at the start.
+    @ObservationIgnored var gizmoLiveOffset: SIMD3<Float> = .zero
 
     /// Show the gizmo for a single selected part (not while sketching/multi-select).
     var showsGizmo: Bool {
@@ -731,11 +734,13 @@ final class EditorModel {
         gizmoStartCenter = c
         gizmoBase = DocEdit.rootTranslateOffset(json, partIndex: pi) ?? (0, 0, 0)
         gizmoT0 = Self.axisParam(rayO: ray.o, rayD: ray.d, center: c, axis: axis)
+        gizmoLiveOffset = .zero
     }
     func gizmoDragTo(ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
         guard let pi = gizmoPart, var json = documentJSON else { return }
         let t = Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: gizmoAxis)
         let delta = t - gizmoT0
+        gizmoLiveOffset = gizmoAxis * delta        // slide the gizmo with the part
         DocEdit.setRootTranslate(&json, partIndex: pi,
                                  gizmoBase.0 + Double(gizmoAxis.x * delta),
                                  gizmoBase.1 + Double(gizmoAxis.y * delta),
@@ -747,7 +752,8 @@ final class EditorModel {
     }
     func endGizmoDrag() {
         gizmoPart = nil
-        gizmoDirty = true           // snap the gizmo to the part's new center
+        gizmoLiveOffset = .zero
+        gizmoDirty = true           // rebuild the gizmo at the part's new center
     }
     /// Whether a ray passes through the gizmo (so a tap on it doesn't deselect).
     func rayHitsGizmo(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Bool {

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -708,6 +708,13 @@ final class EditorModel {
     @ObservationIgnored private var gizmoStartCenter: SIMD3<Float> = .zero
     @ObservationIgnored private var gizmoT0: Float = 0
     @ObservationIgnored private var gizmoStartPlane: SIMD3<Float> = .zero
+    // Rotate-ring drag.
+    @ObservationIgnored private var gizmoRotNode: Int?
+    @ObservationIgnored private var gizmoRotAxisIndex = 0
+    @ObservationIgnored private var gizmoRotU1: SIMD3<Float> = .zero
+    @ObservationIgnored private var gizmoRotU2: SIMD3<Float> = .zero
+    @ObservationIgnored private var gizmoRotPrev: Float = 0
+    @ObservationIgnored private var gizmoRotAccum: Float = 0
     /// Live displacement of the part during a drag, so the viewport can slide the
     /// gizmo with it instead of leaving it at the grab point.
     @ObservationIgnored var gizmoLiveOffset: SIMD3<Float> = .zero
@@ -715,6 +722,7 @@ final class EditorModel {
     enum GizmoHandle {
         case axis(SIMD3<Float>)
         case plane(SIMD3<Float>, SIMD3<Float>)   // two in-plane unit axes
+        case rotate(SIMD3<Float>)                // spin axis
     }
     func gizmoHandle(for name: String) -> GizmoHandle? {
         switch name {
@@ -724,8 +732,21 @@ final class EditorModel {
         case "planeXY": return .plane(SIMD3(1, 0, 0), SIMD3(0, 1, 0))
         case "planeYZ": return .plane(SIMD3(0, 1, 0), SIMD3(0, 0, 1))
         case "planeXZ": return .plane(SIMD3(1, 0, 0), SIMD3(0, 0, 1))
+        case "rotX": return .rotate(SIMD3(1, 0, 0))
+        case "rotY": return .rotate(SIMD3(0, 1, 0))
+        case "rotZ": return .rotate(SIMD3(0, 0, 1))
         default: return nil
         }
+    }
+    static let gizmoRotDefs: [(name: String, axis: SIMD3<Float>)] = [
+        ("rotX", SIMD3(1, 0, 0)), ("rotY", SIMD3(0, 1, 0)), ("rotZ", SIMD3(0, 0, 1)),
+    ]
+    var gizmoRingRadius: Float { gizmoArmLength() * 0.82 }
+    /// Two orthonormal in-plane reference axes for a rotation axis.
+    static func ringBasis(_ axis: SIMD3<Float>) -> (SIMD3<Float>, SIMD3<Float>) {
+        if axis.x != 0 { return (SIMD3(0, 1, 0), SIMD3(0, 0, 1)) }
+        if axis.y != 0 { return (SIMD3(0, 0, 1), SIMD3(1, 0, 0)) }
+        return (SIMD3(1, 0, 0), SIMD3(0, 1, 0))
     }
     static let gizmoAxisDefs: [(name: String, dir: SIMD3<Float>)] = [
         ("gizmoX", SIMD3(1, 0, 0)), ("gizmoY", SIMD3(0, 1, 0)), ("gizmoZ", SIMD3(0, 0, 1)),
@@ -770,24 +791,49 @@ final class EditorModel {
         case .plane(let a, let b):
             let n = simd_normalize(simd_cross(a, b))
             gizmoStartPlane = Self.rayPlane(o: ray.o, d: ray.d, point: c, normal: n) ?? c
+        case .rotate(let ax):
+            let (u1, u2) = Self.ringBasis(ax)
+            gizmoRotU1 = u1; gizmoRotU2 = u2
+            gizmoRotAxisIndex = ax.x != 0 ? 0 : (ax.y != 0 ? 1 : 2)
+            gizmoRotAccum = 0
+            gizmoRotPrev = Self.ringAngle(o: ray.o, d: ray.d, center: c, axis: ax, u1: u1, u2: u2) ?? 0
+            var j = json
+            gizmoRotNode = DocEdit.wrapRotate(&j, partIndex: pi, Double(c.x), Double(c.y), Double(c.z))
+            documentJSON = j
+            if let g = DocumentGraph.parse(j) { documentGraph = g; featureNodes = g.featureRoots() }
         }
     }
     func gizmoDragTo(ray: (o: SIMD3<Float>, d: SIMD3<Float>)) {
         guard let pi = gizmoPart, var json = documentJSON, let h = gizmoActive else { return }
-        var off = SIMD3<Float>.zero
         switch h {
-        case .axis(let ax):
-            off = ax * (Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: ax) - gizmoT0)
-        case .plane(let a, let b):
-            let n = simd_normalize(simd_cross(a, b))
-            guard let p = Self.rayPlane(o: ray.o, d: ray.d, point: gizmoStartCenter, normal: n) else { return }
-            off = p - gizmoStartPlane
+        case .rotate(let ax):
+            guard let rn = gizmoRotNode,
+                  let a = Self.ringAngle(o: ray.o, d: ray.d, center: gizmoStartCenter,
+                                         axis: ax, u1: gizmoRotU1, u2: gizmoRotU2) else { return }
+            var d = a - gizmoRotPrev
+            if d > .pi { d -= 2 * .pi } else if d < -.pi { d += 2 * .pi }   // unwrap
+            gizmoRotAccum += d
+            gizmoRotPrev = a
+            DocEdit.setRotateAngle(&json, rotNodeId: rn, axisIndex: gizmoRotAxisIndex,
+                                   degrees: Double(gizmoRotAccum * 180 / .pi))
+        default:
+            var off = SIMD3<Float>.zero
+            switch h {
+            case .axis(let ax):
+                off = ax * (Self.axisParam(rayO: ray.o, rayD: ray.d, center: gizmoStartCenter, axis: ax) - gizmoT0)
+            case .plane(let a, let b):
+                let n = simd_normalize(simd_cross(a, b))
+                guard let p = Self.rayPlane(o: ray.o, d: ray.d, point: gizmoStartCenter, normal: n) else { return }
+                off = p - gizmoStartPlane
+            case .rotate:
+                break
+            }
+            gizmoLiveOffset = off
+            DocEdit.setRootTranslate(&json, partIndex: pi,
+                                     gizmoBase.0 + Double(off.x),
+                                     gizmoBase.1 + Double(off.y),
+                                     gizmoBase.2 + Double(off.z))
         }
-        gizmoLiveOffset = off
-        DocEdit.setRootTranslate(&json, partIndex: pi,
-                                 gizmoBase.0 + Double(off.x),
-                                 gizmoBase.1 + Double(off.y),
-                                 gizmoBase.2 + Double(off.z))
         documentJSON = json
         documentDirty = true
         if let g = DocumentGraph.parse(json) { documentGraph = g; featureNodes = g.featureRoots() }
@@ -796,6 +842,7 @@ final class EditorModel {
     func endGizmoDrag() {
         gizmoPart = nil
         gizmoActive = nil
+        gizmoRotNode = nil
         gizmoLiveOffset = .zero
         gizmoDirty = true
     }
@@ -817,6 +864,17 @@ final class EditorModel {
         for p in Self.gizmoPlaneDefs {
             let pc = c + (p.a + p.b) * off
             consider(p.name, pc - SIMD3(repeating: hs), pc + SIMD3(repeating: hs))
+        }
+        // Rotate rings: ray ∩ ring plane, then distance ≈ ring radius.
+        let ringR = gizmoRingRadius, ringPad = max(0.8, len * 0.06)
+        for rd in Self.gizmoRotDefs {
+            let denom = simd_dot(d, rd.axis)
+            if abs(denom) < 1e-6 { continue }
+            let t = simd_dot(c - o, rd.axis) / denom
+            if t <= 0 { continue }
+            if abs(simd_length((o + d * t) - c) - ringR) < ringPad, best == nil || t < best!.t {
+                best = (rd.name, t)
+            }
         }
         return best?.name
     }
@@ -844,6 +902,15 @@ final class EditorModel {
         let denom = simd_dot(d, normal)
         if abs(denom) < 1e-6 { return nil }
         return o + d * (simd_dot(point - o, normal) / denom)
+    }
+
+    /// Angle of the cursor around `axis` in the ring plane (atan2 in the u1/u2
+    /// basis) — drives the rotate-ring drag.
+    private static func ringAngle(o: SIMD3<Float>, d: SIMD3<Float>, center: SIMD3<Float>,
+                                  axis: SIMD3<Float>, u1: SIMD3<Float>, u2: SIMD3<Float>) -> Float? {
+        guard let p = rayPlane(o: o, d: d, point: center, normal: axis) else { return nil }
+        let v = p - center
+        return atan2(simd_dot(v, u2), simd_dot(v, u1))
     }
 
     // MARK: save

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -251,6 +251,9 @@ final class EditorModel {
     var selectionDirty = false
     /// Parts ⌘-clicked for a multi-part action (booleans). Ordered: first = base.
     var multiSelectedParts: [Int] = []
+    /// Part under the cursor (documents) — drives a subtle hover highlight.
+    var hoveredPartIndex: Int?
+    var hoverDirty = false
     /// Per-part kernel-space AABBs, index-aligned with the rendered parts —
     /// the cheap basis for picking a part in the viewport (tap → select row).
     @ObservationIgnored var docPartBounds: [(min: SIMD3<Float>, max: SIMD3<Float>)] = []
@@ -263,6 +266,7 @@ final class EditorModel {
         hiddenParts.removeAll()
         isolatedPart = nil
         multiSelectedParts = []
+        hoveredPartIndex = nil
         expandedFeatureIDs.removeAll()
         docPartBounds = []
         documentJSON = nil
@@ -488,14 +492,24 @@ final class EditorModel {
     /// Viewport needs to rebuild the sketch preview overlay.
     var sketchDirty = false
     private let sketchCircleSegments = 48
-    /// Click-to-close radius for the line tool (plane mm).
-    private let sketchCloseDist: Float = 2.5
+    /// Click-to-close radius for the line tool (plane mm). Also drives the
+    /// snap-to-close indicator in the preview, so it's not private.
+    let sketchCloseDist: Float = 2.5
+
+    /// True when the cursor is within snap range of the line tool's first vertex
+    /// (so the preview can flag that clicking will close the loop).
+    var sketchSnapToStart: Bool {
+        guard sketchTool == .line, !sketchClosed, sketchVerts.count >= 3,
+              let f = sketchVerts.first, let c = sketchCursor else { return false }
+        return simd_distance(f, c) < sketchCloseDist
+    }
 
     var canFinishSketch: Bool { sketchClosed && sketchVerts.count >= 3 }
 
     func enterSketch() {
         guard usesDocumentTree else { return }
         sketching = true
+        hoveredPartIndex = nil; hoverDirty = true
         resetSketchShape()
         // Frame the plane head-on so drawing maps 1:1 to the screen.
         switch sketchPlane {

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -28,7 +28,7 @@ enum GeometrySource: Hashable, Identifiable {
     }
     var label: String {
         switch self {
-        case .sandbox: return "Sandbox"
+        case .sandbox: return "Untitled"
         case .document(_, let label): return label
         case .generated(_, let label): return label
         case .gripper: return "Gripper"
@@ -64,6 +64,14 @@ enum Modifier: String, CaseIterable {
         }
     }
     var paramLabel: String { self == .chamfer ? "Distance" : "Radius" }
+}
+
+/// Where the tool palette docks. Prototyping two looks: a Borland-style header
+/// strip vs a footer bar below the composer.
+enum ToolPlacement: String, CaseIterable, Identifiable {
+    case header, footer
+    var id: String { rawValue }
+    var label: String { rawValue.capitalized }
 }
 
 /// A tab in the tool palette (the native reinterpretation of the web app's
@@ -202,6 +210,11 @@ final class EditorModel {
     }
 
     var toolTab: ToolTab = .create
+    /// Header (Borland-style top strip) vs footer (below the composer).
+    var toolPlacement: ToolPlacement = .header
+    func cycleToolPlacement() {
+        toolPlacement = toolPlacement == .header ? .footer : .header
+    }
 
     // Selection binds tree -> inspector AND rolls history (selecting "base"
     // shows the modifier's input).

--- a/apple/VcadApp/Sources/VcadApp/Materials.swift
+++ b/apple/VcadApp/Sources/VcadApp/Materials.swift
@@ -1,0 +1,77 @@
+import AppKit
+
+// The material palette, ported from the web app's `data/materials.ts` (31+
+// real-world PBR presets). A part's render color resolves in this order:
+// the document's own `materials` map → a preset by key → an index fallback.
+// Assigning a preset writes its definition into the doc so it persists + renders
+// identically on reload.
+
+struct MaterialPreset: Identifiable {
+    let key: String
+    let category: String
+    let color: (Double, Double, Double)
+    let metallic: Float
+    let roughness: Float
+    let transmission: Float
+    var id: String { key }
+
+    var name: String {
+        key.split(separator: "-").map { $0.prefix(1).uppercased() + $0.dropFirst() }.joined(separator: " ")
+    }
+    var nsColor: NSColor { NSColor(srgbRed: color.0, green: color.1, blue: color.2, alpha: 1) }
+
+    static func byKey(_ k: String) -> MaterialPreset? { all.first { $0.key == k } }
+
+    static let categoryOrder = ["metals", "plastics", "organic", "glass", "composite", "other"]
+    /// Presets grouped by category in display order.
+    static var grouped: [(category: String, items: [MaterialPreset])] {
+        categoryOrder.compactMap { cat in
+            let items = all.filter { $0.category == cat }
+            return items.isEmpty ? nil : (cat, items)
+        }
+    }
+
+    static let all: [MaterialPreset] = [
+        .init(key: "aluminum", category: "metals", color: (0.8, 0.8, 0.85), metallic: 0.9, roughness: 0.3, transmission: 0),
+        .init(key: "steel", category: "metals", color: (0.7, 0.7, 0.72), metallic: 0.95, roughness: 0.25, transmission: 0),
+        .init(key: "brass", category: "metals", color: (0.85, 0.65, 0.3), metallic: 0.9, roughness: 0.35, transmission: 0),
+        .init(key: "copper", category: "metals", color: (0.95, 0.5, 0.35), metallic: 0.95, roughness: 0.25, transmission: 0),
+        .init(key: "titanium", category: "metals", color: (0.6, 0.6, 0.65), metallic: 0.85, roughness: 0.4, transmission: 0),
+        .init(key: "chrome", category: "metals", color: (0.9, 0.9, 0.92), metallic: 1.0, roughness: 0.05, transmission: 0),
+        .init(key: "gold", category: "metals", color: (1.0, 0.84, 0.0), metallic: 1.0, roughness: 0.1, transmission: 0),
+        .init(key: "silver", category: "metals", color: (0.95, 0.95, 0.97), metallic: 1.0, roughness: 0.1, transmission: 0),
+        .init(key: "abs-white", category: "plastics", color: (0.95, 0.95, 0.93), metallic: 0, roughness: 0.5, transmission: 0),
+        .init(key: "abs-black", category: "plastics", color: (0.1, 0.1, 0.1), metallic: 0, roughness: 0.5, transmission: 0),
+        .init(key: "abs-red", category: "plastics", color: (0.85, 0.15, 0.15), metallic: 0, roughness: 0.5, transmission: 0),
+        .init(key: "abs-blue", category: "plastics", color: (0.2, 0.4, 0.85), metallic: 0, roughness: 0.5, transmission: 0),
+        .init(key: "pla", category: "plastics", color: (0.85, 0.85, 0.8), metallic: 0, roughness: 0.45, transmission: 0),
+        .init(key: "petg", category: "plastics", color: (0.75, 0.85, 0.9), metallic: 0, roughness: 0.35, transmission: 0),
+        .init(key: "nylon", category: "plastics", color: (0.92, 0.9, 0.85), metallic: 0, roughness: 0.55, transmission: 0),
+        .init(key: "resin", category: "plastics", color: (0.6, 0.55, 0.5), metallic: 0, roughness: 0.2, transmission: 0),
+        .init(key: "acrylic", category: "plastics", color: (0.95, 0.95, 0.98), metallic: 0, roughness: 0.1, transmission: 0),
+        .init(key: "rubber", category: "plastics", color: (0.15, 0.15, 0.15), metallic: 0, roughness: 0.8, transmission: 0),
+        .init(key: "oak", category: "organic", color: (0.65, 0.5, 0.35), metallic: 0, roughness: 0.7, transmission: 0),
+        .init(key: "walnut", category: "organic", color: (0.4, 0.28, 0.2), metallic: 0, roughness: 0.65, transmission: 0),
+        .init(key: "leather", category: "organic", color: (0.45, 0.3, 0.2), metallic: 0, roughness: 0.75, transmission: 0),
+        .init(key: "cork", category: "organic", color: (0.75, 0.6, 0.45), metallic: 0, roughness: 0.9, transmission: 0),
+        .init(key: "bamboo", category: "organic", color: (0.85, 0.75, 0.55), metallic: 0, roughness: 0.6, transmission: 0),
+        .init(key: "glass", category: "glass", color: (0.95, 0.97, 1.0), metallic: 0, roughness: 0.02, transmission: 1.0),
+        .init(key: "glass-tinted", category: "glass", color: (0.85, 0.9, 0.95), metallic: 0, roughness: 0.05, transmission: 0.95),
+        .init(key: "acrylic-clear", category: "glass", color: (0.98, 0.98, 1.0), metallic: 0, roughness: 0.05, transmission: 0.95),
+        .init(key: "polycarbonate-frosted", category: "glass", color: (0.92, 0.94, 0.96), metallic: 0, roughness: 0.35, transmission: 0.7),
+        .init(key: "carbon-fiber", category: "composite", color: (0.15, 0.15, 0.18), metallic: 0.3, roughness: 0.3, transmission: 0),
+        .init(key: "fiberglass", category: "composite", color: (0.85, 0.85, 0.75), metallic: 0, roughness: 0.4, transmission: 0),
+        .init(key: "kevlar", category: "composite", color: (0.75, 0.7, 0.3), metallic: 0, roughness: 0.6, transmission: 0),
+        .init(key: "concrete", category: "other", color: (0.6, 0.6, 0.58), metallic: 0, roughness: 0.85, transmission: 0),
+        .init(key: "ceramic", category: "other", color: (0.95, 0.93, 0.9), metallic: 0, roughness: 0.25, transmission: 0),
+        .init(key: "foam", category: "other", color: (0.3, 0.3, 0.35), metallic: 0, roughness: 0.95, transmission: 0),
+    ]
+}
+
+/// A part's render material, resolved from the doc's material def or a preset.
+struct ResolvedMaterial {
+    var color: NSColor
+    var metallic: Float
+    var roughness: Float
+    var transmission: Float
+}

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -367,9 +367,17 @@ struct SketchPaletteView: View {
 struct SketchHintBar: View {
     let model: EditorModel
     var body: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "hand.point.up.left").font(.system(size: 11))
-            Text(hint)
+        HStack(spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "hand.point.up.left").font(.system(size: 11))
+                Text(hint)
+            }
+            if let c = model.sketchCursor {
+                Rectangle().fill(.secondary.opacity(0.25)).frame(width: 1, height: 11)
+                Text(String(format: "%.1f, %.1f mm", c.x, c.y))
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundStyle(model.sketchSnapToStart ? AnyShapeStyle(Color.green) : AnyShapeStyle(.secondary))
+            }
         }
         .font(.system(size: 11))
         .foregroundStyle(.secondary)
@@ -466,9 +474,13 @@ struct FeatureRowView: View {
         guard let pi = node.partIndex else { return false }
         return !model.isPartVisible(pi)
     }
+    /// Hovered via the tree row itself OR via the viewport (bidirectional).
+    private var hovered: Bool {
+        hovering || (node.partIndex != nil && node.partIndex == model.hoveredPartIndex)
+    }
     private var rowBackground: Color {
         if selected { return Color.accentColor.opacity(0.20) }
-        return hovering ? Color.white.opacity(0.06) : .clear
+        return hovered ? Color.white.opacity(0.06) : .clear
     }
 
     var body: some View {
@@ -952,7 +964,7 @@ struct ViewportView: View {
              model.source, model.selectedFeatureID, model.baseShape, model.modifier,
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
-             model.docParamDirty, model.sketchDirty)
+             model.docParamDirty, model.sketchDirty, model.hoverDirty)
 
         return GeometryReader { geo in
           RealityView { content in
@@ -1040,9 +1052,10 @@ struct ViewportView: View {
                 applyVisibility(content)
                 model.visibilityDirty = false
             }
-            if model.selectionDirty {
+            if model.selectionDirty || model.hoverDirty {
                 applySelectionHighlight(content)
                 model.selectionDirty = false
+                model.hoverDirty = false
             }
 
             // Sketch overlay: rebuild the in-progress profile + rubber-band on
@@ -1403,6 +1416,17 @@ struct ViewportView: View {
                 break
             }
         }
+
+        // Landing-point marker: a bright dot where the next click lands, so you
+        // can always see where you're clicking. Turns green + snaps to the first
+        // vertex when a click would close the loop.
+        if let c = model.sketchCursor, !model.sketchClosed {
+            if model.sketchSnapToStart, let f = model.sketchVerts.first {
+                dot(f, NSColor.systemGreen, 1.9)
+            } else {
+                dot(c, live, 1.4)
+            }
+        }
         return root
     }
 
@@ -1424,12 +1448,16 @@ struct ViewportView: View {
               let root = content.entities.first(where: { $0.name == "geomRoot" }),
               let centering = root.findEntity(named: "centering") else { return }
         let sel = model.highlightedParts
+        let hov = model.hoveredPartIndex
         for i in 0..<model.partCount {
             guard let e = centering.findEntity(named: "part\(i)") as? ModelEntity else { continue }
             var m = material(model.documentBaseColor(i))
             if sel.contains(i) {
                 m.emissiveColor = .init(color: EditorModel.brandPink)
                 m.emissiveIntensity = 0.5
+            } else if i == hov {
+                m.emissiveColor = .init(color: EditorModel.brandPink)
+                m.emissiveIntensity = 0.16     // subtle hover glow
             }
             e.model?.materials = [m]
         }
@@ -1577,6 +1605,23 @@ struct ViewportView: View {
             }
             return
         }
+        // Documents: hover-highlight the part under the cursor (ray-AABB pick),
+        // and show a pointing cursor to signal it's clickable.
+        if model.usesDocumentTree {
+            switch phase {
+            case .active(let point):
+                let pi = kernelRay(at: point, viewSize: viewSize).flatMap {
+                    model.pickDocumentPart(originKernel: $0.o, dirKernel: $0.d)
+                }
+                if pi != model.hoveredPartIndex { model.hoveredPartIndex = pi; model.hoverDirty = true }
+                (pi != nil ? NSCursor.pointingHand : NSCursor.arrow).set()
+            case .ended:
+                if model.hoveredPartIndex != nil { model.hoveredPartIndex = nil; model.hoverDirty = true }
+                NSCursor.arrow.set()
+            }
+            return
+        }
+
         switch phase {
         case .active(let point):
             let hit = hitHandle(at: point, viewSize: viewSize)

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -46,7 +46,7 @@ struct EditorView: View {
                     }
                 }
                 .overlay(alignment: compact ? .leading : .top) {
-                    if model.source.isSandbox {
+                    if model.source.isSandbox || model.usesDocumentTree {
                         ToolPaletteView(model: model, axis: compact ? .vertical : .horizontal)
                             .padding(compact ? .leading : .top, 14)
                     }
@@ -92,6 +92,11 @@ struct EditorView: View {
                     // Dev hook: VCAD_GRIPPER=1 [VCAD_CONNECTOR_X=n] launches into
                     // the cross-domain gripper (used to verify without driving the UI).
                     let env = ProcessInfo.processInfo.environment
+                    // Dev hook: VCAD_OPEN=<path> opens a .vcad on launch (handy
+                    // for verifying the feature tree against a real document).
+                    if let path = env["VCAD_OPEN"], !path.isEmpty {
+                        model.openDocument(URL(fileURLWithPath: path))
+                    }
                     guard env["VCAD_GRIPPER"] == "1" else { return }
                     model.openGripper()
                     if let x = env["VCAD_CONNECTOR_X"].flatMap(Double.init) { model.connectorX = x }
@@ -128,15 +133,49 @@ struct DocumentMenu: View {
                     Button(ex.name) { model.openDocument(URL(fileURLWithPath: ex.path)) }
                 }
             }
+            Divider()
+            Button("Undo") { model.undo() }.keyboardShortcut("z").disabled(!model.canUndo)
+            Button("Redo") { model.redo() }
+                .keyboardShortcut("z", modifiers: [.command, .shift]).disabled(!model.canRedo)
+            Divider()
+            if model.usesDocumentTree {
+                Button("Save") { model.saveDocument() }
+                    .keyboardShortcut("s").disabled(!model.documentDirty)
+                Button("Save As…") { saveAsPanel() }
+                    .keyboardShortcut("s", modifiers: [.command, .shift])
+                if model.documentDirty {
+                    Button("Revert Changes") { model.revertDocument() }
+                }
+            }
+            Button("Export STL…") { exportPanel() }.keyboardShortcut("e").disabled(!model.canExport)
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: model.source.isSandbox ? "cube" : "doc").font(.system(size: 12))
                 Text(model.documentName).font(.system(size: 13, weight: .medium))
+                if model.documentDirty {
+                    Circle().fill(Color.accentColor).frame(width: 5, height: 5)
+                }
                 Image(systemName: "chevron.down").font(.system(size: 9)).opacity(0.55)
             }
         }
         .menuStyle(.borderlessButton)
         .fixedSize()
+    }
+
+    private func exportPanel() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "stl") ?? .data]
+        panel.nameFieldStringValue = "\(model.documentName).stl"
+        panel.prompt = "Export"
+        if panel.runModal() == .OK, let url = panel.url { _ = model.exportSTL(to: url) }
+    }
+
+    private func saveAsPanel() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
+        panel.nameFieldStringValue = "\(model.documentName).vcad"
+        panel.prompt = "Save"
+        if panel.runModal() == .OK, let url = panel.url { model.saveDocumentAs(url) }
     }
 
     private func openPanel() {
@@ -163,7 +202,7 @@ struct ToolPaletteView: View {
         let toolsLayout = vertical ? AnyLayout(VStackLayout(spacing: 5)) : AnyLayout(HStackLayout(spacing: 6))
         return outer {
             tabsLayout {
-                ForEach(Array(ToolTab.allCases.enumerated()), id: \.element.id) { idx, tab in
+                ForEach(Array(model.availableTabs.enumerated()), id: \.element.id) { idx, tab in
                     tabButton(tab, idx: idx)
                 }
             }
@@ -245,31 +284,184 @@ struct FeatureTreeView: View {
     @Bindable var model: EditorModel
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            Text("HISTORY")
-                .font(.system(size: 10, weight: .semibold))
-                .tracking(0.6)
-                .foregroundStyle(.tertiary)
-                .padding(.horizontal, 8).padding(.top, 6).padding(.bottom, 4)
-            ForEach(model.features) { f in
-                let selected = model.selectedFeatureID == f.id
-                Button { model.selectedFeatureID = f.id } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: f.symbol).font(.system(size: 13)).frame(width: 16)
-                        Text(f.name).font(.system(size: 13))
-                        Spacer(minLength: 0)
-                    }
-                    .padding(.horizontal, 8).padding(.vertical, 6)
-                    .background(selected ? Color.accentColor.opacity(0.22) : .clear,
-                                in: RoundedRectangle(cornerRadius: 7, style: .continuous))
-                    .foregroundStyle(selected ? Color.primary : Color.secondary)
-                    .contentShape(Rectangle())
+            header
+            if model.usesDocumentTree {
+                ForEach(model.featureNodes) { node in
+                    FeatureRowView(model: model, node: node, depth: 0)
                 }
-                .buttonStyle(.plain)
+            } else {
+                ForEach(model.features) { f in
+                    let selected = model.selectedFeatureID == f.id
+                    Button { model.selectedFeatureID = f.id } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: f.symbol).font(.system(size: 13)).frame(width: 16)
+                            Text(f.name).font(.system(size: 13))
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 8).padding(.vertical, 6)
+                        .background(selected ? Color.accentColor.opacity(0.22) : .clear,
+                                    in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                        .foregroundStyle(selected ? Color.primary : Color.secondary)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
             }
         }
         .padding(6)
         .glassCard()
         .animation(.snappy(duration: 0.18), value: model.selectedFeatureID)
+        .animation(.snappy(duration: 0.2), value: model.expandedFeatureIDs)
+        .animation(.snappy(duration: 0.2), value: model.hiddenParts)
+        .animation(.snappy(duration: 0.2), value: model.isolatedPart)
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Text(model.usesDocumentTree ? "FEATURES" : "HISTORY")
+                .font(.system(size: 10, weight: .semibold)).tracking(0.6)
+                .foregroundStyle(.tertiary)
+            Spacer(minLength: 0)
+            if model.hasHiddenParts {
+                Button { model.showAllParts() } label: {
+                    Label("Show all", systemImage: "eye")
+                        .font(.system(size: 10, weight: .medium))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Show all hidden parts")
+            }
+        }
+        .padding(.horizontal, 8).padding(.top, 6).padding(.bottom, 4)
+    }
+}
+
+/// One row of the hierarchical document feature tree (recurses into operands
+/// when expanded). Root rows carry an eye toggle + a context menu acting on the
+/// part they produce.
+struct FeatureRowView: View {
+    @Bindable var model: EditorModel
+    let node: FeatureNode
+    let depth: Int
+
+    private var expanded: Bool { model.expandedFeatureIDs.contains(node.id) }
+    private var selected: Bool {
+        if model.selectedFeatureID == node.id { return true }
+        if let pi = node.partIndex { return model.multiSelectedParts.contains(pi) }
+        return false
+    }
+    private var dimmed: Bool {
+        guard let pi = node.partIndex else { return false }
+        return !model.isPartVisible(pi)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            row
+            if expanded {
+                ForEach(node.children) { child in
+                    FeatureRowView(model: model, node: child, depth: depth + 1)
+                }
+            }
+        }
+    }
+
+    private var row: some View {
+        HStack(spacing: 6) {
+            if node.hasChildren {
+                Button { model.toggleExpanded(node.id) } label: {
+                    Image(systemName: expanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 12, height: 12)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            } else {
+                Color.clear.frame(width: 12, height: 12)
+            }
+            Image(systemName: node.symbol)
+                .font(.system(size: 12)).frame(width: 16)
+                .foregroundStyle(selected ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+            VStack(alignment: .leading, spacing: 0) {
+                if model.renamingFeatureID == node.id {
+                    RenameField(initial: node.name,
+                                commit: { model.renameFeature(node.nodeId, to: $0); model.renamingFeatureID = nil },
+                                cancel: { model.renamingFeatureID = nil })
+                } else {
+                    Text(node.name).font(.system(size: 12)).lineLimit(1)
+                }
+                if let d = node.detail {
+                    Text(d).font(.system(size: 10).monospacedDigit())
+                        .foregroundStyle(.tertiary).lineLimit(1)
+                }
+            }
+            Spacer(minLength: 0)
+            if let pi = node.partIndex { eyeButton(pi) }
+        }
+        .padding(.leading, CGFloat(depth) * 13 + 4)
+        .padding(.trailing, 5).padding(.vertical, 4)
+        .background(selected ? Color.accentColor.opacity(0.20) : .clear,
+                    in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .foregroundStyle(selected ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
+        .opacity(dimmed ? 0.45 : 1)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard model.renamingFeatureID != node.id else { return }
+            // ⌘-click a part row → toggle it in the multi-selection (for booleans).
+            if NSEvent.modifierFlags.contains(.command), let pi = node.partIndex {
+                model.toggleMultiSelect(part: pi, featureID: node.id)
+            } else {
+                model.selectFeature(node.id)
+            }
+        }
+        .contextMenu { menu }
+    }
+
+    private func eyeButton(_ pi: Int) -> some View {
+        let vis = model.isPartVisible(pi)
+        return Button { model.toggleVisibility(part: pi) } label: {
+            Image(systemName: vis ? "eye" : "eye.slash")
+                .font(.system(size: 11))
+                .foregroundStyle(vis ? AnyShapeStyle(.tertiary) : AnyShapeStyle(Color.accentColor))
+                .frame(width: 18, height: 18)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(vis ? "Hide part" : "Show part")
+    }
+
+    @ViewBuilder private var menu: some View {
+        if let pi = node.partIndex {
+            Button { model.isolate(part: pi) } label: {
+                Label(model.isolatedPart == pi ? "Exit Isolate" : "Isolate",
+                      systemImage: "scope")
+            }
+            Button { model.toggleVisibility(part: pi) } label: {
+                Label(model.isPartVisible(pi) ? "Hide" : "Show",
+                      systemImage: model.isPartVisible(pi) ? "eye.slash" : "eye")
+            }
+            if model.hasHiddenParts {
+                Button { model.showAllParts() } label: { Label("Show All", systemImage: "eye") }
+            }
+            Divider()
+        }
+        if node.hasChildren {
+            Button { model.toggleExpanded(node.id) } label: {
+                Label(expanded ? "Collapse" : "Expand", systemImage: "list.bullet.indent")
+            }
+        }
+        Button { model.renamingFeatureID = node.id } label: { Label("Rename", systemImage: "pencil") }
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(node.name, forType: .string)
+        } label: { Label("Copy Name", systemImage: "doc.on.doc") }
+        if let pi = node.partIndex {
+            Divider()
+            Button(role: .destructive) { model.deletePart(pi) } label: {
+                Label("Delete Part", systemImage: "trash")
+            }
+        }
     }
 }
 
@@ -277,7 +469,25 @@ struct InspectorView: View {
     @Bindable var model: EditorModel
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            if let f = model.selectedFeature {
+            if model.usesDocumentTree {
+                if let node = model.selectedFeatureNode {
+                    section(node.name) {
+                        row("Operation", DocumentGraph.label(node.opType))
+                        if let pi = node.partIndex, let mat = model.materialName(forPart: pi) {
+                            row("Material", mat.capitalized)
+                        }
+                        if let pi = node.partIndex, !model.isPartVisible(pi) {
+                            Label("Hidden", systemImage: "eye.slash")
+                                .font(.system(size: 12)).foregroundStyle(.secondary)
+                        }
+                    }
+                    if Self.editableOps.contains(node.opType) {
+                        section("Parameters") { paramEditors(node) }
+                    } else if let d = node.detail {
+                        section("Parameters") { row("Value", d) }
+                    }
+                }
+            } else if let f = model.selectedFeature {
                 section(f.name) {
                     switch f.kind {
                     case .base:
@@ -341,6 +551,164 @@ struct InspectorView: View {
     private var boundsText: String {
         let s = model.sizeMM
         return String(format: "%.1f × %.1f × %.1f mm", abs(s.x), abs(s.y), abs(s.z))
+    }
+
+    /// Op types that expose live-editable parameters in the inspector.
+    static let editableOps: Set<String> = [
+        "Cube", "Cylinder", "Sphere", "Cone", "Fillet", "Chamfer", "Shell",
+        "Translate", "Rotate", "Scale", "Revolve", "LinearPattern", "CircularPattern",
+    ]
+
+    /// Scrub/stepper editors for the selected feature — each writes back into the
+    /// live document and re-evaluates (parity with the web app's scrub inputs).
+    @ViewBuilder private func paramEditors(_ node: FeatureNode) -> some View {
+        let op = model.opDict(nodeId: node.nodeId) ?? [:]
+        let id = node.nodeId
+        switch node.opType {
+        case "Cube":
+            axisField(op, id, "Width", "size", "x", minV: 0.1)
+            axisField(op, id, "Depth", "size", "y", minV: 0.1)
+            axisField(op, id, "Height", "size", "z", minV: 0.1)
+        case "Cylinder":
+            scalarField(op, id, "Radius", "radius"); scalarField(op, id, "Height", "height")
+        case "Sphere":
+            scalarField(op, id, "Radius", "radius")
+        case "Cone":
+            scalarField(op, id, "Radius 1", "radius1", minV: 0)
+            scalarField(op, id, "Radius 2", "radius2", minV: 0)
+            scalarField(op, id, "Height", "height")
+        case "Fillet":
+            scalarField(op, id, "Radius", "radius", sens: 0.05, minV: 0)
+        case "Chamfer":
+            scalarField(op, id, "Distance", "distance", sens: 0.05, minV: 0)
+        case "Shell":
+            scalarField(op, id, "Thickness", "thickness", sens: 0.05, minV: 0.1)
+        case "Translate":
+            axisField(op, id, "X", "offset", "x"); axisField(op, id, "Y", "offset", "y")
+            axisField(op, id, "Z", "offset", "z")
+        case "Rotate":
+            axisField(op, id, "X", "angles", "x", unit: "°", sens: 0.5)
+            axisField(op, id, "Y", "angles", "y", unit: "°", sens: 0.5)
+            axisField(op, id, "Z", "angles", "z", unit: "°", sens: 0.5)
+        case "Scale":
+            axisField(op, id, "X", "factor", "x", unit: "", sens: 0.01, minV: 0.01)
+            axisField(op, id, "Y", "factor", "y", unit: "", sens: 0.01, minV: 0.01)
+            axisField(op, id, "Z", "factor", "z", unit: "", sens: 0.01, minV: 0.01)
+        case "Revolve":
+            scalarField(op, id, "Angle", "angle_deg", unit: "°", sens: 0.5, minV: 0)
+        case "LinearPattern":
+            countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
+        case "CircularPattern":
+            countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
+            scalarField(op, id, "Span", "angle_deg", unit: "°", sens: 0.5, minV: 0)
+        default:
+            EmptyView()
+        }
+    }
+
+    private func scalarField(_ op: [String: Any], _ id: Int, _ label: String, _ key: String,
+                             unit: String = "mm", sens: Double = 0.1, minV: Double = 0.1) -> some View {
+        let value = (op[key] as? NSNumber)?.doubleValue ?? 0
+        return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
+            model.editScalar(nodeId: id, key: key, value: v, snapshot: s)
+        }
+    }
+
+    private func axisField(_ op: [String: Any], _ id: Int, _ label: String, _ key: String, _ a: String,
+                           unit: String = "mm", sens: Double = 0.1,
+                           minV: Double = -.greatestFiniteMagnitude) -> some View {
+        let value = ((op[key] as? [String: Any])?[a] as? NSNumber)?.doubleValue ?? 0
+        return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
+            model.editVec(nodeId: id, key: key, axis: a, value: v, snapshot: s)
+        }
+    }
+
+    private func countStepper(_ id: Int, _ count: Int) -> some View {
+        Stepper(value: Binding(
+            get: { count },
+            set: { model.editInt(nodeId: id, key: "count", value: max(1, $0), snapshot: true) }
+        ), in: 1...200) {
+            HStack {
+                Text("Count").font(.system(size: 12))
+                Spacer()
+                Text("\(count)").font(.system(size: 12).monospacedDigit()).foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+/// A drag-to-scrub numeric field — the native take on the web app's scrub
+/// inputs. Horizontal drag changes the value; the first tick of a gesture
+/// snapshots for undo. Reads top-down each render so live re-eval stays in sync.
+struct ScrubField: View {
+    let label: String
+    let value: Double
+    var unit: String = "mm"
+    var sensitivity: Double = 0.1
+    var minValue: Double = -.greatestFiniteMagnitude
+    let onChange: (_ value: Double, _ snapshotFirst: Bool) -> Void
+    @State private var base: Double?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(label).font(.system(size: 12)).foregroundStyle(.secondary)
+            Spacer(minLength: 8)
+            Text(formatted).font(.system(size: 12).monospacedDigit())
+                .padding(.horizontal, 8).padding(.vertical, 3)
+                .frame(minWidth: 70, alignment: .trailing)
+                .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .strokeBorder(base != nil ? Color.accentColor.opacity(0.6) : .white.opacity(0.10), lineWidth: 0.5))
+                .contentShape(Rectangle())
+                .onHover { (($0 ? NSCursor.resizeLeftRight : NSCursor.arrow)).set() }
+                .gesture(
+                    DragGesture(minimumDistance: 1)
+                        .onChanged { v in
+                            let first = base == nil
+                            let b = base ?? value
+                            if base == nil { base = b }
+                            onChange(max(minValue, b + Double(v.translation.width) * sensitivity), first)
+                        }
+                        .onEnded { _ in base = nil }
+                )
+        }
+    }
+
+    private var formatted: String {
+        let s = abs(value - value.rounded()) < 0.001 ? String(Int(value.rounded())) : String(format: "%.2f", value)
+        return unit.isEmpty ? s : "\(s) \(unit)"
+    }
+}
+
+/// Inline rename field for a feature-tree row — commits on Return/blur, cancels
+/// on Escape.
+struct RenameField: View {
+    let initial: String
+    let commit: (String) -> Void
+    let cancel: () -> Void
+    @State private var text: String
+    @FocusState private var focused: Bool
+
+    init(initial: String, commit: @escaping (String) -> Void, cancel: @escaping () -> Void) {
+        self.initial = initial
+        self.commit = commit
+        self.cancel = cancel
+        _text = State(initialValue: initial)
+    }
+
+    var body: some View {
+        TextField("", text: $text)
+            .textFieldStyle(.plain)
+            .font(.system(size: 12))
+            .focused($focused)
+            .onAppear { focused = true }
+            .onSubmit { commit(text) }
+            .onExitCommand { cancel() }
+            .onChange(of: focused) { _, now in if !now { commit(text) } }
+            .padding(.horizontal, 4).padding(.vertical, 1)
+            .background(.white.opacity(0.10), in: RoundedRectangle(cornerRadius: 4, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 4, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(0.7), lineWidth: 1))
     }
 }
 
@@ -434,7 +802,8 @@ struct ViewportView: View {
         _ = (model.azimuth, model.elevation, model.distance, model.modifierValue,
              model.source, model.selectedFeatureID, model.baseShape, model.modifier,
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
-             model.copperDirty, model.copperStale)
+             model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
+             model.docParamDirty)
 
         return GeometryReader { geo in
           RealityView { content in
@@ -499,6 +868,32 @@ struct ViewportView: View {
                     }
                 }
                 model.pickDirty = false
+            }
+
+            // Live parameter edit: re-evaluate the doc and swap part meshes in
+            // place (no entity rebuild → smooth scrub, no materialize-pop). Part
+            // count is unchanged for scalar/vec/int edits; materials/highlight
+            // ride along untouched.
+            if model.docParamDirty {
+                if let meshes = model.reevalDocumentMeshes(),
+                   let root = content.entities.first(where: { $0.name == "geomRoot" }),
+                   let centering = root.findEntity(named: "centering") {
+                    for (i, m) in meshes.enumerated() {
+                        (centering.findEntity(named: "part\(i)") as? ModelEntity)?.model?.mesh = m
+                    }
+                }
+                model.docParamDirty = false
+            }
+
+            // Feature-tree → viewport: hide/show parts and highlight the
+            // selected one (documents only; cheap entity-property writes).
+            if model.visibilityDirty {
+                applyVisibility(content)
+                model.visibilityDirty = false
+            }
+            if model.selectionDirty {
+                applySelectionHighlight(content)
+                model.selectionDirty = false
             }
 
             // Settle: the connector stopped moving — run the EXPENSIVE domains
@@ -647,12 +1042,18 @@ struct ViewportView: View {
         let geomRoot = Entity()
         geomRoot.name = "geomRoot"
         geomRoot.addChild(zUp)
-        geomRoot.scale = SIMD3<Float>(repeating: sceneScale * 0.9)
         content.add(geomRoot)
-        // Subtle "materialize" pop when the geometry changes.
-        var grown = geomRoot.transform
-        grown.scale = SIMD3<Float>(repeating: sceneScale)
-        geomRoot.move(to: grown, relativeTo: geomRoot.parent, duration: 0.3, timingFunction: .easeOut)
+        if model.suppressMaterializePop {
+            // An edit re-eval: snap to final size (no pop) so scrubs feel direct.
+            geomRoot.scale = SIMD3<Float>(repeating: sceneScale)
+            model.suppressMaterializePop = false
+        } else {
+            // Subtle "materialize" pop when the geometry changes (load / new part).
+            geomRoot.scale = SIMD3<Float>(repeating: sceneScale * 0.9)
+            var grown = geomRoot.transform
+            grown.scale = SIMD3<Float>(repeating: sceneScale)
+            geomRoot.move(to: grown, relativeTo: geomRoot.parent, duration: 0.3, timingFunction: .easeOut)
+        }
 
         // Grounding floor that catches the soft contact shadow.
         content.entities.filter { $0.name == "floor" }.forEach { $0.removeFromParent() }
@@ -787,6 +1188,35 @@ struct ViewportView: View {
         copperRoot.components.set(OpacityComponent(opacity: dim ? 0.3 : 1.0))
     }
 
+    // MARK: feature-tree sync (visibility + selection highlight)
+
+    /// Enable/disable part entities to honor the tree's eye toggles + isolate.
+    private func applyVisibility(_ content: RealityViewCameraContent) {
+        guard let root = content.entities.first(where: { $0.name == "geomRoot" }),
+              let centering = root.findEntity(named: "centering") else { return }
+        for i in 0..<model.partCount {
+            centering.findEntity(named: "part\(i)")?.isEnabled = model.isPartVisible(i)
+        }
+    }
+
+    /// Tint the selected part's emissive brand-pink so the tree selection reads
+    /// in the viewport. Non-selected parts are restored to their base material.
+    private func applySelectionHighlight(_ content: RealityViewCameraContent) {
+        guard model.usesDocumentTree,
+              let root = content.entities.first(where: { $0.name == "geomRoot" }),
+              let centering = root.findEntity(named: "centering") else { return }
+        let sel = model.highlightedParts
+        for i in 0..<model.partCount {
+            guard let e = centering.findEntity(named: "part\(i)") as? ModelEntity else { continue }
+            var m = material(model.documentBaseColor(i))
+            if sel.contains(i) {
+                m.emissiveColor = .init(color: EditorModel.brandPink)
+                m.emissiveIntensity = 0.5
+            }
+            e.model?.materials = [m]
+        }
+    }
+
     // MARK: gestures
 
     private var handleDrag: some Gesture {
@@ -863,6 +1293,16 @@ struct ViewportView: View {
         let s = model.displayScale
         let camKernel = rxPlus90(cam / s) + model.displayCenter
         let dirKernel = normalize(rxPlus90(dirWorld))
+
+        // Documents: tap a part → select its feature-tree row (parity with the
+        // web app's click-to-select). The kernel-space AABBs make this cheap.
+        if model.usesDocumentTree {
+            if let pi = model.pickDocumentPart(originKernel: camKernel, dirKernel: dirKernel),
+               pi < model.featureNodes.count {
+                model.selectFeature(model.featureNodes[pi].id)
+            }
+            return
+        }
 
         if let hit = model.raycastSandbox(originKernel: camKernel, dirKernel: dirKernel) {
             model.pickPoint = hit.point

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -942,7 +942,7 @@ struct ViewportView: View {
           .onContinuousHover(coordinateSpace: .local) { phase in
               hover(phase, viewSize: geo.size)
           }
-          .onAppear { model.installScrollZoom() }
+          .onAppear { model.installScrollZoom(); model.installKeyMonitor() }
         }
     }
 
@@ -1294,12 +1294,16 @@ struct ViewportView: View {
         let camKernel = rxPlus90(cam / s) + model.displayCenter
         let dirKernel = normalize(rxPlus90(dirWorld))
 
-        // Documents: tap a part → select its feature-tree row (parity with the
-        // web app's click-to-select). The kernel-space AABBs make this cheap.
+        // Documents: tap a part → select its row (⌘-tap toggles multi-select, for
+        // booleans); tap empty space → deselect. Kernel-space AABBs make it cheap.
         if model.usesDocumentTree {
+            let cmd = NSEvent.modifierFlags.contains(.command)
             if let pi = model.pickDocumentPart(originKernel: camKernel, dirKernel: dirKernel),
                pi < model.featureNodes.count {
-                model.selectFeature(model.featureNodes[pi].id)
+                if cmd { model.toggleMultiSelect(part: pi, featureID: model.featureNodes[pi].id) }
+                else { model.selectFeature(model.featureNodes[pi].id) }
+            } else if !cmd {
+                model.deselectAll()
             }
             return
         }

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1222,6 +1222,9 @@ struct ViewportView: View {
                     for (i, m) in meshes.enumerated() {
                         (centering.findEntity(named: "part\(i)") as? ModelEntity)?.model?.mesh = m
                     }
+                    // Slide the gizmo with the part (don't rebuild — that would
+                    // destroy the arm the drag is holding).
+                    centering.findEntity(named: "gizmoRoot")?.position = model.gizmoLiveOffset
                 }
                 model.docParamDirty = false
             }
@@ -1636,37 +1639,47 @@ struct ViewportView: View {
 
     // MARK: transform gizmo overlay
 
-    /// Three axis arms (X red / Y green / Z blue) at the selected part's center.
-    /// Each arm carries collision + input target so `handleDrag` can grab it.
+    /// A refined translate gizmo: thin cylinder shafts with cone arrowheads in
+    /// muted axis colors, an invisible full-length hit proxy per axis (so the
+    /// drag target persists), and a small pearl hub. X red / Y green / Z blue.
     private func buildGizmo() -> Entity {
         let root = Entity(); root.name = "gizmoRoot"
         guard let c = model.gizmoCenterKernel() else { return root }
         let len = model.gizmoArmLength()
-        let r = max(0.6, len * 0.035)
+        let shaftR = max(0.3, len * 0.016)
+        let headLen = len * 0.2
+        let headR = shaftR * 2.8
+        let shaftLen = len - headLen
         let axes: [(name: String, dir: SIMD3<Float>, color: NSColor)] = [
-            ("gizmoX", SIMD3(1, 0, 0), .systemRed),
-            ("gizmoY", SIMD3(0, 1, 0), .systemGreen),
-            ("gizmoZ", SIMD3(0, 0, 1), .systemBlue),
+            ("gizmoX", SIMD3(1, 0, 0), NSColor(srgbRed: 0.95, green: 0.30, blue: 0.34, alpha: 1)),
+            ("gizmoY", SIMD3(0, 1, 0), NSColor(srgbRed: 0.42, green: 0.80, blue: 0.44, alpha: 1)),
+            ("gizmoZ", SIMD3(0, 0, 1), NSColor(srgbRed: 0.32, green: 0.58, blue: 0.98, alpha: 1)),
         ]
         for a in axes {
-            let arm = ModelEntity(mesh: .generateBox(size: SIMD3(len, r * 1.6, r * 1.6)),
-                                  materials: [UnlitMaterial(color: a.color)])
-            arm.name = a.name
-            arm.position = c + a.dir * (len / 2)
-            arm.orientation = simd_quatf(from: SIMD3(1, 0, 0), to: a.dir)
-            arm.components.set(CollisionComponent(shapes: [ShapeResource.generateBox(size: SIMD3(len, r * 5, r * 5))]))
-            arm.components.set(InputTargetComponent())
-            root.addChild(arm)
-            let tip = ModelEntity(mesh: .generateSphere(radius: r * 2.1),
-                                  materials: [UnlitMaterial(color: a.color)])
-            tip.position = c + a.dir * len
-            tip.name = a.name        // grabbing the tip drags the same axis
-            tip.components.set(CollisionComponent(shapes: [ShapeResource.generateSphere(radius: r * 3)]))
-            tip.components.set(InputTargetComponent())
-            root.addChild(tip)
+            let mat = UnlitMaterial(color: a.color)
+            let rot = simd_quatf(from: SIMD3(0, 1, 0), to: a.dir)   // RealityKit shapes are +Y-up
+
+            let shaft = ModelEntity(mesh: .generateCylinder(height: shaftLen, radius: shaftR), materials: [mat])
+            shaft.orientation = rot
+            shaft.position = c + a.dir * (shaftLen / 2)
+            root.addChild(shaft)
+
+            let head = ModelEntity(mesh: .generateCone(height: headLen, radius: headR), materials: [mat])
+            head.orientation = rot
+            head.position = c + a.dir * (shaftLen + headLen / 2)
+            root.addChild(head)
+
+            // Invisible full-length grab proxy — outlives per-frame rebuilds.
+            let hit = ModelEntity()
+            hit.name = a.name
+            hit.orientation = rot
+            hit.position = c + a.dir * (len / 2)
+            hit.components.set(CollisionComponent(shapes: [.generateBox(size: SIMD3(headR * 2.6, len, headR * 2.6))]))
+            hit.components.set(InputTargetComponent())
+            root.addChild(hit)
         }
-        let hub = ModelEntity(mesh: .generateSphere(radius: r * 1.7),
-                              materials: [UnlitMaterial(color: NSColor.white)])
+        let hub = ModelEntity(mesh: .generateSphere(radius: shaftR * 2.4),
+                              materials: [UnlitMaterial(color: NSColor(white: 0.95, alpha: 1))])
         hub.position = c
         root.addChild(hub)
         return root

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -45,14 +45,10 @@ struct EditorView: View {
                             .transition(.move(edge: .leading).combined(with: .opacity))
                     }
                 }
-                .overlay(alignment: compact ? .leading : .top) {
-                    if model.sketching {
-                        SketchPaletteView(model: model)
-                            .padding(.top, 14)
+                .overlay(alignment: .top) {
+                    if showsTools && model.toolPlacement == .header {
+                        toolStrip(header: true)
                             .transition(.move(edge: .top).combined(with: .opacity))
-                    } else if model.source.isSandbox || model.usesDocumentTree {
-                        ToolPaletteView(model: model, axis: compact ? .vertical : .horizontal)
-                            .padding(compact ? .leading : .top, 14)
                     }
                 }
                 .overlay(alignment: .top) {
@@ -83,18 +79,24 @@ struct EditorView: View {
                             ExampleChips(intent: intent)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
-                        StatusBarView(model: model)
+                        ComposerBar(engine: intent, model: model)
+                        if showsTools && model.toolPlacement == .footer {
+                            toolStrip(header: false)
+                                .transition(.move(edge: .bottom).combined(with: .opacity))
+                        }
                     }
                     .padding(.bottom, 14)
                     .animation(.smooth(duration: 0.3), value: model.source.isSandbox)
                     .animation(.smooth(duration: 0.25), value: intent.draft.isEmpty)
                     .animation(.smooth(duration: 0.25), value: model.sketching)
+                    .animation(.smooth(duration: 0.3), value: model.toolPlacement)
                 }
                 .toolbar {
-                    ToolbarItem(placement: .navigation) { DocumentMenu(model: model) }
-                    ToolbarItem(placement: .principal) { CommandBar(engine: intent, model: model) }
+                    ToolbarItem(placement: .navigation) { BrandMark() }
+                    ToolbarItem(placement: .principal) { IdentityStatusBar(model: model) }
+                    ToolbarItem(placement: .primaryAction) { CollabAvatars() }
                 }
-                .navigationTitle("vcad")
+                .navigationTitle(model.documentName)
                 .animation(.smooth(duration: 0.3), value: compact)
                 .task {
                     // Dev hook: VCAD_GRIPPER=1 [VCAD_CONNECTOR_X=n] launches into
@@ -117,6 +119,23 @@ struct EditorView: View {
                         FileHandle.standardError.write(Data(line.utf8))
                     }
                 }
+        }
+    }
+
+    private var showsTools: Bool {
+        model.sketching || model.source.isSandbox || model.usesDocumentTree
+    }
+
+    /// The active tool strip — the sketch palette while drawing, otherwise the
+    /// tool palette, rendered as a docked header bar or a floating footer card.
+    @ViewBuilder private func toolStrip(header: Bool) -> some View {
+        if model.sketching {
+            SketchPaletteView(model: model)
+                .padding(.top, header ? 8 : 0)
+        } else if header {
+            ToolPaletteView(model: model, axis: .horizontal, docked: true)
+        } else {
+            ToolPaletteView(model: model, axis: .horizontal)
         }
     }
 }
@@ -156,6 +175,11 @@ struct DocumentMenu: View {
                 }
             }
             Button("Export STL…") { exportPanel() }.keyboardShortcut("e").disabled(!model.canExport)
+            Divider()
+            Picker("Tool Palette", selection: $model.toolPlacement) {
+                ForEach(ToolPlacement.allCases) { p in Text(p.label).tag(p) }
+            }
+            Button("Toggle Tool Palette") { model.cycleToolPlacement() }.keyboardShortcut("t")
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: model.source.isSandbox ? "cube" : "doc").font(.system(size: 12))
@@ -196,11 +220,121 @@ struct DocumentMenu: View {
     }
 }
 
+// MARK: top chrome — brand · centered identity + status · presence
+
+/// The leading wordmark.
+struct BrandMark: View {
+    var body: some View {
+        Text("vcad")
+            .font(.system(size: 14, weight: .semibold, design: .rounded))
+            .foregroundStyle(.secondary)
+            .padding(.trailing, 2)
+    }
+}
+
+/// Centered identity (the document menu) + a compact live status readout.
+struct IdentityStatusBar: View {
+    @Bindable var model: EditorModel
+    var body: some View {
+        HStack(spacing: 10) {
+            DocumentMenu(model: model)
+            Divider().frame(height: 13)
+            StatusStrip(model: model)
+        }
+    }
+}
+
+/// kernel · tris · bounds · solve — the dense status, inline in the title bar.
+struct StatusStrip: View {
+    let model: EditorModel
+    var body: some View {
+        HStack(spacing: 9) {
+            HStack(spacing: 4) {
+                Circle().fill(.green).frame(width: 5, height: 5)
+                Text("kernel")
+            }
+            bar
+            Text("\(model.triangleCount.formatted()) tris")
+            bar
+            Text(String(format: "%.0f×%.0f×%.0f", abs(model.sizeMM.x), abs(model.sizeMM.y), abs(model.sizeMM.z)))
+            bar
+            Text(String(format: "%.0f ms", model.solveMillis))
+        }
+        .font(.system(size: 11, design: .monospaced))
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
+        .fixedSize()
+    }
+    private var bar: some View { Rectangle().fill(.secondary.opacity(0.25)).frame(width: 1, height: 10) }
+}
+
+/// Presence + share — a share affordance and the current user's avatar.
+struct CollabAvatars: View {
+    var body: some View {
+        HStack(spacing: 9) {
+            Button {} label: { Image(systemName: "person.badge.plus").font(.system(size: 13)) }
+                .buttonStyle(.plain).foregroundStyle(.secondary).help("Share")
+            Circle()
+                .fill(LinearGradient(
+                    colors: [Color(red: 0.98, green: 0.15, blue: 0.45), Color(red: 0.72, green: 0.09, blue: 0.32)],
+                    startPoint: .top, endPoint: .bottom))
+                .frame(width: 22, height: 22)
+                .overlay(Text("C").font(.system(size: 11, weight: .semibold)).foregroundStyle(.white))
+                .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 0.5))
+                .help("You")
+        }
+    }
+}
+
+/// The bottom composer: a `+` quick-start menu beside the AI command field.
+struct ComposerBar: View {
+    @Bindable var engine: IntentEngine
+    let model: EditorModel
+    var body: some View {
+        HStack(spacing: 8) {
+            Menu {
+                Button("New") { model.newDocument() }
+                Button("Open…") { openPanel() }
+                if !model.examples.isEmpty {
+                    Menu("Examples") {
+                        ForEach(model.examples, id: \.path) { ex in
+                            Button(ex.name) { model.openDocument(URL(fileURLWithPath: ex.path)) }
+                        }
+                    }
+                }
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 30, height: 30)
+                    .background(.regularMaterial, in: Circle())
+                    .overlay(Circle().strokeBorder(.white.opacity(0.10), lineWidth: 0.5))
+                    .shadow(color: .black.opacity(0.35), radius: 10, y: 5)
+            }
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            CommandBar(engine: engine, model: model)
+        }
+    }
+
+    private func openPanel() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.prompt = "Open"
+        if panel.runModal() == .OK, let url = panel.url { model.openDocument(url) }
+    }
+}
+
 // MARK: tool palette (native Borland-model)
 
 struct ToolPaletteView: View {
     @Bindable var model: EditorModel
     var axis: Axis = .horizontal
+    /// Docked (Borland-style) full-width top strip vs a floating glass card.
+    var docked: Bool = false
     private var vertical: Bool { axis == .vertical }
     @Namespace private var paletteNS
 
@@ -208,7 +342,7 @@ struct ToolPaletteView: View {
         let outer = vertical ? AnyLayout(VStackLayout(spacing: 6)) : AnyLayout(HStackLayout(spacing: 10))
         let tabsLayout = vertical ? AnyLayout(VStackLayout(spacing: 4)) : AnyLayout(HStackLayout(spacing: 3))
         let toolsLayout = vertical ? AnyLayout(VStackLayout(spacing: 5)) : AnyLayout(HStackLayout(spacing: 6))
-        return outer {
+        let content = outer {
             tabsLayout {
                 ForEach(Array(model.availableTabs.enumerated()), id: \.element.id) { idx, tab in
                     tabButton(tab, idx: idx)
@@ -222,12 +356,27 @@ struct ToolPaletteView: View {
             }
             .id(model.toolTab)
             .transition(.opacity)
+            if docked { Spacer(minLength: 0) }
         }
-        .padding(vertical ? 6 : 8)
-        .glassCard(vertical ? 16 : 13)
         .animation(.snappy(duration: 0.26), value: model.toolTab)
         .animation(.snappy(duration: 0.22), value: model.baseShape)
         .animation(.snappy(duration: 0.22), value: model.modifier)
+
+        return Group {
+            if docked {
+                content
+                    .padding(.horizontal, 14).padding(.vertical, 7)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.regularMaterial)
+                    .overlay(alignment: .bottom) {
+                        Rectangle().fill(.white.opacity(0.08)).frame(height: 0.5)
+                    }
+            } else {
+                content
+                    .padding(vertical ? 6 : 8)
+                    .glassCard(vertical ? 16 : 13)
+            }
+        }
     }
 
     @ViewBuilder private func tabButton(_ tab: ToolTab, idx: Int) -> some View {

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -601,9 +601,7 @@ struct InspectorView: View {
                 if let node = model.selectedFeatureNode {
                     section(node.name) {
                         row("Operation", DocumentGraph.label(node.opType))
-                        if let pi = node.partIndex, let mat = model.materialName(forPart: pi) {
-                            row("Material", mat.capitalized)
-                        }
+                        if let pi = node.partIndex { materialPicker(pi) }
                         if let pi = node.partIndex, !model.isPartVisible(pi) {
                             Label("Hidden", systemImage: "eye.slash")
                                 .font(.system(size: 12)).foregroundStyle(.secondary)
@@ -673,6 +671,39 @@ struct InspectorView: View {
             Text(key).font(.system(size: 12))
             Spacer()
             Text(value).font(.system(size: 12).monospacedDigit()).foregroundStyle(.secondary)
+        }
+    }
+
+    /// Material assignment for a part — a swatch + grouped preset menu.
+    private func materialPicker(_ pi: Int) -> some View {
+        let current = model.materialName(forPart: pi) ?? "default"
+        let resolved = model.resolvedMaterial(forPart: pi)
+        return HStack {
+            Text("Material").font(.system(size: 12))
+            Spacer()
+            Menu {
+                ForEach(MaterialPreset.grouped, id: \.category) { group in
+                    Section(group.category.capitalized) {
+                        ForEach(group.items) { p in
+                            Button { model.setPartMaterial(pi, p.key) } label: {
+                                if p.key == current { Label(p.name, systemImage: "checkmark") }
+                                else { Text(p.name) }
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Circle().fill(Color(nsColor: resolved.color)).frame(width: 11, height: 11)
+                        .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 0.5))
+                    Text(MaterialPreset.byKey(current)?.name ?? current.capitalized)
+                        .font(.system(size: 12))
+                    Image(systemName: "chevron.up.chevron.down").font(.system(size: 8)).opacity(0.5)
+                }
+                .foregroundStyle(.secondary)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
         }
     }
 
@@ -1193,7 +1224,9 @@ struct ViewportView: View {
             // green FR4 board, brushed-metal bracket) so each domain reads as what
             // it is; everything else falls back to the index palette.
             let mat: PhysicallyBasedMaterial =
-                model.source.isGripper ? gripperMaterial(i) : material(item.color)
+                model.source.isGripper ? gripperMaterial(i)
+                : model.usesDocumentTree ? pbrMaterial(model.resolvedMaterial(forPart: i))
+                : material(item.color)
             let entity = ModelEntity(mesh: item.mesh, materials: [mat])
             entity.name = "part\(i)"
             centering.addChild(entity)
@@ -1246,6 +1279,20 @@ struct ViewportView: View {
         m.baseColor = .init(tint: color)
         m.roughness = 0.34
         m.metallic = 0.55
+        return m
+    }
+
+    /// Build a PBR material from a resolved document material (color + metallic +
+    /// roughness, with transmission rendered as translucency).
+    private func pbrMaterial(_ r: ResolvedMaterial) -> PhysicallyBasedMaterial {
+        var m = PhysicallyBasedMaterial()
+        m.baseColor = .init(tint: r.color)
+        m.roughness = .init(floatLiteral: r.roughness)
+        m.metallic = .init(floatLiteral: r.metallic)
+        if r.transmission > 0.02 {
+            m.blending = .transparent(opacity: .init(floatLiteral: max(0.14, 1 - r.transmission * 0.85)))
+            m.faceCulling = .none
+        }
         return m
     }
 
@@ -1451,7 +1498,7 @@ struct ViewportView: View {
         let hov = model.hoveredPartIndex
         for i in 0..<model.partCount {
             guard let e = centering.findEntity(named: "part\(i)") as? ModelEntity else { continue }
-            var m = material(model.documentBaseColor(i))
+            var m = pbrMaterial(model.resolvedMaterial(forPart: i))
             if sel.contains(i) {
                 m.emissiveColor = .init(color: EditorModel.brandPink)
                 m.emissiveIntensity = 0.5

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1760,6 +1760,39 @@ struct ViewportView: View {
             root.addChild(hit)
         }
 
+        // Rotate rings — a circle of grabbable segments around each axis.
+        let ringR = model.gizmoRingRadius
+        let tube = max(0.25, len * 0.013)
+        let segN = 40
+        let rings: [(name: String, axis: SIMD3<Float>, color: NSColor)] = [
+            ("rotX", SIMD3(1, 0, 0), Self.gizmoX),
+            ("rotY", SIMD3(0, 1, 0), Self.gizmoY),
+            ("rotZ", SIMD3(0, 0, 1), Self.gizmoZ),
+        ]
+        for r in rings {
+            let on = hov == r.name
+            let mat = UnlitMaterial(color: (on ? brighten(r.color) : r.color).withAlphaComponent(on ? 1 : 0.85))
+            let (u1, u2) = EditorModel.ringBasis(r.axis)
+            let k: Float = on ? 1.5 : 1.0
+            var prev = c + u1 * ringR
+            for i in 1...segN {
+                let ang = 2 * Float.pi * Float(i) / Float(segN)
+                let pt = c + (u1 * cos(ang) + u2 * sin(ang)) * ringR
+                let mid = (prev + pt) / 2
+                let seg = pt - prev
+                let l = simd_length(seg)
+                let e = ModelEntity(mesh: .generateBox(size: SIMD3(l * 1.06, tube * 2 * k, tube * 2 * k)),
+                                    materials: [mat])
+                e.name = r.name
+                e.position = mid
+                e.orientation = simd_quatf(from: SIMD3(1, 0, 0), to: seg / l)
+                e.components.set(CollisionComponent(shapes: [.generateBox(size: SIMD3(l, tube * 6, tube * 6))]))
+                e.components.set(InputTargetComponent())
+                root.addChild(e)
+                prev = pt
+            }
+        }
+
         let hub = ModelEntity(mesh: .generateSphere(radius: shaftR * 2.4),
                               materials: [UnlitMaterial(color: NSColor(white: 0.95, alpha: 1))])
         hub.position = c

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1639,9 +1639,20 @@ struct ViewportView: View {
 
     // MARK: transform gizmo overlay
 
-    /// A refined translate gizmo: thin cylinder shafts with cone arrowheads in
-    /// muted axis colors, an invisible full-length hit proxy per axis (so the
-    /// drag target persists), and a small pearl hub. X red / Y green / Z blue.
+    private static let gizmoX = NSColor(srgbRed: 0.95, green: 0.30, blue: 0.34, alpha: 1)
+    private static let gizmoY = NSColor(srgbRed: 0.42, green: 0.80, blue: 0.44, alpha: 1)
+    private static let gizmoZ = NSColor(srgbRed: 0.32, green: 0.58, blue: 0.98, alpha: 1)
+
+    private func brighten(_ c: NSColor) -> NSColor {
+        let s = c.usingColorSpace(.sRGB) ?? c
+        return NSColor(srgbRed: min(1, s.redComponent * 1.2 + 0.18),
+                       green: min(1, s.greenComponent * 1.2 + 0.18),
+                       blue: min(1, s.blueComponent * 1.2 + 0.18), alpha: 1)
+    }
+
+    /// A refined translate gizmo: cylinder shafts + cone arrowheads (axis drag),
+    /// corner squares (plane drag), a pearl hub, and invisible full-length grab
+    /// proxies. The hovered handle brightens + thickens. X red / Y green / Z blue.
     private func buildGizmo() -> Entity {
         let root = Entity(); root.name = "gizmoRoot"
         guard let c = model.gizmoCenterKernel() else { return root }
@@ -1650,34 +1661,56 @@ struct ViewportView: View {
         let headLen = len * 0.2
         let headR = shaftR * 2.8
         let shaftLen = len - headLen
+        let hov = model.hoveredGizmoHandle
+
         let axes: [(name: String, dir: SIMD3<Float>, color: NSColor)] = [
-            ("gizmoX", SIMD3(1, 0, 0), NSColor(srgbRed: 0.95, green: 0.30, blue: 0.34, alpha: 1)),
-            ("gizmoY", SIMD3(0, 1, 0), NSColor(srgbRed: 0.42, green: 0.80, blue: 0.44, alpha: 1)),
-            ("gizmoZ", SIMD3(0, 0, 1), NSColor(srgbRed: 0.32, green: 0.58, blue: 0.98, alpha: 1)),
+            ("gizmoX", SIMD3(1, 0, 0), Self.gizmoX),
+            ("gizmoY", SIMD3(0, 1, 0), Self.gizmoY),
+            ("gizmoZ", SIMD3(0, 0, 1), Self.gizmoZ),
         ]
         for a in axes {
-            let mat = UnlitMaterial(color: a.color)
-            let rot = simd_quatf(from: SIMD3(0, 1, 0), to: a.dir)   // RealityKit shapes are +Y-up
+            let on = hov == a.name
+            let mat = UnlitMaterial(color: on ? brighten(a.color) : a.color)
+            let rot = simd_quatf(from: SIMD3(0, 1, 0), to: a.dir)
+            let k: Float = on ? 1.3 : 1.0
 
-            let shaft = ModelEntity(mesh: .generateCylinder(height: shaftLen, radius: shaftR), materials: [mat])
-            shaft.orientation = rot
-            shaft.position = c + a.dir * (shaftLen / 2)
+            let shaft = ModelEntity(mesh: .generateCylinder(height: shaftLen, radius: shaftR * k), materials: [mat])
+            shaft.orientation = rot; shaft.position = c + a.dir * (shaftLen / 2)
             root.addChild(shaft)
-
-            let head = ModelEntity(mesh: .generateCone(height: headLen, radius: headR), materials: [mat])
-            head.orientation = rot
-            head.position = c + a.dir * (shaftLen + headLen / 2)
+            let head = ModelEntity(mesh: .generateCone(height: headLen, radius: headR * k), materials: [mat])
+            head.orientation = rot; head.position = c + a.dir * (shaftLen + headLen / 2)
             root.addChild(head)
 
-            // Invisible full-length grab proxy — outlives per-frame rebuilds.
             let hit = ModelEntity()
-            hit.name = a.name
-            hit.orientation = rot
-            hit.position = c + a.dir * (len / 2)
+            hit.name = a.name; hit.orientation = rot; hit.position = c + a.dir * (len / 2)
             hit.components.set(CollisionComponent(shapes: [.generateBox(size: SIMD3(headR * 2.6, len, headR * 2.6))]))
             hit.components.set(InputTargetComponent())
             root.addChild(hit)
         }
+
+        // Plane handles — a square in the corner of each axis pair (normal colored).
+        let pOff = model.gizmoPlaneOffset, pSize = model.gizmoPlaneSize
+        let planes: [(name: String, a: SIMD3<Float>, b: SIMD3<Float>, color: NSColor)] = [
+            ("planeXY", SIMD3(1, 0, 0), SIMD3(0, 1, 0), Self.gizmoZ),
+            ("planeYZ", SIMD3(0, 1, 0), SIMD3(0, 0, 1), Self.gizmoX),
+            ("planeXZ", SIMD3(1, 0, 0), SIMD3(0, 0, 1), Self.gizmoY),
+        ]
+        for p in planes {
+            let on = hov == p.name
+            let n = simd_normalize(simd_cross(p.a, p.b))
+            let rot = simd_quatf(from: SIMD3(0, 0, 1), to: n)
+            let center = c + (p.a + p.b) * pOff
+            let mat = UnlitMaterial(color: (on ? brighten(p.color) : p.color).withAlphaComponent(on ? 0.7 : 0.4))
+            let sq = ModelEntity(mesh: .generateBox(size: SIMD3(pSize, pSize, max(0.2, pSize * 0.05))), materials: [mat])
+            sq.orientation = rot; sq.position = center
+            root.addChild(sq)
+            let hit = ModelEntity()
+            hit.name = p.name; hit.orientation = rot; hit.position = center
+            hit.components.set(CollisionComponent(shapes: [.generateBox(size: SIMD3(pSize * 1.25, pSize * 1.25, pSize * 0.6))]))
+            hit.components.set(InputTargetComponent())
+            root.addChild(hit)
+        }
+
         let hub = ModelEntity(mesh: .generateSphere(radius: shaftR * 2.4),
                               materials: [UnlitMaterial(color: NSColor(white: 0.95, alpha: 1))])
         hub.position = c
@@ -1731,14 +1764,14 @@ struct ViewportView: View {
         DragGesture()
             .targetedToAnyEntity()
             .onChanged { value in
-                // Transform gizmo: drag an axis arm to translate the part. Uses
-                // the kernel ray from the live cursor + closest-point-on-axis.
-                if let axis = model.gizmoAxis(for: value.entity.name) {
+                // Transform gizmo: drag an axis arm or plane handle to translate
+                // the part. Kernel ray from the live cursor → closest-point math.
+                if model.gizmoHandle(for: value.entity.name) != nil {
                     NSCursor.closedHand.set()
                     if !model.draggingHandle {
                         model.draggingHandle = true
                         if let ray = kernelRay(at: value.startLocation, viewSize: model.viewSize) {
-                            model.beginGizmoDrag(axis: axis, ray: ray)
+                            model.beginGizmoDrag(handle: value.entity.name, ray: ray)
                         }
                     }
                     if let ray = kernelRay(at: value.location, viewSize: model.viewSize) {
@@ -1893,12 +1926,23 @@ struct ViewportView: View {
         if model.usesDocumentTree {
             switch phase {
             case .active(let point):
-                let pi = kernelRay(at: point, viewSize: viewSize).flatMap {
-                    model.pickDocumentPart(originKernel: $0.o, dirKernel: $0.d)
+                let ray = kernelRay(at: point, viewSize: viewSize)
+                // Gizmo handles win over part hover (they sit on top). Never
+                // re-highlight mid-drag — that would rebuild the grabbed arm.
+                let gh = (model.showsGizmo && !model.draggingHandle) ? ray.flatMap {
+                    model.hitGizmoHandle(originKernel: $0.o, dirKernel: $0.d)
+                } : nil
+                if gh != model.hoveredGizmoHandle { model.hoveredGizmoHandle = gh; model.gizmoDirty = true }
+                if gh != nil {
+                    if model.hoveredPartIndex != nil { model.hoveredPartIndex = nil; model.hoverDirty = true }
+                    NSCursor.openHand.set()
+                    return
                 }
+                let pi = ray.flatMap { model.pickDocumentPart(originKernel: $0.o, dirKernel: $0.d) }
                 if pi != model.hoveredPartIndex { model.hoveredPartIndex = pi; model.hoverDirty = true }
                 (pi != nil ? NSCursor.pointingHand : NSCursor.arrow).set()
             case .ended:
+                if model.hoveredGizmoHandle != nil { model.hoveredGizmoHandle = nil; model.gizmoDirty = true }
                 if model.hoveredPartIndex != nil { model.hoveredPartIndex = nil; model.hoverDirty = true }
                 NSCursor.arrow.set()
             }

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1144,7 +1144,7 @@ struct ViewportView: View {
              model.source, model.selectedFeatureID, model.baseShape, model.modifier,
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
-             model.docParamDirty, model.sketchDirty, model.hoverDirty)
+             model.docParamDirty, model.sketchDirty, model.hoverDirty, model.gizmoDirty)
 
         return GeometryReader { geo in
           RealityView { content in
@@ -1234,8 +1234,13 @@ struct ViewportView: View {
             }
             if model.selectionDirty || model.hoverDirty {
                 applySelectionHighlight(content)
+                if model.selectionDirty { rebuildGizmo(content) }   // move to new selection
                 model.selectionDirty = false
                 model.hoverDirty = false
+            }
+            if model.gizmoDirty {
+                rebuildGizmo(content)
+                model.gizmoDirty = false
             }
 
             // Sketch overlay: rebuild the in-progress profile + rubber-band on
@@ -1388,6 +1393,9 @@ struct ViewportView: View {
         }
         if model.source.isGripper {
             centering.addChild(buildCopperRoot(model.routeGripperCopper()))
+        }
+        if model.showsGizmo {
+            centering.addChild(buildGizmo())
         }
 
         let zUp = Entity()
@@ -1626,6 +1634,51 @@ struct ViewportView: View {
         return root
     }
 
+    // MARK: transform gizmo overlay
+
+    /// Three axis arms (X red / Y green / Z blue) at the selected part's center.
+    /// Each arm carries collision + input target so `handleDrag` can grab it.
+    private func buildGizmo() -> Entity {
+        let root = Entity(); root.name = "gizmoRoot"
+        guard let c = model.gizmoCenterKernel() else { return root }
+        let len = model.gizmoArmLength()
+        let r = max(0.6, len * 0.035)
+        let axes: [(name: String, dir: SIMD3<Float>, color: NSColor)] = [
+            ("gizmoX", SIMD3(1, 0, 0), .systemRed),
+            ("gizmoY", SIMD3(0, 1, 0), .systemGreen),
+            ("gizmoZ", SIMD3(0, 0, 1), .systemBlue),
+        ]
+        for a in axes {
+            let arm = ModelEntity(mesh: .generateBox(size: SIMD3(len, r * 1.6, r * 1.6)),
+                                  materials: [UnlitMaterial(color: a.color)])
+            arm.name = a.name
+            arm.position = c + a.dir * (len / 2)
+            arm.orientation = simd_quatf(from: SIMD3(1, 0, 0), to: a.dir)
+            arm.components.set(CollisionComponent(shapes: [ShapeResource.generateBox(size: SIMD3(len, r * 5, r * 5))]))
+            arm.components.set(InputTargetComponent())
+            root.addChild(arm)
+            let tip = ModelEntity(mesh: .generateSphere(radius: r * 2.1),
+                                  materials: [UnlitMaterial(color: a.color)])
+            tip.position = c + a.dir * len
+            tip.name = a.name        // grabbing the tip drags the same axis
+            tip.components.set(CollisionComponent(shapes: [ShapeResource.generateSphere(radius: r * 3)]))
+            tip.components.set(InputTargetComponent())
+            root.addChild(tip)
+        }
+        let hub = ModelEntity(mesh: .generateSphere(radius: r * 1.7),
+                              materials: [UnlitMaterial(color: NSColor.white)])
+        hub.position = c
+        root.addChild(hub)
+        return root
+    }
+
+    private func rebuildGizmo(_ content: RealityViewCameraContent) {
+        guard let root = content.entities.first(where: { $0.name == "geomRoot" }),
+              let centering = root.findEntity(named: "centering") else { return }
+        centering.findEntity(named: "gizmoRoot")?.removeFromParent()
+        if model.showsGizmo { centering.addChild(buildGizmo()) }
+    }
+
     // MARK: feature-tree sync (visibility + selection highlight)
 
     /// Enable/disable part entities to honor the tree's eye toggles + isolate.
@@ -1665,6 +1718,21 @@ struct ViewportView: View {
         DragGesture()
             .targetedToAnyEntity()
             .onChanged { value in
+                // Transform gizmo: drag an axis arm to translate the part. Uses
+                // the kernel ray from the live cursor + closest-point-on-axis.
+                if let axis = model.gizmoAxis(for: value.entity.name) {
+                    NSCursor.closedHand.set()
+                    if !model.draggingHandle {
+                        model.draggingHandle = true
+                        if let ray = kernelRay(at: value.startLocation, viewSize: model.viewSize) {
+                            model.beginGizmoDrag(axis: axis, ray: ray)
+                        }
+                    }
+                    if let ray = kernelRay(at: value.location, viewSize: model.viewSize) {
+                        model.gizmoDragTo(ray: ray)
+                    }
+                    return
+                }
                 let isHandle = value.entity.name == "connectorHandle" || value.entity.name == "filletHandle"
                 if isHandle { NSCursor.closedHand.set() }
                 if value.entity.name == "connectorHandle" {
@@ -1687,6 +1755,7 @@ struct ViewportView: View {
             .onEnded { _ in
                 if model.draggingHandle { NSCursor.arrow.set() }
                 model.draggingHandle = false
+                model.endGizmoDrag()
                 // Connector settled → re-route the copper once (gripper only).
                 if model.source.isGripper { model.copperDirty = true }
             }
@@ -1744,6 +1813,7 @@ struct ViewportView: View {
     }
 
     private func pick(at p: CGPoint, viewSize: CGSize) {
+        model.viewSize = viewSize                 // keep fresh for gizmo drags
         model.stopSpin()                          // a tap settles the camera
         guard let (camKernel, dirKernel) = kernelRay(at: p, viewSize: viewSize) else { return }
 
@@ -1763,8 +1833,8 @@ struct ViewportView: View {
                pi < model.featureNodes.count {
                 if cmd { model.toggleMultiSelect(part: pi, featureID: model.featureNodes[pi].id) }
                 else { model.selectFeature(model.featureNodes[pi].id) }
-            } else if !cmd {
-                model.deselectAll()
+            } else if !cmd, !model.rayHitsGizmo(originKernel: camKernel, dirKernel: dirKernel) {
+                model.deselectAll()        // empty space (but not a tap on the gizmo)
             }
             return
         }
@@ -1791,6 +1861,7 @@ struct ViewportView: View {
     // MARK: hover (cursor + a scale pop on the draggable handles)
 
     private func hover(_ phase: HoverPhase, viewSize: CGSize) {
+        model.viewSize = viewSize                 // keep fresh for gizmo drags
         // Sketch mode: track the cursor on the plane for the rubber-band preview.
         if model.sketching {
             if case .active(let point) = phase,

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1339,32 +1339,67 @@ struct ViewportView: View {
 
     /// A dark studio environment drawn procedurally (no bundled HDR), used for
     /// both the skybox backdrop and image-based reflections on the geometry.
+    /// A soft ceiling, a horizon band, and three softbox highlights at varied
+    /// azimuths give metals real reflection structure as the camera orbits.
     private func makeStudioEnvironment() -> EnvironmentResource? {
-        let w = 1024, h = 512
+        let w = 2048, h = 1024
         let cs = CGColorSpaceCreateDeviceRGB()
         guard let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
                                   bytesPerRow: 0, space: cs,
                                   bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else { return nil }
-        // Vertical gradient: a faintly warm zenith down to a near-black floor.
+        let fw = CGFloat(w), fh = CGFloat(h)
+        // Base: soft ceiling (top) → horizon → near-black floor (bottom).
         let base = CGGradient(colorsSpace: cs, colors: [
-            CGColor(red: 0.12, green: 0.13, blue: 0.16, alpha: 1),
-            CGColor(red: 0.06, green: 0.07, blue: 0.09, alpha: 1),
-            CGColor(red: 0.015, green: 0.015, blue: 0.02, alpha: 1),
-        ] as CFArray, locations: [0, 0.55, 1])!
-        ctx.drawLinearGradient(base, start: CGPoint(x: 0, y: CGFloat(h)),
-                               end: CGPoint(x: 0, y: 0), options: [])
-        // Soft broad key glow → a gentle specular sweep across metal.
+            CGColor(red: 0.20, green: 0.21, blue: 0.25, alpha: 1),   // zenith
+            CGColor(red: 0.13, green: 0.14, blue: 0.17, alpha: 1),
+            CGColor(red: 0.07, green: 0.075, blue: 0.09, alpha: 1),  // horizon
+            CGColor(red: 0.025, green: 0.025, blue: 0.032, alpha: 1),
+            CGColor(red: 0.008, green: 0.008, blue: 0.011, alpha: 1), // nadir
+        ] as CFArray, locations: [0, 0.34, 0.52, 0.74, 1])!
+        ctx.drawLinearGradient(base, start: CGPoint(x: 0, y: fh), end: CGPoint(x: 0, y: 0), options: [])
+
         ctx.setBlendMode(.plusLighter)
-        let glow = CGGradient(colorsSpace: cs, colors: [
-            CGColor(red: 0.42, green: 0.48, blue: 0.58, alpha: 1),
-            CGColor(red: 0.42, green: 0.48, blue: 0.58, alpha: 0),
-        ] as CFArray, locations: [0, 1])!
-        ctx.drawRadialGradient(glow,
-            startCenter: CGPoint(x: CGFloat(w) * 0.34, y: CGFloat(h) * 0.74), startRadius: 0,
-            endCenter: CGPoint(x: CGFloat(w) * 0.34, y: CGFloat(h) * 0.74), endRadius: CGFloat(h) * 0.55,
-            options: [])
+        // A faint horizon band so reflective edges catch a bright line.
+        let horizon = CGGradient(colorsSpace: cs, colors: [
+            CGColor(red: 0.16, green: 0.18, blue: 0.22, alpha: 0),
+            CGColor(red: 0.16, green: 0.18, blue: 0.22, alpha: 0.7),
+            CGColor(red: 0.16, green: 0.18, blue: 0.22, alpha: 0),
+        ] as CFArray, locations: [0, 0.5, 1])!
+        ctx.drawLinearGradient(horizon,
+            start: CGPoint(x: 0, y: fh * 0.40), end: CGPoint(x: 0, y: fh * 0.56), options: [])
+
+        // Softbox highlights — bright soft blobs the metal reflects.
+        func softbox(_ cx: CGFloat, _ cy: CGFloat, _ rad: CGFloat, _ c: CGColor) {
+            let g = CGGradient(colorsSpace: cs, colors: [c, c.copy(alpha: 0)!] as CFArray, locations: [0, 1])!
+            ctx.drawRadialGradient(g, startCenter: CGPoint(x: cx, y: cy), startRadius: 0,
+                                   endCenter: CGPoint(x: cx, y: cy), endRadius: rad, options: [])
+        }
+        softbox(fw * 0.20, fh * 0.80, fh * 0.42, CGColor(red: 0.52, green: 0.58, blue: 0.68, alpha: 1)) // cool key
+        softbox(fw * 0.56, fh * 0.86, fh * 0.30, CGColor(red: 0.55, green: 0.50, blue: 0.42, alpha: 1)) // warm
+        softbox(fw * 0.83, fh * 0.74, fh * 0.32, CGColor(red: 0.38, green: 0.44, blue: 0.54, alpha: 1)) // cool fill
         guard let img = ctx.makeImage() else { return nil }
         return try? EnvironmentResource(equirectangular: img)
+    }
+
+    /// A soft radial alpha disc (dark center → clear edge) for the pooled contact
+    /// shadow. Resolution-independent, so it's built once and stretched per part.
+    private static let contactTexture: TextureResource? = makeContactTexture()
+    private static func makeContactTexture() -> TextureResource? {
+        let s = 256
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: nil, width: s, height: s, bitsPerComponent: 8,
+                                  bytesPerRow: 0, space: cs,
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        let g = CGGradient(colorsSpace: cs, colors: [
+            CGColor(red: 0, green: 0, blue: 0, alpha: 0.5),
+            CGColor(red: 0, green: 0, blue: 0, alpha: 0.32),
+            CGColor(red: 0, green: 0, blue: 0, alpha: 0.0),
+        ] as CFArray, locations: [0, 0.45, 1])!
+        let c = CGFloat(s) / 2
+        ctx.drawRadialGradient(g, startCenter: CGPoint(x: c, y: c), startRadius: 0,
+                               endCenter: CGPoint(x: c, y: c), endRadius: c, options: [])
+        guard let img = ctx.makeImage() else { return nil }
+        return try? TextureResource(image: img, options: .init(semantic: .color))
     }
 
     private func rebuildGeometry(_ content: RealityViewCameraContent) {
@@ -1421,17 +1456,31 @@ struct ViewportView: View {
             geomRoot.move(to: grown, relativeTo: geomRoot.parent, duration: 0.3, timingFunction: .easeOut)
         }
 
-        // Grounding floor that catches the soft contact shadow.
-        content.entities.filter { $0.name == "floor" }.forEach { $0.removeFromParent() }
+        // Grounding floor + pooled contact shadow under the part.
+        content.entities.filter { $0.name == "floor" || $0.name == "contactShadow" }
+            .forEach { $0.removeFromParent() }
         let floorY = -(model.sizeMM.z * 0.5 * sceneScale) - 0.004
         var floorMat = PhysicallyBasedMaterial()
-        floorMat.baseColor = .init(tint: NSColor(white: 0.03, alpha: 1.0))
-        floorMat.roughness = 0.55
+        floorMat.baseColor = .init(tint: NSColor(white: 0.025, alpha: 1.0))
+        floorMat.roughness = 0.42            // a touch glossy → catches the IBL sheen
         floorMat.metallic = 0.0
         let floor = ModelEntity(mesh: .generatePlane(width: 8, depth: 8), materials: [floorMat])
         floor.name = "floor"
         floor.position = [0, floorY, 0]
         content.add(floor)
+
+        // Soft AO blob right under the part (footprint: kernel XY → world XZ).
+        if let tex = Self.contactTexture {
+            var sm = UnlitMaterial()
+            sm.color = .init(tint: .white, texture: .init(tex))
+            sm.blending = .transparent(opacity: .init(floatLiteral: 1.0))
+            let fwd = max(0.05, model.sizeMM.x * sceneScale * 1.8)
+            let dpt = max(0.05, model.sizeMM.y * sceneScale * 1.8)
+            let blob = ModelEntity(mesh: .generatePlane(width: fwd, depth: dpt), materials: [sm])
+            blob.name = "contactShadow"
+            blob.position = [0, floorY + 0.0015, 0]
+            content.add(blob)
+        }
     }
 
     private func material(_ color: NSColor) -> PhysicallyBasedMaterial {

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -46,7 +46,11 @@ struct EditorView: View {
                     }
                 }
                 .overlay(alignment: compact ? .leading : .top) {
-                    if model.source.isSandbox || model.usesDocumentTree {
+                    if model.sketching {
+                        SketchPaletteView(model: model)
+                            .padding(.top, 14)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                    } else if model.source.isSandbox || model.usesDocumentTree {
                         ToolPaletteView(model: model, axis: compact ? .vertical : .horizontal)
                             .padding(compact ? .leading : .top, 14)
                     }
@@ -72,7 +76,10 @@ struct EditorView: View {
                 }
                 .overlay(alignment: .bottom) {
                     VStack(spacing: 10) {
-                        if model.source.isSandbox && intent.draft.isEmpty && !intent.isThinking {
+                        if model.sketching {
+                            SketchHintBar(model: model)
+                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                        } else if model.source.isSandbox && intent.draft.isEmpty && !intent.isThinking {
                             ExampleChips(intent: intent)
                                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                         }
@@ -81,6 +88,7 @@ struct EditorView: View {
                     .padding(.bottom, 14)
                     .animation(.smooth(duration: 0.3), value: model.source.isSandbox)
                     .animation(.smooth(duration: 0.25), value: intent.draft.isEmpty)
+                    .animation(.smooth(duration: 0.25), value: model.sketching)
                 }
                 .toolbar {
                     ToolbarItem(placement: .navigation) { DocumentMenu(model: model) }
@@ -277,6 +285,109 @@ struct ToolPaletteView: View {
         .opacity(tool.enabled ? 1 : 0.32)
         .disabled(!tool.enabled)
         .help(tool.enabled ? tool.label : "\(tool.label) — \(tool.hint)")
+    }
+}
+
+/// The sketch-mode toolbar: plane · tools · extrude depth · Finish / Cancel.
+/// Replaces the Create/Modify/Combine palette while drawing a profile.
+struct SketchPaletteView: View {
+    @Bindable var model: EditorModel
+    var body: some View {
+        HStack(spacing: 10) {
+            segmented(SketchPlane.allCases, get: { model.sketchPlane }, label: { $0.label }) {
+                model.setSketchPlane($0)
+            }
+            Divider().frame(height: 18)
+            HStack(spacing: 6) {
+                ForEach(SketchTool.allCases) { tool in
+                    let active = model.sketchTool == tool
+                    Button { model.setSketchTool(tool) } label: {
+                        HStack(spacing: 5) {
+                            Image(systemName: tool.symbol).font(.system(size: 12))
+                            Text(tool.label).font(.system(size: 12))
+                        }
+                        .padding(.horizontal, 9).padding(.vertical, 5)
+                        .background(active ? Color.accentColor.opacity(0.18) : .clear,
+                                    in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                        .foregroundStyle(active ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            Divider().frame(height: 18)
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.to.line").font(.system(size: 11)).foregroundStyle(.secondary)
+                ScrubField(label: "", value: model.sketchExtrudeDepth, sensitivity: 0.1, minValue: 0.1) { v, _ in
+                    model.sketchExtrudeDepth = v
+                }.frame(width: 96)
+            }
+            Divider().frame(height: 18)
+            Button { model.finishSketch() } label: {
+                Label("Extrude", systemImage: "checkmark")
+                    .font(.system(size: 12, weight: .medium))
+                    .padding(.horizontal, 9).padding(.vertical, 5)
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(model.canFinishSketch ? AnyShapeStyle(Color.green) : AnyShapeStyle(.tertiary))
+            .disabled(!model.canFinishSketch)
+            Button { model.exitSketch() } label: {
+                Image(systemName: "xmark").font(.system(size: 12)).foregroundStyle(.secondary)
+                    .padding(6)
+            }
+            .buttonStyle(.plain)
+            .help("Cancel sketch (Esc)")
+        }
+        .padding(8)
+        .glassCard(13)
+        .animation(.snappy(duration: 0.2), value: model.sketchTool)
+        .animation(.snappy(duration: 0.2), value: model.sketchPlane)
+    }
+
+    private func segmented<T: Identifiable & Equatable>(
+        _ items: [T], get: () -> T, label: @escaping (T) -> String, set: @escaping (T) -> Void
+    ) -> some View {
+        let current = get()
+        return HStack(spacing: 2) {
+            ForEach(items) { item in
+                let active = item == current
+                Button { set(item) } label: {
+                    Text(label(item)).font(.system(size: 11, weight: .medium))
+                        .padding(.horizontal, 8).padding(.vertical, 4)
+                        .background(active ? Color.accentColor.opacity(0.18) : .clear,
+                                    in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+                        .foregroundStyle(active ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.secondary))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+/// A one-line prompt at the bottom telling the user what to click next.
+struct SketchHintBar: View {
+    let model: EditorModel
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "hand.point.up.left").font(.system(size: 11))
+            Text(hint)
+        }
+        .font(.system(size: 11))
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 14).padding(.vertical, 7)
+        .glassCard(11)
+    }
+    private var hint: String {
+        if model.canFinishSketch { return "Profile closed — set a depth and hit Extrude" }
+        switch model.sketchTool {
+        case .line:
+            return model.sketchVerts.isEmpty
+                ? "Line: click to place the first point"
+                : "Line: keep clicking · click the first point to close"
+        case .rectangle:
+            return model.sketchAnchor == nil ? "Rectangle: click the first corner" : "Rectangle: click the opposite corner"
+        case .circle:
+            return model.sketchAnchor == nil ? "Circle: click the center" : "Circle: click to set the radius"
+        }
     }
 }
 
@@ -841,7 +952,7 @@ struct ViewportView: View {
              model.source, model.selectedFeatureID, model.baseShape, model.modifier,
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
-             model.docParamDirty)
+             model.docParamDirty, model.sketchDirty)
 
         return GeometryReader { geo in
           RealityView { content in
@@ -932,6 +1043,17 @@ struct ViewportView: View {
             if model.selectionDirty {
                 applySelectionHighlight(content)
                 model.selectionDirty = false
+            }
+
+            // Sketch overlay: rebuild the in-progress profile + rubber-band on
+            // every tap / cursor move (tiny geometry, so a full rebuild is fine).
+            if model.sketchDirty {
+                if let root = content.entities.first(where: { $0.name == "geomRoot" }),
+                   let centering = root.findEntity(named: "centering") {
+                    centering.findEntity(named: "sketchRoot")?.removeFromParent()
+                    if model.sketching { centering.addChild(buildSketchRoot()) }
+                }
+                model.sketchDirty = false
             }
 
             // Settle: the connector stopped moving — run the EXPENSIVE domains
@@ -1226,6 +1348,64 @@ struct ViewportView: View {
         copperRoot.components.set(OpacityComponent(opacity: dim ? 0.3 : 1.0))
     }
 
+    // MARK: sketch preview overlay
+
+    /// Build the in-progress sketch: committed segments + vertex dots in brand
+    /// pink, plus a cyan rubber-band from the last point / anchor to the cursor.
+    private func buildSketchRoot() -> Entity {
+        let root = Entity(); root.name = "sketchRoot"
+        let ink = NSColor(srgbRed: 0.98, green: 0.15, blue: 0.45, alpha: 1.0)   // brand pink
+        let live = NSColor(srgbRed: 0.55, green: 0.92, blue: 1.0, alpha: 1.0)   // cyan
+        let verts = model.sketchVerts
+
+        func seg(_ a2: SIMD2<Float>, _ b2: SIMD2<Float>, _ color: NSColor) {
+            let a = model.sketchWorld(a2), b = model.sketchWorld(b2)
+            let d = b - a; let len = simd_length(d)
+            guard len > 1e-4 else { return }
+            let e = ModelEntity(mesh: .generateBox(size: SIMD3(len, 0.7, 0.7)),
+                                materials: [UnlitMaterial(color: color)])
+            e.position = (a + b) / 2
+            e.orientation = simd_quatf(from: SIMD3(1, 0, 0), to: d / len)
+            root.addChild(e)
+        }
+        func dot(_ v2: SIMD2<Float>, _ color: NSColor, _ r: Float = 1.1) {
+            let e = ModelEntity(mesh: .generateSphere(radius: r), materials: [UnlitMaterial(color: color)])
+            e.position = model.sketchWorld(v2)
+            root.addChild(e)
+        }
+
+        // Committed profile.
+        if model.sketchTool == .line && !model.sketchClosed {
+            for i in 0..<max(0, verts.count - 1) { seg(verts[i], verts[i + 1], ink) }
+            for v in verts { dot(v, ink) }
+            if let last = verts.last, let c = model.sketchCursor { seg(last, c, live) }
+        } else if !verts.isEmpty {
+            for i in 0..<verts.count { seg(verts[i], verts[(i + 1) % verts.count], ink) }
+            for v in verts { dot(v, ink) }
+        }
+
+        // Two-click rect/circle preview from the anchor to the cursor.
+        if let a = model.sketchAnchor, let c = model.sketchCursor {
+            switch model.sketchTool {
+            case .rectangle:
+                let corners = [a, SIMD2(c.x, a.y), c, SIMD2(a.x, c.y)]
+                for i in 0..<4 { seg(corners[i], corners[(i + 1) % 4], live) }
+            case .circle:
+                let r = simd_distance(a, c)
+                let n = 48
+                let pts = (0..<n).map { i -> SIMD2<Float> in
+                    let t = 2 * Float.pi * Float(i) / Float(n)
+                    return SIMD2(a.x + r * cos(t), a.y + r * sin(t))
+                }
+                for i in 0..<n { seg(pts[i], pts[(i + 1) % n], live) }
+                dot(a, live)
+            case .line:
+                break
+            }
+        }
+        return root
+    }
+
     // MARK: feature-tree sync (visibility + selection highlight)
 
     /// Enable/disable part entities to honor the tree's eye toggles + isolate.
@@ -1320,8 +1500,10 @@ struct ViewportView: View {
 
     // MARK: picking (#7)
 
-    private func pick(at p: CGPoint, viewSize: CGSize) {
-        guard viewSize.width > 1, viewSize.height > 1 else { return }
+    /// Screen point → ray in kernel space (origin, normalized dir). Inverse of
+    /// the pinhole projection; shared by face-pick, part-pick, and sketch-pick.
+    private func kernelRay(at p: CGPoint, viewSize: CGSize) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
+        guard viewSize.width > 1, viewSize.height > 1 else { return nil }
         let cam = model.cameraPosition
         let forward = normalize(model.panOffset - cam)
         let right = normalize(cross(forward, SIMD3<Float>(0, 1, 0)))
@@ -1331,10 +1513,20 @@ struct ViewportView: View {
         let ndcX = Float(2 * p.x / viewSize.width - 1)
         let ndcY = Float(1 - 2 * p.y / viewSize.height)
         let dirWorld = normalize(forward + ndcX * tanHalf * aspect * right + ndcY * tanHalf * up)
-
         let s = model.displayScale
-        let camKernel = rxPlus90(cam / s) + model.displayCenter
-        let dirKernel = normalize(rxPlus90(dirWorld))
+        return (rxPlus90(cam / s) + model.displayCenter, normalize(rxPlus90(dirWorld)))
+    }
+
+    private func pick(at p: CGPoint, viewSize: CGSize) {
+        guard let (camKernel, dirKernel) = kernelRay(at: p, viewSize: viewSize) else { return }
+
+        // Sketch mode: a tap drops a point on the sketch plane.
+        if model.sketching {
+            if let pt = model.sketchPlanePoint(originKernel: camKernel, dirKernel: dirKernel) {
+                model.sketchTap(pt)
+            }
+            return
+        }
 
         // Documents: tap a part → select its row (⌘-tap toggles multi-select, for
         // booleans); tap empty space → deselect. Kernel-space AABBs make it cheap.
@@ -1372,6 +1564,19 @@ struct ViewportView: View {
     // MARK: hover (cursor + a scale pop on the draggable handles)
 
     private func hover(_ phase: HoverPhase, viewSize: CGSize) {
+        // Sketch mode: track the cursor on the plane for the rubber-band preview.
+        if model.sketching {
+            if case .active(let point) = phase,
+               let (o, d) = kernelRay(at: point, viewSize: viewSize),
+               let pt = model.sketchPlanePoint(originKernel: o, dirKernel: d) {
+                model.sketchCursor = pt
+                model.sketchDirty = true
+                NSCursor.crosshair.set()
+            } else if case .ended = phase {
+                NSCursor.arrow.set()
+            }
+            return
+        }
         switch phase {
         case .active(let point):
             let hit = hitHandle(at: point, viewSize: viewSize)

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -86,10 +86,10 @@ struct EditorView: View {
                         }
                     }
                     .padding(.bottom, 14)
-                    .animation(.smooth(duration: 0.3), value: model.source.isSandbox)
-                    .animation(.smooth(duration: 0.25), value: intent.draft.isEmpty)
-                    .animation(.smooth(duration: 0.25), value: model.sketching)
-                    .animation(.smooth(duration: 0.3), value: model.toolPlacement)
+                    .animation(Motion.smooth, value: model.source.isSandbox)
+                    .animation(Motion.smooth, value: intent.draft.isEmpty)
+                    .animation(Motion.panel, value: model.sketching)
+                    .animation(Motion.panel, value: model.toolPlacement)
                 }
                 .toolbar {
                     ToolbarItem(placement: .navigation) { BrandMark() }
@@ -358,9 +358,9 @@ struct ToolPaletteView: View {
             .transition(.opacity)
             if docked { Spacer(minLength: 0) }
         }
-        .animation(.snappy(duration: 0.26), value: model.toolTab)
-        .animation(.snappy(duration: 0.22), value: model.baseShape)
-        .animation(.snappy(duration: 0.22), value: model.modifier)
+        .animation(Motion.snappy, value: model.toolTab)
+        .animation(Motion.snappy, value: model.baseShape)
+        .animation(Motion.snappy, value: model.modifier)
 
         return Group {
             if docked {
@@ -578,10 +578,10 @@ struct FeatureTreeView: View {
         }
         .padding(6)
         .glassCard()
-        .animation(.snappy(duration: 0.18), value: model.selectedFeatureID)
-        .animation(.snappy(duration: 0.2), value: model.expandedFeatureIDs)
-        .animation(.snappy(duration: 0.2), value: model.hiddenParts)
-        .animation(.snappy(duration: 0.2), value: model.isolatedPart)
+        .animation(Motion.snappy, value: model.selectedFeatureID)
+        .animation(Motion.snappy, value: model.expandedFeatureIDs)
+        .animation(Motion.snappy, value: model.hiddenParts)
+        .animation(Motion.snappy, value: model.isolatedPart)
     }
 
     private var header: some View {
@@ -1693,23 +1693,24 @@ struct ViewportView: View {
     }
 
     private var orbitGesture: some Gesture {
-        // Drag orbits; ⇧-drag pans the look-at target.
+        // Drag orbits (with flick-to-spin momentum); ⇧-drag pans the look-at.
         DragGesture()
             .onChanged { value in
                 guard !model.draggingHandle else { return }
+                if model.lastDrag == .zero { model.beginOrbit() }   // grab → stop coasting
                 let dx = Float(value.translation.width - model.lastDrag.width)
                 let dy = Float(value.translation.height - model.lastDrag.height)
                 if NSEvent.modifierFlags.contains(.shift) {
                     model.panBy(dx: dx, dy: dy)
                 } else {
-                    model.azimuth -= dx * 0.01
-                    model.elevation = max(-1.45, min(1.45, model.elevation + dy * 0.01))
+                    model.orbitDrag(dx: dx, dy: dy)
                 }
                 model.lastDrag = value.translation
                 NSCursor.closedHand.set()        // grabbing to orbit/pan
             }
             .onEnded { _ in
                 model.lastDrag = .zero
+                model.endOrbit()                 // coast if the flick was fast
                 if !model.draggingHandle { NSCursor.arrow.set() }
             }
     }
@@ -1717,6 +1718,7 @@ struct ViewportView: View {
     private var zoomGesture: some Gesture {
         MagnifyGesture()
             .onChanged { value in
+                model.stopSpin()
                 model.distance = max(0.45, min(8.0, model.pinchBaseline / Float(value.magnification)))
             }
             .onEnded { _ in model.pinchBaseline = model.distance }
@@ -1742,6 +1744,7 @@ struct ViewportView: View {
     }
 
     private func pick(at p: CGPoint, viewSize: CGSize) {
+        model.stopSpin()                          // a tap settles the camera
         guard let (camKernel, dirKernel) = kernelRay(at: p, viewSize: viewSize) else { return }
 
         // Sketch mode: a tap drops a point on the sketch plane.

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -343,6 +343,7 @@ struct FeatureRowView: View {
     @Bindable var model: EditorModel
     let node: FeatureNode
     let depth: Int
+    @State private var hovering = false
 
     private var expanded: Bool { model.expandedFeatureIDs.contains(node.id) }
     private var selected: Bool {
@@ -353,6 +354,10 @@ struct FeatureRowView: View {
     private var dimmed: Bool {
         guard let pi = node.partIndex else { return false }
         return !model.isPartVisible(pi)
+    }
+    private var rowBackground: Color {
+        if selected { return Color.accentColor.opacity(0.20) }
+        return hovering ? Color.white.opacity(0.06) : .clear
     }
 
     var body: some View {
@@ -401,11 +406,11 @@ struct FeatureRowView: View {
         }
         .padding(.leading, CGFloat(depth) * 13 + 4)
         .padding(.trailing, 5).padding(.vertical, 4)
-        .background(selected ? Color.accentColor.opacity(0.20) : .clear,
-                    in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+        .background(rowBackground, in: RoundedRectangle(cornerRadius: 7, style: .continuous))
         .foregroundStyle(selected ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
         .opacity(dimmed ? 0.45 : 1)
         .contentShape(Rectangle())
+        .onHover { hovering = $0 }
         .onTapGesture {
             guard model.renamingFeatureID != node.id else { return }
             // ⌘-click a part row → toggle it in the multi-selection (for booleans).
@@ -637,9 +642,10 @@ struct InspectorView: View {
     }
 }
 
-/// A drag-to-scrub numeric field — the native take on the web app's scrub
-/// inputs. Horizontal drag changes the value; the first tick of a gesture
-/// snapshots for undo. Reads top-down each render so live re-eval stays in sync.
+/// A numeric field — the native take on the web app's scrub inputs. Drag the
+/// value horizontally to scrub, or double-click to type an exact number. The
+/// first tick of a scrub snapshots for undo; reads top-down each render so live
+/// re-eval stays in sync.
 struct ScrubField: View {
     let label: String
     let value: Double
@@ -648,30 +654,62 @@ struct ScrubField: View {
     var minValue: Double = -.greatestFiniteMagnitude
     let onChange: (_ value: Double, _ snapshotFirst: Bool) -> Void
     @State private var base: Double?
+    @State private var typing: String?
+    @FocusState private var focused: Bool
 
     var body: some View {
         HStack(spacing: 8) {
             Text(label).font(.system(size: 12)).foregroundStyle(.secondary)
             Spacer(minLength: 8)
-            Text(formatted).font(.system(size: 12).monospacedDigit())
-                .padding(.horizontal, 8).padding(.vertical, 3)
-                .frame(minWidth: 70, alignment: .trailing)
-                .background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
-                .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .strokeBorder(base != nil ? Color.accentColor.opacity(0.6) : .white.opacity(0.10), lineWidth: 0.5))
-                .contentShape(Rectangle())
-                .onHover { (($0 ? NSCursor.resizeLeftRight : NSCursor.arrow)).set() }
-                .gesture(
-                    DragGesture(minimumDistance: 1)
-                        .onChanged { v in
-                            let first = base == nil
-                            let b = base ?? value
-                            if base == nil { base = b }
-                            onChange(max(minValue, b + Double(v.translation.width) * sensitivity), first)
-                        }
-                        .onEnded { _ in base = nil }
-                )
+            if typing != nil { editor } else { pill }
         }
+    }
+
+    private var pill: some View {
+        Text(formatted).font(.system(size: 12).monospacedDigit())
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .frame(minWidth: 70, alignment: .trailing)
+            .background(.white.opacity(base != nil ? 0.12 : 0.06),
+                        in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(base != nil ? Color.accentColor.opacity(0.6) : .white.opacity(0.10), lineWidth: 0.5))
+            .contentShape(Rectangle())
+            .onHover { (($0 ? NSCursor.resizeLeftRight : NSCursor.arrow)).set() }
+            .help("Drag to scrub · double-click to type")
+            .onTapGesture(count: 2) { typing = String(format: "%g", value) }
+            .gesture(
+                DragGesture(minimumDistance: 2)
+                    .onChanged { v in
+                        let first = base == nil
+                        let b = base ?? value
+                        if base == nil { base = b }
+                        onChange(max(minValue, b + Double(v.translation.width) * sensitivity), first)
+                    }
+                    .onEnded { _ in base = nil }
+            )
+    }
+
+    private var editor: some View {
+        TextField("", text: Binding(get: { typing ?? "" }, set: { typing = $0 }))
+            .textFieldStyle(.plain)
+            .font(.system(size: 12).monospacedDigit())
+            .multilineTextAlignment(.trailing)
+            .frame(width: 70)
+            .focused($focused)
+            .onAppear { focused = true }
+            .onSubmit { commit() }
+            .onExitCommand { typing = nil }
+            .onChange(of: focused) { _, now in if !now { commit() } }
+            .padding(.horizontal, 8).padding(.vertical, 3)
+            .background(.white.opacity(0.10), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            .overlay(RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .strokeBorder(Color.accentColor.opacity(0.7), lineWidth: 1))
+    }
+
+    private func commit() {
+        defer { typing = nil }
+        guard let t = typing, let v = Double(t.trimmingCharacters(in: .whitespaces)) else { return }
+        onChange(max(minValue, v), true)
     }
 
     private var formatted: String {
@@ -1264,8 +1302,12 @@ struct ViewportView: View {
                     model.elevation = max(-1.45, min(1.45, model.elevation + dy * 0.01))
                 }
                 model.lastDrag = value.translation
+                NSCursor.closedHand.set()        // grabbing to orbit/pan
             }
-            .onEnded { _ in model.lastDrag = .zero }
+            .onEnded { _ in
+                model.lastDrag = .zero
+                if !model.draggingHandle { NSCursor.arrow.set() }
+            }
     }
 
     private var zoomGesture: some Gesture {

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -26,6 +26,10 @@ struct VcadApp: App {
             MainActor.assumeIsolated { sketchSmoke(path: path) }
             exit(0)
         }
+        if let path = ProcessInfo.processInfo.environment["VCAD_MAT_SMOKE"] {
+            MainActor.assumeIsolated { matSmoke(path: path) }
+            exit(0)
+        }
     }
 
     var body: some Scene {
@@ -91,6 +95,31 @@ private func dumpFeatureTree(path: String) {
 
 private func fmt3(_ v: SIMD3<Float>) -> String {
     String(format: "%.1f×%.1f×%.1f", abs(v.x), abs(v.y), abs(v.z))
+}
+
+/// Material assignment + persistence: set part 0 to copper, verify the resolved
+/// color, save, reload, and confirm the assignment + definition round-trip.
+@MainActor private func matSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "mat")
+    guard m.usesDocumentTree else { emit("[VCAD_MAT] load failed"); return }
+    let before = m.resolvedMaterial(forPart: 0).color
+    emit("[VCAD_MAT] part0 material '\(m.materialName(forPart: 0) ?? "—")' color \(rgb(before))")
+    m.setPartMaterial(0, "copper")
+    let after = m.resolvedMaterial(forPart: 0).color
+    emit("[VCAD_MAT] → copper: key '\(m.materialName(forPart: 0) ?? "—")' color \(rgb(after))")
+    let out = URL(fileURLWithPath: "/tmp/vcad_mat.vcad")
+    m.saveDocumentAs(out)
+    if let g = DocumentGraph.load(path: out.path) {
+        let hasDef = g.materials["copper"] != nil
+        emit("[VCAD_MAT] reloaded: part0 key '\(g.visibleRoots.first?.material ?? "—")' · copper def present \(hasDef)")
+    } else { emit("[VCAD_MAT] reload failed") }
+}
+
+private func rgb(_ c: NSColor) -> String {
+    let s = c.usingColorSpace(.sRGB) ?? c
+    return String(format: "(%.2f, %.2f, %.2f)", s.redComponent, s.greenComponent, s.blueComponent)
 }
 
 /// Sketch → extrude authoring: draw a 40×40 square on XY, extrude 12mm, verify

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -141,6 +141,20 @@ private func rgb(_ c: NSColor) -> String {
     _ = m.reevalDocumentMeshes()
     let c1 = m.gizmoCenterKernel() ?? .zero
     emit("[VCAD_GIZMO] +50 X · part0 center \(fmt3(c1)) (Δx \(String(format: "%.1f", c1.x - c0.x)))")
+
+    // Rotate-about-center: 90° about Z should swap the footprint + hold the center.
+    let r = EditorModel()
+    r.source = .document(path: path, label: "rot")
+    _ = r.reevalDocumentMeshes()
+    let rc0 = r.gizmoCenterKernel() ?? .zero
+    let before = r.sizeMM
+    guard var rj = r.documentJSON, let rot = DocEdit.wrapRotate(&rj, partIndex: 0,
+                                                                Double(rc0.x), Double(rc0.y), Double(rc0.z)) else { return }
+    DocEdit.setRotateAngle(&rj, rotNodeId: rot, axisIndex: 2, degrees: 90)
+    r.documentJSON = rj
+    _ = r.reevalDocumentMeshes()
+    let rc1 = r.gizmoCenterKernel() ?? .zero
+    emit("[VCAD_GIZMO] rotate 90°Z · bbox \(fmt3(before)) → \(fmt3(r.sizeMM)) · center \(fmt3(rc0)) → \(fmt3(rc1))")
 }
 
 /// Sketch → extrude authoring: draw a 40×40 square on XY, extrude 12mm, verify

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -30,6 +30,10 @@ struct VcadApp: App {
             MainActor.assumeIsolated { matSmoke(path: path) }
             exit(0)
         }
+        if let path = ProcessInfo.processInfo.environment["VCAD_GIZMO_SMOKE"] {
+            MainActor.assumeIsolated { gizmoSmoke(path: path) }
+            exit(0)
+        }
     }
 
     var body: some Scene {
@@ -120,6 +124,23 @@ private func fmt3(_ v: SIMD3<Float>) -> String {
 private func rgb(_ c: NSColor) -> String {
     let s = c.usingColorSpace(.sRGB) ?? c
     return String(format: "(%.2f, %.2f, %.2f)", s.redComponent, s.greenComponent, s.blueComponent)
+}
+
+/// Gizmo translate: move part 0 by +50 in X via the root Translate, confirm the
+/// bbox shifts, then undo back.
+@MainActor private func gizmoSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "gizmo")
+    guard m.usesDocumentTree, m.reevalDocumentMeshes() != nil else { emit("[VCAD_GIZMO] load failed"); return }
+    let c0 = m.gizmoCenterKernel() ?? .zero
+    emit("[VCAD_GIZMO] loaded · part0 center \(fmt3(c0)) · bbox \(fmt3(m.sizeMM))")
+    guard var json = m.documentJSON else { return }
+    DocEdit.setRootTranslate(&json, partIndex: 0, 50, 0, 0)
+    m.documentJSON = json
+    _ = m.reevalDocumentMeshes()
+    let c1 = m.gizmoCenterKernel() ?? .zero
+    emit("[VCAD_GIZMO] +50 X · part0 center \(fmt3(c1)) (Δx \(String(format: "%.1f", c1.x - c0.x)))")
 }
 
 /// Sketch → extrude authoring: draw a 40×40 square on XY, extrude 12mm, verify

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -22,6 +22,10 @@ struct VcadApp: App {
             MainActor.assumeIsolated { authorSmoke(path: path) }
             exit(0)
         }
+        if let path = ProcessInfo.processInfo.environment["VCAD_SKETCH_SMOKE"] {
+            MainActor.assumeIsolated { sketchSmoke(path: path) }
+            exit(0)
+        }
     }
 
     var body: some Scene {
@@ -87,6 +91,25 @@ private func dumpFeatureTree(path: String) {
 
 private func fmt3(_ v: SIMD3<Float>) -> String {
     String(format: "%.1f×%.1f×%.1f", abs(v.x), abs(v.y), abs(v.z))
+}
+
+/// Sketch → extrude authoring: draw a 40×40 square on XY, extrude 12mm, verify
+/// the kernel builds a 40×40×12 solid.
+@MainActor private func sketchSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "sketch")
+    guard m.usesDocumentTree else { emit("[VCAD_SKETCH] load failed"); return }
+    let parts0 = m.featureNodes.count
+    m.enterSketch()
+    m.setSketchTool(.rectangle)
+    m.sketchTap(SIMD2(0, 0))         // corner
+    m.sketchTap(SIMD2(40, 40))       // opposite corner
+    m.sketchExtrudeDepth = 12
+    emit("[VCAD_SKETCH] profile verts \(m.sketchVerts.count) closed \(m.sketchClosed) canFinish \(m.canFinishSketch)")
+    m.finishSketch()
+    _ = m.reevalDocumentMeshes()
+    emit("[VCAD_SKETCH] extruded → \(m.featureNodes.count) parts (was \(parts0)) · last op '\(m.featureNodes.last?.opType ?? "?")' · bbox \(fmt3(m.sizeMM)) · tris \(m.triangleCount) · sketching \(m.sketching)")
 }
 
 /// Exercise the authoring pipeline: add a primitive, apply a fillet, save,

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -1,9 +1,28 @@
 import SwiftUI
 import AppKit
+import simd
 
 @main
 struct VcadApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+
+    init() {
+        // Headless smoke hook (matches VCAD_GRIPPER/VCAD_ROUTE): dump the parsed
+        // feature tree of a .vcad to stderr and exit — verifies the DAG parser
+        // without driving the GUI. e.g. VCAD_DUMP_TREE=examples/plate.vcad
+        if let path = ProcessInfo.processInfo.environment["VCAD_DUMP_TREE"] {
+            dumpFeatureTree(path: path)
+            exit(0)
+        }
+        if let path = ProcessInfo.processInfo.environment["VCAD_EDIT_SMOKE"] {
+            MainActor.assumeIsolated { editSmoke(path: path) }
+            exit(0)
+        }
+        if let path = ProcessInfo.processInfo.environment["VCAD_AUTHOR_SMOKE"] {
+            MainActor.assumeIsolated { authorSmoke(path: path) }
+            exit(0)
+        }
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -12,6 +31,93 @@ struct VcadApp: App {
         }
         .windowStyle(.automatic)
     }
+}
+
+/// Print a document's parsed feature tree (used by the VCAD_DUMP_TREE hook).
+private func dumpFeatureTree(path: String) {
+    guard let g = DocumentGraph.load(path: path) else {
+        FileHandle.standardError.write(Data("[VCAD_TREE] parse failed: \(path)\n".utf8))
+        return
+    }
+    var out = "[VCAD_TREE] \(path) — \(g.visibleRoots.count) part(s)\n"
+    func walk(_ node: FeatureNode, _ depth: Int) {
+        let pad = String(repeating: "  ", count: depth)
+        let part = node.partIndex.map { " [part \($0)]" } ?? ""
+        let detail = node.detail.map { " — \($0)" } ?? ""
+        out += "\(pad)• \(node.name) (\(node.opType))\(detail)\(part)\n"
+        for c in node.children { walk(c, depth + 1) }
+    }
+    for r in g.featureRoots() { walk(r, 0) }
+    FileHandle.standardError.write(Data(out.utf8))
+}
+
+/// Exercise the edit → re-eval → undo → export pipeline headlessly.
+@MainActor private func editSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    func find(_ nodes: [FeatureNode], _ op: String) -> FeatureNode? {
+        for n in nodes {
+            if n.opType == op { return n }
+            if let f = find(n.children, op) { return f }
+        }
+        return nil
+    }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "smoke")
+    guard m.usesDocumentTree, m.reevalDocumentMeshes() != nil else {
+        emit("[VCAD_EDIT] no renderable geometry for \(path) (e.g. an assembly the scene eval can't handle)")
+        return
+    }
+    let before = m.sizeMM
+    emit("[VCAD_EDIT] loaded: bbox \(fmt3(before)) · tris \(m.triangleCount) · canUndo \(m.canUndo)")
+
+    guard let cube = find(m.featureNodes, "Cube") else { emit("[VCAD_EDIT] no Cube to edit"); return }
+    m.editVec(nodeId: cube.nodeId, key: "size", axis: "x", value: 200, snapshot: true)
+    _ = m.reevalDocumentMeshes()
+    emit("[VCAD_EDIT] after size.x=200 on '\(cube.name)': bbox \(fmt3(m.sizeMM)) · tris \(m.triangleCount) · canUndo \(m.canUndo)")
+
+    m.undo()
+    _ = m.reevalDocumentMeshes()
+    emit("[VCAD_EDIT] after undo: bbox \(fmt3(m.sizeMM)) · canRedo \(m.canRedo)")
+
+    let stl = URL(fileURLWithPath: "/tmp/vcad_edit_smoke.stl")
+    let ok = m.exportSTL(to: stl)
+    let size = (try? Data(contentsOf: stl))?.count ?? 0
+    emit("[VCAD_EDIT] STL export: \(ok) · \(size) bytes")
+}
+
+private func fmt3(_ v: SIMD3<Float>) -> String {
+    String(format: "%.1f×%.1f×%.1f", abs(v.x), abs(v.y), abs(v.z))
+}
+
+/// Exercise the authoring pipeline: add a primitive, apply a fillet, save,
+/// reload — confirming round-trip authoring through the kernel.
+@MainActor private func authorSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "author")
+    guard m.usesDocumentTree else { emit("[VCAD_AUTHOR] load failed"); return }
+    let parts0 = m.featureNodes.count
+    emit("[VCAD_AUTHOR] loaded \(parts0) part(s)")
+
+    m.addPrimitive(.cylinder)
+    _ = m.reevalDocumentMeshes()
+    emit("[VCAD_AUTHOR] +cylinder → \(m.featureNodes.count) parts · tris \(m.triangleCount)")
+
+    m.selectedFeatureID = m.featureNodes.first?.id
+    m.applyModifierToSelected(.fillet)
+    _ = m.reevalDocumentMeshes()
+    let rootOp = m.selectedFeatureNode?.opType ?? "?"
+    emit("[VCAD_AUTHOR] fillet part 0 → root op now '\(rootOp)' · tris \(m.triangleCount)")
+
+    m.multiSelectedParts = [0, 1]
+    m.combineSelected(.difference)
+    _ = m.reevalDocumentMeshes()
+    emit("[VCAD_AUTHOR] subtract parts 0,1 → \(m.featureNodes.count) part(s), root op '\(m.featureNodes.first?.opType ?? "?")' · tris \(m.triangleCount)")
+
+    let out = URL(fileURLWithPath: "/tmp/vcad_authored.vcad")
+    m.saveDocumentAs(out)
+    let reloaded = DocumentGraph.load(path: out.path)
+    emit("[VCAD_AUTHOR] saved + reloaded: \(reloaded?.visibleRoots.count ?? -1) part(s), parses=\(reloaded != nil)")
 }
 
 final class AppDelegate: NSObject, NSApplicationDelegate {

--- a/apple/VcadApp/bundle.sh
+++ b/apple/VcadApp/bundle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Assemble a runnable vcad.app from the SwiftPM build. RealityKit's Metal view
+# renders black from a bare executable; it needs a real .app bundle (Info.plist +
+# ad-hoc codesign) to get a working drawable. Run this, then `open dist/vcad.app`.
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+
+echo "swift build…"
+swift build --package-path "$here" -c "${CONFIG:-debug}"
+bin="$(swift build --package-path "$here" -c "${CONFIG:-debug}" --show-bin-path)/VcadApp"
+
+app="$here/dist/vcad.app"
+rm -rf "$app"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+cp "$bin" "$app/Contents/MacOS/vcad"
+
+cat > "$app/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key><string>vcad</string>
+  <key>CFBundleDisplayName</key><string>vcad</string>
+  <key>CFBundleIdentifier</key><string>io.vcad.m0</string>
+  <key>CFBundleExecutable</key><string>vcad</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>0.1</string>
+  <key>LSMinimumSystemVersion</key><string>15.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+  <key>NSPrincipalClass</key><string>NSApplication</string>
+  <key>LSApplicationCategoryType</key><string>public.app-category.graphics-design</string>
+</dict>
+</plist>
+PLIST
+
+codesign --force --deep --sign - "$app" >/dev/null 2>&1 || echo "(codesign skipped)"
+echo "built: $app"


### PR DESCRIPTION
Turns the native macOS app (`apple/VcadApp`) from a read-only `.vcad` viewer into a working parametric editor with award-grade chrome and feel. Builds entirely on top of the existing kernel — the kernel stays a pure `JSON → meshes` evaluator, so editing is just mutating the document JSON in Swift and re-evaluating. **No new FFI surface.**

14 logical commits (`f76cf20f`→`40d651bd`), each self-contained and building.

## What changed

**Feature tree** — parse the `.vcad` DAG in Swift (`Document.swift`) into a real hierarchical, typed feature tree (per-op icons, parameter summaries, expand/collapse) replacing the flat "Part N" list. Per-part visibility (eye / isolate), selection ↔ viewport, context menu, rich inspector.

**Editing & authoring** — inline drag-to-scrub *and* type-to-edit parameters; rename; delete; undo/redo (JSON snapshots); add primitives; fillet/chamfer; boolean Union/Subtract/Intersect (⌘-click two parts → Combine tab); Save / Save As; STL export (Swift-side binary STL). Live in-place re-eval keeps scrubbing smooth.

**Sketch mode v0** — Create → Sketch: draw a Line/Rectangle/Circle profile on an XY/XZ/YZ plane, then Extrude to a solid. Emits real `Sketch2D` + `Extrude` IR with a live preview overlay (segments, rubber-band, cursor landing-dot, x/y readout, snap-to-close).

**Real materials** (`Materials.swift`) — ports the web app's 33-preset PBR table. Parts render their actual material (doc-def → preset → fallback), with a swatch + grouped picker in the inspector; assignment persists through save/reload. Glass renders translucent.

**Chrome** — centered identity + live status strip, presence (share + avatar), bottom AI composer with a `+`, "Untitled" default, footer tool shelf (⌘T toggles a Borland-style header).

**Feel** — inertial orbit (flick → coast → decay) + a unified `Motion` vocabulary; triangle-precise hover/pick (Möller–Trumbore) with a subtle hover glow; a full 3D transform gizmo (cylinder/cone axis arrows, plane squares, rotate rings) that translates and rotates **about the part's center**, with hover-brighten + cursor.

**Premium studio** — richer 2K procedural IBL (soft ceiling + horizon + softbox highlights so metals catch moving reflections) and a pooled contact shadow under the part.

## Reviewer notes

- **Run it via the bundle, not the raw binary.** `cd apple/VcadApp && ./bundle.sh` then run `dist/vcad.app/Contents/MacOS/vcad` (optionally `VCAD_OPEN=path/to.vcad`). RealityKit's Metal view renders black from a bare SwiftPM binary; it needs a real `.app` bundle. The `Libs/` static lib (~140MB, gitignored) comes from `build-ffi.sh`.
- **`Package.swift`** now resolves the FFI lib dir from `#filePath`, so it's worktree-proof (was pinned to a since-deleted worktree).
- **Headless smoke hooks** verify the risky geometry/JSON logic without the GUI (stderr, exit 0): `VCAD_DUMP_TREE`, `VCAD_EDIT_SMOKE`, `VCAD_AUTHOR_SMOKE`, `VCAD_SKETCH_SMOKE`, `VCAD_MAT_SMOKE`, `VCAD_GIZMO_SMOKE`. e.g. the gizmo smoke confirms a 90° rotation swaps the plate's footprint and holds its center.
- All gizmo drag math is kernel-space ray geometry (closest-point-on-line, ray∩plane, ray∩ring→atan2) — no screen-projection fudge.
- Known gaps (called out, not regressions): **assemblies** (part_defs/instances/joints) still don't render — `vcad_scene_from_json` returns null for them (kernel/FFI limitation); gizmo **always-on-top** is approximated by long arms (true fix = a 2nd overlaid RealityView); sketch **constraints/arcs** and **revolve/sweep/loft** are deferred.
- No changelog entry — this is the experimental native shell, not vcad.io product behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)