### PR TITLE
feat(mcp): enrich unconnected pins with severity + datasheet app-notes

### DIFF
--- a/changelog/entries/2026-06-25-unconnected-pin-app-notes.json
+++ b/changelog/entries/2026-06-25-unconnected-pin-app-notes.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-25-unconnected-pin-app-notes",
+  "version": "0.9.4",
+  "date": "2026-06-25",
+  "category": "feat",
+  "title": "Unconnected pins carry datasheet app-notes",
+  "summary": "create_schematic now reports each unconnected pin with its name, a severity, and the datasheet application notes that reference it (e.g. NE555 CTRL bypass) for parts in the database.",
+  "features": ["schematic", "ecad", "parts-database", "pcb"],
+  "mcpTools": ["create_schematic"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -29,6 +29,8 @@ import {
   aggregateDrc,
   parseNetPair,
   boardFromSolid,
+  appNotesForPin,
+  unconnectedPinSeverity,
 } from "../tools/ecad.js";
 import { documents, getSession, openDocument } from "../tools/session.js";
 import { openInBrowser } from "../tools/share.js";
@@ -82,11 +84,87 @@ describe("ecad session flow", () => {
     expect(created.document_id).toBeTruthy();
     expect(created.document).toBeUndefined();
     expect(created.nets.MID.sort()).toEqual(["R1.2", "R2.1"]);
-    // Pins not in any net are reported immediately.
-    expect(created.unconnected_pins.sort()).toEqual(["R1.1", "R2.2"]);
+    // Pins not in any net are reported immediately, enriched with name + severity.
+    expect(
+      created.unconnected_pins.map((p: { ref: string }) => p.ref).sort(),
+    ).toEqual(["R1.1", "R2.2"]);
+    expect(
+      created.unconnected_pins.every(
+        (p: { severity: string; pin_type: string }) =>
+          p.severity === "info" && p.pin_type === "Passive",
+      ),
+    ).toBe(true);
 
     const doc = getSession(created.document_id);
     expect(doc.schematic?.nets).toEqual({ MID: ["R1.2", "R2.1"] });
+  });
+
+  it("enriches unconnected pins on a known part with severity and datasheet app-notes", async () => {
+    const created = out(
+      await createSchematic({
+        // NE555 resolves its 8 pins from the parts database; wire only the
+        // supply rails so CTRL/RESET/etc. stay open and get flagged.
+        components: [{ ref: "U1", part: "NE555", footprint: "DIP-8", x: 0, y: 0 }],
+        nets: { GND: ["U1.1"], VCC: ["U1.8"] },
+      }),
+    );
+    expect(created.success).toBe(true);
+    const byRef: Record<
+      string,
+      { pin_name: string; pin_type: string; severity: string; app_notes?: string[] }
+    > = Object.fromEntries(
+      (created.unconnected_pins as Array<{ ref: string }>).map((p) => [
+        (p as { ref: string }).ref,
+        p,
+      ]),
+    );
+
+    // CTRL (pin 5, Passive) → info, carrying its own bypass note.
+    expect(byRef["U1.5"]).toMatchObject({
+      pin_name: "CTRL",
+      pin_type: "Passive",
+      severity: "info",
+    });
+    expect((byRef["U1.5"].app_notes ?? []).join(" ")).toContain("CTRL");
+
+    // RESET (pin 4, Input) → warning, with its own note and NOT CTRL's.
+    expect(byRef["U1.4"]).toMatchObject({ pin_name: "RESET", severity: "warning" });
+    const resetNotes = (byRef["U1.4"].app_notes ?? []).join(" ");
+    expect(resetNotes).toContain("RESET");
+    expect(resetNotes).not.toContain("CTRL");
+
+    // Wired supply pins are not reported at all.
+    expect(byRef["U1.1"]).toBeUndefined();
+    expect(byRef["U1.8"]).toBeUndefined();
+  });
+
+  it("appNotesForPin matches by pin number, name token, and skips power rails", () => {
+    const ne555 = [
+      "Pin 5 (CTRL) is commonly bypassed to GND with a 10nF cap when unused.",
+      "Tie RESET (pin 4) to VCC when the reset function is not needed.",
+    ];
+    // By number ("pin 5") and by name token ("CTRL") — same single note.
+    expect(appNotesForPin(ne555, { number: "5", name: "CTRL" })).toEqual([ne555[0]]);
+    expect(appNotesForPin(ne555, { number: "4", name: "RESET" })).toEqual([ne555[1]]);
+    // GND (pin 1) is named incidentally in note 0 but is a rail → no match.
+    expect(appNotesForPin(ne555, { number: "1", name: "GND" })).toEqual([]);
+    // VCC (pin 8) likewise appears in note 1 but is a rail → no match.
+    expect(appNotesForPin(ne555, { number: "8", name: "VCC" })).toEqual([]);
+    // Compound names split on "/" and overline markers are stripped.
+    expect(
+      appNotesForPin(["PB5 doubles as ~RESET; keep it high for normal operation."], {
+        number: "1",
+        name: "PB5/~RESET",
+      }),
+    ).toHaveLength(1);
+  });
+
+  it("unconnectedPinSeverity warns on floating inputs and power, else info", () => {
+    expect(unconnectedPinSeverity("PowerInput")).toBe("warning");
+    expect(unconnectedPinSeverity("Input")).toBe("warning");
+    expect(unconnectedPinSeverity("Passive")).toBe("info");
+    expect(unconnectedPinSeverity("Output")).toBe("info");
+    expect(unconnectedPinSeverity("OpenCollector")).toBe("info");
   });
 
   it("place → route → drc → gerber all work against the session id", async () => {

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -1138,6 +1138,77 @@ function coilWireLengthMm(turns: number, innerR: number, outerR: number): number
 // Tool implementations
 // ============================================================================
 
+/** A pin with no net, enriched with handling guidance from the parts database. */
+export interface UnconnectedPin {
+  /** `${ref}.${number}` — the pin reference (e.g. "U1.5"). */
+  ref: string;
+  /** Pin name from the resolved part (e.g. "CTRL"); "~" when unnamed. */
+  pin_name: string;
+  /** Electrical pin type (PinType variant, e.g. "Input", "PowerInput"). */
+  pin_type: string;
+  /** How much leaving this pin open should worry the caller. */
+  severity: "info" | "warning";
+  /** Datasheet application notes that reference this specific pin, if any. */
+  app_notes?: string[];
+}
+
+/**
+ * Severity of leaving a pin of the given type unconnected. A floating signal
+ * input or an unconnected power input is usually a real mistake (a chip with no
+ * supply, or a logic input left to drift), so those are warnings; spare
+ * outputs, passives, and open-collector pins are informational.
+ */
+export function unconnectedPinSeverity(pinType: string): "info" | "warning" {
+  return pinType === "PowerInput" || pinType === "Input" ? "warning" : "info";
+}
+
+/**
+ * Power/ground rail names that appear incidentally in application-note prose
+ * ("bypass to GND", "decouple VCC") and would otherwise over-match. An
+ * unconnected rail pin is already surfaced by its `warning` severity, so prose
+ * matching doesn't need to flag it too.
+ */
+const RAIL_PIN_NAMES = new Set([
+  "GND",
+  "VCC",
+  "VDD",
+  "VSS",
+  "VEE",
+  "AVCC",
+  "AVDD",
+  "AGND",
+  "DGND",
+  "VDDIO",
+]);
+
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Select the application notes that refer to a specific pin. A note matches when
+ * it cites the pin by number ("pin 5", "pad 4") or names one of the pin's name
+ * tokens — compound names like "PB5/~RESET" are split and overline markers
+ * (`~`, `!`, `#`) dropped, so a note mentioning just "PB5" or "RESET" still
+ * matches. Common power/ground rails are excluded from name matching.
+ */
+export function appNotesForPin(
+  notes: string[],
+  pin: { number: string; name: string },
+): string[] {
+  const numRe = new RegExp(
+    `\\b(?:pin|pins|pad|pads)\\s*${escapeRegExp(pin.number)}\\b`,
+    "i",
+  );
+  const nameRes = (pin.name || "")
+    .split(/[\s/,]+/)
+    .map((t) => t.replace(/[~!#]/g, "").trim())
+    .filter((t) => t.length >= 2 && !RAIL_PIN_NAMES.has(t.toUpperCase()))
+    .map((t) => new RegExp(`\\b${escapeRegExp(t)}\\b`, "i"));
+  return notes.filter((n) => numRe.test(n) || nameRes.some((re) => re.test(n)));
+}
+
 /** Create a schematic from component, wire, and netlist definitions. */
 export async function createSchematic(args: Record<string, unknown>) {
   const title = (args.title as string) || undefined;
@@ -1320,13 +1391,31 @@ export async function createSchematic(args: Record<string, unknown>) {
   for (const [name, pins] of derived.nets) netsPreview[name] = pins;
 
   const connectedPins = new Set(derived.netByPin.keys());
-  const unconnected: string[] = [];
+  // Datasheet app-notes by ref, so an unconnected pin on a known part can carry
+  // the relevant handling guidance instead of a bare reference.
+  const appNotesByRef = new Map<string, string[]>();
+  for (const rp of resolvedParts) {
+    if (rp.app_notes && rp.app_notes.length > 0) {
+      appNotesByRef.set(rp.ref, rp.app_notes);
+    }
+  }
+  const unconnected: UnconnectedPin[] = [];
   for (const comp of components) {
+    const partNotes = appNotesByRef.get(comp.ref);
     for (const pin of comp.pins) {
       if (pin.pin_type === "NotConnected") continue;
-      if (!connectedPins.has(pinKey(comp.ref, pin.number))) {
-        unconnected.push(`${comp.ref}.${pin.number}`);
+      if (connectedPins.has(pinKey(comp.ref, pin.number))) continue;
+      const entry: UnconnectedPin = {
+        ref: `${comp.ref}.${pin.number}`,
+        pin_name: pin.name,
+        pin_type: pin.pin_type,
+        severity: unconnectedPinSeverity(pin.pin_type),
+      };
+      if (partNotes) {
+        const hints = appNotesForPin(partNotes, pin);
+        if (hints.length > 0) entry.app_notes = hints;
       }
+      unconnected.push(entry);
     }
   }
 


### PR DESCRIPTION
## What

`create_schematic` reported unconnected pins as bare strings, leaving the caller (especially an LLM agent) to independently know that pin 5 on an NE555 is `CTRL` and how to handle it. Each entry is now an object carrying the pin name, an electrical-type-derived **severity**, and the datasheet **application notes** that reference that specific pin.

```jsonc
// before
"unconnected_pins": ["U1.5"]

// after
"unconnected_pins": [
  { "ref": "U1.5", "pin_name": "CTRL", "pin_type": "Passive", "severity": "info",
    "app_notes": ["Pin 5 (CTRL) is commonly bypassed to GND with a 10nF cap when unused."] }
]
```

This builds on the jellybean parts database (#334), turning a diagnostic flag into actionable guidance.

## Why

The bare reference put all the domain knowledge on the caller. Severity + the relevant datasheet note let an agent triage and fix unconnected pins without a round-trip to the datasheet.

## How it works

- **Severity** is derived from pin type: floating `PowerInput`/`Input` → `warning` (no supply / drifting logic input), everything else → `info`. This works for *every* part — DB-resolved or not — so there's standalone value even when no app-notes exist.
- **App-note matching** (`appNotesForPin`) attaches a part's notes to a pin when the note cites it by number (`pin 5`, `pad 4`) or by a name token. Compound names like `PB5/~RESET` are split and overline markers (`~`/`!`/`#`) stripped, so prose using just `PB5` or `RESET` matches. Power rails (GND/VCC/…) are excluded from name-matching — they appear incidentally in prose ("bypass to GND") and already get a `warning` severity.
- **Unknown parts** fall back to `ref` + `severity` with no notes.

## Reviewer notes

- **Faithful to the data, not the original mock.** The proposal imagined per-pin `note` + `suggested_connection` objects. The DB actually stores **part-level prose `app_notes`**, so this surfaces the matched prose rather than fabricating structured fields. The matcher was designed against the real 21-part corpus (precision/recall checked per part).
- **Intentional breaking change:** `unconnected_pins` is now `object[]`, not `string[]` (the proposal acknowledged this). Confirmed the changed line is the only producer/consumer of the field — nothing downstream expects strings.
- `run_erc` remains a separate unconnected-pin surface and is untouched.

## Testing

- Full MCP suite: **317 passed / 2 skipped**, including an NE555 end-to-end test through real WASM (CTRL → info + its note, RESET → warning + its own note, not CTRL's) and deterministic unit tests for the matcher + severity mapping.
- `tsc --noEmit` clean; changelog builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)