### PR TITLE
perf(mcp): one live 3D viewport instead of one per tool call

### DIFF
--- a/changelog/entries/2026-06-25-live-viewport-single-canvas.json
+++ b/changelog/entries/2026-06-25-live-viewport-single-canvas.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-06-25-live-viewport-single-canvas",
+  "version": "0.9.4",
+  "date": "2026-06-25",
+  "category": "perf",
+  "title": "One live 3D viewport instead of one per tool call",
+  "summary": "The inline 3D viewer now mounts once per session and self-refreshes as the model edits, so long conversations stay light instead of stacking a heavy iframe on every mutation.",
+  "features": ["mcp", "viewer", "performance", "mcp-apps"],
+  "mcpTools": ["render_view"]
+}

--- a/packages/mcp/src/__tests__/viewer-meta.test.ts
+++ b/packages/mcp/src/__tests__/viewer-meta.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * Locks in the viewer `_meta` split (the "one live canvas, not 100 iframes"
+ * fix): only MOUNT tools carry the UI template; data tools return
+ * structuredContent (document_id + document_version) and no template, so the
+ * host never spawns a fresh iframe per mutation. App-only fetchers stay hidden
+ * from the model. Drives the real ListTools/CallTool handlers end-to-end.
+ */
+
+const VIEWER_URI = "ui://vcad/viewer";
+
+interface ToolMeta {
+  ui?: { resourceUri?: string; visibility?: string[] };
+  "openai/outputTemplate"?: string;
+  "openai/widgetAccessible"?: boolean;
+}
+interface ToolDesc {
+  name: string;
+  _meta?: ToolMeta;
+}
+
+async function connect(engine: Engine) {
+  const server = await createServer(engine, { user: null });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function hasTemplate(m: ToolMeta | undefined): boolean {
+  return Boolean(m?.ui?.resourceUri || m?.["openai/outputTemplate"]);
+}
+
+describe("viewer _meta split (one canvas, not one iframe per call)", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  it("mounts the template ONLY on session openers, not on data tools", async () => {
+    documents.clear();
+    const { client, server } = await connect(engine);
+    const { tools } = (await client.listTools()) as { tools: ToolDesc[] };
+    const by = (n: string) => tools.find((t) => t.name === n);
+
+    // Mount tools: carry the UI template in both dialects.
+    for (const name of ["open_document", "place_components", "build_receipt"]) {
+      const m = by(name)?._meta;
+      expect(m?.ui?.resourceUri, `${name} ui.resourceUri`).toBe(VIEWER_URI);
+      expect(m?.["openai/outputTemplate"], `${name} outputTemplate`).toBeTruthy();
+    }
+
+    // Data tools (frequent mutators): NO template — the canvas self-refreshes.
+    for (const name of ["place_part", "route_nets", "add_via"]) {
+      expect(hasTemplate(by(name)?._meta), `${name} must not mount`).toBe(false);
+    }
+
+    await client.close();
+    await server.close();
+  });
+
+  it("keeps preview fetchers app-only (hidden from the model, no template)", async () => {
+    documents.clear();
+    const { client, server } = await connect(engine);
+    const { tools } = (await client.listTools()) as { tools: ToolDesc[] };
+    const by = (n: string) => tools.find((t) => t.name === n);
+
+    for (const name of ["get_preview_glb", "get_preview_version"]) {
+      const m = by(name)?._meta;
+      expect(by(name), `${name} exists`).toBeDefined();
+      expect(m?.ui?.visibility, `${name} app-only`).toEqual(["app"]);
+      expect(m?.["openai/widgetAccessible"], `${name} widgetAccessible`).toBe(true);
+      expect(hasTemplate(m), `${name} carries no template`).toBe(false);
+    }
+
+    // Widget-callable readers stay reachable from the iframe but don't mount.
+    const getDoc = by("get_document")?._meta;
+    expect(getDoc?.["openai/widgetAccessible"]).toBe(true);
+    expect(hasTemplate(getDoc)).toBe(false);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("data-tool results carry a document_version token for self-refresh", async () => {
+    documents.clear();
+    const { client, server } = await connect(engine);
+
+    const open = await client.callTool({ name: "open_document", arguments: {} });
+    const sc = (open as { structuredContent?: Record<string, unknown> })
+      .structuredContent;
+    expect(typeof sc?.document_id).toBe("string");
+    expect(typeof sc?.document_version).toBe("string");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("empty doc: preview is a soft no-geometry result, not an error, and still has a version", async () => {
+    documents.clear();
+    const { client, server } = await connect(engine);
+    const open = await client.callTool({ name: "open_document", arguments: {} });
+    const docId = (open as { structuredContent?: Record<string, unknown> })
+      .structuredContent?.document_id as string;
+
+    // Soft: the poll loop relies on this NOT throwing for a freshly-opened
+    // empty document (the build-after-open flow), so it doesn't inflate errors.
+    const glb = await client.callTool({
+      name: "get_preview_glb",
+      arguments: { document_id: docId },
+    });
+    expect(glb.isError ?? false).toBe(false);
+    const glbText = (glb as { content: Array<{ type: string; text: string }> })
+      .content[0].text;
+    expect(JSON.parse(glbText)._vcad_glb).toBeNull();
+
+    // A version token exists even with no geometry, so a later build flips it.
+    const ver = await client.callTool({
+      name: "get_preview_version",
+      arguments: { document_id: docId },
+    });
+    const verText = (ver as { content: Array<{ type: string; text: string }> })
+      .content[0].text;
+    expect(typeof JSON.parse(verText).version).toBe("string");
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/notify.ts
+++ b/packages/mcp/src/notify.ts
@@ -79,6 +79,12 @@ export function fireToolAlert(
   args: Record<string, unknown>,
   result: { isError?: boolean },
 ): void {
+  // The viewer polls get_preview_version on a timer to self-refresh; counting
+  // it would swamp PostHog/Discord with non-user traffic. get_preview_glb is
+  // kept — it now fires ~once per real geometry change, which is exactly the
+  // signal for "is the live canvas working" / measuring the iframe-spam fix.
+  if (name === "get_preview_version") return;
+
   // PostHog telemetry is gated independently of the Discord webhook below.
   captureToolCall(name, args, result);
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -218,7 +218,13 @@ import {
   sheetMetalNest,
   sheetMetalNestSchema,
 } from "./tools/sheet-metal.js";
-import { getPreviewGlb, getPreviewGlbSchema } from "./tools/preview.js";
+import {
+  getPreviewGlb,
+  getPreviewGlbSchema,
+  getPreviewVersion,
+  getPreviewVersionSchema,
+  previewVersion,
+} from "./tools/preview.js";
 import {
   getViewerHtml,
   VIEWER_RESOURCE_URI,
@@ -424,6 +430,81 @@ const UI_META = {
 const WIDGET_CALLABLE_META = {
   "openai/widgetAccessible": true,
 };
+
+/**
+ * Tools that MOUNT the live 3D canvas — i.e. carry the UI template
+ * (`ui.resourceUri` / `openai/outputTemplate`). Per the MCP Apps spec
+ * (SEP-1865), the template is static and should be referenced by a SMALL
+ * set of tools, not attached to every result: "If you attach a widget
+ * template to every tool call, [the host] can re-render your iframe too
+ * often." So only the tools that BEGIN a viewable session reference it.
+ *
+ * Everything else (create/update/delete, route/add_*, place_part, …) is a
+ * data tool: it returns `structuredContent` ({document_id, document_version,
+ * changed}) and NO template, so it never spawns a fresh iframe. The canvas
+ * mounted here stays live by polling `get_preview_version` and re-fetching
+ * geometry only when the version changes — one durable surface across a long
+ * session instead of one heavy iframe per mutation.
+ */
+const MOUNT_TOOLS = new Set<string>([
+  // CAD session openers
+  "open_document",
+  "create_cad_loon",
+  "import_step",
+  "load_document",
+  "continue_document",
+  // PCB: place_components creates the first board geometry (create_schematic
+  // has none yet, so it must NOT mount — the canvas would fetch an empty board)
+  "place_components",
+  // Sheet metal: the part, and the flat-pattern drawing
+  "sheet_metal_create",
+  "sheet_metal_unfold",
+  // Verification ledger artifact
+  "build_receipt",
+]);
+
+/** Tools the viewer iframe calls itself but that must NOT mount a template:
+ *  readers reached over the postMessage bridge (deep-link IR fetch, ledger
+ *  re-run). They keep `widgetAccessible` so ChatGPT permits the call. */
+const WIDGET_CALLABLE_TOOLS = new Set<string>(["get_document", "verify_receipt"]);
+
+/** App-only geometry/version fetchers the viewer polls. Hidden from the model
+ *  (`visibility: ["app"]`); never carry a template (they return data the
+ *  iframe consumes, not a surface to render). */
+const PREVIEW_FETCH_TOOLS = new Set<string>([
+  "get_preview_glb",
+  "get_preview_version",
+]);
+
+/**
+ * Single source of truth for viewer `_meta` across the whole tool list.
+ * Applied once to the assembled ListTools array so a new tool can never
+ * accidentally inherit the template — it has to opt into MOUNT_TOOLS. Strips
+ * any stray template meta off data tools.
+ */
+function applyViewerMeta<T extends { name: string; _meta?: Record<string, unknown> }>(
+  tools: T[],
+): T[] {
+  return tools.map((t) => {
+    if (PREVIEW_FETCH_TOOLS.has(t.name)) {
+      return { ...t, _meta: { ...WIDGET_CALLABLE_META, ui: { visibility: ["app"] } } };
+    }
+    if (MOUNT_TOOLS.has(t.name)) {
+      return { ...t, _meta: { ...UI_META } };
+    }
+    if (WIDGET_CALLABLE_TOOLS.has(t.name)) {
+      return { ...t, _meta: { ...WIDGET_CALLABLE_META } };
+    }
+    // Data tool: no viewer template. Drop any inherited _meta so it returns
+    // structuredContent only and the host never mounts a per-call iframe.
+    if (t._meta) {
+      const { _meta: _drop, ...rest } = t;
+      void _drop;
+      return rest as T;
+    }
+    return t;
+  });
+}
 
 /**
  * Domain tool packs. The surface is a small always-on core — the
@@ -702,14 +783,16 @@ export async function createServer(
 
   // List available tools
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: [
+    // Single chokepoint for viewer `_meta`: MOUNT_TOOLS get the template,
+    // everything else returns data only — so a long session is one live
+    // canvas, not one heavy iframe per tool call.
+    tools: applyViewerMeta([
       // ── Session lifecycle ──────────────────────────────────────
       {
         name: "open_document",
         description:
           "Open an editing session for a CAD document. Returns a `document_id` to pass to subsequent tool calls (create, update, place_part, inspect_cad, …). Pass an `initial` IR to begin editing an existing document; omit it for a fresh empty document.",
         inputSchema: openDocumentSchema,
-        _meta: UI_META,
       },
       {
         name: "get_document",
@@ -718,7 +801,6 @@ export async function createServer(
         inputSchema: getDocumentSchema,
         // Widget-callable: the viewer's "Open in vcad.io" button fetches
         // the IR through this tool to build the deep link.
-        _meta: { ...UI_META, ...WIDGET_CALLABLE_META },
       },
       {
         name: "close_document",
@@ -741,7 +823,6 @@ export async function createServer(
           "its new document_id. The cheap way to resume a board/part across runs " +
           "instead of rebuilding it.",
         inputSchema: loadDocumentSchema,
-        _meta: UI_META,
       },
       {
         name: "continue_document",
@@ -762,7 +843,6 @@ export async function createServer(
           idempotentHint: false,
           openWorldHint: true,
         },
-        _meta: UI_META,
       },
       {
         name: "server_info",
@@ -829,33 +909,35 @@ export async function createServer(
         description:
           "Insert a stdlib part into the session's document. Takes a `document_id`, a `path` (from `search_parts.id`), and an optional `params` map; missing params use declared defaults. The part remains parametric — end users can edit its params from the feature tree.",
         inputSchema: placePartSchema,
-        _meta: UI_META,
       },
       // ── Registry-driven kernel tools (auto-exposed) ───────────
       // The next block iterates `commandRegistry.toAnthropicTools()` so the
       // schema lives in one place — the kernel WASM. Same tools, same
       // behavior as the in-app chat surface; viewport-only tools (camera
       // and scene-evaluation tools) are filtered out via blocklists in
-      // tools/registry-dispatch.ts. All of them mutate a session document,
-      // so they all get the inline 3D viewer.
-      ...registryToolDescriptors().map((t) => ({ ...t, _meta: UI_META })),
-      // ── MCP Apps: app-only preview fetch ───────────────────────
-      // visibility: ["app"] — spec-compliant hosts hide this from the
-      // agent's tool list; only the viewer iframe calls it (via
-      // app.callServerTool). Keeps multi-hundred-KB GLB payloads out of
-      // model-visible tool results.
+      // tools/registry-dispatch.ts. They are DATA tools: each mutates a
+      // session document and returns structuredContent (document_id +
+      // document_version + changed), but carries no UI template — the live
+      // canvas self-refreshes from the version token. (applyViewerMeta is the
+      // single place that decides viewer `_meta`.)
+      ...registryToolDescriptors(),
+      // ── MCP Apps: app-only preview fetch + version poll ────────
+      // visibility: ["app"] (set by applyViewerMeta) — spec-compliant hosts
+      // hide these from the agent's tool list; only the viewer iframe calls
+      // them (via app.callServerTool). Keeps multi-hundred-KB GLB payloads
+      // out of model-visible tool results, and lets the canvas poll a cheap
+      // change token to self-refresh without re-evaluating geometry.
       {
         name: "get_preview_glb",
         description:
           "Return a base64 GLB preview of an open session document. Internal to the inline 3D viewer — agents should use `export_cad` for geometry exports.",
         inputSchema: getPreviewGlbSchema,
-        _meta: {
-          ui: {
-            resourceUri: VIEWER_RESOURCE_URI,
-            visibility: ["app"],
-          },
-          ...WIDGET_CALLABLE_META,
-        },
+      },
+      {
+        name: "get_preview_version",
+        description:
+          "Return a cheap {document_id, version} change token for an open session document (no geometry eval). Internal to the inline 3D viewer's self-refresh poll — agents should ignore it.",
+        inputSchema: getPreviewVersionSchema,
       },
       // ── Loon DSL one-shot ──────────────────────────────────────
       {
@@ -874,7 +956,6 @@ export async function createServer(
           "Let bindings: [let body [cube 50 30 5]]\n" +
           "Scene: [root solid \"material-name\"]",
         inputSchema: createCadLoonSchema,
-        _meta: UI_META,
       },
       {
         name: "export_cad",
@@ -931,7 +1012,6 @@ export async function createServer(
         description:
           "Apply an approved DFM fix to the session document. v1 supports `set_param` patches (raise a fillet radius, thicken a wall) — other kinds throw and require manual edits. Re-run `dfm_check` afterwards to confirm the issue cleared.",
         inputSchema: dfmApplyFixSchema,
-        _meta: UI_META,
       },
       // ── Sheet metal (AI-native manufacturability surface) ───────
       {
@@ -939,14 +1019,12 @@ export async function createServer(
         description:
           "Create a sheet-metal part: a rectangular or polygon base flange plus an ordered chain of edge flanges, hems, and jogs. Supports `shop_profile` (e.g. \"sendcutsend\") to resolve bend radii/K-factors from the fab's published catalog, and `bend_relief` to cut relief notches at bend ends. Returns a `document_id` (usable with sheet_metal_unfold/check, inspect_cad, export_cad, open_in_browser), the panel/bend model summary, flat bbox + area, and DFM violations.",
         inputSchema: sheetMetalCreateSchema,
-        _meta: UI_META,
       },
       {
         name: "sheet_metal_unfold",
         description:
           "Return the flat pattern (panel outlines, holes, creases, area, bbox) for a sheet-metal session document, plus a fab-ready merged single-silhouette DXF (millimetres): one closed exterior polyline + holes on CUT, DASHED bend centerlines on BEND_UP/BEND_DOWN. DXF carries no bend angles (entered in the fab's UI); for zero data entry export the folded body as STEP via export_cad instead.",
         inputSchema: sheetMetalUnfoldSchema,
-        _meta: UI_META,
       },
       {
         name: "sheet_metal_check",
@@ -996,7 +1074,6 @@ export async function createServer(
           "Import geometry from a STEP file (.step or .stp). Returns an IR document with ImportedMesh nodes. " +
           "Supports AP203/AP214 STEP files commonly exported from Fusion 360, SolidWorks, Onshape, etc.",
         inputSchema: importStepSchema,
-        _meta: UI_META,
       },
       {
         name: "open_in_browser",
@@ -1167,7 +1244,6 @@ export async function createServer(
           "for coil interconnect, buses, and hand-routes that route_nets " +
           "(pad-driven) won't make. Mutates the session document.",
         inputSchema: addTraceSchema,
-        _meta: UI_META,
       },
       {
         name: "add_via",
@@ -1176,7 +1252,6 @@ export async function createServer(
           "FCu→BCu, diameter/drill from design rules). Pairs with add_trace " +
           "for multi-layer routing. Mutates the session document.",
         inputSchema: addViaSchema,
-        _meta: UI_META,
       },
       {
         name: "set_stackup",
@@ -1198,7 +1273,6 @@ export async function createServer(
           "`placement_drc` (same shape as place_components) so a move can be " +
           "re-checked in one call without running run_drc.",
         inputSchema: setPlacementSchema,
-        _meta: UI_META,
       },
       {
         name: "add_zone",
@@ -1208,7 +1282,6 @@ export async function createServer(
           "voids); or give an explicit polygon for a partial plane. Mutates the " +
           "session document.",
         inputSchema: addZoneSchema,
-        _meta: UI_META,
       },
       {
         name: "set_design_rules",
@@ -1236,7 +1309,6 @@ export async function createServer(
           "Grid vias are clipped to the board outline by default. Mutates the " +
           "session document.",
         inputSchema: addViaArraySchema,
-        _meta: UI_META,
       },
       {
         name: "add_motor_winding",
@@ -1247,7 +1319,6 @@ export async function createServer(
           "termination as a net-tie — closing the winding_layout plan into " +
           "actual copper. Mutates the session document.",
         inputSchema: addMotorWindingSchema,
-        _meta: UI_META,
       },
       {
         name: "calc_motor",
@@ -1318,7 +1389,6 @@ export async function createServer(
           "provenance — a durable proof that round-trips and re-verifies later as " +
           "Holds / Stale / Violated. Renders as an audit ledger in the inline viewer.",
         inputSchema: buildReceiptSchema,
-        _meta: UI_META,
       },
       {
         name: "verify_receipt",
@@ -1327,7 +1397,6 @@ export async function createServer(
           "board and return the verdict — Holds (same board, clean), Stale (board " +
           "changed), or Violated. Powers the ledger's Re-run button.",
         inputSchema: verifyReceiptSchema,
-        _meta: { ...UI_META, ...WIDGET_CALLABLE_META },
       },
       {
         name: "route_diff_pair",
@@ -1416,7 +1485,7 @@ export async function createServer(
           "The RF/AC analyzer (calc_impedance is geometry-only). Pure.",
         inputSchema: calcRfSchema,
       },
-    ].filter((t) => !disabledTools.has(t.name)),
+    ].filter((t) => !disabledTools.has(t.name))),
   }));
 
   // ── MCP Apps: List UI resources ──────────────────────────────
@@ -1592,6 +1661,13 @@ export async function createServer(
 
         case "get_preview_glb":
           result = await getPreviewGlb(getSession(String(args.document_id ?? "")), engine);
+          break;
+
+        case "get_preview_version":
+          result = getPreviewVersion(
+            getSession(String(args.document_id ?? "")),
+            String(args.document_id ?? ""),
+          );
           break;
 
         case "create_cad_loon":
@@ -2080,10 +2156,20 @@ function attachPreviewHandle(
   docId: string,
   toolName?: string,
 ): void {
-  result.structuredContent = {
+  const structured: Record<string, unknown> = {
     ...result.structuredContent,
     document_id: docId,
   };
+  // Cheap, geometry-free change token (FNV-1a over the IR). The live canvas
+  // polls `get_preview_version` and re-fetches the GLB only when this flips —
+  // so a mutation needn't carry a UI template (no per-call iframe), the one
+  // mounted canvas just notices the change and updates itself.
+  try {
+    structured.document_version = previewVersion(getSession(docId));
+  } catch {
+    // session not resolvable here — the id alone is enough for the viewer
+  }
+  result.structuredContent = structured;
   if (toolName && PURE_JSON_RESULT_TOOLS.has(toolName)) return;
   const mentioned = result.content.some(
     (c) => c.type === "text" && c.text.includes(docId),

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -137,9 +137,71 @@ export async function getPreviewGlb(
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
   const glbBase64 = await generateGlbPreview(doc, engine);
   if (!glbBase64) {
-    throw new Error("document produced no previewable geometry");
+    // No previewable geometry yet (e.g. a freshly opened empty document the
+    // agent is about to build into). Return a soft signal, not an error — the
+    // viewer shows "no geometry" and the self-refresh poll just waits for the
+    // next change, and routine empty previews don't inflate the tool error rate.
+    return {
+      content: [{ type: "text", text: JSON.stringify({ _vcad_glb: null }) }],
+    };
   }
   return {
-    content: [{ type: "text", text: JSON.stringify({ _vcad_glb: glbBase64 }) }],
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ _vcad_glb: glbBase64, version: previewVersion(doc) }),
+      },
+    ],
+  };
+}
+
+/**
+ * A cheap, geometry-free change token for a document. FNV-1a over the IR
+ * JSON — no kernel evaluation, no tessellation — so the inline viewer can
+ * poll it on a timer to learn "did the document change?" without paying for
+ * a full GLB rebuild every tick. Stable across server instances because it
+ * hashes the (hydrated) IR, not in-process state.
+ */
+export function previewVersion(doc: Document): string {
+  const s = JSON.stringify(doc);
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/** Schema for the app-only `get_preview_version` tool. */
+export const getPreviewVersionSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description: "Session id of the document to version-check.",
+    },
+  },
+  required: ["document_id"],
+};
+
+/**
+ * Tool handler for `get_preview_version`: returns a cheap `{document_id,
+ * version}` change token (no geometry eval). The inline viewer polls this
+ * to self-refresh — it only re-fetches the heavy GLB when `version` changes.
+ *
+ * Like `get_preview_glb`, this is internal to the viewer (`visibility:
+ * ["app"]`) and excluded from usage telemetry so polling can't flood it.
+ */
+export function getPreviewVersion(
+  doc: Document,
+  docId: string,
+): { content: Array<{ type: "text"; text: string }> } {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({ document_id: docId, version: previewVersion(doc) }),
+      },
+    ],
   };
 }

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -805,6 +805,44 @@ function findDocumentId(result: ToolResultLike): string | null {
   return null;
 }
 
+/** Pull the cheap `version` change token out of a preview result, if any. */
+function findPreviewVersion(result: ToolResultLike): string | null {
+  for (const block of result.content ?? []) {
+    if (block?.type !== "text" || !block.text) continue;
+    try {
+      const parsed = JSON.parse(block.text) as { version?: unknown };
+      if (typeof parsed.version === "string") return parsed.version;
+    } catch {
+      // Not JSON — skip
+    }
+  }
+  return null;
+}
+
+/**
+ * Fetch a document's GLB via the app-only preview tool and render it in
+ * place. Records the version token so the self-refresh poll knows the
+ * current state and only re-fetches when it actually changes. Shared by the
+ * tool-result handler (mount tools) and the poll loop (data-tool mutations).
+ */
+async function fetchAndRenderGlb(
+  docId: string,
+  changed: PartsChanged | null,
+): Promise<void> {
+  const previewResult = (await app.callServerTool({
+    name: "get_preview_glb",
+    arguments: { document_id: docId },
+  })) as ToolResultLike;
+  const glb = findInlineGlb(previewResult);
+  if (!glb) {
+    setStatus("no geometry to preview", "idle");
+    return;
+  }
+  const ver = findPreviewVersion(previewResult);
+  if (ver) lastPreviewVersion = ver;
+  renderGlbForDoc(glb, docId, changed);
+}
+
 /** Capture VCode IR text for the "Open in vcad.io" button. */
 function captureVcode(result: ToolResultLike): void {
   for (const block of result.content ?? []) {
@@ -1121,7 +1159,10 @@ const app = isOpenAiHost()
   ? (createOpenAiShim() as unknown as App)
   : new App(
       { name: "vcad-viewer", version: "2.1.0" },
-      { availableDisplayModes: ["inline", "fullscreen"] },
+      // Declare pip so a host can DOCK the live canvas as a persistent side
+      // panel that updates across the conversation, rather than scrolling
+      // inline. (Capability only — the host/user chooses when to dock.)
+      { availableDisplayModes: ["inline", "pip", "fullscreen"] },
     );
 
 function applyHostContext(ctx: McpUiHostContext | undefined): void {
@@ -1211,16 +1252,7 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
   if (sameDoc) setTicker("updating…", "busy");
   else setStatus("fetching geometry…");
   try {
-    const previewResult = (await app.callServerTool({
-      name: "get_preview_glb",
-      arguments: { document_id: docId },
-    })) as ToolResultLike;
-    const glb = findInlineGlb(previewResult);
-    if (glb) {
-      renderGlbForDoc(glb, docId, changed);
-    } else {
-      setStatus("no geometry to preview", "idle");
-    }
+    await fetchAndRenderGlb(docId, changed);
   } catch (e) {
     console.error("[vcad-viewer] preview fetch failed:", e);
     setStatus("preview unavailable", "error");
@@ -1231,6 +1263,9 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
 // ── "Open in vcad.io" deep link ──────────────────────────────
 let vcodeDoc: string | null = null;
 let lastDocumentId: string | null = null;
+// Last geometry version this canvas has rendered — the self-refresh poll
+// re-fetches only when the server reports a different token (see below).
+let lastPreviewVersion: string | null = null;
 
 openBtn.addEventListener("click", async () => {
   let doc = vcodeDoc;
@@ -1269,6 +1304,94 @@ fullscreenBtn.addEventListener("click", async () => {
     console.warn("[vcad-viewer] display mode change failed:", e);
   }
 });
+
+// ── Auto-dock: pin the canvas as a persistent side panel ─────────────
+// When the host supports pip, dock the freshly-mounted canvas once so it
+// stays visible and updates live as the agent works — instead of scrolling
+// away inline. Capability-guarded + best-effort + one-shot, so hosts without
+// pip (and a user who later un-docks) just stay where they are.
+let autoDocked = false;
+
+async function maybeAutoDock(): Promise<void> {
+  if (autoDocked) return;
+  const modes = app.getHostContext()?.availableDisplayModes ?? [];
+  if (!modes.includes("pip") || currentDisplayMode !== "inline") return;
+  autoDocked = true;
+  try {
+    const result = await app.requestDisplayMode({ mode: "pip" });
+    currentDisplayMode = result.mode;
+  } catch (e) {
+    console.warn("[vcad-viewer] auto-dock (pip) failed:", e);
+  }
+}
+
+// ── Self-refresh: poll a cheap version token, re-fetch on change ─────
+// Data tools (create/update/route/add_*/…) no longer carry a UI template,
+// so the host doesn't push their results to this iframe. Instead the one
+// mounted canvas polls get_preview_version — a geometry-free change token —
+// and re-fetches the GLB only when the document actually changed. Net: one
+// live surface across a long session instead of an iframe per mutation.
+//
+// Cadence is brisk while the document is changing and backs off when idle, so
+// a quiet session isn't a steady drip of calls; it snaps back to brisk on any
+// change or when the tab regains focus.
+const POLL_FAST_MS = 2500;
+const POLL_SLOW_MS = 10000;
+const POLL_IDLE_THRESHOLD = 8; // ~20s with no change → back off
+let pollIdleStreak = 0;
+let pollHandle: ReturnType<typeof setTimeout> | undefined;
+
+async function pollPreviewVersion(): Promise<void> {
+  if (!lastDocumentId) return;
+  if (typeof document !== "undefined" && document.hidden) return;
+  let ver: string | null = null;
+  try {
+    const res = (await app.callServerTool({
+      name: "get_preview_version",
+      arguments: { document_id: lastDocumentId },
+    })) as ToolResultLike;
+    ver = findPreviewVersion(res);
+  } catch {
+    return; // transient poll/network failure — next tick retries
+  }
+  // Refresh on ANY change from what's on screen — including geometry first
+  // appearing in a document that was empty when the canvas mounted (no
+  // baseline guard, or that build would never show).
+  if (!ver || ver === lastPreviewVersion) return;
+  // Record first so a failed/empty render doesn't re-trigger every tick.
+  lastPreviewVersion = ver;
+  setTicker("updating…", "busy");
+  try {
+    await fetchAndRenderGlb(lastDocumentId, null);
+  } catch {
+    // Empty doc or transient fetch failure — version already advanced.
+  }
+}
+
+function scheduleNextPoll(): void {
+  const delay = pollIdleStreak >= POLL_IDLE_THRESHOLD ? POLL_SLOW_MS : POLL_FAST_MS;
+  pollHandle = setTimeout(() => void runPoll(), delay);
+}
+
+async function runPoll(): Promise<void> {
+  const before = lastPreviewVersion;
+  await pollPreviewVersion();
+  pollIdleStreak = lastPreviewVersion !== before ? 0 : pollIdleStreak + 1;
+  scheduleNextPoll();
+}
+
+function startPreviewPolling(): void {
+  // Returning to the tab → back to brisk and check immediately.
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) return;
+      pollIdleStreak = 0;
+      if (pollHandle) clearTimeout(pollHandle);
+      void runPoll();
+    });
+  }
+  scheduleNextPoll();
+}
 
 // ── Dev harness ──────────────────────────────────────────────
 // `#dev` renders sample geometry without an MCP host so the rig
@@ -1385,4 +1508,9 @@ if (location.hash.startsWith("#dev")) {
     "[vcad-viewer] connected to host; capabilities:",
     JSON.stringify(app.getHostCapabilities() ?? {}),
   );
+  // Keep the one mounted canvas live as the agent mutates the document.
+  startPreviewPolling();
+  // Dock as a side panel when the host supports it, so it persists and
+  // updates across the conversation rather than scrolling away.
+  void maybeAutoDock();
 }

--- a/packages/mcp/viewer-app/openai-shim.ts
+++ b/packages/mcp/viewer-app/openai-shim.ts
@@ -93,7 +93,9 @@ export function createOpenAiShim() {
       return {
         theme: oai.theme === "light" ? "light" : "dark",
         displayMode: oai.displayMode ?? "inline",
-        availableDisplayModes: ["inline", "fullscreen"],
+        // ChatGPT supports pip — advertise it so the canvas can auto-dock as a
+        // persistent side panel that updates across the conversation.
+        availableDisplayModes: ["inline", "pip", "fullscreen"],
       };
     },
 


### PR DESCRIPTION
## Problem

The inline 3D viewer attached the UI template (`ui.resourceUri` / `openai/outputTemplate`) to **~70 tools** (`uiTools = GEOMETRY_TOOLS ∪ dispatchableTools`, plus `registryToolDescriptors().map(t => ({...t, _meta: UI_META}))`). Hosts treat each template-bearing result as a widget, so a long session could spawn **a fresh Three.js iframe per mutation** — 100 edits → 100 heavy iframes, which taxes the host on large projects.

This is exactly the anti-pattern the MCP Apps spec (SEP-1865) names: *"If you attach a widget template to every tool call, [the host] re-renders your iframe too often."*

## Fix: the template/data split

One live canvas, not one iframe per call.

- **`applyViewerMeta()` is the single source of truth** for viewer `_meta`, applied once over the whole tool list. All per-descriptor `_meta` was removed — a tool now must *opt in* via `MOUNT_TOOLS`, so a new mutator can't accidentally mount.
  - `MOUNT_TOOLS` (session openers only) carry the template and mount the canvas once.
  - Data tools (create/update/delete, route/add_*, place_part, …) return `structuredContent` (`document_id` + `document_version` + `changed`) and **no template**.
  - Preview fetchers stay app-only (`ui.visibility:["app"]` + `widgetAccessible`); `get_document`/`verify_receipt` stay widget-callable without mounting.
- **Self-refresh, not re-mount.** New app-only `get_preview_version` returns a cheap FNV-1a hash of the IR (no geometry eval). The one mounted canvas polls it and re-fetches the GLB only when it changes — with idle backoff (2.5s → 10s) and reset-to-brisk on tab focus.
- **Auto-dock to PiP** when the host advertises it (incl. the ChatGPT shim), so the canvas pins as a persistent side panel that updates across the conversation.

## Reviewer notes / behavior changes

- **`render_view` is intentionally NOT a mount tool** — its PNG is the model's vision input; cloaking it behind a widget would blind the agent. The live canvas stays current via the poll instead.
- **`get_preview_glb` no longer throws on an empty document** — it returns a soft `{_vcad_glb:null}`. This keeps the open-empty-then-build flow working and keeps routine empty previews out of the error rate. (No test depended on the throw.)
- **Telemetry** now skips only the high-frequency `get_preview_version` poll; `get_preview_glb` stays counted (it fires ~once per real geometry change — the signal for measuring this fix in PostHog).
- New tool `get_preview_version` is internal to the viewer (app-only); agents should ignore it.

## Verification

- `npm run typecheck` clean (viewer + live bundles build, server `tsc --noEmit` clean); targeted `tsc` over `viewer-app` clean for the changed lines.
- **326 mcp tests pass** — adds `viewer-meta.test.ts`, which drives the real ListTools/CallTool through an in-memory client and locks the split (openers mount, `place_part`/`route_nets`/`add_via` don't, fetchers app-only, results carry `document_version`, empty-doc preview is soft).

## Deferred (not in this PR)

- Server-side `previewVersion` cache to skip the DB hydrate on cold-instance polls (backoff already cuts most of that traffic).
- Flashing `changed` parts on a poll-driven refresh (the poll knows *that* it changed, not *which* parts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)