### PR TITLE
fix(pcb): never show an empty preview when the board solid fails to eval

### DIFF
--- a/changelog/entries/2026-06-26-pcb-preview-eval-fallback.json
+++ b/changelog/entries/2026-06-26-pcb-preview-eval-fallback.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-06-26-pcb-preview-eval-fallback",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "fix",
+  "title": "PCB preview never shows an empty viewport",
+  "summary": "The inline 3D viewer now renders the board from PCB data (outline, footprints, pads) independent of the BRep solid, so a placed board always previews even when its canonical solid fails to evaluate.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "place_components"
+  ]
+}

--- a/packages/mcp/src/__tests__/pcb-preview.test.ts
+++ b/packages/mcp/src/__tests__/pcb-preview.test.ts
@@ -117,4 +117,36 @@ describe("PCB GLB preview", () => {
     const colors = gltf.materials.map((m) => m.pbrMetallicRoughness?.baseColorFactor);
     expect(colors.some((c) => near(c, [0.010, 0.060, 0.024]))).toBe(true);
   });
+
+  it("still previews a board when the BRep scene eval throws", async () => {
+    // The board's layered preview is built from the PCB data, not the BRep
+    // boolean pipeline — so a session whose canonical solid fails to evaluate
+    // (degenerate outline, kernel error) must still render the board instead
+    // of showing the viewer an empty grid.
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 40, board_height: 40 }));
+
+    // Stand in a kernel that throws on evaluate to simulate a failing solid.
+    const throwingEngine = {
+      evaluate() {
+        throw new Error("simulated kernel eval failure");
+      },
+    } as unknown as Engine;
+
+    const b64 = await generateGlbPreview(getSession(id), throwingEngine);
+    expect(b64).toBeTruthy();
+    const gltf = parseGlbJson(b64!);
+    expect(gltf.meshes.length).toBeGreaterThan(0);
+    // Soldermask color present → the real board layers rendered, not nothing.
+    const colors = gltf.materials.map((m) => m.pbrMetallicRoughness?.baseColorFactor);
+    expect(colors.some((c) => near(c, [0.010, 0.060, 0.024]))).toBe(true);
+    // Part identity preserved for click-to-select.
+    expect(gltf.nodes.some((n) => (n.name ?? "").includes("PCB Board"))).toBe(true);
+  });
 });

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -24,59 +24,65 @@ import {
 
 /**
  * Generate a base64-encoded GLB preview from an IR document.
- * Returns null if the document cannot be evaluated or has no geometry.
+ * Returns null only when the document has no previewable geometry at all.
+ *
+ * Board roots are rendered from the layered PCB preview meshes, which are
+ * built straight from the PCB data (outline + footprints + pads) and never
+ * touch the BRep boolean pipeline. We build them *before* and independent of
+ * the scene eval, so a PCB session always previews — even when the canonical
+ * board solid fails to evaluate (e.g. a degenerate `board_from_solid` outline)
+ * or `engine.evaluate` throws outright. Otherwise such a session showed the
+ * viewer an empty grid despite having a fully-placed board.
  */
 export async function generateGlbPreview(
   doc: Document,
   engine: Engine,
 ): Promise<string | null> {
+  // Part-identity node names let the viewer map a click back to a part_id
+  // for selection context and "ask about this part".
+  const labels = buildPartLabels(doc);
+  // `scene.parts` is index-aligned with the visible roots.
+  const visibleRoots = doc.roots.filter((r) => r.visible !== false);
+
+  const meshes: GlbMesh[] = [];
+  // Roots already rendered from the PCB-data path — the scene loop skips them.
+  const handledBoards = new Set<number>();
+
+  for (let i = 0; i < visibleRoots.length; i++) {
+    const rootId = visibleRoots[i].root;
+    const node = doc.nodes[String(rootId)];
+    if (node?.op?.type !== "PcbBoard") continue;
+    const pcb = getNodePcb(doc, rootId);
+    const preview = pcb ? await pcbPreviewMeshes(pcb) : [];
+    // Empty preview (older kernel WASM lacks the binding) — leave the board
+    // for the scene loop, which renders its neutral merged slab instead.
+    if (preview.length === 0) continue;
+    handledBoards.add(Number(rootId));
+    pushPcbPreview(meshes, labels[i] ?? `part_${i}`, preview);
+  }
+
+  // Non-board geometry (and any board whose preview meshes were unavailable)
+  // comes from the normal scene eval. Wrapped so a single failing board — or a
+  // hard eval throw — can't blank a preview the PCB-data path already filled.
   try {
     const scene = engine.evaluate(doc);
-    if (!scene || scene.parts.length === 0) return null;
-
-    // Part-identity node names let the viewer map a click back to a
-    // part_id for selection context and "ask about this part".
-    const labels = buildPartLabels(doc);
-    // `scene.parts` is index-aligned with the visible roots.
-    const visibleRoots = doc.roots.filter((r) => r.visible !== false);
-
-    const meshes: GlbMesh[] = [];
-    for (let i = 0; i < scene.parts.length; i++) {
-      const part = scene.parts[i];
-      const name = labels[i] ?? `part_${i}`;
+    for (let i = 0; i < (scene?.parts.length ?? 0); i++) {
       const rootId = visibleRoots[i]?.root;
+      if (rootId !== undefined && handledBoards.has(Number(rootId))) continue;
+
+      const part = scene!.parts[i];
+      const name = labels[i] ?? `part_${i}`;
       const node = rootId !== undefined ? doc.nodes[String(rootId)] : undefined;
 
-      // A board root: replace the merged gray slab with colored layers.
+      // Old-WASM fallback: a board with no preview meshes still renders as the
+      // neutral merged slab rather than being dropped.
       if (node?.op?.type === "PcbBoard" && rootId !== undefined) {
         const pcb = getNodePcb(doc, rootId);
         const preview = pcb ? await pcbPreviewMeshes(pcb) : [];
         if (preview.length > 0) {
-          for (const pm of preview) {
-            const emissive = pm.emissive ?? [0, 0, 0];
-            const glows = emissive[0] > 0 || emissive[1] > 0 || emissive[2] > 0;
-            meshes.push({
-              // Keep the board's part identity on every sub-mesh so a click
-              // anywhere on the board still resolves to the PCB part.
-              name,
-              positions: pm.positions,
-              indices: pm.indices,
-              normals: pm.normals,
-              color: pm.color,
-              metallic: pm.metalness,
-              roughness: pm.roughness,
-              emissive,
-              // Push LED lenses past white so they read as "on" under the
-              // viewer's bright studio IBL.
-              emissiveStrength: glows ? 3.0 : 1,
-              clearcoat: pm.clearcoat ?? 0,
-              clearcoatRoughness: pm.clearcoat_roughness ?? 0,
-            });
-          }
+          pushPcbPreview(meshes, name, preview);
           continue;
         }
-        // Preview meshes unavailable (e.g. older kernel WASM) — fall through
-        // to the neutral merged board rather than dropping it.
       }
 
       meshes.push({
@@ -89,11 +95,44 @@ export async function generateGlbPreview(
         roughness: DEFAULT_MATERIAL.roughness,
       });
     }
-
-    return uint8ArrayToBase64(buildGlb(meshes, "preview"));
   } catch {
-    // Evaluation failures should not break tool responses
-    return null;
+    // Evaluation failures should not break the preview — PCB sessions still
+    // render from the board path above; a non-PCB doc that can't evaluate
+    // falls through to the empty-geometry signal below.
+  }
+
+  if (meshes.length === 0) return null;
+  return uint8ArrayToBase64(buildGlb(meshes, "preview"));
+}
+
+/**
+ * Push a board's layered preview meshes onto `meshes`, all carrying the
+ * board's part-identity `name` so a click anywhere on the board resolves to
+ * the PCB part.
+ */
+function pushPcbPreview(
+  meshes: GlbMesh[],
+  name: string,
+  preview: Awaited<ReturnType<typeof pcbPreviewMeshes>>,
+): void {
+  for (const pm of preview) {
+    const emissive = pm.emissive ?? [0, 0, 0];
+    const glows = emissive[0] > 0 || emissive[1] > 0 || emissive[2] > 0;
+    meshes.push({
+      name,
+      positions: pm.positions,
+      indices: pm.indices,
+      normals: pm.normals,
+      color: pm.color,
+      metallic: pm.metalness,
+      roughness: pm.roughness,
+      emissive,
+      // Push LED lenses past white so they read as "on" under the viewer's
+      // bright studio IBL.
+      emissiveStrength: glows ? 3.0 : 1,
+      clearcoat: pm.clearcoat ?? 0,
+      clearcoatRoughness: pm.clearcoat_roughness ?? 0,
+    });
   }
 }
 


### PR DESCRIPTION
## What

A `place_components` widget rendered as an empty 3D grid ("no geometry to preview") even though the board was fully placed:

<img width="600" alt="empty widget" src="https://github.com/user-attachments/assets/placeholder" />

The inline viewer built the PCB board **inside** the BRep scene-eval loop in `generateGlbPreview`. So when `engine.evaluate(doc)` threw — a degenerate `board_from_solid` outline, a kernel boolean failure, etc. — the whole function hit `catch → return null` and the viewer fell back to its dead empty-state grid, despite the board's full PCB data (outline, footprints, pads) being present in the document.

A normal rectangular board previews fine (verified live). The empty case is specifically a board whose *canonical solid* fails while its *data* is intact.

## Fix

The layered PCB preview (`pcbPreviewMeshes`) is built straight from the PCB data and never touches the BRep boolean pipeline. So board rendering is now **decoupled from** the scene eval:

1. Render every `PcbBoard` root from `pcbPreviewMeshes` first, independent of eval.
2. Run `engine.evaluate` (wrapped) only for the remaining non-board parts, skipping already-handled boards.
3. A hard eval throw can no longer blank a preview the board path already filled.

Old-WASM merged-slab fallback and click-to-select part identity are preserved; shared mesh construction is factored into `pushPcbPreview`.

Net: **a placed board always previews**, even when its solid can't evaluate.

## Testing

- New regression test: a stub engine that throws on `evaluate` still yields a board GLB with the real soldermask layers + `PCB Board` part identity (parses the actual GLB bytes).
- All 352 MCP tests pass; `@vcad/mcp` builds clean (tsc + vite).
- Changelog entry added and validated.

## Note for reviewers

This covers the eval-failure path, the most likely cause. If a specific outline also makes `pcbPreviewMeshes` itself return empty, that's a separate kernel-side bug in `vcad-eval`'s `pcb_preview`, not preview wiring. The viewer's empty-state overlay is intentionally left as-is — it's still the right state for a genuinely empty document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)