### PR TITLE
fix(pcb): clamp auto-placed parts by courtyard so large edge parts stay on-board

### DIFF
--- a/changelog/entries/2026-06-26-place-components-extent-clamp.json
+++ b/changelog/entries/2026-06-26-place-components-extent-clamp.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-06-26-place-components-extent-clamp",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "fix",
+  "title": "Auto-placement keeps large edge parts fully on-board",
+  "summary": "force_directed placement now clamps each component's full courtyard inside the board (not just its center), so big edge parts like an LQFP-64 no longer hang half off the board and overlap neighbors.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "place_components"
+  ]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -993,6 +993,96 @@ describe("ecad session flow", () => {
     expect(d).toBeGreaterThan(8);
   });
 
+  it("force_directed keeps large edge components fully on-board (extent-aware clamp)", async () => {
+    // Cram nine LQFP-64 (~12mm body, ~6mm half-extent) onto a board too small to
+    // space them at their courtyard radius. Repulsion slams the perimeter parts
+    // hard against the placement clamp. The old clamp pinned each *center* to the
+    // raw bounds, so an edge part's 6mm body hung ~half off the board (and over
+    // its neighbor) — many DRC round-trips. The fix insets the clamp by each
+    // part's half-extent, so the whole courtyard stays on the board.
+    const lqfp = (ref: string) => ({
+      ref,
+      value: "MCU",
+      footprint: "Package_QFP:LQFP-64_10x10mm_P0.5mm",
+      x: 0,
+      y: 0,
+      // The parametric engine builds all 64 pads from the footprint id; a few
+      // pins are enough to declare the part.
+      pins: [1, 2, 3, 4].map((n) => ({ number: String(n), name: String(n), type: "Passive" })),
+    });
+    const W = 30;
+    const H = 30;
+    const created = out(
+      await createSchematic({
+        components: ["U1", "U2", "U3", "U4", "U5", "U6", "U7", "U8", "U9"].map(lqfp),
+      }),
+    );
+    const id = created.document_id;
+    out(
+      await placeComponents({
+        document_id: id,
+        board_width: W,
+        board_height: H,
+        strategy: "force_directed",
+      }),
+    );
+    const board = getPcbBoard(getSession(id));
+
+    /** Absolute copper bounding box of a placed footprint (pad land extents). */
+    const padHalf = (shape: { type: string } & Record<string, number>): number =>
+      shape.type === "Circle"
+        ? shape.diameter / 2
+        : shape.type === "Rect" || shape.type === "Oval" || shape.type === "RoundRect"
+          ? Math.max(shape.width, shape.height) / 2
+          : 0.5;
+    const bbox = (fp: (typeof board.footprints)[number]) => {
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      for (const p of fp.pads) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const h = padHalf(p.shape as any);
+        minX = Math.min(minX, fp.position.x + p.position.x - h);
+        minY = Math.min(minY, fp.position.y + p.position.y - h);
+        maxX = Math.max(maxX, fp.position.x + p.position.x + h);
+        maxY = Math.max(maxY, fp.position.y + p.position.y + h);
+      }
+      return { minX, minY, maxX, maxY };
+    };
+
+    // Every part's full courtyard lands inside the (0,0)→(W,H) outline. The 0.01mm
+    // tolerance absorbs the footprint-build position rounding.
+    const eps = 0.02;
+    for (const fp of board.footprints) {
+      const b = bbox(fp);
+      expect(b.minX).toBeGreaterThanOrEqual(-eps);
+      expect(b.minY).toBeGreaterThanOrEqual(-eps);
+      expect(b.maxX).toBeLessThanOrEqual(W + eps);
+      expect(b.maxY).toBeLessThanOrEqual(H + eps);
+    }
+  });
+
+  it("placement_drc flags an off-board part as clean:false so the agent can branch", async () => {
+    // After placement, a part shoved past the outline must flip placement_drc to
+    // clean:false (with its ref in off_board) — the cheap pre-routing signal an
+    // agent branches on before route_nets, instead of discovering it at run_drc.
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 40, board_height: 40 }));
+    const board = getPcbBoard(getSession(id));
+    // On-board placement is clean.
+    expect((await summarizePlacementDrc(board)).clean).toBe(true);
+    // Push R2 off the outline → clean:false, R2 reported off_board.
+    board.footprints.find((f) => f.ref === "R2")!.position = { x: 80, y: 80 };
+    const drc = await summarizePlacementDrc(board);
+    expect(drc.clean).toBe(false);
+    expect(drc.off_board).toContain("R2");
+    expect(drc.off_board).not.toContain("R1");
+  });
+
   it("force_directed never bakes a cross-net pad short into the board", async () => {
     // A tightly-netted NE555-style cluster: the net-attraction can pull
     // different-net pads on top of each other (a VCC/GND short) before any

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -1644,8 +1644,25 @@ function forceDirectedRefine(
     }
 
     for (let i = 0; i < positions.length; i++) {
-      positions[i].x = Math.min(bounds.maxX, Math.max(bounds.minX, positions[i].x + forces[i].x));
-      positions[i].y = Math.min(bounds.maxY, Math.max(bounds.minY, positions[i].y + forces[i].y));
+      // Clamp the component's *courtyard* inside the board, not just its center:
+      // inset each axis by the component's half-extent (reusing the size-aware
+      // `extents` the repulsion pass above already computes) so a large part —
+      // e.g. an LQFP-64 — pushed against an edge lands fully on-board instead of
+      // hanging half off and overlapping its neighbors. If a part is wider than
+      // the available inset span (range inverts), fall back to the plain bounds
+      // clamp — the cross-net legalizer below handles and reports the genuinely
+      // too-tight board rather than stacking every part on the midpoint.
+      const ext = extents[i];
+      const loX = bounds.minX + ext;
+      const hiX = bounds.maxX - ext;
+      const loY = bounds.minY + ext;
+      const hiY = bounds.maxY - ext;
+      const nx = positions[i].x + forces[i].x;
+      const ny = positions[i].y + forces[i].y;
+      positions[i].x =
+        hiX >= loX ? Math.min(hiX, Math.max(loX, nx)) : Math.min(bounds.maxX, Math.max(bounds.minX, nx));
+      positions[i].y =
+        hiY >= loY ? Math.min(hiY, Math.max(loY, ny)) : Math.min(bounds.maxY, Math.max(bounds.minY, ny));
     }
   }
 }


### PR DESCRIPTION
## What

`force_directed` auto-placement clamped each component's **center** to the raw
board bounds, even though the repulsion pass just above already computes
size-aware `extents[]` per component. So a part pushed against an edge — e.g. an
LQFP-64 — hung half off the board and overlapped its neighbors, costing many DRC
round-trips before an agent noticed.

The per-iteration clamp in `forceDirectedRefine` now insets each axis by the
part's half-extent (`[minX + extents[i], maxX - extents[i]]`, same for `y`),
reusing the already-computed `extents`, so the **whole courtyard** lands on the
board. When a part is wider than the inset span (range inverts), it falls back to
the original plain-bounds clamp — leaving the cross-net legalizer to handle and
report a genuinely too-tight board, rather than stacking every part on the
midpoint (a subtle break I hit and fixed mid-change).

`placement_drc` already reports `clean: false` whenever a footprint is off-board
or two courtyards overlap (`summarizePlacementDrc`), so an agent can branch and
fix placement before `route_nets`. No change needed there — now covered by an
explicit test.

## Why

Edge parts hanging off-board produced avoidable DRC failures that an agent had to
discover at `run_drc` and unwind. Keeping the courtyard on-board at placement
time removes that round-trip.

## Tests

- **`force_directed keeps large edge components fully on-board`** — crams nine
  LQFP-64 onto a 30×30 board so repulsion jams the perimeter parts into the
  clamp, then asserts every footprint's full pad bounding box lands inside the
  outline. Verified it's a real regression guard: with the old clamp a part's
  edge reached 32.75 mm on a 30 mm board (test fails); with the fix it's
  on-board.
- **`placement_drc flags an off-board part as clean:false`** — clean before, then
  shoves a part past the outline and asserts `clean: false` with the ref in
  `off_board`.

## Verification

- `npm run build --workspaces` ✓
- `npm test --workspaces` ✓ (mcp 354 passed / 2 skipped; all other workspaces green)
- `tsc --noEmit` clean

Changelog: `fix` entry added.
