### PR TITLE
feat(mcp): happy-path next_actions on success + order-tolerant set_design_rules

### DIFF
--- a/changelog/entries/2026-06-26-pcb-happy-path-next-actions.json
+++ b/changelog/entries/2026-06-26-pcb-happy-path-next-actions.json
@@ -1,0 +1,18 @@
+{
+  "id": "2026-06-26-pcb-happy-path-next-actions",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "feat",
+  "title": "PCB tools suggest the next step on success",
+  "summary": "MCP tool results now carry happy-path next_actions on success (create_schematic → place_components/run_erc, place_components → set_design_rules, route_nets → run_drc/render_pcb), and set_design_rules buffers rules set before the board exists instead of dead-ending.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "create_schematic",
+    "place_components",
+    "set_design_rules",
+    "route_nets"
+  ]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -3319,3 +3319,80 @@ describe("new PCB tools survive the kernel pipeline", () => {
     expect(gerber.files.length).toBeGreaterThan(0);
   });
 });
+
+describe("set_design_rules ordering tolerance (buffering)", () => {
+  const powerSchematic = () =>
+    createSchematic({
+      components: [
+        {
+          ref: "J1",
+          value: "PWR",
+          footprint: "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm",
+          x: 0,
+          y: 0,
+          pins: [
+            { number: "1", name: "V", type: "Passive" },
+            { number: "2", name: "G", type: "Passive" },
+          ],
+        },
+        resistor("R1", 15),
+        resistor("R2", 30),
+      ],
+      nets: { VBAT: ["J1.1", "R1.1"], SIG: ["R1.2", "R2.1"] },
+    });
+
+  it("guides to place_components instead of dead-ending when there's no board yet", async () => {
+    const created = out(await powerSchematic());
+    const id = created.document_id;
+    // set_design_rules BEFORE the board exists used to fail with a bare error.
+    const res = await setDesignRules({ document_id: id, clearance: 0.3 });
+    expect(res.isError).toBeUndefined();
+    const body = out(res);
+    expect(body.success).toBe(true);
+    expect(body.buffered).toBe(true);
+    // It carries a recovery action pointing at the canonical next step.
+    expect(body.next_actions[0].tool).toBe("place_components");
+    expect(res.structuredContent?.next_actions?.[0].tool).toBe("place_components");
+  });
+
+  it("replays buffered rules onto the board when place_components runs", async () => {
+    const created = out(await powerSchematic());
+    const id = created.document_id;
+    // Rules first (no board), then place — the buffered rules must land.
+    out(
+      await setDesignRules({
+        document_id: id,
+        clearance: 0.35,
+        track_width: 0.3,
+        classes: [{ name: "power", nets: ["VBAT"], track_width: 1.5 }],
+      }),
+    );
+    const placed = out(await placeComponents({ document_id: id, board_width: 50, board_height: 40 }));
+    expect(placed.buffered_design_rules_applied).toBe(true);
+
+    const board = getPcbBoard(getSession(id));
+    expect(board.rules.defaultRules.clearance).toBeCloseTo(0.35, 5);
+    expect(board.rules.defaultRules.traceWidth).toBeCloseTo(0.3, 5);
+    expect((board.rules.classRules ?? []).map((c) => c.name)).toContain("power");
+    expect(board.rules.netClassAssignments?.power).toEqual(["VBAT"]);
+
+    // And the buffered rules actually drive routing — VBAT routes at its class width.
+    const routed = out(await routeNets({ document_id: id }));
+    expect(routed.success).toBe(true);
+    if (routed.track_widths_mm?.VBAT !== undefined) {
+      expect(routed.track_widths_mm.VBAT).toBeCloseTo(1.5, 1);
+    }
+  });
+
+  it("still fails fast on a malformed early call (no fields, or a class with no nets)", async () => {
+    const created = out(await powerSchematic());
+    const id = created.document_id;
+    const empty = await setDesignRules({ document_id: id });
+    expect(empty.isError).toBe(true);
+    const badClass = await setDesignRules({
+      document_id: id,
+      classes: [{ name: "power", nets: [] }],
+    });
+    expect(badClass.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/next-actions.test.ts
+++ b/packages/mcp/src/__tests__/next-actions.test.ts
@@ -3,6 +3,8 @@ import {
   suggestNextActions,
   buildErrorResult,
   enrichErrorResult,
+  enrichSuccessResult,
+  happyPathNext,
 } from "../tools/next-actions.js";
 
 describe("suggestNextActions", () => {
@@ -189,5 +191,94 @@ describe("enrichErrorResult (for tools that return isError instead of throwing)"
     const result = { content: [{ type: "text", text: "ok" }], isError: false };
     enrichErrorResult(result, "create", {});
     expect(result.content[0].text).toBe("ok");
+  });
+});
+
+describe("happyPathNext (canonical PCB flow on success)", () => {
+  it("steers create_schematic toward place_components, then run_erc", () => {
+    const next = happyPathNext("create_schematic", "d");
+    expect(next.map((a) => a.tool)).toEqual(["place_components", "run_erc"]);
+    expect(next.every((a) => a.args && a.args.document_id === "d")).toBe(true);
+  });
+
+  it("steers place_components toward set_design_rules", () => {
+    const next = happyPathNext("place_components", "d");
+    expect(next.map((a) => a.tool)).toEqual(["set_design_rules"]);
+  });
+
+  it("steers set_design_rules toward a save_document checkpoint before add_zone, then route_nets", () => {
+    const next = happyPathNext("set_design_rules", "d");
+    expect(next.map((a) => a.tool)).toEqual(["save_document", "route_nets"]);
+    // The checkpoint names add_zone so 'save before you pour' is explicit.
+    expect(next[0].action.toLowerCase()).toContain("add_zone");
+    expect(next[0].action.toLowerCase()).toContain("save_document");
+  });
+
+  it("steers route_nets toward run_drc + render_pcb (cross-check)", () => {
+    const next = happyPathNext("route_nets", "d");
+    expect(next.map((a) => a.tool)).toEqual(["run_drc", "render_pcb"]);
+  });
+
+  it("returns nothing for a tool that isn't on the PCB flow", () => {
+    expect(happyPathNext("export_cad", "d")).toEqual([]);
+  });
+
+  it("omits args when no document_id is known", () => {
+    const next = happyPathNext("place_components");
+    expect(next[0].tool).toBe("set_design_rules");
+    expect(next[0].args).toBeUndefined();
+  });
+});
+
+describe("enrichSuccessResult (happy-path actions on success)", () => {
+  it("injects next_actions INTO a JSON success body, keeping it parseable", () => {
+    const result = {
+      content: [
+        { type: "text", text: JSON.stringify({ success: true, document_id: "doc_1" }) },
+      ],
+      isError: false,
+    };
+    // create_schematic mints the id server-side, so it isn't in args — the id is
+    // recovered from the result body.
+    enrichSuccessResult(result, "create_schematic", {});
+    const parsed = JSON.parse(result.content[0].text) as {
+      success: boolean;
+      next_actions: Array<{ tool?: string; args?: { document_id?: string } }>;
+    };
+    expect(parsed.success).toBe(true);
+    expect(parsed.next_actions.map((a) => a.tool)).toEqual(["place_components", "run_erc"]);
+    expect(parsed.next_actions[0].args?.document_id).toBe("doc_1");
+    expect(
+      (result as { structuredContent?: { next_actions?: unknown[] } }).structuredContent
+        ?.next_actions,
+    ).toHaveLength(2);
+  });
+
+  it("is a no-op on an error result (that's enrichErrorResult's job)", () => {
+    const result = {
+      content: [{ type: "text", text: JSON.stringify({ error: "boom" }) }],
+      isError: true,
+    };
+    enrichSuccessResult(result, "route_nets", { document_id: "d" });
+    expect(JSON.parse(result.content[0].text).next_actions).toBeUndefined();
+  });
+
+  it("is a no-op for a tool that isn't on the PCB flow", () => {
+    const result = { content: [{ type: "text", text: JSON.stringify({ ok: 1 }) }], isError: false };
+    enrichSuccessResult(result, "inspect_cad", { document_id: "d" });
+    expect(JSON.parse(result.content[0].text).next_actions).toBeUndefined();
+    expect((result as { structuredContent?: unknown }).structuredContent).toBeUndefined();
+  });
+
+  it("is idempotent — a buffered set_design_rules keeps its own place_components hint", () => {
+    // A buffered set_design_rules already carries next_actions → place_components;
+    // the generic save_document/route_nets hint must NOT overwrite it.
+    const result = {
+      content: [{ type: "text", text: JSON.stringify({ buffered: true, document_id: "d" }) }],
+      structuredContent: { next_actions: [{ action: "run place_components", tool: "place_components" }] },
+      isError: false,
+    };
+    enrichSuccessResult(result, "set_design_rules", { document_id: "d" });
+    expect(result.structuredContent.next_actions.map((a) => a.tool)).toEqual(["place_components"]);
   });
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -103,7 +103,11 @@ import {
   registryDispatchableNames,
   dispatchRegistryTool,
 } from "./tools/registry-dispatch.js";
-import { buildErrorResult, enrichErrorResult } from "./tools/next-actions.js";
+import {
+  buildErrorResult,
+  enrichErrorResult,
+  enrichSuccessResult,
+} from "./tools/next-actions.js";
 // Re-exported so the Vercel entry point (services/mcp/entry.ts) serves the live
 // window through the same handler as the standalone server (http.ts).
 export { handleLiveRequest } from "./live-route.js";
@@ -2170,8 +2174,11 @@ export async function createServer(
 
       // Tools that RETURN {isError:true} (the ECAD / sheet-metal / DFM surface)
       // never reach the throw-catch below, so enrich them here — every failure
-      // carries next_actions, not just the ones that throw.
+      // carries next_actions, not just the ones that throw. Successes on the
+      // canonical PCB flow carry happy-path next_actions too, so the order of
+      // operations is discoverable without first tripping over an ordering error.
       if (result.isError) enrichErrorResult(result, name, args);
+      else enrichSuccessResult(result, name, args);
 
       // ── Persist ─────────────────────────────────────────────────────────
       // After a creator/mutator settles, write the (possibly newly-minted)

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -54,6 +54,7 @@ import {
 } from "@vcad/engine";
 import type { Engine, NetlistResult, TriangleMesh } from "@vcad/engine";
 import { registerSession, getSession } from "./session.js";
+import type { NextAction } from "./next-actions.js";
 import { sizePdnExact, ecadDiffEngineAvailable } from "../wasm/ecad-diff.js";
 
 /** Get PCB data from a document — checks PcbBoard nodes first, falls back to legacy doc.pcb */
@@ -61,6 +62,132 @@ function getDocPcb(doc: Document): Pcb | null {
   const nodeIds = getPcbNodeIds(doc);
   if (nodeIds.length > 0) return getNodePcb(doc, nodeIds[0]!);
   return (doc as Document & { pcb?: Pcb }).pcb ?? null;
+}
+
+/**
+ * Design-rule args supplied by set_design_rules *before* the board existed.
+ * Stashed on the in-memory document and replayed when place_components builds
+ * the board, so an agent can set rules in any order. An untyped extension (like
+ * the legacy `pcb?` field above) — it round-trips through JSON persistence but
+ * isn't part of the IR schema.
+ */
+type DocWithPendingRules = Document & {
+  __pendingDesignRules?: Record<string, unknown>;
+};
+
+/** The board's starting design rules — JLCPCB-ish 2-layer defaults. */
+function defaultDesignRules(): DesignRules {
+  return {
+    defaultRules: {
+      name: "Default",
+      traceWidth: 0.25,
+      clearance: 0.2,
+      viaDiameter: 0.8,
+      viaDrill: 0.4,
+    },
+    edgeClearance: 0.5,
+    holeToHole: 0.5,
+    minAnnularRing: 0.15,
+    minDrill: 0.2,
+  };
+}
+
+/** Strip the document handle from buffered args so we stash only the rules. */
+function stripDocArgs(args: Record<string, unknown>): Record<string, unknown> {
+  const rest: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(args)) {
+    if (k === "document" || k === "document_id") continue;
+    rest[k] = v;
+  }
+  return rest;
+}
+
+/**
+ * Apply set_design_rules-style args to a DesignRules object in place. Shared by
+ * set_design_rules (which writes pcb.rules directly) and place_components (which
+ * replays rules buffered before the board existed). Returns what changed plus
+ * any warnings; an `error` means the args were malformed (e.g. a class with no
+ * nets) and nothing meaningful should be persisted.
+ */
+function applyDesignRuleArgs(
+  rules: DesignRules,
+  knownNets: Set<string>,
+  args: Record<string, unknown>,
+  opts: { checkNets?: boolean } = {},
+): { touched: boolean; warnings: string[]; classNames?: string[]; error?: string } {
+  // When validating a call made before the board exists (the buffered probe),
+  // there's no netlist yet — skip the "net not on the board" warning so it
+  // doesn't fire spuriously on every buffered class.
+  const checkNets = opts.checkNets ?? true;
+  const dr = rules.defaultRules;
+  const warnings: string[] = [];
+  let touched = false;
+
+  const num = (k: string) => (typeof args[k] === "number" ? (args[k] as number) : undefined);
+  const requirePos = (k: string, v: number | undefined): boolean => {
+    if (v === undefined) return false;
+    if (!(v > 0)) {
+      warnings.push(`${k} must be > 0 — ignored`);
+      return false;
+    }
+    return true;
+  };
+
+  const clearance = num("clearance");
+  if (requirePos("clearance", clearance)) { dr.clearance = clearance!; touched = true; }
+  const trackWidth = num("track_width");
+  if (requirePos("track_width", trackWidth)) { dr.traceWidth = trackWidth!; touched = true; }
+  const viaDiameter = num("via_diameter");
+  if (requirePos("via_diameter", viaDiameter)) { dr.viaDiameter = viaDiameter!; touched = true; }
+  const viaDrill = num("via_drill");
+  if (requirePos("via_drill", viaDrill)) { dr.viaDrill = viaDrill!; touched = true; }
+  const dpg = num("diff_pair_gap");
+  if (requirePos("diff_pair_gap", dpg)) { dr.diffPairGap = dpg!; touched = true; }
+  const dpw = num("diff_pair_width");
+  if (requirePos("diff_pair_width", dpw)) { dr.diffPairWidth = dpw!; touched = true; }
+
+  const edgeClr = num("edge_clearance");
+  if (requirePos("edge_clearance", edgeClr)) { rules.edgeClearance = edgeClr!; touched = true; }
+  const h2h = num("hole_to_hole");
+  if (requirePos("hole_to_hole", h2h)) { rules.holeToHole = h2h!; touched = true; }
+  const minAnnular = num("min_annular_ring");
+  if (requirePos("min_annular_ring", minAnnular)) { rules.minAnnularRing = minAnnular!; touched = true; }
+  const minDrill = num("min_drill");
+  if (requirePos("min_drill", minDrill)) { rules.minDrill = minDrill!; touched = true; }
+
+  let classNames: string[] | undefined;
+  if (Array.isArray(args.classes)) {
+    const classesIn = args.classes as Array<Record<string, unknown>>;
+    const classRules: NetClassRules[] = [];
+    const assignments: Record<string, string[]> = {};
+    for (const c of classesIn) {
+      const name = String(c.name ?? "");
+      const nets = Array.isArray(c.nets) ? (c.nets as unknown[]).map(String) : [];
+      if (!name) return { touched, warnings, error: "each class needs a `name`" };
+      if (nets.length === 0)
+        return { touched, warnings, error: `class "${name}" needs a non-empty nets array` };
+      const unknown = checkNets ? nets.filter((id) => !knownNets.has(id)) : [];
+      if (unknown.length > 0) {
+        warnings.push(`class "${name}" references nets not on the board: ${unknown.join(", ")}`);
+      }
+      classRules.push({
+        name,
+        traceWidth: typeof c.track_width === "number" ? (c.track_width as number) : dr.traceWidth,
+        clearance: typeof c.clearance === "number" ? (c.clearance as number) : dr.clearance,
+        viaDiameter: typeof c.via_diameter === "number" ? (c.via_diameter as number) : dr.viaDiameter,
+        viaDrill: typeof c.via_drill === "number" ? (c.via_drill as number) : dr.viaDrill,
+        ...(typeof c.diff_pair_gap === "number" ? { diffPairGap: c.diff_pair_gap as number } : {}),
+        ...(typeof c.diff_pair_width === "number" ? { diffPairWidth: c.diff_pair_width as number } : {}),
+      });
+      assignments[name] = nets;
+    }
+    rules.classRules = classRules;
+    rules.netClassAssignments = assignments;
+    classNames = classRules.map((c) => c.name);
+    touched = true;
+  }
+
+  return { touched, warnings, classNames };
 }
 
 /** Standard `{ content, isError }` failure result for ECAD tools. */
@@ -1900,21 +2027,8 @@ export async function placeComponents(args: Record<string, unknown>) {
     ],
   };
 
-  const defaultRules: NetClassRules = {
-    name: "Default",
-    traceWidth: 0.25,
-    clearance: 0.2,
-    viaDiameter: 0.8,
-    viaDrill: 0.4,
-  };
-
-  const rules: DesignRules = {
-    defaultRules,
-    edgeClearance: 0.5,
-    holeToHole: 0.5,
-    minAnnularRing: 0.15,
-    minDrill: 0.2,
-  };
+  const rules: DesignRules = defaultDesignRules();
+  const defaultRules = rules.defaultRules;
 
   // Grid placement sized to the outline's bounding box: split the usable
   // area into cells so every component lands inside it regardless of size.
@@ -2187,6 +2301,23 @@ export async function placeComponents(args: Record<string, unknown>) {
     };
   });
 
+  // Replay any design rules the agent set before the board existed (buffered by
+  // set_design_rules). Applied here — once `nets` is populated — so net-class
+  // assignments validate against the real netlist. Malformed buffered args are
+  // surfaced as a warning rather than failing placement.
+  let bufferedRulesApplied = false;
+  const pending = (doc as DocWithPendingRules).__pendingDesignRules;
+  if (pending) {
+    const applied = applyDesignRuleArgs(rules, new Set(nets.map((nn) => nn.id)), pending);
+    if (applied.error) {
+      warnings.push(`buffered design rules ignored: ${applied.error}`);
+    } else {
+      bufferedRulesApplied = applied.touched;
+      warnings.push(...applied.warnings.map((w) => `design rule: ${w}`));
+    }
+    delete (doc as DocWithPendingRules).__pendingDesignRules;
+  }
+
   const pcb: Pcb = {
     outline,
     stackup,
@@ -2305,6 +2436,8 @@ export async function placeComponents(args: Record<string, unknown>) {
             ...(cutouts && cutouts.length > 0 ? { cutouts: cutouts.length } : {}),
           },
           ...(utilization ? { utilization } : {}),
+          // Design rules set before the board existed were replayed onto it.
+          ...(bufferedRulesApplied ? { buffered_design_rules_applied: true } : {}),
           nets: netsSummary,
           ...docResultPayload(ctx),
         }),
@@ -5905,85 +6038,55 @@ export function setDesignRules(args: Record<string, unknown>) {
     content: [{ type: "text" as const, text: `Error: ${text}` }],
     isError: true as const,
   });
+
+  // No board yet: don't dead-end. Validate the shape (so a class with no nets or
+  // an empty call still fails fast), then buffer the rules on the document and
+  // replay them when place_components builds the board. The agent can set rules
+  // in any order; the canonical next step (place_components) rides back as a
+  // next_action so it stays discoverable.
   if (!pcb) {
-    return fail(
-      "Document has no PCB — run place_components first (or open a document that has a board)",
-    );
+    const probe = applyDesignRuleArgs(defaultDesignRules(), new Set<string>(), args, {
+      checkNets: false,
+    });
+    if (probe.error) return fail(probe.error);
+    if (!probe.touched) {
+      return fail("provide at least one rule field (clearance, track_width, …) or `classes`");
+    }
+    (ctx.doc as DocWithPendingRules).__pendingDesignRules = stripDocArgs(args);
+    const next: NextAction[] = [
+      {
+        action:
+          "No board yet — these design rules are buffered and apply automatically when the board is built. Run place_components next.",
+        tool: "place_components",
+        ...(ctx.documentId ? { args: { document_id: ctx.documentId } } : {}),
+      },
+    ];
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: JSON.stringify({
+            success: true,
+            buffered: true,
+            ...(probe.classNames ? { classes: probe.classNames } : {}),
+            ...(probe.warnings.length > 0 ? { warnings: probe.warnings } : {}),
+            next_actions: next,
+            ...docResultPayload(ctx),
+          }),
+        },
+      ],
+      structuredContent: { next_actions: next },
+    };
   }
 
   const rules = pcb.rules;
-  const dr = rules.defaultRules;
-  const warnings: string[] = [];
-  let touched = false;
-
-  const num = (k: string) => (typeof args[k] === "number" ? (args[k] as number) : undefined);
-  const requirePos = (k: string, v: number | undefined): boolean => {
-    if (v === undefined) return false;
-    if (!(v > 0)) {
-      warnings.push(`${k} must be > 0 — ignored`);
-      return false;
-    }
-    return true;
-  };
-
-  const clearance = num("clearance");
-  if (requirePos("clearance", clearance)) { dr.clearance = clearance!; touched = true; }
-  const trackWidth = num("track_width");
-  if (requirePos("track_width", trackWidth)) { dr.traceWidth = trackWidth!; touched = true; }
-  const viaDiameter = num("via_diameter");
-  if (requirePos("via_diameter", viaDiameter)) { dr.viaDiameter = viaDiameter!; touched = true; }
-  const viaDrill = num("via_drill");
-  if (requirePos("via_drill", viaDrill)) { dr.viaDrill = viaDrill!; touched = true; }
-  const dpg = num("diff_pair_gap");
-  if (requirePos("diff_pair_gap", dpg)) { dr.diffPairGap = dpg!; touched = true; }
-  const dpw = num("diff_pair_width");
-  if (requirePos("diff_pair_width", dpw)) { dr.diffPairWidth = dpw!; touched = true; }
-
-  const edgeClr = num("edge_clearance");
-  if (requirePos("edge_clearance", edgeClr)) { rules.edgeClearance = edgeClr!; touched = true; }
-  const h2h = num("hole_to_hole");
-  if (requirePos("hole_to_hole", h2h)) { rules.holeToHole = h2h!; touched = true; }
-  const minAnnular = num("min_annular_ring");
-  if (requirePos("min_annular_ring", minAnnular)) { rules.minAnnularRing = minAnnular!; touched = true; }
-  const minDrill = num("min_drill");
-  if (requirePos("min_drill", minDrill)) { rules.minDrill = minDrill!; touched = true; }
-
-  let classNames: string[] | undefined;
-  if (Array.isArray(args.classes)) {
-    const classesIn = args.classes as Array<Record<string, unknown>>;
-    const classRules: NetClassRules[] = [];
-    const assignments: Record<string, string[]> = {};
-    const knownNets = new Set(pcb.nets.map((n) => n.id));
-    for (const c of classesIn) {
-      const name = String(c.name ?? "");
-      const nets = Array.isArray(c.nets) ? (c.nets as unknown[]).map(String) : [];
-      if (!name) return fail("each class needs a `name`");
-      if (nets.length === 0) return fail(`class "${name}" needs a non-empty nets array`);
-      const unknown = nets.filter((id) => !knownNets.has(id));
-      if (unknown.length > 0) {
-        warnings.push(`class "${name}" references nets not on the board: ${unknown.join(", ")}`);
-      }
-      classRules.push({
-        name,
-        traceWidth: typeof c.track_width === "number" ? (c.track_width as number) : dr.traceWidth,
-        clearance: typeof c.clearance === "number" ? (c.clearance as number) : dr.clearance,
-        viaDiameter: typeof c.via_diameter === "number" ? (c.via_diameter as number) : dr.viaDiameter,
-        viaDrill: typeof c.via_drill === "number" ? (c.via_drill as number) : dr.viaDrill,
-        ...(typeof c.diff_pair_gap === "number" ? { diffPairGap: c.diff_pair_gap as number } : {}),
-        ...(typeof c.diff_pair_width === "number" ? { diffPairWidth: c.diff_pair_width as number } : {}),
-      });
-      assignments[name] = nets;
-    }
-    rules.classRules = classRules;
-    rules.netClassAssignments = assignments;
-    classNames = classRules.map((c) => c.name);
-    touched = true;
-  }
-
-  if (!touched) {
+  const res = applyDesignRuleArgs(rules, new Set(pcb.nets.map((n) => n.id)), args);
+  if (res.error) return fail(res.error);
+  if (!res.touched) {
     return fail("provide at least one rule field (clearance, track_width, …) or `classes`");
   }
 
+  const dr = rules.defaultRules;
   return {
     content: [
       {
@@ -6000,8 +6103,8 @@ export function setDesignRules(args: Record<string, unknown>) {
             min_annular_ring: rules.minAnnularRing,
             min_drill: rules.minDrill,
           },
-          ...(classNames ? { classes: classNames } : {}),
-          ...(warnings.length > 0 ? { warnings } : {}),
+          ...(res.classNames ? { classes: res.classNames } : {}),
+          ...(res.warnings.length > 0 ? { warnings: res.warnings } : {}),
           ...docResultPayload(ctx),
         }),
       },

--- a/packages/mcp/src/tools/next-actions.ts
+++ b/packages/mcp/src/tools/next-actions.ts
@@ -214,6 +214,113 @@ interface MutableResult {
   isError?: boolean;
 }
 
+/**
+ * The success side of the same idea: emit `next_actions` on a SUCCEEDING tool so
+ * the canonical PCB flow is discoverable from a good result, not only by tripping
+ * over an ordering error (set_design_rules before the board exists, …). Keyed by
+ * the tool that just succeeded → the ordered next steps. Returns `[]` for any
+ * tool not on the happy path, so non-PCB tools are untouched.
+ *
+ *   create_schematic → place_components, then run_erc
+ *   place_components → set_design_rules
+ *   set_design_rules → save_document (checkpoint before add_zone), then route_nets
+ *   route_nets       → run_drc + render_pcb (cross-check)
+ */
+export function happyPathNext(toolName: string, docId?: string): NextAction[] {
+  const withDoc = (a: NextAction): NextAction =>
+    docId ? { ...a, args: { document_id: docId } } : a;
+  switch (toolName) {
+    case "create_schematic":
+      return [
+        withDoc({
+          action: "Place the components to create the board.",
+          tool: "place_components",
+        }),
+        withDoc({
+          action:
+            "Check the schematic for electrical errors (unconnected pins, conflicting drivers).",
+          tool: "run_erc",
+        }),
+      ];
+    case "place_components":
+      return [
+        withDoc({
+          action:
+            "Set the design rules (clearances, net classes) before routing — power/HV nets want a wider class than signals.",
+          tool: "set_design_rules",
+        }),
+      ];
+    case "set_design_rules":
+      return [
+        withDoc({
+          action:
+            "Checkpoint the board with save_document before pouring copper zones (add_zone) — a zone fill is a heavy, hard-to-undo edit.",
+          tool: "save_document",
+        }),
+        withDoc({ action: "Route the nets.", tool: "route_nets" }),
+      ];
+    case "route_nets":
+      return [
+        withDoc({
+          action: "Run DRC to check the routed board against the design rules.",
+          tool: "run_drc",
+        }),
+        withDoc({
+          action: "Render the board to visually cross-check the layout.",
+          tool: "render_pcb",
+        }),
+      ];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Attach happy-path `next_actions` to a SUCCEEDING tool result (the mirror of
+ * enrichErrorResult). No-op unless the tool is on the canonical PCB flow and the
+ * result doesn't already carry next_actions (a buffered set_design_rules ships
+ * its own place_components hint and must be left alone). The document_id is read
+ * from the result body first — create_schematic mints the id server-side, so it
+ * isn't in `args` — then falls back to the call args.
+ */
+export function enrichSuccessResult(
+  result: MutableResult,
+  toolName: string,
+  args: Record<string, unknown>,
+): void {
+  if (result.isError) return;
+  if (result.structuredContent && "next_actions" in result.structuredContent) return;
+
+  const block = result.content.find((b) => b.type === "text");
+  let docId = docIdOf(args);
+  let parsedBody: Record<string, unknown> | undefined;
+  if (block) {
+    try {
+      const parsed = JSON.parse(block.text) as Record<string, unknown>;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        parsedBody = parsed;
+        if (typeof parsed.document_id === "string") docId = parsed.document_id;
+      }
+    } catch {
+      // not a JSON body — append a parseable tail instead
+    }
+  }
+
+  const next = happyPathNext(toolName, docId);
+  if (!next.length) return;
+
+  if (parsedBody && block) {
+    parsedBody.next_actions = next;
+    block.text = JSON.stringify(parsedBody);
+  } else if (block) {
+    block.text = `${block.text}\nnext_actions: ${JSON.stringify(next)}`;
+  }
+  result.structuredContent = {
+    ...(result.structuredContent ?? {}),
+    next_actions: next,
+  };
+}
+
 /** Errors that should NOT get a generic recovery floor — either not recoverable
  *  (disabled pack / unknown tool / ordering off) or self-explanatory with their
  *  own instruction (a spend awaiting human approval must NOT be retried, and a


### PR DESCRIPTION
## Why

MCP tools only attached `next_actions` hints on **errors**, so the happy-path PCB workflow ordering wasn't discoverable until an agent tripped over it. The canonical example: `set_design_rules` fails with *"Document has no PCB — run place_components first"* when called too early — an undiscoverable ordering dependency. (The retrospective referenced an `attachNextActions` symbol that doesn't exist; the real attachment lives in `next-actions.ts` as `enrichErrorResult` / `buildErrorResult`, gated on `isError`.)

## What changed

**1. Happy-path `next_actions` on SUCCESS** (`next-actions.ts`, `server.ts`)

New `happyPathNext()` + `enrichSuccessResult()` — the success-side mirror of `enrichErrorResult`, wired into the dispatch as `else enrichSuccessResult(...)`. Succeeding PCB tools now carry the next steps of the canonical flow:

| After | Suggests |
|-------|----------|
| `create_schematic` | `place_components`, then `run_erc` |
| `place_components` | `set_design_rules` |
| `set_design_rules` | `save_document` (checkpoint before `add_zone`), then `route_nets` |
| `route_nets` | `run_drc` + `render_pcb` (cross-check) |

`document_id` is recovered from the result body (`create_schematic` mints it server-side, so it isn't in args). Idempotent and a no-op for off-flow tools — injects into the JSON body and `structuredContent`, matching the error path.

**2. `set_design_rules` is order-tolerant** (`ecad.ts`)

Called before the board exists, it no longer dead-ends with a bare error. It validates the args, **buffers** them on the document, and replays them when `place_components` builds the board (applied once the netlist exists, so net-class assignments validate against real nets). The result returns a `place_components` next_action and `place_components` reports `buffered_design_rules_applied`. Malformed early calls (no fields / class with no nets) still fail fast. Rule-application logic was extracted into a shared `applyDesignRuleArgs()` helper used by both call sites (and the `place_components` default-rules literal deduped into a `defaultDesignRules()` factory).

**3. Tests + changelog**

- `next-actions.test.ts`: 10 tests for `happyPathNext` / `enrichSuccessResult` (ordering, JSON injection, no-op on error/off-flow, idempotency).
- `ecad.test.ts`: 3 tests — early `set_design_rules` guides to `place_components` instead of dead-ending, buffered rules replay onto the board (and drive routing widths), malformed early calls still error.
- Optional `feat` changelog entry (agent-facing DX).

## Reviewer notes

- The `@vcad/mcp` `build` script runs `tsc --noCheck`, so type errors only surface via `tsc --noEmit` (the `typecheck` script) — run that, not `build`, to typecheck.
- Verified: `tsc --noEmit` clean; `npm test --workspaces --if-present` all green (mcp 365 passed / 2 skipped). The existing `dispatch-persist` test covers `enrichSuccessResult` end-to-end through the real server dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)