### PR TITLE
fix(pcb): run_erc checks pin-type conflicts and floating power

### DIFF
--- a/changelog/entries/2026-06-26-erc-pin-type-power-rules.json
+++ b/changelog/entries/2026-06-26-erc-pin-type-power-rules.json
@@ -1,0 +1,17 @@
+{
+  "id": "2026-06-26-erc-pin-type-power-rules",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "fix",
+  "title": "run_erc now checks pin-type conflicts and floating power",
+  "summary": "ERC invokes the kernel rules, so two outputs on one net flag a conflict and an undriven power input flags floating power; it fails closed (kernel unavailable or a parse error reports unverified, never clean).",
+  "features": [
+    "ecad",
+    "pcb",
+    "erc"
+  ],
+  "mcpTools": [
+    "run_erc",
+    "create_schematic"
+  ]
+}

--- a/crates/vcad-ecad-schematic/src/erc.rs
+++ b/crates/vcad-ecad-schematic/src/erc.rs
@@ -757,4 +757,106 @@ mod tests {
             "explicit-net pin flagged unconnected: {violations:?}"
         );
     }
+
+    #[test]
+    fn output_conflict_via_explicit_nets() {
+        // Two Output pins joined purely by the explicit `nets` map (no wires,
+        // no coincident coordinates) — the data-driven authoring path. The
+        // pin-type rule must still see the conflict.
+        let mut nets = std::collections::BTreeMap::new();
+        nets.insert(
+            "BUS".to_string(),
+            vec!["U1.1".to_string(), "U2.1".to_string()],
+        );
+        let sheet = SchematicSheet {
+            nets: Some(nets),
+            title: None,
+            components: vec![
+                make_simple_component(
+                    "U1",
+                    Vec2::new(0.0, 0.0),
+                    vec![SchematicPin {
+                        number: "1".to_string(),
+                        name: "OUT".to_string(),
+                        pin_type: PinType::Output,
+                        position: Vec2::new(0.0, 0.0),
+                    }],
+                ),
+                make_simple_component(
+                    "U2",
+                    Vec2::new(100.0, 100.0),
+                    vec![SchematicPin {
+                        number: "1".to_string(),
+                        name: "OUT".to_string(),
+                        pin_type: PinType::Output,
+                        position: Vec2::new(0.0, 0.0),
+                    }],
+                ),
+            ],
+            wires: vec![],
+            junctions: vec![],
+            labels: vec![],
+        };
+
+        let violations = check_erc(&sheet);
+        let conflict = violations
+            .iter()
+            .find(|v| v.message.contains("multiple outputs"));
+        assert!(
+            conflict.is_some(),
+            "Expected output-output conflict on explicit net BUS, got: {violations:?}"
+        );
+        assert_eq!(conflict.unwrap().severity, ErcSeverity::Error);
+    }
+
+    #[test]
+    fn floating_power_via_explicit_nets() {
+        // A PowerInput pin joined to a Passive pin by the explicit `nets` map,
+        // on a net that is neither power-named nor driven by a PowerOutput.
+        // The floating-power rule must fire on the data-driven netlist.
+        let mut nets = std::collections::BTreeMap::new();
+        nets.insert(
+            "SENSE".to_string(),
+            vec!["U1.1".to_string(), "R1.1".to_string()],
+        );
+        let sheet = SchematicSheet {
+            nets: Some(nets),
+            title: None,
+            components: vec![
+                make_simple_component(
+                    "U1",
+                    Vec2::new(0.0, 0.0),
+                    vec![SchematicPin {
+                        number: "1".to_string(),
+                        name: "VCC".to_string(),
+                        pin_type: PinType::PowerInput,
+                        position: Vec2::new(0.0, 0.0),
+                    }],
+                ),
+                make_simple_component(
+                    "R1",
+                    Vec2::new(100.0, 0.0),
+                    vec![SchematicPin {
+                        number: "1".to_string(),
+                        name: "~".to_string(),
+                        pin_type: PinType::Passive,
+                        position: Vec2::new(0.0, 0.0),
+                    }],
+                ),
+            ],
+            wires: vec![],
+            junctions: vec![],
+            labels: vec![],
+        };
+
+        let violations = check_erc(&sheet);
+        let pwr = violations
+            .iter()
+            .find(|v| v.message.contains("no power source"));
+        assert!(
+            pwr.is_some(),
+            "Expected floating-power warning on explicit net SENSE, got: {violations:?}"
+        );
+        assert_eq!(pwr.unwrap().severity, ErcSeverity::Warning);
+    }
 }

--- a/packages/engine/src/ecad.ts
+++ b/packages/engine/src/ecad.ts
@@ -145,16 +145,43 @@ export async function critiqueRoute(pcb: Pcb, net: string): Promise<NetCritique 
   }
 }
 
-/** Run Electrical Rule Check on a schematic. */
-export async function runErc(sheet: SchematicSheet): Promise<ErcViolationResult[]> {
+/**
+ * Outcome of a kernel ERC run, kept fail-closed: `unavailable` (kernel WASM
+ * not loaded) and `error` (kernel rejected the sheet) are distinct from `ok`
+ * with an empty list (kernel ran and found nothing). A caller that only sees
+ * `ok` can treat the schematic as verified; the other two mean "unverifiable",
+ * never "clean".
+ */
+export type ErcOutcome =
+  | { status: "ok"; violations: ErcViolationResult[] }
+  | { status: "unavailable" }
+  | { status: "error"; message: string };
+
+/**
+ * Run the kernel Electrical Rule Check, reporting whether it actually executed.
+ *
+ * Unlike {@link runErc} (which collapses every failure to `[]`), this keeps
+ * "kernel not loaded" and "kernel rejected the sheet" distinct from "kernel ran
+ * clean", so verification surfaces can fail closed instead of presenting an
+ * unevaluated schematic as passing.
+ */
+export async function checkErc(sheet: SchematicSheet): Promise<ErcOutcome> {
   const wasm = await loadEcadWasm();
-  if (!wasm) return [];
+  if (!wasm) return { status: "unavailable" };
   try {
-    return wasm.ecadCheckErc(JSON.stringify(sheet)) as ErcViolationResult[];
+    const violations = wasm.ecadCheckErc(JSON.stringify(sheet)) as ErcViolationResult[];
+    return { status: "ok", violations };
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     console.warn("[ECAD] ERC failed:", e);
-    return [];
+    return { status: "error", message };
   }
+}
+
+/** Run Electrical Rule Check on a schematic. Empty list on any failure. */
+export async function runErc(sheet: SchematicSheet): Promise<ErcViolationResult[]> {
+  const outcome = await checkErc(sheet);
+  return outcome.status === "ok" ? outcome.violations : [];
 }
 
 /** Inputs for the analytical motor evaluator (mirrors `vcad_ecad_sim::MotorSpec`). */

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -150,6 +150,7 @@ export {
   runDrc,
   critiqueRoute,
   runErc,
+  checkErc,
   generateNetlist,
   routeNet,
   routeNetShove,
@@ -181,6 +182,7 @@ export {
 export type {
   DrcViolationResult,
   ErcViolationResult,
+  ErcOutcome,
   NetlistResult,
   NetlistNet,
   NetConnection,

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -1669,6 +1669,87 @@ describe("schematic label diagnostics", () => {
   });
 });
 
+describe("run_erc kernel pin-type & power rules", () => {
+  /** A 1-pin IC whose single pin carries a real electrical type. */
+  const ic = (ref: string, x: number, type: string, name = "P") => ({
+    ref,
+    value: ref,
+    footprint: "SOIC-8",
+    x,
+    y: 0,
+    pins: [{ number: "1", name, type, x: 0, y: 0 }],
+  });
+
+  it("flags two outputs driving one net (data-driven nets)", async () => {
+    const created = out(
+      await createSchematic({
+        components: [ic("U1", 0, "Output", "OUT"), ic("U2", 40, "Output", "OUT")],
+        nets: { BUS: ["U1.1", "U2.1"] },
+      }),
+    );
+    const erc = out(await runErc({ document_id: created.document_id }));
+    expect(erc.verified).toBe(true);
+    const conflicts = (erc.details as Array<{ message: string; severity: string }>).filter((d) =>
+      d.message.includes("multiple outputs"),
+    );
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]!.severity).toBe("Error");
+    expect(erc.errors).toBeGreaterThanOrEqual(1);
+  });
+
+  it("flags a power input with no driver as floating power", async () => {
+    const created = out(
+      await createSchematic({
+        components: [ic("U1", 0, "PowerInput", "VCC"), resistor("R1", 40)],
+        nets: { SENSE: ["U1.1", "R1.1"] },
+      }),
+    );
+    const erc = out(await runErc({ document_id: created.document_id }));
+    expect(erc.verified).toBe(true);
+    const floating = (erc.details as Array<{ message: string; severity: string }>).filter((d) =>
+      d.message.includes("no power source"),
+    );
+    expect(floating).toHaveLength(1);
+    expect(floating[0]!.severity).toBe("Warning");
+  });
+
+  it("does not flag a power input on a recognized power net", async () => {
+    const created = out(
+      await createSchematic({
+        components: [ic("U1", 0, "PowerInput", "VCC"), resistor("R1", 40)],
+        nets: { VCC: ["U1.1", "R1.1"] },
+      }),
+    );
+    const erc = out(await runErc({ document_id: created.document_id }));
+    expect(erc.verified).toBe(true);
+    expect(
+      (erc.details as Array<{ message: string }>).filter((d) =>
+        d.message.includes("no power source"),
+      ),
+    ).toEqual([]);
+  });
+
+  it("reports an unconnected power pin once, never doubled as floating power", async () => {
+    const created = out(
+      await createSchematic({
+        components: [ic("U1", 0, "PowerInput", "VCC")],
+      }),
+    );
+    const erc = out(await runErc({ document_id: created.document_id }));
+    expect(erc.verified).toBe(true);
+    const unconnected = (erc.details as Array<{ message: string; severity: string }>).filter((d) =>
+      d.message.includes("Unconnected pin"),
+    );
+    expect(unconnected).toHaveLength(1);
+    expect(unconnected[0]!.severity).toBe("Error");
+    expect(
+      (erc.details as Array<{ message: string }>).filter((d) =>
+        d.message.includes("no power source"),
+      ),
+    ).toEqual([]);
+  });
+});
+
 describe("board shapes and radial placement", () => {
   it("creates a circular board with a center bore and rings components radially", async () => {
     const created = out(

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -42,6 +42,7 @@ import {
   routeDiffPair as kernelRouteDiffPair,
   critiqueRoute as kernelCritiqueRoute,
   runDrc as kernelRunDrc,
+  checkErc as kernelCheckErc,
   evaluateMotor,
   airgapFluxDensity,
   resolvePart as kernelResolvePart,
@@ -3388,12 +3389,50 @@ export async function runErc(args: Record<string, unknown>) {
     }
   }
 
+  // Kernel ERC: pin-type conflicts (output driving output) and floating power
+  // inputs. These rules need a netlist; the kernel's own netlist is
+  // coordinate-only, so we hand it the *derived* connectivity (which also
+  // bridges global labels and the explicit `nets` map) re-expressed as an
+  // explicit netlist over only the connected pins. That keeps these rules
+  // judging exactly the nets create_schematic reported — and, because
+  // unconnected pins are excluded, a stray power pin is reported once (above),
+  // never doubled here.
+  const kernelOutcome = await kernelCheckErc(synthesizeNettedSheet(sheet, derived));
+  let verified = false;
+  let unverifiedReason: string | undefined;
+  if (kernelOutcome.status === "ok") {
+    verified = true;
+    for (const v of kernelOutcome.violations) {
+      if (!isPinTypeOrPowerViolation(v.message)) continue;
+      violations.push({
+        severity: v.severity,
+        message: v.message,
+        ...(v.position ? { position: v.position } : {}),
+      });
+    }
+  } else if (kernelOutcome.status === "unavailable") {
+    // Fail closed: the kernel rules did not run, so the schematic is not
+    // verified for pin-type/power conflicts — never report this as clean.
+    unverifiedReason =
+      "kernel ECAD WASM unavailable — pin-type conflict and floating-power rules were not evaluated";
+  } else {
+    unverifiedReason = `kernel ERC could not parse the schematic: ${kernelOutcome.message}`;
+  }
+
+  // Errors first, then by message — matches the kernel's ordering convention.
+  violations.sort((a, b) => {
+    const sev = (a.severity === "Error" ? 0 : 1) - (b.severity === "Error" ? 0 : 1);
+    return sev !== 0 ? sev : a.message.localeCompare(b.message);
+  });
+
   return {
     content: [
       {
         type: "text" as const,
         text: JSON.stringify({
           success: true,
+          verified,
+          ...(unverifiedReason ? { unverified_reason: unverifiedReason } : {}),
           violations: violations.length,
           errors: violations.filter(v => v.severity === "Error").length,
           warnings: violations.filter(v => v.severity === "Warning").length,
@@ -3401,6 +3440,46 @@ export async function runErc(args: Record<string, unknown>) {
         }),
       },
     ],
+  };
+}
+
+/** A kernel ERC message we own here vs. one already reported by the TS checks
+ *  above (duplicate-ref, unconnected). The kernel's pin-type and power messages
+ *  are pinned by its own unit tests ("multiple outputs", "no power source"). */
+function isPinTypeOrPowerViolation(message: string): boolean {
+  return message.startsWith("Pin conflict on net") || message.includes("has no power source");
+}
+
+/**
+ * Re-express derived connectivity as a kernel-consumable sheet: the explicit
+ * `nets` map carries every connected pin's net, wires/labels are dropped (the
+ * map already encodes them), and each component keeps only its connected pins
+ * so the kernel's per-pin netlist never invents singleton nets for open pins.
+ * Pin electrical types are preserved verbatim, which is what gives the kernel's
+ * pin-type and power rules signal.
+ */
+function synthesizeNettedSheet(sheet: SchematicSheet, derived: DerivedNets): SchematicSheet {
+  const connectedByRef = new Map<string, Set<string>>();
+  for (const key of derived.netByPin.keys()) {
+    const sep = key.indexOf(PIN_SEP);
+    const ref = key.slice(0, sep);
+    const pin = key.slice(sep + 1);
+    let set = connectedByRef.get(ref);
+    if (!set) connectedByRef.set(ref, (set = new Set()));
+    set.add(pin);
+  }
+  const nets: Record<string, string[]> = {};
+  for (const [name, pins] of derived.nets) nets[name] = pins;
+  return {
+    ...sheet,
+    wires: [],
+    labels: [],
+    junctions: [],
+    components: sheet.components.map((comp) => ({
+      ...comp,
+      pins: comp.pins.filter((pin) => connectedByRef.get(comp.ref)?.has(pin.number)),
+    })),
+    nets,
   };
 }
 


### PR DESCRIPTION
## Summary

- **Kernel ERC wired up**: `run_erc` now calls `ecadCheckErc` (kernel) after its existing dup-ref + unconnected checks. Kernel violations filtered to pin-type-conflict (`"Pin conflict on net…"`) and floating-power (`"…has no power source"`) messages — no double-reporting.
- **Fail-closed semantics**: Engine gains `checkErc(sheet): ErcOutcome` (`{status:'ok'|'unavailable'|'error', …}`). The MCP response now includes `verified: bool` and optional `unverified_reason` so agents can distinguish "ERC clean" from "ERC unverifiable" (kernel absent or parse failure).
- **`synthesizeNettedSheet`**: Re-expresses `deriveNets` connectivity as an explicit `nets` map over connected-only pins, stripping wires/labels/junctions. Needed because the kernel's `generate_netlist` is coordinate-only and doesn't bridge same-named global labels — passing the raw sheet would give it different nets than `create_schematic` reported. Connected-pins-only also prevents unconnected power pins from forming singleton kernel nets and double-firing.

## What changed

| File | Change |
|------|--------|
| `packages/engine/src/ecad.ts` | `checkErc` + `ErcOutcome` type; `runErc` delegates |
| `packages/engine/src/index.ts` | Export `checkErc` + `ErcOutcome` |
| `packages/mcp/src/tools/ecad.ts` | Kernel ERC call + `synthesizeNettedSheet` + `isPinTypeOrPowerViolation` helpers; `verified`/`unverified_reason` in response |
| `crates/vcad-ecad-schematic/src/erc.rs` | Two new kernel tests (two-output conflict + floating power via explicit nets) |
| `packages/mcp/src/__tests__/ecad.test.ts` | Four new MCP integration tests |
| `changelog/entries/2026-06-26-erc-pin-type-power-rules.json` | Changelog entry |

## Test plan

- [x] `cargo test --workspace` — all tests pass (including the two new kernel ERC tests)
- [x] `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean (vcad-desktop has pre-existing deprecated cocoa crate debt, unrelated to this change)
- [x] `npm run build --workspaces` — builds clean
- [x] `npm test --workspaces --if-present` — MCP tests pass including all four new ERC integration tests

## Notes for reviewer

- No WASM rebuild needed — `ecadCheckErc` was already exported in the checked-in `packages/kernel-wasm/vcad_kernel_wasm.js`
- Pin types were already real (not defaulting to Passive) as of commit c78ef657 — the parts DB assigns real `PinType` variants through to the kernel netlist

🤖 Generated with [Claude Code](https://claude.com/claude-code)