### PR TITLE
feat(mcp): observable session durability + checkpoint/branch tools

### DIFF
--- a/changelog/entries/2026-06-26-checkpoint-branch.json
+++ b/changelog/entries/2026-06-26-checkpoint-branch.json
@@ -1,0 +1,17 @@
+{
+  "id": "2026-06-26-checkpoint-branch",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "feat",
+  "title": "Checkpoint & branch MCP design sessions",
+  "summary": "Agents can snapshot a known-good state (post-schematic, post-place, post-route) with checkpoint_document and rewind with branch_from — fork into a new session or restore in place — instead of rebuilding the netlist.",
+  "features": [
+    "mcp",
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "checkpoint_document",
+    "branch_from"
+  ]
+}

--- a/packages/mcp/src/__tests__/checkpoint.test.ts
+++ b/packages/mcp/src/__tests__/checkpoint.test.ts
@@ -1,0 +1,302 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { setSessionFetch } from "../session-store.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage of checkpoint_document / branch_from, driven through the
+ * real CallTool handler in createServer over an in-memory MCP client, with a
+ * fake PostgREST backend so checkpoints persist (and survive a simulated
+ * redeploy) exactly as in production.
+ */
+
+/** PostgREST + append_session_event stand-in. The `rows` map is the durable
+ *  backend — it survives a "redeploy" (a cleared `documents` cache + a fresh
+ *  server) because it's closed over here, not in instance memory. */
+function installFake() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const eq = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+  setSessionFetch((async (input: unknown, init: RequestInit = {}) => {
+    const url = new URL(String(input));
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && url.pathname.endsWith("/rpc/append_session_event")) {
+      return new Response(JSON.stringify({ ok: true, id: 1, seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (method === "POST") {
+      const body = JSON.parse(String(init.body)) as Array<
+        Record<string, unknown>
+      >;
+      for (const r of body) rows.set(`${r.user_id}|${r.local_id}`, r);
+      return new Response(null, { status: 201 });
+    }
+    const key = `${eq(url.searchParams, "user_id")}|${eq(url.searchParams, "local_id")}`;
+    if (method === "GET") {
+      const row = rows.get(key);
+      if (!row) return new Response("", { status: 406 });
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch);
+  return { rows };
+}
+
+async function connect(
+  engine: Engine,
+  user: { sub: string; email: string } | null,
+) {
+  const server = await createServer(engine, { user });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function parse(result: unknown): Record<string, unknown> {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+/** A two-resistor schematic with one named net — the netlist anchor. */
+const SCHEMATIC_ARGS = {
+  components: [
+    {
+      ref: "R1",
+      value: "1k",
+      footprint: "Resistor_SMD:R_0805",
+      x: 0,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive", x: -5, y: 0 },
+        { number: "2", name: "~", type: "Passive", x: 5, y: 0 },
+      ],
+    },
+    {
+      ref: "R2",
+      value: "1k",
+      footprint: "Resistor_SMD:R_0805",
+      x: 20,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive", x: -5, y: 0 },
+        { number: "2", name: "~", type: "Passive", x: 5, y: 0 },
+      ],
+    },
+  ],
+  nets: { MID: ["R1.2", "R2.1"] },
+};
+
+const USER = { sub: "user-ckpt", email: "c@x.test" };
+
+describe("checkpoint_document / branch_from", () => {
+  let engine: Engine;
+  let prevUrl: string | undefined;
+  let prevKey: string | undefined;
+
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  beforeEach(() => {
+    prevUrl = process.env.SUPABASE_URL;
+    prevKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    documents.clear();
+  });
+
+  afterEach(() => {
+    if (prevUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = prevUrl;
+    if (prevKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
+    setSessionFetch(((...a: Parameters<typeof fetch>) =>
+      fetch(...a)) as typeof fetch);
+  });
+
+  it("snapshots a session and reports the netlist anchor in the summary", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+
+    const created = parse(
+      await client.callTool({
+        name: "create_schematic",
+        arguments: SCHEMATIC_ARGS,
+      }),
+    );
+    const documentId = created.document_id as string;
+
+    const ckpt = parse(
+      await client.callTool({
+        name: "checkpoint_document",
+        arguments: { document_id: documentId, label: "post-schematic" },
+      }),
+    );
+
+    expect(typeof ckpt.checkpoint_id).toBe("string");
+    expect(ckpt.checkpoint_id).not.toBe(documentId);
+    expect(ckpt.of).toBe(documentId);
+    expect(ckpt.label).toBe("post-schematic");
+    const summary = ckpt.summary as Record<string, number>;
+    // The netlist is the anchor — the summary surfaces it so the agent can see
+    // it was captured.
+    expect(summary.schematic_nets).toBe(1);
+    expect(summary.schematic_components).toBe(2);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("branches into a NEW session id with the netlist preserved", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+
+    const documentId = (
+      parse(
+        await client.callTool({
+          name: "create_schematic",
+          arguments: SCHEMATIC_ARGS,
+        }),
+      ).document_id as string
+    );
+    const checkpointId = parse(
+      await client.callTool({
+        name: "checkpoint_document",
+        arguments: { document_id: documentId },
+      }),
+    ).checkpoint_id as string;
+
+    const branch = parse(
+      await client.callTool({
+        name: "branch_from",
+        arguments: { checkpoint_id: checkpointId },
+      }),
+    );
+
+    expect(branch.branched_from).toBe(checkpointId);
+    const branchId = branch.document_id as string;
+    expect(branchId).not.toBe(documentId);
+    expect(branchId).not.toBe(checkpointId);
+    expect((branch.summary as Record<string, number>).schematic_nets).toBe(1);
+
+    // The branch is a real, readable session with the same netlist.
+    const got = parse(
+      await client.callTool({
+        name: "get_document",
+        arguments: { document_id: branchId },
+      }),
+    );
+    expect((got.schematic as { nets: Record<string, unknown> }).nets.MID).toBeDefined();
+
+    await client.close();
+    await server.close();
+  });
+
+  it("restores a checkpoint in place when given `into` (same id)", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+
+    const documentId = parse(
+      await client.callTool({
+        name: "create_schematic",
+        arguments: SCHEMATIC_ARGS,
+      }),
+    ).document_id as string;
+    const checkpointId = parse(
+      await client.callTool({
+        name: "checkpoint_document",
+        arguments: { document_id: documentId },
+      }),
+    ).checkpoint_id as string;
+
+    const restored = parse(
+      await client.callTool({
+        name: "branch_from",
+        arguments: { checkpoint_id: checkpointId, into: documentId },
+      }),
+    );
+    // Restore keeps the original id so existing handles keep working.
+    expect(restored.document_id).toBe(documentId);
+    expect(restored.restored_from).toBe(checkpointId);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("a checkpoint survives a simulated redeploy (branch from a cold instance)", async () => {
+    const fake = installFake();
+    // Instance A: build a netlist and checkpoint it.
+    const a = await connect(engine, USER);
+    const documentId = parse(
+      await a.client.callTool({
+        name: "create_schematic",
+        arguments: SCHEMATIC_ARGS,
+      }),
+    ).document_id as string;
+    const checkpointId = parse(
+      await a.client.callTool({
+        name: "checkpoint_document",
+        arguments: { document_id: documentId },
+      }),
+    ).checkpoint_id as string;
+    // The checkpoint reached the durable backend.
+    expect(fake.rows.has(`${USER.sub}|mcp:${checkpointId}`)).toBe(true);
+    await a.client.close();
+    await a.server.close();
+
+    // ── Redeploy: wipe every warm cache and boot a fresh instance B against
+    // the SAME durable backend.
+    documents.clear();
+    const b = await connect(engine, USER);
+
+    // Branch_from on the cold instance must rehydrate the checkpoint from the
+    // store — not "Unknown checkpoint_id".
+    const branch = parse(
+      await b.client.callTool({
+        name: "branch_from",
+        arguments: { checkpoint_id: checkpointId },
+      }),
+    );
+    expect(branch.isError ?? false).toBe(false);
+    expect(branch.branched_from).toBe(checkpointId);
+    expect((branch.summary as Record<string, number>).schematic_nets).toBe(1);
+
+    await b.client.close();
+    await b.server.close();
+  });
+
+  it("errors clearly on an unknown checkpoint_id", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+    const res = (await client.callTool({
+      name: "branch_from",
+      arguments: { checkpoint_id: "ckpt_nope" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Unknown checkpoint_id/);
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/__tests__/durability-smoke.test.ts
+++ b/packages/mcp/src/__tests__/durability-smoke.test.ts
@@ -1,0 +1,259 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import {
+  setSessionFetch,
+  isSessionStoreDurable,
+  isProductionDeploy,
+  sessionStoreInfo,
+  warnIfSessionStoreNotDurable,
+} from "../session-store.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * Deploy smoke test for session durability — the regression guard for the prod
+ * incident where a production redeploy dropped an open design session because
+ * SUPABASE_SERVICE_ROLE_KEY was unset and the store silently fell back to
+ * in-memory.
+ *
+ * The e2e cases create a doc on one instance, simulate a redeploy (wipe every
+ * warm cache + boot a fresh instance against the same durable backend), and
+ * assert the doc still loads when durable — AND is lost when not (so the test
+ * actually catches the condition it guards). The unit cases pin the observable
+ * surfaces (server_info / /health `durable` flag, the loud boot warning).
+ */
+
+/** PostgREST stand-in whose `rows` map IS the durable backend: it's closed over
+ *  here, so it survives a "redeploy" (a cleared cache + a new server). */
+function installFake() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const eq = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+  setSessionFetch((async (input: unknown, init: RequestInit = {}) => {
+    const url = new URL(String(input));
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && url.pathname.endsWith("/rpc/append_session_event")) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (method === "POST") {
+      const body = JSON.parse(String(init.body)) as Array<
+        Record<string, unknown>
+      >;
+      for (const r of body) rows.set(`${r.user_id}|${r.local_id}`, r);
+      return new Response(null, { status: 201 });
+    }
+    const key = `${eq(url.searchParams, "user_id")}|${eq(url.searchParams, "local_id")}`;
+    if (method === "GET") {
+      const row = rows.get(key);
+      if (!row) return new Response("", { status: 406 });
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch);
+  return { rows };
+}
+
+async function connect(engine: Engine, user: { sub: string; email: string }) {
+  const server = await createServer(engine, { user });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function parse(result: unknown): Record<string, unknown> {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+const USER = { sub: "user-smoke", email: "s@x.test" };
+
+// ─── env helpers ─────────────────────────────────────────────────────────────
+
+const ENV_KEYS = [
+  "SUPABASE_URL",
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "VERCEL_ENV",
+  "NODE_ENV",
+] as const;
+
+describe("session durability self-report", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("isSessionStoreDurable mirrors the createSessionStore env check", () => {
+    expect(isSessionStoreDurable()).toBe(false);
+    process.env.SUPABASE_URL = "https://supa.test";
+    expect(isSessionStoreDurable()).toBe(false); // url alone isn't enough
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    expect(isSessionStoreDurable()).toBe(true);
+  });
+
+  it("isProductionDeploy detects Vercel prod and NODE_ENV=production", () => {
+    expect(isProductionDeploy()).toBe(false);
+    process.env.VERCEL_ENV = "production";
+    expect(isProductionDeploy()).toBe(true);
+    delete process.env.VERCEL_ENV;
+    process.env.NODE_ENV = "production";
+    expect(isProductionDeploy()).toBe(true);
+    process.env.VERCEL_ENV = "preview";
+    process.env.NODE_ENV = "test";
+    expect(isProductionDeploy()).toBe(false);
+  });
+
+  it("sessionStoreInfo reports durable:false / in-memory without the key", () => {
+    expect(sessionStoreInfo()).toEqual({
+      durable: false,
+      session_store: "in-memory",
+      production: false,
+    });
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    expect(sessionStoreInfo()).toEqual({
+      durable: true,
+      session_store: "supabase",
+      production: false,
+    });
+  });
+
+  it("warnIfSessionStoreNotDurable fires loudly ONLY in prod without a key", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Not prod → silent.
+    expect(warnIfSessionStoreNotDurable()).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+
+    // Prod + durable → silent.
+    process.env.VERCEL_ENV = "production";
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    expect(warnIfSessionStoreNotDurable()).toBe(false);
+    expect(spy).not.toHaveBeenCalled();
+
+    // Prod + NO key → loud warning.
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(warnIfSessionStoreNotDurable()).toBe(true);
+    expect(spy).toHaveBeenCalledOnce();
+    expect(String(spy.mock.calls[0][0])).toMatch(/DURABILITY DEGRADED/);
+  });
+});
+
+describe("deploy smoke: a session survives a redeploy", () => {
+  let engine: Engine;
+  let saved: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    documents.clear();
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    setSessionFetch(((...a: Parameters<typeof fetch>) =>
+      fetch(...a)) as typeof fetch);
+  });
+
+  it("DURABLE: doc created on instance A still loads on a fresh instance B", async () => {
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    installFake();
+
+    // Instance A creates a document.
+    const a = await connect(engine, USER);
+    const open = parse(await a.client.callTool({ name: "open_document", arguments: {} }));
+    const documentId = open.document_id as string;
+    // server_info confirms the deploy is durable.
+    expect(parse(await a.client.callTool({ name: "server_info", arguments: {} })).durable).toBe(true);
+    await a.client.close();
+    await a.server.close();
+
+    // ── Redeploy: wipe every warm cache, boot a fresh instance against the
+    // same durable backend.
+    documents.clear();
+    const b = await connect(engine, USER);
+
+    // The doc still loads — hydrated from the durable store, not lost.
+    const got = await b.client.callTool({
+      name: "get_document",
+      arguments: { document_id: documentId },
+    });
+    expect((got as { isError?: boolean }).isError ?? false).toBe(false);
+    expect(parse(got).version).toBeDefined();
+
+    await b.client.close();
+    await b.server.close();
+  });
+
+  it("NEGATIVE CONTROL: without the service-role key the doc is LOST on redeploy", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY; // the prod-incident condition
+    process.env.SUPABASE_URL = "https://supa.test";
+    installFake();
+
+    const a = await connect(engine, USER);
+    const documentId = parse(
+      await a.client.callTool({ name: "open_document", arguments: {} }),
+    ).document_id as string;
+    // server_info / /health would advertise the hazard.
+    expect(parse(await a.client.callTool({ name: "server_info", arguments: {} })).durable).toBe(false);
+    await a.client.close();
+    await a.server.close();
+
+    // Redeploy.
+    documents.clear();
+    const b = await connect(engine, USER);
+
+    // In-memory store can't rehydrate → the open board is gone. This is exactly
+    // the regression the durable path fixes; the negative control proves the
+    // smoke test detects it.
+    const got = (await b.client.callTool({
+      name: "get_document",
+      arguments: { document_id: documentId },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(got.isError).toBe(true);
+    expect(got.content[0].text).toMatch(/Unknown document_id/);
+
+    await b.client.close();
+    await b.server.close();
+  });
+});

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -25,6 +25,7 @@ import { verifyAccessToken } from "./oauth.js";
 import { getViewerHtml, MCP_APP_MIME_TYPE } from "./viewer.js";
 import { flushTelemetry } from "./telemetry.js";
 import { handleLiveRequest } from "./live-route.js";
+import { sessionStoreInfo } from "./session-store.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
 
@@ -237,13 +238,16 @@ const httpServer = createHttpServer(async (req, res) => {
       return;
     }
 
-    // Health check
+    // Health check. `durable` / `session_store` make the session-durability
+    // state observable with a plain curl — durable:false means a redeploy will
+    // drop open sessions (service-role key unset).
     if (path === "/health") {
       const eng = await getEngine();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({
         status: "ok",
         engine: !!eng,
+        ...sessionStoreInfo(),
         timestamp: new Date().toISOString(),
       }));
       return;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -65,10 +65,21 @@ import {
   continueDocumentSchema,
 } from "./tools/continue-doc.js";
 import {
+  checkpointDocument,
+  checkpointDocumentSchema,
+  branchFrom,
+  branchFromSchema,
+} from "./tools/checkpoint.js";
+import {
   createSessionStore,
   createSessionEventStore,
   createShareStore,
+  sessionStoreInfo,
+  warnIfSessionStoreNotDurable,
 } from "./session-store.js";
+// Re-exported so the Vercel entry (services/mcp/entry.ts) and standalone
+// /health (http.ts) report the same durability state as server_info.
+export { sessionStoreInfo } from "./session-store.js";
 import { createFabricateStore } from "./fabricate/store.js";
 import {
   quoteManufacturing,
@@ -352,6 +363,14 @@ export function getBuildInfo(): {
 // instance) — set once at module load.
 configureTelemetry(getBuildInfo());
 
+// Boot-time durability self-check (fires once per cold start, on every entry
+// point that imports this module — Vercel function, standalone HTTP, stdio). A
+// production deploy without a durable session store keeps sessions in-memory
+// only, so a redeploy drops every open board. Make that loud at boot; the same
+// state is observable over the wire via server_info / /health (durable:false).
+// No-op on stdio/local or when durable.
+warnIfSessionStoreNotDurable();
+
 /** Kernel WASM exports this server depends on; checked at startup so a stale or
  *  incomplete dist surfaces as a clear boot error rather than an opaque
  *  mid-call TypeError. Surfaced via `server_info`. */
@@ -389,6 +408,8 @@ const GEOMETRY_TOOLS = new Set([
   "add_motor_winding",
   // Materializes a saved board into a live session — show it like open_document.
   "load_document",
+  // Re-opens a checkpoint snapshot as a live session — seeded with geometry.
+  "branch_from",
 ]);
 
 /**
@@ -415,6 +436,9 @@ const SWITCH_DOC_WRITERS = new Set<string>([
   // local-disk read is a no-op on the serverless deploy, but on success
   // persisting the loaded doc to the user's account is desirable.
   "load_document",
+  // Forks/restores a checkpoint into a session; persist so the branch (or the
+  // in-place restore) survives a cold instance like every other session.
+  "branch_from",
   // CAD / sheet-metal / DFM mutators
   "place_part",
   "dfm_apply_fix",
@@ -479,6 +503,8 @@ const MOUNT_TOOLS = new Set<string>([
   "import_step",
   "load_document",
   "continue_document",
+  // Re-opens a checkpoint into a (new or restored) session — mount its canvas.
+  "branch_from",
   // PCB: place_components creates the first board geometry (create_schematic
   // has none yet, so it must NOT mount — the canvas would fetch an empty board)
   "place_components",
@@ -859,6 +885,28 @@ export async function createServer(
         inputSchema: loadDocumentSchema,
       },
       {
+        name: "checkpoint_document",
+        description:
+          "Snapshot a session's current state as a durable, restorable " +
+          "checkpoint. Returns a `checkpoint_id`. Use it at known-good milestones " +
+          "(post-schematic, post-place, post-route) so you can rewind with " +
+          "branch_from instead of rebuilding. The full IR is captured — the " +
+          "netlist (the most expensive, most stable artifact) is the anchor. On a " +
+          "durable deploy a checkpoint survives a redeploy; check server_info for " +
+          "durable:true.",
+        inputSchema: checkpointDocumentSchema,
+      },
+      {
+        name: "branch_from",
+        description:
+          "Re-open a checkpoint (from checkpoint_document). Omit `into` to BRANCH " +
+          "into a fresh session id — a variant to explore. Pass `into: <document_id>` " +
+          "to RESTORE the checkpoint into an existing session in place (same id). " +
+          "The cheap undo for a bad route or place: rewind to a good state rather " +
+          "than rebuilding the netlist.",
+        inputSchema: branchFromSchema,
+      },
+      {
         name: "continue_document",
         description:
           "Open the user's vcad.io part as an editing session from a 'Continue " +
@@ -882,9 +930,11 @@ export async function createServer(
         name: "server_info",
         description:
           "Report the running build's identity: version, git sha (if stamped), " +
-          "tool count, enabled packs, and whether the kernel WASM loaded. Call " +
-          "this to confirm a tool exists in THIS build before assuming a stale " +
-          "or version-skewed deploy.",
+          "tool count, enabled packs, whether the kernel WASM loaded, and whether " +
+          "sessions are durable (`durable` — survive a redeploy/cold start, vs. " +
+          "in-memory only). Call this to confirm a tool exists in THIS build " +
+          "before assuming a stale or version-skewed deploy, and to check " +
+          "durable:true before relying on checkpoints across a long session.",
         inputSchema: serverInfoSchema,
       },
       // ── vcad Fabricate: order custom-manufactured parts ───────
@@ -2052,6 +2102,14 @@ export async function createServer(
           result = await continueDocument(args, sessionStore);
           break;
 
+        case "checkpoint_document":
+          result = await checkpointDocument(args, sessionStore);
+          break;
+
+        case "branch_from":
+          result = await branchFrom(args, sessionStore);
+          break;
+
         case "server_info":
           result = {
             content: [
@@ -2059,6 +2117,7 @@ export async function createServer(
                 type: "text",
                 text: JSON.stringify({
                   ...getBuildInfo(),
+                  ...sessionStoreInfo(),
                   kernel_wasm: kernelWasmLoaded ? "ok" : "unavailable",
                   ...(kernelWasmMissing.length > 0
                     ? { kernel_wasm_missing_exports: kernelWasmMissing }

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -336,6 +336,69 @@ function unwrapDocument(content: unknown): Document | null {
   return null;
 }
 
+// ─── Durability self-report (boot warning + server_info / /health) ────────────
+//
+// The hosted MCP runs as a serverless function: with no durable store, every
+// open session lives only in the instance's memory and a redeploy / cold start
+// silently drops it (this happened in prod — an open board was lost on
+// redeploy). The helpers below make that condition observable instead of
+// silent: a loud boot warning, and a `durable` flag surfaced in both
+// `server_info` and the `/health` endpoint.
+
+/** True when the session store will persist across serverless instances — i.e.
+ *  the Supabase env `createSessionStore` needs is present. Mirrors the factory's
+ *  env check exactly so the two can't drift. When false, every store degrades to
+ *  in-memory and a redeploy drops every open session. */
+export function isSessionStoreDurable(): boolean {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return !!(url && key);
+}
+
+/** True on a hosted production deploy: Vercel prod (`VERCEL_ENV=production`) or
+ *  `NODE_ENV=production` for the standalone Node/Fly server. Used to decide
+ *  whether a non-durable store is a loud boot error (prod) or the expected
+ *  local/stdio mode (quiet). */
+export function isProductionDeploy(): boolean {
+  return (
+    process.env.VERCEL_ENV === "production" ||
+    process.env.NODE_ENV === "production"
+  );
+}
+
+/** Durability state for `server_info` and the `/health` endpoint, so the
+ *  condition is observable over the wire without reading logs. */
+export function sessionStoreInfo(): {
+  durable: boolean;
+  session_store: "supabase" | "in-memory";
+  production: boolean;
+} {
+  const durable = isSessionStoreDurable();
+  return {
+    durable,
+    session_store: durable ? "supabase" : "in-memory",
+    production: isProductionDeploy(),
+  };
+}
+
+/** Loud boot-time warning when a PRODUCTION deploy is running WITHOUT a durable
+ *  session store: sessions are in-memory only and a redeploy / cold start drops
+ *  every open board. Returns true if it warned (so the smoke test can assert the
+ *  condition fires). No-op outside production, or when durable — stdio/local
+ *  stays quiet. */
+export function warnIfSessionStoreNotDurable(): boolean {
+  if (!isProductionDeploy() || isSessionStoreDurable()) return false;
+  console.error(
+    "[vcad-mcp] ████ SESSION DURABILITY DEGRADED ████ " +
+      "SUPABASE_SERVICE_ROLE_KEY is not set on this PRODUCTION deploy — MCP " +
+      "sessions are IN-MEMORY ONLY and will be LOST on the next redeploy or " +
+      "cold start (an open board has been lost this way before). server_info " +
+      "and /health report durable:false. Set SUPABASE_URL + " +
+      "SUPABASE_SERVICE_ROLE_KEY on this deploy and redeploy to fix.",
+  );
+  return true;
+}
+
 /**
  * Choose the store impl from env + the per-connection user. With Supabase env
  * present: a signed-in user gets the user-owned `documents` store (also renders

--- a/packages/mcp/src/tools/checkpoint.ts
+++ b/packages/mcp/src/tools/checkpoint.ts
@@ -1,0 +1,232 @@
+/**
+ * checkpoint_document / branch_from — durable snapshots of a session's
+ * known-good state.
+ *
+ * WHY: an MCP design session is expensive to rebuild — declare a netlist, place
+ * components, route nets, run DRC. The netlist especially is the most expensive
+ * and most stable artifact. When a route attempt goes wrong, or the agent wants
+ * to explore a variant, rebuilding from scratch wastes turns and reintroduces
+ * mistakes. `checkpoint_document` snapshots the full Document IR (netlist
+ * included) under an unguessable id; `branch_from` re-opens that snapshot as a
+ * fresh session — or restores it into an existing one — so the agent rewinds to
+ * a good state instead of rebuilding.
+ *
+ * A checkpoint is just ANOTHER durable document: it uses the same SessionStore
+ * (the user-owned `documents` table, or the capability-keyed `mcp_sessions`
+ * table) as the live session, so there is no new table and a checkpoint inherits
+ * the exact cold-instance survival the live session has. On a durable deploy a
+ * checkpoint outlives a redeploy; on stdio/local it lives for the process like
+ * any other session (the in-memory store's save is a no-op, but the snapshot is
+ * warm-cached in the `documents` map).
+ */
+
+import { randomBytes } from "node:crypto";
+import type { Document } from "@vcad/ir";
+import type { SessionStore } from "../session-store.js";
+import { documents, getSession, registerSession } from "./session.js";
+
+type ToolText = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+function err(text: string): ToolText {
+  return { isError: true, content: [{ type: "text", text }] };
+}
+
+function ok(body: Record<string, unknown>): ToolText {
+  return { content: [{ type: "text", text: JSON.stringify(body) }] };
+}
+
+let nextCheckpoint = 1;
+
+/** Unguessable checkpoint id. The counter keeps intra-process uniqueness; the
+ *  random suffix makes the id a capability (the anonymous store keys rows by it
+ *  alone), so one caller can't enumerate another's checkpoints. */
+function nextCheckpointId(): string {
+  return `ckpt_${nextCheckpoint++}_${randomBytes(9).toString("base64url")}`;
+}
+
+/** A light, non-throwing summary of what the snapshot captures — surfaced so the
+ *  agent can see the netlist anchor (and placement/routing progress) is held,
+ *  without re-fetching the whole IR. Reads both `pcb` (post-place/route) and
+ *  `schematic` (the netlist declared as data before place_components). */
+function snapshotSummary(doc: Document): Record<string, number> {
+  const s: Record<string, number> = { parts: doc.roots?.length ?? 0 };
+  const pcb = (
+    doc as {
+      pcb?: {
+        nets?: unknown[];
+        footprints?: unknown[];
+        traces?: unknown[];
+        vias?: unknown[];
+      };
+    }
+  ).pcb;
+  if (pcb) {
+    if (Array.isArray(pcb.nets)) s.nets = pcb.nets.length;
+    if (Array.isArray(pcb.footprints)) s.components = pcb.footprints.length;
+    if (Array.isArray(pcb.traces)) s.traces = pcb.traces.length;
+    if (Array.isArray(pcb.vias)) s.vias = pcb.vias.length;
+  }
+  const sch = (
+    doc as {
+      schematic?: { components?: unknown[]; nets?: Record<string, unknown> };
+    }
+  ).schematic;
+  if (sch) {
+    if (Array.isArray(sch.components)) {
+      s.schematic_components = sch.components.length;
+    }
+    if (sch.nets && typeof sch.nets === "object") {
+      s.schematic_nets = Object.keys(sch.nets).length;
+    }
+  }
+  return s;
+}
+
+// ─── checkpoint_document ──────────────────────────────────────────────────
+
+export const checkpointDocumentSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description:
+        "Session id (from open_document / create_schematic / load_document) to snapshot.",
+    },
+    label: {
+      type: "string" as const,
+      description:
+        "Optional human label for the checkpoint, e.g. 'post-schematic', " +
+        "'post-place', or 'post-route'. Echoed back by branch_from.",
+    },
+  },
+  required: ["document_id"],
+};
+
+/**
+ * Snapshot a session's current Document IR as a durable, restorable checkpoint.
+ * The dispatch layer has already hydrated `document_id` from the durable store,
+ * so this works on a cold instance. The snapshot is deep-copied so later edits
+ * to the live session never mutate it.
+ */
+export async function checkpointDocument(
+  args: Record<string, unknown>,
+  store: SessionStore,
+): Promise<ToolText> {
+  const sourceId = String(args.document_id ?? "");
+  const label =
+    typeof args.label === "string" && args.label.trim()
+      ? args.label.trim()
+      : undefined;
+
+  // getSession throws the pinned "Unknown document_id" error if the session
+  // isn't resident (and couldn't be hydrated) — same contract as every reader.
+  const doc = getSession(sourceId);
+
+  // Deep copy: the checkpoint must be frozen at this moment, independent of any
+  // further edits to the live session.
+  const snapshot = JSON.parse(JSON.stringify(doc)) as Document;
+  const checkpointId = nextCheckpointId();
+
+  // Warm-cache the snapshot so a branch on this same instance is instant, and
+  // so stdio/local (where store.save is a no-op) still resolves it. On a durable
+  // deploy store.save persists it so the checkpoint outlives a redeploy.
+  documents.set(checkpointId, snapshot);
+  await store.save(checkpointId, snapshot, label ?? "checkpoint");
+
+  return ok({
+    checkpoint_id: checkpointId,
+    of: sourceId,
+    label: label ?? null,
+    summary: snapshotSummary(snapshot),
+    hint:
+      "Saved a restorable snapshot — the netlist (the most expensive artifact) " +
+      "is captured. Fork it later with branch_from, or restore it in place with " +
+      "branch_from(into: <document_id>).",
+  });
+}
+
+// ─── branch_from ──────────────────────────────────────────────────────────
+
+export const branchFromSchema = {
+  type: "object" as const,
+  properties: {
+    checkpoint_id: {
+      type: "string" as const,
+      description: "A checkpoint id returned by checkpoint_document.",
+    },
+    into: {
+      type: "string" as const,
+      description:
+        "Optional. An existing session id to RESTORE the checkpoint into — " +
+        "overwrites that session's content but keeps its id, so existing " +
+        "handles keep working. Omit to BRANCH into a fresh session id instead.",
+    },
+  },
+  required: ["checkpoint_id"],
+};
+
+/**
+ * Re-open a checkpoint. With no `into`, branches into a fresh session id (a
+ * variant to explore); with `into`, restores the checkpoint into that existing
+ * session in place. Resolves the checkpoint from the warm cache first, then the
+ * durable store — so it survives a redeploy. The result carries `document_id`,
+ * which the dispatch persist wrapper writes back to the durable store (branch_from
+ * is a doc-writer), so the branch/restore is itself durable.
+ */
+export async function branchFrom(
+  args: Record<string, unknown>,
+  store: SessionStore,
+): Promise<ToolText> {
+  const checkpointId = String(args.checkpoint_id ?? "");
+  if (!checkpointId) {
+    return err(
+      "branch_from requires a `checkpoint_id` from a prior checkpoint_document call.",
+    );
+  }
+
+  // Warm cache first, then the durable store: a cold instance after a redeploy
+  // has an empty cache but the checkpoint row survives.
+  let snapshot = documents.get(checkpointId) ?? null;
+  if (!snapshot) snapshot = await store.load(checkpointId);
+  if (!snapshot) {
+    return err(
+      `Unknown checkpoint_id "${checkpointId}". Create one with ` +
+        `checkpoint_document first. (If it existed earlier, this deploy may be ` +
+        `running without a durable session store — check server_info for ` +
+        `durable:false.)`,
+    );
+  }
+
+  // Defensive copy — the branch/restore is an independent document; editing it
+  // must not mutate the checkpoint, so the same checkpoint can be reused.
+  const copy = JSON.parse(JSON.stringify(snapshot)) as Document;
+
+  const into =
+    typeof args.into === "string" && args.into.trim() ? args.into.trim() : null;
+  if (into) {
+    // Restore in place: overwrite the existing session, keep its id.
+    documents.set(into, copy);
+    return ok({
+      document_id: into,
+      restored_from: checkpointId,
+      summary: snapshotSummary(copy),
+      hint:
+        "Restored in place — the session id is unchanged. Re-render with render_view.",
+    });
+  }
+
+  // Branch: a fresh session id. The dispatch persist wrapper writes it through
+  // to the durable store so the fork survives a redeploy too.
+  const newId = registerSession(copy);
+  return ok({
+    document_id: newId,
+    branched_from: checkpointId,
+    summary: snapshotSummary(copy),
+    hint:
+      "Forked into a new session. Continue here, or branch_from the same " +
+      "checkpoint again to try another variant.",
+  });
+}

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -15,6 +15,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import {
   createServer,
   getBuildInfo,
+  sessionStoreInfo,
   flushTelemetry,
   handleLiveRequest,
 } from "@vcad/mcp/server";
@@ -103,6 +104,10 @@ export default async function handler(
       sendJson(res, 200, {
         status: "ok",
         ...getBuildInfo(),
+        // durable:false here means SUPABASE_SERVICE_ROLE_KEY is unset on this
+        // prod deploy → open sessions are in-memory only and a redeploy drops
+        // them. Verifiable with `curl https://mcp.vcad.io/health`.
+        ...sessionStoreInfo(),
         engine: !!engine,
         timestamp: new Date().toISOString(),
       });


### PR DESCRIPTION
## Summary

- **Session durability is now observable**: `durable:false` appears in `server_info` and `curl mcp.vcad.io/health` when `SUPABASE_SERVICE_ROLE_KEY` is unset, and a loud `console.error` fires on every cold start in that state — so the prod incident (open board lost on redeploy) can't happen silently again.
- **`checkpoint_document` + `branch_from` tools**: agents can snapshot a known-good state (post-schematic, post-place, post-route) and restore or fork instead of rebuilding the netlist. A checkpoint is just another durable document (same `SessionStore`, no new table/migration), so it inherits cold-instance survival for free.
- **11 new tests**: durability-smoke (create → redeploy → still loads + negative control that proves the doc is lost without the key) and checkpoint (snapshot/branch/restore + survives-redeploy).

## What changed

**`packages/mcp/src/session-store.ts`**
- `isSessionStoreDurable()` — mirrors `createSessionStore`'s `url && key` check so they can never drift
- `isProductionDeploy()` — `VERCEL_ENV==="production" || NODE_ENV==="production"`
- `sessionStoreInfo()` → `{durable, session_store, production}`
- `warnIfSessionStoreNotDurable()` — loud `console.error` "SESSION DURABILITY DEGRADED"; no-op unless prod && !durable; returns bool so tests can assert it

**`packages/mcp/src/server.ts`**
- Calls `warnIfSessionStoreNotDurable()` at module scope (fires per cold start on every entry point)
- Spreads `...sessionStoreInfo()` into `server_info` response
- Registers `checkpoint_document` and `branch_from` tools
- `branch_from` in `SWITCH_DOC_WRITERS` + `GEOMETRY_TOOLS` + `MOUNT_TOOLS`; `checkpoint_document` is NOT (it calls `store.save` itself, doesn't mutate the live session)

**`packages/mcp/src/http.ts`** + **`services/mcp/entry.ts`**
- Both `/health` endpoints spread `...sessionStoreInfo()` — `durable:false` is now visible at `curl mcp.vcad.io/health`

**`packages/mcp/src/tools/checkpoint.ts`** (new)
- `checkpointDocument`: deep-copies live doc, saves to durable store under `ckpt_<n>_<rand>` id, returns netlist anchor summary
- `branchFrom`: resolves checkpoint from cache→store; `into` omitted = fork to fresh session; `into` set = restore-in-place

## Test plan

- [ ] `npm test -w @vcad/mcp` — all 363 tests pass (11 new: 5 checkpoint, 6 durability-smoke)
- [ ] `curl https://mcp.vcad.io/health` after deploy — confirm `durable:true` now that `SUPABASE_SERVICE_ROLE_KEY` is set in prod
- [ ] `server_info` MCP tool — confirm `durable`, `session_store`, `production` fields present
- [ ] Checkpoint smoke: `create_schematic` → `checkpoint_document` → modify → `branch_from` with `into` → confirm netlist restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)