### PR TITLE
fix(pcb): reject malformed copper-layer names at every MCP write boundary

### DIFF
--- a/changelog/entries/2026-06-26-pcb-layer-name-validation.json
+++ b/changelog/entries/2026-06-26-pcb-layer-name-validation.json
@@ -1,0 +1,21 @@
+{
+  "id": "2026-06-26-pcb-layer-name-validation",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "fix",
+  "title": "PCB tools reject malformed copper-layer names",
+  "summary": "Every PCB write tool now validates layer names against the real enum, rejecting dotted KiCad forms like 'In1.Cu' with a did-you-mean instead of storing them and silently corrupting render_pcb/export_gerber.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "add_trace",
+    "add_via",
+    "add_via_array",
+    "add_zone",
+    "add_coil",
+    "add_motor_winding",
+    "set_stackup"
+  ]
+}

--- a/crates/vcad-ir/src/ecad.rs
+++ b/crates/vcad-ir/src/ecad.rs
@@ -274,58 +274,86 @@ pub struct SymbolDef {
 // ============================================================================
 
 /// PCB layer identifiers (KiCad-compatible).
+///
+/// Each variant carries a `serde(alias = …)` for the dotted KiCad spelling
+/// (`In1.Cu`, `Edge.Cuts`, …) so documents that were corrupted with those
+/// names still deserialize — and re-serialize back to the canonical form. The
+/// MCP write boundaries reject the dotted spellings outright (see
+/// `validateLayer` in `packages/mcp/src/tools/ecad.ts`); the aliases are only a
+/// safety net for data already on disk.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
 pub enum PcbLayer {
     // Copper layers
     /// Front copper.
+    #[serde(alias = "F.Cu")]
     FCu,
     /// Back copper.
+    #[serde(alias = "B.Cu")]
     BCu,
     /// Inner copper layer 1.
+    #[serde(alias = "In1.Cu")]
     In1Cu,
     /// Inner copper layer 2.
+    #[serde(alias = "In2.Cu")]
     In2Cu,
     /// Inner copper layer 3.
+    #[serde(alias = "In3.Cu")]
     In3Cu,
     /// Inner copper layer 4.
+    #[serde(alias = "In4.Cu")]
     In4Cu,
     /// Inner copper layer 5.
+    #[serde(alias = "In5.Cu")]
     In5Cu,
     /// Inner copper layer 6.
+    #[serde(alias = "In6.Cu")]
     In6Cu,
 
     // Mask/paste layers
     /// Front solder mask.
+    #[serde(alias = "F.SilkS")]
     FSilkS,
     /// Back solder mask.
+    #[serde(alias = "B.SilkS")]
     BSilkS,
     /// Front solder mask.
+    #[serde(alias = "F.Mask")]
     FMask,
     /// Back solder mask.
+    #[serde(alias = "B.Mask")]
     BMask,
     /// Front solder paste.
+    #[serde(alias = "F.Paste")]
     FPaste,
     /// Back solder paste.
+    #[serde(alias = "B.Paste")]
     BPaste,
 
     // Fabrication/documentation layers
     /// Front fabrication.
+    #[serde(alias = "F.Fab")]
     FFab,
     /// Back fabrication.
+    #[serde(alias = "B.Fab")]
     BFab,
     /// Front courtyard.
+    #[serde(alias = "F.CrtYd")]
     FCrtYd,
     /// Back courtyard.
+    #[serde(alias = "B.CrtYd")]
     BCrtYd,
 
     // Mechanical layers
     /// Edge cuts (board outline).
+    #[serde(alias = "Edge.Cuts")]
     EdgeCuts,
     /// User drawing layer.
+    #[serde(alias = "User.Drawings")]
     UserDrawings,
     /// User comments layer.
+    #[serde(alias = "User.Comments")]
     UserComments,
 }
 
@@ -1151,6 +1179,32 @@ mod tests {
         assert!(PcbLayer::In1Cu.is_copper());
         assert!(!PcbLayer::FSilkS.is_copper());
         assert!(!PcbLayer::EdgeCuts.is_copper());
+    }
+
+    #[test]
+    fn pcb_layer_serializes_canonical() {
+        // The wire form is always the canonical (dotless) variant name.
+        assert_eq!(serde_json::to_string(&PcbLayer::In1Cu).unwrap(), r#""In1Cu""#);
+        assert_eq!(serde_json::to_string(&PcbLayer::EdgeCuts).unwrap(), r#""EdgeCuts""#);
+    }
+
+    #[test]
+    fn pcb_layer_dotted_alias_deserializes() {
+        // Documents corrupted with the dotted KiCad spelling still load — and
+        // re-serialize back to the canonical form, healing the data on save.
+        for (dotted, want) in [
+            (r#""F.Cu""#, PcbLayer::FCu),
+            (r#""B.Cu""#, PcbLayer::BCu),
+            (r#""In1.Cu""#, PcbLayer::In1Cu),
+            (r#""In6.Cu""#, PcbLayer::In6Cu),
+            (r#""F.SilkS""#, PcbLayer::FSilkS),
+            (r#""Edge.Cuts""#, PcbLayer::EdgeCuts),
+        ] {
+            let got: PcbLayer = serde_json::from_str(dotted).unwrap();
+            assert_eq!(got, want, "alias {dotted} should map to {want:?}");
+            // Round-trips to the canonical spelling, not back to the dotted form.
+            assert!(!serde_json::to_string(&got).unwrap().contains('.'));
+        }
     }
 
     #[test]

--- a/crates/vcad-ir/src/ecad.rs
+++ b/crates/vcad-ir/src/ecad.rs
@@ -1184,8 +1184,14 @@ mod tests {
     #[test]
     fn pcb_layer_serializes_canonical() {
         // The wire form is always the canonical (dotless) variant name.
-        assert_eq!(serde_json::to_string(&PcbLayer::In1Cu).unwrap(), r#""In1Cu""#);
-        assert_eq!(serde_json::to_string(&PcbLayer::EdgeCuts).unwrap(), r#""EdgeCuts""#);
+        assert_eq!(
+            serde_json::to_string(&PcbLayer::In1Cu).unwrap(),
+            r#""In1Cu""#
+        );
+        assert_eq!(
+            serde_json::to_string(&PcbLayer::EdgeCuts).unwrap(),
+            r#""EdgeCuts""#
+        );
     }
 
     #[test]

--- a/packages/engine/src/__tests__/ecad.test.ts
+++ b/packages/engine/src/__tests__/ecad.test.ts
@@ -43,12 +43,14 @@ const validPcb: Pcb = {
   zones: [],
 };
 
-// Same board, but with a trace on a dotted layer name (`In1.Cu`). The kernel's
-// `PcbLayer` enum only knows `In1Cu`, so serde refuses the whole board — the
-// exact bug that used to deserialize-fail and get swallowed into a false-clean.
+// Same board, but with a trace on a completely unknown layer name. The kernel's
+// `PcbLayer` enum has no such variant, so serde refuses the whole board — tests
+// that a deserialize failure is surfaced as `errored`, not swallowed into a false-clean.
+// (Note: dotted KiCad forms like "In1.Cu" are now accepted via serde aliases and
+// auto-coerced to "In1Cu", so they no longer trigger this error path.)
 const malformedPcb = {
   ...validPcb,
-  traces: [{ start: { x: 1, y: 1 }, end: { x: 5, y: 1 }, width: 0.2, layer: "In1.Cu", net: "GND" }],
+  traces: [{ start: { x: 1, y: 1 }, end: { x: 5, y: 1 }, width: 0.2, layer: "UNKNOWN_LAYER", net: "GND" }],
 } as unknown as Pcb;
 
 /** A minimal valid schematic the kernel deserializes cleanly. */
@@ -90,8 +92,8 @@ describe("ecad verification wrappers — three-state outcome", () => {
     // empty violation list.
     expect(outcome.status).toBe("errored");
     if (outcome.status === "errored") {
-      expect(outcome.offending_field).toBe("In1.Cu");
-      expect(outcome.reason).toMatch(/In1\.Cu/);
+      expect(outcome.offending_field).toBe("UNKNOWN_LAYER");
+      expect(outcome.reason).toMatch(/UNKNOWN_LAYER/);
     }
   });
 
@@ -104,7 +106,7 @@ describe("ecad verification wrappers — three-state outcome", () => {
   it("critiqueRoute reports `errored` (NOT null) when the kernel can't parse the board", async () => {
     const outcome = await critiqueRoute(malformedPcb, "GND");
     expect(outcome.status).toBe("errored");
-    if (outcome.status === "errored") expect(outcome.offending_field).toBe("In1.Cu");
+    if (outcome.status === "errored") expect(outcome.offending_field).toBe("UNKNOWN_LAYER");
   });
 
   it("runErc reports `errored` (NOT clean) when the kernel can't parse the schematic", async () => {

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -1877,6 +1877,13 @@ netTies?: Array<NetTie>, };
 
 /**
  * PCB layer identifiers (KiCad-compatible).
+ *
+ * Each variant carries a `serde(alias = …)` for the dotted KiCad spelling
+ * (`In1.Cu`, `Edge.Cuts`, …) so documents that were corrupted with those
+ * names still deserialize — and re-serialize back to the canonical form. The
+ * MCP write boundaries reject the dotted spellings outright (see
+ * `validateLayer` in `packages/mcp/src/tools/ecad.ts`); the aliases are only a
+ * safety net for data already on disk.
  */
 export type PcbLayer = "FCu" | "BCu" | "In1Cu" | "In2Cu" | "In3Cu" | "In4Cu" | "In5Cu" | "In6Cu" | "FSilkS" | "BSilkS" | "FMask" | "BMask" | "FPaste" | "BPaste" | "FFab" | "BFab" | "FCrtYd" | "BCrtYd" | "EdgeCuts" | "UserDrawings" | "UserComments";
 

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -4224,11 +4224,13 @@ describe("run_drc / run_erc / critique_route surface 'unverifiable', not false-c
     zones: [],
   };
 
-  // A trace on a dotted layer name — serde refuses the whole board.
+  // A trace on a completely unknown layer name — serde refuses the whole board.
+  // (Dotted KiCad forms like "In1.Cu" are now accepted via serde aliases and
+  // auto-coerced to "In1Cu", so they no longer trigger the kernel parse error.)
   const malformedPcb = {
     ...validPcb,
     traces: [
-      { start: { x: 1, y: 1 }, end: { x: 5, y: 1 }, width: 0.2, layer: "In1.Cu", net: "GND" },
+      { start: { x: 1, y: 1 }, end: { x: 5, y: 1 }, width: 0.2, layer: "UNKNOWN_LAYER", net: "GND" },
     ],
   } as unknown as Pcb;
 
@@ -4277,7 +4279,7 @@ describe("run_drc / run_erc / critique_route surface 'unverifiable', not false-c
     expect(result.isError).toBe(true);
     expect(result.structuredContent?.verifiable).toBe(false);
     expect(result.structuredContent?.status).toBe("errored");
-    expect(result.structuredContent?.offending_field).toBe("In1.Cu");
+    expect(result.structuredContent?.offending_field).toBe("UNKNOWN_LAYER");
     expect(result.structuredContent?.next_actions?.length).toBeGreaterThan(0);
     // The text must NOT read as a clean pass.
     const text = result.content[0]!.text;
@@ -4295,7 +4297,7 @@ describe("run_drc / run_erc / critique_route surface 'unverifiable', not false-c
     const result = asResult(await critiqueRoute({ document: docWithPcb(malformedPcb), net: "GND" }));
     expect(result.isError).toBe(true);
     expect(result.structuredContent?.verifiable).toBe(false);
-    expect(result.structuredContent?.offending_field).toBe("In1.Cu");
+    expect(result.structuredContent?.offending_field).toBe("UNKNOWN_LAYER");
   });
 
   it("run_erc returns isError + verifiable:false for a malformed schematic", async () => {

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -4382,3 +4382,156 @@ describe("set_design_rules ordering tolerance (buffering)", () => {
     expect(badClass.isError).toBe(true);
   });
 });
+
+describe("layer-name validation at write boundaries", () => {
+  /** Error text of a failed tool result (the content block isn't JSON). */
+  const errText = (r: { content: Array<{ text: string }> }) => r.content[0].text;
+
+  it("add_trace rejects the dotted KiCad form with a did-you-mean + legal list", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addTrace({
+      document_id: id,
+      net: "MID",
+      layer: "In1.Cu",
+      points: [
+        { x: 1, y: 1 },
+        { x: 9, y: 1 },
+      ],
+    });
+    expect(isErr(res)).toBe(true);
+    const t = errText(res);
+    expect(t).toContain("'In1.Cu' is not valid");
+    expect(t).toContain("did you mean 'In1Cu'");
+    expect(t).toContain("Legal: FCu, BCu, In1Cu");
+    // No corrupt copper landed on the board.
+    expect(getPcbBoard(getSession(id)).traces.some((tr) => tr.layer === ("In1.Cu" as never))).toBe(
+      false,
+    );
+  });
+
+  it("add_trace rejects an entirely unknown layer with the legal list", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addTrace({
+      document_id: id,
+      net: "MID",
+      layer: "TopCopper",
+      points: [
+        { x: 1, y: 1 },
+        { x: 9, y: 1 },
+      ],
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("'TopCopper' is not valid");
+    expect(errText(res)).toContain("Legal:");
+  });
+
+  it("add_trace rejects a valid but non-copper layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addTrace({
+      document_id: id,
+      net: "MID",
+      layer: "EdgeCuts",
+      points: [
+        { x: 1, y: 1 },
+        { x: 9, y: 1 },
+      ],
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("not a copper layer");
+  });
+
+  it("add_trace still accepts the canonical layer name", async () => {
+    const id = await boardWithTwoResistors();
+    const res = out(
+      await addTrace({
+        document_id: id,
+        net: "MID",
+        layer: "In1Cu",
+        points: [
+          { x: 1, y: 1 },
+          { x: 9, y: 1 },
+        ],
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.layer).toBe("In1Cu");
+  });
+
+  it("add_via rejects a dotted start_layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addVia({
+      document_id: id,
+      net: "MID",
+      position: { x: 10, y: 10 },
+      start_layer: "F.Cu",
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("start_layer");
+    expect(errText(res)).toContain("did you mean 'FCu'");
+  });
+
+  it("add_zone rejects a dotted layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addZone({ document_id: id, net: "GND", layer: "B.Cu", fill_board: true });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("did you mean 'BCu'");
+    expect(getPcbBoard(getSession(id)).zones).toHaveLength(0);
+  });
+
+  it("add_via_array rejects a dotted end_layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addViaArray({
+      document_id: id,
+      net: "GND",
+      region: { x: 15, y: 15, w: 4, h: 4 },
+      end_layer: "In2.Cu",
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("end_layer");
+    expect(errText(res)).toContain("did you mean 'In2Cu'");
+  });
+
+  it("set_stackup rejects a dotted layer in a per-layer override", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await setStackup({
+      document_id: id,
+      layers: [{ layer: "In1.Cu", copper_oz: 2 }],
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("did you mean 'In1Cu'");
+  });
+
+  it("add_coil rejects a dotted layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addCoil({
+      document_id: id,
+      center: { x: 25, y: 25 },
+      turns: 3,
+      inner_radius: 2,
+      outer_radius: 8,
+      trace_width: 0.3,
+      net: "MID",
+      layer: "In3.Cu",
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("did you mean 'In3Cu'");
+  });
+
+  it("add_motor_winding rejects a dotted copper_layer", async () => {
+    const id = await boardWithTwoResistors();
+    const res = await addMotorWinding({
+      document_id: id,
+      slots: 9,
+      poles: 6,
+      center: { x: 25, y: 25 },
+      pitch_radius: 15,
+      inner_radius: 2,
+      outer_radius: 5,
+      trace_width: 0.3,
+      copper_layer: "F.Cu",
+    });
+    expect(isErr(res)).toBe(true);
+    expect(errText(res)).toContain("copper_layer");
+    expect(errText(res)).toContain("did you mean 'FCu'");
+  });
+});

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -257,6 +257,100 @@ function ecadUnverifiable(
 }
 
 // ============================================================================
+// PCB layer name validation — the single gate guarding every write boundary
+// ============================================================================
+
+/**
+ * Every legal PCB layer name, in board order — the canonical serde variants of
+ * the Rust `PcbLayer` enum (crates/vcad-ir/src/ecad.rs). This is the single
+ * source of truth the write boundaries validate against. The old scattered
+ * `/Cu$/` regex checks let malformed dotted KiCad names (`In1.Cu`) slip through,
+ * which then corrupted documents and broke render_pcb / export_gerber.
+ */
+const PCB_LAYERS: readonly PcbLayer[] = [
+  "FCu", "BCu", "In1Cu", "In2Cu", "In3Cu", "In4Cu", "In5Cu", "In6Cu",
+  "FSilkS", "BSilkS", "FMask", "BMask", "FPaste", "BPaste",
+  "FFab", "BFab", "FCrtYd", "BCrtYd",
+  "EdgeCuts", "UserDrawings", "UserComments",
+];
+
+/** Fast membership test for any legal layer name. */
+const PCB_LAYER_SET: ReadonlySet<string> = new Set(PCB_LAYERS);
+
+/** Copper layers, in board order — the subset traces/vias/zones/coils sit on. */
+const COPPER_LAYERS: readonly PcbLayer[] = [
+  "FCu", "BCu", "In1Cu", "In2Cu", "In3Cu", "In4Cu", "In5Cu", "In6Cu",
+];
+
+/** Fast membership test for copper layers. */
+const COPPER_LAYER_SET: ReadonlySet<string> = new Set(COPPER_LAYERS);
+
+/** True when `layer` is a copper layer (FCu, BCu, In1Cu …). */
+function isCopperLayer(layer: string): boolean {
+  return COPPER_LAYER_SET.has(layer);
+}
+
+/**
+ * Suggest the canonical layer for a malformed name: dotted KiCad form
+ * (`In1.Cu`, `F.Cu`, `Edge.Cuts`) → its serde variant, plus a case-insensitive
+ * fallback. Returns undefined when nothing close matches.
+ */
+function suggestLayer(name: string): PcbLayer | undefined {
+  const dedotted = name.replace(/\./g, "");
+  if (PCB_LAYER_SET.has(dedotted)) return dedotted as PcbLayer;
+  const lower = name.toLowerCase();
+  const lowerDedot = dedotted.toLowerCase();
+  for (const l of PCB_LAYERS) {
+    const ll = l.toLowerCase();
+    if (ll === lower || ll === lowerDedot) return l;
+  }
+  return undefined;
+}
+
+/** Successful layer validation carries the canonical `PcbLayer`. */
+interface LayerOk {
+  layer: PcbLayer;
+}
+/** Failed layer validation carries a ready-to-return error message. */
+interface LayerErr {
+  error: string;
+}
+
+/**
+ * The single gate for a layer name at a write boundary. Accepts only the exact
+ * serde variant (`In1Cu`); a dotted KiCad name (`In1.Cu`) or any unknown string
+ * is rejected with a helpful message that names the closest legal value and
+ * lists them all. This is the durable fix for the malformed names that used to
+ * slip past the `/Cu$/` checks and corrupt documents (a `serde(alias=…)` on the
+ * Rust enum gives round-trip tolerance, but rejecting at the boundary is what
+ * keeps new corruption out).
+ */
+function validateLayer(raw: unknown): LayerOk | LayerErr {
+  const name = String(raw ?? "").trim();
+  if (!name) return { error: `layer is required; legal: ${PCB_LAYERS.join(", ")}` };
+  if (PCB_LAYER_SET.has(name)) return { layer: name as PcbLayer };
+  const suggestion = suggestLayer(name);
+  const hint = suggestion ? ` did you mean '${suggestion}'?` : "";
+  return { error: `layer '${name}' is not valid;${hint} Legal: ${PCB_LAYERS.join(", ")}` };
+}
+
+/**
+ * Like {@link validateLayer} but also requires a copper layer — for traces,
+ * vias, coils, and pours, which can only sit on copper. Rejects valid
+ * non-copper layers (e.g. `EdgeCuts`) with a copper-specific message.
+ */
+function validateCopperLayer(raw: unknown): LayerOk | LayerErr {
+  const res = validateLayer(raw);
+  if ("error" in res) return res;
+  if (!isCopperLayer(res.layer)) {
+    return {
+      error: `layer '${res.layer}' is not a copper layer; copper layers: ${COPPER_LAYERS.join(", ")}`,
+    };
+  }
+  return res;
+}
+
+// ============================================================================
 // Document resolution — session-based (document_id) with inline fallback
 // ============================================================================
 
@@ -5311,7 +5405,6 @@ export function addCoil(args: Record<string, unknown>) {
   const outerR = args.outer_radius as number;
   const traceWidth = args.trace_width as number;
   const net = String(args.net ?? "");
-  const layer = ((args.layer as string) || "FCu") as PcbLayer;
   const direction = (args.direction as string) || "ccw";
   const startAngleDeg = (args.start_angle_deg as number) || 0;
   const segmentsPerTurn = Math.min(
@@ -5330,9 +5423,9 @@ export function addCoil(args: Record<string, unknown>) {
   if (!(outerR > innerR)) return fail("outer_radius must be > inner_radius");
   if (!(traceWidth > 0)) return fail("trace_width must be > 0");
   if (!net) return fail("net is required — coil copper must belong to a net");
-  if (!/Cu$/.test(layer)) {
-    return fail(`layer "${layer}" is not a copper layer (use FCu, BCu, In1Cu, ...)`);
-  }
+  const layerRes = validateCopperLayer((args.layer as string) || "FCu");
+  if ("error" in layerRes) return fail(layerRes.error);
+  const layer = layerRes.layer;
   if (direction !== "ccw" && direction !== "cw") {
     return fail(`direction must be "ccw" or "cw", got "${direction}"`);
   }
@@ -5391,9 +5484,8 @@ export function addCoil(args: Record<string, unknown>) {
   const layersIn = Array.isArray(args.layers) ? (args.layers as string[]) : undefined;
   if (layersIn && layersIn.length >= 2) {
     for (const l of layersIn) {
-      if (!/Cu$/.test(l)) {
-        return fail(`layers entry "${l}" is not a copper layer (use FCu, BCu, In1Cu, ...)`);
-      }
+      const lr = validateCopperLayer(l);
+      if ("error" in lr) return fail(`layers entry: ${lr.error}`);
     }
     const stitchVias: Array<{ position: Vec2; startLayer: PcbLayer; endLayer: PcbLayer }> = [];
     const perLayerLen = segLength(pts);
@@ -5478,7 +5570,9 @@ export function addCoil(args: Record<string, unknown>) {
 
   let via: { position: Vec2; startLayer: PcbLayer; endLayer: PcbLayer } | undefined;
   if (args.inner_via) {
-    const viaTo = ((args.via_to_layer as string) || "BCu") as PcbLayer;
+    const viaToRes = validateCopperLayer((args.via_to_layer as string) || "BCu");
+    if ("error" in viaToRes) return fail(`via_to_layer: ${viaToRes.error}`);
+    const viaTo = viaToRes.layer;
     const v = {
       position: pts[0],
       diameter: pcb.rules.defaultRules.viaDiameter,
@@ -6174,7 +6268,7 @@ export const getPadPositionsSchema = {
 
 /** Copper layers a pad sits on, in board order (drops paste/mask/silk). */
 function padCopperLayers(pad: Pad): PcbLayer[] {
-  return pad.layers.filter((l) => /Cu$/.test(l));
+  return pad.layers.filter((l) => isCopperLayer(l));
 }
 
 /**
@@ -6561,7 +6655,6 @@ export function addTrace(args: Record<string, unknown>) {
 
   const points = Array.isArray(args.points) ? (args.points as Vec2[]) : undefined;
   const net = String(args.net ?? "");
-  const layer = ((args.layer as string) || "FCu") as PcbLayer;
   const width = (args.width as number) ?? pcb.rules.defaultRules.traceWidth;
 
   if (!points || points.length < 2) return fail("points must be an array of >= 2 {x, y}");
@@ -6571,9 +6664,9 @@ export function addTrace(args: Record<string, unknown>) {
     }
   }
   if (!net) return fail("net is required — copper must belong to a net");
-  if (!/Cu$/.test(layer)) {
-    return fail(`layer "${layer}" is not a copper layer (use FCu, BCu, In1Cu, ...)`);
-  }
+  const layerRes = validateCopperLayer((args.layer as string) || "FCu");
+  if ("error" in layerRes) return fail(layerRes.error);
+  const layer = layerRes.layer;
   if (!(width > 0)) return fail("width must be > 0");
 
   if (!pcb.nets.some((n) => n.id === net)) {
@@ -6649,8 +6742,6 @@ export function addVia(args: Record<string, unknown>) {
 
   const position = args.position as Vec2;
   const net = String(args.net ?? "");
-  const startLayer = ((args.start_layer as string) || "FCu") as PcbLayer;
-  const endLayer = ((args.end_layer as string) || "BCu") as PcbLayer;
   const diameter = (args.diameter as number) ?? pcb.rules.defaultRules.viaDiameter;
   const drill = (args.drill as number) ?? pcb.rules.defaultRules.viaDrill;
 
@@ -6658,8 +6749,12 @@ export function addVia(args: Record<string, unknown>) {
     return fail("position must be {x, y} in mm");
   }
   if (!net) return fail("net is required — a via must belong to a net");
-  if (!/Cu$/.test(startLayer)) return fail(`start_layer "${startLayer}" is not a copper layer`);
-  if (!/Cu$/.test(endLayer)) return fail(`end_layer "${endLayer}" is not a copper layer`);
+  const startRes = validateCopperLayer((args.start_layer as string) || "FCu");
+  if ("error" in startRes) return fail(`start_layer: ${startRes.error}`);
+  const startLayer = startRes.layer;
+  const endRes = validateCopperLayer((args.end_layer as string) || "BCu");
+  if ("error" in endRes) return fail(`end_layer: ${endRes.error}`);
+  const endLayer = endRes.layer;
 
   if (!pcb.nets.some((n) => n.id === net)) {
     pcb.nets.push({ id: net, name: net });
@@ -6755,20 +6850,24 @@ export function setStackup(args: Record<string, unknown>) {
   if (copperOz != null) {
     const t = round3(copperOz * OZ_TO_MM);
     for (const l of stackup) {
-      if (/Cu$/.test(l.layer)) l.copperThickness = t;
+      if (isCopperLayer(l.layer)) l.copperThickness = t;
     }
   }
 
   // 2) Per-layer overrides; create copper-layer entries that are missing.
   for (const ov of perLayer ?? []) {
-    const layerName = String(ov.layer ?? "");
-    if (!layerName) return fail("each layers entry needs a `layer`");
+    if (ov.layer == null || String(ov.layer).trim() === "") {
+      return fail("each layers entry needs a `layer`");
+    }
+    const layerRes = validateLayer(ov.layer);
+    if ("error" in layerRes) return fail(layerRes.error);
+    const layerName = layerRes.layer;
     let entry = stackup.find((l) => l.layer === layerName);
     if (!entry) {
-      if (!/Cu$/.test(layerName)) {
+      if (!isCopperLayer(layerName)) {
         return fail(`cannot create non-copper layer "${layerName}" — only copper layers are auto-added`);
       }
-      entry = { layer: layerName as PcbLayer } as StackupLayer;
+      entry = { layer: layerName } as StackupLayer;
       stackup.push(entry);
     }
     if (ov.copper_thickness_mm != null) {
@@ -7037,11 +7136,10 @@ export function addZone(args: Record<string, unknown>) {
   }
 
   const net = String(args.net ?? "");
-  const layer = ((args.layer as string) || "FCu") as PcbLayer;
   if (!net) return fail("net is required — a pour must belong to a net");
-  if (!/Cu$/.test(layer)) {
-    return fail(`layer "${layer}" is not a copper layer (use FCu, BCu, In1Cu, ...)`);
-  }
+  const layerRes = validateCopperLayer((args.layer as string) || "FCu");
+  if ("error" in layerRes) return fail(layerRes.error);
+  const layer = layerRes.layer;
 
   const reliefArg = (args.thermal_relief as string) || "Relief";
   if (!["Direct", "Relief", "None"].includes(reliefArg)) {
@@ -7717,13 +7815,15 @@ export function addViaArray(args: Record<string, unknown>) {
   }
 
   const net = String(args.net ?? "");
-  const startLayer = ((args.start_layer as string) || "FCu") as PcbLayer;
-  const endLayer = ((args.end_layer as string) || "BCu") as PcbLayer;
   const diameter = (args.diameter as number) ?? pcb.rules.defaultRules.viaDiameter;
   const drill = (args.drill as number) ?? pcb.rules.defaultRules.viaDrill;
   if (!net) return fail("net is required — a via must belong to a net");
-  if (!/Cu$/.test(startLayer)) return fail(`start_layer "${startLayer}" is not a copper layer`);
-  if (!/Cu$/.test(endLayer)) return fail(`end_layer "${endLayer}" is not a copper layer`);
+  const startRes = validateCopperLayer((args.start_layer as string) || "FCu");
+  if ("error" in startRes) return fail(`start_layer: ${startRes.error}`);
+  const startLayer = startRes.layer;
+  const endRes = validateCopperLayer((args.end_layer as string) || "BCu");
+  if ("error" in endRes) return fail(`end_layer: ${endRes.error}`);
+  const endLayer = endRes.layer;
 
   const explicitPoints = Array.isArray(args.points)
     ? (args.points as Array<Record<string, unknown>>)
@@ -7902,8 +8002,6 @@ export function addMotorWinding(args: Record<string, unknown>) {
   const traceWidth = args.trace_width as number;
   const turnsPerCoil = (args.turns_per_coil as number) ?? 1;
   const connection = (args.connection as string) === "delta" ? "delta" : "wye";
-  const copperLayer = ((args.copper_layer as string) || "FCu") as PcbLayer;
-  const returnLayer = ((args.return_layer as string) || "BCu") as PcbLayer;
 
   if (!center || typeof center.x !== "number" || typeof center.y !== "number") {
     return fail("center must be {x, y} in mm");
@@ -7911,8 +8009,12 @@ export function addMotorWinding(args: Record<string, unknown>) {
   if (!(pitchRadius >= 0)) return fail("pitch_radius must be >= 0");
   if (!(outerR > innerR)) return fail("outer_radius must be > inner_radius");
   if (!(traceWidth > 0)) return fail("trace_width must be > 0");
-  if (!/Cu$/.test(copperLayer)) return fail(`copper_layer "${copperLayer}" is not a copper layer`);
-  if (!/Cu$/.test(returnLayer)) return fail(`return_layer "${returnLayer}" is not a copper layer`);
+  const copperRes = validateCopperLayer((args.copper_layer as string) || "FCu");
+  if ("error" in copperRes) return fail(`copper_layer: ${copperRes.error}`);
+  const copperLayer = copperRes.layer;
+  const returnRes = validateCopperLayer((args.return_layer as string) || "BCu");
+  if ("error" in returnRes) return fail(`return_layer: ${returnRes.error}`);
+  const returnLayer = returnRes.layer;
 
   // a. Plan the winding.
   const planRes = windingLayout({


### PR DESCRIPTION
## Summary

- Replaces ~13 scattered \`/Cu$/\` regex checks in \`packages/mcp/src/tools/ecad.ts\` with a single \`validateLayer\`/\`validateCopperLayer\` gate backed by the canonical \`PCB_LAYERS\` enum
- Adds \`#[serde(alias)]\` on all 21 \`PcbLayer\` variants in \`crates/vcad-ir/src/ecad.rs\` so already-corrupted docs with dotted names (e.g. \`"In1.Cu"\`) self-heal on read and re-serialize to canonical form
- Adds 10 new TS tests + 2 Rust alias tests covering the validation boundaries

## Root Cause

The old gate used \`/Cu$/\` regex which let dotted KiCad-style names like \`"In1.Cu"\` pass through (they end in \`Cu\`). These got stored verbatim in PCB documents, then broke \`render_pcb\`/\`export_gerber\` deserialization (which only knows strict serde variants like \`In1Cu\`). Combined with lenient DRC that caught the parse error and returned **0 violations**, this produced a false-clean board.

## Changes

**`packages/mcp/src/tools/ecad.ts`**
- Added \`PCB_LAYERS\`, \`PCB_LAYER_SET\`, \`COPPER_LAYERS\`, \`COPPER_LAYER_SET\` as single source of truth
- \`isCopperLayer()\` — fast Set membership check replacing \`/Cu$/\`
- \`suggestLayer()\` — did-you-mean helper: strips dots (\`In1.Cu\` → \`In1Cu\`), case-insensitive fallback
- \`validateLayer()\` / \`validateCopperLayer()\` — gate functions with error messages like: `layer 'In1.Cu' is not valid; did you mean 'In1Cu'? Legal: FCu, BCu, In1Cu, …`
- Replaced all write boundaries: \`add_trace\`, \`add_via\`, \`add_via_array\`, \`add_zone\`, \`add_coil\` (layer + multilayer layers[] + via_to_layer), \`add_motor_winding\`, \`set_stackup\`
- Bonus: \`add_coil\`'s \`via_to_layer\` was previously **completely unvalidated** (raw cast to \`PcbLayer\`); now gated

**`crates/vcad-ir/src/ecad.rs`**
- Added \`#[serde(alias = "F.Cu")]\` etc. on all 21 \`PcbLayer\` variants for round-trip self-heal of existing corrupted docs
- 2 new Rust tests: \`pcb_layer_serializes_canonical\` and \`pcb_layer_dotted_alias_deserializes\`
- Note: serde aliases do NOT affect ts-rs output — only the doc comment regenerated in \`generated.ts\`; \`ir:check\` stays green

**`packages/mcp/src/__tests__/ecad.test.ts`**
- 10 new tests in a \`"layer-name validation at write boundaries"\` block covering all tools
- Verifies: dotted rejected with did-you-mean + legal list; unknown rejected; non-copper rejected from copper-only tools; canonical accepted; zone not stored on error

## Test plan

- [ ] \`cargo test --workspace\` passes
- [ ] \`cargo clippy --workspace --exclude vcad-desktop -- -D warnings\` clean (vcad-desktop has pre-existing debt unrelated to this change)
- [ ] \`npm run build --workspaces\` clean
- [ ] \`npm run ir:check\` passes (generated.ts in sync)
- [ ] 148 ecad MCP tests pass including 10 new layer-validation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)