### PR TITLE
docs(changelog): add entry for add_zone copper-overlap guard

### DIFF
--- a/changelog/entries/2026-06-26-add-zone-overlap-guard.json
+++ b/changelog/entries/2026-06-26-add-zone-overlap-guard.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-06-26-add-zone-overlap-guard",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "feat",
+  "title": "add_zone rejects shorting copper pours at author time",
+  "summary": "add_zone now fails fast when a pour overlaps an existing different-net pour on the same layer (a copper short), naming the conflicting net and overlap bbox in a zone_drc preview — instead of surfacing it only at post-route run_drc. Pass allow_overlap:true to override.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "add_zone"
+  ]
+}


### PR DESCRIPTION
## What this is

A single changelog entry for the `add_zone` author-time copper-overlap guard.

The guard itself (reject a pour overlapping a same-layer different-net pour — a copper short; `zone_drc: { clean, overlaps:[{layer,nets,bbox}] }` preview; `allow_overlap` override) already shipped to `main` via #356/#363. The only thing missing was the changelog entry — this adds it.

## History

This PR briefly also carried a typecheck fix for the `describe_pcb` × `DrcUnverifiable` semantic merge break, but #358 landed the same fix on `main` first, so it's been dropped. The diff is now just the one changelog file.