### PR TITLE
feat(pcb): validate_for_fab readiness gate + clean-DRC export guard

### DIFF
--- a/changelog/entries/2026-06-26-validate-for-fab.json
+++ b/changelog/entries/2026-06-26-validate-for-fab.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-06-26-validate-for-fab",
+  "version": "0.9.4",
+  "date": "2026-06-26",
+  "category": "feat",
+  "title": "validate_for_fab readiness gate + clean-DRC export guard",
+  "summary": "New validate_for_fab tool returns one fail-closed verdict (DRC, renderability, Gerber serialization, unsupported features, blockers, fixes), and export_gerber now blocks a dirty or unverifiable board by default.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "validate_for_fab",
+    "export_gerber"
+  ]
+}

--- a/packages/engine/src/ecad.ts
+++ b/packages/engine/src/ecad.ts
@@ -188,6 +188,35 @@ export async function runDrc(pcb: Pcb): Promise<VerifyOutcome<DrcViolationResult
   );
 }
 
+/**
+ * Discriminated outcome for fab-readiness probes that must distinguish a real
+ * pass from an *unverifiable* one. Surface the kernel error verbatim so callers
+ * can fail closed and quote the exact failing field.
+ *
+ * - `unavailable`: the ECAD kernel WASM isn't loaded (or predates the binding).
+ * - `error`: the kernel ran but threw — almost always a serde parse failure
+ *   whose message names the offending field (e.g. ``missing field `thickness```).
+ */
+export type EcadProbe<T> =
+  | { ok: true; value: T }
+  | { ok: false; reason: "unavailable" | "error"; message: string };
+
+/**
+ * Run DRC, surfacing failures as an {@link EcadProbe} instead of swallowing them.
+ * Use this (not `runDrc`) anywhere a parse failure must read as *unverifiable*.
+ */
+export async function tryRunDrc(pcb: Pcb): Promise<EcadProbe<DrcViolationResult[]>> {
+  const wasm = await loadEcadWasm();
+  if (!wasm) {
+    return { ok: false, reason: "unavailable", message: "ECAD kernel WASM not loaded" };
+  }
+  try {
+    return { ok: true, value: wasm.ecadCheckDrc(JSON.stringify(pcb)) as DrcViolationResult[] };
+  } catch (e) {
+    return { ok: false, reason: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // PCB Design-for-Manufacturing (fab-profile capability checks)
 // ---------------------------------------------------------------------------
@@ -614,13 +643,28 @@ export interface FabFile {
  * distinguish "no kernel" from "export failed".
  */
 export async function exportFabFiles(pcb: Pcb): Promise<FabFile[] | null> {
+  const probe = await tryExportFabFiles(pcb);
+  if (probe.ok) return probe.value;
+  if (probe.reason === "error") console.warn("[ECAD] Fab export failed:", probe.message);
+  return null;
+}
+
+/**
+ * Attempt fabrication-file serialization, surfacing the kernel error instead of
+ * collapsing it to `null`. The error message is the serde failure verbatim — so
+ * a readiness gate can report the exact field the board can't serialize on
+ * (`missing field \`thickness\``, `invalid type: null, expected f64`, …) rather
+ * than a blank "export failed". See {@link EcadProbe}.
+ */
+export async function tryExportFabFiles(pcb: Pcb): Promise<EcadProbe<FabFile[]>> {
   const wasm = await loadEcadWasm();
-  if (!wasm) return null;
+  if (!wasm) {
+    return { ok: false, reason: "unavailable", message: "ECAD kernel WASM not loaded" };
+  }
   try {
-    return wasm.ecadExportFab(JSON.stringify(pcb)) as FabFile[];
+    return { ok: true, value: wasm.ecadExportFab(JSON.stringify(pcb)) as FabFile[] };
   } catch (e) {
-    console.warn("[ECAD] Fab export failed:", e);
-    return null;
+    return { ok: false, reason: "error", message: e instanceof Error ? e.message : String(e) };
   }
 }
 
@@ -875,13 +919,37 @@ export interface PcbPreviewMesh {
  * when the ECAD WASM is unavailable or the build predates the binding.
  */
 export async function pcbPreviewMeshes(pcb: Pcb): Promise<PcbPreviewMesh[]> {
+  const probe = await tryPcbPreviewMeshes(pcb);
+  if (probe.ok) return probe.value;
+  if (probe.reason === "error") console.warn("[ECAD] pcbPreviewMeshes failed:", probe.message);
+  return [];
+}
+
+/**
+ * Attempt to build the layered preview meshes, surfacing failures. An `error`
+ * means the board solid trapped during evaluation (the geometry can't be
+ * visualized); an `ok` result with an empty array means the kernel ran but the
+ * board produced no renderable geometry. A readiness gate treats both as a
+ * renderability blocker rather than a silent empty preview. See {@link EcadProbe}.
+ */
+export async function tryPcbPreviewMeshes(
+  pcb: Pcb,
+): Promise<EcadProbe<PcbPreviewMesh[]>> {
   const wasm = await loadEcadWasm();
-  if (!wasm || typeof wasm.ecadPcbPreviewMeshes !== "function") return [];
+  if (!wasm || typeof wasm.ecadPcbPreviewMeshes !== "function") {
+    return {
+      ok: false,
+      reason: "unavailable",
+      message: "PCB preview-mesh binding unavailable (kernel WASM missing or predates it)",
+    };
+  }
   try {
-    return wasm.ecadPcbPreviewMeshes(JSON.stringify(pcb)) as PcbPreviewMesh[];
+    return {
+      ok: true,
+      value: wasm.ecadPcbPreviewMeshes(JSON.stringify(pcb)) as PcbPreviewMesh[],
+    };
   } catch (e) {
-    console.warn("[ECAD] pcbPreviewMeshes failed:", e);
-    return [];
+    return { ok: false, reason: "error", message: e instanceof Error ? e.message : String(e) };
   }
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -150,6 +150,7 @@ export {
   runDrc,
   runPcbDfm,
   getPcbDfmPack,
+  tryRunDrc,
   critiqueRoute,
   runErc,
   checkErc,
@@ -161,6 +162,7 @@ export {
   routeDiffPair,
   fillZones,
   exportFabFiles,
+  tryExportFabFiles,
   parseKicadPcb,
   exportKicadPcb,
   exportKicadSch,
@@ -170,6 +172,7 @@ export {
   computeRatsnest,
   componentMeshes,
   pcbPreviewMeshes,
+  tryPcbPreviewMeshes,
   createCircuitSim,
   evaluateMotor,
   airgapFluxDensity,
@@ -184,6 +187,7 @@ export {
   verifyReceipt,
 } from "./ecad.js";
 export type {
+  EcadProbe,
   DrcViolationResult,
   PcbFabProfile,
   PcbDfmSeverity,

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -11,6 +11,7 @@ import {
   runErc,
   exportGerber,
   exportKicad,
+  validateForFab,
   calcImpedance,
   sizeImpedance,
   sizePdn,
@@ -993,6 +994,113 @@ describe("ecad session flow", () => {
     // An unsupported extension is a clean tool error, not a throw.
     const bad = await exportKicad({ document_id: id, filename: "nope.brd" });
     expect(bad.isError).toBe(true);
+  });
+
+  it("export_gerber blocks a dirty (unconnected-net) board and returns the DRC summary", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+    // Deliberately NOT routed → MID's two pads sit in disjoint copper groups,
+    // so DRC reports an UnconnectedNet error and the board is not fab-clean.
+
+    const blocked = out(await exportGerber({ document_id: id })); // require_clean_drc defaults true
+    expect(blocked.success).toBe(false);
+    expect(blocked.blocked).toBe(true);
+    expect(blocked.drc.errors).toBeGreaterThan(0);
+    expect(blocked.drc.byRule.UnconnectedNet).toBeGreaterThan(0);
+    expect(blocked.files).toBeUndefined();
+
+    // Opting out of the gate still emits the bundle (caller forced a dirty export).
+    const forced = out(
+      await exportGerber({ document_id: id, require_clean_drc: false }),
+    );
+    expect(forced.success).toBe(true);
+    expect(forced.files.length).toBeGreaterThan(0);
+  });
+
+  it("export_gerber exports a clean routed board under the default DRC gate", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+    expect(out(await routeNets({ document_id: id })).success).toBe(true);
+
+    const gerber = out(await exportGerber({ document_id: id }));
+    expect(gerber.success).toBe(true);
+    expect(gerber.files.length).toBeGreaterThan(0);
+  });
+
+  it("validate_for_fab passes a clean routed board (ready)", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+    out(await routeNets({ document_id: id }));
+
+    const v = out(await validateForFab({ document_id: id }));
+    expect(v.ready).toBe(true);
+    expect(v.verdict).toBe("ready");
+    expect(v.drc.status).toBe("clean");
+    expect(v.renderable.ok).toBe(true);
+    expect(v.gerber_exportable.ok).toBe(true);
+    expect(v.blockers).toHaveLength(0);
+    expect(v.unverifiable).toHaveLength(0);
+  });
+
+  it("validate_for_fab blocks a dirty board and names the DRC errors", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+
+    const v = out(await validateForFab({ document_id: id }));
+    expect(v.ready).toBe(false);
+    expect(v.verdict).toBe("blocked");
+    expect(v.drc.status).toBe("violations");
+    expect(v.blockers.some((b: string) => b.startsWith("DRC:"))).toBe(true);
+    expect(v.suggested_fixes.length).toBeGreaterThan(0);
+  });
+
+  it("validate_for_fab reports a serialization blocker with the exact failing field", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+    out(await routeNets({ document_id: id }));
+
+    // Corrupt the board so the kernel can no longer deserialize it: drop a
+    // required field. Gerber serialization must surface 'thickness' by name, and
+    // — fail-closed — DRC must read 'unverifiable', never clean.
+    const board = getPcbBoard(getSession(id));
+    delete (board.outline as { thickness?: number }).thickness;
+
+    const v = out(await validateForFab({ document_id: id }));
+    expect(v.ready).toBe(false);
+    expect(v.gerber_exportable.ok).toBe(false);
+    expect(v.gerber_exportable.field).toBe("thickness");
+    expect(v.blockers.some((b: string) => b.includes("thickness"))).toBe(true);
+    expect(v.drc.status).toBe("unverifiable");
   });
 
   it("parametric footprint engine resolves QFN/DPAK on-board and reports unknowns", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -172,6 +172,8 @@ import {
   exportGerberSchema,
   exportKicad,
   exportKicadSchema,
+  validateForFab,
+  validateForFabSchema,
   calcImpedance,
   calcImpedanceSchema,
   sizeImpedance,
@@ -661,6 +663,7 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "run_drc",
     "run_erc",
     "export_gerber",
+    "validate_for_fab",
     "render_pcb",
     "render_ratsnest",
     "render_stackup",
@@ -715,7 +718,7 @@ function buildInstructions(kernelPrompt: string | null): string {
     "- Ship with `export_cad` (STL/GLB/STEP) or `open_in_browser` (vcad.io deep link).",
     "- Fix in place: when geometry is wrong, prefer `update` on the offending node over deleting parts and starting over.",
     "",
-    "PCB workflow: `create_schematic` (declare connectivity as data via `nets`) → `place_components` → `route_nets` / `add_coil` / `add_coil_array` → `run_drc` → `export_gerber`. All take the `document_id` from create_schematic and mutate that session — never re-send the document. `board_from_solid` turns a solid part (e.g. an enclosure or stator disc in a CAD session) into an outline polygon for `place_components`. For motors, plan the winding first with `winding_layout` (slots + poles → per-coil phase/polarity/winding-factor, as data — it touches no board), then realize it with `add_coil_array`. `run_drc` returns a summary by default (counts by rule + net-pair, worst clearance, a capped sample); pass `detail:'full'` for every violation.",
+    "PCB workflow: `create_schematic` (declare connectivity as data via `nets`) → `place_components` → `route_nets` / `add_coil` / `add_coil_array` → `run_drc` → `validate_for_fab` → `export_gerber`. All take the `document_id` from create_schematic and mutate that session — never re-send the document. `validate_for_fab` is the single 'is this board ready?' gate (DRC + renderability + Gerber serialization + blockers, all fail-closed); `export_gerber` enforces a clean DRC by default and blocks a dirty board. `board_from_solid` turns a solid part (e.g. an enclosure or stator disc in a CAD session) into an outline polygon for `place_components`. For motors, plan the winding first with `winding_layout` (slots + poles → per-coil phase/polarity/winding-factor, as data — it touches no board), then realize it with `add_coil_array`. `run_drc` returns a summary by default (counts by rule + net-pair, worst clearance, a capped sample); pass `detail:'full'` for every violation.",
   ].join("\n");
   if (!kernelPrompt) return header;
   const sections = new Map<string, string>();
@@ -1707,7 +1710,10 @@ export async function createServer(
         name: "export_gerber",
         description:
           "Export Gerber RS-274X fabrication files from a PCB design. " +
-          "Generates copper layer files, drill file, pick-and-place CSV, and BOM.",
+          "Generates copper layer files, drill file, pick-and-place CSV, and BOM. " +
+          "Gated on a clean DRC by default (require_clean_drc) — a dirty or " +
+          "unverifiable board is BLOCKED with its DRC summary instead of emitting " +
+          "an invalid bundle. Run validate_for_fab first for the full readiness verdict.",
         inputSchema: exportGerberSchema,
       },
       {
@@ -1720,6 +1726,18 @@ export async function createServer(
           "it in KiCad to finish routing nets the autorouter couldn't close, then " +
           "re-import. Large files respect the inline byte cap (use output_dir for those).",
         inputSchema: exportKicadSchema,
+      },
+      {
+        name: "validate_for_fab",
+        description:
+          "The single 'is this board ready to fabricate?' oracle. Runs the whole " +
+          "readiness gate in one call and returns ONE structured verdict: DRC " +
+          "(fail-closed — a board that won't parse is 'unverifiable', never clean), " +
+          "renderability, Gerber-exportability (attempts serialization; names the " +
+          "exact failing field when it can't), unsupported features, the precise " +
+          "blockers, and suggested fixes. Read-only. Use before export_gerber / " +
+          "quote_manufacturing to know — not guess — whether the board is shippable.",
+        inputSchema: validateForFabSchema,
       },
       {
         name: "calc_impedance",
@@ -2381,6 +2399,10 @@ export async function createServer(
 
         case "export_kicad":
           result = await exportKicad(args);
+          break;
+
+        case "validate_for_fab":
+          result = await validateForFab(args);
           break;
 
         case "calc_impedance":

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -38,6 +38,9 @@ import {
   pcbPreviewMeshes,
   exportKicadPcb,
   exportKicadSch,
+  tryExportFabFiles,
+  tryRunDrc,
+  tryPcbPreviewMeshes,
   resolveFootprint,
   generateNetlist,
   isEcadAvailable,
@@ -921,6 +924,27 @@ export const exportGerberSchema = {
         "pass that artifact_id to quote_manufacturing / place_order so the fab " +
         "files never transit model context.",
     },
+    require_clean_drc: {
+      type: "boolean" as const,
+      description:
+        "Gate the export on a clean DRC (default TRUE). When set, the board is " +
+        "DRC-checked first and the export is BLOCKED — returning `blocked:true` " +
+        "plus the DRC summary — if it has any errors (shorts, clearance, " +
+        "unconnected nets, fab-rule breaks) or the check is unverifiable " +
+        "(fail-closed: a board that won't even parse never counts as clean). " +
+        "Set false only to force a Gerber bundle from a board you know is dirty; " +
+        "the resulting files would otherwise fabricate an invalid board. Use " +
+        "validate_for_fab first for the full readiness verdict.",
+    },
+  },
+  required: [],
+};
+
+/** JSON Schema for validate_for_fab tool. */
+export const validateForFabSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
   },
   required: [],
 };
@@ -3673,6 +3697,42 @@ export function summarizeZoneDrc(
   return { clean: overlaps.length === 0, overlaps };
 }
 
+/**
+ * A fail-closed DRC verdict for the fab-readiness gate. Unlike {@link drcPcb}
+ * (which swallows a kernel failure into "0 violations" and looks clean), this
+ * runs DRC through the error-surfacing {@link tryRunDrc} probe so a board that
+ * can't be parsed/checked reads as `unverifiable` — NEVER `clean`.
+ *
+ * - `clean`: DRC ran and found no errors.
+ * - `violations`: DRC ran and found ≥1 error (short, clearance, unconnected
+ *   net, fab-rule break). The summary carries counts + a representative sample.
+ * - `unverifiable`: DRC could not run (kernel missing, or the board threw a
+ *   serde/parse trap). `reason` explains; the board is not certifiable.
+ */
+export type DrcVerdict =
+  | { status: "clean"; summary: DrcSummary }
+  | { status: "violations"; summary: DrcSummary }
+  | { status: "unverifiable"; reason: string };
+
+/** Run the fail-closed DRC verdict against a PCB (shared by validate_for_fab
+ *  and the export_gerber clean-DRC gate, so they can never disagree). */
+export async function drcVerdict(pcb: Pcb, sampleSize = 20): Promise<DrcVerdict> {
+  const probe = await tryRunDrc(pcb);
+  if (!probe.ok) {
+    return {
+      status: "unverifiable",
+      reason:
+        probe.reason === "unavailable"
+          ? `DRC engine unavailable (${probe.message}) — cannot certify the board`
+          : `DRC could not run — the board failed to serialize/parse: ${probe.message}`,
+    };
+  }
+  const summary = aggregateDrc(probe.value as unknown as DrcViol[], sampleSize, "summary");
+  // Unconnected nets are Error severity in the kernel, so `errors` already
+  // captures the "board with unconnected nets" case the fab gate must block.
+  return { status: summary.errors === 0 ? "clean" : "violations", summary };
+}
+
 /** Run DRC against a session/inline document and return the summary-first payload. */
 export async function runDrc(args: Record<string, unknown>) {
   const { doc } = resolveDocInput(args);
@@ -3867,6 +3927,38 @@ export async function exportGerber(args: Record<string, unknown>) {
   const validity = validatePcb(pcb);
   if (!validity.valid) {
     return pcbValidationError("export_gerber", validity, args.document_id ? String(args.document_id) : undefined);
+  }
+
+  // Clean-DRC gate (default ON for agents): never emit a fab bundle from a board
+  // that isn't DRC-clean. Fail closed — an unverifiable board (won't parse) is
+  // blocked too, since shipping Gerbers we couldn't certify is the failure mode
+  // this guards against. Pass require_clean_drc:false to force a known-dirty export.
+  const requireCleanDrc = args.require_clean_drc !== false;
+  if (requireCleanDrc) {
+    const verdict = await drcVerdict(pcb);
+    if (verdict.status !== "clean") {
+      const blocker =
+        verdict.status === "unverifiable"
+          ? verdict.reason
+          : `${verdict.summary.errors} DRC error(s) must be resolved before fabrication`;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              success: false,
+              blocked: true,
+              reason: blocker,
+              drc: verdict.status === "unverifiable" ? { status: "unverifiable" } : verdict.summary,
+              hint:
+                "Resolve the DRC errors (run run_drc / validate_for_fab for details), or " +
+                "re-run export_gerber with require_clean_drc:false to force the bundle anyway.",
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
   }
 
   const files = await exportFabFiles(pcb);
@@ -4089,6 +4181,178 @@ export async function exportKicad(args: Record<string, unknown>) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(payload) }],
     structuredContent: { export_kicad: payload },
+  };
+}
+
+// ============================================================================
+// validate_for_fab — the single fab-readiness oracle
+// ============================================================================
+
+/** Pull the offending field name out of a serde error message, when it names
+ *  one (`missing field \`thickness\``, `unknown field \`foo\``). Returns null
+ *  for location-only messages (`invalid type: null, expected f64 at …`). */
+function extractSerdeField(message: string): string | null {
+  const m = /(?:missing|unknown) field `([^`]+)`/.exec(message);
+  return m ? m[1]! : null;
+}
+
+/** A feature present on the board that the fab/export pipeline can't faithfully
+ *  represent — surfaced loudly rather than silently producing a wrong bundle. */
+interface UnsupportedFeature {
+  feature: string;
+  count: number;
+  detail: string;
+  fix: string;
+}
+
+/** True for a via that spans the outer copper pair (a normal through-via). */
+function isThroughVia(via: Via): boolean {
+  const a = via.startLayer;
+  const b = via.endLayer;
+  return (a === "FCu" && b === "BCu") || (a === "BCu" && b === "FCu");
+}
+
+/** Scan the board for features the Gerber/Excellon export can't faithfully
+ *  produce. Heuristic and intentionally narrow — it flags the known-unsupported
+ *  set, not "everything that could ever be wrong". Today: blind/buried vias,
+ *  which our drill writer collapses to plain through-holes. */
+function detectUnsupportedFeatures(pcb: Pcb): UnsupportedFeature[] {
+  const out: UnsupportedFeature[] = [];
+
+  const blindBuried = pcb.vias.filter((v) => !isThroughVia(v));
+  if (blindBuried.length > 0) {
+    out.push({
+      feature: "blind/buried via",
+      count: blindBuried.length,
+      detail:
+        `${blindBuried.length} via(s) span inner layers (not FCu↔BCu). The Excellon ` +
+        "drill export drills every via straight through, so blind/buried vias would " +
+        "fabricate as through-holes — electrically wrong.",
+      fix: "Re-route these connections with through-vias (FCu↔BCu), or split the board so no via needs controlled depth.",
+    });
+  }
+
+  return out;
+}
+
+/**
+ * Full fab-readiness gate in one verdict. Runs every check an agent would
+ * otherwise have to assemble by hand — DRC (fail-closed), renderability, and
+ * actual Gerber serialization — plus a scan for unsupported features, then
+ * rolls them into one `ready` boolean with the exact blockers and suggested
+ * fixes. Read-only: it mutates nothing.
+ *
+ * Fail-closed throughout: a board that can't be parsed/serialized is reported
+ * `unverifiable` (never silently "clean" or "ready").
+ */
+export async function validateForFab(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  if (!pcb) {
+    return {
+      content: [{ type: "text" as const, text: "Error: Document has no PCB" }],
+      isError: true,
+    };
+  }
+
+  const blockers: string[] = [];
+  const unverifiable: string[] = [];
+  const fixes: string[] = [];
+
+  // 1. DRC — fail-closed: a parse failure is 'unverifiable', not clean.
+  const drc = await drcVerdict(pcb);
+  let drcPayload: Record<string, unknown>;
+  if (drc.status === "unverifiable") {
+    unverifiable.push(`DRC: ${drc.reason}`);
+    drcPayload = { status: "unverifiable", reason: drc.reason };
+    fixes.push("Make the board serialize/parse, then re-run validate_for_fab for a real DRC verdict.");
+  } else {
+    drcPayload = { status: drc.status, ...drc.summary };
+    if (drc.status === "violations") {
+      const topRules = Object.entries(drc.summary.byRule)
+        .sort((a, b) => b[1] - a[1])
+        .map(([rule, n]) => `${rule}×${n}`)
+        .join(", ");
+      blockers.push(`DRC: ${drc.summary.errors} error(s) — ${topRules}`);
+      if (drc.summary.categories.connectivity > 0)
+        fixes.push("Route the remaining nets (route_nets) — unconnected nets can't fabricate.");
+      if (drc.summary.categories.clearance > 0)
+        fixes.push("Resolve clearance/short violations (move pads apart or reroute).");
+      if (drc.summary.categories.manufacturing > 0)
+        fixes.push("Meet the fab rules (widen traces, enlarge drills/annular rings) — see set_design_rules / run_drc.");
+    }
+  }
+
+  // 2. Renderability — can the board geometry be evaluated/visualized?
+  const render = await tryPcbPreviewMeshes(pcb);
+  let renderPayload: Record<string, unknown>;
+  if (render.ok) {
+    if (render.value.length > 0) {
+      renderPayload = { ok: true, meshes: render.value.length };
+    } else {
+      renderPayload = { ok: false, reason: "preview produced no geometry (board solid did not evaluate)" };
+      blockers.push("Renderability: the board produced no preview geometry (empty board solid).");
+      fixes.push("Check the board outline has ≥3 valid vertices and a positive thickness.");
+    }
+  } else if (render.reason === "error") {
+    renderPayload = { ok: false, reason: render.message };
+    blockers.push(`Renderability: board geometry failed to evaluate — ${render.message}`);
+  } else {
+    renderPayload = { ok: false, unverifiable: true, reason: render.message };
+    unverifiable.push(`Renderability: ${render.message}`);
+  }
+
+  // 3. Gerber-exportability — actually attempt serialization; on failure report
+  //    the exact field if the serde error names one.
+  const gerber = await tryExportFabFiles(pcb);
+  let gerberPayload: Record<string, unknown>;
+  if (gerber.ok) {
+    gerberPayload = { ok: true, files: gerber.value.length };
+  } else if (gerber.reason === "error") {
+    const field = extractSerdeField(gerber.message);
+    gerberPayload = { ok: false, ...(field ? { field } : {}), reason: gerber.message };
+    blockers.push(
+      `Gerber export: serialization failed${field ? ` on field '${field}'` : ""} — ${gerber.message}`,
+    );
+    fixes.push(
+      field
+        ? `Provide a valid '${field}' on the board so the fab serializer accepts it.`
+        : "Fix the malformed board field the serializer rejected (see the error above).",
+    );
+  } else {
+    gerberPayload = { ok: false, unverifiable: true, reason: gerber.message };
+    unverifiable.push(`Gerber export: ${gerber.message}`);
+  }
+
+  // 4. Unsupported features — present in the IR but not faithfully fabricable.
+  const unsupported = detectUnsupportedFeatures(pcb);
+  for (const u of unsupported) {
+    blockers.push(`Unsupported feature — ${u.detail}`);
+    fixes.push(u.fix);
+  }
+
+  // Fail-closed: ready only when nothing is blocked AND nothing is unverifiable.
+  const ready = blockers.length === 0 && unverifiable.length === 0;
+  const verdict = ready ? "ready" : blockers.length > 0 ? "blocked" : "unverifiable";
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          ready,
+          verdict,
+          ...docResultPayload(ctx),
+          drc: drcPayload,
+          renderable: renderPayload,
+          gerber_exportable: gerberPayload,
+          unsupported_features: unsupported,
+          blockers,
+          unverifiable,
+          suggested_fixes: [...new Set(fixes)],
+        }),
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary

- **New `validate_for_fab` tool**: single fail-closed fab-readiness oracle that runs all 4 checks in one call — DRC (unverifiable on parse/kernel error, never silently clean), renderability, Gerber serialization (names the exact failing field), and unsupported feature detection (blind/buried vias). Returns `ready`, `verdict`, `blockers`, and `suggested_fixes`.
- **`export_gerber` DRC gate**: new `require_clean_drc: boolean` param (default `true`) blocks export on a dirty or unverifiable board and returns the DRC summary. Pass `false` to force a known-dirty bundle.
- **Fail-closed engine probes**: `tryRunDrc`, `tryExportFabFiles`, `tryPcbPreviewMeshes` in `@vcad/engine` surface kernel errors as `EcadProbe<T>` discriminated unions (`{ok:true,value}|{ok:false,reason,message}`) instead of swallowing them. Existing `runDrc`/`exportFabFiles`/`pcbPreviewMeshes` delegates to these.

## What changed

- `packages/engine/src/ecad.ts` — `EcadProbe<T>` type + 3 try-variant probes; existing helpers delegate
- `packages/engine/src/index.ts` — exports new probes and type
- `packages/mcp/src/tools/ecad.ts` — `drcVerdict()` shared fn, DRC gate in `exportGerber`, `validateForFab` implementation, helpers (`extractSerdeField`, `isThroughVia`, `detectUnsupportedFeatures`)
- `packages/mcp/src/server.ts` — `validate_for_fab` registration + updated workflow hint
- `packages/mcp/src/__tests__/ecad.test.ts` — 5 new tests covering all scenarios
- `changelog/entries/2026-06-26-validate-for-fab.json` — feat entry

## Test plan

- [ ] `npm test -w @vcad/mcp` — all 143+ tests pass including new `validate_for_fab` and `export_gerber` gate tests
- [ ] Dirty board (unconnected nets) → `export_gerber` returns `blocked:true` with DRC summary, no files
- [ ] `require_clean_drc: false` bypasses gate and returns files
- [ ] Clean routed board → `export_gerber` succeeds
- [ ] `validate_for_fab` on clean board → `ready:true`, `verdict:"ready"`
- [ ] `validate_for_fab` on dirty board → `ready:false`, `verdict:"blocked"`, DRC violations in payload
- [ ] `validate_for_fab` with malformed PCB (missing `thickness`) → `gerber_exportable.field === "thickness"`, `drc.status === "unverifiable"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)