### PR TITLE
fix(pcb): point export_gerber DRC block at export_kicad escape hatch

### DIFF
--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -4158,8 +4158,10 @@ export async function exportGerber(args: Record<string, unknown>) {
               reason: blocker,
               drc: verdict.status === "unverifiable" ? { status: "unverifiable" } : verdict.summary,
               hint:
-                "Resolve the DRC errors (run run_drc / validate_for_fab for details), or " +
-                "re-run export_gerber with require_clean_drc:false to force the bundle anyway.",
+                "Resolve the DRC errors (run run_drc / validate_for_fab for details). " +
+                "To get editable files out of the dirty board now, use export_kicad " +
+                "(native .kicad_pcb/.kicad_sch — no DRC gate) or open_in_browser. " +
+                "Or re-run export_gerber with require_clean_drc:false to force the Gerber bundle anyway.",
             }),
           },
         ],


### PR DESCRIPTION
## What

When `export_gerber` blocks a board for failing its clean-DRC gate, the `blocked` response's `hint` now names the two exits that have **no** DRC gate — `export_kicad` (native `.kicad_pcb`/`.kicad_sch`) and `open_in_browser` — alongside the existing "fix the errors / force with `require_clean_drc:false`" options.

One file, +4/−2 — a string literal inside the existing gate in `packages/mcp/src/tools/ecad.ts`.

## Why

The clean-DRC gate already existed, but its hint only offered "resolve the errors" or "force with `require_clean_drc:false`". It never mentioned that editable files can still be pulled out of a dirty board. In a real session, an agent hit this wall on a board with DRC errors, concluded no export was possible, and hand-rolled a footprint-less `.net` netlist — when `export_kicad` would have produced a real, KiCad-openable `.kicad_pcb` from the exact same dirty board. The block message was the discoverability gap; this closes it.

## Reviewer notes

- Behavior is unchanged — only the `hint` string is broader. The gate, the `require_clean_drc` flag, and the `blocked` shape are untouched.
- Verified with `tsc -p packages/mcp`; the edit adds no new type surface. Pre-existing tsc errors in the worktree (`tryExportFabFiles`, `netContinuity`, `RouteAllResult.diagnostics`, ungenerated `live-html`) are dist-staleness, unrelated to this change.
- Gerber unit tests couldn't run locally — the worktree's ECAD WASM is unloaded, which makes `drcPcb` throw suite-wide. Worth a CI run where WASM is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)