### PR TITLE
build: clear new nightly clippy lints (chunks_exact, manual_slice_fill)

### DIFF
--- a/crates/vcad-cli/src/app.rs
+++ b/crates/vcad-cli/src/app.rs
@@ -1536,12 +1536,8 @@ fn render_raytrace(app: &App, buffer: &mut RenderBuffer) {
         buffer.pixels[..size * 4].copy_from_slice(&pixels[..size * 4]);
     }
     // Clear pick_ids (ray tracing doesn't populate them yet)
-    for id in &mut buffer.pick_ids {
-        *id = 0;
-    }
-    for d in &mut buffer.depth {
-        *d = f32::INFINITY;
-    }
+    buffer.pick_ids.fill(0);
+    buffer.depth.fill(f32::INFINITY);
 }
 
 #[cfg(test)]

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -267,7 +267,7 @@ fn canonicalize(mesh: &vcad_kernel::vcad_kernel_tessellate::TriangleMesh) -> Can
     let mut verts: Vec<[f64; 3]> = Vec::new();
     let mut canon: HashMap<(i64, i64, i64), usize> = HashMap::new();
     let mut tris: Vec<[usize; 3]> = Vec::new();
-    for chunk in mesh.indices.chunks_exact(3) {
+    for chunk in mesh.indices.as_chunks::<3>().0 {
         let mut tri = [0usize; 3];
         let mut ok = true;
         for i in 0..3 {

--- a/mecheval/graders/src/fit.rs
+++ b/mecheval/graders/src/fit.rs
@@ -207,7 +207,7 @@ fn vert(mesh: &TriangleMesh, i: u32) -> [f64; 3] {
 
 fn mesh_tris(mesh: &TriangleMesh) -> Vec<Tri> {
     let mut out = Vec::with_capacity(mesh.indices.len() / 3);
-    for tri in mesh.indices.chunks_exact(3) {
+    for tri in mesh.indices.as_chunks::<3>().0 {
         out.push(Tri {
             a: vert(mesh, tri[0]),
             b: vert(mesh, tri[1]),

--- a/mecheval/graders/src/grader.rs
+++ b/mecheval/graders/src/grader.rs
@@ -1052,10 +1052,10 @@ fn sha256(input: &[u8]) -> [u8; 32] {
         msg.push(0);
     }
     msg.extend_from_slice(&bit_len.to_be_bytes());
-    for chunk in msg.chunks_exact(64) {
+    for chunk in msg.as_chunks::<64>().0 {
         let mut w = [0u32; 64];
-        for (i, word) in chunk.chunks_exact(4).enumerate() {
-            w[i] = u32::from_be_bytes(word.try_into().unwrap());
+        for (i, word) in chunk.as_chunks::<4>().0.iter().enumerate() {
+            w[i] = u32::from_be_bytes(*word);
         }
         for i in 16..64 {
             let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);


### PR DESCRIPTION
## What

Fixes the `Rust (nightly)` CI job, which recent nightly toolchains red on every PR via `cargo clippy --workspace -- -D warnings`. Two newly-promoted clippy lints fire on pre-existing code:

- **`clippy::chunks_exact_to_as_chunks`** → `as_chunks::<N>().0` (stable since Rust 1.88)
  - `mecheval/graders/src/fit.rs` (triangle iteration)
  - `mecheval/graders/src/grader.rs` (SHA-256 message/word chunking)
  - `crates/vcad-render/src/lib.rs` (triangle iteration)
- **`clippy::manual_slice_fill`** → `slice::fill`
  - `crates/vcad-cli/src/app.rs` (ray-trace buffer clear)

## Why a separate PR

This is toolchain drift, not a code change — nightly was green on `main` before the roll. It surfaced while CI-checking an unrelated mecheval PR (#367), so it's split out as its own repo-wide fix. The lints appear in *waves* because clippy aborts at the first failing crate, which is why CI reported `chunks_exact` first and `manual_slice_fill` only after.

## Verification

- `cargo +nightly clippy --workspace --exclude vcad-desktop --features vcad-kernel-text/no-builtin-font -- -D warnings` → **exit 0** (nightly `1.98.0 2026-06-26`, matching CI).
- The rewritten SHA-256 (`grader.rs`) was checked against the standard `"abc"` and empty-string test vectors — **byte-identical output**, so `task_sha256` provenance hashes are unchanged.
- `as_chunks::<N>()` confirmed stable on the repo's stable toolchain (1.95.0), so the `Rust (stable)` job is unaffected. An `#[allow]` was deliberately avoided — stable clippy doesn't know these lint names yet and would error on them under `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)