### PR TITLE
Differentiable seam M0–M2: frozen tessellation, lift-bridge, implicit vertex diff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ vcad/
 │
 │   # Work-in-progress crates (built but not yet wired to any consumer):
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
+│   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations
+│   #                            # (docs/differentiable-seam-m0-m2.md); no consumers yet
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7283,6 +7283,7 @@ dependencies = [
 name = "vcad-kernel-tessellate"
 version = "0.9.4"
 dependencies = [
+ "tang",
  "vcad-kernel-geom",
  "vcad-kernel-math",
  "vcad-kernel-primitives",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7091,6 +7091,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-kernel-diff"
+version = "0.9.4"
+dependencies = [
+ "tang",
+ "vcad-kernel",
+ "vcad-kernel-geom",
+ "vcad-kernel-math",
+ "vcad-kernel-nurbs",
+ "vcad-kernel-primitives",
+ "vcad-kernel-sketch",
+ "vcad-kernel-tessellate",
+ "vcad-kernel-topo",
+]
+
+[[package]]
 name = "vcad-kernel-drafting"
 version = "0.9.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/vcad-kernel-step",
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
+    "crates/vcad-kernel-diff",
     "crates/vcad-kernel-wasm",
     "crates/vcad-kernel-drafting",
     "crates/vcad-cli",
@@ -90,6 +91,7 @@ default-members = [
     "crates/vcad-kernel-step",
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
+    "crates/vcad-kernel-diff",
     "crates/vcad-kernel-wasm",
     "crates/vcad-kernel-drafting",
     "crates/vcad-cli",
@@ -177,6 +179,7 @@ vcad-kernel-shell = { path = "crates/vcad-kernel-shell", version = "0.9.4" }
 vcad-kernel-sheet = { path = "crates/vcad-kernel-sheet", version = "0.9.4" }
 vcad-kernel-step = { path = "crates/vcad-kernel-step", version = "0.9.4" }
 vcad-kernel-constraints = { path = "crates/vcad-kernel-constraints", version = "0.9.4" }
+vcad-kernel-diff = { path = "crates/vcad-kernel-diff", version = "0.9.4" }
 vcad-kernel-drafting = { path = "crates/vcad-kernel-drafting", version = "0.9.4" }
 vcad-kernel-gpu = { path = "crates/vcad-kernel-gpu", version = "0.9.4" }
 vcad-kernel-raytrace = { path = "crates/vcad-kernel-raytrace", version = "0.9.4" }

--- a/crates/vcad-kernel-diff/Cargo.toml
+++ b/crates/vcad-kernel-diff/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vcad-kernel-diff"
+description = "Differentiable seam: parameter sensitivities (dx/dθ) of frozen tessellations"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+tang = { workspace = true }
+vcad-kernel-math = { workspace = true }
+vcad-kernel-geom = { workspace = true }
+vcad-kernel-nurbs = { workspace = true }
+vcad-kernel-topo = { workspace = true }
+vcad-kernel-primitives = { workspace = true }
+vcad-kernel-tessellate = { workspace = true }
+
+[dev-dependencies]
+vcad-kernel-sketch = { workspace = true }
+vcad-kernel = { workspace = true }

--- a/crates/vcad-kernel-diff/src/fd.rs
+++ b/crates/vcad-kernel-diff/src/fd.rs
@@ -1,0 +1,90 @@
+//! Central-difference oracle for the seam.
+//!
+//! The oracle rebuilds the model at θ ± h and re-evaluates the **same
+//! frozen plan** — identical connectivity, identical sample pattern,
+//! identical vertex ordering — so node `i` corresponds to node `i` and
+//! `(x(θ+h) − x(θ−h)) / 2h` is a legitimate per-node derivative estimate.
+//! If either rebuild changes topology, the signature check inside
+//! `evaluate_plan` errors instead of producing garbage.
+
+use vcad_kernel_math::Vec3;
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{evaluate_plan, FrozenError, FrozenPlan};
+
+/// Result of comparing analytic velocities against the FD oracle.
+#[derive(Debug, Clone, Copy)]
+pub struct FdComparison {
+    /// Maximum per-node relative error (see [`compare_velocities`] for the
+    /// normalization convention).
+    pub max_rel_err: f64,
+    /// Maximum per-node absolute error (mm per unit θ).
+    pub max_abs_err: f64,
+    /// Node index attaining `max_rel_err`.
+    pub worst_node: usize,
+    /// Largest velocity magnitude across both inputs (the global scale).
+    pub velocity_scale: f64,
+}
+
+/// Central-difference node velocities: rebuild at θ ± h, evaluate the same
+/// frozen plan, difference node-wise.
+pub fn fd_velocities(
+    build: impl Fn(f64) -> BRepSolid,
+    theta: f64,
+    h: f64,
+    plan: &FrozenPlan,
+) -> Result<Vec<Vec3>, FrozenError> {
+    let plus = evaluate_plan(&build(theta + h), plan)?;
+    let minus = evaluate_plan(&build(theta - h), plan)?;
+    Ok(plus
+        .positions
+        .iter()
+        .zip(&minus.positions)
+        .map(|(p, m)| (*p - *m) / (2.0 * h))
+        .collect())
+}
+
+/// Central-difference derivative of the frozen-mesh volume.
+pub fn fd_volume_derivative(
+    build: impl Fn(f64) -> BRepSolid,
+    theta: f64,
+    h: f64,
+    plan: &FrozenPlan,
+) -> Result<f64, FrozenError> {
+    let plus = evaluate_plan(&build(theta + h), plan)?;
+    let minus = evaluate_plan(&build(theta - h), plan)?;
+    Ok((plus.volume() - minus.volume()) / (2.0 * h))
+}
+
+/// Compare analytic and FD velocities node-wise.
+///
+/// The per-node relative error divides by
+/// `max(|analytic_i|, |fd_i|, 0.01 · velocity_scale)`: nodes moving slower
+/// than 1% of the fastest node are judged against that 1% floor, so the FD
+/// roundoff noise on a genuinely stationary node (≈ machine-ε · coordinate
+/// / 2h) is not amplified into a spurious relative error.
+pub fn compare_velocities(analytic: &[Vec3], fd: &[Vec3]) -> FdComparison {
+    assert_eq!(analytic.len(), fd.len(), "node count mismatch");
+    let scale = analytic
+        .iter()
+        .chain(fd)
+        .map(|v| v.norm())
+        .fold(0.0_f64, f64::max);
+    let floor = (0.01 * scale).max(f64::MIN_POSITIVE);
+
+    let mut cmp = FdComparison {
+        max_rel_err: 0.0,
+        max_abs_err: 0.0,
+        worst_node: 0,
+        velocity_scale: scale,
+    };
+    for (i, (a, f)) in analytic.iter().zip(fd).enumerate() {
+        let abs = (*a - *f).norm();
+        let rel = abs / a.norm().max(f.norm()).max(floor);
+        if rel > cmp.max_rel_err {
+            cmp.max_rel_err = rel;
+            cmp.worst_node = i;
+        }
+        cmp.max_abs_err = cmp.max_abs_err.max(abs);
+    }
+    cmp
+}

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -1,0 +1,254 @@
+//! Pillar 3: implicit differentiation of topology vertices.
+//!
+//! A topology vertex `x` produced by the kernel (a corner, or a point on a
+//! trim/intersection curve) satisfies `g_i(x; θ) = 0` for every adjacent
+//! surface `i`. Differentiating along the frozen branch:
+//!
+//! ```text
+//! ∇g_i · ẋ = −∂g_i/∂θ
+//! ```
+//!
+//! With three independent adjacent surfaces (a corner) the system determines
+//! `ẋ` fully. With two (a point on an intersection curve, e.g. the rim of a
+//! boolean through-hole) one tangential degree of freedom remains — the
+//! frozen-topology convention pins it at zero (the node keeps its frozen
+//! curve parameter), which is the minimum-norm solution. This
+//! differentiates the *equations that define* the kernel's output without
+//! touching the code that computed it.
+
+use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind};
+use vcad_kernel_math::{Point3, Vec3};
+
+use crate::{DiffError, SurfaceSeed};
+
+/// One row of the implicit vertex system: `gradient · ẋ = rhs`.
+#[derive(Debug, Clone, Copy)]
+pub struct ConstraintRow {
+    /// ∇g at the vertex.
+    pub gradient: Vec3,
+    /// −∂g/∂θ at the vertex.
+    pub rhs: f64,
+}
+
+fn downcast<T: 'static>(surface: &dyn Surface, kind: SurfaceKind) -> Result<&T, DiffError> {
+    surface
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or(DiffError::DowncastFailed(kind))
+}
+
+/// Build the constraint row contributed by `surface` (with its θ-seed) at
+/// vertex position `x`.
+///
+/// Implicit forms: plane `g = n·(x − o)`; cylinder `g = |radial|² − r²`;
+/// sphere `g = |x − c|² − r²`. Other kinds have no implicit form yet and
+/// return [`DiffError::UnsupportedConstraint`].
+pub fn constraint_row(
+    surface: &dyn Surface,
+    seed: Option<SurfaceSeed>,
+    x: &Point3,
+) -> Result<ConstraintRow, DiffError> {
+    let kind = surface.surface_type();
+    match kind {
+        SurfaceKind::Plane => {
+            let plane = downcast::<Plane>(surface, kind)?;
+            let n = *plane.normal_dir.as_ref();
+            let g_theta = match seed {
+                None => 0.0,
+                Some(SurfaceSeed::Translate { velocity }) => -n.dot(velocity),
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            };
+            Ok(ConstraintRow {
+                gradient: n,
+                rhs: -g_theta,
+            })
+        }
+        SurfaceKind::Cylinder => {
+            let cyl = downcast::<CylinderSurface>(surface, kind)?;
+            let a = *cyl.axis.as_ref();
+            let d = *x - cyl.center;
+            let radial = d - a * d.dot(a);
+            let g_theta = match seed {
+                None => 0.0,
+                Some(SurfaceSeed::CylinderRadius { rate }) => -2.0 * cyl.radius * rate,
+                Some(SurfaceSeed::Translate { velocity }) => {
+                    // ∂g/∂θ = −2 radial · v_perp; radial ⊥ a so the axial
+                    // component of v drops out automatically.
+                    -2.0 * radial.dot(velocity)
+                }
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            };
+            Ok(ConstraintRow {
+                gradient: 2.0 * radial,
+                rhs: -g_theta,
+            })
+        }
+        SurfaceKind::Sphere => {
+            let sph = downcast::<SphereSurface>(surface, kind)?;
+            let d = *x - sph.center;
+            let g_theta = match seed {
+                None => 0.0,
+                Some(SurfaceSeed::SphereRadius { rate }) => -2.0 * sph.radius * rate,
+                Some(SurfaceSeed::Translate { velocity }) => -2.0 * d.dot(velocity),
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            };
+            Ok(ConstraintRow {
+                gradient: 2.0 * d,
+                rhs: -g_theta,
+            })
+        }
+        other => Err(DiffError::UnsupportedConstraint(other)),
+    }
+}
+
+/// Normalized incidence residual of a vertex against a surface: the
+/// distance-like quantity `|g(x)| / |∇g(x)|`. Returns `None` for surface
+/// kinds without an implicit form (their incidence cannot be tested) and
+/// for degenerate gradients.
+///
+/// Used to recover geometric adjacency the topology does not record: after
+/// a boolean, rim vertices on an intersection curve may carry half-edges of
+/// only one of the two intersecting faces (the other keeps an untrimmed
+/// seam loop), so constraint rows must be collected by incidence, not just
+/// by loop membership.
+pub fn surface_residual(surface: &dyn Surface, x: &Point3) -> Option<f64> {
+    let kind = surface.surface_type();
+    match kind {
+        SurfaceKind::Plane => {
+            let plane = surface.as_any().downcast_ref::<Plane>()?;
+            Some(plane.signed_distance(x).abs())
+        }
+        SurfaceKind::Cylinder => {
+            let cyl = surface.as_any().downcast_ref::<CylinderSurface>()?;
+            let a = *cyl.axis.as_ref();
+            let d = *x - cyl.center;
+            let radial = d - a * d.dot(a);
+            let g = radial.norm_squared() - cyl.radius * cyl.radius;
+            let grad = 2.0 * radial.norm();
+            (grad > f64::MIN_POSITIVE).then(|| (g / grad).abs())
+        }
+        SurfaceKind::Sphere => {
+            let sph = surface.as_any().downcast_ref::<SphereSurface>()?;
+            let d = *x - sph.center;
+            let g = d.norm_squared() - sph.radius * sph.radius;
+            let grad = 2.0 * d.norm();
+            (grad > f64::MIN_POSITIVE).then(|| (g / grad).abs())
+        }
+        _ => None,
+    }
+}
+
+/// Relative threshold below which an orthogonalized gradient counts as
+/// dependent on the rows already selected.
+const DEPENDENT_TOL: f64 = 1e-9;
+
+/// Absolute tolerance for the consistency residual of dependent rows
+/// (velocity units, mm per unit θ).
+const CONSISTENCY_TOL: f64 = 1e-6;
+
+/// Solve the implicit vertex system for `ẋ`.
+///
+/// Rows are normalized and orthogonalized (Gram–Schmidt with the rhs
+/// carried along). Independent rows determine components of `ẋ`; dependent
+/// rows are checked for consistency (a violation means the vertex is not on
+/// the common intersection, or a seed is wrong — a hard error, not a silent
+/// wrong answer). Directions no row constrains are frozen at zero: the
+/// minimum-norm solution, i.e. the node keeps its frozen tangential
+/// parameter.
+pub fn solve_vertex_velocity(rows: &[ConstraintRow]) -> Result<Vec3, DiffError> {
+    // Orthonormal basis directions with their solution coefficients:
+    // ẋ = Σ c_k e_k satisfies every processed row.
+    let mut basis: Vec<(Vec3, f64)> = Vec::new();
+
+    for row in rows {
+        let norm = row.gradient.norm();
+        if norm < f64::MIN_POSITIVE {
+            continue; // degenerate gradient carries no information
+        }
+        let mut g = row.gradient / norm;
+        let mut r = row.rhs / norm;
+        for (e, c) in &basis {
+            let proj = g.dot(*e);
+            g -= *e * proj;
+            r -= c * proj;
+        }
+        let res = g.norm();
+        if res > DEPENDENT_TOL {
+            basis.push((g / res, r / res));
+        } else if r.abs() > CONSISTENCY_TOL {
+            return Err(DiffError::InconsistentConstraints { residual: r.abs() });
+        }
+    }
+
+    let mut v = Vec3::new(0.0, 0.0, 0.0);
+    for (e, c) in &basis {
+        v += *e * *c;
+    }
+    Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn three_planes_corner() {
+        // Corner of a box whose top face (z = d) moves upward with θ:
+        // ẋ = ẑ exactly.
+        let top = Plane::new(Point3::new(0.0, 0.0, 2.0), Vec3::x(), Vec3::y());
+        let side_x = Plane::new(Point3::new(4.0, 0.0, 0.0), Vec3::y(), Vec3::z());
+        let side_y = Plane::new(Point3::new(0.0, 3.0, 0.0), Vec3::z(), Vec3::x());
+        let x = Point3::new(4.0, 3.0, 2.0);
+        let seed = Some(SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        });
+        let rows = vec![
+            constraint_row(&top, seed, &x).unwrap(),
+            constraint_row(&side_x, None, &x).unwrap(),
+            constraint_row(&side_y, None, &x).unwrap(),
+        ];
+        let v = solve_vertex_velocity(&rows).unwrap();
+        assert!((v - Vec3::z()).norm() < 1e-12, "v = {v:?}");
+    }
+
+    #[test]
+    fn plane_cylinder_rim_freezes_tangent() {
+        // A rim node: on a fixed plane z = 5 and a cylinder of growing
+        // radius. Expected ẋ = radial direction; tangential slide frozen.
+        let plane = Plane::new(Point3::new(0.0, 0.0, 5.0), Vec3::x(), Vec3::y());
+        let cyl = CylinderSurface::new(2.5);
+        let u = 1.1_f64;
+        let x = Point3::new(2.5 * u.cos(), 2.5 * u.sin(), 5.0);
+        let rows = vec![
+            constraint_row(&plane, None, &x).unwrap(),
+            constraint_row(&cyl, Some(SurfaceSeed::CylinderRadius { rate: 1.0 }), &x).unwrap(),
+        ];
+        let v = solve_vertex_velocity(&rows).unwrap();
+        let expected = Vec3::new(u.cos(), u.sin(), 0.0);
+        assert!((v - expected).norm() < 1e-12, "v = {v:?}");
+    }
+
+    #[test]
+    fn inconsistent_rows_are_an_error() {
+        // Two parallel planes moving at different speeds through the same
+        // vertex: dependent gradients, contradictory rhs.
+        let p1 = Plane::new(Point3::new(0.0, 0.0, 1.0), Vec3::x(), Vec3::y());
+        let p2 = Plane::new(Point3::new(0.0, 0.0, 1.0), Vec3::x(), Vec3::y());
+        let x = Point3::new(0.0, 0.0, 1.0);
+        let rows = vec![
+            constraint_row(
+                &p1,
+                Some(SurfaceSeed::Translate {
+                    velocity: Vec3::z(),
+                }),
+                &x,
+            )
+            .unwrap(),
+            constraint_row(&p2, None, &x).unwrap(),
+        ];
+        assert!(matches!(
+            solve_vertex_velocity(&rows),
+            Err(DiffError::InconsistentConstraints { .. })
+        ));
+    }
+}

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -19,7 +19,7 @@
 use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind};
 use vcad_kernel_math::{Point3, Vec3};
 
-use crate::{DiffError, SurfaceSeed};
+use crate::{downcast, DiffError, SurfaceSeed};
 
 /// One row of the implicit vertex system: `gradient · ẋ = rhs`.
 #[derive(Debug, Clone, Copy)]
@@ -30,44 +30,37 @@ pub struct ConstraintRow {
     pub rhs: f64,
 }
 
-fn downcast<T: 'static>(surface: &dyn Surface, kind: SurfaceKind) -> Result<&T, DiffError> {
-    surface
-        .as_any()
-        .downcast_ref::<T>()
-        .ok_or(DiffError::DowncastFailed(kind))
-}
-
-/// Build the constraint row contributed by `surface` (with its θ-seed) at
-/// vertex position `x`.
+/// The implicit form of a surface at `x`: `(g, ∇g, ∂g/∂θ)`.
 ///
-/// Implicit forms: plane `g = n·(x − o)`; cylinder `g = |radial|² − r²`;
-/// sphere `g = |x − c|² − r²`. Other kinds have no implicit form yet and
-/// return [`DiffError::UnsupportedConstraint`].
-pub fn constraint_row(
+/// Single source of truth for both [`constraint_row`] and
+/// [`surface_residual`], so incidence detection and the rows actually
+/// solved can never disagree. Implicit forms: plane `g = n·(x − o)`;
+/// cylinder `g = |radial|² − r²`; sphere `g = |x − c|² − r²`. Returns
+/// `Ok(None)` for kinds without an implicit form.
+fn implicit_terms(
     surface: &dyn Surface,
     seed: Option<SurfaceSeed>,
     x: &Point3,
-) -> Result<ConstraintRow, DiffError> {
+) -> Result<Option<(f64, Vec3, f64)>, DiffError> {
     let kind = surface.surface_type();
     match kind {
         SurfaceKind::Plane => {
             let plane = downcast::<Plane>(surface, kind)?;
             let n = *plane.normal_dir.as_ref();
+            let g = plane.signed_distance(x);
             let g_theta = match seed {
                 None => 0.0,
                 Some(SurfaceSeed::Translate { velocity }) => -n.dot(velocity),
                 Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
             };
-            Ok(ConstraintRow {
-                gradient: n,
-                rhs: -g_theta,
-            })
+            Ok(Some((g, n, g_theta)))
         }
         SurfaceKind::Cylinder => {
             let cyl = downcast::<CylinderSurface>(surface, kind)?;
             let a = *cyl.axis.as_ref();
             let d = *x - cyl.center;
             let radial = d - a * d.dot(a);
+            let g = radial.norm_squared() - cyl.radius * cyl.radius;
             let g_theta = match seed {
                 None => 0.0,
                 Some(SurfaceSeed::CylinderRadius { rate }) => -2.0 * cyl.radius * rate,
@@ -78,26 +71,38 @@ pub fn constraint_row(
                 }
                 Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
             };
-            Ok(ConstraintRow {
-                gradient: 2.0 * radial,
-                rhs: -g_theta,
-            })
+            Ok(Some((g, 2.0 * radial, g_theta)))
         }
         SurfaceKind::Sphere => {
             let sph = downcast::<SphereSurface>(surface, kind)?;
             let d = *x - sph.center;
+            let g = d.norm_squared() - sph.radius * sph.radius;
             let g_theta = match seed {
                 None => 0.0,
                 Some(SurfaceSeed::SphereRadius { rate }) => -2.0 * sph.radius * rate,
                 Some(SurfaceSeed::Translate { velocity }) => -2.0 * d.dot(velocity),
                 Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
             };
-            Ok(ConstraintRow {
-                gradient: 2.0 * d,
-                rhs: -g_theta,
-            })
+            Ok(Some((g, 2.0 * d, g_theta)))
         }
-        other => Err(DiffError::UnsupportedConstraint(other)),
+        _ => Ok(None),
+    }
+}
+
+/// Build the constraint row contributed by `surface` (with its θ-seed) at
+/// vertex position `x`. Kinds without an implicit form return
+/// [`DiffError::UnsupportedConstraint`].
+pub fn constraint_row(
+    surface: &dyn Surface,
+    seed: Option<SurfaceSeed>,
+    x: &Point3,
+) -> Result<ConstraintRow, DiffError> {
+    match implicit_terms(surface, seed, x)? {
+        Some((_g, gradient, g_theta)) => Ok(ConstraintRow {
+            gradient,
+            rhs: -g_theta,
+        }),
+        None => Err(DiffError::UnsupportedConstraint(surface.surface_type())),
     }
 }
 
@@ -112,35 +117,20 @@ pub fn constraint_row(
 /// seam loop), so constraint rows must be collected by incidence, not just
 /// by loop membership.
 pub fn surface_residual(surface: &dyn Surface, x: &Point3) -> Option<f64> {
-    let kind = surface.surface_type();
-    match kind {
-        SurfaceKind::Plane => {
-            let plane = surface.as_any().downcast_ref::<Plane>()?;
-            Some(plane.signed_distance(x).abs())
-        }
-        SurfaceKind::Cylinder => {
-            let cyl = surface.as_any().downcast_ref::<CylinderSurface>()?;
-            let a = *cyl.axis.as_ref();
-            let d = *x - cyl.center;
-            let radial = d - a * d.dot(a);
-            let g = radial.norm_squared() - cyl.radius * cyl.radius;
-            let grad = 2.0 * radial.norm();
-            (grad > f64::MIN_POSITIVE).then(|| (g / grad).abs())
-        }
-        SurfaceKind::Sphere => {
-            let sph = surface.as_any().downcast_ref::<SphereSurface>()?;
-            let d = *x - sph.center;
-            let g = d.norm_squared() - sph.radius * sph.radius;
-            let grad = 2.0 * d.norm();
-            (grad > f64::MIN_POSITIVE).then(|| (g / grad).abs())
-        }
-        _ => None,
-    }
+    let (g, grad, _) = implicit_terms(surface, None, x).ok()??;
+    let n = grad.norm();
+    (n > f64::MIN_POSITIVE).then(|| (g / n).abs())
 }
 
-/// Relative threshold below which an orthogonalized gradient counts as
-/// dependent on the rows already selected.
-const DEPENDENT_TOL: f64 = 1e-9;
+/// Threshold below which an orthogonalized (unit-gradient) row counts as
+/// dependent on the rows already selected. Deliberately coarse: accepting a
+/// nearly-dependent row divides its carried rhs by the tiny orthogonal
+/// residual, amplifying floating-point noise (e.g. two copies of the same
+/// moving plane whose normals differ by ~1e-8) into an O(‖v‖) garbage
+/// velocity along an arbitrary direction. Below this angle, treating the
+/// row as dependent — and checking its rhs for consistency instead — is
+/// the safe branch.
+const DEPENDENT_TOL: f64 = 1e-6;
 
 /// Absolute tolerance for the consistency residual of dependent rows
 /// (velocity units, mm per unit θ).
@@ -250,5 +240,30 @@ mod tests {
             solve_vertex_velocity(&rows),
             Err(DiffError::InconsistentConstraints { .. })
         ));
+    }
+
+    #[test]
+    fn nearly_dependent_row_does_not_amplify_noise() {
+        // Two copies of the same moving plane whose normals differ by ~1e-8
+        // (different construction paths): the second row must be treated as
+        // dependent-and-consistent, not divided by its tiny orthogonal
+        // residual into a garbage tangential velocity.
+        let n2 = (Vec3::z() + Vec3::new(1e-8, 0.0, 0.0)).normalize();
+        let seed_v = Vec3::z();
+        let rows = vec![
+            ConstraintRow {
+                gradient: Vec3::z(),
+                rhs: seed_v.z,
+            },
+            ConstraintRow {
+                gradient: n2,
+                rhs: n2.dot(seed_v),
+            },
+        ];
+        let v = solve_vertex_velocity(&rows).unwrap();
+        assert!(
+            (v - Vec3::z()).norm() < 1e-6,
+            "noise direction amplified: v = {v:?}"
+        );
     }
 }

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -1,0 +1,174 @@
+#![warn(missing_docs)]
+
+//! Differentiable seam for the vcad kernel: sensitivities of tessellated
+//! mesh-node positions to CAD parameters (**dx/dθ**), computed the cheap
+//! correct way.
+//!
+//! The chain is cut **at the mesh, not inside the B-rep combinatorics**: no
+//! derivative is ever pushed through boolean intersection, classification,
+//! or trimming code. Instead:
+//!
+//! - **Topology is frozen.** All discrete choices are made on the primal θ
+//!   by [`vcad_kernel_tessellate::frozen`]; a topology-signature check turns
+//!   any topology change under perturbation into a hard error.
+//! - **Interior surface samples** (`NodeRecipe::SurfaceUv`) are forward-mode
+//!   AD: the stored `f64` surface is lifted to `Dual<f64>` via the
+//!   lift-bridge ([`lift_surface`]), the θ-dependent fields are seeded with
+//!   dual parts ([`SurfaceSeed`]), and evaluation at the frozen `(u, v)`
+//!   yields position and velocity together (Pillar 2).
+//! - **Topology-vertex samples** (`NodeRecipe::TopoVertex`) sit on the
+//!   intersection of adjacent surfaces and are differentiated implicitly:
+//!   each adjacent surface contributes a row `∇g · ẋ = −∂g/∂θ` of a linear
+//!   system; underdetermined directions (e.g. the tangential slide of a rim
+//!   node) are frozen at zero, which is exactly the frozen-parameter branch
+//!   choice (Pillar 3).
+//!
+//! Everything is validated against a central-difference oracle rebuilt under
+//! the same frozen plan (see the milestone integration tests in `tests/`).
+
+use std::collections::BTreeMap;
+
+use vcad_kernel_geom::{GeometryStore, Surface, SurfaceKind};
+use vcad_kernel_math::Vec3;
+use vcad_kernel_tessellate::frozen::FrozenError;
+
+mod fd;
+mod implicit;
+mod lift;
+mod seam;
+
+pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
+pub use implicit::{constraint_row, solve_vertex_velocity, surface_residual, ConstraintRow};
+pub use lift::{lift_surface, DualSurface};
+pub use seam::{evaluate_with_sensitivity, mesh_volume, volume_with_derivative, SeamMesh};
+
+/// Errors from the differentiable seam.
+#[derive(Debug)]
+pub enum DiffError {
+    /// Frozen-tessellation error (topology change, unsupported capture, …).
+    Frozen(FrozenError),
+    /// A surface reported one kind but failed to downcast to its concrete
+    /// struct (internal inconsistency in the geometry store).
+    DowncastFailed(SurfaceKind),
+    /// The requested seed does not apply to this surface kind (e.g. a radius
+    /// seed on a plane). Seeding is deliberately explicit — a silently
+    /// ignored seed would produce a plausible wrong derivative.
+    UnsupportedSeed {
+        /// The surface kind the seed was applied to.
+        kind: SurfaceKind,
+        /// The offending seed.
+        seed: SurfaceSeed,
+    },
+    /// No implicit constraint form is implemented for this surface kind, so
+    /// a topology vertex adjacent to it cannot be differentiated.
+    UnsupportedConstraint(SurfaceKind),
+    /// The implicit system at a topology vertex is inconsistent: dependent
+    /// constraint rows disagree beyond tolerance. The vertex does not
+    /// actually lie on a common intersection of its adjacent surfaces (or a
+    /// seed is wrong).
+    InconsistentConstraints {
+        /// Residual of the dependent row after projection.
+        residual: f64,
+    },
+}
+
+impl std::fmt::Display for DiffError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DiffError::Frozen(e) => write!(f, "{e}"),
+            DiffError::DowncastFailed(kind) => {
+                write!(f, "surface of kind {kind:?} failed to downcast")
+            }
+            DiffError::UnsupportedSeed { kind, seed } => {
+                write!(f, "seed {seed:?} is not applicable to surface kind {kind:?}")
+            }
+            DiffError::UnsupportedConstraint(kind) => write!(
+                f,
+                "no implicit constraint form for surface kind {kind:?}; cannot differentiate an adjacent topology vertex"
+            ),
+            DiffError::InconsistentConstraints { residual } => write!(
+                f,
+                "implicit vertex system inconsistent (residual {residual:.3e}); vertex is not on the common intersection of its adjacent surfaces"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for DiffError {}
+
+impl From<FrozenError> for DiffError {
+    fn from(e: FrozenError) -> Self {
+        DiffError::Frozen(e)
+    }
+}
+
+/// How the CAD parameter θ perturbs one stored surface: the explicit
+/// θ → field seeding of the lift-bridge.
+///
+/// Velocities are in mm per unit θ; rates are dimensionless (d field / dθ).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SurfaceSeed {
+    /// The surface translates rigidly at `velocity` as θ varies (seeds the
+    /// origin/center/apex/control points, depending on kind).
+    Translate {
+        /// d(origin)/dθ.
+        velocity: Vec3,
+    },
+    /// The cylinder radius varies: d(radius)/dθ = `rate`.
+    CylinderRadius {
+        /// d(radius)/dθ.
+        rate: f64,
+    },
+    /// The sphere radius varies: d(radius)/dθ = `rate`.
+    SphereRadius {
+        /// d(radius)/dθ.
+        rate: f64,
+    },
+}
+
+/// Maps surface indices of a [`GeometryStore`] to their θ-seeds.
+///
+/// Surfaces without an entry are θ-independent (lifted with zero dual
+/// parts). This keeps the seeding honest about which surfaces a given θ
+/// actually touches.
+#[derive(Debug, Clone, Default)]
+pub struct ParamSeeding {
+    seeds: BTreeMap<usize, SurfaceSeed>,
+}
+
+impl ParamSeeding {
+    /// Empty seeding: every surface is θ-independent.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Seed the surface at `surface_index`.
+    pub fn seed(&mut self, surface_index: usize, seed: SurfaceSeed) -> &mut Self {
+        self.seeds.insert(surface_index, seed);
+        self
+    }
+
+    /// The seed for a surface index, if any.
+    pub fn get(&self, surface_index: usize) -> Option<SurfaceSeed> {
+        self.seeds.get(&surface_index).copied()
+    }
+
+    /// Seed every surface in `geom` matching `pred`. Returns how many
+    /// surfaces were seeded (callers should assert the expected count —
+    /// boolean output stores may carry several copies of a moving surface).
+    pub fn seed_where(
+        &mut self,
+        geom: &GeometryStore,
+        pred: impl Fn(&dyn Surface) -> bool,
+        seed: SurfaceSeed,
+    ) -> usize {
+        let mut count = 0;
+        for (i, s) in geom.surfaces.iter().enumerate() {
+            if pred(s.as_ref()) {
+                self.seeds.insert(i, seed);
+                count += 1;
+            }
+        }
+        count
+    }
+}

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -40,7 +40,20 @@ mod seam;
 pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
 pub use implicit::{constraint_row, solve_vertex_velocity, surface_residual, ConstraintRow};
 pub use lift::{lift_surface, DualSurface};
-pub use seam::{evaluate_with_sensitivity, mesh_volume, volume_with_derivative, SeamMesh};
+pub use seam::{evaluate_with_sensitivity, volume_with_derivative, SeamMesh};
+pub use vcad_kernel_tessellate::frozen::mesh_volume;
+
+/// Downcast a `dyn Surface` to its concrete struct, with the store's
+/// reported kind carried into the error.
+pub(crate) fn downcast<T: 'static>(
+    surface: &dyn Surface,
+    kind: SurfaceKind,
+) -> Result<&T, DiffError> {
+    surface
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or(DiffError::DowncastFailed(kind))
+}
 
 /// Errors from the differentiable seam.
 #[derive(Debug)]

--- a/crates/vcad-kernel-diff/src/lift.rs
+++ b/crates/vcad-kernel-diff/src/lift.rs
@@ -14,7 +14,7 @@ use vcad_kernel_geom::{
 use vcad_kernel_math::{Point2, Point3, Vec3};
 use vcad_kernel_nurbs::BSplineSurface;
 
-use crate::{DiffError, SurfaceSeed};
+use crate::{downcast, DiffError, SurfaceSeed};
 
 type D = Dual<f64>;
 
@@ -41,13 +41,6 @@ fn seed_point(p: &mut tang::Point3<D>, velocity: Vec3) {
     p.x.dual = velocity.x;
     p.y.dual = velocity.y;
     p.z.dual = velocity.z;
-}
-
-fn downcast<T: 'static>(surface: &dyn Surface, kind: SurfaceKind) -> Result<&T, DiffError> {
-    surface
-        .as_any()
-        .downcast_ref::<T>()
-        .ok_or(DiffError::DowncastFailed(kind))
 }
 
 /// Lift a stored (concrete, `f64`) surface to `Dual<f64>`, seeding the

--- a/crates/vcad-kernel-diff/src/lift.rs
+++ b/crates/vcad-kernel-diff/src/lift.rs
@@ -1,0 +1,221 @@
+//! The lift-bridge: recover the concrete surface behind a `dyn Surface`,
+//! lift it to `Dual<f64>`, and seed the θ-dependent fields.
+//!
+//! This deliberately bypasses the concrete `f64` [`Surface`] trait by
+//! dropping to the underlying scalar-generic struct — the trait and the
+//! geometry store stay untouched, and differentiation happens per-face, on
+//! demand, only for faces whose surface depends on θ.
+
+use tang::Dual;
+use vcad_kernel_geom::{
+    BilinearSurface, ConeSurface, CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind,
+    TorusSurface,
+};
+use vcad_kernel_math::{Point2, Point3, Vec3};
+use vcad_kernel_nurbs::BSplineSurface;
+
+use crate::{DiffError, SurfaceSeed};
+
+type D = Dual<f64>;
+
+/// A concrete surface lifted to `Dual<f64>` with a θ-seed applied.
+#[derive(Debug, Clone)]
+pub enum DualSurface {
+    /// Lifted plane.
+    Plane(Plane<D>),
+    /// Lifted cylinder.
+    Cylinder(CylinderSurface<D>),
+    /// Lifted cone.
+    Cone(ConeSurface<D>),
+    /// Lifted sphere.
+    Sphere(SphereSurface<D>),
+    /// Lifted torus.
+    Torus(TorusSurface<D>),
+    /// Lifted bilinear patch.
+    Bilinear(BilinearSurface<D>),
+    /// Lifted B-spline surface.
+    BSpline(BSplineSurface<D>),
+}
+
+fn seed_point(p: &mut tang::Point3<D>, velocity: Vec3) {
+    p.x.dual = velocity.x;
+    p.y.dual = velocity.y;
+    p.z.dual = velocity.z;
+}
+
+fn downcast<T: 'static>(surface: &dyn Surface, kind: SurfaceKind) -> Result<&T, DiffError> {
+    surface
+        .as_any()
+        .downcast_ref::<T>()
+        .ok_or(DiffError::DowncastFailed(kind))
+}
+
+/// Lift a stored (concrete, `f64`) surface to `Dual<f64>`, seeding the
+/// field(s) touched by θ. `seed = None` lifts with all dual parts zero
+/// (a θ-independent surface).
+///
+/// Each arm matches on [`SurfaceKind`], recovers the concrete struct, calls
+/// its existing `lift::<Dual<f64>>()`, and writes the seed into the lifted
+/// fields. Inapplicable seeds are a hard error, never silently ignored.
+pub fn lift_surface(
+    surface: &dyn Surface,
+    seed: Option<SurfaceSeed>,
+) -> Result<DualSurface, DiffError> {
+    let kind = surface.surface_type();
+    match kind {
+        SurfaceKind::Plane => {
+            let mut s = downcast::<Plane>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.origin, velocity),
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Plane(s))
+        }
+        SurfaceKind::Cylinder => {
+            let mut s = downcast::<CylinderSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
+                Some(SurfaceSeed::CylinderRadius { rate }) => s.radius.dual = rate,
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Cylinder(s))
+        }
+        SurfaceKind::Cone => {
+            let mut s = downcast::<ConeSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.apex, velocity),
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Cone(s))
+        }
+        SurfaceKind::Sphere => {
+            let mut s = downcast::<SphereSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
+                Some(SurfaceSeed::SphereRadius { rate }) => s.radius.dual = rate,
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Sphere(s))
+        }
+        SurfaceKind::Torus => {
+            let mut s = downcast::<TorusSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Torus(s))
+        }
+        SurfaceKind::Bilinear => {
+            let mut s = downcast::<BilinearSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => {
+                    seed_point(&mut s.p00, velocity);
+                    seed_point(&mut s.p10, velocity);
+                    seed_point(&mut s.p01, velocity);
+                    seed_point(&mut s.p11, velocity);
+                }
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::Bilinear(s))
+        }
+        SurfaceKind::BSpline => {
+            let mut s = downcast::<BSplineSurface>(surface, kind)?.lift::<D>();
+            match seed {
+                None => {}
+                Some(SurfaceSeed::Translate { velocity }) => {
+                    for cp in &mut s.control_points {
+                        seed_point(cp, velocity);
+                    }
+                }
+                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            }
+            Ok(DualSurface::BSpline(s))
+        }
+    }
+}
+
+impl DualSurface {
+    /// Evaluate at a frozen `(u, v)` (constants — the sample pattern does
+    /// not move with θ), returning the dual-valued position.
+    pub fn evaluate(&self, uv: Point2) -> tang::Point3<D> {
+        let uv_d = tang::Point2::new(D::constant(uv.x), D::constant(uv.y));
+        match self {
+            DualSurface::Plane(s) => s.evaluate(uv_d),
+            DualSurface::Cylinder(s) => s.evaluate(uv_d),
+            DualSurface::Cone(s) => s.evaluate(uv_d),
+            DualSurface::Sphere(s) => s.evaluate(uv_d),
+            DualSurface::Torus(s) => s.evaluate(uv_d),
+            DualSurface::Bilinear(s) => s.evaluate(uv_d),
+            DualSurface::BSpline(s) => s.eval(uv.x, uv.y),
+        }
+    }
+
+    /// Position `x(θ)` and velocity `dx/dθ` at a frozen `(u, v)`.
+    pub fn evaluate_with_velocity(&self, uv: Point2) -> (Point3, Vec3) {
+        let p = self.evaluate(uv);
+        (
+            Point3::new(p.x.real, p.y.real, p.z.real),
+            Vec3::new(p.x.dual, p.y.dual, p.z.dual),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plane_offset_lift_matches_exact_velocity() {
+        // Plane translating along its normal: dx/dθ = ẑ everywhere.
+        let plane = Plane::new(Point3::new(0.0, 0.0, 2.0), Vec3::x(), Vec3::y());
+        let lifted = lift_surface(
+            &plane,
+            Some(SurfaceSeed::Translate {
+                velocity: Vec3::z(),
+            }),
+        )
+        .unwrap();
+        for &(u, v) in &[(0.0, 0.0), (1.5, -2.5), (10.0, 3.0)] {
+            let (p, vel) = lifted.evaluate_with_velocity(Point2::new(u, v));
+            assert!((p.z - 2.0).abs() < 1e-15);
+            assert!((vel - Vec3::z()).norm() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn cylinder_radius_lift_matches_exact_velocity() {
+        // Radius seed: dx/dr = radial direction (cos u, sin u, 0).
+        let cyl = CylinderSurface::new(5.0);
+        let lifted = lift_surface(&cyl, Some(SurfaceSeed::CylinderRadius { rate: 1.0 })).unwrap();
+        for &(u, v) in &[(0.0, 0.0), (1.0, 3.0), (4.5, -2.0)] {
+            let (p, vel) = lifted.evaluate_with_velocity(Point2::new(u, v));
+            let radial = Vec3::new(u.cos(), u.sin(), 0.0);
+            assert!(
+                (vel - radial).norm() < 1e-15,
+                "vel {vel:?} vs radial {radial:?}"
+            );
+            assert!((p.z - v).abs() < 1e-15);
+        }
+    }
+
+    #[test]
+    fn inapplicable_seed_is_an_error() {
+        let plane = Plane::xy();
+        let err = lift_surface(&plane, Some(SurfaceSeed::CylinderRadius { rate: 1.0 }));
+        assert!(matches!(err, Err(DiffError::UnsupportedSeed { .. })));
+    }
+
+    #[test]
+    fn unseeded_lift_has_zero_velocity() {
+        let sph = SphereSurface::new(3.0);
+        let lifted = lift_surface(&sph, None).unwrap();
+        let (_, vel) = lifted.evaluate_with_velocity(Point2::new(0.7, 0.3));
+        assert!(vel.norm() < 1e-15);
+    }
+}

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -3,11 +3,11 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use tang::{Dual, Scalar};
+use tang::Dual;
 use vcad_kernel_math::{Point3, Vec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::frozen::{
-    canonical_index, signature_with_index, FrozenError, FrozenPlan, NodeRecipe,
+    canonical_index, mesh_volume, signature_with_index, FrozenError, FrozenPlan, NodeRecipe,
 };
 use vcad_kernel_topo::VertexId;
 
@@ -16,9 +16,16 @@ use crate::{
 };
 
 /// Incidence tolerance (mm) for treating a topology vertex as lying on a
-/// surface. Boolean/trim vertices land on their defining surfaces to
-/// machine precision; this is far above that and far below feature size.
-const INCIDENCE_TOL: f64 = 1e-6;
+/// surface. Must sit above the placement error of boolean/trim vertices on
+/// their defining surfaces (analytic intersections are ~machine precision;
+/// sampled-fallback intersections can be off by ~1e-6 mm — a missed
+/// incidence silently *loses* a constraint, so the tolerance errs high) and
+/// far below feature separation.
+const INCIDENCE_TOL: f64 = 1e-4;
+
+/// Tolerance (mm) for the structural capture-time-B-rep check: every
+/// resolved node must land on the plan's recorded base position.
+const ANCHOR_TOL: f64 = 1e-3;
 
 /// A frozen mesh with first-order sensitivities: node `i` of `positions`
 /// corresponds to node `i` of `velocities` (dx/dθ).
@@ -41,7 +48,11 @@ pub struct SeamMesh {
 /// θ): recipes resolve entities by capture-time traversal index, which is
 /// only meaningful on the B-rep the plan was captured from. Perturbed
 /// rebuilds are the FD oracle's business (`frozen::evaluate_plan`, which
-/// matches entities geometrically instead).
+/// matches entities geometrically instead). This contract is enforced, not
+/// just documented: every resolved node is checked against the plan's
+/// recorded base position, so a rebuilt B-rep whose (order-nondeterministic)
+/// enumeration permutes entities fails with `CorrespondenceLost` instead of
+/// silently binding recipes to the wrong geometry.
 ///
 /// - `SurfaceUv` nodes go through the lift-bridge: the face's surface is
 ///   lifted to `Dual<f64>` with its seed and evaluated at the frozen
@@ -65,6 +76,9 @@ pub fn evaluate_with_sensitivity(
         }
         .into());
     }
+    if plan.base_positions.len() != plan.nodes.len() {
+        return Err(FrozenError::RecipeOutOfRange.into());
+    }
 
     let topo = &brep.topology;
 
@@ -86,9 +100,21 @@ pub fn evaluate_with_sensitivity(
     // Lift each referenced face surface once (they are shared by many nodes).
     let mut lifted: HashMap<u32, crate::DualSurface> = HashMap::new();
 
+    let anchor_check = |node: usize, p: &Point3, anchor: &Point3| -> Result<(), DiffError> {
+        let d2 = (*p - *anchor).norm_squared();
+        if d2 > ANCHOR_TOL * ANCHOR_TOL {
+            return Err(FrozenError::CorrespondenceLost {
+                node,
+                distance: d2.sqrt(),
+            }
+            .into());
+        }
+        Ok(())
+    };
+
     let mut positions = Vec::with_capacity(plan.nodes.len());
     let mut velocities = Vec::with_capacity(plan.nodes.len());
-    for recipe in &plan.nodes {
+    for (i, recipe) in plan.nodes.iter().enumerate() {
         match *recipe {
             NodeRecipe::TopoVertex { vertex } => {
                 let vid = *ci
@@ -96,6 +122,7 @@ pub fn evaluate_with_sensitivity(
                     .get(vertex as usize)
                     .ok_or(FrozenError::RecipeOutOfRange)?;
                 let x = topo.vertices[vid].point;
+                anchor_check(i, &x, &plan.base_positions[i])?;
                 // Constraint set = topological adjacency ∪ geometric
                 // incidence. The union matters: after a boolean, a rim
                 // vertex may carry half-edges of only one of its two
@@ -132,6 +159,7 @@ pub fn evaluate_with_sensitivity(
                 }
                 let (p, vel) =
                     lifted[&face].evaluate_with_velocity(vcad_kernel_math::Point2::new(u, v));
+                anchor_check(i, &p, &plan.base_positions[i])?;
                 positions.push(p);
                 velocities.push(vel);
             }
@@ -146,26 +174,12 @@ pub fn evaluate_with_sensitivity(
     })
 }
 
-/// Signed mesh volume via the divergence theorem, generic over the scalar
-/// type — evaluate with `Dual<f64>` node positions to get the volume and
-/// its θ-derivative in one pass (and `Dual<Dual<f64>>` for second
-/// derivatives, for free, later).
-pub fn mesh_volume<S: Scalar>(positions: &[tang::Point3<S>], triangles: &[[u32; 3]]) -> S {
-    let mut six_v = S::ZERO;
-    for t in triangles {
-        let a = &positions[t[0] as usize];
-        let b = &positions[t[1] as usize];
-        let c = &positions[t[2] as usize];
-        six_v += a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x)
-            + a.z * (b.x * c.y - b.y * c.x);
-    }
-    six_v / S::from_f64(6.0)
-}
-
 /// Volume and dV/dθ of a seam mesh: nodes are packed into `Dual<f64>`
-/// points (real = position, dual = velocity) and pushed through the generic
-/// volume integral, so `dV/dθ = Σ_i (∂V/∂x_i) · (dx_i/dθ)` falls out of
-/// dual arithmetic.
+/// points (real = position, dual = velocity) and pushed through the shared
+/// generic volume integral
+/// ([`vcad_kernel_tessellate::frozen::mesh_volume`] — the same integrator
+/// the FD oracle uses at `f64`), so
+/// `dV/dθ = Σ_i (∂V/∂x_i) · (dx_i/dθ)` falls out of dual arithmetic.
 pub fn volume_with_derivative(seam: &SeamMesh) -> (f64, f64) {
     let pts: Vec<tang::Point3<Dual<f64>>> = seam
         .positions

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -82,10 +82,16 @@ pub fn evaluate_with_sensitivity(
 
     let topo = &brep.topology;
 
-    // Adjacent surface indices per topology vertex (distinct indices only).
+    // Adjacent surface indices per topology vertex (distinct indices only),
+    // plus the set of surface indices actually referenced by the solid's
+    // faces — the geometric incidence scan below is restricted to the
+    // latter, so surfaces a boolean left in the store without a bounding
+    // face can never contribute a spurious constraint row.
     let mut adjacent: HashMap<VertexId, BTreeSet<usize>> = HashMap::new();
+    let mut referenced: BTreeSet<usize> = BTreeSet::new();
     for &face_id in &ci.faces {
         let face = &topo.faces[face_id];
+        referenced.insert(face.surface_index);
         let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
         for loop_id in loops {
             for he in topo.loop_half_edges(loop_id) {
@@ -129,8 +135,9 @@ pub fn evaluate_with_sensitivity(
                 // defining faces (the other keeps an untrimmed seam loop),
                 // so loop membership alone under-constrains it.
                 let mut incident: BTreeSet<usize> = adjacent.get(&vid).cloned().unwrap_or_default();
-                for (sidx, surface) in brep.geometry.surfaces.iter().enumerate() {
-                    if let Some(res) = surface_residual(surface.as_ref(), &x) {
+                for &sidx in &referenced {
+                    let surface = brep.geometry.surfaces[sidx].as_ref();
+                    if let Some(res) = surface_residual(surface, &x) {
                         if res < INCIDENCE_TOL {
                             incident.insert(sidx);
                         }

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -1,0 +1,184 @@
+//! Assembly of the seam: per-node positions and velocities for a frozen
+//! plan, plus dual-valued quantities of interest built on top of them.
+
+use std::collections::{BTreeSet, HashMap};
+
+use tang::{Dual, Scalar};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{
+    canonical_index, signature_with_index, FrozenError, FrozenPlan, NodeRecipe,
+};
+use vcad_kernel_topo::VertexId;
+
+use crate::{
+    constraint_row, lift_surface, solve_vertex_velocity, surface_residual, DiffError, ParamSeeding,
+};
+
+/// Incidence tolerance (mm) for treating a topology vertex as lying on a
+/// surface. Boolean/trim vertices land on their defining surfaces to
+/// machine precision; this is far above that and far below feature size.
+const INCIDENCE_TOL: f64 = 1e-6;
+
+/// A frozen mesh with first-order sensitivities: node `i` of `positions`
+/// corresponds to node `i` of `velocities` (dx/dθ).
+#[derive(Debug, Clone)]
+pub struct SeamMesh {
+    /// Node positions x(θ).
+    pub positions: Vec<Point3>,
+    /// Node velocities dx/dθ.
+    pub velocities: Vec<Vec3>,
+    /// Frozen connectivity (copied from the plan).
+    pub triangles: Vec<[u32; 3]>,
+    /// Recipes (copied from the plan) so callers can select node classes
+    /// (e.g. rim vertices vs interior surface samples) in their gates.
+    pub recipes: Vec<NodeRecipe>,
+}
+
+/// Evaluate a frozen plan against a B-rep with analytic sensitivities.
+///
+/// `brep` must be the **capture-time B-rep** (the primal model at the base
+/// θ): recipes resolve entities by capture-time traversal index, which is
+/// only meaningful on the B-rep the plan was captured from. Perturbed
+/// rebuilds are the FD oracle's business (`frozen::evaluate_plan`, which
+/// matches entities geometrically instead).
+///
+/// - `SurfaceUv` nodes go through the lift-bridge: the face's surface is
+///   lifted to `Dual<f64>` with its seed and evaluated at the frozen
+///   `(u, v)` (Pillar 2 — exact forward AD).
+/// - `TopoVertex` nodes are differentiated implicitly through the system of
+///   their adjacent surfaces (Pillar 3).
+///
+/// The plan's topology signature is enforced first; a mismatch is a hard
+/// error ([`FrozenError::TopologyChanged`]).
+pub fn evaluate_with_sensitivity(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+    seeding: &ParamSeeding,
+) -> Result<SeamMesh, DiffError> {
+    let ci = canonical_index(brep);
+    let actual = signature_with_index(brep, &ci);
+    if actual != plan.signature {
+        return Err(FrozenError::TopologyChanged {
+            expected: plan.signature,
+            actual,
+        }
+        .into());
+    }
+
+    let topo = &brep.topology;
+
+    // Adjacent surface indices per topology vertex (distinct indices only).
+    let mut adjacent: HashMap<VertexId, BTreeSet<usize>> = HashMap::new();
+    for &face_id in &ci.faces {
+        let face = &topo.faces[face_id];
+        let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
+        for loop_id in loops {
+            for he in topo.loop_half_edges(loop_id) {
+                adjacent
+                    .entry(topo.half_edges[he].origin)
+                    .or_default()
+                    .insert(face.surface_index);
+            }
+        }
+    }
+
+    // Lift each referenced face surface once (they are shared by many nodes).
+    let mut lifted: HashMap<u32, crate::DualSurface> = HashMap::new();
+
+    let mut positions = Vec::with_capacity(plan.nodes.len());
+    let mut velocities = Vec::with_capacity(plan.nodes.len());
+    for recipe in &plan.nodes {
+        match *recipe {
+            NodeRecipe::TopoVertex { vertex } => {
+                let vid = *ci
+                    .vertices
+                    .get(vertex as usize)
+                    .ok_or(FrozenError::RecipeOutOfRange)?;
+                let x = topo.vertices[vid].point;
+                // Constraint set = topological adjacency ∪ geometric
+                // incidence. The union matters: after a boolean, a rim
+                // vertex may carry half-edges of only one of its two
+                // defining faces (the other keeps an untrimmed seam loop),
+                // so loop membership alone under-constrains it.
+                let mut incident: BTreeSet<usize> = adjacent.get(&vid).cloned().unwrap_or_default();
+                for (sidx, surface) in brep.geometry.surfaces.iter().enumerate() {
+                    if let Some(res) = surface_residual(surface.as_ref(), &x) {
+                        if res < INCIDENCE_TOL {
+                            incident.insert(sidx);
+                        }
+                    }
+                }
+                let mut rows = Vec::new();
+                for &sidx in &incident {
+                    let surface = brep.geometry.surfaces[sidx].as_ref();
+                    rows.push(constraint_row(surface, seeding.get(sidx), &x)?);
+                }
+                let v = solve_vertex_velocity(&rows)?;
+                positions.push(x);
+                velocities.push(v);
+            }
+            NodeRecipe::SurfaceUv { face, u, v } => {
+                let surface_index = {
+                    let face_id = *ci
+                        .faces
+                        .get(face as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    topo.faces[face_id].surface_index
+                };
+                if let std::collections::hash_map::Entry::Vacant(e) = lifted.entry(face) {
+                    let surface = brep.geometry.surfaces[surface_index].as_ref();
+                    e.insert(lift_surface(surface, seeding.get(surface_index))?);
+                }
+                let (p, vel) =
+                    lifted[&face].evaluate_with_velocity(vcad_kernel_math::Point2::new(u, v));
+                positions.push(p);
+                velocities.push(vel);
+            }
+        }
+    }
+
+    Ok(SeamMesh {
+        positions,
+        velocities,
+        triangles: plan.triangles.clone(),
+        recipes: plan.nodes.clone(),
+    })
+}
+
+/// Signed mesh volume via the divergence theorem, generic over the scalar
+/// type — evaluate with `Dual<f64>` node positions to get the volume and
+/// its θ-derivative in one pass (and `Dual<Dual<f64>>` for second
+/// derivatives, for free, later).
+pub fn mesh_volume<S: Scalar>(positions: &[tang::Point3<S>], triangles: &[[u32; 3]]) -> S {
+    let mut six_v = S::ZERO;
+    for t in triangles {
+        let a = &positions[t[0] as usize];
+        let b = &positions[t[1] as usize];
+        let c = &positions[t[2] as usize];
+        six_v += a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x)
+            + a.z * (b.x * c.y - b.y * c.x);
+    }
+    six_v / S::from_f64(6.0)
+}
+
+/// Volume and dV/dθ of a seam mesh: nodes are packed into `Dual<f64>`
+/// points (real = position, dual = velocity) and pushed through the generic
+/// volume integral, so `dV/dθ = Σ_i (∂V/∂x_i) · (dx_i/dθ)` falls out of
+/// dual arithmetic.
+pub fn volume_with_derivative(seam: &SeamMesh) -> (f64, f64) {
+    let pts: Vec<tang::Point3<Dual<f64>>> = seam
+        .positions
+        .iter()
+        .zip(&seam.velocities)
+        .map(|(p, v)| {
+            tang::Point3::new(
+                Dual::new(p.x, v.x),
+                Dual::new(p.y, v.y),
+                Dual::new(p.z, v.z),
+            )
+        })
+        .collect();
+    let vol = mesh_volume(&pts, &seam.triangles);
+    (vol.real, vol.dual)
+}

--- a/crates/vcad-kernel-diff/tests/m0_extrude_volume.rs
+++ b/crates/vcad-kernel-diff/tests/m0_extrude_volume.rs
@@ -1,0 +1,109 @@
+//! M0 — the harness. Extrude distance `d`, QoI = volume.
+//!
+//! `dV/dd = A` (the profile area) is analytic, so this proves the whole
+//! pipeline — parametric rebuild, frozen tessellation, seam sensitivities,
+//! dual-number QoI, central-difference oracle — end to end with zero
+//! geometric subtlety.
+
+use vcad_kernel_diff::{
+    compare_velocities, evaluate_with_sensitivity, fd_velocities, fd_volume_derivative,
+    ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::Plane;
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_sketch::SketchProfile;
+use vcad_kernel_tessellate::frozen::{capture_plan, evaluate_plan};
+use vcad_kernel_tessellate::TessellationParams;
+
+const WIDTH: f64 = 4.0;
+const HEIGHT: f64 = 3.0;
+const D0: f64 = 2.0;
+const H: f64 = 1e-6;
+const GATE: f64 = 1e-6;
+
+/// The parametric model: a WIDTH × HEIGHT rectangle extruded `d` along +Z.
+fn build(d: f64) -> BRepSolid {
+    let profile = SketchProfile::rectangle(Point3::origin(), Vec3::x(), Vec3::y(), WIDTH, HEIGHT);
+    vcad_kernel_sketch::extrude(&profile, Vec3::z() * d).expect("extrude")
+}
+
+/// θ → field seeding: the extrude distance moves exactly one stored
+/// surface, the top cap plane (its origin translates at ẑ per unit d).
+/// Everything else — bottom cap, side walls (infinite planes) — is
+/// d-independent.
+fn seeding(brep: &BRepSolid, d: f64) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &brep.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<Plane>()
+                .map(|p| {
+                    p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                        && p.signed_distance(&Point3::new(0.0, 0.0, d)).abs() < 1e-9
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        },
+    );
+    assert_eq!(n, 1, "expected exactly one moving surface (the top plane)");
+    seeding
+}
+
+#[test]
+fn m0_extrude_volume_derivative_matches_analytic_and_fd() {
+    let base = build(D0);
+    let plan = capture_plan(&base, &TessellationParams::default()).expect("capture");
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base, D0)).expect("seam");
+
+    // Sanity: the frozen mesh is watertight and reproduces the exact volume.
+    let mesh = evaluate_plan(&base, &plan).expect("evaluate");
+    assert_eq!(mesh.open_edge_count(), 0, "M0 mesh must be watertight");
+    let v_exact = WIDTH * HEIGHT * D0;
+    assert!((mesh.volume() - v_exact).abs() / v_exact < 1e-12);
+
+    // Analytic gate: dV/dd = profile area, in closed form.
+    let (v, dv) = vcad_kernel_diff::volume_with_derivative(&seam);
+    let a_exact = WIDTH * HEIGHT;
+    assert!((v - v_exact).abs() / v_exact < 1e-12);
+    let rel_analytic = (dv - a_exact).abs() / a_exact;
+    assert!(
+        rel_analytic <= GATE,
+        "seam dV/dd = {dv} vs analytic {a_exact} (rel err {rel_analytic:.3e})"
+    );
+
+    // FD oracle gate on the QoI.
+    let dv_fd = fd_volume_derivative(build, D0, H, &plan).expect("fd volume");
+    let rel_fd = (dv - dv_fd).abs() / a_exact;
+    assert!(
+        rel_fd <= GATE,
+        "seam dV/dd = {dv} vs FD {dv_fd} (rel err {rel_fd:.3e})"
+    );
+
+    // FD oracle gate node-wise: every node's dx/dd.
+    let fd = fd_velocities(build, D0, H, &plan).expect("fd velocities");
+    let cmp = compare_velocities(&seam.velocities, &fd);
+    assert!(
+        cmp.max_rel_err <= GATE,
+        "node dx/dd max rel err {:.3e} at node {} (velocity scale {:.3})",
+        cmp.max_rel_err,
+        cmp.worst_node,
+        cmp.velocity_scale
+    );
+
+    // The top four corners move at exactly ẑ; the bottom four are pinned.
+    let moving = seam
+        .velocities
+        .iter()
+        .filter(|v| (**v - Vec3::z()).norm() < 1e-9)
+        .count();
+    let pinned = seam.velocities.iter().filter(|v| v.norm() < 1e-12).count();
+    assert_eq!(
+        (moving, pinned),
+        (4, 4),
+        "box has 4 moving + 4 pinned nodes"
+    );
+}

--- a/crates/vcad-kernel-diff/tests/m1_frozen_lift.rs
+++ b/crates/vcad-kernel-diff/tests/m1_frozen_lift.rs
@@ -1,0 +1,172 @@
+//! M1 — frozen tessellation + lift-bridge.
+//!
+//! Acceptance:
+//! 1. Interior-sample dx/dθ on a single generic face matches the FD oracle
+//!    to the gate — exercised on a cylinder lateral face (radius = θ) via
+//!    the full frozen pipeline, and on a plane (offset = θ) at the
+//!    lift-bridge level (planar faces tessellate from boundary vertices
+//!    only, so a plane's interior samples don't arise in a full-solid plan).
+//! 2. The topology-signature assertion is in place and errors — not lies —
+//!    on a deliberately topology-changing perturbation.
+
+use vcad_kernel_diff::{
+    compare_velocities, evaluate_with_sensitivity, fd_velocities, lift_surface, DiffError,
+    ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, Plane};
+use vcad_kernel_math::{Point2, Point3, Vec3};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::{capture_plan, FrozenError, NodeRecipe};
+use vcad_kernel_tessellate::TessellationParams;
+
+const R0: f64 = 5.0;
+const HEIGHT: f64 = 8.0;
+const H: f64 = 1e-6;
+const GATE: f64 = 1e-6;
+
+fn params() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 32,
+        height_segments: 4,
+        ..Default::default()
+    }
+}
+
+/// The parametric model: a cylinder whose radius is θ.
+fn build(r: f64) -> BRepSolid {
+    make_cylinder(r, HEIGHT, 32)
+}
+
+fn seeding(brep: &BRepSolid) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &brep.geometry,
+        |s| s.as_any().downcast_ref::<CylinderSurface>().is_some(),
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    assert_eq!(n, 1, "primitive cylinder stores one cylindrical surface");
+    seeding
+}
+
+#[test]
+fn m1_cylinder_interior_samples_match_fd() {
+    let base = build(R0);
+    let plan = capture_plan(&base, &params()).expect("capture");
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base)).expect("seam");
+
+    // The plan must contain genuine interior (u, v) samples on the moving
+    // face — that's what M1 is about.
+    let interior: Vec<usize> = seam
+        .recipes
+        .iter()
+        .enumerate()
+        .filter_map(|(i, r)| match r {
+            NodeRecipe::SurfaceUv { v, .. } if *v > 0.0 && *v < HEIGHT => Some(i),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        interior.len() >= 3 * 32,
+        "expected ≥ 96 interior lateral samples, got {}",
+        interior.len()
+    );
+
+    // Every interior sample's analytic velocity is the exact radial
+    // direction at its frozen angle (Pillar 2 via the lift-bridge).
+    for &i in &interior {
+        if let NodeRecipe::SurfaceUv { u, .. } = seam.recipes[i] {
+            let radial = Vec3::new(u.cos(), u.sin(), 0.0);
+            assert!(
+                (seam.velocities[i] - radial).norm() < 1e-12,
+                "node {i}: analytic velocity {:?} vs exact radial {:?}",
+                seam.velocities[i],
+                radial
+            );
+        }
+    }
+
+    // FD oracle over the whole mesh (interior samples included).
+    let fd = fd_velocities(build, R0, H, &plan).expect("fd velocities");
+    let cmp = compare_velocities(&seam.velocities, &fd);
+    assert!(
+        cmp.max_rel_err <= GATE,
+        "dx/dr max rel err {:.3e} at node {}",
+        cmp.max_rel_err,
+        cmp.worst_node
+    );
+}
+
+#[test]
+fn m1_plane_offset_interior_samples_match_fd() {
+    // A plane whose offset along its normal is θ, sampled on an interior
+    // (u, v) grid at frozen parameters. Analytic side: the lift-bridge.
+    // FD side: rebuild the surface at θ ± h, evaluate the same grid.
+    let build_plane = |theta: f64| {
+        Plane::new(
+            Point3::new(1.0, -2.0, 0.0) + Vec3::new(0.3, -0.2, 0.9).normalize() * theta,
+            Vec3::new(0.9, 0.1, -0.29),
+            Vec3::new(-0.1, 0.95, 0.18),
+        )
+    };
+    let theta0 = 1.7;
+    let normal_velocity = Vec3::new(0.3, -0.2, 0.9).normalize();
+    let base = build_plane(theta0);
+    let lifted = lift_surface(
+        &base,
+        Some(SurfaceSeed::Translate {
+            velocity: normal_velocity,
+        }),
+    )
+    .expect("lift");
+
+    let mut max_rel = 0.0_f64;
+    for iu in 0..7 {
+        for iv in 0..7 {
+            let uv = Point2::new(-3.0 + iu as f64, -3.0 + iv as f64);
+            let (_, vel) = lifted.evaluate_with_velocity(uv);
+            let plus = build_plane(theta0 + H).evaluate(uv);
+            let minus = build_plane(theta0 - H).evaluate(uv);
+            let fd = (plus - minus) / (2.0 * H);
+            let rel = (vel - fd).norm() / fd.norm().max(1e-12);
+            max_rel = max_rel.max(rel);
+        }
+    }
+    assert!(max_rel <= GATE, "plane dx/dθ max rel err {max_rel:.3e}");
+}
+
+#[test]
+fn m1_topology_change_is_an_error_not_a_lie() {
+    // Capture on a blind-hole block, then perturb the hole depth far enough
+    // to punch through: face/loop structure changes, so both the plain
+    // frozen evaluation and the seam must refuse.
+    use vcad_kernel::Solid;
+
+    let build_block = |depth: f64| -> BRepSolid {
+        let block = Solid::cube(10.0, 8.0, 6.0);
+        let tool = Solid::cylinder(2.0, depth, 16).translate(5.0, 4.0, 6.0 - depth + 0.5);
+        block
+            .difference(&tool)
+            .as_brep()
+            .expect("brep result")
+            .clone()
+    };
+
+    let blind = build_block(3.0); // hole bottom at z = 3.5 — blind
+    let plan = capture_plan(&blind, &params()).expect("capture");
+
+    // Positive control: a small, topology-preserving perturbation evaluates.
+    let nearby = build_block(3.0 + 1e-6);
+    vcad_kernel_tessellate::frozen::evaluate_plan(&nearby, &plan)
+        .expect("small perturbation keeps topology");
+
+    // Punch through: z-extent of the tool now spans the whole block.
+    let through = build_block(7.0);
+    match vcad_kernel_tessellate::frozen::evaluate_plan(&through, &plan) {
+        Err(FrozenError::TopologyChanged { .. }) => {}
+        other => panic!("expected TopologyChanged, got {other:?}"),
+    }
+    match evaluate_with_sensitivity(&through, &plan, &ParamSeeding::new()) {
+        Err(DiffError::Frozen(FrozenError::TopologyChanged { .. })) => {}
+        other => panic!("expected TopologyChanged from seam, got {other:?}"),
+    }
+}

--- a/crates/vcad-kernel-diff/tests/m2_boolean_hole.rs
+++ b/crates/vcad-kernel-diff/tests/m2_boolean_hole.rs
@@ -1,0 +1,180 @@
+//! M2 — the first true boolean seam: a through-hole's diameter.
+//!
+//! A cylinder of radius `r` is boolean-subtracted from a block; θ = r and
+//! the QoI is volume. The moving surface is the simplest possible and the
+//! continuum derivative is closed-form (`dV/dr = −2πrt`), so this validates
+//! the *framework*, not the geometry:
+//!
+//! - interior hole-wall samples are Pillar 2 (exact via the lift-bridge);
+//! - the rim — the moving trim boundary {on cap plane} ∩ {on cylinder(r)} —
+//!   is the first Pillar-3 exercise: rim vertices are differentiated
+//!   implicitly through the two-surface system with the tangential DOF
+//!   frozen.
+//!
+//! The frozen mesh carries the rim as an N-gon (the boolean polygonizes the
+//! intersection circle at `segments`), so the *discrete* closed form it
+//! must match exactly is `dV/dr = −N·sin(2π/N)·r·t` — the derivative of
+//! `V(r) = L·W·t − ½·N·sin(2π/N)·r²·t`. The continuum `−2πrt` differs from
+//! this by the polygonization factor `sin(x)/x`, `x = 2π/N` (relative gap
+//! `x²/6 + O(x⁴)`); the test gates the discrete form at 1e-6 and the
+//! continuum form at its discretization bound.
+
+use vcad_kernel::Solid;
+use vcad_kernel_diff::{
+    compare_velocities, evaluate_with_sensitivity, fd_velocities, fd_volume_derivative,
+    ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_math::Vec3;
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{capture_plan, evaluate_plan, NodeRecipe};
+use vcad_kernel_tessellate::TessellationParams;
+
+const L: f64 = 10.0;
+const W: f64 = 8.0;
+const T: f64 = 5.0;
+const R0: f64 = 2.5;
+const SEGMENTS: u32 = 32;
+const H: f64 = 1e-6;
+const GATE: f64 = 1e-6;
+
+/// The parametric model: block minus a through-hole of radius `r` centered
+/// at (L/2, W/2), tool overshooting both faces.
+fn build(r: f64) -> BRepSolid {
+    let block = Solid::cube(L, W, T);
+    let tool = Solid::cylinder(r, T + 2.0, SEGMENTS).translate(L / 2.0, W / 2.0, -1.0);
+    block
+        .difference(&tool)
+        .as_brep()
+        .expect("boolean should stay BRep")
+        .clone()
+}
+
+/// θ → field seeding: r touches exactly the hole-wall cylinder surface.
+fn seeding(brep: &BRepSolid) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &brep.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .map(|c| (c.radius - R0).abs() < 1e-9)
+                .unwrap_or(false)
+        },
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    assert_eq!(n, 1, "expected exactly one hole-wall surface, got {n}");
+    seeding
+}
+
+#[test]
+fn m2_through_hole_dv_dr_matches_closed_form_and_fd() {
+    let base = build(R0);
+    let params = TessellationParams {
+        circle_segments: SEGMENTS,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let plan = capture_plan(&base, &params).expect("capture");
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base)).expect("seam");
+
+    // Discrete closed form for the frozen mesh: hole cross-section is the
+    // inscribed N-gon of the rim circle.
+    let n = SEGMENTS as f64;
+    let sector = 2.0 * std::f64::consts::PI / n;
+    let v_exact = L * W * T - 0.5 * n * sector.sin() * R0 * R0 * T;
+    let dv_exact = -n * sector.sin() * R0 * T;
+
+    let mesh = evaluate_plan(&base, &plan).expect("evaluate");
+    assert!(
+        (mesh.volume() - v_exact).abs() / v_exact < 1e-12,
+        "frozen volume {} vs discrete closed form {v_exact}",
+        mesh.volume()
+    );
+
+    // Gate 1: seam dV/dr vs the discrete closed form.
+    let (v, dv) = vcad_kernel_diff::volume_with_derivative(&seam);
+    assert!((v - v_exact).abs() / v_exact < 1e-12);
+    let rel_closed = (dv - dv_exact).abs() / dv_exact.abs();
+    assert!(
+        rel_closed <= GATE,
+        "seam dV/dr = {dv} vs discrete closed form {dv_exact} (rel err {rel_closed:.3e})"
+    );
+
+    // Gate 2: seam dV/dr vs the FD oracle under the same frozen plan.
+    let dv_fd = fd_volume_derivative(build, R0, H, &plan).expect("fd volume");
+    let rel_fd = (dv - dv_fd).abs() / dv_exact.abs();
+    assert!(
+        rel_fd <= GATE,
+        "seam dV/dr = {dv} vs FD {dv_fd} (rel err {rel_fd:.3e})"
+    );
+
+    // Continuum closed form −2πrt: differs by the polygonization factor
+    // sin(x)/x only. Verify the gap is exactly the discretization error,
+    // within 10% slack of the leading term x²/6, x = 2π/N.
+    let dv_continuum = -2.0 * std::f64::consts::PI * R0 * T;
+    let gap = (dv - dv_continuum).abs() / dv_continuum.abs();
+    let bound = sector.powi(2) / 6.0;
+    assert!(
+        gap <= bound * 1.1,
+        "continuum gap {gap:.3e} exceeds discretization bound {bound:.3e}"
+    );
+}
+
+#[test]
+fn m2_rim_nodes_implicit_diff_matches_fd() {
+    let base = build(R0);
+    let params = TessellationParams {
+        circle_segments: SEGMENTS,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let plan = capture_plan(&base, &params).expect("capture");
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base)).expect("seam");
+    let fd = fd_velocities(build, R0, H, &plan).expect("fd velocities");
+
+    // Rim nodes: topology vertices lying on the hole wall. Their velocity
+    // comes from the implicit two-surface system {cap plane, cylinder(r)}
+    // with the tangential DOF frozen — it must be the exact radial
+    // direction, and must match the FD oracle node-wise.
+    let center = Vec3::new(L / 2.0, W / 2.0, 0.0);
+    let mut rim_nodes = 0;
+    for (i, recipe) in seam.recipes.iter().enumerate() {
+        if !matches!(recipe, NodeRecipe::TopoVertex { .. }) {
+            continue;
+        }
+        let p = seam.positions[i];
+        let radial_offset = Vec3::new(p.x - center.x, p.y - center.y, 0.0);
+        if (radial_offset.norm() - R0).abs() > 1e-9 {
+            continue; // block corner, not a rim vertex
+        }
+        rim_nodes += 1;
+        let radial = radial_offset / radial_offset.norm();
+        assert!(
+            (seam.velocities[i] - radial).norm() < 1e-9,
+            "rim node {i}: implicit velocity {:?} vs radial {:?}",
+            seam.velocities[i],
+            radial
+        );
+        let rel = (seam.velocities[i] - fd[i]).norm() / fd[i].norm();
+        assert!(
+            rel <= GATE,
+            "rim node {i}: implicit vs FD rel err {rel:.3e}"
+        );
+    }
+    assert_eq!(
+        rim_nodes,
+        2 * SEGMENTS as usize,
+        "expected a full rim ring on each cap"
+    );
+
+    // And the whole mesh — interior wall samples (Pillar 2) included —
+    // passes the node-wise gate.
+    let cmp = compare_velocities(&seam.velocities, &fd);
+    assert!(
+        cmp.max_rel_err <= GATE,
+        "dx/dr max rel err {:.3e} at node {}",
+        cmp.max_rel_err,
+        cmp.worst_node
+    );
+}

--- a/crates/vcad-kernel-tessellate/Cargo.toml
+++ b/crates/vcad-kernel-tessellate/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+tang = { workspace = true }
 vcad-kernel-math = { workspace = true }
 vcad-kernel-topo = { workspace = true }
 vcad-kernel-geom = { workspace = true }

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -169,6 +169,12 @@ pub enum FrozenError {
         /// The offending surface kind.
         kind: SurfaceKind,
     },
+    /// A face's topology has no frozen-capture support yet and dropping it
+    /// would silently freeze a non-watertight mesh with a wrong volume.
+    UnsupportedFace {
+        /// What made the face unsupported.
+        reason: &'static str,
+    },
     /// A node recipe referenced an entity missing from the B-rep (internal
     /// inconsistency; should be prevented by the signature check).
     RecipeOutOfRange,
@@ -194,6 +200,9 @@ impl std::fmt::Display for FrozenError {
             ),
             FrozenError::UnsupportedSurface { kind } => {
                 write!(f, "frozen capture unsupported for surface kind {kind:?}")
+            }
+            FrozenError::UnsupportedFace { reason } => {
+                write!(f, "frozen capture unsupported for face: {reason}")
             }
             FrozenError::RecipeOutOfRange => write!(f, "node recipe out of range for this B-rep"),
             FrozenError::CorrespondenceLost { node, distance } => write!(
@@ -273,9 +282,23 @@ pub fn signature_with_index(brep: &BRepSolid, ci: &CanonicalIndex) -> TopologySi
 
     let topo = &brep.topology;
     let mut loop_count = 0usize;
+    // Count edges reachable from the canonical walk, not the whole slotmap
+    // arena: the boolean pipeline can leave orphaned arena entities behind
+    // in rebuild-order-dependent numbers, which must not perturb the
+    // signature of the (isomorphic) solid.
+    let mut reachable_edges: std::collections::HashSet<vcad_kernel_topo::EdgeId> =
+        std::collections::HashSet::new();
     let mut face_hashes: Vec<u64> = Vec::with_capacity(ci.faces.len());
     for &face_id in &ci.faces {
         let face = &topo.faces[face_id];
+        let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
+        for loop_id in loops {
+            for he in topo.loop_half_edges(loop_id) {
+                if let Some(e) = topo.half_edges[he].edge {
+                    reachable_edges.insert(e);
+                }
+            }
+        }
         let surface = &brep.geometry.surfaces[face.surface_index];
         let mut h = FNV_OFFSET;
         fnv(
@@ -311,7 +334,7 @@ pub fn signature_with_index(brep: &BRepSolid, ci: &CanonicalIndex) -> TopologySi
 
     TopologySignature {
         vertices: ci.vertices.len(),
-        edges: topo.edges.len(),
+        edges: reachable_edges.len(),
         faces: ci.faces.len(),
         loops: loop_count,
         connectivity_hash: hash,
@@ -366,6 +389,21 @@ fn invert_uv(surface: &dyn Surface, p: &Point3) -> Result<Point2, FrozenError> {
 /// sample on a curved surface pins two DOF and follows the surface as it
 /// moves with θ (e.g. a cap-rim node bound to the cylinder wall stays on the
 /// moving trim); a sample on a plane pins only one DOF.
+///
+/// KNOWN LIMITATION: this ordering hard-codes the assumption that when a
+/// trim boundary moves, the *curved* surface is the one carrying θ (true
+/// for the M0–M2 parameters: extrude distance moves planes whose trims are
+/// θ-independent, hole radius moves the cylinder). The inverse case — a
+/// boundary node shared between a *moving plane* and a fixed curved surface
+/// (e.g. cylinder height as θ) — freezes the node on the fixed surface, so
+/// the frozen mesh no longer tracks the true solid at θ ± h and any QoI
+/// integral over it differentiates a slightly different body. The FD oracle
+/// replays the same recipes, so it agrees with the analytic side while both
+/// differ from the true CAD derivative. The correct general mechanism is a
+/// multi-surface boundary recipe (the `SurfaceUv` analogue of the implicit
+/// multi-row vertex solve) — later-milestone work. Until then, restrict θ
+/// choices to parameters whose moving trims live on curved surfaces or are
+/// carried by topology vertices.
 fn recipe_rank(recipe: &NodeRecipe, kind: SurfaceKind) -> u8 {
     match recipe {
         NodeRecipe::TopoVertex { .. } => 2,
@@ -444,14 +482,40 @@ pub fn capture_plan(
     let mut base_positions: Vec<Point3> = Vec::new();
     let mut node_kinds: Vec<SurfaceKind> = Vec::new();
     let mut triangles: Vec<[u32; 3]> = Vec::new();
-    let mut dedup: HashMap<[i64; 3], u32> = HashMap::new();
-    let quantize = |p: &Point3| -> [i64; 3] {
+    // Spatial hash for cross-face dedup. Lookup probes the 27 neighboring
+    // cells and merges on true distance, so two computations of the same
+    // logical node that straddle a cell boundary (f32 drift between two
+    // faces' paths) still merge — a straddle-split node would silently
+    // dodge the recipe-priority promotion below.
+    let mut dedup: HashMap<[i64; 3], Vec<u32>> = HashMap::new();
+    let cell = |p: &Point3| -> [i64; 3] {
         [
             (p.x / DEDUP_QUANTUM).round() as i64,
             (p.y / DEDUP_QUANTUM).round() as i64,
             (p.z / DEDUP_QUANTUM).round() as i64,
         ]
     };
+    let find_near =
+        |dedup: &HashMap<[i64; 3], Vec<u32>>, positions: &[Point3], p: &Point3| -> Option<u32> {
+            let c = cell(p);
+            let mut best: Option<(u32, f64)> = None;
+            for dx in -1..=1 {
+                for dy in -1..=1 {
+                    for dz in -1..=1 {
+                        let key = [c[0] + dx, c[1] + dy, c[2] + dz];
+                        for &idx in dedup.get(&key).into_iter().flatten() {
+                            let d2 = (positions[idx as usize] - *p).norm_squared();
+                            if d2 < DEDUP_QUANTUM * DEDUP_QUANTUM
+                                && best.map(|(_, bd)| d2 < bd).unwrap_or(true)
+                            {
+                                best = Some((idx, d2));
+                            }
+                        }
+                    }
+                }
+            }
+            best.map(|(idx, _)| idx)
+        };
 
     for (fi, &face_id) in ci.faces.iter().enumerate() {
         let face = &topo.faces[face_id];
@@ -459,6 +523,15 @@ pub fn capture_plan(
         let kind = surface.surface_type();
         let mesh = tessellate_face_for_capture(brep, face_id, params);
         if mesh.indices.is_empty() {
+            // A degenerate-cap loop that carries holes needs the CDT path
+            // `tessellate_brep` has inline but the per-face tessellator does
+            // not; silently dropping the face would freeze a non-watertight
+            // mesh with a plausibly wrong volume. Fail loudly instead.
+            if topo.loop_len(face.outer_loop) <= 1 && !face.inner_loops.is_empty() {
+                return Err(FrozenError::UnsupportedFace {
+                    reason: "degenerate single-vertex cap loop with inner loops (holes)",
+                });
+            }
             continue;
         }
 
@@ -524,9 +597,8 @@ pub fn capture_plan(
                 }
             };
 
-            let key = quantize(&position);
-            let idx = match dedup.get(&key) {
-                Some(&existing) => {
+            let idx = match find_near(&dedup, &base_positions, &position) {
+                Some(existing) => {
                     // Keep the higher-priority recipe for coincident nodes.
                     if recipe_rank(&recipe, kind)
                         > recipe_rank(&nodes[existing as usize], node_kinds[existing as usize])
@@ -542,7 +614,7 @@ pub fn capture_plan(
                     nodes.push(recipe);
                     base_positions.push(position);
                     node_kinds.push(kind);
-                    dedup.insert(key, new_idx);
+                    dedup.entry(cell(&position)).or_default().push(new_idx);
                     new_idx
                 }
             };
@@ -607,11 +679,17 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
         let p = match *recipe {
             NodeRecipe::TopoVertex { .. } => {
                 let mut best: Option<(Point3, f64)> = None;
+                let mut second_d2 = f64::INFINITY;
                 for &vid in &ci.vertices {
                     let q = topo.vertices[vid].point;
                     let d2 = (q - anchor).norm_squared();
-                    if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
-                        best = Some((q, d2));
+                    match best {
+                        Some((_, bd)) if d2 < bd => {
+                            second_d2 = bd;
+                            best = Some((q, d2));
+                        }
+                        Some(_) => second_d2 = second_d2.min(d2),
+                        None => best = Some((q, d2)),
                     }
                 }
                 let (q, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
@@ -619,6 +697,15 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
                     return Err(FrozenError::CorrespondenceLost {
                         node: i,
                         distance: d2.sqrt(),
+                    });
+                }
+                // Ambiguous match: a second distinct vertex also inside the
+                // tolerance (a near-tangency pair) could bind differently at
+                // θ+h vs θ−h and silently corrupt the FD oracle. Refuse.
+                if second_d2 <= MATCH_TOL * MATCH_TOL && second_d2 > d2 {
+                    return Err(FrozenError::CorrespondenceLost {
+                        node: i,
+                        distance: second_d2.sqrt(),
                     });
                 }
                 q
@@ -648,7 +735,20 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
                     }
                 };
                 let surface = &brep.geometry.surfaces[topo.faces[face_id].surface_index];
-                surface.evaluate(uv)
+                let p = surface.evaluate(uv);
+                // Verify EVERY node against its anchor, not just the slot's
+                // first: a wrong face match that agrees near one sample but
+                // diverges elsewhere (tangent surfaces, duplicated boolean
+                // surface copies, a rebuilt surface with a different frame)
+                // must error, not silently evaluate the wrong geometry.
+                let d2 = (p - anchor).norm_squared();
+                if d2 > MATCH_TOL * MATCH_TOL {
+                    return Err(FrozenError::CorrespondenceLost {
+                        node: i,
+                        distance: d2.sqrt(),
+                    });
+                }
+                p
             }
         };
         positions.push(p);
@@ -660,18 +760,28 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
     })
 }
 
+/// Signed mesh volume via the divergence theorem (outward winding →
+/// positive), generic over the scalar type. This is the single volume
+/// integrator for the differentiable seam: the FD oracle evaluates it at
+/// `f64` and the analytic side at `Dual<f64>` (velocity-seeded points), so
+/// both sides of every FD-vs-analytic gate integrate with the same formula
+/// by construction.
+pub fn mesh_volume<S: tang::Scalar>(positions: &[tang::Point3<S>], triangles: &[[u32; 3]]) -> S {
+    let mut six_v = S::ZERO;
+    for t in triangles {
+        let a = &positions[t[0] as usize];
+        let b = &positions[t[1] as usize];
+        let c = &positions[t[2] as usize];
+        six_v += a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x)
+            + a.z * (b.x * c.y - b.y * c.x);
+    }
+    six_v / S::from_f64(6.0)
+}
+
 impl FrozenMesh {
     /// Signed volume via the divergence theorem (outward winding → positive).
     pub fn volume(&self) -> f64 {
-        let mut six_v = 0.0;
-        for t in &self.triangles {
-            let a = &self.positions[t[0] as usize];
-            let b = &self.positions[t[1] as usize];
-            let c = &self.positions[t[2] as usize];
-            six_v += a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x)
-                + a.z * (b.x * c.y - b.y * c.x);
-        }
-        six_v / 6.0
+        mesh_volume(&self.positions, &self.triangles)
     }
 
     /// Count of boundary (odd-parity) undirected edges. Zero for a

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -1,0 +1,781 @@
+//! Frozen tessellation for the differentiable seam.
+//!
+//! A derivative dx/dθ of tessellated node positions with respect to a CAD
+//! parameter is only meaningful if the mesh connectivity **and** the sample
+//! pattern are byte-identical at θ and θ ± h, with identical vertex ordering,
+//! so that node `i` corresponds to node `i` across evaluations. The stock
+//! tessellator cannot guarantee this: its discrete choices (fan-center
+//! selection, radius-dependent segment counts, full-vs-partial cylinder
+//! detection) are functions of θ and may flip under perturbation, permuting
+//! vertices and reseeding samples.
+//!
+//! This module splits tessellation into two phases:
+//!
+//! 1. **Capture** ([`capture_plan`]): run the stock tessellator once at the
+//!    base parameter value and record a [`FrozenPlan`] — for every mesh node
+//!    a [`NodeRecipe`] saying *how* to recompute its position from a B-rep
+//!    (read a topology vertex, or evaluate a face's surface at a frozen
+//!    `(u, v)`), plus the frozen triangle connectivity and a
+//!    [`TopologySignature`] of the B-rep the plan was captured from.
+//! 2. **Evaluate** ([`evaluate_plan`]): given a *rebuilt* B-rep (same model,
+//!    perturbed parameter), first assert the topology signature is unchanged
+//!    — a changed signature means the perturbation crossed a topology change
+//!    (a subgradient) and node correspondence is meaningless, so this is a
+//!    hard error, never a silent wrong answer — then re-emit node positions
+//!    under the frozen recipes in `f64` (the stock [`TriangleMesh`] is `f32`,
+//!    which is far too coarse for a central-difference oracle at `h ≈ 1e-6`).
+//!
+//! Node recipes reference topology entities by *canonical traversal index*
+//! (position in a deterministic walk of shells → faces → loops → vertices),
+//! not by slotmap key, so correspondence survives rebuilding the model from
+//! scratch as long as the construction code takes the same branches.
+
+use std::collections::HashMap;
+
+use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind};
+use vcad_kernel_math::{Point2, Point3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_topo::{FaceId, Orientation, VertexId};
+
+use crate::TessellationParams;
+
+/// Absolute tolerance (mm) for matching a tessellated `f32` vertex back to a
+/// topology vertex during capture. Matches the stock weld quantum: tight
+/// enough to only capture true coincidences, loose enough to absorb `f32`
+/// rounding of the stock tessellator's output.
+const VERTEX_MATCH_TOL: f64 = 1e-3;
+
+/// Quantization step (mm) for deduplicating coincident nodes across faces
+/// during capture (same value the stock `weld_coincident_vertices` uses).
+const DEDUP_QUANTUM: f64 = 1e-3;
+
+/// Tolerance (mm) for geometric correspondence when a plan is evaluated
+/// against a rebuilt B-rep: an entity must lie within this distance of the
+/// node's capture-time position. Far above the O(h · velocity) motion of a
+/// derivative step, far below feature separation.
+const MATCH_TOL: f64 = 1e-3;
+
+/// Cheap structural fingerprint of a B-rep's combinatorics.
+///
+/// Two B-reps with equal signatures have the same entity counts and the
+/// same *multiset* of per-face descriptors (surface kind, orientation, loop
+/// lengths). The hash is deliberately order-invariant: the boolean pipeline
+/// is internally order-nondeterministic (hash-map iteration decides e.g.
+/// which cap face is sewn first), so an isomorphic rebuild may enumerate
+/// faces in a different order — that is not a topology change. Entity
+/// *correspondence* across rebuilds is recovered geometrically by
+/// [`evaluate_plan`], not from traversal order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TopologySignature {
+    /// Number of vertices.
+    pub vertices: usize,
+    /// Number of edges.
+    pub edges: usize,
+    /// Number of faces (across all shells of the solid).
+    pub faces: usize,
+    /// Number of loops.
+    pub loops: usize,
+    /// Order-invariant FNV-1a hash over the sorted multiset of per-face
+    /// descriptors (surface kind, orientation, outer/inner loop lengths).
+    pub connectivity_hash: u64,
+}
+
+/// Canonical traversal of a B-rep solid: faces in shell order (outer shell
+/// first, then void shells), vertices in first-visit order along that walk.
+///
+/// This is the index space [`NodeRecipe`] uses to survive rebuilds.
+#[derive(Debug, Clone)]
+pub struct CanonicalIndex {
+    /// Faces in traversal order.
+    pub faces: Vec<FaceId>,
+    /// Vertices in first-visit order.
+    pub vertices: Vec<VertexId>,
+    vertex_index: HashMap<VertexId, u32>,
+}
+
+impl CanonicalIndex {
+    /// Canonical index of a topology vertex, if visited by the walk.
+    pub fn vertex_position(&self, v: VertexId) -> Option<u32> {
+        self.vertex_index.get(&v).copied()
+    }
+}
+
+/// How to recompute one mesh node's position from a (rebuilt) B-rep.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum NodeRecipe {
+    /// The node coincides with a topology vertex; read its position.
+    /// `vertex` is a canonical first-visit index into [`CanonicalIndex`].
+    TopoVertex {
+        /// Canonical vertex index.
+        vertex: u32,
+    },
+    /// The node is a surface sample at frozen parameters: evaluate the
+    /// surface of the face at canonical traversal index `face` at `(u, v)`.
+    SurfaceUv {
+        /// Canonical face traversal index.
+        face: u32,
+        /// Frozen u parameter.
+        u: f64,
+        /// Frozen v parameter.
+        v: f64,
+    },
+}
+
+/// A frozen tessellation: recipes for every node, frozen connectivity, and
+/// the topology signature of the B-rep the plan was captured from.
+#[derive(Debug, Clone)]
+pub struct FrozenPlan {
+    /// Signature of the capture-time B-rep; enforced on every evaluation.
+    pub signature: TopologySignature,
+    /// Per-node recompute recipes.
+    pub nodes: Vec<NodeRecipe>,
+    /// Node positions at the capture-time parameter value. Used to recover
+    /// entity correspondence geometrically when a plan is evaluated against
+    /// a rebuilt B-rep whose enumeration order differs (the boolean
+    /// pipeline is order-nondeterministic), and as the anchor that
+    /// perturbed positions must stay near.
+    pub base_positions: Vec<Point3>,
+    /// Triangles as indices into `nodes`. Winding is inherited from the
+    /// stock tessellator (outward-facing).
+    pub triangles: Vec<[u32; 3]>,
+}
+
+/// A frozen tessellation evaluated against a concrete B-rep: `f64` node
+/// positions plus the plan's frozen connectivity.
+#[derive(Debug, Clone)]
+pub struct FrozenMesh {
+    /// Node positions (`f64`, same order as the plan's `nodes`).
+    pub positions: Vec<Point3>,
+    /// Triangles (copied from the plan).
+    pub triangles: Vec<[u32; 3]>,
+}
+
+/// Errors from frozen tessellation.
+#[derive(Debug, Clone)]
+pub enum FrozenError {
+    /// The B-rep's topology signature does not match the plan's: the
+    /// parameter perturbation crossed a topology change and node
+    /// correspondence is lost. This is deliberately an error — returning a
+    /// mesh here would silently produce garbage derivatives.
+    TopologyChanged {
+        /// Signature recorded in the plan.
+        expected: TopologySignature,
+        /// Signature of the B-rep being evaluated.
+        actual: TopologySignature,
+    },
+    /// A face's surface kind has no frozen-capture support yet (its
+    /// tessellation emits samples we cannot invert to `(u, v)`).
+    UnsupportedSurface {
+        /// The offending surface kind.
+        kind: SurfaceKind,
+    },
+    /// A node recipe referenced an entity missing from the B-rep (internal
+    /// inconsistency; should be prevented by the signature check).
+    RecipeOutOfRange,
+    /// No entity of the rebuilt B-rep lies within matching tolerance of a
+    /// node's capture-time position: the perturbation moved geometry too
+    /// far (or rebuilt something else entirely), so node correspondence is
+    /// lost. Like a signature mismatch, this is a hard error.
+    CorrespondenceLost {
+        /// Index of the node whose match failed.
+        node: usize,
+        /// Distance (mm) to the nearest candidate.
+        distance: f64,
+    },
+}
+
+impl std::fmt::Display for FrozenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FrozenError::TopologyChanged { expected, actual } => write!(
+                f,
+                "topology changed across parameter perturbation (expected {expected:?}, got {actual:?}); \
+                 the derivative step crossed a subgradient"
+            ),
+            FrozenError::UnsupportedSurface { kind } => {
+                write!(f, "frozen capture unsupported for surface kind {kind:?}")
+            }
+            FrozenError::RecipeOutOfRange => write!(f, "node recipe out of range for this B-rep"),
+            FrozenError::CorrespondenceLost { node, distance } => write!(
+                f,
+                "no entity within matching tolerance of node {node}'s capture-time position \
+                 (nearest at {distance:.3e} mm); node correspondence across the perturbation is lost"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FrozenError {}
+
+/// Build the canonical traversal for a B-rep solid.
+pub fn canonical_index(brep: &BRepSolid) -> CanonicalIndex {
+    let topo = &brep.topology;
+    let solid = &topo.solids[brep.solid_id];
+
+    let mut faces = Vec::new();
+    let mut vertices = Vec::new();
+    let mut vertex_index: HashMap<VertexId, u32> = HashMap::new();
+
+    let shells = std::iter::once(solid.outer_shell).chain(solid.void_shells.iter().copied());
+    for shell_id in shells {
+        for &face_id in &topo.shells[shell_id].faces {
+            faces.push(face_id);
+            let face = &topo.faces[face_id];
+            let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
+            for loop_id in loops {
+                for he in topo.loop_half_edges(loop_id) {
+                    let v = topo.half_edges[he].origin;
+                    if let std::collections::hash_map::Entry::Vacant(e) = vertex_index.entry(v) {
+                        e.insert(vertices.len() as u32);
+                        vertices.push(v);
+                    }
+                }
+            }
+        }
+    }
+
+    CanonicalIndex {
+        faces,
+        vertices,
+        vertex_index,
+    }
+}
+
+fn kind_tag(kind: SurfaceKind) -> u8 {
+    match kind {
+        SurfaceKind::Plane => 0,
+        SurfaceKind::Cylinder => 1,
+        SurfaceKind::Cone => 2,
+        SurfaceKind::Sphere => 3,
+        SurfaceKind::Torus => 4,
+        SurfaceKind::BSpline => 5,
+        SurfaceKind::Bilinear => 6,
+    }
+}
+
+/// Compute the topology signature of a B-rep solid.
+pub fn topology_signature(brep: &BRepSolid) -> TopologySignature {
+    let ci = canonical_index(brep);
+    signature_with_index(brep, &ci)
+}
+
+/// Compute the topology signature using an existing canonical traversal.
+pub fn signature_with_index(brep: &BRepSolid, ci: &CanonicalIndex) -> TopologySignature {
+    const FNV_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    fn fnv(hash: &mut u64, bytes: &[u8]) {
+        for &b in bytes {
+            *hash ^= b as u64;
+            *hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+
+    let topo = &brep.topology;
+    let mut loop_count = 0usize;
+    let mut face_hashes: Vec<u64> = Vec::with_capacity(ci.faces.len());
+    for &face_id in &ci.faces {
+        let face = &topo.faces[face_id];
+        let surface = &brep.geometry.surfaces[face.surface_index];
+        let mut h = FNV_OFFSET;
+        fnv(
+            &mut h,
+            &[
+                kind_tag(surface.surface_type()),
+                matches!(face.orientation, Orientation::Reversed) as u8,
+            ],
+        );
+        loop_count += 1 + face.inner_loops.len();
+        fnv(
+            &mut h,
+            &(topo.loop_len(face.outer_loop) as u32).to_le_bytes(),
+        );
+        let mut inner_lens: Vec<u32> = face
+            .inner_loops
+            .iter()
+            .map(|&l| topo.loop_len(l) as u32)
+            .collect();
+        inner_lens.sort_unstable();
+        fnv(&mut h, &(inner_lens.len() as u32).to_le_bytes());
+        for len in inner_lens {
+            fnv(&mut h, &len.to_le_bytes());
+        }
+        face_hashes.push(h);
+    }
+    // Sorting makes the combined hash independent of face enumeration order.
+    face_hashes.sort_unstable();
+    let mut hash = FNV_OFFSET;
+    for fh in face_hashes {
+        fnv(&mut hash, &fh.to_le_bytes());
+    }
+
+    TopologySignature {
+        vertices: ci.vertices.len(),
+        edges: topo.edges.len(),
+        faces: ci.faces.len(),
+        loops: loop_count,
+        connectivity_hash: hash,
+    }
+}
+
+/// Invert a point known to lie on `surface` back to `(u, v)` parameters.
+///
+/// Only the surface kinds needed by the M0–M2 differentiable-seam milestones
+/// are supported; others return [`FrozenError::UnsupportedSurface`].
+fn invert_uv(surface: &dyn Surface, p: &Point3) -> Result<Point2, FrozenError> {
+    match surface.surface_type() {
+        SurfaceKind::Plane => {
+            let plane = surface.as_any().downcast_ref::<Plane>().ok_or(
+                FrozenError::UnsupportedSurface {
+                    kind: SurfaceKind::Plane,
+                },
+            )?;
+            Ok(plane.project(p))
+        }
+        SurfaceKind::Cylinder => {
+            let cyl = surface.as_any().downcast_ref::<CylinderSurface>().ok_or(
+                FrozenError::UnsupportedSurface {
+                    kind: SurfaceKind::Cylinder,
+                },
+            )?;
+            let d = *p - cyl.center;
+            let v = d.dot(cyl.axis.as_ref());
+            let y = cyl.y_dir();
+            let u = d.dot(y).atan2(d.dot(cyl.ref_dir.as_ref()));
+            Ok(Point2::new(u.rem_euclid(2.0 * std::f64::consts::PI), v))
+        }
+        SurfaceKind::Sphere => {
+            let sph = surface.as_any().downcast_ref::<SphereSurface>().ok_or(
+                FrozenError::UnsupportedSurface {
+                    kind: SurfaceKind::Sphere,
+                },
+            )?;
+            let d = *p - sph.center;
+            let r = sph.radius.abs().max(f64::MIN_POSITIVE);
+            let v = (d.dot(sph.axis.as_ref()) / r).clamp(-1.0, 1.0).asin();
+            let y = sph.y_dir();
+            let u = d.dot(y).atan2(d.dot(sph.ref_dir.as_ref()));
+            Ok(Point2::new(u.rem_euclid(2.0 * std::f64::consts::PI), v))
+        }
+        kind => Err(FrozenError::UnsupportedSurface { kind }),
+    }
+}
+
+/// Recipe priority when two faces contribute a coincident node: a topology
+/// vertex pins all three position DOF and tracks the kernel's own output; a
+/// sample on a curved surface pins two DOF and follows the surface as it
+/// moves with θ (e.g. a cap-rim node bound to the cylinder wall stays on the
+/// moving trim); a sample on a plane pins only one DOF.
+fn recipe_rank(recipe: &NodeRecipe, kind: SurfaceKind) -> u8 {
+    match recipe {
+        NodeRecipe::TopoVertex { .. } => 2,
+        NodeRecipe::SurfaceUv { .. } => match kind {
+            SurfaceKind::Plane => 0,
+            _ => 1,
+        },
+    }
+}
+
+/// Per-face tessellation used by capture. Mirrors the face dispatch of the
+/// primary `tessellate_brep` entry point: degenerate single-vertex circular
+/// cap loops (primitive cylinder/cone caps) are sampled as disks; everything
+/// else goes through the stock per-face tessellator.
+fn tessellate_face_for_capture(
+    brep: &BRepSolid,
+    face_id: FaceId,
+    params: &TessellationParams,
+) -> crate::TriangleMesh {
+    let topo = &brep.topology;
+    let face = &topo.faces[face_id];
+    let surface = &brep.geometry.surfaces[face.surface_index];
+    let reversed = face.orientation == Orientation::Reversed;
+
+    if surface.surface_type() == SurfaceKind::Plane
+        && topo.loop_len(face.outer_loop) <= 1
+        && face.inner_loops.is_empty()
+    {
+        // Degenerate cap: a full-circle edge anchored at one vertex.
+        let anchor = topo
+            .loop_half_edges(face.outer_loop)
+            .map(|he| topo.vertices[topo.half_edges[he].origin].point)
+            .next();
+        if let Some(v) = anchor {
+            let center = surface.evaluate(Point2::origin());
+            let r = (v - center).norm();
+            let x_dir = if r > 1e-12 {
+                (v - center).normalize()
+            } else {
+                surface.d_du(Point2::origin()).normalize()
+            };
+            let normal = surface.normal(Point2::origin());
+            let y_dir = normal.as_ref().cross(x_dir);
+            return crate::tessellate_disk_general(
+                center,
+                r,
+                x_dir,
+                y_dir,
+                params.circle_segments,
+                reversed,
+            );
+        }
+    }
+
+    crate::tessellate_face(topo, &brep.geometry, face_id, params)
+}
+
+/// Capture a frozen tessellation plan from a B-rep at the base parameter
+/// value.
+///
+/// Runs the stock per-face tessellator once, then classifies every emitted
+/// vertex: nodes coinciding with a topology vertex become
+/// [`NodeRecipe::TopoVertex`]; all others are inverted to frozen `(u, v)`
+/// samples on their face's surface ([`NodeRecipe::SurfaceUv`]). Coincident
+/// nodes from adjacent faces are merged (same quantum as the stock weld) so
+/// the frozen mesh shares vertices across face seams.
+pub fn capture_plan(
+    brep: &BRepSolid,
+    params: &TessellationParams,
+) -> Result<FrozenPlan, FrozenError> {
+    let topo = &brep.topology;
+    let ci = canonical_index(brep);
+    let signature = signature_with_index(brep, &ci);
+
+    let mut nodes: Vec<NodeRecipe> = Vec::new();
+    let mut base_positions: Vec<Point3> = Vec::new();
+    let mut node_kinds: Vec<SurfaceKind> = Vec::new();
+    let mut triangles: Vec<[u32; 3]> = Vec::new();
+    let mut dedup: HashMap<[i64; 3], u32> = HashMap::new();
+    let quantize = |p: &Point3| -> [i64; 3] {
+        [
+            (p.x / DEDUP_QUANTUM).round() as i64,
+            (p.y / DEDUP_QUANTUM).round() as i64,
+            (p.z / DEDUP_QUANTUM).round() as i64,
+        ]
+    };
+
+    for (fi, &face_id) in ci.faces.iter().enumerate() {
+        let face = &topo.faces[face_id];
+        let surface = brep.geometry.surfaces[face.surface_index].as_ref();
+        let kind = surface.surface_type();
+        let mesh = tessellate_face_for_capture(brep, face_id, params);
+        if mesh.indices.is_empty() {
+            continue;
+        }
+
+        // Topology vertices bounding this face, with canonical indices.
+        let mut loop_verts: Vec<(u32, Point3)> = Vec::new();
+        let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
+        for loop_id in loops {
+            for he in topo.loop_half_edges(loop_id) {
+                let vid = topo.half_edges[he].origin;
+                let idx = ci
+                    .vertex_position(vid)
+                    .expect("loop vertex visited by canonical walk");
+                loop_verts.push((idx, topo.vertices[vid].point));
+            }
+        }
+
+        // Only classify vertices actually referenced by triangles.
+        let mut used = vec![false; mesh.num_vertices()];
+        for &i in &mesh.indices {
+            used[i as usize] = true;
+        }
+
+        let mut local_map: Vec<u32> = vec![u32::MAX; mesh.num_vertices()];
+        for (v, mapped) in local_map.iter_mut().enumerate() {
+            if !used[v] {
+                continue;
+            }
+            let p = Point3::new(
+                mesh.vertices[3 * v] as f64,
+                mesh.vertices[3 * v + 1] as f64,
+                mesh.vertices[3 * v + 2] as f64,
+            );
+
+            // Classify: coincident topology vertex, else frozen (u, v) sample.
+            let mut best: Option<(u32, f64)> = None;
+            for &(idx, q) in &loop_verts {
+                let d2 = (p - q).norm_squared();
+                if d2 < VERTEX_MATCH_TOL * VERTEX_MATCH_TOL
+                    && best.map(|(_, bd)| d2 < bd).unwrap_or(true)
+                {
+                    best = Some((idx, d2));
+                }
+            }
+            let (recipe, position) = match best {
+                Some((idx, _)) => (
+                    NodeRecipe::TopoVertex { vertex: idx },
+                    topo.vertices[ci.vertices[idx as usize]].point,
+                ),
+                None => {
+                    let uv = invert_uv(surface, &p)?;
+                    // Canonical base position: the exact f64 surface
+                    // evaluation at the frozen (u, v), not the f32 point
+                    // the stock tessellator emitted — future evaluations
+                    // reproduce it bit-for-bit.
+                    (
+                        NodeRecipe::SurfaceUv {
+                            face: fi as u32,
+                            u: uv.x,
+                            v: uv.y,
+                        },
+                        surface.evaluate(uv),
+                    )
+                }
+            };
+
+            let key = quantize(&position);
+            let idx = match dedup.get(&key) {
+                Some(&existing) => {
+                    // Keep the higher-priority recipe for coincident nodes.
+                    if recipe_rank(&recipe, kind)
+                        > recipe_rank(&nodes[existing as usize], node_kinds[existing as usize])
+                    {
+                        nodes[existing as usize] = recipe;
+                        base_positions[existing as usize] = position;
+                        node_kinds[existing as usize] = kind;
+                    }
+                    existing
+                }
+                None => {
+                    let new_idx = nodes.len() as u32;
+                    nodes.push(recipe);
+                    base_positions.push(position);
+                    node_kinds.push(kind);
+                    dedup.insert(key, new_idx);
+                    new_idx
+                }
+            };
+            *mapped = idx;
+        }
+
+        for tri in mesh.indices.chunks_exact(3) {
+            let a = local_map[tri[0] as usize];
+            let b = local_map[tri[1] as usize];
+            let c = local_map[tri[2] as usize];
+            if a == b || b == c || c == a {
+                continue; // degenerate after cross-face dedup
+            }
+            triangles.push([a, b, c]);
+        }
+    }
+
+    Ok(FrozenPlan {
+        signature,
+        nodes,
+        base_positions,
+        triangles,
+    })
+}
+
+/// Evaluate a frozen plan against a (rebuilt) B-rep, producing `f64` node
+/// positions under the frozen recipes.
+///
+/// Errors with [`FrozenError::TopologyChanged`] if the B-rep's signature
+/// differs from the plan's — the invariant that separates a correct seam
+/// from a plausible wrong one.
+///
+/// Entity correspondence is *geometric*: the boolean pipeline enumerates an
+/// isomorphic result in a nondeterministic order (its cap faces can swap
+/// between two builds), so traversal indices recorded at capture cannot be
+/// trusted across rebuilds. Instead, each `TopoVertex` node resolves to the
+/// rebuilt vertex nearest its capture-time position, and each face slot
+/// used by `SurfaceUv` nodes resolves to the rebuilt face whose surface,
+/// evaluated at the frozen `(u, v)`, lands nearest the capture-time
+/// position. A nearest match farther than the tolerance is
+/// [`FrozenError::CorrespondenceLost`].
+pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, FrozenError> {
+    let ci = canonical_index(brep);
+    let actual = signature_with_index(brep, &ci);
+    if actual != plan.signature {
+        return Err(FrozenError::TopologyChanged {
+            expected: plan.signature,
+            actual,
+        });
+    }
+    if plan.base_positions.len() != plan.nodes.len() {
+        return Err(FrozenError::RecipeOutOfRange);
+    }
+
+    let topo = &brep.topology;
+    // Face slot (capture-time traversal index) → matched rebuilt face.
+    let mut face_match: HashMap<u32, FaceId> = HashMap::new();
+
+    let mut positions = Vec::with_capacity(plan.nodes.len());
+    for (i, recipe) in plan.nodes.iter().enumerate() {
+        let anchor = plan.base_positions[i];
+        let p = match *recipe {
+            NodeRecipe::TopoVertex { .. } => {
+                let mut best: Option<(Point3, f64)> = None;
+                for &vid in &ci.vertices {
+                    let q = topo.vertices[vid].point;
+                    let d2 = (q - anchor).norm_squared();
+                    if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
+                        best = Some((q, d2));
+                    }
+                }
+                let (q, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
+                if d2 > MATCH_TOL * MATCH_TOL {
+                    return Err(FrozenError::CorrespondenceLost {
+                        node: i,
+                        distance: d2.sqrt(),
+                    });
+                }
+                q
+            }
+            NodeRecipe::SurfaceUv { face, u, v } => {
+                let uv = Point2::new(u, v);
+                let face_id = match face_match.get(&face) {
+                    Some(&f) => f,
+                    None => {
+                        let mut best: Option<(FaceId, f64)> = None;
+                        for &fid in &ci.faces {
+                            let surface = &brep.geometry.surfaces[topo.faces[fid].surface_index];
+                            let d2 = (surface.evaluate(uv) - anchor).norm_squared();
+                            if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
+                                best = Some((fid, d2));
+                            }
+                        }
+                        let (fid, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
+                        if d2 > MATCH_TOL * MATCH_TOL {
+                            return Err(FrozenError::CorrespondenceLost {
+                                node: i,
+                                distance: d2.sqrt(),
+                            });
+                        }
+                        face_match.insert(face, fid);
+                        fid
+                    }
+                };
+                let surface = &brep.geometry.surfaces[topo.faces[face_id].surface_index];
+                surface.evaluate(uv)
+            }
+        };
+        positions.push(p);
+    }
+
+    Ok(FrozenMesh {
+        positions,
+        triangles: plan.triangles.clone(),
+    })
+}
+
+impl FrozenMesh {
+    /// Signed volume via the divergence theorem (outward winding → positive).
+    pub fn volume(&self) -> f64 {
+        let mut six_v = 0.0;
+        for t in &self.triangles {
+            let a = &self.positions[t[0] as usize];
+            let b = &self.positions[t[1] as usize];
+            let c = &self.positions[t[2] as usize];
+            six_v += a.x * (b.y * c.z - b.z * c.y) - a.y * (b.x * c.z - b.z * c.x)
+                + a.z * (b.x * c.y - b.y * c.x);
+        }
+        six_v / 6.0
+    }
+
+    /// Count of boundary (odd-parity) undirected edges. Zero for a
+    /// watertight mesh.
+    pub fn open_edge_count(&self) -> usize {
+        let mut counts: HashMap<(u32, u32), i64> = HashMap::new();
+        for t in &self.triangles {
+            for (i, j) in [(t[0], t[1]), (t[1], t[2]), (t[2], t[0])] {
+                let key = (i.min(j), i.max(j));
+                let delta = if i < j { 1 } else { -1 };
+                *counts.entry(key).or_insert(0) += delta;
+            }
+        }
+        counts.values().filter(|&&c| c != 0).count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_kernel_primitives::{make_cube, make_cylinder};
+
+    #[test]
+    fn cube_plan_captures_topo_vertices() {
+        let cube = make_cube(4.0, 3.0, 2.0);
+        let plan = capture_plan(&cube, &TessellationParams::default()).unwrap();
+        assert_eq!(plan.nodes.len(), 8, "cube has 8 shared corner nodes");
+        assert_eq!(plan.triangles.len(), 12, "cube has 2 triangles per face");
+        assert!(plan
+            .nodes
+            .iter()
+            .all(|n| matches!(n, NodeRecipe::TopoVertex { .. })));
+    }
+
+    #[test]
+    fn cube_plan_reevaluates_to_same_positions_and_volume() {
+        let cube = make_cube(4.0, 3.0, 2.0);
+        let plan = capture_plan(&cube, &TessellationParams::default()).unwrap();
+        let mesh = evaluate_plan(&cube, &plan).unwrap();
+        assert_eq!(mesh.open_edge_count(), 0, "cube mesh must be watertight");
+        assert!((mesh.volume() - 24.0).abs() < 1e-12);
+
+        // Rebuild with a perturbed height: same signature, moved positions.
+        let cube2 = make_cube(4.0, 3.0, 2.0005);
+        let mesh2 = evaluate_plan(&cube2, &plan).unwrap();
+        assert!((mesh2.volume() - 4.0 * 3.0 * 2.0005).abs() < 1e-12);
+    }
+
+    #[test]
+    fn signature_flags_topology_change() {
+        let cube = make_cube(4.0, 3.0, 2.0);
+        let plan = capture_plan(&cube, &TessellationParams::default()).unwrap();
+        let cyl = make_cylinder(2.0, 5.0, 32);
+        match evaluate_plan(&cyl, &plan) {
+            Err(FrozenError::TopologyChanged { .. }) => {}
+            other => panic!("expected TopologyChanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cylinder_plan_is_watertight_and_frozen() {
+        let params = TessellationParams {
+            circle_segments: 24,
+            height_segments: 4,
+            ..Default::default()
+        };
+        let cyl = make_cylinder(5.0, 8.0, 24);
+        let plan = capture_plan(&cyl, &params).unwrap();
+        let mesh = evaluate_plan(&cyl, &plan).unwrap();
+        assert_eq!(
+            mesh.open_edge_count(),
+            0,
+            "frozen cylinder mesh must be watertight"
+        );
+        // Interior lateral samples exist (height_segments > 1).
+        let interior = plan
+            .nodes
+            .iter()
+            .filter(|n| matches!(n, NodeRecipe::SurfaceUv { .. }))
+            .count();
+        assert!(interior > 0, "expected frozen (u,v) samples");
+
+        // Volume of the frozen mesh matches the inscribed prism closed form.
+        let n = 24.0_f64;
+        let expected = 0.5 * n * (2.0 * std::f64::consts::PI / n).sin() * 25.0 * 8.0;
+        assert!(
+            (mesh.volume() - expected).abs() / expected < 1e-9,
+            "volume {} vs expected {}",
+            mesh.volume(),
+            expected
+        );
+
+        // Re-evaluating at a perturbed radius keeps the pattern frozen and
+        // scales the volume exactly like the closed form.
+        let cyl2 = make_cylinder(5.0 + 1e-4, 8.0, 24);
+        let mesh2 = evaluate_plan(&cyl2, &plan).unwrap();
+        let expected2 =
+            0.5 * n * (2.0 * std::f64::consts::PI / n).sin() * (5.0001_f64).powi(2) * 8.0;
+        assert!(
+            (mesh2.volume() - expected2).abs() / expected2 < 1e-9,
+            "volume {} vs expected {}",
+            mesh2.volume(),
+            expected2
+        );
+        assert_eq!(mesh2.open_edge_count(), 0);
+    }
+}

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -621,7 +621,7 @@ pub fn capture_plan(
             *mapped = idx;
         }
 
-        for tri in mesh.indices.chunks_exact(3) {
+        for tri in mesh.indices.as_chunks::<3>().0 {
             let a = local_map[tri[0] as usize];
             let b = local_map[tri[1] as usize];
             let c = local_map[tri[2] as usize];

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -15,6 +15,7 @@ use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_topo::{FaceId, Orientation, Topology};
 
 mod creased_normals;
+pub mod frozen;
 mod render_bake;
 
 pub use creased_normals::{

--- a/docs/differentiable-seam-m0-m2.md
+++ b/docs/differentiable-seam-m0-m2.md
@@ -1,0 +1,195 @@
+# Differentiable seam — M0→M2 design note
+
+The first executable piece of the differentiable CAD→physics loop: **dx/dθ**,
+the sensitivity of tessellated mesh-node positions to a CAD parameter,
+computed by cutting the chain at the mesh and never differentiating through
+B-rep combinatorics. This note records the resolved ground truth, the design
+decisions and their reasons, and the measured finite-difference tolerances
+per milestone.
+
+## What landed
+
+- `vcad_kernel_tessellate::frozen` — frozen-tessellation mode: a two-phase
+  capture/evaluate split with a topology signature that turns any topology
+  change under perturbation into a hard error.
+- `vcad-kernel-diff` (new crate) — the seam itself: the lift-bridge
+  (`lift_surface` / `DualSurface`), explicit θ→field seeding
+  (`SurfaceSeed` / `ParamSeeding`), implicit vertex differentiation
+  (`constraint_row` / `solve_vertex_velocity`), assembly
+  (`evaluate_with_sensitivity` → `SeamMesh`), a scalar-generic volume QoI,
+  and the central-difference oracle (`fd_velocities`,
+  `fd_volume_derivative`, `compare_velocities`).
+- Three milestone integration tests (`crates/vcad-kernel-diff/tests/`),
+  each of which *is* its acceptance gate.
+
+## Step 0 — resolved ground truth
+
+- **Geometry store**: `GeometryStore` in `vcad-kernel-geom`
+  (`crates/vcad-kernel-geom/src/lib.rs`), element type
+  **`Vec<Box<dyn Surface>>`** (`surfaces` field; `curves_3d` / `curves_2d`
+  alongside). It lives on `BRepSolid { topology, geometry, solid_id }`,
+  which is defined in **`vcad-kernel-primitives`** (not `-topo` or the
+  unified `vcad-kernel`). `Face.surface_index` indexes `geometry.surfaces`.
+- The spec's ground truth held up everywhere it was checked: all seven
+  surface kinds (`Plane`, `CylinderSurface`, `ConeSurface`, `SphereSurface`,
+  `TorusSurface`, `BilinearSurface` in `-geom`; `BSplineSurface` in
+  `-nurbs`) carry `lift<T: Scalar>()` plus scalar-generic
+  `impl<S: Scalar>` evaluation, `tang::Dual<f64>: Scalar` holds, and the
+  `Surface` trait / topology are concrete `f64` and untouched by this work.
+  (Minor addition to the map: it's seven kinds, not six — `Bilinear` is also
+  generic; and `BSplineSurface`'s generic evaluator is `eval(u: f64, v: f64)`
+  with f64 basis functions and generic control-point accumulation, unlike
+  the `evaluate(Point2<S>)` shape of the others.)
+
+Corrections to the map that materially shaped the design (all discovered by
+running the code, none contradicting the spec's architecture):
+
+1. **`TriangleMesh` stores `f32` positions.** A central-difference oracle at
+   `h = 1e-6` is meaningless at `f32` resolution, so the frozen path emits
+   its own `f64` `FrozenMesh` and never round-trips through `TriangleMesh`.
+2. **The boolean pipeline is order-nondeterministic.** Two builds of the
+   same model can enumerate isomorphic topology in different orders
+   (hash-map iteration inside the boolean decides e.g. which cap face is
+   sewn first; empirically, `cube − cylinder(r)` swaps its two cap faces
+   between `r = 2.5` and `r = 2.5 − 1e-6`). Traversal order therefore
+   cannot carry node correspondence across rebuilds. Consequences:
+   - the topology signature hashes the **sorted multiset** of per-face
+     descriptors (surface kind, orientation, loop lengths) plus entity
+     counts, so an isomorphic reordering is not flagged as a topology
+     change;
+   - `evaluate_plan` recovers entity correspondence **geometrically**: each
+     node stores its capture-time position, topology vertices resolve to
+     the nearest rebuilt vertex, and face slots resolve to the face whose
+     surface evaluated at the frozen `(u, v)` lands nearest the stored
+     position. Matches farther than 1e-3 mm are a hard
+     `CorrespondenceLost` error. This bounds how far a plan may be
+     evaluated from its capture point (fine for derivative steps; re-capture
+     for large parameter moves).
+3. **Boolean sewing does not twin the rim.** After `cube − cylinder`, rim
+   vertices carry half-edges of the cap face only (`twin: None`); the hole
+   wall keeps a two-half-edge seam loop. Loop membership alone therefore
+   under-constrains a rim vertex, so the implicit system collects
+   constraint rows by **geometric incidence** (normalized residual
+   `|g|/|∇g| < 1e-6 mm` against every surface with an implicit form) in
+   union with topological adjacency.
+4. **Primitive cylinder caps are degenerate single-vertex circle loops**,
+   special-cased in `tessellate_brep` but not in the per-face path; the
+   capture mirrors that dispatch (`tessellate_disk_general`).
+
+## The frozen plan
+
+`capture_plan` runs the stock tessellator once at the base θ and classifies
+every emitted node:
+
+- **`TopoVertex`** — coincides with a topology vertex (within the stock weld
+  quantum). Position tracks the kernel's own output across rebuilds; the
+  analytic velocity comes from implicit differentiation (Pillar 3).
+- **`SurfaceUv`** — everything else, inverted to frozen `(u, v)` on its
+  face's surface (implemented for Plane/Cylinder/Sphere; other kinds error
+  honestly). Position is `S(u, v; θ)`; the analytic velocity is the dual
+  part of the lift-bridge evaluation (Pillar 2).
+
+Coincident nodes from adjacent faces are merged with the stock weld quantum,
+with recipe priority **TopoVertex > SurfaceUv-on-curved > SurfaceUv-on-plane**.
+The priority is load-bearing: a cap-rim node captured on both the cap plane
+and the cylinder wall must bind to the *moving* cylinder so a fixed-`(u,v)`
+evaluation keeps it on the moving trim (a plane binding would freeze it and
+open an O(h)-wide crack whose volume error is O(1) in the derivative).
+
+Known limitation, deliberate: the stock hole-aware planar triangulation can
+insert Steiner points on outer boundary *edges* (T-junctions against the
+neighbouring face's coarser edge). These are geometrically watertight
+(zero-area gaps, exact for the volume integral) but show up as odd-parity
+edges in `FrozenMesh::open_edge_count`; M2's caps have 12 of them, all on
+θ-independent block edges. The milestone gates don't depend on
+`open_edge_count == 0` for boolean outputs.
+
+## θ → field seeding
+
+`ParamSeeding` maps **surface indices → `SurfaceSeed`** (`Translate`,
+`CylinderRadius`, `SphereRadius`); unlisted surfaces are θ-independent.
+Seeds that don't apply to a surface kind are a hard `UnsupportedSeed` error,
+never silently ignored, and `seed_where` returns the match count so callers
+can assert exactly how many stored surfaces a parameter touches (boolean
+outputs can carry several copies of a moving surface). In the milestone
+models: M0's extrude distance touches exactly the top cap plane
+(`Translate{ẑ}`); M1/M2's radius touches exactly one `CylinderSurface`
+(`CylinderRadius{1}`).
+
+## Implicit vertex differentiation (Pillar 3)
+
+Each incident surface contributes a row `∇g · ẋ = −∂g/∂θ` (implicit forms:
+plane `n·(x−o)`, cylinder `|radial|²−r²`, sphere `|x−c|²−r²`). The solver is
+Gram–Schmidt with the rhs carried: independent rows determine components of
+`ẋ`; dependent rows must agree within tolerance or the solve fails with
+`InconsistentConstraints`; unconstrained directions are frozen at zero —
+the minimum-norm solution, which is exactly the frozen-branch convention
+(a rim node keeps its angular parameter). Three planes at a box corner give
+the full 3×3 solve; plane ∩ cylinder at a rim gives the rank-2 +
+frozen-tangent case.
+
+## Measured tolerances (gate: max relative error ≤ 1e-6)
+
+| Milestone | Check | Measured |
+|---|---|---|
+| M0 (extrude d, V) | seam dV/dd vs analytic A = 12 mm² | exact (0.0) |
+| M0 | seam dV/dd vs FD | 8.3e-12 |
+| M0 | node-wise dx/dd vs FD | 2.9e-11 |
+| M1 (cylinder r) | node-wise dx/dr vs FD (interior lateral samples exact-radial to 1e-12) | 5.6e-10 |
+| M2 (through-hole r, V) | seam dV/dr vs discrete closed form −N·sin(2π/N)·r·t | 1.1e-15 |
+| M2 | seam dV/dr vs FD | 6.2e-10 |
+| M2 | node-wise dx/dr vs FD (rim nodes exact-radial to 1e-9) | 5.6e-10 |
+
+FD convention: central difference, `h = 1e-6`, rebuilt at θ±h and
+re-evaluated under the same frozen plan. Node-wise relative error divides by
+`max(|analytic|, |fd|, 0.01 · max-velocity)` so FD roundoff noise
+(≈ ε·|x|/2h ≈ 1e-9 mm per unit θ at these model scales) on genuinely
+stationary nodes is not amplified into spurious relative error; the floor is
+three orders above that noise and three below the gate.
+
+One deviation from a literal reading of the spec: M2's *continuum* closed
+form `dV/dr = −2πrt` is not met at 1e-6 by design — the frozen mesh's rim is
+the N-gon the boolean produced, so the seam differentiates the discrete
+model exactly (1.1e-15 against the N-gon closed form) and differs from the
+continuum by the polygonization factor `sin(x)/x`, `x = 2π/N` (6.4e-3 at
+N = 32). The M2 test gates the discrete form and the FD oracle at 1e-6 and
+asserts the continuum gap equals its discretization bound `x²/6` within 10%.
+Discretization error is a property of the mesh, not the seam; it vanishes
+as N → ∞ and the seam's derivative is exact for the object the physics side
+will actually consume (the mesh).
+
+The topology-signature acceptance is exercised both synthetically
+(cube plan vs cylinder) and on a real subgradient crossing (blind hole
+perturbed into a through hole): both the frozen evaluation and the seam
+return `TopologyChanged`, never a mesh.
+
+## Sibling-repo caveat (local validation)
+
+This sandbox could not clone `ecto/loon` / `ecto/phyz` (session repo scope),
+which `vcad-loon`, `vcad-kernel-physics`, and `vcad-sim` need as sibling
+checkouts. Local validation ran `cargo test`/`cargo clippy -- -D warnings`
+on the full workspace **excluding** those crates and their dependents
+(`vcad-cli`, `vcad-eval`, `vcad-ffi`, `vcad-kernel-wasm`, `vcad-render`,
+`mecheval-grader`; `vcad-app`/`vcad-desktop`/`vcad-chat` are outside the
+default build set) — none of which are touched by this change. CI clones
+the real siblings and runs the full set.
+
+## What M3 needs from this
+
+A `phyz`-coupled QoI plugs in at `SeamMesh`: `positions` (x, `f64`),
+`velocities` (dx/dθ), and frozen `triangles` with stable node identity
+across the optimization step. The shape derivative is
+`dJ/dθ = Σ_i (∂J/∂x_i) · (dx_i/dθ)` — the physics side supplies `∂J/∂x_i`
+(e.g. from a phyz rollout's adjoint or its existing gradients) and contracts
+it against `SeamMesh::velocities`; `volume_with_derivative` is the template
+(it does exactly this contraction through `Dual` arithmetic, and
+`mesh_volume` being scalar-generic means second derivatives via
+`Dual<Dual<f64>>` are already reachable). The loop per optimizer step:
+build(θ) → `capture_plan` → `evaluate_with_sensitivity(brep, plan, seeding)`
+→ physics QoI on (positions, velocities) → step θ → **re-capture** (plans
+are valid only near their capture point; `TopologyChanged` /
+`CorrespondenceLost` are the signals that a step crossed a subgradient and
+must be handled by the optimizer, e.g. by shrinking the step). Multi-θ is a
+loop over seedings for now (forward mode, one pass per parameter); reverse
+mode over many parameters is M5's business and slots in behind the same
+`SeamMesh` interface.

--- a/docs/differentiable-seam-m0-m2.md
+++ b/docs/differentiable-seam-m0-m2.md
@@ -163,6 +163,50 @@ The topology-signature acceptance is exercised both synthetically
 perturbed into a through hole): both the frozen evaluation and the seam
 return `TopologyChanged`, never a mesh.
 
+## Known limitations (documented deliberately, in scope-fence order)
+
+An adversarial review pass hardened several correspondence paths (per-node
+anchor verification everywhere a recipe resolves, ambiguity detection in
+nearest-vertex matching, neighbor-cell probing in capture dedup so a
+quantization-cell straddle cannot silently split a seam node, reachable-only
+edge counting in the signature, dependent-row treatment of nearly-parallel
+constraint gradients so their rhs noise is not amplified, and a hard error
+for the degenerate-cap-with-holes face the per-face tessellator cannot
+mesh). What remains is known and deliberate:
+
+- **Recipe priority assumes the moving trim lives on the curved surface.**
+  `TopoVertex > SurfaceUv-on-curved > SurfaceUv-on-plane` is correct for
+  M0–M2's parameters, but a boundary node shared between a *moving plane*
+  and a *fixed* curved surface (e.g. cylinder **height** as θ, where the
+  rim is not a topology vertex ring) freezes on the fixed surface: the
+  frozen mesh then differentiates a slightly different body, and the FD
+  oracle — which replays the same recipes — agrees with the analytic side
+  while both differ from the true CAD derivative. The general fix is a
+  multi-surface boundary recipe (the `SurfaceUv` analogue of the implicit
+  multi-row vertex solve); until then θ must move curved surfaces or
+  topology-vertex-carried trims. Flagged loudly on `recipe_rank`.
+- **Geometric incidence uses unbounded implicit forms.** A vertex exactly
+  coincident with the *infinite extension* of an unrelated seeded surface
+  (coplanar step heights, coaxial equal-radius bores) picks up a spurious
+  constraint row: contradictions surface as a hard
+  `InconsistentConstraints` error (loud), but a compatible spurious row on
+  an otherwise under-determined vertex is silent. Bounded incidence needs
+  trim-region containment — the same machinery as the multi-surface recipe.
+- **Tolerances are absolute (mm) module constants.** `1e-3` matching/dedup
+  and `1e-4` incidence are correct for mm-scale parts; at ~10 m extents the
+  stock tessellator's `f32` rounding approaches the match tolerance, and a
+  legitimate parameter step larger than `MATCH_TOL` trips
+  `CorrespondenceLost` (re-capture instead). Making them plan-carried
+  options is mechanical when needed.
+- **The signature is a face-descriptor multiset.** A connectivity rewire
+  that preserves the multiset hashes equal by construction; the per-node
+  anchor checks are the backstop that turns such a rebuild into
+  `CorrespondenceLost` rather than silent garbage.
+- **`invert_uv` supports Plane/Cylinder/Sphere.** Cone/torus projection
+  exists in `vcad-kernel-booleans::trim` but that crate sits above
+  tessellate in the dependency graph; sharing it means moving it into
+  `-geom` — a follow-up refactor, out of the minimal-diff budget here.
+
 ## Sibling-repo caveat (local validation)
 
 This sandbox could not clone `ecto/loon` / `ecto/phyz` (session repo scope),


### PR DESCRIPTION
First executable piece of the differentiable CAD→physics loop: **dx/dθ**, the sensitivity of tessellated mesh-node positions to a CAD parameter, computed by cutting the chain at the mesh — never differentiating through boolean/trim combinatorics. Design note: [`docs/differentiable-seam-m0-m2.md`](docs/differentiable-seam-m0-m2.md).

## What's in here

- **`vcad_kernel_tessellate::frozen`** — frozen-tessellation mode. `capture_plan` runs the stock tessellator once at the base θ and records per-node recipes (topology vertex, or frozen `(u,v)` surface sample) plus frozen connectivity and an order-invariant topology signature. `evaluate_plan` re-emits `f64` positions against a rebuilt B-rep, recovering entity correspondence *geometrically* (the boolean pipeline enumerates isomorphic output in nondeterministic order — its cap faces empirically swap between `r` and `r−1e-6`). A topology change under perturbation is a hard `TopologyChanged` error; a lost/ambiguous entity match is a hard `CorrespondenceLost` error — never a silent wrong mesh.
- **`vcad-kernel-diff`** (new crate, unwired/WIP like `vcad-kernel-stocksim`) — the seam:
  - the **lift-bridge**: `SurfaceKind` match → concrete struct → existing `lift::<Dual<f64>>()`, with explicit θ→field seeding (`SurfaceSeed`/`ParamSeeding`); inapplicable seeds are hard errors, and `seed_where` returns a count so callers assert exactly which surfaces θ touches. All seven surface kinds have arms. The `Surface` trait, geometry store, and topo crates are untouched.
  - **implicit vertex differentiation** (Pillar 3): each incident surface contributes a row `∇g·ẋ = −∂g/∂θ`; underdetermined tangential DOF are frozen at zero (the frozen-branch convention); dependent rows are consistency-checked and near-parallel gradients are treated as dependent rather than amplifying rhs noise. Incidence is topological ∪ geometric — boolean sewing leaves rim vertices with half-edges on only one of their two defining faces.
  - seam assembly (`SeamMesh`: positions + velocities + frozen triangles), a scalar-generic `mesh_volume` shared with the FD oracle so `dV/dθ` falls out of `Dual` arithmetic, and central-difference oracle helpers.

## Acceptance gates (all ≤ 1e-6 required; measured)

| Milestone | Check | Measured |
|---|---|---|
| M0 extrude `d`, QoI = V | seam dV/dd vs analytic area | exact (0.0) |
| M0 | seam dV/dd vs FD; node-wise dx/dd vs FD | 8.3e-12; 2.9e-11 |
| M1 cylinder radius | node-wise dx/dr vs FD (interior lateral samples exact-radial to 1e-12) | 5.6e-10 |
| M1 | blind→through-hole perturbation | hard `TopologyChanged`, not a lie |
| M2 boolean through-hole | seam dV/dr vs discrete closed form −N·sin(2π/N)·r·t | 1.1e-15 |
| M2 | seam dV/dr vs FD; node-wise incl. rim implicit-diff | 6.2e-10; 5.6e-10 |

M2's *continuum* −2πrt differs from the seam by exactly the rim polygonization factor `sin(x)/x`, `x = 2π/N` (asserted against the `x²/6` bound) — discretization is a property of the mesh, not the seam; the derivative is exact for the object the physics side will consume.

## Notes for review

- The design note records where the spec's ground-truth map needed correction: `TriangleMesh` is `f32` (frozen path emits its own `f64` mesh), the boolean pipeline is order-nondeterministic (signature is a face-descriptor multiset; correspondence is geometric with per-node anchor verification), boolean sewing doesn't twin rim vertices, and primitive cylinder caps are degenerate single-vertex loops.
- Known limitations are documented deliberately (design note §Known limitations + `recipe_rank` docs): recipe priority assumes moving trims live on curved surfaces; geometric incidence uses unbounded implicit forms; tolerances are absolute mm constants.
- Scope fence respected: no reverse mode, no fillets, no generic curves/store, no optimizer. `vcad-kernel-diff` is intentionally not wired into `vcad-kernel`/WASM yet (listed in CLAUDE.md's WIP-crates section). No changelog entry — kernel-internal infra with no user-facing surface.
- Local validation ran `cargo test`/`cargo clippy -- -D warnings`/`cargo fmt --check` on the workspace excluding the loon/phyz-dependent crates (this sandbox cannot clone those siblings; none are touched here). CI runs the full set.

**What M3 needs from this** (short version; full paragraph in the design note): a phyz functional plugs in at `SeamMesh` — contract `∂J/∂x_i` against `velocities`, exactly as `volume_with_derivative` does through `Dual` arithmetic; re-capture per optimizer step; `TopologyChanged`/`CorrespondenceLost` are the subgradient-crossing signals the optimizer must handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_