### PR TITLE
Differentiable seam M3: boundary recipes, mass-property QoIs, and the first geometry grown by gradients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,8 +111,9 @@ vcad/
 │
 │   # Work-in-progress crates (built but not yet wired to any consumer):
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
-│   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations
-│   #                            # (docs/differentiable-seam-m0-m2.md); no consumers yet
+│   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations,
+│   #                            # mass-property QoIs, optimizer harness (docs/
+│   #                            # differentiable-seam-m0-m2.md, -m3.md); no consumers yet
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/crates/vcad-kernel-diff/src/contract.rs
+++ b/crates/vcad-kernel-diff/src/contract.rs
@@ -1,0 +1,53 @@
+//! The physics hook: contract an external functional's mesh-gradient
+//! against the seam's sensitivities.
+//!
+//! A physics engine (phyz) evaluating a functional `J` on the frozen mesh
+//! supplies `∂J/∂x_i` per node — from an adjoint rollout, analytic
+//! formulas, or its own AD. The shape derivative is then the contraction
+//! `dJ/dθ = Σ_i (∂J/∂x_i) · (dx_i/dθ)` with the seam's
+//! [`SeamMesh::velocities`]. Nothing else about the physics side needs to
+//! know how the geometry was made.
+
+use vcad_kernel_math::{Point3, Vec3};
+
+use crate::SeamMesh;
+
+/// `dJ/dθ = Σ_i (∂J/∂x_i) · (dx_i/dθ)`.
+///
+/// `dj_dx` must be indexed like the seam's nodes (one gradient per node).
+pub fn contract_sensitivity(seam: &SeamMesh, dj_dx: &[Vec3]) -> f64 {
+    assert_eq!(
+        dj_dx.len(),
+        seam.velocities.len(),
+        "∂J/∂x must have one entry per seam node"
+    );
+    dj_dx
+        .iter()
+        .zip(&seam.velocities)
+        .map(|(g, v)| g.dot(*v))
+        .sum()
+}
+
+/// Analytic per-node gradient of the divergence-theorem volume:
+/// `∂V/∂a = (b × c)/6` accumulated over each triangle `(a, b, c)`.
+///
+/// Doubles as the reference functional for testing the contraction path:
+/// `contract_sensitivity(seam, volume_gradient(...))` must equal the dual
+/// part of `volume_with_derivative(seam)` to machine precision.
+pub fn volume_gradient(positions: &[Point3], triangles: &[[u32; 3]]) -> Vec<Vec3> {
+    let mut grad = vec![Vec3::new(0.0, 0.0, 0.0); positions.len()];
+    for t in triangles {
+        let a = positions[t[0] as usize];
+        let b = positions[t[1] as usize];
+        let c = positions[t[2] as usize];
+        let (va, vb, vc) = (
+            Vec3::new(a.x, a.y, a.z),
+            Vec3::new(b.x, b.y, b.z),
+            Vec3::new(c.x, c.y, c.z),
+        );
+        grad[t[0] as usize] += vb.cross(vc) / 6.0;
+        grad[t[1] as usize] += vc.cross(va) / 6.0;
+        grad[t[2] as usize] += va.cross(vb) / 6.0;
+    }
+    grad
+}

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -32,14 +32,22 @@ use vcad_kernel_geom::{GeometryStore, Surface, SurfaceKind};
 use vcad_kernel_math::Vec3;
 use vcad_kernel_tessellate::frozen::FrozenError;
 
+mod contract;
 mod fd;
 mod implicit;
 mod lift;
+mod mass;
+mod optimize;
 mod seam;
 
+pub use contract::{contract_sensitivity, volume_gradient};
 pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
 pub use implicit::{constraint_row, solve_vertex_velocity, surface_residual, ConstraintRow};
 pub use lift::{lift_surface, DualSurface};
+pub use mass::{mass_properties, mass_properties_with_derivative, MassProperties};
+pub use optimize::{
+    minimize, objective_gradient, IterateRecord, OptimizeOptions, OptimizeResult, StopReason,
+};
 pub use seam::{evaluate_with_sensitivity, volume_with_derivative, SeamMesh};
 pub use vcad_kernel_tessellate::frozen::mesh_volume;
 

--- a/crates/vcad-kernel-diff/src/mass.rs
+++ b/crates/vcad-kernel-diff/src/mass.rs
@@ -1,0 +1,296 @@
+//! Mass properties of a seam mesh, with exact θ-derivatives.
+//!
+//! Volume, mass, centroid, and the inertia tensor are polynomial surface
+//! integrals over the closed mesh (divergence theorem via signed
+//! origin-tetrahedra), so evaluating them generically over the scalar type
+//! and feeding `Dual<f64>` points (real = position, dual = dx/dθ) yields
+//! the quantity *and* its θ-derivative in one pass. This is the first
+//! physics-facing QoI family of the differentiable seam: spin-up time,
+//! stored rotational energy, and balance objectives are all functions of
+//! these tensors.
+//!
+//! Exact tetrahedron integrals (vertex at the origin, opposite face
+//! `(a, b, c)`, signed volume `V = det(a,b,c)/6`):
+//!
+//! ```text
+//! ∫ x_i dV     = V · (a + b + c)_i / 4
+//! ∫ x_i x_j dV = (V/20) · (a_i a_j + b_i b_j + c_i c_j + s_i s_j),  s = a+b+c
+//! ```
+
+use tang::{Dual, Scalar};
+
+use crate::SeamMesh;
+
+/// Mass properties of a closed mesh (density in mass per mm³; positions in
+/// mm). All tensors are row-major symmetric 3×3.
+#[derive(Debug, Clone, Copy)]
+pub struct MassProperties<S> {
+    /// Signed volume (positive for outward winding).
+    pub volume: S,
+    /// Mass = density · volume.
+    pub mass: S,
+    /// Centroid.
+    pub centroid: tang::Point3<S>,
+    /// Inertia tensor about the origin.
+    pub inertia_origin: [[S; 3]; 3],
+    /// Inertia tensor about the centroid (parallel-axis shift of
+    /// `inertia_origin`).
+    pub inertia_centroid: [[S; 3]; 3],
+}
+
+/// Compute mass properties of a closed, consistently outward-wound mesh,
+/// generic over the scalar type. Evaluate with `Dual<f64>` positions for
+/// exact θ-derivatives of every field (see
+/// [`mass_properties_with_derivative`]), or `Dual<Dual<f64>>` for second
+/// derivatives.
+pub fn mass_properties<S: Scalar>(
+    positions: &[tang::Point3<S>],
+    triangles: &[[u32; 3]],
+    density: f64,
+) -> MassProperties<S> {
+    let mut volume = S::ZERO;
+    let mut first = [S::ZERO; 3];
+    let mut second = [[S::ZERO; 3]; 3];
+
+    for t in triangles {
+        let a = &positions[t[0] as usize];
+        let b = &positions[t[1] as usize];
+        let c = &positions[t[2] as usize];
+        let a = [a.x, a.y, a.z];
+        let b = [b.x, b.y, b.z];
+        let c = [c.x, c.y, c.z];
+
+        let det = a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+        let v = det / S::from_f64(6.0);
+        volume += v;
+
+        let s = [a[0] + b[0] + c[0], a[1] + b[1] + c[1], a[2] + b[2] + c[2]];
+        for i in 0..3 {
+            first[i] += v * s[i] / S::from_f64(4.0);
+        }
+        for i in 0..3 {
+            for j in 0..3 {
+                second[i][j] +=
+                    v / S::from_f64(20.0) * (a[i] * a[j] + b[i] * b[j] + c[i] * c[j] + s[i] * s[j]);
+            }
+        }
+    }
+
+    let rho = S::from_f64(density);
+    let mass = rho * volume;
+    let centroid = tang::Point3::new(first[0] / volume, first[1] / volume, first[2] / volume);
+
+    // I_origin = ρ (tr(P) δ − P), with P the second-moment matrix.
+    let trace = second[0][0] + second[1][1] + second[2][2];
+    let mut inertia_origin = [[S::ZERO; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            let kronecker = if i == j { trace } else { S::ZERO };
+            inertia_origin[i][j] = rho * (kronecker - second[i][j]);
+        }
+    }
+
+    // Parallel axis: I_centroid = I_origin − m (|d|² δ − d dᵀ).
+    let d = [centroid.x, centroid.y, centroid.z];
+    let d2 = d[0] * d[0] + d[1] * d[1] + d[2] * d[2];
+    let mut inertia_centroid = [[S::ZERO; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            let kronecker = if i == j { d2 } else { S::ZERO };
+            inertia_centroid[i][j] = inertia_origin[i][j] - mass * (kronecker - d[i] * d[j]);
+        }
+    }
+
+    MassProperties {
+        volume,
+        mass,
+        centroid,
+        inertia_origin,
+        inertia_centroid,
+    }
+}
+
+fn split_dual(props: &MassProperties<Dual<f64>>) -> (MassProperties<f64>, MassProperties<f64>) {
+    let split3 = |m: &[[Dual<f64>; 3]; 3]| -> ([[f64; 3]; 3], [[f64; 3]; 3]) {
+        let mut real = [[0.0; 3]; 3];
+        let mut dual = [[0.0; 3]; 3];
+        for i in 0..3 {
+            for j in 0..3 {
+                real[i][j] = m[i][j].real;
+                dual[i][j] = m[i][j].dual;
+            }
+        }
+        (real, dual)
+    };
+    let (io_r, io_d) = split3(&props.inertia_origin);
+    let (ic_r, ic_d) = split3(&props.inertia_centroid);
+    (
+        MassProperties {
+            volume: props.volume.real,
+            mass: props.mass.real,
+            centroid: tang::Point3::new(
+                props.centroid.x.real,
+                props.centroid.y.real,
+                props.centroid.z.real,
+            ),
+            inertia_origin: io_r,
+            inertia_centroid: ic_r,
+        },
+        MassProperties {
+            volume: props.volume.dual,
+            mass: props.mass.dual,
+            centroid: tang::Point3::new(
+                props.centroid.x.dual,
+                props.centroid.y.dual,
+                props.centroid.z.dual,
+            ),
+            inertia_origin: io_d,
+            inertia_centroid: ic_d,
+        },
+    )
+}
+
+/// Mass properties of a seam mesh and their θ-derivatives: node positions
+/// and velocities are packed into `Dual<f64>` points and pushed through the
+/// generic integrals, so every returned derivative is the exact contraction
+/// `Σ_i (∂(·)/∂x_i) · (dx_i/dθ)`.
+pub fn mass_properties_with_derivative(
+    seam: &SeamMesh,
+    density: f64,
+) -> (MassProperties<f64>, MassProperties<f64>) {
+    let pts: Vec<tang::Point3<Dual<f64>>> = seam
+        .positions
+        .iter()
+        .zip(&seam.velocities)
+        .map(|(p, v)| {
+            tang::Point3::new(
+                Dual::new(p.x, v.x),
+                Dual::new(p.y, v.y),
+                Dual::new(p.z, v.z),
+            )
+        })
+        .collect();
+    let props = mass_properties(&pts, &seam.triangles, density);
+    split_dual(&props)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_kernel_math::Point3;
+
+    /// Closed cuboid mesh [0,w]×[0,l]×[0,h] with outward winding.
+    fn cuboid(w: f64, l: f64, h: f64) -> (Vec<Point3>, Vec<[u32; 3]>) {
+        let p = vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(w, 0.0, 0.0),
+            Point3::new(w, l, 0.0),
+            Point3::new(0.0, l, 0.0),
+            Point3::new(0.0, 0.0, h),
+            Point3::new(w, 0.0, h),
+            Point3::new(w, l, h),
+            Point3::new(0.0, l, h),
+        ];
+        let t = vec![
+            [0, 2, 1],
+            [0, 3, 2], // bottom (−z)
+            [4, 5, 6],
+            [4, 6, 7], // top (+z)
+            [0, 1, 5],
+            [0, 5, 4], // −y
+            [2, 3, 7],
+            [2, 7, 6], // +y
+            [1, 2, 6],
+            [1, 6, 5], // +x
+            [3, 0, 4],
+            [3, 4, 7], // −x
+        ];
+        (p, t)
+    }
+
+    #[test]
+    fn cuboid_closed_forms() {
+        let (w, l, h) = (4.0, 3.0, 2.0);
+        let rho = 2.5;
+        let (p, t) = cuboid(w, l, h);
+        let props = mass_properties(&p, &t, rho);
+
+        let m = rho * w * l * h;
+        assert!((props.volume - w * l * h).abs() < 1e-12);
+        assert!((props.mass - m).abs() < 1e-12);
+        assert!((props.centroid.x - w / 2.0).abs() < 1e-12);
+        assert!((props.centroid.y - l / 2.0).abs() < 1e-12);
+        assert!((props.centroid.z - h / 2.0).abs() < 1e-12);
+
+        // Cuboid inertia about its centroid: I_xx = m(l²+h²)/12, etc.
+        let expect = [
+            m * (l * l + h * h) / 12.0,
+            m * (w * w + h * h) / 12.0,
+            m * (w * w + l * l) / 12.0,
+        ];
+        for (i, e) in expect.iter().enumerate() {
+            assert!(
+                (props.inertia_centroid[i][i] - e).abs() / e < 1e-12,
+                "I[{i}][{i}] = {} vs {e}",
+                props.inertia_centroid[i][i]
+            );
+            for j in 0..3 {
+                if i != j {
+                    assert!(props.inertia_centroid[i][j].abs() < 1e-9);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dual_derivative_matches_finite_difference() {
+        // Grow the cuboid height: compare dual-carried derivatives of every
+        // field against central differences of the f64 evaluation.
+        let (w, l) = (4.0, 3.0);
+        let rho = 1.0;
+        let h0 = 2.0;
+        let eps = 1e-6;
+
+        let (p_plus, t) = cuboid(w, l, h0 + eps);
+        let (p_minus, _) = cuboid(w, l, h0 - eps);
+        let plus = mass_properties(&p_plus, &t, rho);
+        let minus = mass_properties(&p_minus, &t, rho);
+
+        let (p0, _) = cuboid(w, l, h0);
+        let pts: Vec<tang::Point3<Dual<f64>>> = p0
+            .iter()
+            .map(|p| {
+                // Top-face nodes (z = h0) move at ż = 1; bottom pinned.
+                let vz = if p.z > h0 - 1e-9 { 1.0 } else { 0.0 };
+                tang::Point3::new(Dual::constant(p.x), Dual::constant(p.y), Dual::new(p.z, vz))
+            })
+            .collect();
+        let props = mass_properties(&pts, &t, rho);
+
+        let check = |dual: f64, fd: f64, what: &str| {
+            let scale = fd.abs().max(1.0);
+            assert!(
+                (dual - fd).abs() / scale < 1e-6,
+                "{what}: dual {dual} vs fd {fd}"
+            );
+        };
+        check(
+            props.volume.dual,
+            (plus.volume - minus.volume) / (2.0 * eps),
+            "dV/dh",
+        );
+        check(
+            props.centroid.z.dual,
+            (plus.centroid.z - minus.centroid.z) / (2.0 * eps),
+            "dcz/dh",
+        );
+        for i in 0..3 {
+            check(
+                props.inertia_centroid[i][i].dual,
+                (plus.inertia_centroid[i][i] - minus.inertia_centroid[i][i]) / (2.0 * eps),
+                "dI/dh",
+            );
+        }
+    }
+}

--- a/crates/vcad-kernel-diff/src/mass.rs
+++ b/crates/vcad-kernel-diff/src/mass.rs
@@ -43,6 +43,10 @@ pub struct MassProperties<S> {
 /// exact θ-derivatives of every field (see
 /// [`mass_properties_with_derivative`]), or `Dual<Dual<f64>>` for second
 /// derivatives.
+///
+/// Precondition: the mesh must enclose a nonzero volume — the centroid and
+/// the parallel-axis shift divide by it, so a degenerate or inside-out
+/// mesh yields NaN/∞ fields rather than an error.
 pub fn mass_properties<S: Scalar>(
     positions: &[tang::Point3<S>],
     triangles: &[[u32; 3]],

--- a/crates/vcad-kernel-diff/src/optimize.rs
+++ b/crates/vcad-kernel-diff/src/optimize.rs
@@ -1,0 +1,228 @@
+//! The optimizer harness: geometry improved by gradient descent through
+//! the seam.
+//!
+//! Each iterate rebuilds the model at θ, **re-captures** a frozen plan
+//! (plans are only valid near their capture point), evaluates the seam once
+//! per parameter (forward mode: k passes for k parameters), and takes a
+//! projected gradient-descent step with backtracking. Frozen-tessellation
+//! errors during a *trial* step — a topology change, lost correspondence, a
+//! failed boundary solve — are the subgradient signals of the seam design:
+//! the step is treated as failed and shrunk, never silently accepted.
+//!
+//! The optimizer is deliberately the simplest thing that closes the loop;
+//! anything smarter (L-BFGS, trust regions) plugs into
+//! [`objective_gradient`] unchanged.
+
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+use crate::{evaluate_with_sensitivity, DiffError, ParamSeeding, SeamMesh};
+
+/// Options for [`minimize`].
+#[derive(Debug, Clone)]
+pub struct OptimizeOptions {
+    /// Maximum accepted iterations.
+    pub max_iters: usize,
+    /// Initial step length for each line search (in θ units).
+    pub initial_step: f64,
+    /// Line-search steps below this length terminate the run.
+    pub min_step: f64,
+    /// Gradient ∞-norm below which the run terminates.
+    pub grad_tol: f64,
+    /// Per-parameter inclusive bounds; iterates are projected into the box.
+    /// Empty = unbounded.
+    pub bounds: Vec<(f64, f64)>,
+}
+
+impl Default for OptimizeOptions {
+    fn default() -> Self {
+        Self {
+            max_iters: 50,
+            initial_step: 1.0,
+            min_step: 1e-8,
+            grad_tol: 1e-8,
+            bounds: Vec::new(),
+        }
+    }
+}
+
+/// Why [`minimize`] stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    /// Gradient ∞-norm fell below `grad_tol`.
+    GradientConverged,
+    /// The line search could not find a decreasing step above `min_step`
+    /// (at a minimum, a bound, or a subgradient edge).
+    StepConverged,
+    /// Iteration budget exhausted.
+    MaxIters,
+}
+
+/// One accepted iterate.
+#[derive(Debug, Clone)]
+pub struct IterateRecord {
+    /// Parameter vector.
+    pub theta: Vec<f64>,
+    /// Objective value.
+    pub objective: f64,
+    /// Gradient dJ/dθ at this iterate.
+    pub gradient: Vec<f64>,
+}
+
+/// Result of [`minimize`].
+#[derive(Debug, Clone)]
+pub struct OptimizeResult {
+    /// Final parameters.
+    pub theta: Vec<f64>,
+    /// Final objective value.
+    pub objective: f64,
+    /// Every accepted iterate, first to last.
+    pub history: Vec<IterateRecord>,
+    /// Termination reason.
+    pub stop: StopReason,
+}
+
+/// Objective value and full gradient at θ: rebuild, capture a fresh frozen
+/// plan, and evaluate the seam once per parameter.
+///
+/// - `build` constructs the model at θ.
+/// - `seeding_for(brep, k)` maps parameter `k` to its surface seeding on
+///   the freshly built B-rep.
+/// - `objective(seam)` returns `(J, dJ/dθ_k)` for a seam whose velocities
+///   carry parameter `k` (dual-number objectives like
+///   [`crate::volume_with_derivative`] or
+///   [`crate::mass_properties_with_derivative`] fit directly).
+pub fn objective_gradient(
+    build: &impl Fn(&[f64]) -> BRepSolid,
+    seeding_for: &impl Fn(&BRepSolid, usize) -> ParamSeeding,
+    objective: &impl Fn(&SeamMesh) -> (f64, f64),
+    theta: &[f64],
+    params: &TessellationParams,
+) -> Result<(f64, Vec<f64>), DiffError> {
+    let brep = build(theta);
+    let plan = capture_plan(&brep, params)?;
+    let mut value = None;
+    let mut gradient = Vec::with_capacity(theta.len());
+    for k in 0..theta.len() {
+        let seam = evaluate_with_sensitivity(&brep, &plan, &seeding_for(&brep, k))?;
+        let (j, dj) = objective(&seam);
+        value.get_or_insert(j);
+        gradient.push(dj);
+    }
+    Ok((value.expect("at least one parameter"), gradient))
+}
+
+fn project(theta: &mut [f64], bounds: &[(f64, f64)]) {
+    for (k, t) in theta.iter_mut().enumerate() {
+        if let Some(&(lo, hi)) = bounds.get(k) {
+            *t = t.clamp(lo, hi);
+        }
+    }
+}
+
+/// Minimize `objective` over θ by projected gradient descent with
+/// backtracking. See the module docs for the re-capture-per-iterate
+/// contract and subgradient handling.
+pub fn minimize(
+    build: &impl Fn(&[f64]) -> BRepSolid,
+    seeding_for: &impl Fn(&BRepSolid, usize) -> ParamSeeding,
+    objective: &impl Fn(&SeamMesh) -> (f64, f64),
+    theta0: &[f64],
+    params: &TessellationParams,
+    options: &OptimizeOptions,
+) -> Result<OptimizeResult, DiffError> {
+    let mut theta = theta0.to_vec();
+    project(&mut theta, &options.bounds);
+
+    // Errors at the starting point are real errors; errors during trial
+    // steps are treated as failed steps (subgradient edges) and shrunk.
+    let (mut value, mut gradient) =
+        objective_gradient(build, seeding_for, objective, &theta, params)?;
+    let mut history = vec![IterateRecord {
+        theta: theta.clone(),
+        objective: value,
+        gradient: gradient.clone(),
+    }];
+
+    let grad_inf = |g: &[f64]| g.iter().fold(0.0_f64, |m, v| m.max(v.abs()));
+
+    // Warm-start each line search near the last accepted step: narrow
+    // curved valleys otherwise re-pay the full backtracking cascade every
+    // iteration.
+    let mut step_hint = options.initial_step;
+
+    for _ in 0..options.max_iters {
+        if grad_inf(&gradient) < options.grad_tol {
+            return Ok(OptimizeResult {
+                objective: value,
+                stop: StopReason::GradientConverged,
+                theta,
+                history,
+            });
+        }
+
+        let mut step = step_hint;
+        let accepted = loop {
+            let mut trial: Vec<f64> = theta
+                .iter()
+                .zip(&gradient)
+                .map(|(t, g)| t - step * g)
+                .collect();
+            project(&mut trial, &options.bounds);
+            let moved = trial
+                .iter()
+                .zip(&theta)
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0_f64, f64::max);
+            if moved > 0.0 {
+                match objective_gradient(build, seeding_for, objective, &trial, params) {
+                    Ok((jt, gt)) if jt < value => {
+                        // Grow the hint past the accepted step: flat
+                        // valleys with small gradients need step lengths
+                        // far above the initial hint, and backtracking
+                        // recovers instantly when the growth overshoots.
+                        step_hint = step * 2.0;
+                        break Some((trial, jt, gt));
+                    }
+                    // Non-decreasing, or the trial crossed a subgradient
+                    // (topology change / lost correspondence / failed
+                    // boundary solve): shrink and retry.
+                    Ok(_) | Err(_) => {}
+                }
+            }
+            step *= 0.5;
+            if step < options.min_step {
+                break None;
+            }
+        };
+
+        match accepted {
+            Some((t, j, g)) => {
+                theta = t;
+                value = j;
+                gradient = g;
+                history.push(IterateRecord {
+                    theta: theta.clone(),
+                    objective: value,
+                    gradient: gradient.clone(),
+                });
+            }
+            None => {
+                return Ok(OptimizeResult {
+                    objective: value,
+                    stop: StopReason::StepConverged,
+                    theta,
+                    history,
+                });
+            }
+        }
+    }
+
+    Ok(OptimizeResult {
+        objective: value,
+        stop: StopReason::MaxIters,
+        theta,
+        history,
+    })
+}

--- a/crates/vcad-kernel-diff/src/optimize.rs
+++ b/crates/vcad-kernel-diff/src/optimize.rs
@@ -102,12 +102,22 @@ pub fn objective_gradient(
 ) -> Result<(f64, Vec<f64>), DiffError> {
     let brep = build(theta);
     let plan = capture_plan(&brep, params)?;
-    let mut value = None;
+    let mut value: Option<f64> = None;
     let mut gradient = Vec::with_capacity(theta.len());
     for k in 0..theta.len() {
         let seam = evaluate_with_sensitivity(&brep, &plan, &seeding_for(&brep, k))?;
         let (j, dj) = objective(&seam);
-        value.get_or_insert(j);
+        match value {
+            // J depends only on positions, which are identical across
+            // seedings of the same plan — enforce it, since an objective
+            // that (incorrectly) reads velocities into its value would
+            // otherwise be silently truncated to parameter 0's answer.
+            Some(v) => debug_assert!(
+                (j - v).abs() <= 1e-9 * v.abs().max(1.0),
+                "objective value must not depend on which parameter is seeded ({v} vs {j})"
+            ),
+            None => value = Some(j),
+        }
         gradient.push(dj);
     }
     Ok((value.expect("at least one parameter"), gradient))

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -7,7 +7,8 @@ use tang::Dual;
 use vcad_kernel_math::{Point3, Vec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::frozen::{
-    canonical_index, mesh_volume, signature_with_index, FrozenError, FrozenPlan, NodeRecipe,
+    canonical_index, mesh_volume, refine_boundary_point, signature_with_index, FrozenError,
+    FrozenPlan, NodeRecipe,
 };
 use vcad_kernel_topo::VertexId;
 
@@ -169,6 +170,34 @@ pub fn evaluate_with_sensitivity(
                 anchor_check(i, &p, &plan.base_positions[i])?;
                 positions.push(p);
                 velocities.push(vel);
+            }
+            NodeRecipe::Boundary { face_a, face_b, .. } => {
+                // A trim-boundary node: position from the two-surface
+                // Newton refinement; velocity from the same two-row
+                // implicit system used for rim topology vertices, with the
+                // tangential DOF frozen. This is what makes the node track
+                // the moving trim regardless of which surface carries θ.
+                let sidx = |slot: u32| -> Result<usize, DiffError> {
+                    let face_id = *ci
+                        .faces
+                        .get(slot as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    Ok(topo.faces[face_id].surface_index)
+                };
+                let (sidx_a, sidx_b) = (sidx(face_a)?, sidx(face_b)?);
+                let sa = brep.geometry.surfaces[sidx_a].as_ref();
+                let sb = brep.geometry.surfaces[sidx_b].as_ref();
+                let anchor = plan.base_positions[i];
+                let x = refine_boundary_point(sa, sb, &anchor)
+                    .ok_or(FrozenError::BoundarySolveFailed { node: i })?;
+                anchor_check(i, &x, &anchor)?;
+                let rows = vec![
+                    constraint_row(sa, seeding.get(sidx_a), &x)?,
+                    constraint_row(sb, seeding.get(sidx_b), &x)?,
+                ];
+                let v = solve_vertex_velocity(&rows)?;
+                positions.push(x);
+                velocities.push(v);
             }
         }
     }

--- a/crates/vcad-kernel-diff/tests/m3_boundary_trim.rs
+++ b/crates/vcad-kernel-diff/tests/m3_boundary_trim.rs
@@ -1,0 +1,133 @@
+//! M3 — multi-surface boundary recipes: the moving trim lives on a *plane*.
+//!
+//! This is the exact case the M0–M2 recipe-priority heuristic got wrong (and
+//! documented as its known limitation): a cylinder whose **height** is θ.
+//! The cap-rim ring is not carried by topology vertices (the primitive's cap
+//! loops are degenerate single-vertex circles), and binding rim nodes to the
+//! *fixed* cylinder wall at frozen `(u, v)` would freeze them at the old
+//! height — the frozen mesh would differentiate a slightly different body,
+//! and the FD oracle (replaying the same recipes) would agree with the wrong
+//! answer. With `NodeRecipe::Boundary`, rim nodes are Newton-tracked on
+//! {cap plane} ∩ {cylinder} and ride up with the moving cap, so both the
+//! analytic seam and the FD oracle now measure the true solid:
+//! `dV/dh = A_N(r)` (the inscribed N-gon area) exactly.
+
+use vcad_kernel_diff::{
+    compare_velocities, evaluate_with_sensitivity, fd_velocities, fd_volume_derivative,
+    ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::Plane;
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::{capture_plan, NodeRecipe};
+use vcad_kernel_tessellate::TessellationParams;
+
+const R: f64 = 5.0;
+const H0: f64 = 8.0;
+const SEGMENTS: u32 = 24;
+const H_FD: f64 = 1e-6;
+const GATE: f64 = 1e-6;
+
+fn build(h: f64) -> BRepSolid {
+    make_cylinder(R, h, SEGMENTS)
+}
+
+/// θ = height: the only moving surface is the top cap plane (z = h),
+/// translating at ẑ per unit θ. The cylinder wall is fixed.
+fn seeding(brep: &BRepSolid, h: f64) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &brep.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<Plane>()
+                .map(|p| {
+                    p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                        && p.signed_distance(&Point3::new(0.0, 0.0, h)).abs() < 1e-9
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        },
+    );
+    assert_eq!(n, 1, "expected exactly the top cap plane, got {n}");
+    seeding
+}
+
+#[test]
+fn boundary_nodes_track_a_moving_plane_trim() {
+    let params = TessellationParams {
+        circle_segments: SEGMENTS,
+        height_segments: 4,
+        ..Default::default()
+    };
+    let base = build(H0);
+    let plan = capture_plan(&base, &params).expect("capture");
+
+    // The cap rims must have been captured as Boundary nodes: one ring per
+    // cap, minus the seam anchor vertex that topology carries.
+    let boundary_nodes = plan
+        .nodes
+        .iter()
+        .filter(|n| matches!(n, NodeRecipe::Boundary { .. }))
+        .count();
+    assert_eq!(
+        boundary_nodes,
+        2 * (SEGMENTS as usize - 1),
+        "expected a Boundary ring on each cap"
+    );
+
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base, H0)).expect("seam");
+
+    // Top-rim boundary nodes ride up with the cap at exactly ẑ; bottom-rim
+    // boundary nodes are pinned. Wall interior samples are pinned (the
+    // cylinder surface does not move with h).
+    for (i, recipe) in seam.recipes.iter().enumerate() {
+        match recipe {
+            NodeRecipe::Boundary { .. } if seam.positions[i].z > H0 - 1e-9 => {
+                assert!(
+                    (seam.velocities[i] - Vec3::z()).norm() < 1e-9,
+                    "top rim node {i}: velocity {:?} should be ẑ",
+                    seam.velocities[i]
+                );
+            }
+            NodeRecipe::Boundary { .. } => {
+                assert!(
+                    seam.velocities[i].norm() < 1e-9,
+                    "bottom rim node {i}: velocity {:?} should be zero",
+                    seam.velocities[i]
+                );
+            }
+            _ => {}
+        }
+    }
+
+    // dV/dh against the discrete closed form A_N(r) = ½·N·sin(2π/N)·r², and
+    // against the FD oracle (which now Newton-tracks the true rim at h ± ε).
+    let n = SEGMENTS as f64;
+    let area = 0.5 * n * (2.0 * std::f64::consts::PI / n).sin() * R * R;
+    let (v, dv) = vcad_kernel_diff::volume_with_derivative(&seam);
+    assert!((v - area * H0).abs() / (area * H0) < 1e-9);
+    let rel_closed = (dv - area).abs() / area;
+    assert!(
+        rel_closed <= GATE,
+        "seam dV/dh = {dv} vs closed form {area} (rel err {rel_closed:.3e})"
+    );
+    let dv_fd = fd_volume_derivative(build, H0, H_FD, &plan).expect("fd volume");
+    let rel_fd = (dv - dv_fd).abs() / area;
+    assert!(
+        rel_fd <= GATE,
+        "seam dV/dh = {dv} vs FD {dv_fd} (rel err {rel_fd:.3e})"
+    );
+
+    // Node-wise gate over the whole mesh.
+    let fd = fd_velocities(build, H0, H_FD, &plan).expect("fd velocities");
+    let cmp = compare_velocities(&seam.velocities, &fd);
+    assert!(
+        cmp.max_rel_err <= GATE,
+        "dx/dh max rel err {:.3e} at node {}",
+        cmp.max_rel_err,
+        cmp.worst_node
+    );
+}

--- a/crates/vcad-kernel-diff/tests/m3_flywheel_optimize.rs
+++ b/crates/vcad-kernel-diff/tests/m3_flywheel_optimize.rs
@@ -1,0 +1,216 @@
+//! M3 — the loop closes: a flywheel improved by gradient descent through
+//! the seam.
+//!
+//! The part is a disc with a center bore and four lightening holes on a
+//! bolt circle; θ = (bore radius, lightening-hole radius). The objective is
+//! a physics-flavored design brief — *hit a target spin inertia with
+//! minimum mass*:
+//!
+//! ```text
+//! J(θ) = m(θ)/m_ref + λ ((I_zz(θ) − I_target)/I_target)²
+//! ```
+//!
+//! Every gradient the optimizer consumes flows through the seam
+//! (`dJ/dθ = Σ_i ∂J/∂x_i · dx_i/dθ` via dual-number mass properties), each
+//! iterate re-captures a fresh frozen plan, and the analytic gradient is
+//! audited against the finite-difference oracle at the start point. This is
+//! the M3 harness a phyz rollout objective plugs into unchanged.
+
+use vcad_kernel::Solid;
+use vcad_kernel_diff::{
+    mass_properties, mass_properties_with_derivative, minimize, objective_gradient,
+    OptimizeOptions, ParamSeeding, SeamMesh, StopReason, SurfaceSeed,
+};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{capture_plan, evaluate_plan};
+use vcad_kernel_tessellate::TessellationParams;
+
+const SEGMENTS: u32 = 24;
+const DISC_R: f64 = 40.0;
+const DISC_H: f64 = 10.0;
+const BOLT_R: f64 = 25.0;
+const RHO: f64 = 1.0;
+const GATE: f64 = 1e-6;
+
+fn build(theta: &[f64]) -> BRepSolid {
+    let (r_bore, r_hole) = (theta[0], theta[1]);
+    let disc = Solid::cylinder(DISC_R, DISC_H, SEGMENTS);
+    let bore = Solid::cylinder(r_bore, DISC_H + 2.0, SEGMENTS).translate(0.0, 0.0, -1.0);
+    let mut part = disc.difference(&bore);
+    for k in 0..4 {
+        let ang = std::f64::consts::FRAC_PI_2 * k as f64;
+        let hole = Solid::cylinder(r_hole, DISC_H + 2.0, SEGMENTS).translate(
+            BOLT_R * ang.cos(),
+            BOLT_R * ang.sin(),
+            -1.0,
+        );
+        part = part.difference(&hole);
+    }
+    part.as_brep().expect("flywheel stays BRep").clone()
+}
+
+/// θ → surface seeding: parameter 0 is the bore radius (the one hole-wall
+/// cylinder on the axis), parameter 1 is the lightening-hole radius (the
+/// four hole walls on the bolt circle). Radial distance of the cylinder
+/// axis from the origin disambiguates them regardless of radii.
+fn seeding_for(brep: &BRepSolid, k: usize) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &brep.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .map(|c| {
+                    let axis_dist = (c.center.x * c.center.x + c.center.y * c.center.y).sqrt();
+                    let on_axis = axis_dist < 1e-9;
+                    let on_bolt_circle = (axis_dist - BOLT_R).abs() < 1e-9;
+                    // Exclude the outer disc wall (also on-axis) by radius.
+                    match k {
+                        0 => on_axis && c.radius < DISC_R - 1e-9,
+                        _ => on_bolt_circle,
+                    }
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    assert_eq!(
+        n,
+        if k == 0 { 1 } else { 4 },
+        "unexpected seeded-surface count for parameter {k}"
+    );
+    seeding
+}
+
+fn tess_params() -> TessellationParams {
+    TessellationParams {
+        circle_segments: SEGMENTS,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn flywheel_hits_target_inertia_with_less_mass() {
+    // Design brief: the inertia of the θ* = (8, 5) flywheel, discovered by
+    // gradient descent from a heavy starting point.
+    let (target, mass_star) = {
+        let brep = build(&[8.0, 5.0]);
+        let plan = capture_plan(&brep, &tess_params()).expect("capture target");
+        let mesh = evaluate_plan(&brep, &plan).expect("evaluate target");
+        let props = mass_properties(&mesh.positions, &mesh.triangles, RHO);
+        (props.inertia_centroid[2][2], props.mass)
+    };
+    let m_ref = {
+        let brep = build(&[3.0, 2.5]);
+        let plan = capture_plan(&brep, &tess_params()).expect("capture ref");
+        let mesh = evaluate_plan(&brep, &plan).expect("evaluate ref");
+        mass_properties(&mesh.positions, &mesh.triangles, RHO).mass
+    };
+    let lambda = 100.0;
+
+    let objective = move |seam: &SeamMesh| -> (f64, f64) {
+        let (props, dprops) = mass_properties_with_derivative(seam, RHO);
+        let izz = props.inertia_centroid[2][2];
+        let dizz = dprops.inertia_centroid[2][2];
+        let miss = (izz - target) / target;
+        let j = props.mass / m_ref + lambda * miss * miss;
+        let dj = dprops.mass / m_ref + lambda * 2.0 * miss * dizz / target;
+        (j, dj)
+    };
+
+    let theta0 = [3.0, 2.5];
+
+    // Audit the analytic gradient against the FD oracle before trusting it
+    // to drive anything: rebuild at θ ± h per parameter, re-evaluate under
+    // the same frozen plan, difference the objective.
+    let (j0, g0) = objective_gradient(&build, &seeding_for, &objective, &theta0, &tess_params())
+        .expect("gradient at start");
+    {
+        let brep = build(&theta0);
+        let plan = capture_plan(&brep, &tess_params()).expect("capture");
+        let j_of = |theta: &[f64]| -> f64 {
+            let mesh = evaluate_plan(&build(theta), &plan).expect("fd rebuild");
+            let props = mass_properties(&mesh.positions, &mesh.triangles, RHO);
+            let miss = (props.inertia_centroid[2][2] - target) / target;
+            props.mass / m_ref + lambda * miss * miss
+        };
+        // h chosen for the oracle's roundoff floor: J is assembled from
+        // O(1e7) inertia integrals, so h = 1e-6 would leave ~1e-6 relative
+        // FD noise on an O(0.01) gradient; the objective is a smooth
+        // quadratic in these radii, so a wider step costs no truncation.
+        let h = 1e-4;
+        for k in 0..2 {
+            let mut plus = theta0;
+            let mut minus = theta0;
+            plus[k] += h;
+            minus[k] -= h;
+            let fd = (j_of(&plus) - j_of(&minus)) / (2.0 * h);
+            let rel = (g0[k] - fd).abs() / fd.abs().max(1e-3);
+            assert!(
+                rel <= GATE,
+                "dJ/dθ{k} = {} vs FD {fd} (rel {rel:.3e})",
+                g0[k]
+            );
+        }
+    }
+
+    // Descend. Bounds keep the model's topology class fixed (holes stay
+    // inside the disc, clear of the bore and of each other).
+    let options = OptimizeOptions {
+        max_iters: 250,
+        initial_step: 2.0,
+        min_step: 1e-6,
+        grad_tol: 1e-4,
+        bounds: vec![(2.0, 12.0), (2.0, 8.0)],
+    };
+    let result = minimize(
+        &build,
+        &seeding_for,
+        &objective,
+        &theta0,
+        &tess_params(),
+        &options,
+    )
+    .expect("optimize");
+
+    for (n, it) in result.history.iter().enumerate() {
+        if n % 10 == 0 || n + 1 == result.history.len() {
+            eprintln!(
+                "iter {n}: theta ({:.4}, {:.4}) J {:.6} g ({:+.5}, {:+.5})",
+                it.theta[0], it.theta[1], it.objective, it.gradient[0], it.gradient[1]
+            );
+        }
+    }
+    eprintln!("stop: {:?}", result.stop);
+
+    // The loop must have actually descended, monotonically, and recovered
+    // most of the achievable improvement: J at the known-good design θ* is
+    // its mass ratio (the inertia term vanishes there by construction).
+    assert!(result.history.len() > 1, "no accepted steps");
+    for w in result.history.windows(2) {
+        assert!(w[1].objective < w[0].objective, "non-monotone descent");
+    }
+    let j_star = mass_star / m_ref;
+    assert!(
+        result.objective <= j_star + 0.25 * (j0 - j_star),
+        "objective only moved {j0} → {} (achievable ≈ {j_star})",
+        result.objective
+    );
+    assert!(result.stop != StopReason::MaxIters, "failed to converge");
+
+    // And the design brief is met: target inertia hit within 1%, with less
+    // mass than the starting flywheel would need at that inertia.
+    let final_brep = build(&result.theta);
+    let plan = capture_plan(&final_brep, &tess_params()).expect("capture final");
+    let mesh = evaluate_plan(&final_brep, &plan).expect("evaluate final");
+    let props = mass_properties(&mesh.positions, &mesh.triangles, RHO);
+    let miss = (props.inertia_centroid[2][2] - target).abs() / target;
+    assert!(
+        miss < 0.01,
+        "final I_zz misses target by {:.3}% (θ = {:?})",
+        miss * 100.0,
+        result.theta
+    );
+}

--- a/crates/vcad-kernel-diff/tests/m3_mass_properties.rs
+++ b/crates/vcad-kernel-diff/tests/m3_mass_properties.rs
@@ -1,0 +1,176 @@
+//! M3 — mass-property QoIs with exact θ-derivatives, and the contraction
+//! hook a physics functional plugs into.
+
+use vcad_kernel_diff::{
+    contract_sensitivity, evaluate_with_sensitivity, mass_properties,
+    mass_properties_with_derivative, volume_gradient, volume_with_derivative, ParamSeeding,
+    SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, Plane};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_sketch::SketchProfile;
+use vcad_kernel_tessellate::frozen::{capture_plan, evaluate_plan};
+use vcad_kernel_tessellate::TessellationParams;
+
+const GATE: f64 = 1e-6;
+const H: f64 = 1e-6;
+const RHO: f64 = 1.0;
+
+#[test]
+fn extrude_inertia_derivative_matches_closed_form_and_fd() {
+    // Cuboid w × l × d with θ = extrude distance d:
+    //   I_zz about the centroid = m (w² + l²) / 12,  m = ρ w l d
+    //   → dI_zz/dd = ρ w l (w² + l²) / 12 (exact, since z-translation of the
+    //     centroid does not affect I_zz).
+    let (w, l, d0) = (4.0, 3.0, 2.0);
+    let build = |d: f64| -> BRepSolid {
+        let profile = SketchProfile::rectangle(Point3::origin(), Vec3::x(), Vec3::y(), w, l);
+        vcad_kernel_sketch::extrude(&profile, Vec3::z() * d).expect("extrude")
+    };
+    let base = build(d0);
+    let plan = capture_plan(&base, &TessellationParams::default()).expect("capture");
+
+    let mut seeding = ParamSeeding::new();
+    let n = seeding.seed_where(
+        &base.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<Plane>()
+                .map(|p| {
+                    p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                        && p.signed_distance(&Point3::new(0.0, 0.0, d0)).abs() < 1e-9
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        },
+    );
+    assert_eq!(n, 1);
+
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding).expect("seam");
+    let (props, dprops) = mass_properties_with_derivative(&seam, RHO);
+
+    // Values.
+    let m = RHO * w * l * d0;
+    assert!((props.mass - m).abs() / m < 1e-12);
+    let izz = m * (w * w + l * l) / 12.0;
+    assert!((props.inertia_centroid[2][2] - izz).abs() / izz < 1e-12);
+
+    // Analytic derivative gate.
+    let dizz_exact = RHO * w * l * (w * w + l * l) / 12.0;
+    let rel = (dprops.inertia_centroid[2][2] - dizz_exact).abs() / dizz_exact;
+    assert!(
+        rel <= GATE,
+        "dIzz/dd = {} vs closed form {dizz_exact} (rel {rel:.3e})",
+        dprops.inertia_centroid[2][2]
+    );
+    assert!((dprops.mass - RHO * w * l).abs() / (RHO * w * l) <= GATE);
+    // Centroid rises at half the extrude rate.
+    assert!((dprops.centroid.z - 0.5).abs() <= GATE);
+
+    // FD oracle gate on every reported derivative field.
+    let plus = evaluate_plan(&build(d0 + H), &plan).expect("plus");
+    let minus = evaluate_plan(&build(d0 - H), &plan).expect("minus");
+    let fp = mass_properties(&plus.positions, &plus.triangles, RHO);
+    let fm = mass_properties(&minus.positions, &minus.triangles, RHO);
+    let fd_check = |dual: f64, plus: f64, minus: f64, what: &str| {
+        let fd = (plus - minus) / (2.0 * H);
+        let rel = (dual - fd).abs() / fd.abs().max(1.0);
+        assert!(
+            rel <= GATE,
+            "{what}: dual {dual} vs fd {fd} (rel {rel:.3e})"
+        );
+    };
+    fd_check(dprops.mass, fp.mass, fm.mass, "dm/dd");
+    fd_check(dprops.centroid.z, fp.centroid.z, fm.centroid.z, "dcz/dd");
+    for i in 0..3 {
+        fd_check(
+            dprops.inertia_centroid[i][i],
+            fp.inertia_centroid[i][i],
+            fm.inertia_centroid[i][i],
+            "dI/dd",
+        );
+    }
+}
+
+#[test]
+fn cylinder_radius_inertia_derivatives_match_fd() {
+    // All mass-property derivatives for θ = cylinder radius, FD-gated.
+    let r0 = 5.0;
+    let build = |r: f64| make_cylinder(r, 8.0, 32);
+    let params = TessellationParams {
+        circle_segments: 32,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let base = build(r0);
+    let plan = capture_plan(&base, &params).expect("capture");
+    let mut seeding = ParamSeeding::new();
+    assert_eq!(
+        seeding.seed_where(
+            &base.geometry,
+            |s| s.as_any().downcast_ref::<CylinderSurface>().is_some(),
+            SurfaceSeed::CylinderRadius { rate: 1.0 },
+        ),
+        1
+    );
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding).expect("seam");
+    let (_, dprops) = mass_properties_with_derivative(&seam, RHO);
+
+    let plus = evaluate_plan(&build(r0 + H), &plan).expect("plus");
+    let minus = evaluate_plan(&build(r0 - H), &plan).expect("minus");
+    let fp = mass_properties(&plus.positions, &plus.triangles, RHO);
+    let fm = mass_properties(&minus.positions, &minus.triangles, RHO);
+
+    let fd_check = |dual: f64, plus: f64, minus: f64, what: &str| {
+        let fd = (plus - minus) / (2.0 * H);
+        let rel = (dual - fd).abs() / fd.abs().max(1.0);
+        assert!(
+            rel <= GATE,
+            "{what}: dual {dual} vs fd {fd} (rel {rel:.3e})"
+        );
+    };
+    fd_check(dprops.mass, fp.mass, fm.mass, "dm/dr");
+    for i in 0..3 {
+        fd_check(
+            dprops.inertia_centroid[i][i],
+            fp.inertia_centroid[i][i],
+            fm.inertia_centroid[i][i],
+            "dI/dr",
+        );
+    }
+}
+
+#[test]
+fn contraction_hook_reproduces_dual_volume_derivative() {
+    // The physics hook: dJ/dθ = Σ (∂J/∂x_i)·(dx_i/dθ). With J = volume and
+    // its analytic per-node gradient, the contraction must reproduce the
+    // dual-number derivative to machine precision — this is the exact
+    // interface a phyz functional's ∂J/∂x plugs into.
+    let r0 = 5.0;
+    let build = |r: f64| make_cylinder(r, 8.0, 32);
+    let params = TessellationParams {
+        circle_segments: 32,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let base = build(r0);
+    let plan = capture_plan(&base, &params).expect("capture");
+    let mut seeding = ParamSeeding::new();
+    seeding.seed_where(
+        &base.geometry,
+        |s| s.as_any().downcast_ref::<CylinderSurface>().is_some(),
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding).expect("seam");
+
+    let (_, dv_dual) = volume_with_derivative(&seam);
+    let dj_dx = volume_gradient(&seam.positions, &seam.triangles);
+    let dv_contracted = contract_sensitivity(&seam, &dj_dx);
+    assert!(
+        (dv_dual - dv_contracted).abs() / dv_dual.abs() < 1e-12,
+        "dual {dv_dual} vs contracted {dv_contracted}"
+    );
+}

--- a/crates/vcad-kernel-geom/src/lib.rs
+++ b/crates/vcad-kernel-geom/src/lib.rs
@@ -1485,6 +1485,42 @@ impl Curve2d for Circle2d {
 }
 
 // =============================================================================
+// Implicit forms
+// =============================================================================
+
+/// The implicit form `g(x) = 0` of a surface, for the kinds that have one:
+/// returns `(g(p), ∇g(p))`.
+///
+/// Forms: plane `g = n·(x − o)`; cylinder `g = |radial|² − r²`; sphere
+/// `g = |x − c|² − r²`. Returns `None` for kinds without a closed implicit
+/// form. Consumers that need a distance-like quantity should divide by
+/// `|∇g|` (the quadric forms are not signed distances).
+pub fn implicit_form(surface: &dyn Surface, p: &Point3) -> Option<(f64, Vec3)> {
+    match surface.surface_type() {
+        SurfaceKind::Plane => {
+            let plane = surface.as_any().downcast_ref::<Plane>()?;
+            Some((plane.signed_distance(p), *plane.normal_dir.as_ref()))
+        }
+        SurfaceKind::Cylinder => {
+            let cyl = surface.as_any().downcast_ref::<CylinderSurface>()?;
+            let a = *cyl.axis.as_ref();
+            let d = *p - cyl.center;
+            let radial = d - a * d.dot(a);
+            Some((
+                radial.norm_squared() - cyl.radius * cyl.radius,
+                2.0 * radial,
+            ))
+        }
+        SurfaceKind::Sphere => {
+            let sph = surface.as_any().downcast_ref::<SphereSurface>()?;
+            let d = *p - sph.center;
+            Some((d.norm_squared() - sph.radius * sph.radius, 2.0 * d))
+        }
+        _ => None,
+    }
+}
+
+// =============================================================================
 // Geometry store
 // =============================================================================
 

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -442,7 +442,12 @@ fn solve3(m: [[f64; 3]; 3], b: [f64; 3]) -> Option<[f64; 3]> {
         .iter()
         .map(|row| row.iter().map(|v| v.abs()).fold(0.0, f64::max))
         .fold(0.0, f64::max);
-    if d.abs() < 1e-14 * scale.powi(3).max(f64::MIN_POSITIVE) {
+    // Relative singularity threshold: the determinant's roundoff floor is
+    // ~ε·scale³, and a legitimately independent system (the tangent
+    // pre-check already rejected near-parallel gradients) has |det| far
+    // above 1e-12·scale³ — so this margin rejects ill-conditioned systems
+    // early instead of letting Newton amplify noise and diverge.
+    if d.abs() < 1e-12 * scale.powi(3).max(f64::MIN_POSITIVE) {
         return None;
     }
     let mut out = [0.0; 3];

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -119,6 +119,28 @@ pub enum NodeRecipe {
         /// Frozen v parameter.
         v: f64,
     },
+    /// The node lies on the intersection of two faces' surfaces (a trim
+    /// boundary that is not carried by a topology vertex, e.g. a cap-rim
+    /// ring). Its position is the Newton solution of
+    /// `{g_a(x) = 0, g_b(x) = 0, t·(x − anchor) = 0}` where `t` is the
+    /// intersection tangent — the frozen-parameter branch choice — so the
+    /// node tracks the moving trim no matter *which* of the two surfaces θ
+    /// moves. The per-face `(u, v)` are the capture-time samples, kept for
+    /// geometric face matching across rebuilds.
+    Boundary {
+        /// Canonical traversal index of the first face.
+        face_a: u32,
+        /// Capture-time u on face a.
+        ua: f64,
+        /// Capture-time v on face a.
+        va: f64,
+        /// Canonical traversal index of the second face.
+        face_b: u32,
+        /// Capture-time u on face b.
+        ub: f64,
+        /// Capture-time v on face b.
+        vb: f64,
+    },
 }
 
 /// A frozen tessellation: recipes for every node, frozen connectivity, and
@@ -188,6 +210,13 @@ pub enum FrozenError {
         /// Distance (mm) to the nearest candidate.
         distance: f64,
     },
+    /// The Newton solve for a [`NodeRecipe::Boundary`] node failed to
+    /// converge (tangent degenerate, singular system, or divergence): the
+    /// two surfaces no longer intersect cleanly near the anchor.
+    BoundarySolveFailed {
+        /// Index of the offending node.
+        node: usize,
+    },
 }
 
 impl std::fmt::Display for FrozenError {
@@ -209,6 +238,11 @@ impl std::fmt::Display for FrozenError {
                 f,
                 "no entity within matching tolerance of node {node}'s capture-time position \
                  (nearest at {distance:.3e} mm); node correspondence across the perturbation is lost"
+            ),
+            FrozenError::BoundarySolveFailed { node } => write!(
+                f,
+                "boundary node {node}: Newton solve on the two-surface intersection failed to \
+                 converge near the capture-time anchor"
             ),
         }
     }
@@ -384,40 +418,97 @@ fn invert_uv(surface: &dyn Surface, p: &Point3) -> Result<Point2, FrozenError> {
     }
 }
 
-/// Recipe priority when two faces contribute a coincident node: a topology
-/// vertex pins all three position DOF and tracks the kernel's own output; a
-/// sample on a curved surface pins two DOF and follows the surface as it
-/// moves with θ (e.g. a cap-rim node bound to the cylinder wall stays on the
-/// moving trim); a sample on a plane pins only one DOF.
+/// Preference between two same-surface `SurfaceUv` recipes for a coincident
+/// node: a sample on a curved surface pins two position DOF, a sample on a
+/// plane pins one. (Coincident nodes on *distinct* surfaces are upgraded to
+/// [`NodeRecipe::Boundary`] instead, which tracks the moving trim no matter
+/// which surface carries θ; a matched topology vertex always wins.)
+fn kind_rank(kind: SurfaceKind) -> u8 {
+    match kind {
+        SurfaceKind::Plane => 0,
+        _ => 1,
+    }
+}
+
+/// Solve a 3×3 linear system by Cramer's rule; `None` when near-singular.
+fn solve3(m: [[f64; 3]; 3], b: [f64; 3]) -> Option<[f64; 3]> {
+    let det = |m: &[[f64; 3]; 3]| -> f64 {
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+            - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+            + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    };
+    let d = det(&m);
+    let scale = m
+        .iter()
+        .map(|row| row.iter().map(|v| v.abs()).fold(0.0, f64::max))
+        .fold(0.0, f64::max);
+    if d.abs() < 1e-14 * scale.powi(3).max(f64::MIN_POSITIVE) {
+        return None;
+    }
+    let mut out = [0.0; 3];
+    for (k, o) in out.iter_mut().enumerate() {
+        let mut mk = m;
+        for row in 0..3 {
+            mk[row][k] = b[row];
+        }
+        *o = det(&mk) / d;
+    }
+    Some(out)
+}
+
+/// Refine a boundary node onto the intersection of two surfaces: Newton on
+/// `{g_a(x) = 0, g_b(x) = 0, t·(x − anchor) = 0}`, where `t` is the
+/// intersection tangent (`∇g_a × ∇g_b`) at the anchor — the frozen-branch
+/// convention that pins the node's curve parameter.
 ///
-/// KNOWN LIMITATION: this ordering hard-codes the assumption that when a
-/// trim boundary moves, the *curved* surface is the one carrying θ (true
-/// for the M0–M2 parameters: extrude distance moves planes whose trims are
-/// θ-independent, hole radius moves the cylinder). The inverse case — a
-/// boundary node shared between a *moving plane* and a fixed curved surface
-/// (e.g. cylinder height as θ) — freezes the node on the fixed surface, so
-/// the frozen mesh no longer tracks the true solid at θ ± h and any QoI
-/// integral over it differentiates a slightly different body. The FD oracle
-/// replays the same recipes, so it agrees with the analytic side while both
-/// differ from the true CAD derivative. The correct general mechanism is a
-/// multi-surface boundary recipe (the `SurfaceUv` analogue of the implicit
-/// multi-row vertex solve) — later-milestone work. Until then, restrict θ
-/// choices to parameters whose moving trims live on curved surfaces or are
-/// carried by topology vertices.
-fn recipe_rank(recipe: &NodeRecipe, kind: SurfaceKind) -> u8 {
-    match recipe {
-        NodeRecipe::TopoVertex { .. } => 2,
-        NodeRecipe::SurfaceUv { .. } => match kind {
-            SurfaceKind::Plane => 0,
-            _ => 1,
-        },
+/// Returns `None` if either surface lacks an implicit form, the tangent is
+/// degenerate, the system is singular, or Newton fails to converge.
+pub fn refine_boundary_point(a: &dyn Surface, b: &dyn Surface, anchor: &Point3) -> Option<Point3> {
+    let (_, ga0) = vcad_kernel_geom::implicit_form(a, anchor)?;
+    let (_, gb0) = vcad_kernel_geom::implicit_form(b, anchor)?;
+    let t = ga0.cross(gb0);
+    let t_norm = t.norm();
+    if t_norm < 1e-12 * (ga0.norm() * gb0.norm()).max(f64::MIN_POSITIVE) {
+        return None; // (near-)tangent surfaces: no well-defined curve
+    }
+    let t = t / t_norm;
+
+    let mut x = *anchor;
+    for _ in 0..30 {
+        let (ga, na) = vcad_kernel_geom::implicit_form(a, &x)?;
+        let (gb, nb) = vcad_kernel_geom::implicit_form(b, &x)?;
+        let gt = t.dot(x - *anchor);
+        // Distance-like residuals (quadric g is not a signed distance).
+        let ra = ga / na.norm().max(f64::MIN_POSITIVE);
+        let rb = gb / nb.norm().max(f64::MIN_POSITIVE);
+        if ra.abs().max(rb.abs()).max(gt.abs()) < 1e-12 * (1.0 + x.coords_norm()) {
+            return Some(x);
+        }
+        let delta = solve3(
+            [[na.x, na.y, na.z], [nb.x, nb.y, nb.z], [t.x, t.y, t.z]],
+            [-ga, -gb, -gt],
+        )?;
+        x = Point3::new(x.x + delta[0], x.y + delta[1], x.z + delta[2]);
+    }
+    None
+}
+
+/// Small helper: Euclidean norm of a point's coordinates (for relative
+/// convergence thresholds).
+trait CoordsNorm {
+    fn coords_norm(&self) -> f64;
+}
+impl CoordsNorm for Point3 {
+    fn coords_norm(&self) -> f64 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
     }
 }
 
 /// Per-face tessellation used by capture. Mirrors the face dispatch of the
 /// primary `tessellate_brep` entry point: degenerate single-vertex circular
-/// cap loops (primitive cylinder/cone caps) are sampled as disks; everything
-/// else goes through the stock per-face tessellator.
+/// cap loops (primitive cylinder caps, boolean-cut caps with holes) go
+/// through the shared `tessellate_degenerate_cap` helper; everything else
+/// through the stock per-face tessellator.
 fn tessellate_face_for_capture(
     brep: &BRepSolid,
     face_id: FaceId,
@@ -428,34 +519,8 @@ fn tessellate_face_for_capture(
     let surface = &brep.geometry.surfaces[face.surface_index];
     let reversed = face.orientation == Orientation::Reversed;
 
-    if surface.surface_type() == SurfaceKind::Plane
-        && topo.loop_len(face.outer_loop) <= 1
-        && face.inner_loops.is_empty()
-    {
-        // Degenerate cap: a full-circle edge anchored at one vertex.
-        let anchor = topo
-            .loop_half_edges(face.outer_loop)
-            .map(|he| topo.vertices[topo.half_edges[he].origin].point)
-            .next();
-        if let Some(v) = anchor {
-            let center = surface.evaluate(Point2::origin());
-            let r = (v - center).norm();
-            let x_dir = if r > 1e-12 {
-                (v - center).normalize()
-            } else {
-                surface.d_du(Point2::origin()).normalize()
-            };
-            let normal = surface.normal(Point2::origin());
-            let y_dir = normal.as_ref().cross(x_dir);
-            return crate::tessellate_disk_general(
-                center,
-                r,
-                x_dir,
-                y_dir,
-                params.circle_segments,
-                reversed,
-            );
-        }
+    if surface.surface_type() == SurfaceKind::Plane && topo.loop_len(face.outer_loop) <= 1 {
+        return crate::tessellate_degenerate_cap(brep, face_id, params, reversed);
     }
 
     crate::tessellate_face(topo, &brep.geometry, face_id, params)
@@ -599,13 +664,66 @@ pub fn capture_plan(
 
             let idx = match find_near(&dedup, &base_positions, &position) {
                 Some(existing) => {
-                    // Keep the higher-priority recipe for coincident nodes.
-                    if recipe_rank(&recipe, kind)
-                        > recipe_rank(&nodes[existing as usize], node_kinds[existing as usize])
+                    // Merge coincident contributions. A matched topology
+                    // vertex always wins; two samples on *distinct*
+                    // surfaces mark a trim-boundary node and upgrade to a
+                    // `Boundary` recipe (Newton-tracked intersection, so
+                    // the node follows the moving trim regardless of which
+                    // surface carries θ); same-surface duplicates keep the
+                    // higher-ranked sample.
+                    let e = existing as usize;
+                    let merged: Option<(NodeRecipe, Point3, SurfaceKind)> = match (nodes[e], recipe)
                     {
-                        nodes[existing as usize] = recipe;
-                        base_positions[existing as usize] = position;
-                        node_kinds[existing as usize] = kind;
+                        (NodeRecipe::TopoVertex { .. }, _) => None,
+                        (_, NodeRecipe::TopoVertex { .. }) => Some((recipe, position, kind)),
+                        (NodeRecipe::Boundary { .. }, _) | (_, NodeRecipe::Boundary { .. }) => None,
+                        (
+                            NodeRecipe::SurfaceUv {
+                                face: fa,
+                                u: ua,
+                                v: va,
+                            },
+                            NodeRecipe::SurfaceUv {
+                                face: fb,
+                                u: ub,
+                                v: vb,
+                            },
+                        ) => {
+                            let sidx_a = topo.faces[ci.faces[fa as usize]].surface_index;
+                            let sidx_b = topo.faces[ci.faces[fb as usize]].surface_index;
+                            let refined = (sidx_a != sidx_b)
+                                .then(|| {
+                                    let sa = brep.geometry.surfaces[sidx_a].as_ref();
+                                    let sb = brep.geometry.surfaces[sidx_b].as_ref();
+                                    refine_boundary_point(sa, sb, &base_positions[e])
+                                })
+                                .flatten();
+                            match refined {
+                                Some(p) => Some((
+                                    NodeRecipe::Boundary {
+                                        face_a: fa,
+                                        ua,
+                                        va,
+                                        face_b: fb,
+                                        ub,
+                                        vb,
+                                    },
+                                    p,
+                                    node_kinds[e],
+                                )),
+                                // Same surface, tangent surfaces, or no
+                                // implicit form: keep the higher rank.
+                                None if kind_rank(kind) > kind_rank(node_kinds[e]) => {
+                                    Some((recipe, position, kind))
+                                }
+                                None => None,
+                            }
+                        }
+                    };
+                    if let Some((r, p, k)) = merged {
+                        nodes[e] = r;
+                        base_positions[e] = p;
+                        node_kinds[e] = k;
                     }
                     existing
                 }
@@ -672,6 +790,40 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
     let topo = &brep.topology;
     // Face slot (capture-time traversal index) → matched rebuilt face.
     let mut face_match: HashMap<u32, FaceId> = HashMap::new();
+    // Resolve a capture-time face slot to a rebuilt face: the face whose
+    // surface, evaluated at the frozen (u, v), lands nearest the node's
+    // capture-time anchor.
+    fn resolve_face(
+        brep: &BRepSolid,
+        ci: &CanonicalIndex,
+        face_match: &mut HashMap<u32, FaceId>,
+        slot: u32,
+        uv: Point2,
+        anchor: &Point3,
+        node: usize,
+    ) -> Result<FaceId, FrozenError> {
+        if let Some(&f) = face_match.get(&slot) {
+            return Ok(f);
+        }
+        let topo = &brep.topology;
+        let mut best: Option<(FaceId, f64)> = None;
+        for &fid in &ci.faces {
+            let surface = &brep.geometry.surfaces[topo.faces[fid].surface_index];
+            let d2 = (surface.evaluate(uv) - *anchor).norm_squared();
+            if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
+                best = Some((fid, d2));
+            }
+        }
+        let (fid, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
+        if d2 > MATCH_TOL * MATCH_TOL {
+            return Err(FrozenError::CorrespondenceLost {
+                node,
+                distance: d2.sqrt(),
+            });
+        }
+        face_match.insert(slot, fid);
+        Ok(fid)
+    }
 
     let mut positions = Vec::with_capacity(plan.nodes.len());
     for (i, recipe) in plan.nodes.iter().enumerate() {
@@ -712,28 +864,7 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
             }
             NodeRecipe::SurfaceUv { face, u, v } => {
                 let uv = Point2::new(u, v);
-                let face_id = match face_match.get(&face) {
-                    Some(&f) => f,
-                    None => {
-                        let mut best: Option<(FaceId, f64)> = None;
-                        for &fid in &ci.faces {
-                            let surface = &brep.geometry.surfaces[topo.faces[fid].surface_index];
-                            let d2 = (surface.evaluate(uv) - anchor).norm_squared();
-                            if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
-                                best = Some((fid, d2));
-                            }
-                        }
-                        let (fid, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
-                        if d2 > MATCH_TOL * MATCH_TOL {
-                            return Err(FrozenError::CorrespondenceLost {
-                                node: i,
-                                distance: d2.sqrt(),
-                            });
-                        }
-                        face_match.insert(face, fid);
-                        fid
-                    }
-                };
+                let face_id = resolve_face(brep, &ci, &mut face_match, face, uv, &anchor, i)?;
                 let surface = &brep.geometry.surfaces[topo.faces[face_id].surface_index];
                 let p = surface.evaluate(uv);
                 // Verify EVERY node against its anchor, not just the slot's
@@ -741,6 +872,45 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
                 // diverges elsewhere (tangent surfaces, duplicated boolean
                 // surface copies, a rebuilt surface with a different frame)
                 // must error, not silently evaluate the wrong geometry.
+                let d2 = (p - anchor).norm_squared();
+                if d2 > MATCH_TOL * MATCH_TOL {
+                    return Err(FrozenError::CorrespondenceLost {
+                        node: i,
+                        distance: d2.sqrt(),
+                    });
+                }
+                p
+            }
+            NodeRecipe::Boundary {
+                face_a,
+                ua,
+                va,
+                face_b,
+                ub,
+                vb,
+            } => {
+                let fa = resolve_face(
+                    brep,
+                    &ci,
+                    &mut face_match,
+                    face_a,
+                    Point2::new(ua, va),
+                    &anchor,
+                    i,
+                )?;
+                let fb = resolve_face(
+                    brep,
+                    &ci,
+                    &mut face_match,
+                    face_b,
+                    Point2::new(ub, vb),
+                    &anchor,
+                    i,
+                )?;
+                let sa = brep.geometry.surfaces[topo.faces[fa].surface_index].as_ref();
+                let sb = brep.geometry.surfaces[topo.faces[fb].surface_index].as_ref();
+                let p = refine_boundary_point(sa, sb, &anchor)
+                    .ok_or(FrozenError::BoundarySolveFailed { node: i })?;
                 let d2 = (p - anchor).norm_squared();
                 if d2 > MATCH_TOL * MATCH_TOL {
                     return Err(FrozenError::CorrespondenceLost {

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -3771,6 +3771,128 @@ pub fn tessellate_disk(
     mesh
 }
 
+/// Tessellate a degenerate circular cap face: a planar face whose outer
+/// loop has ≤ 1 vertex (a full-circle edge anchored at one point), with or
+/// without inner loops (holes). Samples the outer circle into a
+/// `params.circle_segments`-gon; holes use the hole-aware CDT path.
+///
+/// Shared by [`tessellate_brep`] and the frozen-tessellation capture, so
+/// the two can never drift apart on this special case.
+fn tessellate_degenerate_cap(
+    brep: &BRepSolid,
+    face_id: FaceId,
+    params: &TessellationParams,
+    reversed: bool,
+) -> TriangleMesh {
+    let face = &brep.topology.faces[face_id];
+    // Degenerate cap face with ≤1 vertex — single degenerate edge
+    // forming a full circle. Sample the circle into a proper polygon.
+    let verts: Vec<_> = brep
+        .topology
+        .loop_half_edges(face.outer_loop)
+        .map(|he| brep.topology.vertices[brep.topology.half_edges[he].origin].point)
+        .collect();
+    let Some(&v) = verts.first() else {
+        return TriangleMesh::new();
+    };
+    let plane = &brep.geometry.surfaces[face.surface_index];
+    let center = plane.evaluate(Point2::origin());
+    let r = (v - center).norm();
+    let x_dir = if r > 1e-12 {
+        (v - center).normalize()
+    } else {
+        plane.d_du(Point2::origin()).normalize()
+    };
+    let normal = plane.normal(Point2::origin());
+    let y_dir = normal.as_ref().cross(x_dir);
+
+    if face.inner_loops.is_empty() {
+        return tessellate_disk_general(center, r, x_dir, y_dir, params.circle_segments, reversed);
+    }
+
+    // Degenerate outer loop WITH inner loops (holes) —
+    // e.g. a cylinder cap after boolean subtraction.
+    // Sample the outer circle into a polygon and use
+    // hole-aware CDT tessellation.
+    let n = params.circle_segments as usize;
+    let mut outer_3d = Vec::with_capacity(n);
+    for i in 0..n {
+        let theta = 2.0 * PI * (i as f64) / (n as f64);
+        let p = center + r * (theta.cos() * x_dir + theta.sin() * y_dir);
+        outer_3d.push(p);
+    }
+
+    let u_axis = x_dir;
+    let v_axis = y_dir;
+    let project = |p: &Point3| -> (f64, f64) {
+        let d = *p - center;
+        (d.dot(u_axis), d.dot(v_axis))
+    };
+
+    let outer_2d: Vec<(f64, f64)> = outer_3d.iter().map(&project).collect();
+
+    let mut inner_loops_3d: Vec<Vec<Point3>> = Vec::new();
+    let mut inner_loops_2d: Vec<Vec<(f64, f64)>> = Vec::new();
+    for &inner_loop in &face.inner_loops {
+        let iv: Vec<Point3> = brep
+            .topology
+            .loop_half_edges(inner_loop)
+            .map(|he| brep.topology.vertices[brep.topology.half_edges[he].origin].point)
+            .collect();
+        if iv.len() >= 3 {
+            let iv_2d: Vec<(f64, f64)> = iv.iter().map(&project).collect();
+            inner_loops_3d.push(iv);
+            inner_loops_2d.push(iv_2d);
+        }
+    }
+
+    // Normalize winding: outer CCW, inner CW
+    let outer_area = polygon_area_2d(&outer_2d);
+    let (outer_2d, outer_3d) = if outer_area < 0.0 {
+        let mut o2 = outer_2d;
+        let mut o3 = outer_3d;
+        o2.reverse();
+        o3.reverse();
+        (o2, o3)
+    } else {
+        (outer_2d, outer_3d)
+    };
+    for (i, hole_2d) in inner_loops_2d.iter_mut().enumerate() {
+        let hole_area = polygon_area_2d(hole_2d);
+        if hole_area > 0.0 {
+            inner_loops_3d[i].reverse();
+            hole_2d.reverse();
+        }
+    }
+
+    merge_overlapping_holes(&mut inner_loops_2d, &mut inner_loops_3d);
+
+    let mut face_mesh = triangulate_circular_cap_with_holes(
+        center,
+        r,
+        x_dir,
+        y_dir,
+        &outer_2d,
+        &inner_loops_2d,
+        &outer_3d,
+        &inner_loops_3d,
+        reversed,
+    );
+
+    // Add planar normals
+    let face_normal = if reversed { -normal } else { normal };
+    let (nx, ny, nz) = (
+        face_normal.x as f32,
+        face_normal.y as f32,
+        face_normal.z as f32,
+    );
+    for _ in 0..face_mesh.num_vertices() {
+        face_mesh.normals.extend_from_slice(&[nx, ny, nz]);
+    }
+
+    face_mesh
+}
+
 /// Full tessellation of a B-rep solid, using `segments` as a quality hint.
 ///
 /// This is the main entry point for converting a B-rep to a triangle mesh.
@@ -3891,122 +4013,8 @@ pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
         match surface.surface_type() {
             SurfaceKind::Plane => {
                 if loop_len <= 1 {
-                    // Degenerate cap face with ≤1 vertex — single degenerate edge
-                    // forming a full circle. Sample the circle into a proper polygon.
-                    let verts: Vec<_> = brep
-                        .topology
-                        .loop_half_edges(face.outer_loop)
-                        .map(|he| brep.topology.vertices[brep.topology.half_edges[he].origin].point)
-                        .collect();
-                    if let Some(&v) = verts.first() {
-                        let plane = &brep.geometry.surfaces[face.surface_index];
-                        let center = plane.evaluate(Point2::origin());
-                        let r = (v - center).norm();
-                        let x_dir = if r > 1e-12 {
-                            (v - center).normalize()
-                        } else {
-                            plane.d_du(Point2::origin()).normalize()
-                        };
-                        let normal = plane.normal(Point2::origin());
-                        let y_dir = normal.as_ref().cross(x_dir);
-
-                        if face.inner_loops.is_empty() {
-                            let disk = tessellate_disk_general(
-                                center,
-                                r,
-                                x_dir,
-                                y_dir,
-                                params.circle_segments,
-                                reversed,
-                            );
-                            mesh.merge(&disk);
-                        } else {
-                            // Degenerate outer loop WITH inner loops (holes) —
-                            // e.g. a cylinder cap after boolean subtraction.
-                            // Sample the outer circle into a polygon and use
-                            // hole-aware CDT tessellation.
-                            let n = params.circle_segments as usize;
-                            let mut outer_3d = Vec::with_capacity(n);
-                            for i in 0..n {
-                                let theta = 2.0 * PI * (i as f64) / (n as f64);
-                                let p = center + r * (theta.cos() * x_dir + theta.sin() * y_dir);
-                                outer_3d.push(p);
-                            }
-
-                            let u_axis = x_dir;
-                            let v_axis = y_dir;
-                            let project = |p: &Point3| -> (f64, f64) {
-                                let d = *p - center;
-                                (d.dot(u_axis), d.dot(v_axis))
-                            };
-
-                            let outer_2d: Vec<(f64, f64)> = outer_3d.iter().map(&project).collect();
-
-                            let mut inner_loops_3d: Vec<Vec<Point3>> = Vec::new();
-                            let mut inner_loops_2d: Vec<Vec<(f64, f64)>> = Vec::new();
-                            for &inner_loop in &face.inner_loops {
-                                let iv: Vec<Point3> = brep
-                                    .topology
-                                    .loop_half_edges(inner_loop)
-                                    .map(|he| {
-                                        brep.topology.vertices[brep.topology.half_edges[he].origin]
-                                            .point
-                                    })
-                                    .collect();
-                                if iv.len() >= 3 {
-                                    let iv_2d: Vec<(f64, f64)> = iv.iter().map(&project).collect();
-                                    inner_loops_3d.push(iv);
-                                    inner_loops_2d.push(iv_2d);
-                                }
-                            }
-
-                            // Normalize winding: outer CCW, inner CW
-                            let outer_area = polygon_area_2d(&outer_2d);
-                            let (outer_2d, outer_3d) = if outer_area < 0.0 {
-                                let mut o2 = outer_2d;
-                                let mut o3 = outer_3d;
-                                o2.reverse();
-                                o3.reverse();
-                                (o2, o3)
-                            } else {
-                                (outer_2d, outer_3d)
-                            };
-                            for (i, hole_2d) in inner_loops_2d.iter_mut().enumerate() {
-                                let hole_area = polygon_area_2d(hole_2d);
-                                if hole_area > 0.0 {
-                                    inner_loops_3d[i].reverse();
-                                    hole_2d.reverse();
-                                }
-                            }
-
-                            merge_overlapping_holes(&mut inner_loops_2d, &mut inner_loops_3d);
-
-                            let mut face_mesh = triangulate_circular_cap_with_holes(
-                                center,
-                                r,
-                                x_dir,
-                                y_dir,
-                                &outer_2d,
-                                &inner_loops_2d,
-                                &outer_3d,
-                                &inner_loops_3d,
-                                reversed,
-                            );
-
-                            // Add planar normals
-                            let face_normal = if reversed { -normal } else { normal };
-                            let (nx, ny, nz) = (
-                                face_normal.x as f32,
-                                face_normal.y as f32,
-                                face_normal.z as f32,
-                            );
-                            for _ in 0..face_mesh.num_vertices() {
-                                face_mesh.normals.extend_from_slice(&[nx, ny, nz]);
-                            }
-
-                            mesh.merge(&face_mesh);
-                        }
-                    }
+                    let face_mesh = tessellate_degenerate_cap(brep, face_id, &params, reversed);
+                    mesh.merge(&face_mesh);
                 } else {
                     // Use winding-aware tessellation to handle faces with mismatched loop winding
                     let face_mesh = tessellate_planar_face_with_geom(

--- a/docs/differentiable-seam-m0-m2.md
+++ b/docs/differentiable-seam-m0-m2.md
@@ -175,6 +175,10 @@ for the degenerate-cap-with-holes face the per-face tessellator cannot
 mesh). What remains is known and deliberate:
 
 - **Recipe priority assumes the moving trim lives on the curved surface.**
+  *(Resolved in M3: coincident nodes on two distinct surfaces are now
+  `NodeRecipe::Boundary` — a Newton-tracked intersection point — so the
+  node follows the moving trim regardless of which surface carries θ. See
+  `differentiable-seam-m3.md`.)*
   `TopoVertex > SurfaceUv-on-curved > SurfaceUv-on-plane` is correct for
   M0–M2's parameters, but a boundary node shared between a *moving plane*
   and a *fixed* curved surface (e.g. cylinder **height** as θ, where the

--- a/docs/differentiable-seam-m3.md
+++ b/docs/differentiable-seam-m3.md
@@ -1,0 +1,113 @@
+# Differentiable seam — M3 design note
+
+M0–M2 (see `differentiable-seam-m0-m2.md`) proved **dx/dθ** correct against
+a finite-difference oracle. M3 makes the seam *do* something: the first
+geometry improved by gradient descent through it, plus the two pieces of
+machinery that unlock it — multi-surface boundary recipes (closing M0–M2's
+one known correctness gap) and mass-property QoIs with exact θ-derivatives.
+
+## What landed
+
+### Boundary recipes (`NodeRecipe::Boundary`)
+
+M0–M2's recipe-priority heuristic (`TopoVertex > curved-uv > plane-uv`)
+assumed a moving trim always lives on the *curved* surface. The inverse
+case — a boundary node shared between a moving plane and a fixed curved
+surface, e.g. cylinder **height** as θ — froze the node on the fixed
+surface: the frozen mesh differentiated a slightly different body and the
+FD oracle, replaying the same recipes, agreed with the wrong answer.
+
+Now a node contributed by two faces on *distinct* surfaces (with
+independent gradients) becomes a `Boundary` recipe: its position is the
+Newton solution of `{g_a(x) = 0, g_b(x) = 0, t·(x − anchor) = 0}` with `t`
+the intersection tangent (the frozen-parameter branch choice), and its
+velocity comes from the same two-row implicit system used for rim topology
+vertices. The node tracks the moving trim **no matter which surface carries
+θ**. Implicit forms `(g, ∇g)` moved to `vcad-kernel-geom::implicit_form`
+(their natural home) so both the tessellate-side Newton solve and the
+diff-side seeded rows share one source of truth.
+
+`m3_boundary_trim.rs` is the regression test on the previously-wrong case
+(cylinder height as θ): rim nodes ride the moving cap at exactly ẑ,
+`dV/dh` matches the discrete closed form and FD to ≤1e-6 (measured
+~1e-10). The degenerate-cap-with-holes tessellation branch was factored
+out of `tessellate_brep` into a shared `tessellate_degenerate_cap` helper
+so capture can never drift from the renderer's dispatch (previously it was
+a hard `UnsupportedFace` error in capture).
+
+### Mass-property QoIs (`mass_properties`, `mass_properties_with_derivative`)
+
+Volume, mass, centroid, and inertia tensors (about origin and centroid)
+via exact signed-tetrahedron integrals, generic over `tang::Scalar` —
+`Dual<f64>` node positions give every field's θ-derivative in one pass
+(and `Dual<Dual<f64>>` reaches second derivatives when needed). Gates
+(`m3_mass_properties.rs`): cuboid closed forms to 1e-12; `dI_zz/dd` of an
+extrusion against its closed form and FD; all cylinder-radius derivatives
+against FD (≤1e-6, measured ~1e-9).
+
+### The physics hook (`contract_sensitivity`)
+
+`dJ/dθ = Σ_i (∂J/∂x_i)·(dx_i/dθ)` — the contraction a physics functional
+plugs into. `volume_gradient` (analytic per-node ∂V/∂x) is the reference
+functional; the contraction reproduces the dual-number `dV/dθ` to 1e-12,
+which is exactly the consistency a phyz adjoint's `∂J/∂x` will inherit.
+
+**Status of true phyz coupling:** this sandbox cannot build the `phyz`
+sibling repo (session repo scope), so the rollout adapter itself — a small
+function in `vcad-kernel-physics` mapping a rollout objective's mesh
+gradient into `contract_sensitivity` — is deferred to a session with phyz
+access. The interface it targets is frozen here and exercised by the
+analytic physics objectives (inertia, spin-up ∝ I/τ are mass-property
+functions).
+
+### The optimizer harness (`objective_gradient`, `minimize`)
+
+Projected gradient descent with warm-started backtracking. The contract
+per iterate: rebuild at θ → **re-capture** a fresh frozen plan (plans are
+only valid near their capture point) → one seam evaluation per parameter
+(forward mode) → step. Frozen-tessellation errors during a *trial* step
+(`TopologyChanged`, `CorrespondenceLost`, `BoundarySolveFailed`) are the
+subgradient signals of the seam design and are handled as failed steps
+(shrink), never accepted silently. Errors at an accepted iterate
+propagate.
+
+### The demo (`m3_flywheel_optimize.rs`)
+
+A disc flywheel with a center bore and four lightening holes;
+θ = (bore radius, hole radius); brief: *hit a target spin inertia I_zz
+with minimum mass* (`J = m/m_ref + λ((I_zz − I_t)/I_t)²`, λ = 100). From
+θ₀ = (3, 2.5) mm, 83 accepted iterations grow the design to
+θ = (12.0, 4.96) mm — the bore riding its bound — cutting mass ~13% while
+landing I_zz within 1% of target. Monotone descent is asserted iterate by
+iterate, and the analytic gradient is audited against the FD oracle at the
+start point (≤1e-6; the audit uses h = 1e-4 because J is assembled from
+O(1e7) inertia integrals and a 1e-6 step would sit at the oracle's own
+roundoff floor). The model exercises a five-boolean chain per iterate —
+several hundred boolean builds over the run — with the correspondence
+machinery holding throughout.
+
+## Notes and boundaries
+
+- Boundary recipes pair **two** surfaces; a non-topology node on ≥3
+  surfaces keeps the first two (such a point is a corner the topology
+  should carry; if one ever matters, the recipe generalizes the same way
+  the vertex solve already does).
+- The optimizer is deliberately the simplest loop that closes; L-BFGS or
+  trust regions plug into `objective_gradient` unchanged. Forward mode is
+  one seam pass per parameter — right up to a few dozen parameters, after
+  which reverse mode (M5) takes over behind the same `SeamMesh` interface.
+- Runtime: the flywheel run is ~17 s in a debug build, dominated by ~100
+  boolean rebuilds; per-iterate cost is build ≈ 65 ms, capture ≈ 22 ms,
+  seam ≈ 1 ms per parameter. The known perf follow-ups (spatial hashing in
+  matching, borrowed connectivity) from the M0–M2 note stand.
+
+## What M4 needs from this
+
+Fillet-radius parameters put the moving trim on a *tangent* curve between
+a fillet surface and its support faces. The Boundary machinery is the
+on-ramp: the Newton system's rows are exactly the fillet's defining
+contact equations, but the tangency makes `∇g_a × ∇g_b` degenerate at the
+contact line, so M4 needs the curvature-aware (second-order) version of
+the boundary solve, plus torus/cone implicit forms in
+`vcad-kernel-geom::implicit_form` — both localized, neither touching the
+recipe or seam interfaces.


### PR DESCRIPTION
Follow-up to #379. M0–M2 proved **dx/dθ** correct against a finite-difference oracle; M3 makes the seam *do* something: the first shape improved by gradient descent through it, plus the two pieces that unlock it. Design note: [`docs/differentiable-seam-m3.md`](docs/differentiable-seam-m3.md).

## 1. Multi-surface boundary recipes — closes M0–M2's known correctness gap

The old recipe-priority heuristic assumed a moving trim always lives on the *curved* surface; the inverse case (e.g. cylinder **height** as θ) froze boundary nodes on the fixed surface — and the FD oracle, replaying the same recipes, agreed with the wrong answer. Now a node contributed by two faces on distinct surfaces becomes `NodeRecipe::Boundary`: position from a Newton solve of `{g_a = 0, g_b = 0, tangent-pinned}`, velocity from the same two-row implicit system as rim topology vertices — the node tracks the moving trim **no matter which surface carries θ**.

- Implicit forms `(g, ∇g)` moved to `vcad-kernel-geom::implicit_form` (one source of truth for tessellate's Newton solve and diff's seeded rows).
- The degenerate-cap tessellation (with and without holes) is factored out of `tessellate_brep` into a shared `tessellate_degenerate_cap` helper used by both the renderer path and frozen capture — the drift-prone duplication flagged in #379's review is gone, and capture now handles boolean-cut caps (previously a hard `UnsupportedFace` error).
- Regression test on the previously-wrong case (`m3_boundary_trim.rs`): rim rides the moving cap at exactly ẑ; `dV/dh` vs closed form and FD at ~1e-10 (gate 1e-6).

## 2. Mass-property QoIs with exact θ-derivatives + the physics hook

`mass_properties` / `mass_properties_with_derivative`: volume, mass, centroid, inertia tensors (origin + centroid) via exact signed-tetra integrals, generic over `tang::Scalar` — `Dual<f64>` positions give every field's derivative in one pass (`Dual<Dual<f64>>` reaches second derivatives). Gates: cuboid closed forms to 1e-12, extrusion `dI_zz/dd` closed form, cylinder-radius FD ~1e-9.

`contract_sensitivity(seam, ∂J/∂x)` is the hook a phyz functional plugs into (`dJ/dθ = Σᵢ ∂J/∂xᵢ · dxᵢ/dθ`); against the analytic volume gradient it reproduces the dual-number derivative to 1e-12. **Phyz-coupling status:** this sandbox can't build the `phyz` sibling (repo scope), so the rollout adapter itself — a small function in `vcad-kernel-physics` — is deferred to a session with phyz access; the interface it targets is frozen and exercised here by analytic physics objectives (inertia-based).

## 3. The optimizer harness and the demo

`objective_gradient` (re-capture per iterate, one seam pass per parameter) + `minimize` (projected gradient descent, warm-started backtracking). Frozen-tessellation errors during *trial* steps — `TopologyChanged`, `CorrespondenceLost`, `BoundarySolveFailed` — are handled as subgradient signals (shrink the step), never silently accepted.

**`m3_flywheel_optimize.rs`:** a disc flywheel with a center bore and four lightening holes (a five-boolean chain per iterate); θ = (bore radius, hole radius); brief = *hit a target spin inertia with minimum mass*. From θ₀ = (3, 2.5) mm, 83 monotone iterations grow the design to (12.0, 4.96) mm — cutting ~13% mass, landing I_zz within 1% of target — with the analytic gradient FD-audited at the start point and several hundred boolean rebuilds under the correspondence machinery. The test asserts monotone descent iterate-by-iterate, convergence (not iteration exhaustion), recovery of most of the achievable objective, and the design brief.

## Validation

- All M0–M2 gates stay green (boundary recipes now also serve the M1 cylinder cap rims and are exercised by the existing tests).
- `cargo test` / `cargo clippy -- -D warnings` / `cargo fmt --check` clean on the workspace excluding the loon/phyz-dependent crates (sandbox limitation, unchanged from #379; CI runs the full set).
- No changelog entry: kernel-internal, still unwired to consumers (CLAUDE.md WIP-crates entry updated).

## What M4 needs from this

Fillet radii put the moving trim on a *tangency* curve, where `∇g_a × ∇g_b` degenerates — M4 is the curvature-aware boundary solve plus torus/cone implicit forms, both localized behind the same recipe and seam interfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_