### PR TITLE
Differentiable seam M4: the fillet radius

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,9 @@ vcad/
 │   # Work-in-progress crates (built but not yet wired to any consumer):
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
 │   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations,
-│   #                            # mass-property QoIs, optimizer harness (docs/
-│   #                            # differentiable-seam-m0-m2.md, -m3.md); no consumers yet
+│   #                            # mass-property QoIs, optimizer harness, differentiable
+│   #                            # fillet radius (docs/differentiable-seam-m0-m2.md,
+│   #                            # -m3.md, -m4.md); no consumers yet
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7096,6 +7096,7 @@ version = "0.9.4"
 dependencies = [
  "tang",
  "vcad-kernel",
+ "vcad-kernel-fillet",
  "vcad-kernel-geom",
  "vcad-kernel-math",
  "vcad-kernel-nurbs",

--- a/crates/vcad-kernel-diff/Cargo.toml
+++ b/crates/vcad-kernel-diff/Cargo.toml
@@ -16,5 +16,6 @@ vcad-kernel-primitives = { workspace = true }
 vcad-kernel-tessellate = { workspace = true }
 
 [dev-dependencies]
+vcad-kernel-fillet = { workspace = true }
 vcad-kernel-sketch = { workspace = true }
 vcad-kernel = { workspace = true }

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -30,7 +30,9 @@ pub struct ConstraintRow {
     pub rhs: f64,
 }
 
-/// The implicit form of a surface at `x`: `(g, ∇g, ∂g/∂θ)`.
+/// The implicit form of a surface at `x`: `(g, ∇g, ∂g/∂θ)`, with the
+/// θ-term summed over composed seeds (a fillet blend's radius and axis
+/// position both carry the fillet-radius parameter).
 ///
 /// Single source of truth for both [`constraint_row`] and
 /// [`surface_residual`], so incidence detection and the rows actually
@@ -39,7 +41,7 @@ pub struct ConstraintRow {
 /// `Ok(None)` for kinds without an implicit form.
 fn implicit_terms(
     surface: &dyn Surface,
-    seed: Option<SurfaceSeed>,
+    seeds: &[SurfaceSeed],
     x: &Point3,
 ) -> Result<Option<(f64, Vec3, f64)>, DiffError> {
     let kind = surface.surface_type();
@@ -48,11 +50,13 @@ fn implicit_terms(
             let plane = downcast::<Plane>(surface, kind)?;
             let n = *plane.normal_dir.as_ref();
             let g = plane.signed_distance(x);
-            let g_theta = match seed {
-                None => 0.0,
-                Some(SurfaceSeed::Translate { velocity }) => -n.dot(velocity),
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
-            };
+            let mut g_theta = 0.0;
+            for seed in seeds {
+                g_theta += match *seed {
+                    SurfaceSeed::Translate { velocity } => -n.dot(velocity),
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                };
+            }
             Ok(Some((g, n, g_theta)))
         }
         SurfaceKind::Cylinder => {
@@ -61,48 +65,136 @@ fn implicit_terms(
             let d = *x - cyl.center;
             let radial = d - a * d.dot(a);
             let g = radial.norm_squared() - cyl.radius * cyl.radius;
-            let g_theta = match seed {
-                None => 0.0,
-                Some(SurfaceSeed::CylinderRadius { rate }) => -2.0 * cyl.radius * rate,
-                Some(SurfaceSeed::Translate { velocity }) => {
-                    // ∂g/∂θ = −2 radial · v_perp; radial ⊥ a so the axial
-                    // component of v drops out automatically.
-                    -2.0 * radial.dot(velocity)
-                }
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
-            };
+            let mut g_theta = 0.0;
+            for seed in seeds {
+                g_theta += match *seed {
+                    SurfaceSeed::CylinderRadius { rate } => -2.0 * cyl.radius * rate,
+                    SurfaceSeed::Translate { velocity } => {
+                        // ∂g/∂θ = −2 radial · v_perp; radial ⊥ a so the axial
+                        // component of v drops out automatically.
+                        -2.0 * radial.dot(velocity)
+                    }
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                };
+            }
             Ok(Some((g, 2.0 * radial, g_theta)))
         }
         SurfaceKind::Sphere => {
             let sph = downcast::<SphereSurface>(surface, kind)?;
             let d = *x - sph.center;
             let g = d.norm_squared() - sph.radius * sph.radius;
-            let g_theta = match seed {
-                None => 0.0,
-                Some(SurfaceSeed::SphereRadius { rate }) => -2.0 * sph.radius * rate,
-                Some(SurfaceSeed::Translate { velocity }) => -2.0 * d.dot(velocity),
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
-            };
+            let mut g_theta = 0.0;
+            for seed in seeds {
+                g_theta += match *seed {
+                    SurfaceSeed::SphereRadius { rate } => -2.0 * sph.radius * rate,
+                    SurfaceSeed::Translate { velocity } => -2.0 * d.dot(velocity),
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                };
+            }
             Ok(Some((g, 2.0 * d, g_theta)))
         }
         _ => Ok(None),
     }
 }
 
-/// Build the constraint row contributed by `surface` (with its θ-seed) at
-/// vertex position `x`. Kinds without an implicit form return
+/// Build the constraint row contributed by `surface` (with its composed
+/// θ-seeds) at vertex position `x`. Kinds without an implicit form return
 /// [`DiffError::UnsupportedConstraint`].
 pub fn constraint_row(
     surface: &dyn Surface,
-    seed: Option<SurfaceSeed>,
+    seeds: &[SurfaceSeed],
     x: &Point3,
 ) -> Result<ConstraintRow, DiffError> {
-    match implicit_terms(surface, seed, x)? {
+    match implicit_terms(surface, seeds, x)? {
         Some((_g, gradient, g_theta)) => Ok(ConstraintRow {
             gradient,
             rhs: -g_theta,
         }),
         None => Err(DiffError::UnsupportedConstraint(surface.surface_type())),
+    }
+}
+
+/// Extra first-order rows for a **tangency contact** at a vertex.
+///
+/// When a curved surface touches a plane with parallel gradients (a fillet
+/// blend resting on its support face), the surface's implicit row is
+/// dependent on the plane's and carries no tangential information — the
+/// rank-deficient system would silently freeze a vertex that actually
+/// slides along the support face (e.g. the corner of two tangent lines on
+/// a rounded cube moves at `(±1, ±1, 0)` per unit fillet radius). The
+/// missing information lives in the *tangent-curve* equations:
+///
+/// - cylinder tangent to plane `n`: the tangent line satisfies
+///   `q·(x − center(θ)) = 0` with `q = axis × n`, giving the row
+///   `q·ẋ = q·(d center/dθ)` (the radius rate drops out since the contact
+///   direction is parallel to `n`);
+/// - sphere tangent to plane `n`: the tangent point tracks the center in
+///   every direction perpendicular to `n` — two rows `q_i·ẋ = q_i·(d
+///   center/dθ)` for a basis `{q_1, q_2}` of `n⊥`.
+///
+/// Returns no rows when the surface is not tangent to the plane at `x`
+/// (transverse contacts are fully handled by the ordinary implicit rows).
+pub fn tangency_rows(
+    plane_normal: Vec3,
+    surface: &dyn Surface,
+    seeds: &[SurfaceSeed],
+    x: &Point3,
+) -> Result<Vec<ConstraintRow>, DiffError> {
+    let translate: Vec3 = seeds
+        .iter()
+        .fold(Vec3::new(0.0, 0.0, 0.0), |acc, s| match *s {
+            SurfaceSeed::Translate { velocity } => acc + velocity,
+            _ => acc,
+        });
+    let n = plane_normal.normalize();
+    let kind = surface.surface_type();
+    match kind {
+        SurfaceKind::Cylinder => {
+            let cyl = downcast::<CylinderSurface>(surface, kind)?;
+            let a = *cyl.axis.as_ref();
+            let d = *x - cyl.center;
+            let radial = d - a * d.dot(a);
+            let rn = radial.norm();
+            if rn < f64::MIN_POSITIVE || radial.cross(n).norm() > 1e-6 * rn {
+                return Ok(Vec::new()); // transverse (or on-axis): no tangency
+            }
+            let q = a.cross(n);
+            let qn = q.norm();
+            if qn < 1e-9 {
+                return Ok(Vec::new()); // axis ∥ n: degenerate contact
+            }
+            let q = q / qn;
+            Ok(vec![ConstraintRow {
+                gradient: q,
+                rhs: q.dot(translate),
+            }])
+        }
+        SurfaceKind::Sphere => {
+            let sph = downcast::<SphereSurface>(surface, kind)?;
+            let d = *x - sph.center;
+            let dn = d.norm();
+            if dn < f64::MIN_POSITIVE || d.cross(n).norm() > 1e-6 * dn {
+                return Ok(Vec::new());
+            }
+            let arbitrary = if n.x.abs() < 0.9 {
+                Vec3::new(1.0, 0.0, 0.0)
+            } else {
+                Vec3::new(0.0, 1.0, 0.0)
+            };
+            let q1 = n.cross(arbitrary).normalize();
+            let q2 = n.cross(q1);
+            Ok(vec![
+                ConstraintRow {
+                    gradient: q1,
+                    rhs: q1.dot(translate),
+                },
+                ConstraintRow {
+                    gradient: q2,
+                    rhs: q2.dot(translate),
+                },
+            ])
+        }
+        _ => Ok(Vec::new()),
     }
 }
 
@@ -117,7 +209,7 @@ pub fn constraint_row(
 /// seam loop), so constraint rows must be collected by incidence, not just
 /// by loop membership.
 pub fn surface_residual(surface: &dyn Surface, x: &Point3) -> Option<f64> {
-    let (g, grad, _) = implicit_terms(surface, None, x).ok()??;
+    let (g, grad, _) = implicit_terms(surface, &[], x).ok()??;
     let n = grad.norm();
     (n > f64::MIN_POSITIVE).then(|| (g / n).abs())
 }
@@ -189,13 +281,13 @@ mod tests {
         let side_x = Plane::new(Point3::new(4.0, 0.0, 0.0), Vec3::y(), Vec3::z());
         let side_y = Plane::new(Point3::new(0.0, 3.0, 0.0), Vec3::z(), Vec3::x());
         let x = Point3::new(4.0, 3.0, 2.0);
-        let seed = Some(SurfaceSeed::Translate {
+        let seed = [SurfaceSeed::Translate {
             velocity: Vec3::z(),
-        });
+        }];
         let rows = vec![
-            constraint_row(&top, seed, &x).unwrap(),
-            constraint_row(&side_x, None, &x).unwrap(),
-            constraint_row(&side_y, None, &x).unwrap(),
+            constraint_row(&top, &seed, &x).unwrap(),
+            constraint_row(&side_x, &[], &x).unwrap(),
+            constraint_row(&side_y, &[], &x).unwrap(),
         ];
         let v = solve_vertex_velocity(&rows).unwrap();
         assert!((v - Vec3::z()).norm() < 1e-12, "v = {v:?}");
@@ -210,8 +302,8 @@ mod tests {
         let u = 1.1_f64;
         let x = Point3::new(2.5 * u.cos(), 2.5 * u.sin(), 5.0);
         let rows = vec![
-            constraint_row(&plane, None, &x).unwrap(),
-            constraint_row(&cyl, Some(SurfaceSeed::CylinderRadius { rate: 1.0 }), &x).unwrap(),
+            constraint_row(&plane, &[], &x).unwrap(),
+            constraint_row(&cyl, &[SurfaceSeed::CylinderRadius { rate: 1.0 }], &x).unwrap(),
         ];
         let v = solve_vertex_velocity(&rows).unwrap();
         let expected = Vec3::new(u.cos(), u.sin(), 0.0);
@@ -228,13 +320,13 @@ mod tests {
         let rows = vec![
             constraint_row(
                 &p1,
-                Some(SurfaceSeed::Translate {
+                &[SurfaceSeed::Translate {
                     velocity: Vec3::z(),
-                }),
+                }],
                 &x,
             )
             .unwrap(),
-            constraint_row(&p2, None, &x).unwrap(),
+            constraint_row(&p2, &[], &x).unwrap(),
         ];
         assert!(matches!(
             solve_vertex_velocity(&rows),

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -134,6 +134,10 @@ pub fn constraint_row(
 ///
 /// Returns no rows when the surface is not tangent to the plane at `x`
 /// (transverse contacts are fully handled by the ordinary implicit rows).
+/// Surface kinds without tangency support — planes included — also return
+/// no rows, **never** an error: callers are expected to pass every
+/// incident surface and let this function decide which pairs participate,
+/// so an unknown kind is "no tangency information", not a failure.
 pub fn tangency_rows(
     plane_normal: Vec3,
     surface: &dyn Surface,

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -185,10 +185,11 @@ impl ParamSeeding {
             .unwrap_or(&[])
     }
 
-    /// Add `seed` to every surface in `geom` matching `pred`. Returns how
-    /// many surfaces were seeded (callers should assert the expected count
-    /// — boolean output stores may carry several copies of a moving
-    /// surface).
+    /// Add `seed` to every surface in `geom` matching `pred`. Like
+    /// [`ParamSeeding::seed`], this **composes** with seeds already present
+    /// on a matching surface — it never replaces them. Returns how many
+    /// surfaces were seeded (callers should assert the expected count —
+    /// boolean output stores may carry several copies of a moving surface).
     pub fn seed_where(
         &mut self,
         geom: &GeometryStore,

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -42,7 +42,9 @@ mod seam;
 
 pub use contract::{contract_sensitivity, volume_gradient};
 pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
-pub use implicit::{constraint_row, solve_vertex_velocity, surface_residual, ConstraintRow};
+pub use implicit::{
+    constraint_row, solve_vertex_velocity, surface_residual, tangency_rows, ConstraintRow,
+};
 pub use lift::{lift_surface, DualSurface};
 pub use mass::{mass_properties, mass_properties_with_derivative, MassProperties};
 pub use optimize::{
@@ -152,9 +154,14 @@ pub enum SurfaceSeed {
 /// Surfaces without an entry are θ-independent (lifted with zero dual
 /// parts). This keeps the seeding honest about which surfaces a given θ
 /// actually touches.
+///
+/// A surface may carry **several seeds**, which compose additively — the
+/// canonical case is a fillet blend, whose radius *and* axis position both
+/// depend on the fillet-radius parameter (the axis retreats from the edge
+/// as the radius grows).
 #[derive(Debug, Clone, Default)]
 pub struct ParamSeeding {
-    seeds: BTreeMap<usize, SurfaceSeed>,
+    seeds: BTreeMap<usize, Vec<SurfaceSeed>>,
 }
 
 impl ParamSeeding {
@@ -163,20 +170,25 @@ impl ParamSeeding {
         Self::default()
     }
 
-    /// Seed the surface at `surface_index`.
+    /// Add a seed to the surface at `surface_index` (composes with seeds
+    /// already present on that surface).
     pub fn seed(&mut self, surface_index: usize, seed: SurfaceSeed) -> &mut Self {
-        self.seeds.insert(surface_index, seed);
+        self.seeds.entry(surface_index).or_default().push(seed);
         self
     }
 
-    /// The seed for a surface index, if any.
-    pub fn get(&self, surface_index: usize) -> Option<SurfaceSeed> {
-        self.seeds.get(&surface_index).copied()
+    /// The seeds for a surface index (empty = θ-independent).
+    pub fn get(&self, surface_index: usize) -> &[SurfaceSeed] {
+        self.seeds
+            .get(&surface_index)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 
-    /// Seed every surface in `geom` matching `pred`. Returns how many
-    /// surfaces were seeded (callers should assert the expected count —
-    /// boolean output stores may carry several copies of a moving surface).
+    /// Add `seed` to every surface in `geom` matching `pred`. Returns how
+    /// many surfaces were seeded (callers should assert the expected count
+    /// — boolean output stores may carry several copies of a moving
+    /// surface).
     pub fn seed_where(
         &mut self,
         geom: &GeometryStore,
@@ -186,7 +198,7 @@ impl ParamSeeding {
         let mut count = 0;
         for (i, s) in geom.surfaces.iter().enumerate() {
             if pred(s.as_ref()) {
-                self.seeds.insert(i, seed);
+                self.seeds.entry(i).or_default().push(seed);
                 count += 1;
             }
         }

--- a/crates/vcad-kernel-diff/src/lift.rs
+++ b/crates/vcad-kernel-diff/src/lift.rs
@@ -38,95 +38,104 @@ pub enum DualSurface {
 }
 
 fn seed_point(p: &mut tang::Point3<D>, velocity: Vec3) {
-    p.x.dual = velocity.x;
-    p.y.dual = velocity.y;
-    p.z.dual = velocity.z;
+    p.x.dual += velocity.x;
+    p.y.dual += velocity.y;
+    p.z.dual += velocity.z;
 }
 
 /// Lift a stored (concrete, `f64`) surface to `Dual<f64>`, seeding the
-/// field(s) touched by θ. `seed = None` lifts with all dual parts zero
-/// (a θ-independent surface).
+/// field(s) touched by θ. An empty seed slice lifts with all dual parts
+/// zero (a θ-independent surface); multiple seeds compose additively (a
+/// fillet blend's radius and axis position both move with the fillet
+/// radius).
 ///
 /// Each arm matches on [`SurfaceKind`], recovers the concrete struct, calls
-/// its existing `lift::<Dual<f64>>()`, and writes the seed into the lifted
+/// its existing `lift::<Dual<f64>>()`, and writes the seeds into the lifted
 /// fields. Inapplicable seeds are a hard error, never silently ignored.
 pub fn lift_surface(
     surface: &dyn Surface,
-    seed: Option<SurfaceSeed>,
+    seeds: &[SurfaceSeed],
 ) -> Result<DualSurface, DiffError> {
     let kind = surface.surface_type();
     match kind {
         SurfaceKind::Plane => {
             let mut s = downcast::<Plane>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.origin, velocity),
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => seed_point(&mut s.origin, velocity),
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                }
             }
             Ok(DualSurface::Plane(s))
         }
         SurfaceKind::Cylinder => {
             let mut s = downcast::<CylinderSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
-                Some(SurfaceSeed::CylinderRadius { rate }) => s.radius.dual = rate,
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => seed_point(&mut s.center, velocity),
+                    SurfaceSeed::CylinderRadius { rate } => s.radius.dual += rate,
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                }
             }
             Ok(DualSurface::Cylinder(s))
         }
         SurfaceKind::Cone => {
             let mut s = downcast::<ConeSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.apex, velocity),
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => seed_point(&mut s.apex, velocity),
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                }
             }
             Ok(DualSurface::Cone(s))
         }
         SurfaceKind::Sphere => {
             let mut s = downcast::<SphereSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
-                Some(SurfaceSeed::SphereRadius { rate }) => s.radius.dual = rate,
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => seed_point(&mut s.center, velocity),
+                    SurfaceSeed::SphereRadius { rate } => s.radius.dual += rate,
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                }
             }
             Ok(DualSurface::Sphere(s))
         }
         SurfaceKind::Torus => {
             let mut s = downcast::<TorusSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => seed_point(&mut s.center, velocity),
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => seed_point(&mut s.center, velocity),
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+                }
             }
             Ok(DualSurface::Torus(s))
         }
         SurfaceKind::Bilinear => {
             let mut s = downcast::<BilinearSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => {
-                    seed_point(&mut s.p00, velocity);
-                    seed_point(&mut s.p10, velocity);
-                    seed_point(&mut s.p01, velocity);
-                    seed_point(&mut s.p11, velocity);
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => {
+                        seed_point(&mut s.p00, velocity);
+                        seed_point(&mut s.p10, velocity);
+                        seed_point(&mut s.p01, velocity);
+                        seed_point(&mut s.p11, velocity);
+                    }
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
                 }
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
             }
             Ok(DualSurface::Bilinear(s))
         }
         SurfaceKind::BSpline => {
             let mut s = downcast::<BSplineSurface>(surface, kind)?.lift::<D>();
-            match seed {
-                None => {}
-                Some(SurfaceSeed::Translate { velocity }) => {
-                    for cp in &mut s.control_points {
-                        seed_point(cp, velocity);
+            for seed in seeds {
+                match *seed {
+                    SurfaceSeed::Translate { velocity } => {
+                        for cp in &mut s.control_points {
+                            seed_point(cp, velocity);
+                        }
                     }
+                    other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
                 }
-                Some(other) => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
             }
             Ok(DualSurface::BSpline(s))
         }
@@ -169,9 +178,9 @@ mod tests {
         let plane = Plane::new(Point3::new(0.0, 0.0, 2.0), Vec3::x(), Vec3::y());
         let lifted = lift_surface(
             &plane,
-            Some(SurfaceSeed::Translate {
+            &[SurfaceSeed::Translate {
                 velocity: Vec3::z(),
-            }),
+            }],
         )
         .unwrap();
         for &(u, v) in &[(0.0, 0.0), (1.5, -2.5), (10.0, 3.0)] {
@@ -185,7 +194,7 @@ mod tests {
     fn cylinder_radius_lift_matches_exact_velocity() {
         // Radius seed: dx/dr = radial direction (cos u, sin u, 0).
         let cyl = CylinderSurface::new(5.0);
-        let lifted = lift_surface(&cyl, Some(SurfaceSeed::CylinderRadius { rate: 1.0 })).unwrap();
+        let lifted = lift_surface(&cyl, &[SurfaceSeed::CylinderRadius { rate: 1.0 }]).unwrap();
         for &(u, v) in &[(0.0, 0.0), (1.0, 3.0), (4.5, -2.0)] {
             let (p, vel) = lifted.evaluate_with_velocity(Point2::new(u, v));
             let radial = Vec3::new(u.cos(), u.sin(), 0.0);
@@ -200,14 +209,14 @@ mod tests {
     #[test]
     fn inapplicable_seed_is_an_error() {
         let plane = Plane::xy();
-        let err = lift_surface(&plane, Some(SurfaceSeed::CylinderRadius { rate: 1.0 }));
+        let err = lift_surface(&plane, &[SurfaceSeed::CylinderRadius { rate: 1.0 }]);
         assert!(matches!(err, Err(DiffError::UnsupportedSeed { .. })));
     }
 
     #[test]
     fn unseeded_lift_has_zero_velocity() {
         let sph = SphereSurface::new(3.0);
-        let lifted = lift_surface(&sph, None).unwrap();
+        let lifted = lift_surface(&sph, &[]).unwrap();
         let (_, vel) = lifted.evaluate_with_velocity(Point2::new(0.7, 0.3));
         assert!(vel.norm() < 1e-15);
     }

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -13,7 +13,8 @@ use vcad_kernel_tessellate::frozen::{
 use vcad_kernel_topo::VertexId;
 
 use crate::{
-    constraint_row, lift_surface, solve_vertex_velocity, surface_residual, DiffError, ParamSeeding,
+    constraint_row, lift_surface, solve_vertex_velocity, surface_residual, tangency_rows,
+    DiffError, ParamSeeding,
 };
 
 /// Incidence tolerance (mm) for treating a topology vertex as lying on a
@@ -148,6 +149,26 @@ pub fn evaluate_with_sensitivity(
                 for &sidx in &incident {
                     let surface = brep.geometry.surfaces[sidx].as_ref();
                     rows.push(constraint_row(surface, seeding.get(sidx), &x)?);
+                }
+                // Tangency completion: a curved surface resting on an
+                // incident plane duplicates the plane's row instead of
+                // pinning the vertex tangentially; its tangent-curve rows
+                // carry the missing directions (a rounded-cube corner
+                // vertex slides along the support face as the fillet
+                // radius grows).
+                for &pidx in &incident {
+                    let plane = brep.geometry.surfaces[pidx].as_ref();
+                    let Some(p) = plane.as_any().downcast_ref::<vcad_kernel_geom::Plane>() else {
+                        continue;
+                    };
+                    let n = *p.normal_dir.as_ref();
+                    for &sidx in &incident {
+                        if sidx == pidx {
+                            continue;
+                        }
+                        let surface = brep.geometry.surfaces[sidx].as_ref();
+                        rows.extend(tangency_rows(n, surface, seeding.get(sidx), &x)?);
+                    }
                 }
                 let v = solve_vertex_velocity(&rows)?;
                 positions.push(x);

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -155,7 +155,12 @@ pub fn evaluate_with_sensitivity(
                 // pinning the vertex tangentially; its tangent-curve rows
                 // carry the missing directions (a rounded-cube corner
                 // vertex slides along the support face as the fillet
-                // radius grows).
+                // radius grows). Looping over all (plane, surface) pairs
+                // over-generates safely: non-tangent pairs contribute no
+                // rows at all, and redundant rows from multiple tangent
+                // contacts are orthogonalized away by the solver after a
+                // consistency check — disagreement is a hard error, never
+                // a silent average.
                 for &pidx in &incident {
                     let plane = brep.geometry.surfaces[pidx].as_ref();
                     let Some(p) = plane.as_any().downcast_ref::<vcad_kernel_geom::Plane>() else {

--- a/crates/vcad-kernel-diff/tests/m1_frozen_lift.rs
+++ b/crates/vcad-kernel-diff/tests/m1_frozen_lift.rs
@@ -113,9 +113,9 @@ fn m1_plane_offset_interior_samples_match_fd() {
     let base = build_plane(theta0);
     let lifted = lift_surface(
         &base,
-        Some(SurfaceSeed::Translate {
+        &[SurfaceSeed::Translate {
             velocity: normal_velocity,
-        }),
+        }],
     )
     .expect("lift");
 

--- a/crates/vcad-kernel-diff/tests/m4_fillet_radius.rs
+++ b/crates/vcad-kernel-diff/tests/m4_fillet_radius.rs
@@ -1,0 +1,260 @@
+//! M4 — differentiable fillet radius.
+//!
+//! The model is a cube with **all edges filleted** (the kernel's supported
+//! fillet path): 6 inset planes, 12 quarter-cylinder edge blends, 8
+//! sphere-octant corners. θ = the fillet radius, and it moves *twenty*
+//! surfaces at once, each with a **composite seed**: every blend's radius
+//! grows at rate 1 while its axis/center simultaneously retreats from the
+//! edge (velocity ±1 per non-axial coordinate), which is exactly what the
+//! composite `ParamSeeding` exists for.
+//!
+//! What makes fillets the hard case (and why this test exists):
+//!
+//! - Blend surfaces meet their support faces **tangentially**, so the
+//!   two-surface Boundary Newton system is singular exactly on the moving
+//!   trim. The seam handles this without a special case: a tangent line is
+//!   `u = const` on the blend, so a frozen-`(u,v)` sample with the
+//!   composite seed already tracks it exactly (Pillar 2), and the Boundary
+//!   upgrade's tangency check routes those nodes away from the singular
+//!   solve.
+//! - The fillet kernel rebuilds blend frames **nondeterministically**
+//!   (axis signs flip between builds), so the FD oracle transports frozen
+//!   samples through each rebuilt surface's frame (`FaceFrame` /
+//!   `transport_uv`) instead of trusting raw parameters.
+//!
+//! Volume gates: the seam derivative must match the FD oracle at 1e-6 (the
+//! framework test), and sit within the documented polygonization band of
+//! the continuum closed form — the Minkowski sum of the shrunken cube with
+//! a ball: `V(r) = a³ + 6a²r + 3πar² + (4/3)πr³`, `a = L − 2r`.
+
+use vcad_kernel_diff::{
+    compare_velocities, evaluate_with_sensitivity, fd_velocities, fd_volume_derivative, minimize,
+    volume_with_derivative, OptimizeOptions, ParamSeeding, SeamMesh, StopReason, SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, SphereSurface};
+use vcad_kernel_math::Vec3;
+use vcad_kernel_primitives::{make_cube, BRepSolid};
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+const L: f64 = 10.0;
+const R0: f64 = 1.5;
+const H: f64 = 1e-6;
+const GATE: f64 = 1e-6;
+
+fn build(theta: &[f64]) -> BRepSolid {
+    vcad_kernel_fillet::fillet_all_edges(&make_cube(L, L, L), theta[0])
+}
+
+fn minkowski(r: f64) -> f64 {
+    let a = L - 2.0 * r;
+    a * a * a
+        + 6.0 * a * a * r
+        + 3.0 * std::f64::consts::PI * a * r * r
+        + 4.0 / 3.0 * std::f64::consts::PI * r * r * r
+}
+
+/// Retreat velocity of a fillet-surface center: for every coordinate
+/// pinned at `r` off a face of the cube, +1; at `L − r`, −1; otherwise 0
+/// (the blend's axial direction). Same rule covers edge cylinders (two
+/// pinned coordinates) and corner spheres (three).
+fn retreat_velocity(center: vcad_kernel_math::Point3, r: f64) -> Vec3 {
+    let component = |c: f64| {
+        if (c - r).abs() < 1e-9 {
+            1.0
+        } else if (c - (L - r)).abs() < 1e-9 {
+            -1.0
+        } else {
+            0.0
+        }
+    };
+    Vec3::new(
+        component(center.x),
+        component(center.y),
+        component(center.z),
+    )
+}
+
+/// θ = fillet radius: composite seeds on all 12 blend cylinders and all 8
+/// corner spheres (radius rate 1 + center retreat); the 6 planes are
+/// θ-independent.
+fn seeding(brep: &BRepSolid, r: f64) -> ParamSeeding {
+    let mut seeding = ParamSeeding::new();
+    let mut cylinders = 0;
+    let mut spheres = 0;
+    for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+        if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+            assert!((c.radius - r).abs() < 1e-9, "unexpected blend radius");
+            seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat_velocity(c.center, r),
+                },
+            );
+            cylinders += 1;
+        } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+            assert!((sp.radius - r).abs() < 1e-9, "unexpected corner radius");
+            seeding.seed(i, SurfaceSeed::SphereRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat_velocity(sp.center, r),
+                },
+            );
+            spheres += 1;
+        }
+    }
+    assert_eq!((cylinders, spheres), (12, 8), "rounded cube surface census");
+    seeding
+}
+
+fn tess_params() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 16,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn m4_fillet_radius_derivative_matches_fd_and_continuum() {
+    let build1 = |r: f64| build(&[r]);
+    let base = build1(R0);
+    let plan = capture_plan(&base, &tess_params()).expect("capture");
+    let seam = evaluate_with_sensitivity(&base, &plan, &seeding(&base, R0)).expect("seam");
+
+    // Gate 1 (the framework test): seam dV/dr vs the FD oracle across
+    // twenty simultaneously-moving surfaces with composite seeds, under
+    // frame-transported correspondence.
+    let (v, dv) = volume_with_derivative(&seam);
+    let dv_fd = fd_volume_derivative(build1, R0, H, &plan).expect("fd volume");
+    let rel_fd = (dv - dv_fd).abs() / dv_fd.abs();
+    assert!(
+        rel_fd <= GATE,
+        "seam dV/dr = {dv} vs FD {dv_fd} (rel err {rel_fd:.3e})"
+    );
+
+    // Gate 2: node-wise dx/dr across the whole mesh.
+    let fd = fd_velocities(build1, R0, H, &plan).expect("fd velocities");
+    let cmp = compare_velocities(&seam.velocities, &fd);
+    assert!(
+        cmp.max_rel_err <= GATE,
+        "dx/dr max rel err {:.3e} at node {}",
+        cmp.max_rel_err,
+        cmp.worst_node
+    );
+
+    // Exact spot-checks on the moving tangent lines: a node on the top
+    // face's front tangent line (z = L, y = r) slides at exactly +ŷ — the
+    // frozen u = const sample composed of the blend's retreat (0, 1, −1)
+    // and its radial growth (0, 0, 1).
+    let mut tangent_nodes = 0;
+    let mut corner_nodes = 0;
+    for (i, p) in seam.positions.iter().enumerate() {
+        if (p.z - L).abs() < 1e-9 && (p.y - R0).abs() < 1e-9 {
+            if p.x > R0 + 1e-9 && p.x < L - R0 - 1e-9 {
+                tangent_nodes += 1;
+                assert!(
+                    (seam.velocities[i] - Vec3::new(0.0, 1.0, 0.0)).norm() < 1e-9,
+                    "tangent-line node {i}: velocity {:?}",
+                    seam.velocities[i]
+                );
+            } else if (p.x - R0).abs() < 1e-9 {
+                // The corner where two tangent lines cross: it slides
+                // diagonally along the top face — the rank-deficient case
+                // the tangency-completion rows exist for.
+                corner_nodes += 1;
+                assert!(
+                    (seam.velocities[i] - Vec3::new(1.0, 1.0, 0.0)).norm() < 1e-9,
+                    "tangent-corner node {i}: velocity {:?}",
+                    seam.velocities[i]
+                );
+            }
+        }
+    }
+    assert!(
+        tangent_nodes >= 1,
+        "expected tangent-line nodes on the top face"
+    );
+    assert!(
+        corner_nodes >= 1,
+        "expected a tangent-corner vertex on the top face"
+    );
+
+    // Gate 3: continuum closed form within the polygonization band. The
+    // frozen mesh carries 16-segment blends and coarse sphere octants, so
+    // the discrete derivative differs from −(dV_minkowski/dr) by a few
+    // percent — bounded here at 10% and expected to shrink with segment
+    // count. (The exact framework agreement is Gate 1; discretization is a
+    // property of the mesh, not the seam.)
+    let dmink = {
+        let h = 1e-6;
+        (minkowski(R0 + h) - minkowski(R0 - h)) / (2.0 * h)
+    };
+    let gap = (dv - dmink).abs() / dmink.abs();
+    assert!(
+        gap < 0.10,
+        "continuum gap {gap:.3} exceeds the documented polygonization band"
+    );
+    assert!((v - minkowski(R0)).abs() / minkowski(R0) < 0.01);
+}
+
+#[test]
+fn m4_fillet_radius_optimized_to_target_volume() {
+    // Close the loop on the fillet parameter itself: pick the radius whose
+    // rounded cube matches a target volume, by gradient descent through
+    // the seam. Target = volume at r* = 2.2 (computed with the same frozen
+    // discretization so the optimum is exact for the discrete objective).
+    let r_star = 2.2;
+    let target = {
+        let brep = build(&[r_star]);
+        let plan = capture_plan(&brep, &tess_params()).expect("capture target");
+        let seam =
+            evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new()).expect("seam target");
+        volume_with_derivative(&seam).0
+    };
+
+    let objective = move |seam: &SeamMesh| -> (f64, f64) {
+        let (v, dv) = volume_with_derivative(seam);
+        let miss = (v - target) / target;
+        (miss * miss, 2.0 * miss * dv / target)
+    };
+
+    let result = minimize(
+        &build,
+        &|brep, _k| {
+            seeding(brep, {
+                // The blend radius IS θ; read it back from the built model so
+                // the seeding stays honest at every iterate.
+                brep.geometry
+                    .surfaces
+                    .iter()
+                    .find_map(|s| {
+                        s.as_any()
+                            .downcast_ref::<CylinderSurface>()
+                            .map(|c| c.radius)
+                    })
+                    .expect("rounded cube has blends")
+            })
+        },
+        &objective,
+        &[1.0],
+        &tess_params(),
+        &OptimizeOptions {
+            max_iters: 60,
+            initial_step: 5.0,
+            min_step: 1e-9,
+            grad_tol: 1e-10,
+            bounds: vec![(0.5, 4.0)],
+        },
+    )
+    .expect("optimize");
+
+    assert!(result.stop != StopReason::MaxIters, "failed to converge");
+    assert!(
+        (result.theta[0] - r_star).abs() < 1e-3,
+        "found r = {} vs target r* = {r_star}",
+        result.theta[0]
+    );
+}

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -33,7 +33,7 @@
 use std::collections::HashMap;
 
 use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind};
-use vcad_kernel_math::{Point2, Point3};
+use vcad_kernel_math::{Point2, Point3, Vec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_topo::{FaceId, Orientation, VertexId};
 
@@ -143,6 +143,138 @@ pub enum NodeRecipe {
     },
 }
 
+/// The parameterization frame of a face's surface, snapshotted at capture.
+///
+/// Construction-order-nondeterministic kernels (the fillet pipeline picks
+/// blend-cylinder axis signs by hash order) can rebuild the *same
+/// geometric surface* with a different frame, silently changing what a
+/// frozen `(u, v)` means. Evaluation therefore transports frozen samples
+/// through the rebuilt frame (see `transport_uv`) instead of trusting raw
+/// parameters across builds.
+#[derive(Debug, Clone, Copy)]
+pub enum FaceFrame {
+    /// Planar frame: `(u, v)` are in-plane coordinates.
+    Plane {
+        /// Frame origin.
+        origin: Point3,
+    },
+    /// Cylindrical frame: `u` is the angle from `ref_dir` about `axis`,
+    /// `v` the height along `axis` from `center`.
+    Cylinder {
+        /// Axis base point.
+        center: Point3,
+        /// Unit axis.
+        axis: Vec3,
+        /// Unit u = 0 direction.
+        ref_dir: Vec3,
+    },
+    /// Spherical frame: `u` longitude from `ref_dir`, `v` latitude toward
+    /// `axis`.
+    Sphere {
+        /// Sphere center.
+        center: Point3,
+        /// Unit pole direction.
+        axis: Vec3,
+        /// Unit u = 0 direction.
+        ref_dir: Vec3,
+    },
+    /// No transport support: frozen `(u, v)` are used verbatim (correct
+    /// only when the construction rebuilds frames deterministically).
+    Other,
+}
+
+/// Snapshot a surface's parameterization frame.
+pub fn face_frame(surface: &dyn Surface) -> FaceFrame {
+    match surface.surface_type() {
+        SurfaceKind::Plane => match surface.as_any().downcast_ref::<Plane>() {
+            Some(p) => FaceFrame::Plane { origin: p.origin },
+            None => FaceFrame::Other,
+        },
+        SurfaceKind::Cylinder => match surface.as_any().downcast_ref::<CylinderSurface>() {
+            Some(c) => FaceFrame::Cylinder {
+                center: c.center,
+                axis: *c.axis.as_ref(),
+                ref_dir: *c.ref_dir.as_ref(),
+            },
+            None => FaceFrame::Other,
+        },
+        SurfaceKind::Sphere => match surface.as_any().downcast_ref::<SphereSurface>() {
+            Some(s) => FaceFrame::Sphere {
+                center: s.center,
+                axis: *s.axis.as_ref(),
+                ref_dir: *s.ref_dir.as_ref(),
+            },
+            None => FaceFrame::Other,
+        },
+        _ => FaceFrame::Other,
+    }
+}
+
+/// Map a frozen `(u, v)` from its capture-time frame into `rebuilt`'s
+/// frame, so the sample denotes the same *material* point regardless of
+/// how the rebuild chose axis signs / reference directions.
+///
+/// Planes use anchor projection (in-plane motion of an infinite plane is
+/// unobservable, so the projection of the capture-time anchor is the
+/// frozen-sample convention); cylinders and spheres transport the sample's
+/// direction vector; unsupported kinds return the parameters verbatim.
+pub fn transport_uv(
+    frame: &FaceFrame,
+    rebuilt: &dyn Surface,
+    uv: Point2,
+    anchor: &Point3,
+) -> Point2 {
+    match frame {
+        FaceFrame::Plane { .. } => match rebuilt.as_any().downcast_ref::<Plane>() {
+            Some(p) => p.project(anchor),
+            None => uv,
+        },
+        FaceFrame::Cylinder {
+            center,
+            axis,
+            ref_dir,
+        } => match rebuilt.as_any().downcast_ref::<CylinderSurface>() {
+            Some(c) => {
+                let y = axis.cross(*ref_dir);
+                let d = *ref_dir * uv.x.cos() + y * uv.x.sin();
+                let axis2 = *c.axis.as_ref();
+                let ref2 = *c.ref_dir.as_ref();
+                let y2 = axis2.cross(ref2);
+                let u2 = d
+                    .dot(y2)
+                    .atan2(d.dot(ref2))
+                    .rem_euclid(2.0 * std::f64::consts::PI);
+                let v2 = (*center - c.center).dot(axis2) + uv.y * axis.dot(axis2);
+                Point2::new(u2, v2)
+            }
+            None => uv,
+        },
+        FaceFrame::Sphere {
+            center: _,
+            axis,
+            ref_dir,
+        } => match rebuilt.as_any().downcast_ref::<SphereSurface>() {
+            Some(s) => {
+                let y = axis.cross(*ref_dir);
+                let (cu, su) = (uv.x.cos(), uv.x.sin());
+                let (cv, sv) = (uv.y.cos(), uv.y.sin());
+                let d = (*ref_dir * cu + y * su) * cv + *axis * sv;
+                let axis2 = *s.axis.as_ref();
+                let ref2 = *s.ref_dir.as_ref();
+                let y2 = axis2.cross(ref2);
+                let v2 = d.dot(axis2).clamp(-1.0, 1.0).asin();
+                let u2 = d
+                    .dot(y2)
+                    .atan2(d.dot(ref2))
+                    .rem_euclid(2.0 * std::f64::consts::PI);
+                Point2::new(u2, v2)
+            }
+            None => uv,
+        },
+        FaceFrame::Other => uv,
+    }
+}
+
 /// A frozen tessellation: recipes for every node, frozen connectivity, and
 /// the topology signature of the B-rep the plan was captured from.
 #[derive(Debug, Clone)]
@@ -151,6 +283,9 @@ pub struct FrozenPlan {
     pub signature: TopologySignature,
     /// Per-node recompute recipes.
     pub nodes: Vec<NodeRecipe>,
+    /// Capture-time parameterization frame of each face in the canonical
+    /// traversal (indexed by the same slots recipes use).
+    pub face_frames: Vec<FaceFrame>,
     /// Node positions at the capture-time parameter value. Used to recover
     /// entity correspondence geometrically when a plan is evaluated against
     /// a rebuilt B-rep whose enumeration order differs (the boolean
@@ -418,15 +553,21 @@ fn invert_uv(surface: &dyn Surface, p: &Point3) -> Result<Point2, FrozenError> {
     }
 }
 
-/// Preference between two same-surface `SurfaceUv` recipes for a coincident
-/// node: a sample on a curved surface pins two position DOF, a sample on a
-/// plane pins one. (Coincident nodes on *distinct* surfaces are upgraded to
-/// [`NodeRecipe::Boundary`] instead, which tracks the moving trim no matter
-/// which surface carries θ; a matched topology vertex always wins.)
+/// Preference between two `SurfaceUv` recipes for a coincident node,
+/// by how many position DOF the surface's curvature pins: doubly-curved >
+/// singly-curved > flat. This also decides *tangent* pairs, where the
+/// Boundary upgrade correctly refuses (no transverse intersection): e.g.
+/// a corner-sphere/blend-cylinder contact arc must bind to the sphere —
+/// the sphere's frozen sample tracks the arc under a fillet-radius change
+/// while a cylinder-bound sample would freeze its axial coordinate.
+/// (Coincident nodes on *distinct, transverse* surfaces are upgraded to
+/// [`NodeRecipe::Boundary`] instead; a matched topology vertex always
+/// wins.)
 fn kind_rank(kind: SurfaceKind) -> u8 {
     match kind {
         SurfaceKind::Plane => 0,
-        _ => 1,
+        SurfaceKind::Cylinder | SurfaceKind::Cone | SurfaceKind::Bilinear => 1,
+        SurfaceKind::Sphere | SurfaceKind::Torus | SurfaceKind::BSpline => 2,
     }
 }
 
@@ -548,6 +689,11 @@ pub fn capture_plan(
     let ci = canonical_index(brep);
     let signature = signature_with_index(brep, &ci);
 
+    let face_frames: Vec<FaceFrame> = ci
+        .faces
+        .iter()
+        .map(|&fid| face_frame(brep.geometry.surfaces[topo.faces[fid].surface_index].as_ref()))
+        .collect();
     let mut nodes: Vec<NodeRecipe> = Vec::new();
     let mut base_positions: Vec<Point3> = Vec::new();
     let mut node_kinds: Vec<SurfaceKind> = Vec::new();
@@ -758,6 +904,7 @@ pub fn capture_plan(
     Ok(FrozenPlan {
         signature,
         nodes,
+        face_frames,
         base_positions,
         triangles,
     })
@@ -793,33 +940,72 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
     }
 
     let topo = &brep.topology;
-    // Face slot (capture-time traversal index) → matched rebuilt face.
-    let mut face_match: HashMap<u32, FaceId> = HashMap::new();
-    // Resolve a capture-time face slot to a rebuilt face: the face whose
-    // surface, evaluated at the frozen (u, v), lands nearest the node's
-    // capture-time anchor.
-    fn resolve_face(
-        brep: &BRepSolid,
-        ci: &CanonicalIndex,
-        face_match: &mut HashMap<u32, FaceId>,
-        slot: u32,
-        uv: Point2,
-        anchor: &Point3,
-        node: usize,
-    ) -> Result<FaceId, FrozenError> {
-        if let Some(&f) = face_match.get(&slot) {
-            return Ok(f);
+
+    // Resolve every referenced face slot up front, against ALL of the
+    // slot's samples at once: the matched face must reproduce every frozen
+    // sample (frame-transported) near its anchor. Matching per-node would
+    // let an ambiguous first sample — e.g. a node on the shared edge of
+    // two faces, whose anchor lies on both planes — poison the slot's
+    // cache for every later node. Transporting through each candidate's
+    // frame makes the match robust to rebuilds that pick different axis
+    // signs / reference directions for the same geometric surface (the
+    // fillet pipeline does), while the worst-sample distance criterion
+    // still disambiguates coplanar/co-axial distinct faces.
+    let mut slot_samples: std::collections::BTreeMap<u32, Vec<(Point2, Point3, usize)>> =
+        std::collections::BTreeMap::new();
+    for (i, recipe) in plan.nodes.iter().enumerate() {
+        let anchor = plan.base_positions[i];
+        match *recipe {
+            NodeRecipe::SurfaceUv { face, u, v } => {
+                slot_samples
+                    .entry(face)
+                    .or_default()
+                    .push((Point2::new(u, v), anchor, i));
+            }
+            NodeRecipe::Boundary {
+                face_a,
+                ua,
+                va,
+                face_b,
+                ub,
+                vb,
+            } => {
+                slot_samples
+                    .entry(face_a)
+                    .or_default()
+                    .push((Point2::new(ua, va), anchor, i));
+                slot_samples
+                    .entry(face_b)
+                    .or_default()
+                    .push((Point2::new(ub, vb), anchor, i));
+            }
+            NodeRecipe::TopoVertex { .. } => {}
         }
-        let topo = &brep.topology;
-        let mut best: Option<(FaceId, f64)> = None;
+    }
+    let mut face_match: HashMap<u32, FaceId> = HashMap::new();
+    for (&slot, samples) in &slot_samples {
+        let frame = plan
+            .face_frames
+            .get(slot as usize)
+            .ok_or(FrozenError::RecipeOutOfRange)?;
+        let mut best: Option<(FaceId, f64, usize)> = None;
         for &fid in &ci.faces {
-            let surface = &brep.geometry.surfaces[topo.faces[fid].surface_index];
-            let d2 = (surface.evaluate(uv) - *anchor).norm_squared();
-            if best.map(|(_, bd)| d2 < bd).unwrap_or(true) {
-                best = Some((fid, d2));
+            let surface = brep.geometry.surfaces[topo.faces[fid].surface_index].as_ref();
+            let mut worst = 0.0_f64;
+            let mut worst_node = samples[0].2;
+            for &(uv, anchor, node) in samples {
+                let uv2 = transport_uv(frame, surface, uv, &anchor);
+                let d2 = (surface.evaluate(uv2) - anchor).norm_squared();
+                if d2 > worst {
+                    worst = d2;
+                    worst_node = node;
+                }
+            }
+            if best.map(|(_, bd, _)| worst < bd).unwrap_or(true) {
+                best = Some((fid, worst, worst_node));
             }
         }
-        let (fid, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
+        let (fid, d2, node) = best.ok_or(FrozenError::RecipeOutOfRange)?;
         if d2 > MATCH_TOL * MATCH_TOL {
             return Err(FrozenError::CorrespondenceLost {
                 node,
@@ -827,8 +1013,13 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
             });
         }
         face_match.insert(slot, fid);
-        Ok(fid)
     }
+    let resolve_face = |slot: u32| -> Result<FaceId, FrozenError> {
+        face_match
+            .get(&slot)
+            .copied()
+            .ok_or(FrozenError::RecipeOutOfRange)
+    };
 
     let mut positions = Vec::with_capacity(plan.nodes.len());
     for (i, recipe) in plan.nodes.iter().enumerate() {
@@ -869,9 +1060,13 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
             }
             NodeRecipe::SurfaceUv { face, u, v } => {
                 let uv = Point2::new(u, v);
-                let face_id = resolve_face(brep, &ci, &mut face_match, face, uv, &anchor, i)?;
-                let surface = &brep.geometry.surfaces[topo.faces[face_id].surface_index];
-                let p = surface.evaluate(uv);
+                let face_id = resolve_face(face)?;
+                let surface = brep.geometry.surfaces[topo.faces[face_id].surface_index].as_ref();
+                let frame = plan
+                    .face_frames
+                    .get(face as usize)
+                    .ok_or(FrozenError::RecipeOutOfRange)?;
+                let p = surface.evaluate(transport_uv(frame, surface, uv, &anchor));
                 // Verify EVERY node against its anchor, not just the slot's
                 // first: a wrong face match that agrees near one sample but
                 // diverges elsewhere (tangent surfaces, duplicated boolean
@@ -886,32 +1081,9 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
                 }
                 p
             }
-            NodeRecipe::Boundary {
-                face_a,
-                ua,
-                va,
-                face_b,
-                ub,
-                vb,
-            } => {
-                let fa = resolve_face(
-                    brep,
-                    &ci,
-                    &mut face_match,
-                    face_a,
-                    Point2::new(ua, va),
-                    &anchor,
-                    i,
-                )?;
-                let fb = resolve_face(
-                    brep,
-                    &ci,
-                    &mut face_match,
-                    face_b,
-                    Point2::new(ub, vb),
-                    &anchor,
-                    i,
-                )?;
+            NodeRecipe::Boundary { face_a, face_b, .. } => {
+                let fa = resolve_face(face_a)?;
+                let fb = resolve_face(face_b)?;
                 let sa = brep.geometry.surfaces[topo.faces[fa].surface_index].as_ref();
                 let sb = brep.geometry.surfaces[topo.faces[fb].surface_index].as_ref();
                 let p = refine_boundary_point(sa, sb, &anchor)

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -218,6 +218,13 @@ pub fn face_frame(surface: &dyn Surface) -> FaceFrame {
 /// unobservable, so the projection of the capture-time anchor is the
 /// frozen-sample convention); cylinders and spheres transport the sample's
 /// direction vector; unsupported kinds return the parameters verbatim.
+///
+/// The direction reconstruction relies on the geom kernel's frame
+/// convention `y_dir = axis × ref_dir` (see `CylinderSurface::y_dir` /
+/// `SphereSurface::y_dir`) on both the capture and rebuilt sides; the
+/// `transport_uv_survives_reframed_cylinder_and_sphere` test round-trips
+/// through those surfaces' own `evaluate`, so a convention change in
+/// either crate fails loudly.
 pub fn transport_uv(
     frame: &FaceFrame,
     rebuilt: &dyn Surface,

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -1235,4 +1235,73 @@ mod tests {
         );
         assert_eq!(mesh2.open_edge_count(), 0);
     }
+
+    #[test]
+    fn transport_uv_survives_reframed_cylinder_and_sphere() {
+        // The scenario frame transport exists for: the same geometric
+        // surface rebuilt with a different frame (flipped axis, rotated
+        // ref_dir, center slid along the axis — the fillet kernel does all
+        // three between builds). Transporting a capture-time (u, v) must
+        // land the *rebuilt* surface's evaluate on the same material point.
+        // This also pins the frame convention: both sides reconstruct with
+        // y = axis × ref_dir, matching CylinderSurface/SphereSurface::y_dir.
+        use vcad_kernel_math::Dir3;
+
+        let axis = Vec3::new(0.3, -0.4, 0.85).normalize();
+        let ref_dir = axis.cross(Vec3::new(0.0, 0.0, 1.0)).normalize();
+        let y = axis.cross(ref_dir);
+        let cyl = CylinderSurface {
+            center: Point3::new(1.0, 2.0, 3.0),
+            axis: Dir3::new_normalize(axis),
+            ref_dir: Dir3::new_normalize(ref_dir),
+            radius: 2.5,
+        };
+        // Same cylinder: axis flipped, ref_dir rotated 0.7 rad about the
+        // axis, center slid 1.7 along it.
+        let phi = 0.7_f64;
+        let cyl2 = CylinderSurface {
+            center: cyl.center + axis * 1.7,
+            axis: Dir3::new_normalize(-axis),
+            ref_dir: Dir3::new_normalize(ref_dir * phi.cos() + y * phi.sin()),
+            radius: 2.5,
+        };
+        let frame = face_frame(&cyl);
+        for &(u, v) in &[(0.0, 0.0), (1.1, 4.0), (5.9, -2.5)] {
+            let uv = Point2::new(u, v);
+            let p = CylinderSurface::evaluate(&cyl, uv);
+            let uv2 = transport_uv(&frame, &cyl2, uv, &p);
+            let p2 = CylinderSurface::evaluate(&cyl2, uv2);
+            assert!(
+                (p2 - p).norm() < 1e-12,
+                "cylinder ({u}, {v}): {p:?} vs {p2:?}"
+            );
+        }
+
+        let sph = SphereSurface {
+            center: Point3::new(-2.0, 0.5, 4.0),
+            radius: 1.5,
+            ref_dir: Dir3::new_normalize(ref_dir),
+            axis: Dir3::new_normalize(axis),
+        };
+        // Same sphere under a completely different orthonormal frame.
+        let axis2 = Vec3::new(0.9, 0.1, -0.3).normalize();
+        let ref2 = axis2.cross(Vec3::new(0.0, 1.0, 0.0)).normalize();
+        let sph2 = SphereSurface {
+            center: sph.center,
+            radius: 1.5,
+            ref_dir: Dir3::new_normalize(ref2),
+            axis: Dir3::new_normalize(axis2),
+        };
+        let frame = face_frame(&sph);
+        for &(u, v) in &[(0.2, 0.3), (2.8, -1.1), (4.4, 1.4)] {
+            let uv = Point2::new(u, v);
+            let p = SphereSurface::evaluate(&sph, uv);
+            let uv2 = transport_uv(&frame, &sph2, uv, &p);
+            let p2 = SphereSurface::evaluate(&sph2, uv2);
+            assert!(
+                (p2 - p).norm() < 1e-12,
+                "sphere ({u}, {v}): {p:?} vs {p2:?}"
+            );
+        }
+    }
 }

--- a/docs/differentiable-seam-m4.md
+++ b/docs/differentiable-seam-m4.md
@@ -1,0 +1,118 @@
+# Differentiable seam — M4 design note
+
+M3 (see `differentiable-seam-m3.md`) closed the loop on primitive
+parameters: boundary recipes, mass-property QoIs, and the first geometry
+grown by gradient descent. M4 differentiates the parameter the whole
+project was aimed at from the start: a **fillet radius** — the canonical
+"real CAD" parameter, and the hard case for a frozen-topology seam,
+because one θ moves twenty surfaces at once, every moving trim is a
+*tangent* contact, and the fillet kernel itself is
+construction-order-nondeterministic.
+
+The proving model is the all-edges-filleted cube (the kernel's supported
+fillet path): 6 inset planes, 12 quarter-cylinder edge blends, 8
+sphere-octant corners. θ = the blend radius `r`. The continuum ground
+truth is the Minkowski sum of the shrunken cube with a ball:
+`V(r) = a³ + 6a²r + 3πar² + (4/3)πr³` with `a = L − 2r`.
+
+## What landed
+
+### Composite seeds (`ParamSeeding` now composes)
+
+A fillet radius does not perturb any surface through a single field: each
+blend cylinder's **radius grows at rate 1 while its axis simultaneously
+retreats from the edge** (velocity ±1 per non-axial coordinate), and each
+corner sphere does the same in three coordinates. `ParamSeeding` therefore
+maps a surface index to a *list* of `SurfaceSeed`s, applied additively by
+the lift-bridge and by the implicit rows (`∂g/∂θ` sums over seeds). One
+seed per surface — the M0–M3 shape — is just the singleton case, so all
+existing call sites kept their meaning.
+
+### Frame transport (`FaceFrame`, `transport_uv`)
+
+The fillet pipeline picks blend-frame axis signs by hash order, so a
+rebuild at θ + h can produce the *same geometric surface* with a flipped
+axis or rotated `ref_dir` — silently changing what a frozen `(u, v)`
+means and poisoning the FD oracle. The plan now snapshots each face's
+parameterization frame at capture, and `evaluate_plan` transports frozen
+samples through the rebuilt frame instead of trusting raw parameters:
+angle/height transport for cylinders and spheres (project the captured
+`u = 0` direction into the rebuilt frame), anchor projection for planes.
+
+Face-slot resolution had to harden with it: a slot is matched to the
+rebuilt face minimizing the **worst** transported-sample distance over
+*all* of the slot's samples, not the first — an edge node shared by two
+faces can agree with the wrong face near one sample and diverge
+elsewhere, and a first-sample match cached that wrong binding for the
+whole slot. Every node is still verified against its capture-time anchor
+after transport (`CorrespondenceLost` on failure, never a silent wrong
+answer).
+
+### Tangency completion (`tangency_rows`)
+
+M3's closing note predicted the tangent trim would need a second-order
+boundary solve. It doesn't — the resolution is cheaper and more
+instructive, in two parts:
+
+- **On the tangent line itself** there is nothing to solve. The tangent
+  line is `u = const` on the blend, so a frozen-`(u, v)` interior sample
+  with the composite seed already tracks it *exactly* (Pillar 2): retreat
+  `(0, 1, −1)` plus radial growth `(0, 0, 1)` compose to the true slide
+  `(0, 1, 0)` along the support face. The Boundary-upgrade check refuses
+  tangent pairs (their Newton system is singular), routing these nodes to
+  the lift-bridge — the machinery that was already correct.
+- **At the corner vertices** where tangent lines cross, the implicit
+  system is genuinely rank-deficient: a curved surface resting
+  tangentially on a plane contributes a row parallel to the plane's row,
+  so the completion policy ("frozen directions stay put") pinned a vertex
+  that actually slides diagonally along the support face — the analytic
+  velocity came out 0 where FD said `(±1, ±1, 0)`. The missing
+  information is the **tangent-curve constraint**: the vertex must stay
+  on the curve where the moving surface touches the plane. `tangency_rows`
+  adds it — for a cylinder tangent to a plane with normal `n`, direction
+  `q = axis × n` with rhs `q · ẋ_translate`; for a sphere, two such rows
+  spanning `n⊥`. First-order rows, no curvature solve, and they vanish
+  identically for non-tangent configurations.
+
+Recipe preference during capture also learned curvature rank
+(plane < singly-curved < doubly-curved), so a node shared by a blend and
+its support plane freezes `(u, v)` on the surface whose parameters pin it
+in more directions.
+
+### The gates (`m4_fillet_radius.rs`)
+
+- **Seam vs FD oracle** at `r = 1.5`, `L = 10`: `dV/dr = −72.807`,
+  matching central differences at `h = 1e-6` to **1.7e-8** (gate 1e-6) —
+  across all 20 simultaneously-moving composite-seeded surfaces, under
+  frame-transported correspondence.
+- **Node-wise dx/dr** over all 836 mesh nodes: max rel err **3.2e-9**.
+- **Exact spot-checks**: interior tangent-line nodes slide at exactly
+  `(0, 1, 0)`; the corner vertex at `(r, r, L)` slides at exactly
+  `(1, 1, 0)` — the rank-deficient case the tangency rows exist for.
+- **Continuum**: 6.7% from the closed-form Minkowski derivative, inside
+  the documented polygonization band for 16-segment blends (the exact
+  framework agreement is the FD gate; discretization is a property of the
+  mesh, not the seam).
+- **The loop closes on the fillet itself**: projected gradient descent
+  through the seam recovers the radius whose rounded cube hits a target
+  volume to 1e-3 (`r* = 2.2` from `r₀ = 1.0`), reading the radius back
+  from the built model at every iterate so the seeding stays honest.
+
+## Notes and boundaries
+
+- The model uses `fillet_all_edges`; single-edge `fillet_edges_detailed`
+  currently produces a malformed solid (it insets all six faces but emits
+  one blend), which is a fillet-kernel bug independent of the seam — the
+  seam's topology-signature and anchor checks are exactly the machinery
+  that caught it.
+- `tangency_rows` covers cylinder-on-plane and sphere-on-plane, the
+  contacts fillets and chamfers of planar-faced parts produce. Tangent
+  pairs of two curved surfaces (variable-radius blends over curved
+  supports) extend the same way: the tangent-curve direction is
+  `∇g_a × (∇g_a × ∇g_b)`-degenerate, but the rows stay first-order.
+- Frame transport currently covers plane/cylinder/sphere frames — the
+  kinds the fillet pipeline emits. Cone/torus transport slots into the
+  same `FaceFrame` enum when a consumer needs it.
+- Forward mode remains one seam pass per parameter; a part with dozens of
+  independent fillet radii is where reverse mode (M5) picks up, behind
+  the same `SeamMesh` interface.


### PR DESCRIPTION
## What this is

M4 of the differentiable seam (M0–M2: #379, M3: #380): **dV/dr of a fillet radius** — the canonical "real CAD" parameter, and the hard case for a frozen-topology seam. The proving model is the all-edges-filleted cube (6 inset planes, 12 quarter-cylinder edge blends, 8 sphere-octant corners): one θ moves **twenty surfaces at once**, every moving trim is a *tangent* contact, and the fillet kernel rebuilds blend frames nondeterministically between builds.

Design note: `docs/differentiable-seam-m4.md`.

## What landed

**Composite seeds.** A fillet radius perturbs no surface through a single field: each blend's radius grows at rate 1 while its axis simultaneously retreats from the edge. `ParamSeeding` now maps a surface to a *list* of `SurfaceSeed`s, applied additively by the lift-bridge and the implicit rows. The M0–M3 single-seed shape is the singleton case; all existing call sites keep their meaning.

**Frame transport (`FaceFrame` / `transport_uv`).** The fillet pipeline picks blend-frame axis signs by hash order, so a rebuild at θ+h can produce the same geometric surface with a flipped axis — silently changing what a frozen `(u, v)` means and poisoning the FD oracle. The plan now snapshots each face's parameterization frame at capture, and evaluation transports frozen samples through the rebuilt frame (angle/height transport for cylinders and spheres, anchor projection for planes). Face-slot resolution matches on the **worst** transported-sample distance over all of a slot's samples, and every node is still anchor-verified after transport (`CorrespondenceLost` on failure, never a silent wrong answer).

**Tangency completion (`tangency_rows`).** The M3 note predicted the tangent trim would need a second-order boundary solve. It doesn't:

- *On the tangent line*, there is nothing to solve — a frozen-`(u,v)` interior sample with the composite seed already tracks it exactly (retreat `(0,1,−1)` + radial growth `(0,0,1)` compose to the true slide `(0,1,0)`), and the Boundary-upgrade check refuses the singular tangent pair, routing those nodes to the lift-bridge.
- *At corner vertices* where tangent lines cross, the implicit system is genuinely rank-deficient (a surface tangent to a plane contributes a row parallel to the plane's row), so the frozen-direction completion pinned a vertex that actually slides diagonally along its support face. `tangency_rows` adds the missing tangent-curve constraint — first-order rows (`q = axis × n` for a cylinder, two rows spanning `n⊥` for a sphere), no curvature solve, vanishing identically for non-tangent configurations.

Recipe preference during capture also learned curvature rank (plane < singly-curved < doubly-curved) for `(u,v)`-freezing at shared nodes.

## Gates (`m4_fillet_radius.rs`)

| Gate | Requirement | Measured |
|---|---|---|
| Seam dV/dr vs FD oracle (h = 1e-6) | ≤ 1e-6 | **1.7e-8** |
| Node-wise dx/dr, all 836 nodes | ≤ 1e-6 | **3.2e-9** |
| Tangent-line node slide | exact `(0,1,0)` | < 1e-9 |
| Corner-vertex diagonal slide | exact `(1,1,0)` | < 1e-9 |
| Continuum (Minkowski closed form) | within polygonization band | 6.7% (< 10%) |
| Optimizer recovers target radius | — | r* = 2.2 hit to 1e-3 from r₀ = 1.0 |

The optimizer test closes the loop on the fillet parameter itself: projected gradient descent through the seam picks the radius whose rounded cube hits a target volume, reading the radius back from the built model at every iterate so the seeding stays honest.

## Validation

- `cargo test` on the touched crates + scoped workspace suite: **1604 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings` clean on touched crates
- `cargo fmt --all --check` clean

## Notes

- The model uses `fillet_all_edges`; single-edge `fillet_edges_detailed` currently produces a malformed solid (insets all six faces, emits one blend) — a pre-existing fillet-kernel bug independent of the seam, which the seam's signature/anchor checks are exactly the machinery that caught. Filed in the design note.
- No changelog entry: `vcad-kernel-diff` remains a WIP crate with no consumers (per the changelog policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_