### PR TITLE
Differentiable seam M5: reverse mode — one pullback prices every parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,8 +113,8 @@ vcad/
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
 │   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations,
 │   #                            # mass-property QoIs, optimizer harness, differentiable
-│   #                            # fillet radius (docs/differentiable-seam-m0-m2.md,
-│   #                            # -m3.md, -m4.md); no consumers yet
+│   #                            # fillet radius, reverse-mode adjoint (docs/
+│   #                            # differentiable-seam-m0-m2.md … -m5.md); no consumers yet
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/crates/vcad-kernel-diff/src/adjoint.rs
+++ b/crates/vcad-kernel-diff/src/adjoint.rs
@@ -1,0 +1,325 @@
+//! M5 — reverse mode: the adjoint seam.
+//!
+//! Forward mode ([`crate::evaluate_with_sensitivity`]) costs one seam pass
+//! **per parameter**: each θ_k needs its own [`ParamSeeding`] and its own
+//! velocity field. Reverse mode transposes the seam once: given a mesh
+//! functional's gradient `∂J/∂x_i` (from [`crate::volume_gradient`], a
+//! physics adjoint, or any other source), [`evaluate_with_pullback`]
+//! accumulates the gradient of `J` with respect to every surface's
+//! *seed slots* — its translation velocity and radius rate. Contracting
+//! those cotangents against any number of seedings
+//! ([`MeshCotangents::contract`]) is then a handful of dot products per
+//! parameter, with **no further seam evaluations**:
+//!
+//! ```text
+//! dJ/dθ_k = Σ_s ⟨cotangent_s, seeds_k(s)⟩
+//! ```
+//!
+//! The transpose never re-derives a formula the forward path owns. Node
+//! velocities are linear in the seed values, through two linear maps:
+//!
+//! - **Lift-bridge nodes** (`SurfaceUv`): the map's columns are read off by
+//!   evaluating the *forward* lift with unit basis seeds (unit translations
+//!   and a unit radius rate), so the adjoint is exact by construction.
+//! - **Implicit nodes** (`TopoVertex`, `Boundary`): the vertex solve is
+//!   linear in the row rhs vector ([`crate::row_pullbacks`] returns
+//!   `m_j = ∂ẋ/∂rhs_j`), and each row's rhs is linear in its owning
+//!   surface's seeds — columns again read off by re-materializing the row
+//!   with unit basis seeds through the same constructors the forward pass
+//!   uses ([`RowSource`] keeps the correspondence).
+//!
+//! Basis probing happens strictly **per row / per surface**, never through
+//! a joint vertex solve: seeding one surface at a time through the full
+//! solve would trip the consistency check whenever a moving surface has
+//! duplicate copies in a boolean's store (each copy's row would contradict
+//! the others'), which is precisely the case `seed_where` exists for.
+
+use std::collections::{BTreeMap, HashMap};
+
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{refine_boundary_point, FrozenError, FrozenPlan, NodeRecipe};
+
+use crate::seam::{
+    assemble_vertex_rows, checked_index, incidence_context, vertex_incident_surfaces, RowSource,
+};
+use crate::{
+    lift_surface, row_pullbacks, ConstraintRow, DiffError, DualSurface, ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::SurfaceKind;
+
+/// Gradient of a mesh functional `J` with respect to one surface's seed
+/// slots.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct SurfaceCotangent {
+    /// ∂J/∂(translation velocity): contract with a
+    /// [`SurfaceSeed::Translate`]'s velocity.
+    pub translate: Vec3,
+    /// ∂J/∂(radius rate): contract with a [`SurfaceSeed::CylinderRadius`] /
+    /// [`SurfaceSeed::SphereRadius`] rate. Zero for kinds without a radius.
+    pub radius: f64,
+}
+
+/// Per-surface cotangents of a mesh functional: the output of one
+/// reverse-mode seam pass, contractable against any number of parameter
+/// seedings.
+#[derive(Debug, Clone, Default)]
+pub struct MeshCotangents {
+    per_surface: BTreeMap<usize, SurfaceCotangent>,
+}
+
+impl MeshCotangents {
+    /// The cotangent of the surface at `surface_index` (zero if the
+    /// functional is insensitive to it).
+    pub fn get(&self, surface_index: usize) -> SurfaceCotangent {
+        self.per_surface
+            .get(&surface_index)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// `dJ/dθ = Σ_s ⟨cotangent_s, seeds(s)⟩` for one parameter's seeding.
+    ///
+    /// The seeding must be one the forward path would accept for the same
+    /// B-rep: valid seed kinds per surface, and every copy of a moving
+    /// surface seeded together (as [`ParamSeeding::seed_where`] does).
+    /// Forward evaluation is where invalid seedings are *detected*; the
+    /// contraction is a plain bilinear form and cannot check them.
+    pub fn contract(&self, seeding: &ParamSeeding) -> f64 {
+        let mut total = 0.0;
+        for (&sidx, cot) in &self.per_surface {
+            for seed in seeding.get(sidx) {
+                total += match *seed {
+                    SurfaceSeed::Translate { velocity } => cot.translate.dot(velocity),
+                    SurfaceSeed::CylinderRadius { rate } | SurfaceSeed::SphereRadius { rate } => {
+                        cot.radius * rate
+                    }
+                };
+            }
+        }
+        total
+    }
+}
+
+/// The unit basis seed for a surface's radius slot, if the kind has one.
+fn radius_basis(kind: SurfaceKind) -> Option<SurfaceSeed> {
+    match kind {
+        SurfaceKind::Cylinder => Some(SurfaceSeed::CylinderRadius { rate: 1.0 }),
+        SurfaceKind::Sphere => Some(SurfaceSeed::SphereRadius { rate: 1.0 }),
+        _ => None,
+    }
+}
+
+fn translate_bases() -> [Vec3; 3] {
+    [
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+    ]
+}
+
+/// Re-materialize one vertex-system row from its source with a single
+/// basis seed and read its rhs — the row's seed-Jacobian column.
+fn row_rhs_column(
+    brep: &BRepSolid,
+    source: &RowSource,
+    seed: SurfaceSeed,
+    x: &Point3,
+) -> Result<f64, DiffError> {
+    match *source {
+        RowSource::Constraint { surface } => {
+            let s = brep.geometry.surfaces[surface].as_ref();
+            Ok(crate::constraint_row(s, &[seed], x)?.rhs)
+        }
+        RowSource::Tangency {
+            plane_normal,
+            surface,
+            index,
+        } => {
+            let s = brep.geometry.surfaces[surface].as_ref();
+            let rows = crate::tangency_rows(plane_normal, s, &[seed], x)?;
+            Ok(rows[index].rhs)
+        }
+    }
+}
+
+fn source_surface(source: &RowSource) -> usize {
+    match *source {
+        RowSource::Constraint { surface } | RowSource::Tangency { surface, .. } => surface,
+    }
+}
+
+/// Accumulate `λ · ∂rhs/∂seeds` of one row into its surface's cotangent.
+fn accumulate_row(
+    brep: &BRepSolid,
+    source: &RowSource,
+    lambda: f64,
+    x: &Point3,
+    cots: &mut BTreeMap<usize, SurfaceCotangent>,
+) -> Result<(), DiffError> {
+    if lambda == 0.0 {
+        return Ok(());
+    }
+    let sidx = source_surface(source);
+    let kind = brep.geometry.surfaces[sidx].surface_type();
+    let mut translate = Vec3::new(0.0, 0.0, 0.0);
+    for (axis, e) in translate_bases().iter().enumerate() {
+        let col = row_rhs_column(brep, source, SurfaceSeed::Translate { velocity: *e }, x)?;
+        match axis {
+            0 => translate.x = col,
+            1 => translate.y = col,
+            _ => translate.z = col,
+        }
+    }
+    let radius = match radius_basis(kind) {
+        Some(seed) => row_rhs_column(brep, source, seed, x)?,
+        None => 0.0,
+    };
+    let cot = cots.entry(sidx).or_default();
+    cot.translate += translate * lambda;
+    cot.radius += radius * lambda;
+    Ok(())
+}
+
+/// Reverse-mode seam evaluation: pull a mesh functional's gradient
+/// `∂J/∂x` back to per-surface seed cotangents in **one pass**.
+///
+/// `brep` must be the capture-time B-rep, exactly as for
+/// [`crate::evaluate_with_sensitivity`] — the same signature and anchor
+/// checks are enforced. `mesh_gradient` is indexed like the plan's nodes
+/// (one gradient per node, e.g. from [`crate::volume_gradient`]).
+///
+/// The returned cotangents satisfy, for every seeding the forward path
+/// accepts on this B-rep,
+///
+/// ```text
+/// cotangents.contract(seeding) == contract_sensitivity(forward(seeding), mesh_gradient)
+/// ```
+///
+/// so `n` parameters cost one pullback plus `n` dot products instead of
+/// `n` forward passes.
+pub fn evaluate_with_pullback(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+    mesh_gradient: &[Vec3],
+) -> Result<MeshCotangents, DiffError> {
+    if mesh_gradient.len() != plan.nodes.len() {
+        return Err(DiffError::GradientLengthMismatch {
+            expected: plan.nodes.len(),
+            got: mesh_gradient.len(),
+        });
+    }
+    let ci = checked_index(brep, plan)?;
+    let topo = &brep.topology;
+    let ctx = incidence_context(brep, &ci.faces);
+    let empty = ParamSeeding::new();
+
+    // Forward-lifted surfaces with one unit basis seed each, cached per
+    // (face slot, basis): 0..=2 are unit translations, 3 the radius rate.
+    let mut lifted: HashMap<(u32, u8), DualSurface> = HashMap::new();
+
+    let anchor_check = |node: usize, p: &Point3, anchor: &Point3| -> Result<(), DiffError> {
+        let d2 = (*p - *anchor).norm_squared();
+        if d2 > crate::seam::ANCHOR_TOL * crate::seam::ANCHOR_TOL {
+            return Err(FrozenError::CorrespondenceLost {
+                node,
+                distance: d2.sqrt(),
+            }
+            .into());
+        }
+        Ok(())
+    };
+
+    let mut cots: BTreeMap<usize, SurfaceCotangent> = BTreeMap::new();
+
+    for (i, recipe) in plan.nodes.iter().enumerate() {
+        let w = mesh_gradient[i];
+        match *recipe {
+            NodeRecipe::TopoVertex { vertex } => {
+                let vid = *ci
+                    .vertices
+                    .get(vertex as usize)
+                    .ok_or(FrozenError::RecipeOutOfRange)?;
+                let x = topo.vertices[vid].point;
+                anchor_check(i, &x, &plan.base_positions[i])?;
+                let incident = vertex_incident_surfaces(brep, &ctx, vid, &x);
+                let sourced = assemble_vertex_rows(brep, &incident, &empty, &x)?;
+                let rows: Vec<ConstraintRow> = sourced.iter().map(|(_, row)| *row).collect();
+                let m = row_pullbacks(&rows);
+                for ((source, _), mj) in sourced.iter().zip(&m) {
+                    accumulate_row(brep, source, w.dot(*mj), &x, &mut cots)?;
+                }
+            }
+            NodeRecipe::SurfaceUv { face, u, v } => {
+                let surface_index = {
+                    let face_id = *ci
+                        .faces
+                        .get(face as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    topo.faces[face_id].surface_index
+                };
+                let kind = brep.geometry.surfaces[surface_index].surface_type();
+                let uv = vcad_kernel_math::Point2::new(u, v);
+                let mut basis_velocity = |basis: u8| -> Result<(Point3, Vec3), DiffError> {
+                    if let std::collections::hash_map::Entry::Vacant(e) =
+                        lifted.entry((face, basis))
+                    {
+                        let seed = match basis {
+                            0..=2 => SurfaceSeed::Translate {
+                                velocity: translate_bases()[basis as usize],
+                            },
+                            _ => radius_basis(kind).expect("radius basis exists"),
+                        };
+                        let surface = brep.geometry.surfaces[surface_index].as_ref();
+                        e.insert(lift_surface(surface, &[seed])?);
+                    }
+                    Ok(lifted[&(face, basis)].evaluate_with_velocity(uv))
+                };
+                let (p, vx) = basis_velocity(0)?;
+                anchor_check(i, &p, &plan.base_positions[i])?;
+                let (_, vy) = basis_velocity(1)?;
+                let (_, vz) = basis_velocity(2)?;
+                let vr = match radius_basis(kind) {
+                    Some(_) => basis_velocity(3)?.1,
+                    None => Vec3::new(0.0, 0.0, 0.0),
+                };
+                let cot = cots.entry(surface_index).or_default();
+                cot.translate += Vec3::new(w.dot(vx), w.dot(vy), w.dot(vz));
+                cot.radius += w.dot(vr);
+            }
+            NodeRecipe::Boundary { face_a, face_b, .. } => {
+                let sidx = |slot: u32| -> Result<usize, DiffError> {
+                    let face_id = *ci
+                        .faces
+                        .get(slot as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    Ok(topo.faces[face_id].surface_index)
+                };
+                let (sidx_a, sidx_b) = (sidx(face_a)?, sidx(face_b)?);
+                let sa = brep.geometry.surfaces[sidx_a].as_ref();
+                let sb = brep.geometry.surfaces[sidx_b].as_ref();
+                let anchor = plan.base_positions[i];
+                let x = refine_boundary_point(sa, sb, &anchor)
+                    .ok_or(FrozenError::BoundarySolveFailed { node: i })?;
+                anchor_check(i, &x, &anchor)?;
+                let sourced = [
+                    (
+                        RowSource::Constraint { surface: sidx_a },
+                        crate::constraint_row(sa, &[], &x)?,
+                    ),
+                    (
+                        RowSource::Constraint { surface: sidx_b },
+                        crate::constraint_row(sb, &[], &x)?,
+                    ),
+                ];
+                let rows: Vec<ConstraintRow> = sourced.iter().map(|(_, row)| *row).collect();
+                let m = row_pullbacks(&rows);
+                for ((source, _), mj) in sourced.iter().zip(&m) {
+                    accumulate_row(brep, source, w.dot(*mj), &x, &mut cots)?;
+                }
+            }
+        }
+    }
+
+    Ok(MeshCotangents { per_surface: cots })
+}

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -273,6 +273,59 @@ pub fn solve_vertex_velocity(rows: &[ConstraintRow]) -> Result<Vec3, DiffError> 
     Ok(v)
 }
 
+/// The reverse-mode companion of [`solve_vertex_velocity`]: the solution's
+/// sensitivity `m_j = ∂ẋ/∂rhs_j` to each row's right-hand side, so that
+/// `ẋ = Σ_j m_j · rhs_j` for any rhs assignment over the same gradients.
+///
+/// The Gram–Schmidt solution is linear in the rhs vector with coefficients
+/// determined by the gradients alone; this runs the same elimination while
+/// carrying each basis coefficient as a linear functional over the rows
+/// (a vector of weights) instead of a scalar, then transposes. Rows dropped
+/// as dependent get a **zero column**: their rhs never enters the solution.
+/// In the forward path a dependent row's rhs is consistency-checked against
+/// the rows that were kept; the pullback has no concrete rhs to check, so it
+/// *presumes* the seedings it will be contracted against are consistent
+/// (every copy of a moving surface seeded together, as
+/// [`crate::ParamSeeding::seed_where`] does) — inconsistency detection
+/// remains the forward solve's job.
+pub fn row_pullbacks(rows: &[ConstraintRow]) -> Vec<Vec3> {
+    // Basis directions with their coefficients as linear functionals over
+    // the rows: ẋ = Σ_k e_k (α_k · rhs).
+    let mut basis: Vec<(Vec3, Vec<f64>)> = Vec::new();
+
+    for (j, row) in rows.iter().enumerate() {
+        let norm = row.gradient.norm();
+        if norm < f64::MIN_POSITIVE {
+            continue;
+        }
+        let mut g = row.gradient / norm;
+        let mut alpha = vec![0.0; rows.len()];
+        alpha[j] = 1.0 / norm;
+        for (e, a) in &basis {
+            let proj = g.dot(*e);
+            g -= *e * proj;
+            for (ai, bi) in alpha.iter_mut().zip(a) {
+                *ai -= proj * bi;
+            }
+        }
+        let res = g.norm();
+        if res > DEPENDENT_TOL {
+            for ai in alpha.iter_mut() {
+                *ai /= res;
+            }
+            basis.push((g / res, alpha));
+        }
+    }
+
+    let mut m = vec![Vec3::new(0.0, 0.0, 0.0); rows.len()];
+    for (e, a) in &basis {
+        for (mj, aj) in m.iter_mut().zip(a) {
+            *mj += *e * *aj;
+        }
+    }
+    m
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -336,6 +389,74 @@ mod tests {
             solve_vertex_velocity(&rows),
             Err(DiffError::InconsistentConstraints { .. })
         ));
+    }
+
+    #[test]
+    fn row_pullbacks_reproduce_the_forward_solve() {
+        // ẋ = Σ_j m_j rhs_j must hold for every system the forward solver
+        // accepts — full-rank corner, underdetermined rim, and a system
+        // with a dependent (dropped) row.
+        let top = Plane::new(Point3::new(0.0, 0.0, 2.0), Vec3::x(), Vec3::y());
+        let side_x = Plane::new(Point3::new(4.0, 0.0, 0.0), Vec3::y(), Vec3::z());
+        let side_y = Plane::new(Point3::new(0.0, 3.0, 0.0), Vec3::z(), Vec3::x());
+        let cyl = CylinderSurface::new(2.5);
+        let corner = Point3::new(4.0, 3.0, 2.0);
+        let u = 1.1_f64;
+        let rim = Point3::new(2.5 * u.cos(), 2.5 * u.sin(), 5.0);
+
+        let systems: Vec<Vec<ConstraintRow>> = vec![
+            vec![
+                constraint_row(
+                    &top,
+                    &[SurfaceSeed::Translate {
+                        velocity: Vec3::z(),
+                    }],
+                    &corner,
+                )
+                .unwrap(),
+                constraint_row(&side_x, &[], &corner).unwrap(),
+                constraint_row(&side_y, &[], &corner).unwrap(),
+            ],
+            vec![
+                constraint_row(&top, &[], &rim).unwrap(),
+                constraint_row(&cyl, &[SurfaceSeed::CylinderRadius { rate: 1.0 }], &rim).unwrap(),
+            ],
+            vec![
+                // Duplicate copies of the same moving plane: the second row
+                // is dropped as dependent, and its pullback column is zero.
+                constraint_row(
+                    &top,
+                    &[SurfaceSeed::Translate {
+                        velocity: Vec3::z(),
+                    }],
+                    &corner,
+                )
+                .unwrap(),
+                constraint_row(
+                    &top,
+                    &[SurfaceSeed::Translate {
+                        velocity: Vec3::z(),
+                    }],
+                    &corner,
+                )
+                .unwrap(),
+                constraint_row(&side_x, &[], &corner).unwrap(),
+            ],
+        ];
+        for rows in &systems {
+            let v = solve_vertex_velocity(rows).unwrap();
+            let m = row_pullbacks(rows);
+            let rebuilt = rows
+                .iter()
+                .zip(&m)
+                .fold(Vec3::new(0.0, 0.0, 0.0), |acc, (row, mj)| {
+                    acc + *mj * row.rhs
+                });
+            assert!(
+                (rebuilt - v).norm() < 1e-13,
+                "pullback rebuild {rebuilt:?} vs forward {v:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -32,6 +32,7 @@ use vcad_kernel_geom::{GeometryStore, Surface, SurfaceKind};
 use vcad_kernel_math::Vec3;
 use vcad_kernel_tessellate::frozen::FrozenError;
 
+mod adjoint;
 mod contract;
 mod fd;
 mod implicit;
@@ -40,10 +41,12 @@ mod mass;
 mod optimize;
 mod seam;
 
+pub use adjoint::{evaluate_with_pullback, MeshCotangents, SurfaceCotangent};
 pub use contract::{contract_sensitivity, volume_gradient};
 pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
 pub use implicit::{
-    constraint_row, solve_vertex_velocity, surface_residual, tangency_rows, ConstraintRow,
+    constraint_row, row_pullbacks, solve_vertex_velocity, surface_residual, tangency_rows,
+    ConstraintRow,
 };
 pub use lift::{lift_surface, DualSurface};
 pub use mass::{mass_properties, mass_properties_with_derivative, MassProperties};
@@ -93,6 +96,14 @@ pub enum DiffError {
         /// Residual of the dependent row after projection.
         residual: f64,
     },
+    /// A reverse-mode mesh gradient has the wrong number of entries for
+    /// the plan it was pulled back through.
+    GradientLengthMismatch {
+        /// Node count of the plan.
+        expected: usize,
+        /// Entries supplied.
+        got: usize,
+    },
 }
 
 impl std::fmt::Display for DiffError {
@@ -112,6 +123,10 @@ impl std::fmt::Display for DiffError {
             DiffError::InconsistentConstraints { residual } => write!(
                 f,
                 "implicit vertex system inconsistent (residual {residual:.3e}); vertex is not on the common intersection of its adjacent surfaces"
+            ),
+            DiffError::GradientLengthMismatch { expected, got } => write!(
+                f,
+                "mesh gradient has {got} entries but the plan has {expected} nodes"
             ),
         }
     }

--- a/crates/vcad-kernel-diff/src/seam.rs
+++ b/crates/vcad-kernel-diff/src/seam.rs
@@ -14,7 +14,7 @@ use vcad_kernel_topo::VertexId;
 
 use crate::{
     constraint_row, lift_surface, solve_vertex_velocity, surface_residual, tangency_rows,
-    DiffError, ParamSeeding,
+    ConstraintRow, DiffError, ParamSeeding,
 };
 
 /// Incidence tolerance (mm) for treating a topology vertex as lying on a
@@ -27,7 +27,7 @@ const INCIDENCE_TOL: f64 = 1e-4;
 
 /// Tolerance (mm) for the structural capture-time-B-rep check: every
 /// resolved node must land on the plan's recorded base position.
-const ANCHOR_TOL: f64 = 1e-3;
+pub(crate) const ANCHOR_TOL: f64 = 1e-3;
 
 /// A frozen mesh with first-order sensitivities: node `i` of `positions`
 /// corresponds to node `i` of `velocities` (dx/dθ).
@@ -42,6 +42,166 @@ pub struct SeamMesh {
     /// Recipes (copied from the plan) so callers can select node classes
     /// (e.g. rim vertices vs interior surface samples) in their gates.
     pub recipes: Vec<NodeRecipe>,
+}
+
+/// Enforce the seam's capture-time-B-rep contract and return the canonical
+/// index: topology signature match plus plan-shape sanity. Shared by the
+/// forward pass and the reverse-mode pullback so both enforce identical
+/// preconditions.
+pub(crate) fn checked_index(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+) -> Result<vcad_kernel_tessellate::frozen::CanonicalIndex, DiffError> {
+    let ci = canonical_index(brep);
+    let actual = signature_with_index(brep, &ci);
+    if actual != plan.signature {
+        return Err(FrozenError::TopologyChanged {
+            expected: plan.signature,
+            actual,
+        }
+        .into());
+    }
+    if plan.base_positions.len() != plan.nodes.len() {
+        return Err(FrozenError::RecipeOutOfRange.into());
+    }
+    Ok(ci)
+}
+
+/// Adjacency and referenced-surface context for implicit vertex
+/// differentiation, built once per evaluation.
+pub(crate) struct IncidenceContext {
+    /// Adjacent surface indices per topology vertex (distinct only).
+    pub adjacent: HashMap<VertexId, BTreeSet<usize>>,
+    /// Surface indices actually referenced by the solid's faces. The
+    /// geometric incidence scan is restricted to these, so surfaces a
+    /// boolean left in the store without a bounding face can never
+    /// contribute a spurious constraint row.
+    pub referenced: BTreeSet<usize>,
+}
+
+pub(crate) fn incidence_context(
+    brep: &BRepSolid,
+    faces: &[vcad_kernel_topo::FaceId],
+) -> IncidenceContext {
+    let topo = &brep.topology;
+    let mut adjacent: HashMap<VertexId, BTreeSet<usize>> = HashMap::new();
+    let mut referenced: BTreeSet<usize> = BTreeSet::new();
+    for &face_id in faces {
+        let face = &topo.faces[face_id];
+        referenced.insert(face.surface_index);
+        let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
+        for loop_id in loops {
+            for he in topo.loop_half_edges(loop_id) {
+                adjacent
+                    .entry(topo.half_edges[he].origin)
+                    .or_default()
+                    .insert(face.surface_index);
+            }
+        }
+    }
+    IncidenceContext {
+        adjacent,
+        referenced,
+    }
+}
+
+/// The constraint set of a topology vertex = topological adjacency ∪
+/// geometric incidence. The union matters: after a boolean, a rim vertex
+/// may carry half-edges of only one of its two defining faces (the other
+/// keeps an untrimmed seam loop), so loop membership alone
+/// under-constrains it.
+pub(crate) fn vertex_incident_surfaces(
+    brep: &BRepSolid,
+    ctx: &IncidenceContext,
+    vid: VertexId,
+    x: &Point3,
+) -> BTreeSet<usize> {
+    let mut incident: BTreeSet<usize> = ctx.adjacent.get(&vid).cloned().unwrap_or_default();
+    for &sidx in &ctx.referenced {
+        let surface = brep.geometry.surfaces[sidx].as_ref();
+        if let Some(res) = surface_residual(surface, x) {
+            if res < INCIDENCE_TOL {
+                incident.insert(sidx);
+            }
+        }
+    }
+    incident
+}
+
+/// Where a vertex-system row came from — which surface owns it and through
+/// which construction. The reverse-mode pullback re-materializes rows from
+/// their source with basis seeds to read off each row's seed-Jacobian, so
+/// forward and reverse can never disagree about a row's seed dependence.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum RowSource {
+    /// An implicit-form constraint row of the surface at this index.
+    Constraint {
+        /// Surface index in the geometry store.
+        surface: usize,
+    },
+    /// Row `index` of the tangency completion of `surface` against an
+    /// incident plane with this normal.
+    Tangency {
+        /// Normal of the incident plane.
+        plane_normal: Vec3,
+        /// Surface index of the tangent curved surface.
+        surface: usize,
+        /// Index into the rows `tangency_rows` returned for this pair.
+        index: usize,
+    },
+}
+
+/// Assemble the full implicit system of a topology vertex: one constraint
+/// row per incident surface, plus tangency completion. A curved surface
+/// resting on an incident plane duplicates the plane's row instead of
+/// pinning the vertex tangentially; its tangent-curve rows carry the
+/// missing directions (a rounded-cube corner vertex slides along the
+/// support face as the fillet radius grows). Looping over all
+/// (plane, surface) pairs over-generates safely: non-tangent pairs
+/// contribute no rows at all, and redundant rows from multiple tangent
+/// contacts are orthogonalized away by the solver after a consistency
+/// check — disagreement is a hard error, never a silent average.
+pub(crate) fn assemble_vertex_rows(
+    brep: &BRepSolid,
+    incident: &BTreeSet<usize>,
+    seeding: &ParamSeeding,
+    x: &Point3,
+) -> Result<Vec<(RowSource, ConstraintRow)>, DiffError> {
+    let mut rows = Vec::new();
+    for &sidx in incident {
+        let surface = brep.geometry.surfaces[sidx].as_ref();
+        rows.push((
+            RowSource::Constraint { surface: sidx },
+            constraint_row(surface, seeding.get(sidx), x)?,
+        ));
+    }
+    for &pidx in incident {
+        let plane = brep.geometry.surfaces[pidx].as_ref();
+        let Some(p) = plane.as_any().downcast_ref::<vcad_kernel_geom::Plane>() else {
+            continue;
+        };
+        let n = *p.normal_dir.as_ref();
+        for &sidx in incident {
+            if sidx == pidx {
+                continue;
+            }
+            let surface = brep.geometry.surfaces[sidx].as_ref();
+            for (index, row) in tangency_rows(n, surface, seeding.get(sidx), x)?
+                .into_iter()
+                .enumerate()
+            {
+                rows.push((
+                    RowSource::Tangency {
+                        plane_normal: n,
+                        surface: sidx,
+                        index,
+                    },
+                    row,
+                ));
+            }
+        }
+    }
+    Ok(rows)
 }
 
 /// Evaluate a frozen plan against a B-rep with analytic sensitivities.
@@ -69,41 +229,9 @@ pub fn evaluate_with_sensitivity(
     plan: &FrozenPlan,
     seeding: &ParamSeeding,
 ) -> Result<SeamMesh, DiffError> {
-    let ci = canonical_index(brep);
-    let actual = signature_with_index(brep, &ci);
-    if actual != plan.signature {
-        return Err(FrozenError::TopologyChanged {
-            expected: plan.signature,
-            actual,
-        }
-        .into());
-    }
-    if plan.base_positions.len() != plan.nodes.len() {
-        return Err(FrozenError::RecipeOutOfRange.into());
-    }
-
+    let ci = checked_index(brep, plan)?;
     let topo = &brep.topology;
-
-    // Adjacent surface indices per topology vertex (distinct indices only),
-    // plus the set of surface indices actually referenced by the solid's
-    // faces — the geometric incidence scan below is restricted to the
-    // latter, so surfaces a boolean left in the store without a bounding
-    // face can never contribute a spurious constraint row.
-    let mut adjacent: HashMap<VertexId, BTreeSet<usize>> = HashMap::new();
-    let mut referenced: BTreeSet<usize> = BTreeSet::new();
-    for &face_id in &ci.faces {
-        let face = &topo.faces[face_id];
-        referenced.insert(face.surface_index);
-        let loops = std::iter::once(face.outer_loop).chain(face.inner_loops.iter().copied());
-        for loop_id in loops {
-            for he in topo.loop_half_edges(loop_id) {
-                adjacent
-                    .entry(topo.half_edges[he].origin)
-                    .or_default()
-                    .insert(face.surface_index);
-            }
-        }
-    }
+    let ctx = incidence_context(brep, &ci.faces);
 
     // Lift each referenced face surface once (they are shared by many nodes).
     let mut lifted: HashMap<u32, crate::DualSurface> = HashMap::new();
@@ -131,50 +259,11 @@ pub fn evaluate_with_sensitivity(
                     .ok_or(FrozenError::RecipeOutOfRange)?;
                 let x = topo.vertices[vid].point;
                 anchor_check(i, &x, &plan.base_positions[i])?;
-                // Constraint set = topological adjacency ∪ geometric
-                // incidence. The union matters: after a boolean, a rim
-                // vertex may carry half-edges of only one of its two
-                // defining faces (the other keeps an untrimmed seam loop),
-                // so loop membership alone under-constrains it.
-                let mut incident: BTreeSet<usize> = adjacent.get(&vid).cloned().unwrap_or_default();
-                for &sidx in &referenced {
-                    let surface = brep.geometry.surfaces[sidx].as_ref();
-                    if let Some(res) = surface_residual(surface, &x) {
-                        if res < INCIDENCE_TOL {
-                            incident.insert(sidx);
-                        }
-                    }
-                }
-                let mut rows = Vec::new();
-                for &sidx in &incident {
-                    let surface = brep.geometry.surfaces[sidx].as_ref();
-                    rows.push(constraint_row(surface, seeding.get(sidx), &x)?);
-                }
-                // Tangency completion: a curved surface resting on an
-                // incident plane duplicates the plane's row instead of
-                // pinning the vertex tangentially; its tangent-curve rows
-                // carry the missing directions (a rounded-cube corner
-                // vertex slides along the support face as the fillet
-                // radius grows). Looping over all (plane, surface) pairs
-                // over-generates safely: non-tangent pairs contribute no
-                // rows at all, and redundant rows from multiple tangent
-                // contacts are orthogonalized away by the solver after a
-                // consistency check — disagreement is a hard error, never
-                // a silent average.
-                for &pidx in &incident {
-                    let plane = brep.geometry.surfaces[pidx].as_ref();
-                    let Some(p) = plane.as_any().downcast_ref::<vcad_kernel_geom::Plane>() else {
-                        continue;
-                    };
-                    let n = *p.normal_dir.as_ref();
-                    for &sidx in &incident {
-                        if sidx == pidx {
-                            continue;
-                        }
-                        let surface = brep.geometry.surfaces[sidx].as_ref();
-                        rows.extend(tangency_rows(n, surface, seeding.get(sidx), &x)?);
-                    }
-                }
+                let incident = vertex_incident_surfaces(brep, &ctx, vid, &x);
+                let rows: Vec<ConstraintRow> = assemble_vertex_rows(brep, &incident, seeding, &x)?
+                    .into_iter()
+                    .map(|(_, row)| row)
+                    .collect();
                 let v = solve_vertex_velocity(&rows)?;
                 positions.push(x);
                 velocities.push(v);

--- a/crates/vcad-kernel-diff/tests/m5_reverse_mode.rs
+++ b/crates/vcad-kernel-diff/tests/m5_reverse_mode.rs
@@ -1,0 +1,323 @@
+//! M5 — reverse mode: one pullback pass prices every parameter.
+//!
+//! Forward mode costs one seam evaluation per θ. The adjoint seam
+//! (`evaluate_with_pullback`) pulls a mesh functional's gradient `∂J/∂x`
+//! back to per-surface seed cotangents once; `dJ/dθ_k` for each parameter
+//! is then a dot product (`MeshCotangents::contract`), with no further
+//! seam evaluations.
+//!
+//! Gate: for every model class the seam supports — pure topology vertices,
+//! boolean rims with duplicated store surfaces, Boundary trim rings, and
+//! the full rounded cube with composite seeds and tangency-completion rows
+//! — the contraction of one pullback must reproduce the forward-mode
+//! derivative to near machine precision (the two sides share row
+//! construction and differ only in linear-algebra order), and the forward
+//! side is itself FD-validated.
+
+use vcad_kernel::Solid;
+use vcad_kernel_diff::{
+    evaluate_with_pullback, evaluate_with_sensitivity, fd_volume_derivative, volume_gradient,
+    volume_with_derivative, ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::{make_cube, make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::{capture_plan, FrozenPlan};
+use vcad_kernel_tessellate::TessellationParams;
+
+/// Reverse-vs-forward agreement gate: the two modes share row construction
+/// and differ only in the order of linear operations.
+const AGREE: f64 = 1e-11;
+const FD_GATE: f64 = 1e-6;
+const H: f64 = 1e-6;
+
+/// One pullback, then per-seeding forward reference: returns
+/// `(forward dJ/dθ, reverse dJ/dθ)` pairs for the volume functional.
+fn pullback_vs_forward(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+    seedings: &[ParamSeeding],
+) -> Vec<(f64, f64)> {
+    let base = evaluate_with_sensitivity(brep, plan, &ParamSeeding::new()).expect("base seam");
+    let w = volume_gradient(&base.positions, &base.triangles);
+    let cots = evaluate_with_pullback(brep, plan, &w).expect("pullback");
+    seedings
+        .iter()
+        .map(|s| {
+            let fwd = volume_with_derivative(
+                &evaluate_with_sensitivity(brep, plan, s).expect("forward seam"),
+            )
+            .1;
+            (fwd, cots.contract(s))
+        })
+        .collect()
+}
+
+fn assert_agree(fwd: f64, rev: f64, what: &str) {
+    let scale = fwd.abs().max(1.0);
+    assert!(
+        (fwd - rev).abs() / scale <= AGREE,
+        "{what}: forward {fwd} vs reverse {rev}"
+    );
+}
+
+#[test]
+fn m5_pullback_matches_forward_across_model_classes() {
+    // (a) Pure topology vertices: cube with a moving top face.
+    let cube = make_cube(4.0, 3.0, 2.0);
+    let plan = capture_plan(&cube, &TessellationParams::default()).expect("capture cube");
+    let mut top = ParamSeeding::new();
+    let n = top.seed_where(
+        &cube.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<Plane>()
+                .map(|p| {
+                    p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                        && p.signed_distance(&Point3::new(0.0, 0.0, 2.0)).abs() < 1e-9
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        },
+    );
+    assert_eq!(n, 1);
+    let pairs = pullback_vs_forward(&cube, &plan, &[top]);
+    assert_agree(pairs[0].0, pairs[0].1, "cube dV/dh");
+    assert!((pairs[0].1 - 12.0).abs() < 1e-9, "dV/dh = {}", pairs[0].1);
+
+    // (b) Boolean through-hole: rim topology vertices + lift-bridge wall
+    // samples, radius seed (the M2 model).
+    let hole = {
+        let block = Solid::cube(10.0, 8.0, 5.0);
+        let tool = Solid::cylinder(2.5, 7.0, 32).translate(5.0, 4.0, -1.0);
+        block
+            .difference(&tool)
+            .as_brep()
+            .expect("boolean stays BRep")
+            .clone()
+    };
+    let params = TessellationParams {
+        circle_segments: 32,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let plan = capture_plan(&hole, &params).expect("capture hole");
+    let mut radius = ParamSeeding::new();
+    let n = radius.seed_where(
+        &hole.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .map(|c| (c.radius - 2.5).abs() < 1e-9)
+                .unwrap_or(false)
+        },
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    assert!(n >= 1);
+    let pairs = pullback_vs_forward(&hole, &plan, &[radius]);
+    assert_agree(pairs[0].0, pairs[0].1, "hole dV/dr");
+
+    // (c) Boundary trim rings: cylinder height (the M3 model — cap rims
+    // are Newton-tracked Boundary nodes, not topology vertices).
+    let cyl = make_cylinder(5.0, 8.0, 24);
+    let params = TessellationParams {
+        circle_segments: 24,
+        height_segments: 4,
+        ..Default::default()
+    };
+    let plan = capture_plan(&cyl, &params).expect("capture cylinder");
+    let mut height = ParamSeeding::new();
+    let n = height.seed_where(
+        &cyl.geometry,
+        |s| {
+            s.as_any()
+                .downcast_ref::<Plane>()
+                .map(|p| {
+                    p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                        && p.signed_distance(&Point3::new(0.0, 0.0, 8.0)).abs() < 1e-9
+                })
+                .unwrap_or(false)
+        },
+        SurfaceSeed::Translate {
+            velocity: Vec3::z(),
+        },
+    );
+    assert_eq!(n, 1);
+    let pairs = pullback_vs_forward(&cyl, &plan, &[height]);
+    assert_agree(pairs[0].0, pairs[0].1, "cylinder dV/dh");
+}
+
+// ---- the flagship: every fillet-cube parameter from one pullback ----
+
+const A0: f64 = 10.0;
+const R0: f64 = 1.5;
+
+fn build_rc(theta: &[f64]) -> BRepSolid {
+    vcad_kernel_fillet::fillet_all_edges(&make_cube(theta[0], theta[0], theta[0]), theta[1])
+}
+
+fn coord(p: Point3, k: usize) -> f64 {
+    match k {
+        0 => p.x,
+        1 => p.y,
+        _ => p.z,
+    }
+}
+
+fn axes() -> [Vec3; 3] {
+    [
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+    ]
+}
+
+/// θ = fillet radius (the M4 seeding): every blend's radius grows at rate 1
+/// while its center retreats from the edge.
+fn seeding_r(brep: &BRepSolid, a: f64, r: f64) -> ParamSeeding {
+    let retreat = |center: Point3| {
+        let component = |c: f64| {
+            if (c - r).abs() < 1e-9 {
+                1.0
+            } else if (c - (a - r)).abs() < 1e-9 {
+                -1.0
+            } else {
+                0.0
+            }
+        };
+        Vec3::new(
+            component(center.x),
+            component(center.y),
+            component(center.z),
+        )
+    };
+    let mut seeding = ParamSeeding::new();
+    for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+        if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+            seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(c.center),
+                },
+            );
+        } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+            seeding.seed(i, SurfaceSeed::SphereRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(sp.center),
+                },
+            );
+        }
+    }
+    seeding
+}
+
+/// θ = the cube edge length `a`: the three far planes translate outward,
+/// and every blend whose center is pinned at `a − r` on some coordinate
+/// rides along; radii are unchanged.
+fn seeding_a(brep: &BRepSolid, a: f64, r: f64) -> ParamSeeding {
+    let ride = |center: Point3, skip_axis: Option<Vec3>| {
+        let mut vel = Vec3::new(0.0, 0.0, 0.0);
+        for (k, e) in axes().iter().enumerate() {
+            if let Some(axis) = skip_axis {
+                if axis.dot(*e).abs() > 0.9 {
+                    continue;
+                }
+            }
+            let c = coord(center, k);
+            if (c - (a - r)).abs() < 1e-9 {
+                vel += *e;
+            } else {
+                assert!(
+                    (c - r).abs() < 1e-9,
+                    "unexpected blend center coordinate {c}"
+                );
+            }
+        }
+        vel
+    };
+    let mut seeding = ParamSeeding::new();
+    let (mut planes, mut cylinders, mut spheres) = (0, 0, 0);
+    for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+        if let Some(p) = s.as_any().downcast_ref::<Plane>() {
+            let n = *p.normal_dir.as_ref();
+            for e in &axes() {
+                let probe = Point3::new(a * e.x, a * e.y, a * e.z);
+                if n.dot(*e).abs() > 1.0 - 1e-9 && p.signed_distance(&probe).abs() < 1e-9 {
+                    seeding.seed(i, SurfaceSeed::Translate { velocity: *e });
+                    planes += 1;
+                }
+            }
+        } else if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+            let vel = ride(c.center, Some(*c.axis.as_ref()));
+            if vel.norm() > 0.0 {
+                seeding.seed(i, SurfaceSeed::Translate { velocity: vel });
+            }
+            cylinders += 1;
+        } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+            let vel = ride(sp.center, None);
+            if vel.norm() > 0.0 {
+                seeding.seed(i, SurfaceSeed::Translate { velocity: vel });
+            }
+            spheres += 1;
+        }
+    }
+    assert_eq!(
+        (planes, cylinders, spheres),
+        (3, 12, 8),
+        "rounded cube census"
+    );
+    seeding
+}
+
+#[test]
+fn m5_one_pullback_prices_every_fillet_cube_parameter() {
+    let base = build_rc(&[A0, R0]);
+    let params = TessellationParams {
+        circle_segments: 16,
+        height_segments: 2,
+        ..Default::default()
+    };
+    let plan = capture_plan(&base, &params).expect("capture");
+
+    // One reverse pass...
+    let seam0 = evaluate_with_sensitivity(&base, &plan, &ParamSeeding::new()).expect("seam");
+    let w = volume_gradient(&seam0.positions, &seam0.triangles);
+    let cots = evaluate_with_pullback(&base, &plan, &w).expect("pullback");
+
+    // ...contracted against both parameters' seedings.
+    let s_a = seeding_a(&base, A0, R0);
+    let s_r = seeding_r(&base, A0, R0);
+    let dv_da_rev = cots.contract(&s_a);
+    let dv_dr_rev = cots.contract(&s_r);
+
+    // Gate 1: agree with forward mode (composite seeds, duplicated-copy
+    // handling, and tangency-completion rows all live on both sides).
+    let dv_da_fwd =
+        volume_with_derivative(&evaluate_with_sensitivity(&base, &plan, &s_a).expect("fwd a")).1;
+    let dv_dr_fwd =
+        volume_with_derivative(&evaluate_with_sensitivity(&base, &plan, &s_r).expect("fwd r")).1;
+    assert_agree(dv_da_fwd, dv_da_rev, "rounded cube dV/da");
+    assert_agree(dv_dr_fwd, dv_dr_rev, "rounded cube dV/dr");
+
+    // Gate 2: both parameters against the FD oracle (each direction is a
+    // fresh 1-D family through (A0, R0) under the same frozen plan).
+    let fd_a = fd_volume_derivative(|a| build_rc(&[a, R0]), A0, H, &plan).expect("fd a");
+    let fd_r = fd_volume_derivative(|r| build_rc(&[A0, r]), R0, H, &plan).expect("fd r");
+    let rel_a = (dv_da_rev - fd_a).abs() / fd_a.abs();
+    let rel_r = (dv_dr_rev - fd_r).abs() / fd_r.abs();
+    assert!(rel_a <= FD_GATE, "dV/da reverse {dv_da_rev} vs FD {fd_a}");
+    assert!(rel_r <= FD_GATE, "dV/dr reverse {dv_dr_rev} vs FD {fd_r}");
+
+    // Gate 3: continuum sanity — the Minkowski closed form
+    // V = s³ + 6s²r + 3πsr² + (4/3)πr³ with s = a − 2r gives
+    // dV/da = 3s² + 12sr + 3πr², matched within the polygonization band.
+    let s = A0 - 2.0 * R0;
+    let dv_da_cont = 3.0 * s * s + 12.0 * s * R0 + 3.0 * std::f64::consts::PI * R0 * R0;
+    let gap = (dv_da_rev - dv_da_cont).abs() / dv_da_cont;
+    assert!(gap < 0.10, "continuum gap {gap:.3}");
+}

--- a/docs/differentiable-seam-m5.md
+++ b/docs/differentiable-seam-m5.md
@@ -1,0 +1,117 @@
+# Differentiable seam — M5 design note
+
+M0–M4 (`differentiable-seam-m0-m2.md`, `-m3.md`, `-m4.md`) built forward
+mode: pick a parameter θ, seed the surfaces it moves, run one seam pass,
+read dx/dθ everywhere. That is the right shape up to a few dozen
+parameters — and exactly the wrong shape beyond, because each θ pays a
+full pass. M5 adds **reverse mode**: one adjoint pass prices *every*
+parameter of a design at once.
+
+## The transpose, not an AD framework
+
+The insight that keeps this small: node velocities are **linear in the
+seed values**. A seam evaluation is one linear map per node from
+"per-surface seed slots" — each surface's translation velocity (ℝ³) and
+radius rate (ℝ) — to that node's velocity. Reverse mode is just the
+transpose of those maps, contracted with a mesh functional's gradient:
+
+```text
+∂J/∂(seed slots of surface s)  =  Σ_i  A_{i,s}ᵀ (∂J/∂x_i)
+dJ/dθ_k                        =  Σ_s ⟨cotangent_s, seeds_k(s)⟩
+```
+
+`evaluate_with_pullback(brep, plan, ∂J/∂x)` computes the per-surface
+cotangents once; `MeshCotangents::contract(seeding_k)` is then a handful
+of dot products per parameter — no further seam evaluations, no tapes, no
+graph capture. `n` parameters cost one pullback + `n` dot products
+instead of `n` forward passes.
+
+## What landed
+
+### `row_pullbacks` — the transposed vertex solve
+
+The implicit vertex solve (Gram–Schmidt with the rhs carried) is linear
+in the rhs vector, with coefficients fixed by the row gradients alone.
+`row_pullbacks` runs the same elimination carrying each basis coefficient
+as a linear functional over the rows instead of a scalar, and returns
+`m_j = ∂ẋ/∂rhs_j`. Rows dropped as dependent get a zero column — their
+rhs never enters the solution (in forward mode it is only
+consistency-checked). This matters more than it looks:
+
+**Why not just probe with basis seedings through the forward solve?**
+Because a moving surface can have duplicate copies in a boolean's store
+(the case `seed_where` exists for). Seeding one copy at a time through
+the joint solve makes its row contradict the unseeded twin's — the
+forward consistency check would (correctly!) reject every probe. The
+transpose never needs a joint solve per basis: basis probing happens
+strictly per row, through the same row constructors the forward pass
+uses.
+
+### Per-row seed-Jacobians by forward probing
+
+No formula is re-derived. Each row's rhs-dependence on its owning
+surface's seeds is read off by re-materializing that row with unit basis
+seeds (three unit translations; a unit radius rate where the kind has
+one) through `constraint_row` / `tangency_rows` themselves — `RowSource`
+records which constructor and which output row. Lift-bridge nodes do the
+same through `lift_surface` with basis seeds (cached per face slot).
+Forward and reverse cannot disagree about a row's seed dependence,
+because they ask the same code.
+
+### Shared skeleton
+
+The forward pass's per-node machinery was factored (`checked_index`,
+`incidence_context`, `vertex_incident_surfaces`, `assemble_vertex_rows`)
+and both modes now walk it: same signature enforcement, same anchor
+checks, same incidence union, same tangency completion. The refactor is
+behavior-preserving for forward mode — the M0–M4 suites run unchanged.
+
+### The contract
+
+`contract` is a plain bilinear form; it cannot *detect* an invalid
+seeding (wrong seed kind for a surface, or duplicate copies seeded
+unequally). Detection stays where it always lived — the forward solve —
+and the pullback documents that it presumes seedings the forward path
+would accept. This is the same division of labor as
+`fillet_edges_detailed` vs the signature checks: validation happens on
+the primal path, and the derivative machinery refuses to silently guess.
+
+## Gates (`m5_reverse_mode.rs`)
+
+Reverse-vs-forward agreement (same rows, different linear-algebra order),
+measured:
+
+| Model class | dV/dθ forward | reverse rel err |
+|---|---|---|
+| Cube, moving top face (topology vertices) | 12 (exact) | 0 |
+| Boolean through-hole, radius (rim vertices + lift bridge) | −78.036 | 5.5e-16 |
+| Cylinder height (Boundary trim rings) | 77.646 | 1.8e-16 |
+| Rounded cube, dV/da (composite + tangency rows) | 293.665 | 2.7e-15 |
+| Rounded cube, dV/dr | −72.807 | 5.9e-16 |
+
+The flagship test prices **both** parameters of the all-edges-filleted
+cube — edge length `a` and fillet radius `r`, 20 moving surfaces with
+composite seeds — from **one** pullback, then checks each against forward
+mode (≤ 3e-15), against the FD oracle (1.7e-9 and 5.6e-9 vs the 1e-6
+gate), and dV/da against the Minkowski closed form
+`3s² + 12sr + 3πr²`, `s = a − 2r` (0.18% gap at 16-segment blends).
+
+## Notes and boundaries
+
+- The cotangent space is the current seed vocabulary: translation ℝ³ +
+  radius ℝ per surface. New `SurfaceSeed` kinds (cone half-angle, torus
+  radii) extend `SurfaceCotangent` with one slot and `radius_basis` with
+  one arm; nothing else changes.
+- The pullback costs ~4 row re-materializations per vertex row and ~4
+  lift evaluations per interior node — a small constant over one forward
+  pass. The crossover vs forward mode is therefore at *n ≈ small
+  constant*: reverse wins from a handful of parameters up.
+- `objective_gradient` / `minimize` still drive forward mode (they need
+  per-node velocities for their FD audit machinery). Wiring the optimizer
+  to prefer pullback when the objective exposes a mesh gradient is
+  mechanical and deferred until a many-parameter optimization demands it.
+- The phyz coupling this was built for — a rollout adjoint supplies
+  `∂J/∂x`, the pullback prices every CAD parameter of the robot at once —
+  still needs the `phyz` sibling repo in the session scope; the interface
+  (`∂J/∂x` in, cotangents out) is frozen here and exercised by the
+  analytic volume functional.


### PR DESCRIPTION
## What this is

M5 of the differentiable seam (M0–M2: #379, M3: #380, M4: #381): **reverse mode**. Forward mode costs one seam pass per parameter — the right shape up to a few dozen θs and exactly the wrong shape beyond. The adjoint seam transposes the whole thing once: given a mesh functional's gradient `∂J/∂x` (from `volume_gradient`, a physics adjoint, or any other source), `evaluate_with_pullback` accumulates the gradient of `J` with respect to every surface's *seed slots* — translation velocity (ℝ³) and radius rate (ℝ) — and `MeshCotangents::contract(seeding_k)` then prices each parameter as a dot product:

```text
dJ/dθ_k = Σ_s ⟨cotangent_s, seeds_k(s)⟩
```

`n` parameters cost one pullback + `n` dot products instead of `n` forward passes. No tapes, no graph capture — node velocities are *linear* in the seed values, so reverse mode is literally the transpose of the per-node maps.

Design note: `docs/differentiable-seam-m5.md`.

## What landed

**`row_pullbacks` — the transposed vertex solve.** The implicit vertex solve is linear in the row rhs vector with coefficients fixed by the gradients alone; the pullback runs the same Gram–Schmidt carrying each basis coefficient as a linear functional over the rows and returns `m_j = ∂ẋ/∂rhs_j`. Rows dropped as dependent get a **zero column**. That detail is the load-bearing one: a moving surface can have duplicate copies in a boolean's store (the case `seed_where` exists for), and probing one copy at a time through the joint solve would make its row contradict the unseeded twin's — the forward consistency check would correctly reject every probe. The transpose never needs a joint solve per basis.

**Per-row seed-Jacobians by forward probing.** No formula is re-derived: each row's rhs-dependence on its surface's seeds is read off by re-materializing that row with unit basis seeds through the *same* constructors forward mode uses (`constraint_row` / `tangency_rows` / `lift_surface`), with `RowSource` recording which constructor and which output row. Forward and reverse cannot drift, because they ask the same code.

**Shared skeleton.** The forward pass's per-node machinery is factored (`checked_index`, `incidence_context`, `vertex_incident_surfaces`, `assemble_vertex_rows`) and both modes walk it — same signature enforcement, anchor checks, incidence union, and tangency completion. Behavior-preserving for forward mode: the full M0–M4 suites run unchanged.

## Gates (`m5_reverse_mode.rs`)

Reverse-vs-forward agreement (same rows, different linear-algebra order):

| Model class | dV/dθ | reverse rel err |
|---|---|---|
| Cube, moving top face (topology vertices) | 12 (exact) | 0 |
| Boolean through-hole radius (rim vertices + lift bridge) | −78.036 | 5.5e-16 |
| Cylinder height (Boundary trim rings) | 77.646 | 1.8e-16 |
| Rounded cube dV/da (composite seeds + tangency rows) | 293.665 | 2.7e-15 |
| Rounded cube dV/dr | −72.807 | 5.9e-16 |

The flagship prices **both** parameters of the all-edges-filleted cube — edge length `a` and fillet radius `r`, 20 moving surfaces with composite seeds — from **one** pullback, then gates each against forward mode (≤ 3e-15), the FD oracle (1.7e-9 and 5.6e-9 vs the 1e-6 gate), and dV/da against the Minkowski closed form `3s² + 12sr + 3πr²` (0.18% gap at 16-segment blends).

## Validation

- `cargo test` on touched crates + scoped workspace suite: **1608 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings` clean on touched crates
- `cargo fmt --all --check` clean

## Notes

- The cotangent space is the current seed vocabulary; a new `SurfaceSeed` kind (cone half-angle, torus radii) extends `SurfaceCotangent` by one slot and `radius_basis` by one arm.
- `minimize` still drives forward mode (its FD-audit machinery wants per-node velocities); wiring it to prefer the pullback when an objective exposes a mesh gradient is mechanical and deferred until a many-parameter optimization demands it.
- The phyz coupling this was built for — rollout adjoint supplies `∂J/∂x`, the pullback prices every CAD parameter of the robot at once — still needs the `phyz` sibling repo in session scope; the interface is frozen here and exercised by the analytic volume functional.
- No changelog entry: `vcad-kernel-diff` remains a WIP crate with no consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_