### PR TITLE
feat(mcp): fab-ready handoff for sheet-metal quotes + ACP-CM spec draft

### DIFF
--- a/changelog/entries/2026-07-01-sheet-metal-fab-handoff.json
+++ b/changelog/entries/2026-07-01-sheet-metal-fab-handoff.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-01-sheet-metal-fab-handoff",
+  "version": "0.9.4",
+  "date": "2026-07-01",
+  "category": "feat",
+  "title": "Fab-ready handoff for sheet-metal quotes",
+  "summary": "quote_manufacturing for sheet metal now returns a fab_handoff: curated instant-quote shops, the exact DXF/STEP file recipe, and what to enter at upload — finish the order on the fab's site today.",
+  "features": ["fabricate", "sheet-metal", "ordering"],
+  "mcpTools": ["quote_manufacturing"]
+}

--- a/docs/agentic-commerce-custom-manufacturing.md
+++ b/docs/agentic-commerce-custom-manufacturing.md
@@ -1,0 +1,150 @@
+# Agentic Commerce for Custom Manufacturing (ACP-CM)
+
+Draft 0.1 — 2026-07-01. Reference implementation: the vcad MCP server
+(`quote_manufacturing` / `authorize_spend` / `place_order`).
+
+## The gap
+
+Every shipped agentic-commerce rail — the OpenAI/Stripe Agentic Commerce
+Protocol (ACP), Google UCP, AP2, Visa Intelligent Commerce, Mastercard Agent
+Pay — assumes a **fixed-price catalog SKU**: a product feed the agent browses,
+a price known before checkout, an item that exists before it is bought.
+
+Custom manufacturing has none of that. The price is computed from geometry.
+There is no feed. The "product" is a design that may still change between
+quote and checkout, and a manufacturability (DFM) check can change the part —
+or kill the order — after the buyer has decided to buy. No protocol in the
+catalog-retail lineage can express "buy *this exact geometry* at the price
+you quoted for it."
+
+ACP-CM closes that gap with one primitive: **coupling the payment mandate to
+a content hash of the design**. Everything else follows from it.
+
+## Roles
+
+- **Design surface** — where the geometry and its manufacturability live
+  (vcad: parametric IR, kernel DFM, cost model). Issues quotes.
+- **Buyer agent** — the AI agent acting for a human. Requests quotes,
+  proposes spends. Never holds payment credentials.
+- **Human principal** — approves spend out-of-band (never through the agent's
+  own tool channel), funds the wallet, owns disputes.
+- **Merchant of record** — charges the human, pays the fab (vcad in the
+  reference implementation).
+- **Fab** — manufactures. Accepts or declines each order, exactly as an ACP
+  merchant does. Never sees the buyer-side economics.
+
+## Objects
+
+### Quote (extends ACP's line item)
+
+```jsonc
+{
+  "quote_id": "…",
+  "doc_hash": "sha256(canonical design IR), truncated",   // THE binding
+  "fab_artifact": {                                        // optional but recommended
+    "artifact_id": "…",
+    "manifest": [{ "name": "part.dxf", "sha256": "…" }]    // exact fab bytes
+  },
+  "process": "sheet_metal",
+  "quantity": 3,
+  "dfm": { "checked": true, "passed": true, "violations": [] },
+  "total_amount_minor": 4250,
+  "currency": "USD",
+  "pricing_basis": "estimate | binding",
+  "expires_at": "…"                                        // quotes decay; SKUs don't
+}
+```
+
+A quote is only meaningful **with** its `doc_hash`. If the design changes, the
+quote is dead — there is nothing to re-price against, only a new quote to
+issue. `pricing_basis` distinguishes the design surface's own estimate from a
+fab-committed price; only `binding` quotes should gate real money.
+
+### Spend authorization (the mandate)
+
+A human-approved credential that authorizes the *agent* to place the order —
+scoped, expiring, revocable, and **bound to the hash**:
+
+```jsonc
+{
+  "authorization_id": "…",
+  "quote_id": "…",
+  "doc_hash": "…",              // mandate is void if the design changed
+  "max_amount_minor": 5000,     // ceiling, not blank check
+  "process_allowlist": ["sheet_metal"],
+  "fab_allowlist": ["sendcutsend"],
+  "expires_at": "…",
+  "one_time": true,
+  "status": "pending_human | approved | consumed | revoked"
+}
+```
+
+Requirements that catalog-retail mandates don't have:
+
+1. **DB-backed, not stateless.** A signed token alone cannot be revoked.
+   Every `place_order` re-verifies status against the store of record.
+2. **Approval happens out-of-band.** The agent *proposes* (`authorize_spend`);
+   the human approves in a channel the agent does not control (web app,
+   push). An agent must never be able to satisfy its own approval gate.
+3. **Hash-checked at spend time.** If `doc_hash(current design) !=
+   authorization.doc_hash`, the spend fails closed. This is the whole point:
+   the human approved a *geometry*, not a conversation.
+
+### Order
+
+Standard lifecycle (`QUOTED → PENDING_HUMAN → PAID → SUBMITTED → IN_PRODUCTION
+→ SHIPPED`, plus `RECONCILING`/`EXPIRED`), with two custom-manufacturing
+additions: the order carries the `fab_artifact` manifest (per-file sha256 —
+the order is traceable to the exact bytes the fab received), and a
+**re-quote-on-DFM-change** rule: if the fab's own DFM alters the part after
+payment, the order returns to a quote state and the mandate must be re-bound.
+Silent post-payment mutation of a custom part is the custom-goods equivalent
+of price switching.
+
+## Flow
+
+```
+agent                       human                    fab
+  │ quote_manufacturing        │                       │
+  │──────────────► quote{doc_hash, price, dfm}         │
+  │ authorize_spend(quote)     │                       │
+  │──────────────► pending ───► approve (out-of-band)  │
+  │ place_order(authorization) │                       │
+  │   verify status ∧ hash ∧ caps ∧ expiry (fail closed)
+  │   atomic debit ────────────┼──────────► submit(artifact manifest)
+  │                            │            accept / decline (ACP semantics)
+  │ get_order_status ◄─────────┴─────────── tracking / events
+```
+
+The **reorder** flow is the parametric dividend: re-evaluate the design (same
+parameters or new ones) → new `doc_hash` → new quote → new mandate. A reorder
+is a first-class re-derivation, never a replay of stale bytes.
+
+## Relationship to ACP
+
+ACP-CM is intended as an **extension profile**, not a rival. Reused as-is:
+checkout-session semantics, merchant accept/decline, delegated-payment token
+shape, MCP-as-transport (ACP's `docs/mcp-binding.md` pattern). Added: the
+quote object with `doc_hash` + `expires_at` + `dfm`, the hash-bound spend
+authorization, artifact-manifest traceability, and re-quote-on-change. A fab
+that already speaks ACP could adopt the profile by treating a quote as a
+short-lived, single-SKU product feed of one.
+
+## Consent and liability (non-negotiables)
+
+- Human approval on every spend until standing budgets are earned trust, and
+  3DS/SCA on the *funding* event (a signed mandate is not cardholder
+  authentication and does not shift chargeback liability by itself).
+- Custom parts are final-sale; disclose at approval time. The build receipt
+  (DFM + verification evidence) is representment evidence, and is explicitly
+  a manufacturability check, not a fitness-for-purpose warranty.
+- Export control stays a human attestation (geometry-based classification is
+  not automatable); default domestic fab lanes.
+
+## Status
+
+Implemented in the vcad MCP server: quotes with `doc_hash` and artifact
+binding (Phase 0, live), hash-and-cap-enforced atomic spend
+(`debit_wallet`, migration 027), flag-gated `authorize_spend`/`place_order`
+with out-of-band approval. Open: fab-side adoption (the partner rail),
+binding-quote adapters, standing budgets.

--- a/packages/mcp/src/__tests__/fabricate.test.ts
+++ b/packages/mcp/src/__tests__/fabricate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Engine } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { openDocument, documents } from "../tools/session.js";
@@ -7,6 +7,8 @@ import {
   getOrderStatus,
   listOrders,
 } from "../tools/order.js";
+import { buildFabHandoff } from "../fabricate/handoff.js";
+import { telemetryConfig, flushTelemetry } from "../telemetry.js";
 import { InMemoryFabricateStore } from "../fabricate/store.js";
 import { storeArtifact, clearArtifacts } from "../tools/artifact-store.js";
 import { FulfillmentBroker } from "../fabricate/broker.js";
@@ -279,5 +281,83 @@ describe("fabricate quote loop (engine)", () => {
       null,
     );
     expect(res.isError).toBe(true);
+  });
+});
+
+describe("fab handoff (sheet metal interim rail)", () => {
+  it("builds a sheet-metal handoff with curated shops and no ordering claim", () => {
+    const h = buildFabHandoff("sheet_metal", { hasArtifact: false });
+    expect(h).not.toBeNull();
+    expect(h!.orderable_via_vcad).toBe(false);
+    const ids = h!.shops.map((s) => s.id);
+    expect(ids).toEqual(["sendcutsend", "oshcut", "fabworks"]);
+    // SendCutSend is the only shop whose tooling the kernel encodes today.
+    expect(h!.shops.find((s) => s.id === "sendcutsend")!.shop_profile).toBe("sendcutsend");
+    expect(h!.shops.find((s) => s.id === "oshcut")!.shop_profile).toBeNull();
+    // Without a bound artifact the recipe explains how to produce the files.
+    expect(h!.file_recipe.join(" ")).toContain("sheet_metal_unfold");
+  });
+
+  it("shortens the recipe when fab files are already bound", () => {
+    const h = buildFabHandoff("sheet_metal", { hasArtifact: true });
+    expect(h!.file_recipe).toHaveLength(1);
+    expect(h!.file_recipe[0]).toContain("already bound");
+  });
+
+  it("returns null for processes with a real or absent ordering path", () => {
+    expect(buildFabHandoff("cnc", { hasArtifact: false })).toBeNull();
+    expect(buildFabHandoff("pcb", { hasArtifact: false })).toBeNull();
+    expect(buildFabHandoff("cast_metal", { hasArtifact: false })).toBeNull();
+  });
+});
+
+describe("fab handoff in quote_manufacturing (engine)", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  it("attaches fab_handoff to sheet_metal quotes and emits the BD event", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: true, status: 200, statusText: "OK" }));
+    vi.stubGlobal("fetch", fetchMock);
+    telemetryConfig.apiKey = "phc_test_key";
+    try {
+      const res = await quoteManufacturing(
+        { ir: cubeDoc(), process: "sheet_metal", quantity: 3, material: "aluminum" },
+        engine,
+        new InMemoryFabricateStore(),
+        null,
+      );
+      expect(res.isError).toBeFalsy();
+      const quote = JSON.parse(res.content[0].text);
+      expect(quote.fab_handoff).toBeDefined();
+      expect(quote.fab_handoff.orderable_via_vcad).toBe(false);
+      expect(quote.fab_handoff.shops).toHaveLength(3);
+
+      await flushTelemetry();
+      const handoffCall = fetchMock.mock.calls
+        .map(([, init]) => JSON.parse((init as { body: string }).body))
+        .find((p) => p.event === "fab_handoff_generated");
+      expect(handoffCall).toBeDefined();
+      expect(handoffCall.properties.process).toBe("sheet_metal");
+      expect(handoffCall.properties.quantity).toBe(3);
+      expect(handoffCall.properties.total_usd).toBeGreaterThan(0);
+      // Aggregates only — no IR or shop payloads in the event.
+      expect(handoffCall.properties.ir).toBeUndefined();
+    } finally {
+      telemetryConfig.apiKey = "";
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("omits fab_handoff for non-sheet-metal quotes", async () => {
+    const res = await quoteManufacturing(
+      { ir: cubeDoc(), process: "cnc", quantity: 1, material: "aluminum" },
+      engine,
+      new InMemoryFabricateStore(),
+      null,
+    );
+    const quote = JSON.parse(res.content[0].text);
+    expect(quote.fab_handoff).toBeUndefined();
   });
 });

--- a/packages/mcp/src/__tests__/telemetry.test.ts
+++ b/packages/mcp/src/__tests__/telemetry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
+  captureEvent,
   captureToolCall,
   configureTelemetry,
   flushTelemetry,
@@ -73,6 +74,25 @@ describe("captureToolCall (PostHog)", () => {
     await flushTelemetry();
     const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(payload.properties.is_error).toBe(true);
+  });
+
+  it("captures a named business event with explicit properties", async () => {
+    telemetryConfig.apiKey = KEY;
+    captureEvent("fab_handoff_generated", {
+      process: "sheet_metal",
+      quantity: 3,
+      total_usd: 42.5,
+    });
+    await flushTelemetry();
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload.event).toBe("fab_handoff_generated");
+    expect(payload.properties.process).toBe("sheet_metal");
+    expect(payload.properties.quantity).toBe(3);
+    expect(payload.properties.total_usd).toBe(42.5);
+    // Carries the same build identity + auth flags as tool events.
+    expect(payload.properties.build_sha).toBe("abc1234");
+    expect(payload.properties.authenticated).toBe(false);
   });
 
   it("never throws when the capture POST fails", async () => {

--- a/packages/mcp/src/fabricate/handoff.ts
+++ b/packages/mcp/src/fabricate/handoff.ts
@@ -1,0 +1,123 @@
+/**
+ * Fab-ready handoff — the interim ordering rail for processes where no fab
+ * partner is signed yet (today: sheet metal).
+ *
+ * Until a partner adapter can flip `orderable: true`, the most useful thing a
+ * quote can do is hand the agent (and its human) everything needed to finish
+ * the order on a fab's own instant-quote site in one pass: which shops fit,
+ * which file each shop needs, the exact vcad tool calls that produce those
+ * files, and what to type into the shop's UI. The struct is data, not prose,
+ * so agents can act on it; `summary` is the human-readable line.
+ *
+ * This is deliberately NOT browser automation of a fab's checkout — the human
+ * places the order in their own account on the fab's site. vcad's job is that
+ * the files arrive pre-validated against the shop's published tooling
+ * (shop_profile catalogs in vcad-kernel-sheet), so the upload quotes clean on
+ * the first try.
+ */
+
+import type { Process } from "./types.js";
+
+/** One fab a handoff can target. `upload_url` is the shop's public entry
+ *  point (never a deep link into their app — those churn). */
+export interface HandoffShop {
+  id: string;
+  label: string;
+  region: "US";
+  upload_url: string;
+  /** File kinds this shop's instant-quote flow accepts for this process. */
+  formats: Array<"dxf" | "step">;
+  /** vcad shop-profile catalog id when the kernel encodes this shop's
+   *  tooling (fixed bend radii, K-factors, reliefs) — quote-clean uploads. */
+  shop_profile: string | null;
+  notes: string;
+}
+
+export interface FabHandoff {
+  process: Process;
+  /** False until a partner adapter can place this order via place_order. */
+  orderable_via_vcad: false;
+  shops: HandoffShop[];
+  /** Ordered tool-call recipe that produces the upload-ready files. */
+  file_recipe: string[];
+  /** What the shop's UI will ask for that the files don't carry. */
+  at_upload: string[];
+  summary: string;
+}
+
+const SHEET_METAL_SHOPS: HandoffShop[] = [
+  {
+    id: "sendcutsend",
+    label: "SendCutSend",
+    region: "US",
+    upload_url: "https://sendcutsend.com",
+    formats: ["dxf", "step"],
+    shop_profile: "sendcutsend",
+    notes:
+      "vcad encodes SendCutSend's published bend catalog — create the part with " +
+      'shop_profile: "sendcutsend" and the flat pattern matches their tooling ' +
+      "exactly. STEP uploads auto-detect bends (zero data entry). Note 6061 is " +
+      "not bendable at SCS; flat 6061 parts are fine.",
+  },
+  {
+    id: "oshcut",
+    label: "OSH Cut",
+    region: "US",
+    upload_url: "https://www.oshcut.com",
+    formats: ["dxf", "step"],
+    shop_profile: null,
+    notes:
+      "Instant quote with strong in-browser DFM feedback; typically fast " +
+      "turnaround. No vcad shop profile yet — verify bend radii against their " +
+      "quoter after upload.",
+  },
+  {
+    id: "fabworks",
+    label: "Fabworks",
+    region: "US",
+    upload_url: "https://www.fabworks.com",
+    formats: ["dxf", "step"],
+    shop_profile: null,
+    notes:
+      "Fastest typical ship times (1-2 business days) and often the lowest " +
+      "price. No vcad shop profile yet — verify bend radii against their " +
+      "quoter after upload.",
+  },
+];
+
+/**
+ * Build the handoff block for a quote, or null when the process either has a
+ * real ordering path or no curated shop list yet.
+ */
+export function buildFabHandoff(
+  process: Process,
+  opts: { hasArtifact: boolean },
+): FabHandoff | null {
+  if (process !== "sheet_metal") return null;
+
+  const file_recipe = opts.hasArtifact
+    ? [
+        "Fab files are already bound to this order (fab_artifact_id) — fetch them from the artifact store and upload to the chosen shop.",
+      ]
+    : [
+        'For a bent part: sheet_metal_unfold(document_id) returns the fab-ready DXF (merged silhouette + DASHED bend lines), or export_cad with a ".step" filename for the folded body (bends auto-detected by the shop, zero data entry — requires the part was created with the shop\'s shop_profile so radii match their tooling).',
+        "Re-run quote_manufacturing with the export's fab_artifact_id to bind the exact bytes to this order for traceability.",
+      ];
+
+  return {
+    process,
+    orderable_via_vcad: false,
+    shops: SHEET_METAL_SHOPS,
+    file_recipe,
+    at_upload: [
+      "Material + thickness (must match the sheet_metal_create material — the DXF does not carry it).",
+      "Bend angles when uploading DXF (the DXF marks bend lines, not angles). STEP uploads skip this.",
+      "Quantity and finish (deburring/powder/anodize) in the shop's UI.",
+    ],
+    summary:
+      "Sheet metal isn't agent-orderable through vcad yet — a fab partner rail is in progress. " +
+      "This handoff has everything needed to finish the order on a fab's instant-quote site: " +
+      "upload the recipe's files, enter material/thickness, and check out. " +
+      "Files produced with a matching shop_profile quote clean on the first try.",
+  };
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1005,7 +1005,7 @@ export async function createServer(
       {
         name: "quote_manufacturing",
         description:
-          "Quote manufacturing a part: measures the design, runs light DFM, and returns margin-inclusive price options per fab (pcb/cnc/3dprint/sheet_metal/cast_metal). Pass `ir` (inline Document — stateless, no open_document needed, serverless-safe, parallel-safe) OR a `document_id` from an open session. Persists a quote + a QUOTED order. Phase 0 is quote-only — prices are estimates and ordering/payment ship next; no money moves.",
+          "Quote manufacturing a part: measures the design, runs light DFM, and returns margin-inclusive price options per fab (pcb/cnc/3dprint/sheet_metal/cast_metal). Pass `ir` (inline Document — stateless, no open_document needed, serverless-safe, parallel-safe) OR a `document_id` from an open session. Persists a quote + a QUOTED order. Phase 0 is quote-only — prices are estimates and ordering/payment ship next; no money moves. For sheet_metal the result includes `fab_handoff`: curated US instant-quote shops (SendCutSend/OSH Cut/Fabworks), the exact file recipe (DXF via sheet_metal_unfold or folded STEP via export_cad), and what to enter at upload — everything needed to finish the order on the fab's site today.",
         inputSchema: quoteManufacturingSchema,
       },
       {

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -61,13 +61,34 @@ export function captureToolCall(
   args: Record<string, unknown>,
   result: { isError?: boolean },
 ): void {
+  const docId =
+    typeof args?.document_id === "string" && args.document_id
+      ? args.document_id
+      : undefined;
+  captureEvent("mcp_tool_call", {
+    tool: name,
+    is_error: !!result.isError,
+    ...(docId ? { document_id: docId } : {}),
+  });
+}
+
+/**
+ * Capture a named business event (e.g. `fab_handoff_generated`) with explicit
+ * aggregate properties. Same rules as captureToolCall: fire-and-forget, never
+ * throws, no-op without an API key — and callers must pass only aggregate
+ * fields, never argument values or IR.
+ */
+export function captureEvent(
+  event: string,
+  eventProperties: Record<string, unknown>,
+): void {
   const key = telemetryConfig.apiKey;
   if (!key) return;
 
   const user = currentUser();
   const docId =
-    typeof args?.document_id === "string" && args.document_id
-      ? args.document_id
+    typeof eventProperties.document_id === "string" && eventProperties.document_id
+      ? eventProperties.document_id
       : undefined;
 
   // Signed-in → attribute to the user (matches the web app's posthog.identify).
@@ -77,18 +98,16 @@ export function captureToolCall(
   const distinctId = user?.sub ?? docId ?? "mcp-anonymous";
 
   const properties: Record<string, unknown> = {
-    tool: name,
-    is_error: !!result.isError,
+    ...eventProperties,
     authenticated: !!user,
     ...buildContext,
     $process_person_profile: !!user,
   };
-  if (docId) properties.document_id = docId;
   if (user?.email) properties.$set = { email: user.email };
 
   const body = JSON.stringify({
     api_key: key,
-    event: "mcp_tool_call",
+    event,
     distinct_id: distinctId,
     properties,
     timestamp: new Date().toISOString(),

--- a/packages/mcp/src/tools/order.ts
+++ b/packages/mcp/src/tools/order.ts
@@ -21,6 +21,8 @@ import { measureDocument } from "../fabricate/geometry.js";
 import { FulfillmentBroker } from "../fabricate/broker.js";
 import { toDfmProcess, catalogMaterial } from "../fabricate/process-map.js";
 import { ownerId, type FabricateStore } from "../fabricate/store.js";
+import { buildFabHandoff } from "../fabricate/handoff.js";
+import { captureEvent } from "../telemetry.js";
 import { resolveArtifactRef } from "./artifact-store.js";
 import {
   PROCESSES,
@@ -242,6 +244,22 @@ export async function quoteManufacturing(
     /* in-memory never throws; cloud logs internally */
   }
 
+  // Interim rail for processes with no signed fab partner: hand the agent a
+  // structured path to finish the order on a fab's own instant-quote site.
+  const fabHandoff = buildFabHandoff(process, { hasArtifact: fabArtifact != null });
+  if (fabHandoff) {
+    // Aggregate BD telemetry — how much order-ready demand the handoff rail
+    // generates (counts + totals only; no argument values or IR).
+    captureEvent("fab_handoff_generated", {
+      process,
+      quantity,
+      material: quote.material ?? "unspecified",
+      total_usd: toUsd(quote.total_amount_minor),
+      has_fab_artifact: fabArtifact != null,
+      dfm_passed: dfm.passed,
+    });
+  }
+
   // Agent-facing payload: margin-inclusive prices only; fab cost / margin never appear.
   return ok({
     quote_id: quoteId,
@@ -286,6 +304,7 @@ export async function quoteManufacturing(
     },
     margin_hidden: true,
     orderable: result.recommended.orderable,
+    ...(fabHandoff ? { fab_handoff: fabHandoff } : {}),
     expires_at: expiresAt,
     fab_artifact: fabArtifact
       ? {


### PR DESCRIPTION
## What

The interim ordering rail for the metal wedge, while fab partnerships are negotiated.

**`fab_handoff` in `quote_manufacturing`** — for `process: "sheet_metal"` the quote now includes a structured handoff block:
- curated US instant-quote shops (SendCutSend — with its kernel `shop_profile` so files quote clean first try — plus OSH Cut and Fabworks)
- the file recipe: `sheet_metal_unfold` DXF or folded STEP via `export_cad`, rebound to the order with `fab_artifact_id`
- an at-upload checklist (material/thickness, bend angles for DXF, qty/finish)
- explicit `orderable_via_vcad: false` until a partner adapter flips it

**Demand telemetry** — each handoff emits a `fab_handoff_generated` PostHog event via a new generic `captureEvent` (aggregates only: process, qty, total, DFM pass — same no-payload rules as `captureToolCall`). This is the data behind the fab BD conversations.

**ACP-CM spec draft** (`docs/agentic-commerce-custom-manufacturing.md`) — extension profile for agentic commerce on custom-manufactured goods: doc_hash-bound quotes, hash-checked spend mandates, artifact-manifest traceability, re-quote-on-DFM-change. Documents what the money plane already implements.

## Why

Verified 2026-07-01 (104-agent deep research + direct primary-source checks): zero public buyer-facing metal-cutting APIs exist; nobody has shipped agent-orderable custom manufacturing; the partner-rail strategy replaces the browser-agent idea (Chicago v. DoorDash consumer-protection precedent). The handoff ships the demand loop today and starts the telemetry clock for BD.

## Test plan

- `packages/mcp`: 494 passed / 2 skipped, `tsc --noEmit` clean
- new unit tests for `buildFabHandoff` (shape, artifact-bound recipe, non-sheet-metal null) and e2e sheet-metal quote asserting `fab_handoff` + the PostHog event body
- telemetry test for `captureEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)