### PR TITLE
Differentiable seam M8 + M10: physics-rollout gradients, second order, and perf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,10 @@ vcad/
 │   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations,
 │   #                            # mass-property QoIs, differentiable fillet radius,
 │   #                            # reverse-mode adjoint, seeding synthesis, cone/torus
-│   #                            # coverage, L-BFGS many-parameter optimizer (docs/
-│   #                            # differentiable-seam-m0-m2.md … -m9.md); no consumers yet
+│   #                            # coverage, L-BFGS many-parameter optimizer, second-order
+│   #                            # derivatives (docs/differentiable-seam-m0-m2.md … -m10.md);
+│   #                            # first consumer: vcad-kernel-physics::diff (rollout
+│   #                            # gradients — d(sim objective)/d(CAD parameter))
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "loon-lang"
-version = "0.5.0"
+version = "0.7.0"
 dependencies = [
  "codespan-reporting",
  "dirs-next",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tang",
 ]
@@ -7175,6 +7175,10 @@ dependencies = [
  "thiserror 2.0.18",
  "vcad-ir",
  "vcad-kernel",
+ "vcad-kernel-diff",
+ "vcad-kernel-geom",
+ "vcad-kernel-math",
+ "vcad-kernel-primitives",
  "vcad-kernel-tessellate",
  "vcad-kernel-urdf",
 ]

--- a/crates/vcad-kernel-diff/src/gauss_newton.rs
+++ b/crates/vcad-kernel-diff/src/gauss_newton.rs
@@ -1,0 +1,204 @@
+//! M10 — Gauss–Newton curvature for least-squares QoI objectives.
+//!
+//! For an objective assembled as a sum of squared residuals
+//!
+//! ```text
+//! J(θ) = Σ_q r_q(θ)²
+//! ```
+//!
+//! (the shape every mass-property recovery objective in this crate takes —
+//! `VolumeMatch`, the M9 five-QoI `QoiMatch`, each residual a *relative* miss
+//! `r_q = (Q_q − t_q)/t_q`), the exact gradient and Hessian are
+//!
+//! ```text
+//! g   = 2 Jᵀ r
+//! H   = 2 Jᵀ J  +  2 Σ_q r_q ∇²r_q ,     J = ∂r/∂θ  (m residuals × n params)
+//! ```
+//!
+//! The **Gauss–Newton** approximation keeps only the first Hessian term,
+//! `H_GN = 2 JᵀJ`. That term needs nothing but the residual Jacobian `J` —
+//! which the differentiable seam already produces exactly: each row
+//! `∂r_q/∂θ` is `(1/t_q)` times the QoI derivative the seam computes in
+//! forward mode (one seam pass per parameter, [`crate::objective_gradient`])
+//! or reverse mode (one pullback per residual QoI,
+//! [`crate::evaluate_with_pullback`]). No node accelerations, no second-order
+//! seeding — the curvature that *is* recoverable from first derivatives
+//! alone, priced honestly.
+//!
+//! # What these functions compute, exactly
+//!
+//! They compute `H_GN = 2 JᵀJ` and products with it. They **drop** the
+//! residual-curvature term `2 Σ_q r_q ∇²r_q`. The two agree exactly when
+//! every residual is zero (at a perfect fit) and to `O(‖r‖)` near it, so the
+//! Gauss–Newton Hessian is the trusted curvature model at and near an
+//! optimum — the regime a Newton-type step is taken in — and is a positive
+//! semidefinite lower model everywhere else. It is **not** the full Hessian
+//! of `J`; a caller wanting the exact second derivative of a *single* QoI (as
+//! opposed to the least-squares assembly) wants
+//! [`crate::volume_with_second_derivative`], which carries the dropped
+//! node-acceleration term.
+
+/// The Gauss–Newton Hessian `H_GN = 2 JᵀJ` of a least-squares objective
+/// `J = Σ_q r_q²`, formed explicitly (`n × n`, row-major).
+///
+/// `residual_jacobian` is `J = ∂r/∂θ`: one row per residual `r_q`, each of
+/// length `n` (the number of parameters). Every row must have the same
+/// length; the result is `n × n` symmetric.
+///
+/// Exact-at-zero-residual: this is the full Hessian of `J` only where all
+/// residuals vanish (see the module docs). Prefer [`gauss_newton_hvp`] when
+/// `n` is large and only Hessian–vector products are needed.
+pub fn gauss_newton_hessian(residual_jacobian: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let n = residual_jacobian.first().map(Vec::len).unwrap_or(0);
+    debug_assert!(
+        residual_jacobian.iter().all(|row| row.len() == n),
+        "every residual-Jacobian row must have the same parameter count"
+    );
+    let mut h = vec![vec![0.0; n]; n];
+    for row in residual_jacobian {
+        // Rank-1 update H += 2 · (row ⊗ row); the factor 2 is the derivative
+        // of the square in J = Σ r².
+        for i in 0..n {
+            let ri = row[i];
+            if ri == 0.0 {
+                continue;
+            }
+            let hi = &mut h[i];
+            for (j, &rj) in row.iter().enumerate() {
+                hi[j] += 2.0 * ri * rj;
+            }
+        }
+    }
+    h
+}
+
+/// A Gauss–Newton Hessian–vector product `H_GN · v = 2 Jᵀ(Jv)`, formed
+/// **without** materializing the `n × n` Hessian.
+///
+/// `residual_jacobian` is `J = ∂r/∂θ` (one row per residual). `v` has length
+/// `n` (the parameter count). Cost is `O(m·n)` — one pass to form `Jv`
+/// (length `m`), one to accumulate `Jᵀ(Jv)` — so this is the form to use in a
+/// truncated-Newton / conjugate-gradient inner loop where `H_GN` is only ever
+/// touched through products.
+///
+/// Computes exactly the same operator as [`gauss_newton_hessian`] applied to
+/// `v`; same exact-at-zero-residual contract.
+pub fn gauss_newton_hvp(residual_jacobian: &[Vec<f64>], v: &[f64]) -> Vec<f64> {
+    let n = v.len();
+    // Jv: one entry per residual.
+    let jv: Vec<f64> = residual_jacobian
+        .iter()
+        .map(|row| {
+            debug_assert_eq!(row.len(), n, "Jacobian row / vector length mismatch");
+            row.iter().zip(v).map(|(a, b)| a * b).sum::<f64>()
+        })
+        .collect();
+    // 2 Jᵀ(Jv).
+    let mut out = vec![0.0; n];
+    for (row, &s) in residual_jacobian.iter().zip(&jv) {
+        let two_s = 2.0 * s;
+        if two_s == 0.0 {
+            continue;
+        }
+        for (o, &a) in out.iter_mut().zip(row) {
+            *o += two_s * a;
+        }
+    }
+    out
+}
+
+/// The exact least-squares gradient `g = 2 Jᵀ r` of `J = Σ_q r_q²`.
+///
+/// Provided alongside the curvature so a caller assembling a Gauss–Newton
+/// step `H_GN Δ = −g` has both halves from the same convention (`J = ∂r/∂θ`,
+/// `r` the residual vector). This gradient is **exact** — no approximation —
+/// unlike the Hessian; it is here only so the factor-of-two bookkeeping lives
+/// in one place.
+pub fn gauss_newton_gradient(residual_jacobian: &[Vec<f64>], residual: &[f64]) -> Vec<f64> {
+    debug_assert_eq!(
+        residual_jacobian.len(),
+        residual.len(),
+        "one residual per Jacobian row"
+    );
+    let n = residual_jacobian.first().map(Vec::len).unwrap_or(0);
+    let mut g = vec![0.0; n];
+    for (row, &r) in residual_jacobian.iter().zip(residual) {
+        let two_r = 2.0 * r;
+        if two_r == 0.0 {
+            continue;
+        }
+        for (gi, &a) in g.iter_mut().zip(row) {
+            *gi += two_r * a;
+        }
+    }
+    g
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `H_GN v` via the matrix-free product must equal the explicit-Hessian
+    /// multiply for a hand Jacobian.
+    #[test]
+    fn hvp_matches_explicit_hessian() {
+        let jac = vec![
+            vec![1.0, 2.0, -1.0],
+            vec![0.0, 1.0, 3.0],
+            vec![2.0, -1.0, 0.5],
+        ];
+        let h = gauss_newton_hessian(&jac);
+        // Symmetry.
+        for (i, row) in h.iter().enumerate() {
+            for (j, &hij) in row.iter().enumerate() {
+                assert!((hij - h[j][i]).abs() < 1e-14);
+            }
+        }
+        for v in [[1.0, 0.0, 0.0], [1.0, -2.0, 3.0], [0.5, 0.5, 0.5]] {
+            let hv_free = gauss_newton_hvp(&jac, &v);
+            let hv_mat: Vec<f64> = (0..3)
+                .map(|i| (0..3).map(|j| h[i][j] * v[j]).sum())
+                .collect();
+            for k in 0..3 {
+                assert!(
+                    (hv_free[k] - hv_mat[k]).abs() < 1e-12,
+                    "row {k}: {} vs {}",
+                    hv_free[k],
+                    hv_mat[k]
+                );
+            }
+        }
+    }
+
+    /// For a *linear* residual `r(θ) = Jθ − b`, every `∇²r_q = 0`, so the
+    /// Gauss–Newton Hessian is the exact Hessian and one Newton step
+    /// `H Δ = −g` lands on the least-squares minimizer.
+    #[test]
+    fn linear_residual_newton_step_is_exact() {
+        // r = J θ − b, over-determined but consistent at θ* = (1, −1).
+        let jmat = [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]];
+        let theta_star = [1.0, -1.0];
+        let b: Vec<f64> = jmat
+            .iter()
+            .map(|row| row[0] * theta_star[0] + row[1] * theta_star[1])
+            .collect();
+
+        let theta0 = [0.0, 0.0];
+        let residual: Vec<f64> = jmat
+            .iter()
+            .zip(&b)
+            .map(|(row, bi)| row[0] * theta0[0] + row[1] * theta0[1] - bi)
+            .collect();
+        let jac: Vec<Vec<f64>> = jmat.iter().map(|r| r.to_vec()).collect();
+
+        let g = gauss_newton_gradient(&jac, &residual);
+        let h = gauss_newton_hessian(&jac);
+        // Solve H Δ = −g (2×2).
+        let det = h[0][0] * h[1][1] - h[0][1] * h[1][0];
+        let dx = (-g[0] * h[1][1] + g[1] * h[0][1]) / det;
+        let dy = (-g[1] * h[0][0] + g[0] * h[1][0]) / det;
+        let theta1 = [theta0[0] + dx, theta0[1] + dy];
+        assert!((theta1[0] - theta_star[0]).abs() < 1e-12);
+        assert!((theta1[1] - theta_star[1]).abs() < 1e-12);
+    }
+}

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -264,6 +264,129 @@ pub fn tangency_rows(
     }
 }
 
+/// Second-order (acceleration) constraint row of a surface at a topology
+/// vertex: `∇g · ẍ = rhs₂`.
+///
+/// Differentiating the frozen-branch identity `∇g·ẋ = −∂g/∂θ` a second time,
+///
+/// ```text
+/// ∇g · ẍ = −( ∂²g/∂θ²  +  2 ẋᵀ ∇ₓ(∂g/∂θ)  +  ẋᵀ ∇²g ẋ )
+/// ```
+///
+/// The gradient `∇g` is **identical** to the first-order row
+/// ([`constraint_row`]), so the same Gram–Schmidt solve
+/// ([`solve_vertex_velocity`]) recovers `ẍ` with the tangential DOF frozen at
+/// zero — exactly the frozen-parameter convention the velocity solve uses.
+/// The right-hand side splits into two pieces this function sums:
+///
+/// - the **field-acceleration** part, which is precisely the first-order rhs
+///   evaluated with the field *accelerations* seeded where velocities
+///   normally go (`constraint_row(surface, acc_seeds, x).rhs`) — the plane's
+///   whole contribution, and the field-second-derivative `∂²g/∂θ²` term of
+///   the quadrics;
+/// - the **velocity-curvature** part `−2‖ẋ⊥ − v_c⊥‖² + 2ṙ²` (plane: `0`), the
+///   collected `ẋ`- and field-velocity-quadratic terms. Only the implicit
+///   form's *constant* Hessian (`∇²g` = `0` plane / `2I` sphere / `2P`
+///   cylinder, `P = I − aaᵀ`) and the seeded field velocities enter it, so it
+///   is closed form.
+///
+/// `x` is the vertex position, `xdot` its already-solved velocity (from
+/// [`solve_vertex_velocity`] on the first-order rows). Implemented for
+/// plane/cylinder/sphere — enough for the boolean-hole and rounded-cube
+/// second-order volume gates; cone/torus return
+/// [`DiffError::UnsupportedConstraint`], since their curvature term carries a
+/// non-constant `∇²g` (a mechanical extension, deliberately not shipped).
+pub fn constraint_row_2(
+    surface: &dyn Surface,
+    vel_seeds: &[SurfaceSeed],
+    acc_seeds: &[SurfaceSeed],
+    x: &Point3,
+    xdot: &Vec3,
+) -> Result<ConstraintRow, DiffError> {
+    // Field-acceleration part: the first-order machinery, fed accelerations.
+    let base = constraint_row(surface, acc_seeds, x)?;
+    let curv = velocity_curvature(surface, vel_seeds, x, xdot)?;
+    Ok(ConstraintRow {
+        gradient: base.gradient,
+        rhs: base.rhs + curv,
+    })
+}
+
+/// The velocity-quadratic part of the second-order rhs (see
+/// [`constraint_row_2`]). Plane: identically zero (`∇²g = 0`, `g` linear in
+/// both `x` and the origin). Sphere/cylinder: `−2‖ẋ − v_c‖² + 2ṙ²`, projected
+/// perpendicular to the axis for the cylinder. Errors on kinds without a
+/// second-order form, and on inapplicable seeds.
+fn velocity_curvature(
+    surface: &dyn Surface,
+    vel_seeds: &[SurfaceSeed],
+    _x: &Point3,
+    xdot: &Vec3,
+) -> Result<f64, DiffError> {
+    let kind = surface.surface_type();
+    match kind {
+        SurfaceKind::Plane => {
+            for seed in vel_seeds {
+                if !matches!(seed, SurfaceSeed::Translate { .. }) {
+                    return Err(DiffError::UnsupportedSeed { kind, seed: *seed });
+                }
+            }
+            Ok(0.0)
+        }
+        SurfaceKind::Sphere => {
+            let (vc, rdot) = sphere_field_velocity(kind, vel_seeds)?;
+            let rel = *xdot - vc;
+            Ok(-2.0 * rel.norm_squared() + 2.0 * rdot * rdot)
+        }
+        SurfaceKind::Cylinder => {
+            let cyl = downcast::<CylinderSurface>(surface, kind)?;
+            let a = *cyl.axis.as_ref();
+            let (vc, rdot) = cylinder_field_velocity(kind, vel_seeds)?;
+            let xperp = *xdot - a * xdot.dot(a);
+            let vcperp = vc - a * vc.dot(a);
+            let rel = xperp - vcperp;
+            Ok(-2.0 * rel.norm_squared() + 2.0 * rdot * rdot)
+        }
+        _ => Err(DiffError::UnsupportedConstraint(kind)),
+    }
+}
+
+/// Sum the seeded (center velocity, radius rate) of a sphere's velocity
+/// seeds, rejecting inapplicable kinds.
+fn sphere_field_velocity(
+    kind: SurfaceKind,
+    seeds: &[SurfaceSeed],
+) -> Result<(Vec3, f64), DiffError> {
+    let mut vc = Vec3::new(0.0, 0.0, 0.0);
+    let mut rate = 0.0;
+    for seed in seeds {
+        match *seed {
+            SurfaceSeed::Translate { velocity } => vc += velocity,
+            SurfaceSeed::SphereRadius { rate: r } => rate += r,
+            other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+        }
+    }
+    Ok((vc, rate))
+}
+
+/// Sum the seeded (center velocity, radius rate) of a cylinder's velocity
+/// seeds, rejecting inapplicable kinds.
+fn cylinder_field_velocity(
+    kind: SurfaceKind,
+    seeds: &[SurfaceSeed],
+) -> Result<(Vec3, f64), DiffError> {
+    let mut vc = Vec3::new(0.0, 0.0, 0.0);
+    let mut rate = 0.0;
+    for seed in seeds {
+        match *seed {
+            SurfaceSeed::Translate { velocity } => vc += velocity,
+            SurfaceSeed::CylinderRadius { rate: r } => rate += r,
+            other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+        }
+    }
+    Ok((vc, rate))
+}
+
 /// Normalized incidence residual of a vertex against a surface: the
 /// distance-like quantity `|g(x)| / |∇g(x)|`. Returns `None` for surface
 /// kinds without an implicit form (their incidence cannot be tested) and
@@ -624,5 +747,81 @@ mod tests {
             (v - Vec3::z()).norm() < 1e-6,
             "noise direction amplified: v = {v:?}"
         );
+    }
+
+    #[test]
+    fn cylinder_radius_acceleration_matches_nonlinear_field() {
+        // A rim vertex on a fixed plane z = 5 and a cylinder whose radius is a
+        // *nonlinear* function of θ: r(θ) = r0 + ṙθ + ½r̈θ². The vertex rides
+        // radially: x(θ) = center + r(θ)·û + cap, so ẋ = ṙû and ẍ = r̈û with
+        // the angular slide frozen. This exercises the velocity-curvature term
+        // (ẋ nonzero) *and* the field-acceleration term (r̈ nonzero).
+        let plane = Plane::new(Point3::new(0.0, 0.0, 5.0), Vec3::x(), Vec3::y());
+        let r0 = 2.5;
+        let cyl = CylinderSurface::new(r0);
+        let (rdot, rddot) = (0.7, 1.3);
+        let u = 1.1_f64;
+        let uhat = Vec3::new(u.cos(), u.sin(), 0.0);
+        let x = Point3::new(r0 * u.cos(), r0 * u.sin(), 5.0);
+
+        let rows1 = vec![
+            constraint_row(&plane, &[], &x).unwrap(),
+            constraint_row(&cyl, &[SurfaceSeed::CylinderRadius { rate: rdot }], &x).unwrap(),
+        ];
+        let xdot = solve_vertex_velocity(&rows1).unwrap();
+        assert!((xdot - uhat * rdot).norm() < 1e-12, "xdot = {xdot:?}");
+
+        let rows2 = vec![
+            constraint_row_2(&plane, &[], &[], &x, &xdot).unwrap(),
+            constraint_row_2(
+                &cyl,
+                &[SurfaceSeed::CylinderRadius { rate: rdot }],
+                &[SurfaceSeed::CylinderRadius { rate: rddot }],
+                &x,
+                &xdot,
+            )
+            .unwrap(),
+        ];
+        let xddot = solve_vertex_velocity(&rows2).unwrap();
+        assert!(
+            (xddot - uhat * rddot).norm() < 1e-12,
+            "xddot = {xddot:?} vs expected {:?}",
+            uhat * rddot
+        );
+    }
+
+    #[test]
+    fn sphere_growing_corner_acceleration_matches_fd() {
+        // A corner where three orthogonal planes meet a growing sphere is
+        // over-determined by the planes alone; use a single sphere + two planes
+        // pinning a point that rides the sphere along a fixed direction as the
+        // radius grows nonlinearly. Validate ẍ against a central difference of
+        // the analytic ẋ under r ± δ (the sphere row's curvature is 2I).
+        let sph = SphereSurface::new(3.0);
+        let px = Plane::new(Point3::new(0.0, 0.0, 0.0), Vec3::y(), Vec3::z()); // x = 0
+        let py = Plane::new(Point3::new(0.0, 0.0, 0.0), Vec3::z(), Vec3::x()); // y = 0
+                                                                               // Point on the +z pole of the sphere (x = y = 0, z = r).
+        let x = Point3::new(0.0, 0.0, 3.0);
+        let rate = 1.0;
+
+        let vel = |s: &[SurfaceSeed]| {
+            let rows = vec![
+                constraint_row(&px, &[], &x).unwrap(),
+                constraint_row(&py, &[], &x).unwrap(),
+                constraint_row(&sph, s, &x).unwrap(),
+            ];
+            solve_vertex_velocity(&rows).unwrap()
+        };
+        let xdot = vel(&[SurfaceSeed::SphereRadius { rate }]);
+        assert!((xdot - Vec3::z()).norm() < 1e-12, "xdot = {xdot:?}");
+
+        let rows2 = vec![
+            constraint_row_2(&px, &[], &[], &x, &xdot).unwrap(),
+            constraint_row_2(&py, &[], &[], &x, &xdot).unwrap(),
+            constraint_row_2(&sph, &[SurfaceSeed::SphereRadius { rate }], &[], &x, &xdot).unwrap(),
+        ];
+        let xddot = solve_vertex_velocity(&rows2).unwrap();
+        // Pole rides at exactly z = r (linear in r), so ẍ = 0.
+        assert!(xddot.norm() < 1e-12, "xddot = {xddot:?}");
     }
 }

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -35,20 +35,23 @@ use vcad_kernel_tessellate::frozen::FrozenError;
 mod adjoint;
 mod contract;
 mod fd;
+mod gauss_newton;
 mod implicit;
 mod lbfgs;
 mod lift;
 mod mass;
 mod optimize;
 mod seam;
+mod second_order;
 mod synthesize;
 
 pub use adjoint::{evaluate_with_pullback, MeshCotangents, SurfaceCotangent};
 pub use contract::{contract_sensitivity, volume_gradient};
 pub use fd::{compare_velocities, fd_velocities, fd_volume_derivative, FdComparison};
+pub use gauss_newton::{gauss_newton_gradient, gauss_newton_hessian, gauss_newton_hvp};
 pub use implicit::{
-    constraint_row, row_pullbacks, solve_vertex_velocity, surface_residual, tangency_rows,
-    ConstraintRow,
+    constraint_row, constraint_row_2, row_pullbacks, solve_vertex_velocity, surface_residual,
+    tangency_rows, ConstraintRow,
 };
 pub use lbfgs::minimize_lbfgs;
 pub use lift::{lift_surface, DualSurface};
@@ -58,6 +61,10 @@ pub use optimize::{
     OptimizeOptions, OptimizeResult, StopReason, VolumeMatch,
 };
 pub use seam::{evaluate_with_sensitivity, volume_with_derivative, SeamMesh};
+pub use second_order::{
+    evaluate_with_second_derivative, volume_with_second_derivative, SeamMeshSecond,
+    SecondOrderSeeding,
+};
 pub use synthesize::{synthesize_all, synthesize_seeding};
 pub use vcad_kernel_tessellate::frozen::mesh_volume;
 
@@ -93,6 +100,15 @@ pub enum DiffError {
     /// No implicit constraint form is implemented for this surface kind, so
     /// a topology vertex adjacent to it cannot be differentiated.
     UnsupportedConstraint(SurfaceKind),
+    /// No second-order (acceleration) form is implemented for this surface
+    /// kind yet. The volume second derivative supports plane/cylinder/sphere,
+    /// whose surface points are **linear** in the seeded fields (translation,
+    /// radius), so the node acceleration is just the first-order lift fed the
+    /// field accelerations. Cone/torus points are nonlinear in their shape
+    /// fields (half-angle, radii), so their acceleration carries an extra
+    /// `∂²x/∂field²·fielḋ²` term — a mechanical extension, deliberately not
+    /// shipped.
+    SecondOrderUnsupported(SurfaceKind),
     /// The implicit system at a topology vertex is inconsistent: dependent
     /// constraint rows disagree beyond tolerance. The vertex does not
     /// actually lie on a common intersection of its adjacent surfaces (or a
@@ -144,6 +160,10 @@ impl std::fmt::Display for DiffError {
             DiffError::UnsupportedConstraint(kind) => write!(
                 f,
                 "no implicit constraint form for surface kind {kind:?}; cannot differentiate an adjacent topology vertex"
+            ),
+            DiffError::SecondOrderUnsupported(kind) => write!(
+                f,
+                "no second-order form for surface kind {kind:?}; volume second derivative supports plane/cylinder/sphere"
             ),
             DiffError::InconsistentConstraints { residual } => write!(
                 f,

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -134,7 +134,8 @@ pub enum DiffError {
         len: usize,
     },
     /// Seeding synthesis met a surface kind outside the seed vocabulary
-    /// (only plane / cylinder / sphere can be expressed as [`SurfaceSeed`]s).
+    /// (plane / cylinder / sphere / cone / torus are expressible as
+    /// [`SurfaceSeed`]s; NURBS and bilinear patches are not).
     UnsupportedSynthesis(SurfaceKind),
     /// Seeding synthesis found two genuinely distinct surfaces both within
     /// the matching tolerance of one base surface, so the perturbed

--- a/crates/vcad-kernel-diff/src/second_order.rs
+++ b/crates/vcad-kernel-diff/src/second_order.rs
@@ -1,0 +1,344 @@
+//! M10 — exact directional second derivatives of the volume QoI.
+//!
+//! The seam already prices `dx/dθ` (velocities) and, through them,
+//! `dV/dθ = Σ_i (∂V/∂x_i)·ẋ_i`. The honest second derivative of the volume
+//! along one parameter is
+//!
+//! ```text
+//! d²V/dθ² = Σ_ij (∂²V/∂x_i∂x_j) ẋ_i ẋ_j  +  Σ_i (∂V/∂x_i) ẍ_i,
+//! ```
+//!
+//! two contributions this module carries in full:
+//!
+//! - the **curvature of `V` in the node positions**, contracted with the
+//!   velocities twice — nonzero even when every node moves at constant speed
+//!   (the boolean hole's `V(r)` is quadratic in `r` with *zero* node
+//!   acceleration, yet `d²V/dr² ≠ 0`); and
+//! - the **node accelerations** `ẍ_i = d²x_i/dθ²`.
+//!
+//! Both fall out of one pass of the shared generic volume integral
+//! [`crate::mesh_volume`] over the nested scalar `Dual<Dual<f64>>`: seed each
+//! node coordinate as `((x, ẋ), (ẋ, ẍ))` and read `V`, `dV/dθ`, `d²V/dθ²`
+//! off the value / first-tangent / second-tangent slots. `Dual<Dual<f64>>`
+//! satisfies `tang::Scalar` (every `Dual<S: Scalar>` does), so `mesh_volume`
+//! compiles at that type unchanged — the genericity that was always the
+//! second-order on-ramp.
+//!
+//! # Node accelerations
+//!
+//! - **Lift nodes** (`SurfaceUv`) on plane/cylinder/sphere: the surface point
+//!   `x(θ) = S(u, v; fields(θ))` is **linear** in the seeded fields
+//!   (translation, radius) at a frozen `(u, v)`, so `∂x/∂field` is a constant
+//!   map and `ẍ = (∂x/∂field)·field̈` — exactly the first-order lift
+//!   ([`crate::lift_surface`]) evaluated with the field *accelerations*
+//!   seeded where velocities normally go. No second-order lift is needed for
+//!   these kinds; cone/torus (nonlinear in half-angle / radii) are rejected
+//!   with [`DiffError::SecondOrderUnsupported`].
+//! - **Vertex / Boundary nodes** solve the second-order implicit system
+//!   ([`crate::constraint_row_2`]): the same row gradients as the velocity
+//!   solve, the frozen tangential completion reused verbatim, only the
+//!   right-hand side carries the curvature. Tangency-completion rows are
+//!   linear in `x` and the surface center, so their second-order form is the
+//!   first-order [`crate::tangency_rows`] fed the acceleration seeds.
+//!
+//! What this computes, exactly: the volume second derivative with the node
+//! accelerations of plane/cylinder/sphere nodes carried in full. It is not a
+//! generic Hessian over many parameters (that is [`crate::gauss_newton_hvp`]'s
+//! job for least-squares QoIs) — it is `d²V/dθ²` along one seeded direction,
+//! with every term stated.
+
+use std::collections::{BTreeSet, HashMap};
+
+use tang::Dual;
+use vcad_kernel_geom::SurfaceKind;
+use vcad_kernel_math::{Point2, Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::{refine_boundary_point, FrozenError, FrozenPlan, NodeRecipe};
+
+use crate::seam::{
+    assemble_vertex_rows, checked_index, incidence_context, vertex_incident_surfaces,
+};
+use crate::{
+    constraint_row, constraint_row_2, lift_surface, mesh_volume, solve_vertex_velocity,
+    tangency_rows, ConstraintRow, DiffError, DualSurface, ParamSeeding,
+};
+
+/// A parameter's first- **and** second-order seeding: how θ moves each
+/// surface's fields to first order (`velocity`) and to second order
+/// (`acceleration`).
+///
+/// For the common case where θ enters the fields *linearly* (a radius equal
+/// to θ, a face translating at constant rate), the `acceleration` seeding is
+/// empty and every node acceleration is zero — yet `d²V/dθ²` is still
+/// generally nonzero (it is the position-curvature term). A genuinely
+/// nonlinear θ → field map (a radius `r(θ) = θ²`, a cone half-angle) fills in
+/// the `acceleration` seeds with the field's `d²/dθ²`.
+#[derive(Debug, Clone, Default)]
+pub struct SecondOrderSeeding {
+    /// First-order seeding (`d field/dθ`) — identical to the forward seam's
+    /// [`ParamSeeding`], so a first-order problem lifts to second order by
+    /// adding accelerations and nothing else.
+    pub velocity: ParamSeeding,
+    /// Second-order seeding (`d² field/dθ²`), reusing the same
+    /// [`crate::SurfaceSeed`] vocabulary with each rate/velocity read as the
+    /// field's acceleration. Empty for fields linear in θ.
+    pub acceleration: ParamSeeding,
+}
+
+impl SecondOrderSeeding {
+    /// A seeding whose field velocities are `velocity` and whose field
+    /// accelerations are all zero (the θ-linear case).
+    pub fn linear(velocity: ParamSeeding) -> Self {
+        Self {
+            velocity,
+            acceleration: ParamSeeding::new(),
+        }
+    }
+}
+
+/// A frozen mesh with first- and second-order sensitivities: node `i` of
+/// `positions` has velocity `velocities[i]` (`dx/dθ`) and acceleration
+/// `accelerations[i]` (`d²x/dθ²`).
+#[derive(Debug, Clone)]
+pub struct SeamMeshSecond {
+    /// Node positions `x(θ)`.
+    pub positions: Vec<Point3>,
+    /// Node velocities `dx/dθ`.
+    pub velocities: Vec<Vec3>,
+    /// Node accelerations `d²x/dθ²`.
+    pub accelerations: Vec<Vec3>,
+    /// Frozen connectivity (copied from the plan).
+    pub triangles: Vec<[u32; 3]>,
+    /// Recipes (copied from the plan) so callers can select node classes.
+    pub recipes: Vec<NodeRecipe>,
+}
+
+/// Second-order rows of a topology vertex: the same incident-surface and
+/// tangency-pair walk as the first-order [`assemble_vertex_rows`], but each
+/// row's rhs carries the acceleration curvature. Gradients are identical to
+/// first order, so [`solve_vertex_velocity`] recovers `ẍ`.
+fn assemble_vertex_rows_second(
+    brep: &BRepSolid,
+    incident: &BTreeSet<usize>,
+    seeding: &SecondOrderSeeding,
+    x: &Point3,
+    xdot: &Vec3,
+) -> Result<Vec<ConstraintRow>, DiffError> {
+    let mut rows = Vec::new();
+    for &sidx in incident {
+        let surface = brep.geometry.surfaces[sidx].as_ref();
+        rows.push(constraint_row_2(
+            surface,
+            seeding.velocity.get(sidx),
+            seeding.acceleration.get(sidx),
+            x,
+            xdot,
+        )?);
+    }
+    for &pidx in incident {
+        let plane = brep.geometry.surfaces[pidx].as_ref();
+        let Some(p) = plane.as_any().downcast_ref::<vcad_kernel_geom::Plane>() else {
+            continue;
+        };
+        let n = *p.normal_dir.as_ref();
+        for &sidx in incident {
+            if sidx == pidx {
+                continue;
+            }
+            let surface = brep.geometry.surfaces[sidx].as_ref();
+            // A tangency constraint q·(x − center) = 0 is linear in x and the
+            // center (q constant), so its second total derivative is
+            // q·ẍ = q·center̈ — the first-order row fed the acceleration seeds.
+            for row in tangency_rows(n, surface, seeding.acceleration.get(sidx), x)? {
+                rows.push(row);
+            }
+        }
+    }
+    Ok(rows)
+}
+
+/// Evaluate a frozen plan against its capture-time B-rep with **first- and
+/// second-order** analytic sensitivities.
+///
+/// `brep` must be the capture-time B-rep, exactly as for
+/// [`crate::evaluate_with_sensitivity`] (the same signature and anchor checks
+/// hold). The first-order path is identical to that function; the addition is
+/// the per-node acceleration `ẍ` (see the module docs for the kinematics).
+///
+/// `SurfaceUv` nodes are restricted to plane/cylinder/sphere; a lift node on
+/// a cone/torus errors with [`DiffError::SecondOrderUnsupported`].
+pub fn evaluate_with_second_derivative(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+    seeding: &SecondOrderSeeding,
+) -> Result<SeamMeshSecond, DiffError> {
+    let ci = checked_index(brep, plan)?;
+    let topo = &brep.topology;
+    let ctx = incidence_context(brep, &ci.faces);
+    let vel = &seeding.velocity;
+    let acc = &seeding.acceleration;
+
+    // Lift each referenced face surface once per (velocity / acceleration)
+    // seeding — shared by every sample on the face.
+    let mut lifted_vel: HashMap<u32, DualSurface> = HashMap::new();
+    let mut lifted_acc: HashMap<u32, DualSurface> = HashMap::new();
+
+    let anchor_check = |node: usize, p: &Point3, anchor: &Point3| -> Result<(), DiffError> {
+        let d2 = (*p - *anchor).norm_squared();
+        if d2 > crate::seam::ANCHOR_TOL * crate::seam::ANCHOR_TOL {
+            return Err(FrozenError::CorrespondenceLost {
+                node,
+                distance: d2.sqrt(),
+            }
+            .into());
+        }
+        Ok(())
+    };
+
+    let mut positions = Vec::with_capacity(plan.nodes.len());
+    let mut velocities = Vec::with_capacity(plan.nodes.len());
+    let mut accelerations = Vec::with_capacity(plan.nodes.len());
+
+    for (i, recipe) in plan.nodes.iter().enumerate() {
+        match *recipe {
+            NodeRecipe::TopoVertex { vertex } => {
+                let vid = *ci
+                    .vertices
+                    .get(vertex as usize)
+                    .ok_or(FrozenError::RecipeOutOfRange)?;
+                let x = topo.vertices[vid].point;
+                anchor_check(i, &x, &plan.base_positions[i])?;
+                let incident = vertex_incident_surfaces(brep, &ctx, vid, &x);
+                let rows1: Vec<ConstraintRow> = assemble_vertex_rows(brep, &incident, vel, &x)?
+                    .into_iter()
+                    .map(|(_, row)| row)
+                    .collect();
+                let xdot = solve_vertex_velocity(&rows1)?;
+                let rows2 = assemble_vertex_rows_second(brep, &incident, seeding, &x, &xdot)?;
+                let xddot = solve_vertex_velocity(&rows2)?;
+                positions.push(x);
+                velocities.push(xdot);
+                accelerations.push(xddot);
+            }
+            NodeRecipe::SurfaceUv { face, u, v } => {
+                let surface_index = {
+                    let face_id = *ci
+                        .faces
+                        .get(face as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    topo.faces[face_id].surface_index
+                };
+                let kind = brep.geometry.surfaces[surface_index].surface_type();
+                // Only kinds whose points are linear in the seeded fields.
+                if !matches!(
+                    kind,
+                    SurfaceKind::Plane | SurfaceKind::Cylinder | SurfaceKind::Sphere
+                ) {
+                    return Err(DiffError::SecondOrderUnsupported(kind));
+                }
+                let uv = Point2::new(u, v);
+                if let std::collections::hash_map::Entry::Vacant(e) = lifted_vel.entry(face) {
+                    let surface = brep.geometry.surfaces[surface_index].as_ref();
+                    e.insert(lift_surface(surface, vel.get(surface_index))?);
+                }
+                if let std::collections::hash_map::Entry::Vacant(e) = lifted_acc.entry(face) {
+                    let surface = brep.geometry.surfaces[surface_index].as_ref();
+                    e.insert(lift_surface(surface, acc.get(surface_index))?);
+                }
+                let (p, vx) = lifted_vel[&face].evaluate_with_velocity(uv);
+                anchor_check(i, &p, &plan.base_positions[i])?;
+                // x is linear in the fields ⇒ ẍ = (∂x/∂field)·field̈, which is
+                // the first-order lift evaluated with the acceleration seeds.
+                let (_, ax) = lifted_acc[&face].evaluate_with_velocity(uv);
+                positions.push(p);
+                velocities.push(vx);
+                accelerations.push(ax);
+            }
+            NodeRecipe::Boundary { face_a, face_b, .. } => {
+                let sidx = |slot: u32| -> Result<usize, DiffError> {
+                    let face_id = *ci
+                        .faces
+                        .get(slot as usize)
+                        .ok_or(FrozenError::RecipeOutOfRange)?;
+                    Ok(topo.faces[face_id].surface_index)
+                };
+                let (sidx_a, sidx_b) = (sidx(face_a)?, sidx(face_b)?);
+                let sa = brep.geometry.surfaces[sidx_a].as_ref();
+                let sb = brep.geometry.surfaces[sidx_b].as_ref();
+                let anchor = plan.base_positions[i];
+                let x = refine_boundary_point(sa, sb, &anchor)
+                    .ok_or(FrozenError::BoundarySolveFailed { node: i })?;
+                anchor_check(i, &x, &anchor)?;
+                let rows1 = vec![
+                    constraint_row(sa, vel.get(sidx_a), &x)?,
+                    constraint_row(sb, vel.get(sidx_b), &x)?,
+                ];
+                let xdot = solve_vertex_velocity(&rows1)?;
+                let rows2 = vec![
+                    constraint_row_2(sa, vel.get(sidx_a), acc.get(sidx_a), &x, &xdot)?,
+                    constraint_row_2(sb, vel.get(sidx_b), acc.get(sidx_b), &x, &xdot)?,
+                ];
+                let xddot = solve_vertex_velocity(&rows2)?;
+                positions.push(x);
+                velocities.push(xdot);
+                accelerations.push(xddot);
+            }
+        }
+    }
+
+    Ok(SeamMeshSecond {
+        positions,
+        velocities,
+        accelerations,
+        triangles: plan.triangles.clone(),
+        recipes: plan.nodes.clone(),
+    })
+}
+
+/// Volume, `dV/dθ`, and `d²V/dθ²` of a second-order seam mesh, in one pass of
+/// the shared generic integral over `Dual<Dual<f64>>`.
+///
+/// Each node coordinate is packed as `((x, ẋ), (ẋ, ẍ))` — the standard
+/// nested-dual seeding of a scalar function of one variable — so the returned
+/// triple is `(V, dV/dθ, d²V/dθ²)` read off the value, first-tangent, and
+/// second-tangent slots. The result is **exact** for the frozen mesh: both
+/// the `∂²V/∂x²:ẋẋ` position-curvature term and the `∂V/∂x·ẍ`
+/// node-acceleration term are carried (see the module docs).
+pub fn volume_with_second_derivative(seam: &SeamMeshSecond) -> (f64, f64, f64) {
+    type Dd = Dual<Dual<f64>>;
+    let pack = |x: f64, v: f64, a: f64| -> Dd { Dual::new(Dual::new(x, v), Dual::new(v, a)) };
+    let pts: Vec<tang::Point3<Dd>> = seam
+        .positions
+        .iter()
+        .zip(&seam.velocities)
+        .zip(&seam.accelerations)
+        .map(|((p, v), a)| {
+            tang::Point3::new(
+                pack(p.x, v.x, a.x),
+                pack(p.y, v.y, a.y),
+                pack(p.z, v.z, a.z),
+            )
+        })
+        .collect();
+    let vol = mesh_volume(&pts, &seam.triangles);
+    (vol.real.real, vol.real.dual, vol.dual.dual)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `Dual<Dual<f64>>` satisfies `tang::Scalar`, and the nested-dual seeding
+    /// recovers `f`, `f'`, `f''` of a scalar polynomial — the on-ramp probe.
+    #[test]
+    fn nested_dual_recovers_second_derivative() {
+        type Dd = Dual<Dual<f64>>;
+        // f(θ) = θ³ at θ = 2, with θ seeded as the variable.
+        let theta = 2.0;
+        let seed: Dd = Dual::new(Dual::new(theta, 1.0), Dual::new(1.0, 0.0));
+        let f = seed * seed * seed;
+        assert!((f.real.real - 8.0).abs() < 1e-12); // 2³
+        assert!((f.real.dual - 12.0).abs() < 1e-12); // 3·2²
+        assert!((f.dual.dual - 12.0).abs() < 1e-12); // 6·2
+    }
+}

--- a/crates/vcad-kernel-diff/tests/m10_perf.rs
+++ b/crates/vcad-kernel-diff/tests/m10_perf.rs
@@ -1,0 +1,242 @@
+//! M10 — performance: spatial-hash accelerator for the evaluation-time
+//! vertex resolution.
+//!
+//! Profiling (the timing test below) settled where the seam actually spends
+//! its time: capture, seam, and pullback are all **linear in node count**
+//! (the cross-face dedup was already spatial-hashed in the M0–M2 hardening,
+//! and the per-face topology-vertex classification is bounded by a face's
+//! boundary loop, not by tessellation density — grid-accelerating it measured
+//! *slower*, so it was left alone). The one genuinely `O(nodes · vertices)`
+//! scan is the **evaluation-time** (`evaluate_plan`, the FD oracle) resolution
+//! of each frozen node to its nearest rebuilt vertex. M10 grids that.
+//!
+//! Two things here:
+//!
+//! 1. **Bit-identical equivalence** — [`evaluate_plan`] (grid) vs
+//!    [`evaluate_plan_naive`] (linear), on the rounded cube and a
+//!    flywheel-class drilled disc, asserted byte-for-byte.
+//! 2. **Timing evidence** — a non-criterion harness printing capture / seam /
+//!    pullback (to show their linearity) and `evaluate_plan` naive-vs-grid (to
+//!    show the win), at `circle_segments ∈ {16, 64, 128}`. No timing
+//!    assertions.
+
+use std::time::Instant;
+
+use vcad_kernel::Solid;
+use vcad_kernel_diff::{
+    evaluate_with_pullback, evaluate_with_sensitivity, volume_gradient, ParamSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, SphereSurface};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::{make_cube, BRepSolid};
+use vcad_kernel_tessellate::frozen::{
+    capture_plan, evaluate_plan, evaluate_plan_naive, FrozenMesh,
+};
+use vcad_kernel_tessellate::TessellationParams;
+
+// -------------------------------------------------------------- the models
+
+fn rounded_cube() -> BRepSolid {
+    vcad_kernel_fillet::fillet_all_edges(&make_cube(10.0, 10.0, 10.0), 1.5)
+}
+
+/// A flywheel-class part: a disc with a center bore and four lightening holes
+/// (all boolean cuts, so the topology carries many polygonized rim vertices —
+/// the worst case for the per-node nearest-vertex resolution).
+fn flywheel() -> BRepSolid {
+    let disc = Solid::cylinder(20.0, 6.0, 64);
+    let bore = Solid::cylinder(5.0, 8.0, 48).translate(0.0, 0.0, -1.0);
+    let mut body = disc.difference(&bore);
+    for (dx, dy) in [(11.0, 0.0), (-11.0, 0.0), (0.0, 11.0), (0.0, -11.0)] {
+        let hole = Solid::cylinder(3.0, 8.0, 32).translate(dx, dy, -1.0);
+        body = body.difference(&hole);
+    }
+    body.as_brep().expect("flywheel stays BRep").clone()
+}
+
+/// The M4/M5 fillet-radius seeding on the rounded cube (a representative
+/// composite seeding to price the seam / pullback against).
+fn rc_seeding(brep: &BRepSolid) -> ParamSeeding {
+    let r = brep
+        .geometry
+        .surfaces
+        .iter()
+        .find_map(|s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .map(|c| c.radius)
+        })
+        .expect("blend cylinders");
+    let a = 10.0;
+    let retreat = |center: Point3| {
+        let comp = |c: f64| {
+            if (c - r).abs() < 1e-9 {
+                1.0
+            } else if (c - (a - r)).abs() < 1e-9 {
+                -1.0
+            } else {
+                0.0
+            }
+        };
+        Vec3::new(comp(center.x), comp(center.y), comp(center.z))
+    };
+    let mut seeding = ParamSeeding::new();
+    for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+        if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+            seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(c.center),
+                },
+            );
+        } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+            seeding.seed(i, SurfaceSeed::SphereRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(sp.center),
+                },
+            );
+        }
+    }
+    seeding
+}
+
+// ----------------------------------------------------- equivalence (gated)
+
+/// Assert two evaluated meshes are bit-identical: same triangles, same node
+/// positions to the bit (both paths run identical float arithmetic).
+fn assert_meshes_identical(grid: &FrozenMesh, naive: &FrozenMesh, what: &str) {
+    assert_eq!(grid.triangles, naive.triangles, "{what}: triangles");
+    assert_eq!(
+        grid.positions.len(),
+        naive.positions.len(),
+        "{what}: node count"
+    );
+    for (i, (a, b)) in grid.positions.iter().zip(&naive.positions).enumerate() {
+        assert!(
+            a.x.to_bits() == b.x.to_bits()
+                && a.y.to_bits() == b.y.to_bits()
+                && a.z.to_bits() == b.z.to_bits(),
+            "{what}: position {i} differs: {a:?} vs {b:?}"
+        );
+    }
+}
+
+#[test]
+fn m10_grid_evaluation_is_bit_identical_to_linear() {
+    for segs in [16u32, 64, 128] {
+        let params = TessellationParams {
+            circle_segments: segs,
+            height_segments: 2,
+            ..Default::default()
+        };
+        let rc = rounded_cube();
+        let plan = capture_plan(&rc, &params).expect("capture");
+        let grid = evaluate_plan(&rc, &plan).expect("grid eval");
+        let naive = evaluate_plan_naive(&rc, &plan).expect("naive eval");
+        assert_meshes_identical(&grid, &naive, &format!("rounded cube @ {segs}"));
+    }
+
+    let fw = flywheel();
+    let params = TessellationParams {
+        circle_segments: 64,
+        height_segments: 1,
+        ..Default::default()
+    };
+    let plan = capture_plan(&fw, &params).expect("capture");
+    let grid = evaluate_plan(&fw, &plan).expect("grid eval");
+    let naive = evaluate_plan_naive(&fw, &plan).expect("naive eval");
+    assert_meshes_identical(&grid, &naive, "flywheel");
+}
+
+// -------------------------------------------------------- timing (printed)
+
+fn median_ms(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    samples[samples.len() / 2]
+}
+
+fn time_ms(reps: usize, mut f: impl FnMut()) -> f64 {
+    let mut samples = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let t = Instant::now();
+        f();
+        samples.push(t.elapsed().as_secs_f64() * 1e3);
+    }
+    median_ms(samples)
+}
+
+#[test]
+fn m10_capture_seam_pullback_timings() {
+    eprintln!("\n=== M10 timings (median ms) ===");
+    eprintln!("-- rounded cube: capture / seam / pullback (all ~linear in nodes) --");
+    let rc = rounded_cube();
+    let seeding = rc_seeding(&rc);
+    for segs in [16u32, 64, 128] {
+        let params = TessellationParams {
+            circle_segments: segs,
+            height_segments: 2,
+            ..Default::default()
+        };
+        let reps = if segs >= 128 { 15 } else { 40 };
+
+        let cap_ms = time_ms(reps, || {
+            let _ = capture_plan(&rc, &params).unwrap();
+        });
+        let plan = capture_plan(&rc, &params).unwrap();
+        let nodes = plan.nodes.len();
+        let seam_ms = time_ms(reps, || {
+            let _ = evaluate_with_sensitivity(&rc, &plan, &seeding).unwrap();
+        });
+        let base = evaluate_with_sensitivity(&rc, &plan, &ParamSeeding::new()).unwrap();
+        let w = volume_gradient(&base.positions, &base.triangles);
+        let pull_ms = time_ms(reps, || {
+            let _ = evaluate_with_pullback(&rc, &plan, &w).unwrap();
+        });
+        eprintln!(
+            "  segs={segs:>3} nodes={nodes:>6}: capture {cap_ms:7.3}  seam {seam_ms:6.3}  pullback {pull_ms:6.3}"
+        );
+    }
+
+    // The gridded win: evaluation-time vertex resolution, naive vs grid, where
+    // the topology carries many rebuilt vertices (the flywheel's boolean rims).
+    eprintln!("-- evaluate_plan (FD-oracle resolution): naive O(nodes·verts) vs grid --");
+    for (name, brep, hseg) in [
+        ("rounded cube", rounded_cube(), 2u32),
+        ("flywheel    ", flywheel(), 1u32),
+    ] {
+        for segs in [16u32, 64, 128] {
+            let params = TessellationParams {
+                circle_segments: segs,
+                height_segments: hseg,
+                ..Default::default()
+            };
+            let plan = capture_plan(&brep, &params).unwrap();
+            let verts = plan
+                .nodes
+                .iter()
+                .filter(|n| {
+                    matches!(
+                        n,
+                        vcad_kernel_tessellate::frozen::NodeRecipe::TopoVertex { .. }
+                    )
+                })
+                .count();
+            let reps = if segs >= 128 { 20 } else { 60 };
+            let naive_ms = time_ms(reps, || {
+                let _ = evaluate_plan_naive(&brep, &plan).unwrap();
+            });
+            let grid_ms = time_ms(reps, || {
+                let _ = evaluate_plan(&brep, &plan).unwrap();
+            });
+            eprintln!(
+                "  {name} segs={segs:>3} nodes={:>6} topo-verts={verts:>4}: naive {naive_ms:7.3}  grid {grid_ms:7.3}  (speedup {:.2}x)",
+                plan.nodes.len(),
+                naive_ms / grid_ms
+            );
+        }
+    }
+    eprintln!();
+}

--- a/crates/vcad-kernel-diff/tests/m10_second_order.rs
+++ b/crates/vcad-kernel-diff/tests/m10_second_order.rs
@@ -1,0 +1,616 @@
+//! M10 — second-order derivatives.
+//!
+//! Two families, each stating exactly what it computes:
+//!
+//! 1. **Gauss–Newton curvature** for least-squares mass-property objectives:
+//!    `H_GN = 2 JᵀJ` from the QoI Jacobian the seam already prices, validated
+//!    on the M9 five-parameter model near its optimum against a finite
+//!    difference of the *exact* gradient (= the full Hessian; near the optimum
+//!    the two differ only by the residual-curvature term, which vanishes at a
+//!    perfect fit). Gated loosely — the fillet model's re-capture
+//!    correspondence noise dominates the FD Hessian (documented).
+//!
+//! 2. **Exact `d²V/dθ²`** for the volume QoI via second-order node kinematics:
+//!    the boolean hole against its quadratic closed form
+//!    `d²V/dr² = −N·sin(2π/N)·t` and a central FD of the analytic `dV/dr`;
+//!    the cylinder height (`d²V/dh² = 0`, `V` linear); and the rounded cube
+//!    `d²V/dr²` against a central FD of the analytic `dV/dr` (plane, cylinder,
+//!    and sphere lift nodes, boundary rings, and tangency-completed corners
+//!    all exercised).
+
+use vcad_kernel::Solid;
+use vcad_kernel_diff::{
+    evaluate_with_second_derivative, evaluate_with_sensitivity, gauss_newton_gradient,
+    gauss_newton_hessian, mass_properties, mass_properties_with_derivative, volume_with_derivative,
+    volume_with_second_derivative, ParamSeeding, SecondOrderSeeding, SurfaceSeed,
+};
+use vcad_kernel_geom::{CylinderSurface, Plane, SphereSurface};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::{make_cube, make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+// ============================================================ volume gates
+
+/// Second-order volume of a fresh capture at `theta`, given a first-order
+/// velocity seeding derived from the built B-rep. Returns `(V, dV/dθ, d²V/dθ²)`.
+fn second_order_volume(
+    build: &dyn Fn(f64) -> BRepSolid,
+    velocity_seeding: &dyn Fn(&BRepSolid) -> ParamSeeding,
+    theta: f64,
+    params: &TessellationParams,
+) -> (f64, f64, f64) {
+    let brep = build(theta);
+    let plan = capture_plan(&brep, params).expect("capture");
+    let seeding = SecondOrderSeeding::linear(velocity_seeding(&brep));
+    let seam = evaluate_with_second_derivative(&brep, &plan, &seeding).expect("second-order seam");
+    volume_with_second_derivative(&seam)
+}
+
+/// The analytic `dV/dθ` of a fresh capture at `theta` (first-order seam).
+fn analytic_dv(
+    build: &dyn Fn(f64) -> BRepSolid,
+    velocity_seeding: &dyn Fn(&BRepSolid) -> ParamSeeding,
+    theta: f64,
+    params: &TessellationParams,
+) -> f64 {
+    let brep = build(theta);
+    let plan = capture_plan(&brep, params).expect("capture");
+    let seam = evaluate_with_sensitivity(&brep, &plan, &velocity_seeding(&brep))
+        .expect("first-order seam");
+    volume_with_derivative(&seam).1
+}
+
+/// Central FD of the analytic `dV/dθ` at `theta` (a fresh capture per probe):
+/// the honest second-derivative oracle for the re-captured family.
+fn fd_of_analytic_dv(
+    build: &dyn Fn(f64) -> BRepSolid,
+    velocity_seeding: &dyn Fn(&BRepSolid) -> ParamSeeding,
+    theta: f64,
+    h: f64,
+    params: &TessellationParams,
+) -> f64 {
+    let plus = analytic_dv(build, velocity_seeding, theta + h, params);
+    let minus = analytic_dv(build, velocity_seeding, theta - h, params);
+    (plus - minus) / (2.0 * h)
+}
+
+const HOLE_L: f64 = 10.0;
+const HOLE_W: f64 = 8.0;
+const HOLE_T: f64 = 5.0;
+const HOLE_SEGMENTS: u32 = 32;
+
+fn build_hole(r: f64) -> BRepSolid {
+    let block = Solid::cube(HOLE_L, HOLE_W, HOLE_T);
+    let tool =
+        Solid::cylinder(r, HOLE_T + 2.0, HOLE_SEGMENTS).translate(HOLE_L / 2.0, HOLE_W / 2.0, -1.0);
+    block
+        .difference(&tool)
+        .as_brep()
+        .expect("boolean stays BRep")
+        .clone()
+}
+
+/// Seed every cylinder's radius at rate 1 (the hole model has exactly one).
+fn hole_seeding(brep: &BRepSolid) -> ParamSeeding {
+    let mut s = ParamSeeding::new();
+    let n = s.seed_where(
+        &brep.geometry,
+        |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+        SurfaceSeed::CylinderRadius { rate: 1.0 },
+    );
+    assert_eq!(n, 1, "hole model should carry exactly one cylinder");
+    s
+}
+
+#[test]
+fn m10_hole_second_derivative_matches_closed_form_and_fd() {
+    let params = TessellationParams {
+        circle_segments: HOLE_SEGMENTS,
+        height_segments: 3,
+        ..Default::default()
+    };
+    let r0 = 2.5;
+    let (v, dv, ddv) = second_order_volume(&build_hole, &hole_seeding, r0, &params);
+
+    // V(r) = LWT − ½ N sin(2π/N) r² T (inscribed N-gon rim) ⇒
+    // dV/dr = −N sin(2π/N) r T, d²V/dr² = −N sin(2π/N) T (constant).
+    let n = HOLE_SEGMENTS as f64;
+    let sector = 2.0 * std::f64::consts::PI / n;
+    let v_exact = HOLE_L * HOLE_W * HOLE_T - 0.5 * n * sector.sin() * r0 * r0 * HOLE_T;
+    let dv_exact = -n * sector.sin() * r0 * HOLE_T;
+    let ddv_exact = -n * sector.sin() * HOLE_T;
+
+    assert!((v - v_exact).abs() / v_exact < 1e-12, "V {v} vs {v_exact}");
+    assert!(
+        (dv - dv_exact).abs() / dv_exact.abs() < 1e-9,
+        "dV {dv} vs {dv_exact}"
+    );
+    let rel_closed = (ddv - ddv_exact).abs() / ddv_exact.abs();
+    assert!(
+        rel_closed <= 1e-9,
+        "d²V/dr² {ddv} vs closed form {ddv_exact} (rel {rel_closed:.3e})"
+    );
+
+    // Central FD of the analytic dV/dr at h = 1e-6.
+    let fd = fd_of_analytic_dv(&build_hole, &hole_seeding, r0, 1e-6, &params);
+    let rel_fd = (ddv - fd).abs() / ddv_exact.abs();
+    eprintln!(
+        "hole d²V/dr²: analytic {ddv:.6} closed {ddv_exact:.6} FD {fd:.6} (rel_fd {rel_fd:.3e})"
+    );
+    assert!(
+        rel_fd <= 1e-6,
+        "d²V/dr² {ddv} vs FD {fd} (rel {rel_fd:.3e})"
+    );
+}
+
+#[test]
+fn m10_cylinder_height_second_derivative_is_zero() {
+    let params = TessellationParams {
+        circle_segments: 24,
+        height_segments: 4,
+        ..Default::default()
+    };
+    let build = |h: f64| make_cylinder(5.0, h, 24);
+    // The top cap plane translates at ẑ; V = area·h is linear ⇒ d²V/dh² = 0.
+    let seeding = |brep: &BRepSolid| {
+        let mut s = ParamSeeding::new();
+        let n = s.seed_where(
+            &brep.geometry,
+            |surf| {
+                surf.as_any()
+                    .downcast_ref::<Plane>()
+                    .map(|p| {
+                        p.normal_dir.as_ref().cross(Vec3::z()).norm() < 1e-12
+                            && p.signed_distance(&Point3::new(0.0, 0.0, 8.0)).abs() < 1e-9
+                    })
+                    .unwrap_or(false)
+            },
+            SurfaceSeed::Translate {
+                velocity: Vec3::z(),
+            },
+        );
+        assert_eq!(n, 1, "expected exactly the top cap plane");
+        s
+    };
+    let (_, dv, ddv) = second_order_volume(&build, &seeding, 8.0, &params);
+    let area = 0.5 * 24.0 * (2.0 * std::f64::consts::PI / 24.0).sin() * 25.0;
+    eprintln!("cylinder height: dV/dh {dv:.6} (area {area:.6}), d²V/dh² {ddv:.3e}");
+    assert!((dv - area).abs() / area < 1e-9, "dV/dh {dv} vs area {area}");
+    assert!(ddv.abs() < 1e-6, "d²V/dh² should vanish, got {ddv:.3e}");
+}
+
+const RC_A: f64 = 10.0;
+
+fn build_rc(r: f64) -> BRepSolid {
+    vcad_kernel_fillet::fillet_all_edges(&make_cube(RC_A, RC_A, RC_A), r)
+}
+
+/// The M4/M5 fillet-radius seeding: every blend radius grows at rate 1 while
+/// its center retreats from the edge.
+fn rc_seeding(brep: &BRepSolid) -> ParamSeeding {
+    // Read the radius back off any blend cylinder (they all carry it).
+    let r = brep
+        .geometry
+        .surfaces
+        .iter()
+        .find_map(|s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .map(|c| c.radius)
+        })
+        .expect("rounded cube has blend cylinders");
+    let a = RC_A;
+    let retreat = |center: Point3| {
+        let component = |c: f64| {
+            if (c - r).abs() < 1e-9 {
+                1.0
+            } else if (c - (a - r)).abs() < 1e-9 {
+                -1.0
+            } else {
+                0.0
+            }
+        };
+        Vec3::new(
+            component(center.x),
+            component(center.y),
+            component(center.z),
+        )
+    };
+    let mut seeding = ParamSeeding::new();
+    for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+        if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+            seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(c.center),
+                },
+            );
+        } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+            seeding.seed(i, SurfaceSeed::SphereRadius { rate: 1.0 });
+            seeding.seed(
+                i,
+                SurfaceSeed::Translate {
+                    velocity: retreat(sp.center),
+                },
+            );
+        }
+    }
+    seeding
+}
+
+#[test]
+fn m10_rounded_cube_second_derivative_matches_fd() {
+    let params = TessellationParams {
+        circle_segments: 16,
+        height_segments: 2,
+        ..Default::default()
+    };
+    let r0 = 1.5;
+    let (_, dv, ddv) = second_order_volume(&build_rc, &rc_seeding, r0, &params);
+    // Every node position is linear in r here (blend centers retreat and radii
+    // grow at constant rate), so the second-order vertex/lift machinery
+    // correctly computes *zero* node acceleration and d²V/dr² is the
+    // position-curvature term alone — asserted below.
+    let max_accel = {
+        let brep = build_rc(r0);
+        let plan = capture_plan(&brep, &params).unwrap();
+        let seam = evaluate_with_second_derivative(
+            &brep,
+            &plan,
+            &SecondOrderSeeding::linear(rc_seeding(&brep)),
+        )
+        .unwrap();
+        seam.accelerations
+            .iter()
+            .map(|a| a.norm())
+            .fold(0.0_f64, f64::max)
+    };
+    assert!(
+        max_accel < 1e-9,
+        "expected zero node acceleration, max {max_accel:.3e}"
+    );
+
+    // FD of the analytic dV/dr. A filleted solid re-captured at r ± h carries
+    // O(1e-4)-scale mesh-correspondence jitter (the M9 fillet-frame caveat),
+    // so a 1e-6 step sits in the noise; a 1e-3 step clears it and the central
+    // difference of the (smooth in r) analytic derivative converges to the
+    // second derivative. Gated at 5e-3, well inside the 1e-3-scale residual.
+    let fd = fd_of_analytic_dv(&build_rc, &rc_seeding, r0, 1e-3, &params);
+    let rel = (ddv - fd).abs() / fd.abs().max(1.0);
+    eprintln!(
+        "rounded cube: dV/dr {dv:.6}, d²V/dr² analytic {ddv:.6} vs FD {fd:.6} (rel {rel:.3e})"
+    );
+    assert!(
+        rel <= 5e-3,
+        "rounded-cube d²V/dr² {ddv} vs FD {fd} (rel {rel:.3e})"
+    );
+}
+
+// ================================================= Gauss–Newton curvature
+
+// The M9 five-parameter model: fillet_all_edges(cube(sx,sy,sz), r) drilled by
+// a centered ẑ hole of radius r_hole. Replicated here (test-local) so the GN
+// gate stands on the same geometry M9's recovery does.
+
+const THETA_STAR: [f64; 5] = [10.0, 12.0, 8.0, 1.8, 2.2];
+const GEOM_EPS: f64 = 1e-6;
+const RHO: f64 = 1.0;
+
+fn m9_build(theta: &[f64]) -> BRepSolid {
+    let (sx, sy, sz, r, rhole) = (theta[0], theta[1], theta[2], theta[3], theta[4]);
+    let rounded = vcad_kernel_fillet::fillet_all_edges(&make_cube(sx, sy, sz), r);
+    let tool = Solid::cylinder(rhole, sz + 2.0, 24).translate(sx / 2.0, sy / 2.0, -1.0);
+    Solid::from_brep(rounded)
+        .difference(&tool)
+        .as_brep()
+        .expect("boolean stays BRep")
+        .clone()
+}
+
+fn m9_tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 16,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+fn m9_dims(brep: &BRepSolid) -> [f64; 3] {
+    let mut mx = [f64::MIN; 3];
+    for v in brep.topology.vertices.values() {
+        mx[0] = mx[0].max(v.point.x);
+        mx[1] = mx[1].max(v.point.y);
+        mx[2] = mx[2].max(v.point.z);
+    }
+    mx
+}
+
+fn axis(k: usize) -> Vec3 {
+    [
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        Vec3::new(0.0, 0.0, 1.0),
+    ][k]
+}
+fn coord(p: Point3, k: usize) -> f64 {
+    [p.x, p.y, p.z][k]
+}
+fn is_hole(c: &CylinderSurface, d: [f64; 3]) -> bool {
+    c.axis.as_ref().cross(Vec3::z()).norm() < 1e-9
+        && (c.center.x - d[0] / 2.0).abs() < GEOM_EPS
+        && (c.center.y - d[1] / 2.0).abs() < GEOM_EPS
+}
+fn fillet_radius(brep: &BRepSolid, d: [f64; 3]) -> f64 {
+    brep.geometry
+        .surfaces
+        .iter()
+        .find_map(|s| {
+            s.as_any()
+                .downcast_ref::<CylinderSurface>()
+                .filter(|c| !is_hole(c, d))
+                .map(|c| c.radius)
+        })
+        .expect("rounded box has blend cylinders")
+}
+
+fn m9_seeding_for(brep: &BRepSolid, k: usize) -> ParamSeeding {
+    let d = m9_dims(brep);
+    let r = fillet_radius(brep, d);
+    let mut seeding = ParamSeeding::new();
+    match k {
+        0..=2 => {
+            let e = axis(k);
+            for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+                if let Some(p) = s.as_any().downcast_ref::<Plane>() {
+                    if (*p.normal_dir.as_ref() - e).norm() < 1e-9 {
+                        seeding.seed(i, SurfaceSeed::Translate { velocity: e });
+                    }
+                } else if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+                    if is_hole(c, d) {
+                        if k < 2 {
+                            seeding.seed(i, SurfaceSeed::Translate { velocity: e * 0.5 });
+                        }
+                    } else if (coord(c.center, k) - (d[k] - r)).abs() < GEOM_EPS {
+                        seeding.seed(i, SurfaceSeed::Translate { velocity: e });
+                    }
+                } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+                    if (coord(sp.center, k) - (d[k] - r)).abs() < GEOM_EPS {
+                        seeding.seed(i, SurfaceSeed::Translate { velocity: e });
+                    }
+                }
+            }
+        }
+        3 => {
+            let comp = |c: f64, dim: f64| {
+                if (c - r).abs() < GEOM_EPS {
+                    1.0
+                } else if (c - (dim - r)).abs() < GEOM_EPS {
+                    -1.0
+                } else {
+                    0.0
+                }
+            };
+            let retreat =
+                |ctr: Point3| Vec3::new(comp(ctr.x, d[0]), comp(ctr.y, d[1]), comp(ctr.z, d[2]));
+            for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+                if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+                    if !is_hole(c, d) {
+                        seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+                        seeding.seed(
+                            i,
+                            SurfaceSeed::Translate {
+                                velocity: retreat(c.center),
+                            },
+                        );
+                    }
+                } else if let Some(sp) = s.as_any().downcast_ref::<SphereSurface>() {
+                    seeding.seed(i, SurfaceSeed::SphereRadius { rate: 1.0 });
+                    seeding.seed(
+                        i,
+                        SurfaceSeed::Translate {
+                            velocity: retreat(sp.center),
+                        },
+                    );
+                }
+            }
+        }
+        _ => {
+            for (i, s) in brep.geometry.surfaces.iter().enumerate() {
+                if let Some(c) = s.as_any().downcast_ref::<CylinderSurface>() {
+                    if is_hole(c, d) {
+                        seeding.seed(i, SurfaceSeed::CylinderRadius { rate: 1.0 });
+                    }
+                }
+            }
+        }
+    }
+    seeding
+}
+
+/// QoI vector `[V, cx, cy, cz, I_zz]` and its Jacobian `dQ/dθ` (5×5) at
+/// `theta`, both from a fresh forward-mode seam capture.
+fn m9_qoi_and_jacobian(theta: &[f64]) -> ([f64; 5], [[f64; 5]; 5]) {
+    let brep = m9_build(theta);
+    let plan = capture_plan(&brep, &m9_tess()).expect("capture");
+    let mut q = [0.0; 5];
+    let mut jac = [[0.0; 5]; 5]; // rows = QoIs, cols = params
+                                 // k is a parameter index (into the seeding) as well as a column index.
+    #[allow(clippy::needless_range_loop)]
+    for k in 0..5 {
+        let seam =
+            evaluate_with_sensitivity(&brep, &plan, &m9_seeding_for(&brep, k)).expect("seam");
+        let (p, dp) = mass_properties_with_derivative(&seam, RHO);
+        if k == 0 {
+            q = [
+                p.volume,
+                p.centroid.x,
+                p.centroid.y,
+                p.centroid.z,
+                p.inertia_origin[2][2],
+            ];
+        }
+        jac[0][k] = dp.volume;
+        jac[1][k] = dp.centroid.x;
+        jac[2][k] = dp.centroid.y;
+        jac[3][k] = dp.centroid.z;
+        jac[4][k] = dp.inertia_origin[2][2];
+    }
+    (q, jac)
+}
+
+fn m9_targets() -> [f64; 5] {
+    let brep = m9_build(&THETA_STAR);
+    let plan = capture_plan(&brep, &m9_tess()).expect("capture");
+    let seam = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new()).expect("seam");
+    let mp = mass_properties(&seam.positions, &seam.triangles, RHO);
+    [
+        mp.volume,
+        mp.centroid.x,
+        mp.centroid.y,
+        mp.centroid.z,
+        mp.inertia_origin[2][2],
+    ]
+}
+
+/// Relative residuals `r_q = (Q_q − t_q)/t_q` and their Jacobian rows
+/// `∂r_q/∂θ = (1/t_q) ∂Q_q/∂θ` — the least-squares residual Jacobian the seam
+/// hands Gauss–Newton.
+fn residual_jacobian(theta: &[f64], targets: &[f64; 5]) -> (Vec<f64>, Vec<Vec<f64>>) {
+    let (q, jac) = m9_qoi_and_jacobian(theta);
+    let r: Vec<f64> = (0..5).map(|i| (q[i] - targets[i]) / targets[i]).collect();
+    let rows: Vec<Vec<f64>> = (0..5)
+        .map(|i| (0..5).map(|k| jac[i][k] / targets[i]).collect())
+        .collect();
+    (r, rows)
+}
+
+/// The exact least-squares gradient `g = 2 Jᵀ r` at `theta`.
+fn exact_gradient(theta: &[f64], targets: &[f64; 5]) -> Vec<f64> {
+    let (r, rows) = residual_jacobian(theta, targets);
+    gauss_newton_gradient(&rows, &r)
+}
+
+/// Eigenvalues of a symmetric 5×5 matrix by Jacobi rotation (annihilate the
+/// largest off-diagonal each sweep), ascending. Each rotation applies
+/// `A ← JᵀAJ` through fresh copies so the pivot block is never double-updated.
+fn sym_eigenvalues(mut a: [[f64; 5]; 5]) -> [f64; 5] {
+    for _ in 0..200 {
+        let (mut p, mut q, mut off) = (0, 1, 0.0);
+        // i, j are the pivot indices being searched for (stored as p, q).
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..5 {
+            for j in i + 1..5 {
+                if a[i][j].abs() > off {
+                    off = a[i][j].abs();
+                    p = i;
+                    q = j;
+                }
+            }
+        }
+        if off < 1e-13 {
+            break;
+        }
+        // Jacobi rotation angle for A ← JᵀAJ with J[p][q] = +sin θ:
+        // zeroing a'_pq needs θ = ½ atan2(−2·a_pq, a_pp − a_qq).
+        let phi = 0.5 * (-2.0 * a[p][q]).atan2(a[p][p] - a[q][q]);
+        let (s, c) = phi.sin_cos();
+        // B = A·J (rotate columns p, q).
+        let mut b = a;
+        for k in 0..5 {
+            b[k][p] = c * a[k][p] - s * a[k][q];
+            b[k][q] = s * a[k][p] + c * a[k][q];
+        }
+        // A' = Jᵀ·B (rotate rows p, q).
+        let mut d = b;
+        for k in 0..5 {
+            d[p][k] = c * b[p][k] - s * b[q][k];
+            d[q][k] = s * b[p][k] + c * b[q][k];
+        }
+        a = d;
+    }
+    let mut ev = [a[0][0], a[1][1], a[2][2], a[3][3], a[4][4]];
+    ev.sort_by(|x, y| x.partial_cmp(y).unwrap());
+    ev
+}
+
+#[test]
+fn m10_gauss_newton_hessian_matches_full_hessian_near_optimum() {
+    let targets = m9_targets();
+
+    // Gauss–Newton Hessian at θ* (residuals ≈ 0 by construction): H_GN = 2 JᵀJ.
+    let (_r, rows) = residual_jacobian(&THETA_STAR, &targets);
+    let h_gn_vec = gauss_newton_hessian(&rows);
+    let mut h_gn = [[0.0; 5]; 5];
+    for i in 0..5 {
+        for j in 0..5 {
+            h_gn[i][j] = h_gn_vec[i][j];
+        }
+    }
+
+    // Full Hessian ≈ central FD of the exact gradient g(θ) = 2 Jᵀ r. Near θ*
+    // the residual term 2 Σ r_q ∇²r_q vanishes, so H_full ≈ H_GN. The fillet
+    // model's re-capture correspondence noise (the M9 fillet-frame caveat)
+    // dominates the FD estimate: a filleted, drilled solid captured freshly at
+    // each θ ± h carries O(1e-4) mesh jitter, so the FD Hessian is only good
+    // to a few percent — hence a *loose, documented* gate (aggregate spectrum
+    // agreement, not per-eigenvalue). The step is 1e-3 so the jitter divided
+    // by 2h clears the truncation.
+    let h = 1e-3;
+    let mut h_full = [[0.0; 5]; 5];
+    for l in 0..5 {
+        let mut plus = THETA_STAR;
+        let mut minus = THETA_STAR;
+        plus[l] += h;
+        minus[l] -= h;
+        let gp = exact_gradient(&plus, &targets);
+        let gm = exact_gradient(&minus, &targets);
+        for k in 0..5 {
+            h_full[k][l] = (gp[k] - gm[k]) / (2.0 * h);
+        }
+    }
+    // Symmetrize the FD Hessian before comparing.
+    let mut h_sym = [[0.0; 5]; 5];
+    for i in 0..5 {
+        for j in 0..5 {
+            h_sym[i][j] = 0.5 * (h_full[i][j] + h_full[j][i]);
+        }
+    }
+
+    let ev_gn = sym_eigenvalues(h_gn);
+    let ev_full = sym_eigenvalues(h_sym);
+    eprintln!("GN eigenvalues   : {ev_gn:?}");
+    eprintln!("full eigenvalues : {ev_full:?}");
+
+    // (a) H_GN is positive semidefinite by construction (a Gram matrix).
+    assert!(ev_gn[0] >= -1e-6, "H_GN not PSD: min eig {}", ev_gn[0]);
+
+    // (b) Total curvature (trace = Σ eigenvalues) — the robust aggregate — is
+    // reproduced tightly.
+    let tr_gn: f64 = ev_gn.iter().sum();
+    let tr_full: f64 = ev_full.iter().sum();
+    let rel_trace = (tr_gn - tr_full).abs() / tr_gn.abs();
+    eprintln!("trace: GN {tr_gn:.5e} vs full {tr_full:.5e} (rel {rel_trace:.3e})");
+    assert!(
+        rel_trace < 0.02,
+        "trace GN {tr_gn:.5e} vs full {tr_full:.5e} (rel {rel_trace:.3e})"
+    );
+
+    // (c) Whole-matrix agreement: relative Frobenius distance inside the
+    // documented FD-noise band.
+    let mut num = 0.0;
+    let mut den = 0.0;
+    for i in 0..5 {
+        for j in 0..5 {
+            num += (h_gn[i][j] - h_sym[i][j]).powi(2);
+            den += h_gn[i][j].powi(2);
+        }
+    }
+    let rel_frob = (num / den).sqrt();
+    eprintln!("relative Frobenius ‖H_GN − H_full‖/‖H_GN‖ = {rel_frob:.3e}");
+    assert!(
+        rel_frob < 0.15,
+        "relative Frobenius {rel_frob:.3e} exceeds noise band"
+    );
+}

--- a/crates/vcad-kernel-physics/Cargo.toml
+++ b/crates/vcad-kernel-physics/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 vcad-ir = { workspace = true }
 vcad-kernel = { workspace = true }
 vcad-kernel-tessellate = { workspace = true }
+vcad-kernel-diff = { workspace = true }
+vcad-kernel-primitives = { workspace = true }
+vcad-kernel-math = { workspace = true }
 phyz = { path = "../../../phyz/crates/phyz", version = "0.3" }
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -17,3 +20,4 @@ stl_io = "0.8"
 
 [dev-dependencies]
 vcad-kernel-urdf = { workspace = true }
+vcad-kernel-geom = { workspace = true }

--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -1,0 +1,426 @@
+//! Physics-rollout gradients: differentiating a phyz simulation objective
+//! with respect to CAD parameters θ (milestone M8 of the differentiable
+//! seam).
+//!
+//! # What this computes
+//!
+//! For a **contact-free articulated rigid-body rollout**, CAD geometry enters
+//! the dynamics through exactly one channel: each body's **mass properties** —
+//! mass, center of mass, and inertia tensor about the COM (10 scalars per
+//! body). Everything downstream (Featherstone ABA, the integrator, the
+//! objective) is a smooth function of those 10 scalars per body. That gives an
+//! exact chain rule
+//!
+//! ```text
+//! dJ/dθ = Σ_bodies  ∂J/∂p_body · dp_body/dθ
+//! ```
+//!
+//! where `p_body` is the 10-vector `[m, c_x, c_y, c_z, I_xx, I_yy, I_zz,
+//! I_xy, I_xz, I_yz]` (COM-frame inertia). The two factors come from two
+//! different places, each computed the correct way for its side of the seam:
+//!
+//! - **`dp_body/dθ`** — *exact*, from the differentiable seam. The frozen
+//!   plan plus a per-parameter [`ParamSeeding`] feeds
+//!   [`mass_properties_with_derivative`], which carries dual numbers through
+//!   the polynomial mass-property integrals: every field's θ-derivative in
+//!   one pass, to machine precision. No remeshing, no topology risk.
+//!
+//! - **`∂J/∂p_body`** — *central finite differences on the mass-property
+//!   scalars themselves*. Each scalar is perturbed ±h and the rollout is
+//!   re-run (≈20 rollouts per body: 10 scalars × 2). This is cheap and
+//!   robust: no CAD rebuild, no re-tessellation, no boolean/fillet
+//!   combinatorics under perturbation — only the physics integrator re-runs,
+//!   on a body whose inertia scalar moved by a hair.
+//!
+//! ## Why finite differences for `∂J/∂p`, not a phyz adjoint
+//!
+//! phyz ships `phyz-diff`, but it differentiates a single dynamics step with
+//! respect to **state and control** (`∂(q',v')/∂(q,v,ctrl)`), not with respect
+//! to **model inertia parameters**. The factor M8 needs — sensitivity of the
+//! rollout objective to a body's mass/COM/inertia — is not exposed by phyz at
+//! any version currently vendored. So the live, and only, path for
+//! `∂J/∂p_body` is central FD on the mass-property scalars, exactly the
+//! fallback the seam design anticipated. If a future phyz grows a
+//! parameter-adjoint, it drops in behind this same factorization: replace the
+//! FD loop in [`rollout_gradient`] with the analytic `∂J/∂p` and the chain is
+//! unchanged.
+//!
+//! # Contract and boundaries
+//!
+//! - **Contact-free only.** The factorization is exact *because* geometry
+//!   reaches the dynamics solely through mass properties. The moment collision
+//!   geometry participates (a contact, a joint limit that bottoms out under
+//!   load, a ground penalty), contact forces depend on the *surface* — a
+//!   channel this gradient does not see. The rollout closure you pass **must**
+//!   build a contact-free model; if it does not, the returned gradient is
+//!   silently incomplete. Extending to contacts means pulling `∂J/∂x` back
+//!   onto the collision-mesh nodes through the M5 pullback
+//!   ([`evaluate_with_pullback`](vcad_kernel_diff::evaluate_with_pullback)) —
+//!   future work, noted in `docs/differentiable-seam-m8.md`.
+//! - **Mass-property channel only.** θ is assumed to move geometry, hence mass
+//!   properties. If θ also moves a **joint anchor / mount frame**, that
+//!   sensitivity is *not* included here (the rollout applies mounts as fixed
+//!   transforms). The same FD-on-scalars pattern extends to anchor coordinates
+//!   when a model needs it.
+//! - **Determinism.** phyz's ABA + semi-implicit Euler are deterministic;
+//!   the FD estimate of `∂J/∂p` is only meaningful if the rollout closure is a
+//!   pure function of its mass-property input (fixed initial state, fixed
+//!   control law, fixed step count). Keep it so.
+
+use phyz::math::{Mat3, Vec3 as PVec3};
+use phyz::SpatialInertia;
+use vcad_kernel_diff::{
+    evaluate_with_sensitivity, mass_properties, mass_properties_with_derivative, DiffError,
+    MassProperties, ParamSeeding,
+};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+/// Millimetres to metres.
+const MM_TO_M: f64 = 1e-3;
+/// mm² to m² (COM-frame inertia carries a squared length).
+const MM2_TO_M2: f64 = 1e-6;
+/// kg·m⁻³ to kg·mm⁻³ (1 m³ = 1e9 mm³), so seam integrals in mm come out in kg.
+const KGM3_TO_KGMM3: f64 = 1e-9;
+
+/// The mass properties of one rigid body, in **SI units** (kg, m, kg·m²),
+/// expressed in the body's own CAD frame.
+///
+/// The inertia is about the **center of mass** (COM), matching
+/// [`phyz::SpatialInertia`]. Field order for the packed 10-vector used by the
+/// finite-difference loop is `[m, c_x, c_y, c_z, I_xx, I_yy, I_zz, I_xy,
+/// I_xz, I_yz]`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BodyMassProps {
+    /// Mass (kg).
+    pub mass: f64,
+    /// Center of mass in the body frame (m).
+    pub com: [f64; 3],
+    /// Inertia about the COM, `[I_xx, I_yy, I_zz, I_xy, I_xz, I_yz]` (kg·m²).
+    pub inertia: [f64; 6],
+}
+
+impl BodyMassProps {
+    /// Pack into the canonical 10-vector `[m, c_x, c_y, c_z, I_xx, I_yy,
+    /// I_zz, I_xy, I_xz, I_yz]`.
+    pub fn scalars(&self) -> [f64; 10] {
+        [
+            self.mass,
+            self.com[0],
+            self.com[1],
+            self.com[2],
+            self.inertia[0],
+            self.inertia[1],
+            self.inertia[2],
+            self.inertia[3],
+            self.inertia[4],
+            self.inertia[5],
+        ]
+    }
+
+    /// Inverse of [`Self::scalars`].
+    pub fn from_scalars(s: [f64; 10]) -> Self {
+        Self {
+            mass: s[0],
+            com: [s[1], s[2], s[3]],
+            inertia: [s[4], s[5], s[6], s[7], s[8], s[9]],
+        }
+    }
+
+    /// Build a [`phyz::SpatialInertia`] (mass, COM offset, COM-frame inertia
+    /// matrix) from these properties.
+    pub fn to_spatial_inertia(&self) -> SpatialInertia {
+        let [ixx, iyy, izz, ixy, ixz, iyz] = self.inertia;
+        let m = Mat3::new(ixx, ixy, ixz, ixy, iyy, iyz, ixz, iyz, izz);
+        SpatialInertia::new(
+            self.mass,
+            PVec3::new(self.com[0], self.com[1], self.com[2]),
+            m,
+        )
+    }
+
+    /// Convert seam mass properties (mm, seam density) to SI, given the body's
+    /// physical density in kg/m³. `props.mass` is already in kg (the seam was
+    /// fed `density · 1e-9`); the centroid and inertia carry length factors.
+    fn from_seam(props: &MassProperties<f64>) -> Self {
+        let c = props.centroid;
+        let i = &props.inertia_centroid;
+        Self {
+            mass: props.mass,
+            com: [c.x * MM_TO_M, c.y * MM_TO_M, c.z * MM_TO_M],
+            inertia: [
+                i[0][0] * MM2_TO_M2,
+                i[1][1] * MM2_TO_M2,
+                i[2][2] * MM2_TO_M2,
+                i[0][1] * MM2_TO_M2,
+                i[0][2] * MM2_TO_M2,
+                i[1][2] * MM2_TO_M2,
+            ],
+        }
+    }
+
+    /// Convert a seam **derivative** of mass properties into the SI 10-vector
+    /// `dp/dθ`. Same linear unit factors as [`Self::from_seam`] (θ is a length
+    /// in mm, so the factors carry through unchanged).
+    fn deriv_scalars(dprops: &MassProperties<f64>) -> [f64; 10] {
+        let dc = dprops.centroid;
+        let di = &dprops.inertia_centroid;
+        [
+            dprops.mass,
+            dc.x * MM_TO_M,
+            dc.y * MM_TO_M,
+            dc.z * MM_TO_M,
+            di[0][0] * MM2_TO_M2,
+            di[1][1] * MM2_TO_M2,
+            di[2][2] * MM2_TO_M2,
+            di[0][1] * MM2_TO_M2,
+            di[0][2] * MM2_TO_M2,
+            di[1][2] * MM2_TO_M2,
+        ]
+    }
+}
+
+/// Finite-difference step sizes for the `∂J/∂p` estimate, one policy for each
+/// class of mass-property scalar.
+///
+/// Central differences trade truncation error `O(h²)` against roundoff
+/// `O(ε·|J|/h)`; the defaults sit near the `~1e-5` relative sweet spot for a
+/// smooth `f64` rollout. Mass and inertia use a **relative** step (scaled to
+/// the body's own magnitude); the COM uses an **absolute** step (a centered
+/// body's COM is ~0, where a relative step would collapse to nothing).
+#[derive(Debug, Clone, Copy)]
+pub struct MassPropFdSteps {
+    /// Relative step for the mass scalar.
+    pub mass_rel: f64,
+    /// Floor for the mass step (kg).
+    pub mass_min: f64,
+    /// Absolute step for each COM component (m).
+    pub com_abs: f64,
+    /// Relative step for inertia components, scaled to the body's reference
+    /// inertia (max |diagonal|).
+    pub inertia_rel: f64,
+    /// Floor for the inertia step (kg·m²).
+    pub inertia_min: f64,
+}
+
+impl Default for MassPropFdSteps {
+    fn default() -> Self {
+        Self {
+            mass_rel: 1e-5,
+            mass_min: 1e-12,
+            com_abs: 1e-7,
+            inertia_rel: 1e-5,
+            inertia_min: 1e-18,
+        }
+    }
+}
+
+impl MassPropFdSteps {
+    /// The 10 per-scalar step sizes for one body's nominal properties.
+    fn steps_for(&self, p: &BodyMassProps) -> [f64; 10] {
+        let mass_h = (self.mass_rel * p.mass.abs()).max(self.mass_min);
+        let ref_i = p.inertia[0]
+            .abs()
+            .max(p.inertia[1].abs())
+            .max(p.inertia[2].abs());
+        let inertia_h = (self.inertia_rel * ref_i).max(self.inertia_min);
+        [
+            mass_h,
+            self.com_abs,
+            self.com_abs,
+            self.com_abs,
+            inertia_h,
+            inertia_h,
+            inertia_h,
+            inertia_h,
+            inertia_h,
+            inertia_h,
+        ]
+    }
+}
+
+/// A rigid body whose mass properties depend on CAD parameters θ through the
+/// differentiable seam.
+///
+/// The three fields are the CAD side of the M8 factorization: a build
+/// function over θ, a per-parameter seeding source (hand-written or
+/// [`synthesize_seeding`](vcad_kernel_diff::synthesize_seeding)), and the
+/// physical density.
+#[allow(clippy::type_complexity)]
+pub struct DiffBody<'a> {
+    /// Build this body's B-rep at θ (geometry in millimetres).
+    pub build: Box<dyn Fn(&[f64]) -> BRepSolid + 'a>,
+    /// Surface seeding for parameter `k`, given the freshly built B-rep and the
+    /// current θ. Returns a `Result` so
+    /// [`synthesize_seeding`](vcad_kernel_diff::synthesize_seeding) composes
+    /// directly — `|_brep, theta, k| synthesize_seeding(&build, theta, k, h)` —
+    /// while a hand-written seeding just reads the B-rep and wraps in `Ok`.
+    ///
+    /// The seeding must key into the **passed** `BRepSolid` (the one the
+    /// adapter captured its plan from). A synthesized seeding satisfies this
+    /// only when `build` is deterministic in its surface ordering; the
+    /// hand-written path always does.
+    #[allow(clippy::type_complexity)]
+    pub seeding_for: Box<dyn Fn(&BRepSolid, &[f64], usize) -> Result<ParamSeeding, DiffError> + 'a>,
+    /// Physical density (kg/m³).
+    pub density_kg_m3: f64,
+    /// Tessellation parameters for the frozen plan.
+    pub tess: TessellationParams,
+}
+
+impl DiffBody<'_> {
+    /// Seam density (kg/mm³): fed to the mm-frame integrals so mass comes out
+    /// in kg.
+    fn seam_density(&self) -> f64 {
+        self.density_kg_m3 * KGM3_TO_KGMM3
+    }
+}
+
+/// Objective value and full CAD-parameter gradient of a physics rollout,
+/// `(J, dJ/dθ)`, via the mass-property factorization.
+///
+/// This is shaped exactly like
+/// [`objective_gradient`](vcad_kernel_diff::objective_gradient) — a value plus
+/// a `Vec<f64>` gradient, `Result` on the seam errors — so a projected
+/// gradient-descent / L-BFGS driver can call it as its oracle.
+///
+/// # Arguments
+///
+/// - `bodies` — the differentiable rigid bodies. Body `i`'s mass properties
+///   are `bodies[i]` evaluated at θ; the rollout receives them in the same
+///   order.
+/// - `rollout` — builds a **contact-free** phyz model from the per-body mass
+///   properties, simulates a fixed trajectory, and returns the scalar
+///   objective `J`. Must be deterministic and a pure function of its input
+///   (see the module contract).
+/// - `theta` — the CAD parameters.
+/// - `fd` — finite-difference step policy for `∂J/∂p`.
+///
+/// # What runs
+///
+/// One frozen-plan capture per body, one positions-only seam pass per body
+/// for the nominal properties, `n·10·2` rollouts for the per-body `∂J/∂p`
+/// (`n` = number of bodies), and one seam pass per (body, parameter) for the
+/// exact `dp/dθ`. The rollout count is independent of the θ dimension; adding
+/// a CAD parameter costs one extra seam pass per body, nothing more.
+///
+/// # Errors
+///
+/// Any seam error — capture failure, a topology change under the frozen plan,
+/// an inconsistent implicit vertex system, a synthesis ambiguity — surfaces as
+/// [`DiffError`], exactly as the seam optimizer's does.
+pub fn rollout_gradient(
+    bodies: &[DiffBody],
+    rollout: &impl Fn(&[BodyMassProps]) -> f64,
+    theta: &[f64],
+    fd: &MassPropFdSteps,
+) -> Result<(f64, Vec<f64>), DiffError> {
+    let n = theta.len();
+
+    // 1. Nominal mass properties per body (positions-only seam), and the
+    //    frozen plan / B-rep kept for the exact dp/dθ below.
+    let mut breps = Vec::with_capacity(bodies.len());
+    let mut plans = Vec::with_capacity(bodies.len());
+    let mut nominal = Vec::with_capacity(bodies.len());
+    for body in bodies {
+        let brep = (body.build)(theta);
+        let plan = capture_plan(&brep, &body.tess)?;
+        let seam0 = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new())?;
+        let props = mass_properties(&seam0.positions, &seam0.triangles, body.seam_density());
+        nominal.push(BodyMassProps::from_seam(&props));
+        breps.push(brep);
+        plans.push(plan);
+    }
+
+    // Primal objective at the nominal properties.
+    let j0 = rollout(&nominal);
+
+    // 2. ∂J/∂p per body by central FD on the 10 mass-property scalars.
+    //    Each body is perturbed independently; the others hold their nominal
+    //    values, so the estimate is the true partial.
+    let mut djdp: Vec<[f64; 10]> = Vec::with_capacity(bodies.len());
+    for (i, nom) in nominal.iter().enumerate() {
+        let steps = fd.steps_for(nom);
+        let mut grad_p = [0.0f64; 10];
+        let mut work = nominal.clone();
+        for j in 0..10 {
+            let h = steps[j];
+            let mut sp = nom.scalars();
+            sp[j] += h;
+            work[i] = BodyMassProps::from_scalars(sp);
+            let jp = rollout(&work);
+
+            let mut sm = nom.scalars();
+            sm[j] -= h;
+            work[i] = BodyMassProps::from_scalars(sm);
+            let jm = rollout(&work);
+
+            grad_p[j] = (jp - jm) / (2.0 * h);
+        }
+        // Restore body i for the next body's perturbations.
+        work[i] = *nom;
+        djdp.push(grad_p);
+    }
+
+    // 3 + 4. Exact dp/dθ from the seam, contracted with ∂J/∂p and summed
+    //         over bodies.
+    let mut gradient = vec![0.0f64; n];
+    for (i, body) in bodies.iter().enumerate() {
+        for (k, g) in gradient.iter_mut().enumerate() {
+            let seeding = (body.seeding_for)(&breps[i], theta, k)?;
+            let seam_k = evaluate_with_sensitivity(&breps[i], &plans[i], &seeding)?;
+            let (_props, dprops) = mass_properties_with_derivative(&seam_k, body.seam_density());
+            let dp = BodyMassProps::deriv_scalars(&dprops);
+            let mut acc = 0.0;
+            for j in 0..10 {
+                acc += djdp[i][j] * dp[j];
+            }
+            *g += acc;
+        }
+    }
+
+    Ok((j0, gradient))
+}
+
+/// The nominal SI mass properties of each body at θ (positions-only seam).
+///
+/// A convenience for callers that want the primal properties — to build the
+/// rollout model at θ, or to check a target QoI — without the gradient.
+pub fn nominal_mass_props(
+    bodies: &[DiffBody],
+    theta: &[f64],
+) -> Result<Vec<BodyMassProps>, DiffError> {
+    let mut out = Vec::with_capacity(bodies.len());
+    for body in bodies {
+        let brep = (body.build)(theta);
+        let plan = capture_plan(&brep, &body.tess)?;
+        let seam = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new())?;
+        let props = mass_properties(&seam.positions, &seam.triangles, body.seam_density());
+        out.push(BodyMassProps::from_seam(&props));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spatial_inertia_roundtrip() {
+        let p = BodyMassProps {
+            mass: 2.0,
+            com: [0.1, -0.2, 0.3],
+            inertia: [1.0, 2.0, 3.0, 0.1, 0.2, 0.3],
+        };
+        let si = p.to_spatial_inertia();
+        assert!((si.mass - 2.0).abs() < 1e-15);
+        assert!((si.com.x - 0.1).abs() < 1e-15);
+        // Symmetric off-diagonals mirror into the matrix.
+        assert!((si.inertia[(0, 1)] - 0.1).abs() < 1e-15);
+        assert!((si.inertia[(1, 0)] - 0.1).abs() < 1e-15);
+        assert!((si.inertia[(2, 2)] - 3.0).abs() < 1e-15);
+        // Pack / unpack.
+        assert_eq!(BodyMassProps::from_scalars(p.scalars()), p);
+    }
+}

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -34,6 +34,9 @@
 
 /// Mesh-to-collider conversion + mass / inertia estimation.
 pub mod colliders;
+/// Physics-rollout gradients: `dJ/dθ` of a simulation objective with respect
+/// to CAD parameters, via the mass-property factorization (M8).
+pub mod diff;
 mod error;
 mod gym;
 /// Joint conversion utilities.
@@ -42,6 +45,7 @@ pub mod joints;
 pub mod stl;
 mod world;
 
+pub use diff::{nominal_mass_props, rollout_gradient, BodyMassProps, DiffBody, MassPropFdSteps};
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};
 pub use world::{JointState, PhysicsWorld};

--- a/crates/vcad-kernel-physics/tests/m8_rollout_gradient.rs
+++ b/crates/vcad-kernel-physics/tests/m8_rollout_gradient.rs
@@ -1,0 +1,263 @@
+//! M8 — physics-rollout gradients: `dJ/dθ` of a simulation objective with
+//! respect to a CAD parameter, via the mass-property factorization.
+//!
+//! Three gates:
+//!
+//! 1. **Mass-property chain in isolation** (`1e-6`): the seam's exact
+//!    `d(I_zz)/dr` against a central difference of a CAD rebuild. This is the
+//!    `dp/dθ` factor, and it reproduces the M3 result inside the physics
+//!    crate.
+//! 2. **End-to-end rollout gradient** (`1e-4`): the adapter's `dJ/dr` against a
+//!    *full* central FD — rebuild the CAD at `r ± h`, convert to mass
+//!    properties, re-simulate. Two dynamically meaningful objectives:
+//!    a torque-driven flywheel spin-up (isolates the inertia channel) and a
+//!    gravity pendulum (exercises the mass, COM, and inertia channels
+//!    together).
+//! 3. **Determinism**: two identical rollouts return a bit-identical objective,
+//!    so the FD estimate of `∂J/∂p` is meaningful.
+
+use phyz::math::{SpatialTransform, Vec3};
+use phyz::{aba_with_external_forces, ModelBuilder};
+use vcad_kernel_diff::{
+    evaluate_with_sensitivity, mass_properties, mass_properties_with_derivative, ParamSeeding,
+    SurfaceSeed,
+};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::{
+    nominal_mass_props, rollout_gradient, BodyMassProps, DiffBody, MassPropFdSteps,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+/// Aluminium-ish density (kg/m³).
+const DENSITY: f64 = 2700.0;
+/// Cylinder height (mm).
+const HEIGHT_MM: f64 = 8.0;
+/// Nominal radius (mm).
+const R0: f64 = 10.0;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 64,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+/// The single differentiable body: a cylinder of radius `θ[0]` (mm), axis Z.
+fn cylinder_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|theta: &[f64]| make_cylinder(theta[0], HEIGHT_MM, 64)),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            let n = s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            assert_eq!(n, 1, "expected exactly one cylinder surface");
+            Ok(s)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rollouts (contact-free, deterministic, pure in their mass-property input).
+// ---------------------------------------------------------------------------
+
+/// Torque-driven flywheel: a body on a revolute joint about Z (its COM on the
+/// axis, so gravity exerts no moment), spun from rest by a constant torque.
+/// Returns the final angular speed ω(T) in rad/s.
+///
+/// With constant torque and constant inertia, semi-implicit Euler gives
+/// `ω(T) = τ·T / I_zz` exactly (independent of dt), so this isolates the
+/// inertia channel of the factorization.
+fn flywheel_rollout(props: &[BodyMassProps], torque: f64, t_final: f64, dt: f64) -> f64 {
+    let si = props[0].to_spatial_inertia();
+    let model = ModelBuilder::new()
+        .gravity(Vec3::new(0.0, 0.0, -9.81))
+        .dt(dt)
+        .add_revolute_body("bob", -1, SpatialTransform::identity(), si)
+        .build();
+    let mut state = model.default_state();
+    let steps = (t_final / dt).round() as usize;
+    for _ in 0..steps {
+        state.ctrl[0] = torque;
+        let qdd = aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * dt;
+        state.q[0] += state.v[0] * dt;
+    }
+    state.v[0]
+}
+
+/// Gravity pendulum: the cylinder is mounted with its axis rotated to lie
+/// along +X (via a 90° rotation about Y), so its COM sits off the revolute
+/// axis (Z, at the origin). Released from `q0`, it swings under gravity.
+/// Returns the joint angle q(T) in radians.
+///
+/// Gravity is set along −X so the pendulum is planar in the XY plane about the
+/// Z joint axis. The gravity torque depends on **mass** and **COM lever arm**;
+/// the swing rate depends on the **inertia about the pivot** — so all three
+/// mass-property channels enter.
+fn pendulum_rollout(props: &[BodyMassProps], q0: f64, t_final: f64, dt: f64) -> f64 {
+    // Mount rotation: body-Z (cylinder axis, COM at (0,0,h/2)) → joint +X.
+    let ry90 = phyz::math::Mat3::new(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0);
+    let mount = SpatialTransform::new(ry90, Vec3::zeros());
+    let si_body = props[0].to_spatial_inertia();
+    let si = si_body.transform(&mount);
+
+    let model = ModelBuilder::new()
+        .gravity(Vec3::new(-9.81, 0.0, 0.0))
+        .dt(dt)
+        .add_revolute_body("bob", -1, SpatialTransform::identity(), si)
+        .build();
+    let mut state = model.default_state();
+    state.q[0] = q0;
+    let steps = (t_final / dt).round() as usize;
+    for _ in 0..steps {
+        // No control torque — free swing under gravity.
+        let qdd = aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * dt;
+        state.q[0] += state.v[0] * dt;
+    }
+    state.q[0]
+}
+
+// ---------------------------------------------------------------------------
+// Gate 1 — the dp/dθ factor in isolation (1e-6), M3 pattern.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mass_property_chain_isolation() {
+    const H: f64 = 1e-6;
+    const GATE: f64 = 1e-6;
+    let body = cylinder_body();
+    let seam_density = body.density_kg_m3 * 1e-9;
+
+    let brep = (body.build)(&[R0]);
+    let plan = capture_plan(&brep, &body.tess).expect("capture");
+    let seeding = (body.seeding_for)(&brep, &[R0], 0).expect("seeding");
+    let seam = evaluate_with_sensitivity(&brep, &plan, &seeding).expect("seam");
+    let (_props, dprops) = mass_properties_with_derivative(&seam, seam_density);
+
+    // CAD-rebuild central difference of the mass properties (same frozen plan
+    // is not required here — the cylinder topology is invariant in r — so a
+    // fresh evaluation at r ± h and the exact integral compare directly).
+    let props_at = |r: f64| {
+        let b = (body.build)(&[r]);
+        let p = capture_plan(&b, &body.tess).expect("capture");
+        let s = evaluate_with_sensitivity(&b, &p, &ParamSeeding::new()).expect("seam");
+        mass_properties(&s.positions, &s.triangles, seam_density)
+    };
+    let plus = props_at(R0 + H);
+    let minus = props_at(R0 - H);
+
+    let check = |dual: f64, fd: f64, what: &str| {
+        let rel = (dual - fd).abs() / fd.abs().max(1.0);
+        assert!(
+            rel <= GATE,
+            "{what}: seam {dual} vs fd {fd} (rel {rel:.3e})"
+        );
+    };
+    check(dprops.mass, (plus.mass - minus.mass) / (2.0 * H), "dm/dr");
+    for i in 0..3 {
+        check(
+            dprops.inertia_centroid[i][i],
+            (plus.inertia_centroid[i][i] - minus.inertia_centroid[i][i]) / (2.0 * H),
+            "dI/dr",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2a — end-to-end flywheel spin-up gradient (1e-4).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn flywheel_spinup_gradient_matches_end_to_end_fd() {
+    const TORQUE: f64 = 1e-4;
+    const T_FINAL: f64 = 0.2;
+    const DT: f64 = 1.0 / 480.0;
+    const GATE: f64 = 1e-4;
+    // Outer FD step in θ = mm; the mass properties are smooth in r (no
+    // topology change), so a relative step of 1e-4 sits well inside the
+    // O(h²)-truncation / roundoff sweet spot.
+    const H_THETA: f64 = 1e-3;
+
+    let bodies = [cylinder_body()];
+    let rollout = |p: &[BodyMassProps]| flywheel_rollout(p, TORQUE, T_FINAL, DT);
+
+    let (j, grad) =
+        rollout_gradient(&bodies, &rollout, &[R0], &MassPropFdSteps::default()).expect("gradient");
+    assert_eq!(grad.len(), 1);
+
+    // Full end-to-end central FD: rebuild CAD at r ± h, convert, re-simulate.
+    let j_at = |r: f64| {
+        let props = nominal_mass_props(&bodies, &[r]).expect("props");
+        rollout(&props)
+    };
+    let fd = (j_at(R0 + H_THETA) - j_at(R0 - H_THETA)) / (2.0 * H_THETA);
+    let rel = (grad[0] - fd).abs() / fd.abs().max(1.0);
+    assert!(
+        rel <= GATE,
+        "dω/dr: adapter {} vs end-to-end fd {fd} (rel {rel:.3e}); J = {j}",
+        grad[0]
+    );
+
+    // Sign / magnitude sanity: I_zz ∝ r⁴, so ω = τT/I_zz falls with r.
+    assert!(
+        grad[0] < 0.0,
+        "spin-up speed must decrease as the disc grows"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2b — end-to-end gravity pendulum gradient (1e-4), all channels.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gravity_pendulum_gradient_matches_end_to_end_fd() {
+    const Q0: f64 = 0.4; // rad off the gravity-aligned rest
+    const T_FINAL: f64 = 0.15;
+    const DT: f64 = 1.0 / 960.0;
+    const GATE: f64 = 1e-4;
+    const H_THETA: f64 = 1e-3;
+
+    let bodies = [cylinder_body()];
+    let rollout = |p: &[BodyMassProps]| pendulum_rollout(p, Q0, T_FINAL, DT);
+
+    let (_j, grad) =
+        rollout_gradient(&bodies, &rollout, &[R0], &MassPropFdSteps::default()).expect("gradient");
+
+    let j_at = |r: f64| {
+        let props = nominal_mass_props(&bodies, &[r]).expect("props");
+        rollout(&props)
+    };
+    let fd = (j_at(R0 + H_THETA) - j_at(R0 - H_THETA)) / (2.0 * H_THETA);
+    let rel = (grad[0] - fd).abs() / fd.abs().max(1.0);
+    assert!(
+        rel <= GATE,
+        "dq(T)/dr: adapter {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        grad[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3 — determinism.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rollout_is_deterministic() {
+    let bodies = [cylinder_body()];
+    let props = nominal_mass_props(&bodies, &[R0]).expect("props");
+    let a = flywheel_rollout(&props, 1e-4, 0.2, 1.0 / 480.0);
+    let b = flywheel_rollout(&props, 1e-4, 0.2, 1.0 / 480.0);
+    assert_eq!(a, b, "flywheel rollout must be bit-identical across runs");
+
+    let c = pendulum_rollout(&props, 0.4, 0.15, 1.0 / 960.0);
+    let d = pendulum_rollout(&props, 0.4, 0.15, 1.0 / 960.0);
+    assert_eq!(c, d, "pendulum rollout must be bit-identical across runs");
+}

--- a/crates/vcad-kernel-physics/tests/m8_spinup_demo.rs
+++ b/crates/vcad-kernel-physics/tests/m8_spinup_demo.rs
@@ -1,0 +1,180 @@
+//! M8 demo — gradient descent through the full CAD → physics chain.
+//!
+//! Brief: a torque-driven flywheel (a parametric disc on a revolute joint)
+//! must spin up to a **target speed** `ω*` after a fixed time under a fixed
+//! torque. The single CAD parameter is the disc radius `r`. Recover the
+//! radius `r*` that hits the target, by projected gradient descent whose
+//! gradient flows entirely through the M8 factorization:
+//!
+//! ```text
+//! J(r) = (ω(r) − ω*)²,   dJ/dr = ∂J/∂p · dp/dr   (mass-property factorization)
+//! ```
+//!
+//! The optimizer never sees the physics internals — it drives
+//! [`rollout_gradient`] as a black-box `(J, dJ/dr)` oracle, exactly the shape
+//! [`objective_gradient`](vcad_kernel_diff::objective_gradient) presents to the
+//! seam's own `minimize`. (The seam's `minimize` / `minimize_lbfgs` take
+//! B-rep build functions and mesh objectives, so they do not compose with a
+//! physics objective directly; this demo drives a small projected-GD loop over
+//! the same oracle shape instead.)
+
+use phyz::math::{SpatialTransform, Vec3};
+use phyz::{aba_with_external_forces, ModelBuilder};
+use vcad_kernel_diff::{synthesize_seeding, ParamSeeding, SurfaceSeed};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::{
+    nominal_mass_props, rollout_gradient, BodyMassProps, DiffBody, MassPropFdSteps,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::TessellationParams;
+
+const DENSITY: f64 = 2700.0;
+const HEIGHT_MM: f64 = 8.0;
+const TORQUE: f64 = 1e-4;
+const T_FINAL: f64 = 0.2;
+const DT: f64 = 1.0 / 480.0;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 64,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+fn build_cylinder(theta: &[f64]) -> BRepSolid {
+    make_cylinder(theta[0], HEIGHT_MM, 64)
+}
+
+/// Final spin speed ω(T) of the torque-driven disc.
+fn spin(props: &[BodyMassProps]) -> f64 {
+    let si = props[0].to_spatial_inertia();
+    let model = ModelBuilder::new()
+        .gravity(Vec3::new(0.0, 0.0, -9.81))
+        .dt(DT)
+        .add_revolute_body("disc", -1, SpatialTransform::identity(), si)
+        .build();
+    let mut state = model.default_state();
+    let steps = (T_FINAL / DT).round() as usize;
+    for _ in 0..steps {
+        state.ctrl[0] = TORQUE;
+        let qdd = aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * DT;
+        state.q[0] += state.v[0] * DT;
+    }
+    state.v[0]
+}
+
+fn hand_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(build_cylinder),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            Ok(s)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+#[test]
+fn recover_radius_hitting_target_spin_speed() {
+    // Target: the spin speed of the *true* radius r* = 12 mm.
+    let r_star = 12.0;
+    let target = spin(&nominal_mass_props(&[hand_body()], &[r_star]).expect("props"));
+
+    // The optimization objective is the squared miss, differentiated through
+    // the full chain by the adapter.
+    let rollout = |p: &[BodyMassProps]| {
+        let w = spin(p);
+        let miss = w - target;
+        miss * miss
+    };
+
+    let bodies = [hand_body()];
+    let fd = MassPropFdSteps::default();
+    let bounds = (1.0, 30.0);
+
+    // Projected gradient descent with backtracking. Start well away from r*.
+    let mut r = 8.0_f64;
+    let (mut j, mut grad) =
+        rollout_gradient(&bodies, &rollout, &[r], &fd).expect("initial gradient");
+    let mut step = 1.0;
+    let mut iters = 0;
+    for _ in 0..200 {
+        if grad[0].abs() < 1e-14 {
+            break;
+        }
+        // Backtracking line search on the projected step.
+        let accepted = loop {
+            let trial = (r - step * grad[0]).clamp(bounds.0, bounds.1);
+            if (trial - r).abs() > 0.0 {
+                match rollout_gradient(&bodies, &rollout, &[trial], &fd) {
+                    Ok((jt, gt)) if jt < j => break Some((trial, jt, gt)),
+                    _ => {}
+                }
+            }
+            step *= 0.5;
+            if step < 1e-10 {
+                break None;
+            }
+        };
+        match accepted {
+            Some((rt, jt, gt)) => {
+                r = rt;
+                j = jt;
+                grad = gt;
+                step *= 2.0; // warm-start the next search a little longer
+                iters += 1;
+            }
+            None => break,
+        }
+    }
+
+    let achieved = spin(&nominal_mass_props(&bodies, &[r]).expect("props"));
+    // Recovered the radius, and the simulated spin matches the target.
+    assert!(
+        (r - r_star).abs() < 1e-2,
+        "recovered r = {r} mm vs r* = {r_star} mm after {iters} iters (J = {j})"
+    );
+    assert!(
+        (achieved - target).abs() / target.abs() < 1e-5,
+        "achieved spin {achieved} vs target {target}"
+    );
+}
+
+/// The `seeding_for` closure supports [`synthesize_seeding`] naturally: a
+/// machine-derived seeding drives the same gradient as the hand-written one,
+/// to the seam's agreement tolerance.
+#[test]
+fn synthesized_seeding_matches_hand_written() {
+    let rollout = |p: &[BodyMassProps]| spin(p);
+    let fd = MassPropFdSteps::default();
+    let r0 = 10.0;
+
+    let hand = [hand_body()];
+    let (_j_h, g_h) = rollout_gradient(&hand, &rollout, &[r0], &fd).expect("hand gradient");
+
+    let synth = [DiffBody {
+        build: Box::new(build_cylinder),
+        seeding_for: Box::new(|_brep: &BRepSolid, theta: &[f64], k: usize| {
+            synthesize_seeding(&build_cylinder, theta, k, 1e-6)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }];
+    let (_j_s, g_s) = rollout_gradient(&synth, &rollout, &[r0], &fd).expect("synth gradient");
+
+    let rel = (g_h[0] - g_s[0]).abs() / g_h[0].abs().max(1.0);
+    assert!(
+        rel < 1e-4,
+        "synthesized dω/dr {} vs hand-written {} (rel {rel:.3e})",
+        g_s[0],
+        g_h[0]
+    );
+}

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -823,6 +823,84 @@ fn tessellate_face_for_capture(
     crate::tessellate_face(topo, &brep.geometry, face_id, params)
 }
 
+/// A uniform spatial hash over `quantum`-sized cells for O(1)-amortized
+/// nearest-point-within-tolerance queries — the accelerator for the capture-
+/// and evaluation-time matches flagged as `O(n²)`-ish since M0–M2.
+///
+/// Points are bucketed by their rounded integer cell; a query probes the
+/// 3×3×3 neighborhood of its own cell. That neighborhood is **exhaustive**
+/// whenever the match tolerance does not exceed the cell size — which holds
+/// for every use here (`VERTEX_MATCH_TOL`, `DEDUP_QUANTUM`, and `MATCH_TOL`
+/// all equal their grid's quantum), so the nearest match is bit-identical to
+/// a full linear scan. The linear reference paths are kept and checked
+/// against the grid (see [`capture_plan_naive`] and the M10 equivalence test).
+struct PointGrid {
+    quantum: f64,
+    cells: HashMap<[i64; 3], Vec<u32>>,
+    pts: Vec<Point3>,
+}
+
+impl PointGrid {
+    fn new(quantum: f64) -> Self {
+        Self {
+            quantum,
+            cells: HashMap::new(),
+            pts: Vec::new(),
+        }
+    }
+
+    fn cell(&self, p: &Point3) -> [i64; 3] {
+        [
+            (p.x / self.quantum).round() as i64,
+            (p.y / self.quantum).round() as i64,
+            (p.z / self.quantum).round() as i64,
+        ]
+    }
+
+    /// Insert a point, returning its local index (parallel to insertion order).
+    fn insert(&mut self, p: Point3) -> u32 {
+        let idx = self.pts.len() as u32;
+        let c = self.cell(&p);
+        self.cells.entry(c).or_default().push(idx);
+        self.pts.push(p);
+        idx
+    }
+
+    /// The two nearest inserted points within `tol` of `p`: `(best, second)`
+    /// where `best = (local index, d²)` and `second` is the second-smallest
+    /// squared distance (`∞` if none), for the evaluation-time ambiguity
+    /// check. The 3×3×3 probe holds every point within `tol`, so both are
+    /// exact.
+    fn two_nearest(&self, p: &Point3, tol: f64) -> (Option<(u32, f64)>, f64) {
+        let c = self.cell(p);
+        let tol2 = tol * tol;
+        let mut best: Option<(u32, f64)> = None;
+        let mut second = f64::INFINITY;
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                for dz in -1..=1 {
+                    let key = [c[0] + dx, c[1] + dy, c[2] + dz];
+                    for &idx in self.cells.get(&key).into_iter().flatten() {
+                        let d2 = (self.pts[idx as usize] - *p).norm_squared();
+                        if d2 >= tol2 {
+                            continue;
+                        }
+                        match best {
+                            Some((_, bd)) if d2 < bd => {
+                                second = bd;
+                                best = Some((idx, d2));
+                            }
+                            Some(_) => second = second.min(d2),
+                            None => best = Some((idx, d2)),
+                        }
+                    }
+                }
+            }
+        }
+        (best, second)
+    }
+}
+
 /// Capture a frozen tessellation plan from a B-rep at the base parameter
 /// value.
 ///
@@ -832,6 +910,13 @@ fn tessellate_face_for_capture(
 /// samples on their face's surface ([`NodeRecipe::SurfaceUv`]). Coincident
 /// nodes from adjacent faces are merged (same quantum as the stock weld) so
 /// the frozen mesh shares vertices across face seams.
+///
+/// The cross-face dedup is already spatial-hashed ([`PointGrid`]-style, since
+/// the M0–M2 hardening). The remaining per-face topology-vertex
+/// classification scans a face's boundary loop, which is topology-bounded
+/// (not a function of tessellation density), so it is not a hot spot — see
+/// the M10 design note for the measurement that led this to be left as a
+/// linear scan.
 pub fn capture_plan(
     brep: &BRepSolid,
     params: &TessellationParams,
@@ -942,8 +1027,8 @@ pub fn capture_plan(
                     best = Some((idx, d2));
                 }
             }
-            let (recipe, position) = match best {
-                Some((idx, _)) => (
+            let (recipe, position) = match best.map(|(idx, _)| idx) {
+                Some(idx) => (
                     NodeRecipe::TopoVertex { vertex: idx },
                     topo.vertices[ci.vertices[idx as usize]].point,
                 ),
@@ -1077,7 +1162,30 @@ pub fn capture_plan(
 /// evaluated at the frozen `(u, v)`, lands nearest the capture-time
 /// position. A nearest match farther than the tolerance is
 /// [`FrozenError::CorrespondenceLost`].
+///
+/// The `TopoVertex` resolution is grid-accelerated ([`PointGrid`]) — turning
+/// the per-node scan over all rebuilt vertices (`O(nodes · vertices)`, the one
+/// genuinely quadratic scan in the seam once dedup was hashed) into O(1)
+/// amortized. Because a node's anchor sits ~1e-6 mm from its rebuilt vertex
+/// (far inside `MATCH_TOL`), the grid's 3×3×3 probe is exhaustive and the
+/// result is **bit-identical** to the linear reference [`evaluate_plan_naive`]
+/// (which the M10 equivalence test checks).
 pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, FrozenError> {
+    evaluate_plan_impl(brep, plan, true)
+}
+
+/// The linear-scan reference of [`evaluate_plan`]: bit-identical output, the
+/// `O(nodes · vertices)` vertex resolution instead of the grid. Exposed for
+/// the M10 perf equivalence test and as the accelerator's defining oracle.
+pub fn evaluate_plan_naive(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, FrozenError> {
+    evaluate_plan_impl(brep, plan, false)
+}
+
+fn evaluate_plan_impl(
+    brep: &BRepSolid,
+    plan: &FrozenPlan,
+    use_grid: bool,
+) -> Result<FrozenMesh, FrozenError> {
     let ci = canonical_index(brep);
     let actual = signature_with_index(brep, &ci);
     if actual != plan.signature {
@@ -1172,32 +1280,74 @@ pub fn evaluate_plan(brep: &BRepSolid, plan: &FrozenPlan) -> Result<FrozenMesh, 
             .ok_or(FrozenError::RecipeOutOfRange)
     };
 
+    // Grid the rebuilt topology vertices once: resolving each `TopoVertex`
+    // node to its nearest rebuilt vertex was an O(vertices) scan per node
+    // (quadratic overall). The probe is exhaustive within `MATCH_TOL` (the
+    // grid quantum), so the resolved vertex and the ambiguity decision are
+    // bit-identical to the linear scan. `evaluate_plan_naive` takes the
+    // linear branch to serve as that reference.
+    let vgrid = use_grid.then(|| {
+        let mut g = PointGrid::new(MATCH_TOL);
+        for &vid in &ci.vertices {
+            g.insert(topo.vertices[vid].point);
+        }
+        g
+    });
+
+    // The two nearest rebuilt vertices to `anchor` within `MATCH_TOL`, as
+    // `(best point, best d², second d²)`; grid- or linear-resolved. Both take
+    // the strict-minimum squared distance in `ci.vertices` order, so ties
+    // resolve identically.
+    let resolve_vertex = |anchor: &Point3| -> (Option<(Point3, f64)>, f64) {
+        if let Some(g) = &vgrid {
+            let (best, second) = g.two_nearest(anchor, MATCH_TOL);
+            (best.map(|(local, d2)| (g.pts[local as usize], d2)), second)
+        } else {
+            let tol2 = MATCH_TOL * MATCH_TOL;
+            let mut best: Option<(Point3, f64)> = None;
+            let mut second = f64::INFINITY;
+            for &vid in &ci.vertices {
+                let q = topo.vertices[vid].point;
+                let d2 = (q - *anchor).norm_squared();
+                if d2 >= tol2 {
+                    continue;
+                }
+                match best {
+                    Some((_, bd)) if d2 < bd => {
+                        second = bd;
+                        best = Some((q, d2));
+                    }
+                    Some(_) => second = second.min(d2),
+                    None => best = Some((q, d2)),
+                }
+            }
+            (best, second)
+        }
+    };
+
     let mut positions = Vec::with_capacity(plan.nodes.len());
     for (i, recipe) in plan.nodes.iter().enumerate() {
         let anchor = plan.base_positions[i];
         let p = match *recipe {
             NodeRecipe::TopoVertex { .. } => {
-                let mut best: Option<(Point3, f64)> = None;
-                let mut second_d2 = f64::INFINITY;
-                for &vid in &ci.vertices {
-                    let q = topo.vertices[vid].point;
-                    let d2 = (q - anchor).norm_squared();
-                    match best {
-                        Some((_, bd)) if d2 < bd => {
-                            second_d2 = bd;
-                            best = Some((q, d2));
-                        }
-                        Some(_) => second_d2 = second_d2.min(d2),
-                        None => best = Some((q, d2)),
+                let (best, second_d2) = resolve_vertex(&anchor);
+                let (q, d2) = match best {
+                    Some(hit) => hit,
+                    // Nothing within tolerance: the perturbation moved the
+                    // vertex too far. Recover the true nearest distance for
+                    // the error (rare, off the hot path).
+                    None => {
+                        let nearest = ci
+                            .vertices
+                            .iter()
+                            .map(|&vid| (topo.vertices[vid].point - anchor).norm_squared())
+                            .fold(f64::INFINITY, f64::min);
+                        return Err(FrozenError::CorrespondenceLost {
+                            node: i,
+                            distance: nearest.sqrt(),
+                        });
                     }
-                }
-                let (q, d2) = best.ok_or(FrozenError::RecipeOutOfRange)?;
-                if d2 > MATCH_TOL * MATCH_TOL {
-                    return Err(FrozenError::CorrespondenceLost {
-                        node: i,
-                        distance: d2.sqrt(),
-                    });
-                }
+                };
                 // Ambiguous match: a second distinct vertex also inside the
                 // tolerance (a near-tangency pair) could bind differently at
                 // θ+h vs θ−h and silently corrupt the FD oracle. Refuse.

--- a/docs/differentiable-seam-m10.md
+++ b/docs/differentiable-seam-m10.md
@@ -1,0 +1,233 @@
+# Differentiable seam — M10 design note
+
+M0–M9 built the first-order seam: `dx/dθ` (forward and reverse), mass-property
+QoIs, seeding synthesis, and an L-BFGS optimizer that prices every parameter
+from one adjoint pass. M10 is the last milestone of the wave — **second-order
+derivatives** where they are cheap and honest, and **performance**, guided by
+measurement rather than assumption.
+
+The governing rule of this milestone: *every second-order object states
+exactly what it computes and what it drops.* Nothing here silently ships a
+"full Hessian" with a missing term.
+
+## What landed
+
+### Part 1 — second order
+
+1. **Gauss–Newton curvature** (`gauss_newton.rs`:
+   `gauss_newton_hessian`, `gauss_newton_hvp`, `gauss_newton_gradient`).
+2. **Exact directional `d²V/dθ²`** for the volume QoI via second-order node
+   kinematics (`second_order.rs`: `evaluate_with_second_derivative`,
+   `volume_with_second_derivative`, `SecondOrderSeeding`, `SeamMeshSecond`;
+   `implicit.rs`: `constraint_row_2`).
+
+### Part 2 — performance
+
+3. Grid-accelerated evaluation-time vertex resolution (`frozen.rs`:
+   `PointGrid`, `evaluate_plan` / `evaluate_plan_naive`), after profiling
+   redirected the effort from capture (already hashed / not a bottleneck) to
+   the one genuinely `O(nodes·vertices)` scan.
+
+---
+
+## Part 1.1 — Gauss–Newton curvature
+
+For a least-squares objective `J(θ) = Σ_q r_q(θ)²` — the shape *every*
+mass-property recovery objective in this crate takes (`VolumeMatch`, the M9
+five-QoI `QoiMatch`, each residual a relative miss `r_q = (Q_q − t_q)/t_q`) —
+the exact gradient and Hessian are
+
+```text
+g = 2 Jᵀ r
+H = 2 JᵀJ  +  2 Σ_q r_q ∇²r_q ,     J = ∂r/∂θ  (m residuals × n params)
+```
+
+**What `gauss_newton_hessian` / `gauss_newton_hvp` compute:** exactly the first
+term, `H_GN = 2 JᵀJ`, and products with it. They **drop** the residual-
+curvature term `2 Σ_q r_q ∇²r_q`. That term needs the second derivatives of
+each QoI (node accelerations); the Gauss–Newton term needs only the residual
+Jacobian `J`, which the seam already prices exactly (forward: one seam pass per
+parameter; reverse: one pullback per residual QoI). So `H_GN` is **exact at
+zero residual** and `O(‖r‖)`-accurate near it — the trusted curvature model in
+the neighbourhood of an optimum, and a positive-semidefinite lower model
+everywhere. `gauss_newton_hvp` forms `H_GN·v = 2 Jᵀ(Jv)` matrix-free (`O(m·n)`)
+for a truncated-Newton inner loop; `gauss_newton_gradient` returns the
+*exact* `g = 2 Jᵀr` so the factor-of-two bookkeeping lives in one place.
+
+**Gate** (`m10_second_order.rs::m10_gauss_newton_hessian_matches_full_hessian_near_optimum`):
+on the M9 five-parameter model at θ* = `[10, 12, 8, 1.8, 2.2]`, the QoI Jacobian
+is built from the trusted forward-mode `mass_properties_with_derivative`, and
+`H_GN = 2 JᵀJ` is compared against a central finite difference of the *exact*
+gradient `g(θ) = 2 Jᵀr` (= the full Hessian). Near θ* the residuals vanish, so
+the dropped term is ≈ 0 and `H_full ≈ H_GN`; the fillet model's re-capture
+correspondence noise (the M9 fillet-frame caveat) dominates the FD Hessian, so
+the gate is loose and aggregate. Measured (FD step `h = 1e-3`):
+
+| Quantity | GN | full (FD) |
+|---|---|---|
+| eigenvalues | `[4.97e-4, 1.08e-2, 1.69e-2, 3.15e-2, 4.116e-1]` | `[4.96e-4, 1.09e-2, 1.70e-2, 3.16e-2, 4.130e-1]` |
+| trace | `0.47132` | `0.47288` (rel **3.3e-3**) |
+| ‖H_GN − H_full‖_F / ‖H_GN‖_F | — | **4.6e-3** |
+
+`H_GN` is PSD by construction; the whole spectrum matches the full Hessian to
+~0.3–0.5% near the optimum, i.e. the residual term is negligible there exactly
+as the theory says.
+
+## Part 1.2 — exact `d²V/dθ²` for the volume QoI
+
+The honest second derivative of the volume along one parameter is
+
+```text
+d²V/dθ² = Σ_ij (∂²V/∂x_i∂x_j) ẋ_i ẋ_j  +  Σ_i (∂V/∂x_i) ẍ_i,
+```
+
+both terms carried in full. The whole computation reduces to one pass of the
+shared generic integral `mesh_volume` over the nested scalar
+`Dual<Dual<f64>>`: seed each node coordinate as `((x, ẋ), (ẋ, ẍ))` and read
+`(V, dV/dθ, d²V/dθ²)` off the value / first-tangent / second-tangent slots.
+`Dual<Dual<f64>>` satisfies `tang::Scalar` (every `Dual<S: Scalar>` does — probed
+by `second_order::tests::nested_dual_recovers_second_derivative`), so
+`mesh_volume` compiles at that type unchanged. This genericity was always the
+second-order on-ramp; M10 walks up it.
+
+The work is the node accelerations `ẍ_i`:
+
+- **Lift nodes** (`SurfaceUv`) on plane/cylinder/sphere: the surface point
+  `x(θ) = S(u, v; fields(θ))` is **linear** in the seeded fields (translation,
+  radius) at a frozen `(u, v)`, so `∂x/∂field` is a constant map and
+  `ẍ = (∂x/∂field)·field̈` — exactly the first-order lift evaluated with the
+  field *accelerations* seeded where velocities go. No `Dual<Dual>` lift is
+  needed for these kinds. Cone/torus points are nonlinear in their shape
+  fields, so they carry an extra `∂²x/∂field²·fielḋ²` term and are rejected
+  with `DiffError::SecondOrderUnsupported` — a documented, mechanical
+  extension.
+- **Vertex / Boundary nodes** solve the second-order implicit system
+  (`constraint_row_2`). Differentiating the frozen-branch identity
+  `∇g·ẋ = −∂g/∂θ` once more,
+
+  ```text
+  ∇g · ẍ = −( ∂²g/∂θ²  +  2 ẋᵀ∇ₓ(∂g/∂θ)  +  ẋᵀ ∇²g ẋ ),
+  ```
+
+  with the **same** row gradients `∇g` as the velocity solve, so the same
+  Gram–Schmidt routine (`solve_vertex_velocity`) recovers `ẍ` with the
+  tangential DOF frozen. The rhs splits cleanly: a *field-acceleration* part
+  that is the first-order rhs fed the field accelerations
+  (`constraint_row(surface, acc_seeds, x).rhs` — the plane's whole share, and
+  the `∂²g/∂θ²` term of the quadrics), plus a *velocity-curvature* part
+  `−2‖ẋ⊥ − v_c⊥‖² + 2ṙ²` (plane: 0) that uses only the implicit form's constant
+  Hessian (`∇²g` = `0` / `2I` / `2P`, `P = I − aaᵀ`). Tangency-completion rows
+  are linear in `x` and the surface center, so their second-order form is the
+  first-order `tangency_rows` fed the acceleration seeds.
+
+**Implemented for plane, cylinder, sphere** — enough for the boolean-hole and
+rounded-cube gates. Cone/torus vertex rows are the mechanical extension
+(non-constant `∇²g`).
+
+**What `volume_with_second_derivative` computes, exactly:** `d²V/dθ²` along one
+seeded direction, with both the position-curvature term and the
+plane/cylinder/sphere node accelerations carried. It is *not* a many-parameter
+Hessian (that is Part 1.1's job for least-squares QoIs).
+
+### Gates (`m10_second_order.rs`)
+
+| Model | check | measured |
+|---|---|---|
+| Boolean hole, `d²V/dr²` | vs closed form `−N·sin(2π/N)·t` (`V` quadratic in `r`) | rel **≤ 1e-9** |
+| Boolean hole, `d²V/dr²` | vs central FD of analytic `dV/dr` (`h = 1e-6`) | rel **5.3e-10** |
+| Cylinder height, `d²V/dh²` | `V` linear in `h` ⇒ 0 | `|d²V/dh²| < 1e-6` (exact 0) |
+| Rounded cube, `d²V/dr²` | vs central FD of analytic `dV/dr` (`h = 1e-3`) | rel **1.2e-3** |
+
+Node-acceleration machinery is exercised both ways: on the rounded cube every
+node position is linear in `r`, so the second-order vertex/lift solve correctly
+computes **zero** acceleration (asserted: `max‖ẍ‖ < 1e-9`) and `d²V/dr²` is the
+position-curvature term alone; the unit test
+`implicit::tests::cylinder_radius_acceleration_matches_nonlinear_field` drives
+a genuinely nonlinear `r(θ)` and checks the resulting nonzero `ẍ = r̈·û`
+against the closed form.
+
+Two honest notes:
+
+- The rounded-cube FD uses `h = 1e-3`, not `1e-6`: a filleted solid re-captured
+  at `r ± h` carries O(1e-4) mesh-correspondence jitter (the M9 fillet-frame
+  caveat), so a 1e-6 step sits in the noise. At 1e-3 the jitter/2h clears and
+  the central difference of the (smooth-in-r) analytic derivative converges to
+  the second derivative (rel 1.2e-3; the same value is reached at `h = 1e-2`).
+- The boolean-hole gate is exact against the discrete N-gon closed form because
+  `V(r)` is genuinely quadratic in `r` with zero node acceleration, so both the
+  closed form and `Dual<Dual>` land on `−N·sin(2π/N)·t`.
+
+Cone/torus second-order lift and vertex rows are the only deliberate omission,
+documented as mechanical (the linear-field structure that makes plane/cylinder/
+sphere a one-liner does not hold there).
+
+---
+
+## Part 2 — performance
+
+The task premise was quadratic scans in capture matching / dedup. **Profiling
+found otherwise**, and the milestone rule "only optimize what you can measure"
+took over:
+
+- The **cross-face dedup is already spatial-hashed** (`HashMap` over quantized
+  cells with a 3×3×3 probe, since the M0–M2 adversarial hardening).
+- The **per-face topology-vertex classification** scans a face's boundary loop,
+  which is bounded by *topology*, not tessellation density. Grid-accelerating
+  it measured **slower** — building a per-face `HashMap` costs more than the
+  short linear scan — and worse, near-tolerance classification matches (a mesh
+  node ~`VERTEX_MATCH_TOL` from a rim vertex) can straddle to a cell two away,
+  so the 3×3×3 probe is not exhaustive there and the plan is not bit-identical.
+  Both reasons: **reverted**, left as the linear scan.
+- Capture, seam, and pullback are all **linear in node count** (measured
+  below).
+
+The one genuinely `O(nodes · vertices)` scan is the **evaluation-time**
+(`evaluate_plan`, the finite-difference oracle) resolution of each frozen node
+to its nearest rebuilt vertex. Here the accelerator is both safe and a win: a
+node's anchor sits ~1e-6 mm from its rebuilt vertex — far inside `MATCH_TOL` —
+so the grid's 3×3×3 probe *is* exhaustive and the result is **bit-identical**
+to the linear reference (`evaluate_plan_naive`), which the equivalence gate
+asserts. A shared `PointGrid` (quantum = the existing `MATCH_TOL`) drives it;
+the tie-break is insertion order = `ci.vertices` order, matching the linear
+scan's first-on-tie exactly.
+
+### Bit-identical (`m10_perf.rs::m10_grid_evaluation_is_bit_identical_to_linear`)
+
+`evaluate_plan` (grid) vs `evaluate_plan_naive` (linear) produce byte-for-byte
+identical meshes — same triangles, node positions equal to the bit — on the
+rounded cube at `circle_segments ∈ {16, 64, 128}` and on a flywheel-class
+drilled disc (asserted).
+
+### Timings (`m10_perf.rs::m10_capture_seam_pullback_timings`, median ms, debug build)
+
+Capture / seam / pullback on the rounded cube — all linear in node count
+(nodes ×7.8 from segs 16→128, capture ×7.5):
+
+| segs | nodes | capture | seam | pullback |
+|---|---|---|---|---|
+| 16 | 836 | 16.5 | 1.46 | 4.58 |
+| 64 | 3284 | 61.6 | 4.08 | 15.9 |
+| 128 | 6548 | 123.9 | 7.49 | 30.6 |
+
+`evaluate_plan` naive (`O(nodes·verts)`) vs grid, before/after:
+
+| model | segs | nodes | topo-verts | naive | grid | speedup |
+|---|---|---|---|---|---|---|
+| rounded cube | 16 | 836 | 24 | 5.98 | 6.36 | 0.94× |
+| rounded cube | 64 | 3284 | 24 | 23.3 | 23.7 | 0.98× |
+| rounded cube | 128 | 6548 | 24 | 45.8 | 46.1 | 0.99× |
+| flywheel | 16 | 728 | 642 | 21.6 | 10.8 | **2.00×** |
+| flywheel | 64 | 824 | 642 | 22.0 | 11.3 | **1.94×** |
+| flywheel | 128 | 1592 | 642 | 25.0 | 14.3 | **1.75×** |
+
+The win scales with topology-vertex count: the rounded cube carries only 24
+(so `O(24·nodes)` is already cheap and the grid's build overhead makes it a
+wash — a ~1× no-op), while the flywheel's boolean rims carry 642, where the
+grid halves the resolution time. The grid never meaningfully hurts and helps a
+lot exactly where the quadratic bites.
+
+## Regression
+
+`cargo test` green on `vcad-kernel-diff`, `vcad-kernel-tessellate`,
+`vcad-kernel-geom`, `vcad-kernel-fillet`; `cargo clippy --all-targets -D
+warnings` clean on the four; `cargo fmt --all --check` clean.

--- a/docs/differentiable-seam-m8.md
+++ b/docs/differentiable-seam-m8.md
@@ -1,0 +1,209 @@
+# Differentiable seam — M8 design note
+
+M3 built the mass-property QoIs and named the physics hook it was for; M5
+built the adjoint that prices every parameter from one pullback. Both left the
+same sentence in their notes: *the phyz coupling needs the sibling repo in the
+session scope; the interface is frozen here and exercised by an analytic
+functional.* M8 is that session. The real `phyz` and `loon` repos are cloned,
+`vcad-kernel-physics` builds and passes against them, and this milestone closes
+the loop the whole seam was built toward: **the gradient of a physics-rollout
+objective with respect to a CAD parameter**, `dJ/dθ`, validated end to end
+against a rebuild-and-resimulate finite difference.
+
+## The factorization: geometry enters dynamics through ten scalars per body
+
+For a **contact-free articulated rigid-body rollout**, CAD geometry reaches the
+dynamics through exactly one channel. Featherstone ABA, the integrator, and any
+objective read off the trajectory depend on the geometry of body *b* only
+through its **mass properties**: mass `m`, center of mass `c`, and the inertia
+tensor about the COM — ten scalars, `p_b = [m, c_x, c_y, c_z, I_xx, I_yy,
+I_zz, I_xy, I_xz, I_yz]`. Nothing else about the mesh enters (contacts would;
+see the boundary below). That is not an approximation — it is the structure of
+rigid-body dynamics, and it gives an exact chain rule:
+
+```text
+dJ/dθ = Σ_bodies  ∂J/∂p_b · dp_b/dθ
+```
+
+Two factors, each computed the correct way for its side of the seam.
+
+### `dp_b/dθ` — exact, from the seam
+
+The differentiable seam already produces this. `mass_properties_with_derivative`
+(M3) carries dual numbers through the polynomial mass-property integrals over
+the frozen mesh: a per-parameter `ParamSeeding` (hand-written, or synthesized by
+M6's `synthesize_seeding`) drives one seam pass, and every field's θ-derivative
+falls out in that pass, to machine precision. No remeshing, no topology risk,
+no combinatorics. This is the trusted half — the same pipeline M3 gated against
+closed forms at 1e-12 and against FD at ~1e-9.
+
+### `∂J/∂p_b` — central finite differences on the mass-property scalars
+
+Here is the design decision the milestone turns on. The sensitivity of the
+rollout objective to a body's ten mass-property scalars is computed by
+**perturbing those scalars and re-running the rollout** — central differences,
+≈20 rollouts per body (10 scalars × 2). This is the path the M3 note named as
+the fallback and called cheap, and it earns the name: no CAD rebuild, no
+re-tessellation, no boolean or fillet combinatorics under perturbation, no
+chance of a topology flip. Only the physics integrator re-runs, on a body whose
+inertia scalar moved by a hair. The trajectory is a smooth function of those
+scalars, so the FD is clean.
+
+#### Why not a phyz adjoint
+
+phyz **does** ship a differentiation crate — `phyz-diff` — so this was probed
+before defaulting to FD, per the brief. What it offers is the Jacobian of a
+single dynamics step with respect to **state and control**:
+`∂(q', v')/∂(q, v, ctrl)`, both finite-difference and (partially) symbolic.
+That is the machinery you assemble a trajectory adjoint *through the state*
+from. It is **not** a derivative with respect to **model inertia parameters**:
+`Body::inertia` is baked into the `Model`, outside the `(q, v, ctrl)`
+`phyz-diff` differentiates. The factor M8 needs — `∂J/∂p_b` — is not exposed by
+phyz at the vendored version (0.3.1). So the live, and only, path for `∂J/∂p_b`
+is central FD on the mass-property scalars.
+
+This is a clean seam, not a compromise. If a future phyz grows a
+parameter-adjoint (`∂J/∂inertia`), it drops in behind the *same* factorization:
+replace the FD loop in `rollout_gradient` with the analytic `∂J/∂p_b` and the
+chain rule, the seam's `dp_b/dθ`, and the optimizer above it are all unchanged.
+The factorization is the contribution; which routine fills the physics factor
+is an implementation detail it isolates.
+
+## What landed
+
+### The adapter — `vcad_kernel_physics::diff`
+
+`rollout_gradient(bodies, rollout, θ, fd) -> Result<(J, dJ/dθ), DiffError>`.
+
+- `bodies: &[DiffBody]` — each a CAD-parametric rigid body: a `build(θ)`
+  B-rep function, a `seeding_for(brep, θ, k)` source (hand-written, or a
+  one-liner over `synthesize_seeding`), a density, and tessellation params.
+- `rollout: Fn(&[BodyMassProps]) -> f64` — builds a **contact-free** phyz
+  model from the per-body mass properties, simulates a fixed trajectory, and
+  returns the scalar objective. Deterministic, pure in its input.
+
+Per call: one frozen-plan capture and one positions-only seam pass per body for
+the nominal properties; `n·10·2` rollouts for the per-body `∂J/∂p` (independent
+of the θ dimension); one seam pass per (body, parameter) for the exact
+`dp/dθ`. Adding a CAD parameter costs one extra seam pass per body and nothing
+in the rollout budget.
+
+The return shape — a value and a `Vec<f64>` gradient behind a `Result` on seam
+errors — is deliberately identical to the seam's own `objective_gradient`, so a
+projected-GD or L-BFGS driver treats it as a black-box oracle. `BodyMassProps`
+converts seam units (mm, `density·1e-9`) to SI (kg, m, kg·m²) and builds a
+`phyz::SpatialInertia` (COM-frame inertia + COM offset — exactly the ten
+scalars). The unit factors — `1e-3` on the centroid, `1e-6` on the inertia —
+carry through the derivative unchanged, since θ is a length.
+
+### The FD-step policy — `MassPropFdSteps`
+
+Central differences trade `O(h²)` truncation against `O(ε·|J|/h)` roundoff. The
+defaults sit near the `~1e-5`-relative sweet spot for a smooth `f64` rollout:
+mass and inertia use a **relative** step (scaled to the body's own magnitude,
+the inertia to its reference diagonal); the COM uses an **absolute** step,
+because a centered body's COM is ~0 where a relative step would collapse.
+
+## Gates (`tests/m8_rollout_gradient.rs`, `tests/m8_spinup_demo.rs`)
+
+Two articulated models, both built from a single parametric CAD cylinder
+(radius `θ = r`, axis Z) on a revolute joint:
+
+- **Flywheel spin-up.** COM on the spin axis (gravity exerts no moment), spun
+  from rest by a constant torque τ. `J = ω(T)`, the final angular speed. With
+  constant torque and inertia, semi-implicit Euler gives `ω(T) = τT/I_zz`
+  exactly, so this **isolates the inertia channel**: only `I_zz` of the ten
+  scalars has nonzero `∂J/∂p`.
+- **Gravity pendulum.** The same cylinder mounted with its axis rotated to +X,
+  COM off the revolute (Z) axis, released from rest and swung under gravity.
+  `J = q(T)`, the joint angle after T. The gravity torque scales with **mass**
+  and **COM lever arm**; the swing rate with **inertia about the pivot** — all
+  three channels enter.
+
+| Gate | Model | Measured | Bound |
+|---|---|---|---|
+| `dp/dθ` in isolation (seam vs CAD-rebuild FD) | cylinder | `dI/dr` rel **~1.7e-10**, `dm/dr` exact | 1e-6 |
+| End-to-end `dJ/dr` (adapter vs rebuild-and-resim FD) | flywheel | **4.99e-8** (`ω = 59.1`, `dω/dr = −23.654`) | 1e-4 |
+| End-to-end `dJ/dr` (adapter vs rebuild-and-resim FD) | pendulum | **8.23e-10** (`dq/dr = −0.22795`) | 1e-4 |
+| Determinism (two identical rollouts) | both | **bit-identical** | — |
+| Synthesized vs hand-written seeding | flywheel | rel **< 1e-4** | — |
+
+The end-to-end FD is the honest test the brief asks for: it rebuilds the CAD at
+`r ± h`, re-derives the mass properties from the fresh mesh, and re-simulates —
+the whole chain, differentiated numerically, against the adapter's analytic
+`dp/dθ` fed through the FD `∂J/∂p`.
+
+### The FD-noise analysis behind the 1e-4 bound
+
+The gate tolerance is set at 1e-4 because a rollout FD is, in general, noisier
+than a geometry FD — but on these models the measured agreement is far tighter
+(5e-8 and 8e-10), and it is worth being precise about why, so the bound is
+honest rather than lucky.
+
+Three error sources stack into the comparison:
+
+1. **The adapter's inner `∂J/∂p` FD** — relative step `~1e-5`, so `O(h²)`
+   truncation `~1e-10` relative, roundoff `ε·|J|/h ~ 1e-11` absolute. This is
+   the adapter's own noise floor.
+2. **The reference end-to-end `∂J/∂θ` FD** — outer step `h_θ = 1e-3` mm on
+   `r = 10` mm. The mass properties are smooth in `r` with no topology change
+   (a cylinder stays a cylinder), so the mesh integral is `O(h_θ²)`-accurate
+   just as the M3 isolation gate is; truncation `~1e-6` relative, roundoff
+   negligible.
+3. **The seam's `dp/dθ`** — exact (dual numbers), contributing nothing.
+
+The flywheel's `ω(T) = τT/I_zz` is *linear* in `1/I_zz`, so both sides are
+differentiating the same near-linear map through `I_zz(r)`; the residual is set
+by source 1 and lands at 5e-8. The pendulum's swing is nonlinear but the short
+horizon (`T = 0.15 s`, well before the bob swings far) keeps it smooth, and it
+lands at 8e-10. Neither model touches a topology wall — the CAD is a lone
+cylinder — so the M4/M9 fillet-correspondence noise (which forced M9's FD
+spot-check up to `~1e-4`) is simply absent here. The 1e-4 bound is the honest
+ceiling for a rollout FD on a smooth model; the models clear it by four to six
+orders because the objectives are smooth and the geometry has no seam to graze.
+
+### The demo — gradient descent through the full chain
+
+`recover_radius_hitting_target_spin_speed`: a torque-driven disc must spin up to
+a **target speed** `ω*` — the speed of the true radius `r* = 12 mm` — after a
+fixed time under a fixed torque. Objective `J(r) = (ω(r) − ω*)²`, gradient
+`dJ/dr = 2(ω − ω*)·dω/dr` flowing entirely through the M8 factorization.
+Projected gradient descent with backtracking, driving `rollout_gradient` as a
+black-box oracle, from `r₀ = 8 mm`:
+
+**Recovered `r = 12.000000 mm` in 27 accepted iterations, `J = 1.2e-20`** —
+`|r − r*| < 1e-8 mm`, and the achieved spin matches the target to `< 1e-5`
+relative. Geometry driven by the gradient of a simulation. That is the
+milestone.
+
+The demo also proves `seeding_for` accepts `synthesize_seeding` naturally
+(`|_brep, θ, k| synthesize_seeding(&build, θ, k, h)`): the machine-derived
+seeding drives the same `dω/dr` as the hand-written one to `< 1e-4`.
+
+## Notes and boundaries
+
+- **Contact-free contract.** The factorization is exact *because* geometry
+  reaches the dynamics solely through mass properties. The moment collision
+  geometry participates — a contact, a joint limit bottoming out under load, a
+  ground penalty — contact forces depend on the *surface*, a channel this
+  gradient does not see, and the returned `dJ/dθ` is silently incomplete. The
+  adapter's contract requires the rollout closure to build a contact-free
+  model; it is documented on the module and on `rollout_gradient`, and the demo
+  and gate models carry no colliders. The extension is real and known: the M5
+  pullback (`evaluate_with_pullback`) already takes `∂J/∂x` on mesh nodes
+  directly, so a contact adjoint that produces `∂J/∂x` on the collision surface
+  prices every CAD parameter through the *same* pullback — the mass-property
+  factorization is the smooth core, the surface pullback the contact skin. Not
+  built here; the seam for it is.
+- **Mass-property channel only.** If θ also moves a **joint anchor / mount
+  frame**, that sensitivity is not included — the rollout applies mounts as
+  fixed transforms. The same FD-on-scalars pattern extends to anchor
+  coordinates when a model needs it; the factorization already sums over an
+  arbitrary per-body scalar set, so anchor coordinates slot in as more scalars.
+- **Multi-body.** `rollout_gradient` sums over `bodies`; the gates use one, but
+  the loop and the `∂J/∂p`-per-body FD are written for the general case, and
+  the reverse-mode seam (M5) is what keeps `dp/dθ` cheap when many bodies each
+  carry many parameters.
+- **phyz version.** The first build against the real siblings bumps
+  `Cargo.lock` (phyz 0.3.0 → 0.3.1, loon-lang 0.5.0 → 0.7.0); committed with the
+  milestone.


### PR DESCRIPTION
## What this is

The final two milestones of the differentiable-seam roadmap (M0–M2 #379, M3 #380, M4 #381, M5 #382, M6/M7/M9 #384), developed in parallel worktrees and integrated together. **M8 is the milestone the whole seam was built toward** — and it just became possible: the real `phyz` and `loon` siblings are now in the environment (the old stubs are gone; `Cargo.lock` picks up the real versions).

Design notes: `docs/differentiable-seam-m8.md`, `-m10.md`.

## M8 — d(simulation objective)/d(CAD parameter)

For contact-free articulated rigid-body dynamics, CAD geometry enters a rollout **only through each body's ten mass-property scalars** (mass, center of mass, inertia). That factorization is the exact, tractable chain, and `vcad_kernel_physics::diff::rollout_gradient` implements it:

```text
dJ/dθ = Σ_bodies ∂J/∂(mass props of body) · d(mass props)/dθ
```

- `d(mass props)/dθ` — **exact** from the seam (`mass_properties_with_derivative`; synthesized seedings from M6 compose naturally, no hand seeding).
- `∂J/∂(mass props)` — central FD on the ten scalars per body: ~20 extra rollouts, **no CAD rebuilds, no remeshing, no topology risk**. We probed `phyz-diff` first: it exposes state/control Jacobians (`∂(q′,v′)/∂(q,v,ctrl)`) but no inertia-parameter sensitivity, so FD-on-mass-props is the live path; a future phyz parameter adjoint drops in behind the same factorization unchanged.

Gates (all green):

| Check | Result |
|---|---|
| Seam d(inertia)/dr vs CAD-rebuild FD (isolation) | 1.7e-10 |
| Flywheel spin-up dω/dr vs **full rebuild-and-resimulate FD** | 5.0e-8 (gate 1e-4) |
| Gravity pendulum dq/dr (mass + COM + inertia together) | 8.2e-10 |
| Rollout determinism | bit-identical |
| Synthesized vs hand seeding through the chain | < 1e-4 |

**The demo:** gradient descent through the full CAD→physics chain recovers `r* = 12.000000 mm` from `r₀ = 8 mm` in 27 iterations by matching a simulated spin-up target. The contract is explicit: contact-free dynamics only — collision-surface contributions are scoped out and documented, with the M5 pullback named as the extension path.

This also makes `vcad-kernel-physics::diff` the seam's **first consumer** — CLAUDE.md updated accordingly.

## M10 — second order and performance

**Gauss–Newton curvature** (`gauss_newton_{hessian,hvp,gradient}`): exact-at-zero-residual curvature for least-squares QoI objectives. Validated against the full FD Hessian on the M9 five-parameter model at its optimum: relative Frobenius gap 4.6e-3, spectrum matching to ~0.4%, PSD as required.

**Exact directional second derivatives** (`evaluate_with_second_derivative`, `volume_with_second_derivative`): `Dual<Dual<f64>>` through the shared volume integral, field accelerations through the lift, and a second-order implicit vertex solve — `∇g·ẍ = −(∂²g/∂θ² + 2ẋᵀ∇(∂g/∂θ) + ẋᵀ∇²g ẋ)` — reusing the frozen Gram–Schmidt completion. Gates: the boolean hole's `d²V/dr²` matches its **exact closed form** `−N·sin(2π/N)·t` at ≤1e-9 (V is exactly quadratic in r — a zero-discretization-error target); cylinder height gives exactly 0 (linear); rounded cube vs FD at 1.2e-3 (bounded by fillet re-capture jitter in the oracle, not the analytic side — documented). Cone/torus second order is documented as the mechanical extension; `SecondOrderUnsupported` refuses rather than silently dropping terms.

**Performance, measurement-led:** capture/seam/pullback measured **linear** in node count already; the one genuinely quadratic hot spot was the evaluation-time nearest-vertex resolution in `evaluate_plan` (the FD oracle path), now grid-accelerated — **bit-identical to the naive path by assertion**, 2.0×/1.9×/1.8× on the flywheel at 16/64/128 segments. A capture-side grid measured *slower* and broke bit-identity near tolerance boundaries, so it was reverted rather than shipped.

## Validation

With the real siblings present, the workspace suite ran with only the GTK-dependent `vcad-desktop` excluded (its system libraries don't exist in this container): **2013 passed, 0 failed** — including `vcad-kernel-physics`, `vcad-loon`, `vcad-sim`, `vcad-cli`, `vcad-eval`, `vcad-ffi`, and `vcad-render` for the first time in this environment. Clippy `-D warnings` and `cargo fmt --check` clean. `Cargo.lock` bump (real phyz/loon versions replacing the stub era) included.

## Roadmap

This completes M0–M10. Named follow-ups live in the design notes: contact-surface rollout gradients via the M5 pullback, cone/torus second order, corner blends for adjacent-edge fillets, and a phyz inertia-parameter adjoint to replace the FD factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_