### PR TITLE
Differentiable seam closeout: every named follow-up that's reachable from this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,18 @@ vcad/
 │
 │   # Work-in-progress crates (built but not yet wired to any consumer):
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
-│   # - vcad-kernel-diff         # Differentiable seam: dx/dθ of frozen tessellations,
-│   #                            # mass-property QoIs, differentiable fillet radius,
-│   #                            # reverse-mode adjoint, seeding synthesis, cone/torus
-│   #                            # coverage, L-BFGS many-parameter optimizer, second-order
-│   #                            # derivatives (docs/differentiable-seam-m0-m2.md … -m10.md);
-│   #                            # first consumer: vcad-kernel-physics::diff (rollout
-│   #                            # gradients — d(sim objective)/d(CAD parameter))
+│   #
+│   # - vcad-kernel-diff         # Differentiable seam, COMPLETE (M0–M10 + closeout):
+│   #                            # dx/dθ of frozen tessellations, mass-property QoIs,
+│   #                            # differentiable fillet radius, reverse-mode adjoint,
+│   #                            # seeding synthesis, cone/torus coverage incl. second
+│   #                            # order, L-BFGS optimizer
+│   #                            # (docs/differentiable-seam-m0-m2.md … -closeout.md).
+│   #                            # Consumers: vcad-kernel-physics::diff (rollout
+│   #                            # gradients — mass-property core, anchor channel,
+│   #                            # surface skin) and vcad-eval::diff
+│   #                            # (document_parameter_gradient — d(mass props)/d(named
+│   #                            # .vcad parameter))
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6959,6 +6959,7 @@ dependencies = [
  "vcad-ecad-pcb",
  "vcad-ir",
  "vcad-kernel",
+ "vcad-kernel-diff",
  "vcad-kernel-geom",
  "vcad-kernel-math",
  "vcad-kernel-sketch",

--- a/changelog/entries/2026-07-02-fillet-adjacent-edges.json
+++ b/changelog/entries/2026-07-02-fillet-adjacent-edges.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-02-fillet-adjacent-edges",
+  "version": "0.9.4",
+  "date": "2026-07-02",
+  "category": "fix",
+  "title": "Filleting adjacent edges meets in clean miter corners",
+  "summary": "Selecting edges that share a corner now produces a watertight miter joint between the blends instead of falling back to a whole-body inset that malformed the part.",
+  "features": ["fillet", "kernel"]
+}

--- a/crates/vcad-eval/Cargo.toml
+++ b/crates/vcad-eval/Cargo.toml
@@ -16,6 +16,7 @@ vcad-kernel-sketch.workspace = true
 vcad-kernel-sweep.workspace = true
 vcad-kernel-text.workspace = true
 vcad-kernel-tessellate.workspace = true
+vcad-kernel-diff.workspace = true
 vcad-kernel-geom.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/vcad-eval/src/diff.rs
+++ b/crates/vcad-eval/src/diff.rs
@@ -1,0 +1,171 @@
+//! Document-parameter gradients: the differentiable seam over parametric
+//! `.vcad` documents.
+//!
+//! The M6 design note rejected this as unreachable — a Rust-side
+//! document → BRep evaluator sat behind the excluded `loon` sibling. With the
+//! sibling in scope, `vcad-eval` *is* that evaluator, and the seam's
+//! document-agnostic machinery ([`synthesize_seeding`] takes any
+//! `Fn(&[f64]) -> BRepSolid`) composes with it directly:
+//!
+//! 1. A **named document parameter** (the `parameters` + `bindings` sidecar
+//!    the product's parametric documents already carry) is the θ.
+//! 2. The **build closure** clones the document, overwrites the parameter's
+//!    value, and runs [`evaluate_document`](crate::evaluate_document) — the
+//!    same resolve-and-walk every other consumer uses.
+//! 3. **Seeding synthesis** (M6) machine-derives how θ moves every surface;
+//!    the frozen-plan seam prices the mass-property derivatives exactly.
+//!
+//! The result: `d(mass properties)/d(parameter)` for every solid part of a
+//! document, with zero hand seeding — a `.vcad` file with a named `"r"`
+//! differentiates end to end. Documents authored in loon reach this path by
+//! evaluating to a [`Document`] first (`vcad_loon::eval_vcad`) and binding
+//! the parameter onto the produced nodes (exercised in the tests).
+
+use vcad_ir::{Document, Expr};
+use vcad_kernel::vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_diff::{
+    evaluate_with_sensitivity, mass_properties_with_derivative, synthesize_seeding, DiffError,
+    MassProperties,
+};
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+use crate::{evaluate_document, EvalError, EvalOptions};
+
+/// Gradient of one solid part's mass properties with respect to a document
+/// parameter.
+#[derive(Debug, Clone)]
+pub struct DocumentPartGradient {
+    /// Index of the part in the evaluated scene's solid-part order (parts
+    /// without a BRep solid are skipped and do not consume an index).
+    pub part_index: usize,
+    /// Mass properties at the current parameter value.
+    pub properties: MassProperties<f64>,
+    /// `d(properties)/dθ` — every field differentiated with respect to the
+    /// named parameter.
+    pub derivative: MassProperties<f64>,
+}
+
+/// Errors from [`document_parameter_gradient`].
+#[derive(Debug, thiserror::Error)]
+pub enum DocDiffError {
+    /// The named parameter is not declared in `doc.parameters`.
+    #[error("document has no parameter named {0:?}")]
+    UnknownParameter(String),
+    /// Parameter resolution failed (cycle, malformed formula, …).
+    #[error("parameter resolution failed: {0}")]
+    Resolve(String),
+    /// Document evaluation failed.
+    #[error("document evaluation failed: {0}")]
+    Eval(#[from] EvalError),
+    /// The document evaluated to no BRep-solid parts.
+    #[error("document has no solid parts to differentiate")]
+    NoSolidParts,
+    /// A probe evaluation (θ ± h) produced a different number of solid parts
+    /// than the base — the parameter crosses a topology/part-count boundary
+    /// at this value and the frozen-plan contract cannot hold.
+    #[error("solid part count changed under probe: {base} at θ, {probe} at θ ± h")]
+    PartCountChanged {
+        /// Solid parts at θ.
+        base: usize,
+        /// Solid parts at the probe value.
+        probe: usize,
+    },
+    /// A seam error (capture, synthesis, evaluation).
+    #[error("seam error: {0}")]
+    Seam(#[from] DiffError),
+}
+
+/// Evaluate the document with `parameter = value` and collect the BRep solid
+/// of every part that has one (skipping mesh-only or empty parts).
+fn solids_at(
+    doc: &Document,
+    parameter: &str,
+    value: f64,
+    options: &EvalOptions,
+) -> Result<Vec<BRepSolid>, DocDiffError> {
+    let mut d = doc.clone();
+    match d.parameters.get_mut(parameter) {
+        Some(p) => p.value = Expr::Number(value),
+        None => return Err(DocDiffError::UnknownParameter(parameter.to_string())),
+    }
+    let scene = evaluate_document(&d, options)?;
+    Ok(scene
+        .parts
+        .iter()
+        .filter_map(|p| p.solid.as_ref().and_then(|s| s.as_brep()).cloned())
+        .collect())
+}
+
+/// Differentiate every solid part's mass properties with respect to a named
+/// document parameter, `d(V, m, centroid, inertia)/dθ`, via the seam.
+///
+/// `density` is the physical density fed to the mass-property integrals
+/// (geometry is in mm; pass `kg/m³ · 1e-9` for masses in kg, or `1.0` for
+/// raw volume moments). `probe_step` is the finite step used **only** by
+/// seeding synthesis to *match* surfaces between θ and θ ± h (M6); the
+/// returned derivatives are analytic seam evaluations, not finite
+/// differences.
+///
+/// The document is re-evaluated three times (θ, θ ± h for synthesis probes)
+/// plus one frozen-plan capture and one seam pass per solid part. Parameter
+/// values that change the part count or a part's topology between θ − h and
+/// θ + h error rather than returning a wrong gradient.
+pub fn document_parameter_gradient(
+    doc: &Document,
+    parameter: &str,
+    density: f64,
+    tess: &TessellationParams,
+    probe_step: f64,
+) -> Result<Vec<DocumentPartGradient>, DocDiffError> {
+    let options = EvalOptions {
+        skip_clash_detection: true,
+        clock: None,
+    };
+    let env = vcad_ir::resolve_parameters(&doc.parameters)
+        .map_err(|e| DocDiffError::Resolve(e.to_string()))?;
+    let theta0 = *env
+        .get(parameter)
+        .ok_or_else(|| DocDiffError::UnknownParameter(parameter.to_string()))?;
+
+    let base = solids_at(doc, parameter, theta0, &options)?;
+    if base.is_empty() {
+        return Err(DocDiffError::NoSolidParts);
+    }
+
+    // Pre-validate the synthesis probes: both must evaluate cleanly and hold
+    // the part count, because the synthesis closure below cannot propagate
+    // errors (`synthesize_seeding` takes an infallible build function).
+    for probe in [theta0 - probe_step, theta0 + probe_step] {
+        let parts = solids_at(doc, parameter, probe, &options)?;
+        if parts.len() != base.len() {
+            return Err(DocDiffError::PartCountChanged {
+                base: base.len(),
+                probe: parts.len(),
+            });
+        }
+    }
+
+    let mut out = Vec::with_capacity(base.len());
+    for (i, brep) in base.iter().enumerate() {
+        // Build closure for this part alone. Probe failures were ruled out
+        // above, so the expects are unreachable under the validated contract.
+        let build = |theta: &[f64]| -> BRepSolid {
+            solids_at(doc, parameter, theta[0], &options)
+                .expect("probe evaluation validated above")
+                .into_iter()
+                .nth(i)
+                .expect("part count validated above")
+        };
+        let seeding = synthesize_seeding(&build, &[theta0], 0, probe_step)?;
+        let plan = capture_plan(brep, tess).map_err(DiffError::from)?;
+        let seam = evaluate_with_sensitivity(brep, &plan, &seeding)?;
+        let (properties, derivative) = mass_properties_with_derivative(&seam, density);
+        out.push(DocumentPartGradient {
+            part_index: i,
+            properties,
+            derivative,
+        });
+    }
+    Ok(out)
+}

--- a/crates/vcad-eval/src/lib.rs
+++ b/crates/vcad-eval/src/lib.rs
@@ -17,6 +17,7 @@
 //! ```
 
 pub mod convert;
+pub mod diff;
 pub mod evaluate;
 pub mod kinematics;
 pub mod pcb_preview;

--- a/crates/vcad-eval/tests/document_gradient.rs
+++ b/crates/vcad-eval/tests/document_gradient.rs
@@ -1,0 +1,192 @@
+//! Document-parameter gradients — the M6 stretch goal, unlocked.
+//!
+//! A `.vcad` document with a named parameter differentiates end to end:
+//! parameter → bindings → document evaluation → BRep → synthesized seeding →
+//! seam → `d(mass properties)/dθ`. Two gates:
+//!
+//! 1. **Parametric IR document**: a cylinder whose radius is bound to
+//!    parameter `"r"`. `dV/dr` against the N-gon prism closed form
+//!    `2·k·r·h` (the capture tessellation's own discrete truth, machine
+//!    precision) and the inertia derivative against a rebuild central FD.
+//! 2. **Loon-authored document**: the same part authored as loon source,
+//!    evaluated through `vcad_loon::eval_vcad`, parameterized after the
+//!    fact — proving documents from the loon path reach the same seam.
+
+use vcad_eval::diff::{document_parameter_gradient, DocDiffError};
+use vcad_eval::{evaluate_document, EvalOptions};
+use vcad_ir::{Bindings, CsgOp, Document, Expr, MaterialDef, Node, Parameter, SceneEntry};
+use vcad_kernel_diff::mass_properties;
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+const R0: f64 = 10.0;
+const HEIGHT: f64 = 8.0;
+const SEGS: u32 = 64;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: SEGS,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+/// N-gon prism factor: V = k·r²·h.
+fn kfac() -> f64 {
+    let n = SEGS as f64;
+    0.5 * n * (2.0 * std::f64::consts::PI / n).sin()
+}
+
+fn parametric_cylinder_doc(r: f64) -> Document {
+    let mut doc = Document::new();
+    doc.nodes.insert(
+        1,
+        Node {
+            id: 1,
+            name: Some("disc".to_string()),
+            op: CsgOp::Cylinder {
+                radius: 1.0, // overwritten by the binding at resolve time
+                height: HEIGHT,
+                segments: SEGS,
+            },
+        },
+    );
+    doc.roots.push(SceneEntry {
+        root: 1,
+        material: "default".to_string(),
+        visible: None,
+    });
+    doc.materials.insert(
+        "default".to_string(),
+        MaterialDef {
+            name: "default".to_string(),
+            color: [0.8, 0.8, 0.8],
+            metallic: 0.0,
+            roughness: 0.5,
+            density: None,
+            friction: None,
+            ..Default::default()
+        },
+    );
+    doc.parameters
+        .insert("r".to_string(), Parameter::literal(r));
+    doc.bindings.bind(
+        vcad_ir::BindingKey {
+            node_id: 1,
+            field_path: "radius".to_string(),
+        },
+        Expr::formula("r"),
+    );
+    doc
+}
+
+/// Mass properties of the document's single part at its current parameters,
+/// via a fresh evaluation + capture (the rebuild oracle).
+fn oracle_props(doc: &Document, density: f64) -> vcad_kernel_diff::MassProperties<f64> {
+    let scene = evaluate_document(doc, &EvalOptions::default()).expect("evaluate");
+    let brep = scene.parts[0]
+        .solid
+        .as_ref()
+        .and_then(|s| s.as_brep())
+        .expect("solid part");
+    let plan = capture_plan(brep, &tess()).expect("capture");
+    let seam = vcad_kernel_diff::evaluate_with_sensitivity(
+        brep,
+        &plan,
+        &vcad_kernel_diff::ParamSeeding::new(),
+    )
+    .expect("seam");
+    mass_properties(&seam.positions, &seam.triangles, density)
+}
+
+#[test]
+fn parametric_document_cylinder_gradient() {
+    const DENSITY: f64 = 2.0;
+    let doc = parametric_cylinder_doc(R0);
+    let grads = document_parameter_gradient(&doc, "r", DENSITY, &tess(), 1e-4).expect("gradient");
+    assert_eq!(grads.len(), 1, "one solid part");
+    let g = &grads[0];
+
+    // Closed forms for the N-gon prism: V = k r² h.
+    let k = kfac();
+    let v_exact = k * R0 * R0 * HEIGHT;
+    let dv_exact = 2.0 * k * R0 * HEIGHT;
+    assert!(
+        (g.properties.volume - v_exact).abs() / v_exact < 1e-12,
+        "V {} vs {v_exact}",
+        g.properties.volume
+    );
+    let rel = (g.derivative.volume - dv_exact).abs() / dv_exact;
+    assert!(
+        rel <= 1e-9,
+        "dV/dr {} vs closed form {dv_exact} (rel {rel:.3e})",
+        g.derivative.volume
+    );
+    // Mass scales by density; centroid is r-invariant.
+    assert!((g.derivative.mass - DENSITY * dv_exact).abs() / (DENSITY * dv_exact) <= 1e-9);
+    assert!(
+        g.derivative.centroid.x.abs() < 1e-9
+            && g.derivative.centroid.y.abs() < 1e-9
+            && g.derivative.centroid.z.abs() < 1e-9,
+        "centroid of a centered disc must not move with r: {:?}",
+        g.derivative.centroid
+    );
+
+    // Inertia derivative vs a document-rebuild central FD (h = 1e-5).
+    let h = 1e-5;
+    let plus = oracle_props(&parametric_cylinder_doc(R0 + h), DENSITY);
+    let minus = oracle_props(&parametric_cylinder_doc(R0 - h), DENSITY);
+    let fd_izz = (plus.inertia_origin[2][2] - minus.inertia_origin[2][2]) / (2.0 * h);
+    let rel_izz = (g.derivative.inertia_origin[2][2] - fd_izz).abs() / fd_izz.abs();
+    assert!(
+        rel_izz <= 1e-6,
+        "dIzz/dr {} vs rebuild FD {fd_izz} (rel {rel_izz:.3e})",
+        g.derivative.inertia_origin[2][2]
+    );
+}
+
+#[test]
+fn unknown_parameter_is_an_error() {
+    let doc = parametric_cylinder_doc(R0);
+    let err = document_parameter_gradient(&doc, "nope", 1.0, &tess(), 1e-4);
+    assert!(matches!(err, Err(DocDiffError::UnknownParameter(_))));
+}
+
+#[test]
+fn loon_authored_document_gradient() {
+    // Author the part in loon, evaluate to a Document through the sibling
+    // interpreter, then parameterize the produced node — the full loon path
+    // the M6 note deferred.
+    let source = format!("[root [cylinder {R0} {HEIGHT}] \"steel\"]");
+    let mut doc = vcad_loon::eval_vcad(&source, None).expect("loon eval");
+
+    // Find the cylinder node the loon program produced and bind its radius.
+    let cyl_id = *doc
+        .nodes
+        .iter()
+        .find(|(_, n)| matches!(n.op, CsgOp::Cylinder { .. }))
+        .expect("loon program produced a cylinder")
+        .0;
+    doc.parameters
+        .insert("r".to_string(), Parameter::literal(R0));
+    if doc.bindings.is_empty() {
+        doc.bindings = Bindings::new();
+    }
+    doc.bindings.bind(
+        vcad_ir::BindingKey {
+            node_id: cyl_id,
+            field_path: "radius".to_string(),
+        },
+        Expr::formula("r"),
+    );
+
+    let grads = document_parameter_gradient(&doc, "r", 1.0, &tess(), 1e-4).expect("gradient");
+    assert_eq!(grads.len(), 1);
+    let dv = grads[0].derivative.volume;
+    let dv_exact = 2.0 * kfac() * R0 * HEIGHT;
+    let rel = (dv - dv_exact).abs() / dv_exact;
+    assert!(
+        rel <= 1e-9,
+        "loon-authored dV/dr {dv} vs closed form {dv_exact} (rel {rel:.3e})"
+    );
+}

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -284,18 +284,15 @@ pub fn tangency_rows(
 ///   normally go (`constraint_row(surface, acc_seeds, x).rhs`) — the plane's
 ///   whole contribution, and the field-second-derivative `∂²g/∂θ²` term of
 ///   the quadrics;
-/// - the **velocity-curvature** part `−2‖ẋ⊥ − v_c⊥‖² + 2ṙ²` (plane: `0`), the
-///   collected `ẋ`- and field-velocity-quadratic terms. Only the implicit
-///   form's *constant* Hessian (`∇²g` = `0` plane / `2I` sphere / `2P`
-///   cylinder, `P = I − aaᵀ`) and the seeded field velocities enter it, so it
-///   is closed form.
+/// - the **velocity-curvature** part (plane: `0`), the collected `ẋ`- and
+///   field-velocity-quadratic terms. For sphere/cylinder it is the closed
+///   form `−2‖ẋ⊥ − v_c⊥‖² + 2ṙ²` of their *constant* Hessian (`∇²g` = `2I` /
+///   `2P`, `P = I − aaᵀ`); cone and torus carry their non-constant curvature
+///   in closed form too (see [`velocity_curvature`]'s per-kind derivations).
 ///
 /// `x` is the vertex position, `xdot` its already-solved velocity (from
 /// [`solve_vertex_velocity`] on the first-order rows). Implemented for
-/// plane/cylinder/sphere — enough for the boolean-hole and rounded-cube
-/// second-order volume gates; cone/torus return
-/// [`DiffError::UnsupportedConstraint`], since their curvature term carries a
-/// non-constant `∇²g` (a mechanical extension, deliberately not shipped).
+/// plane/cylinder/sphere/cone/torus — every kind with an implicit form.
 pub fn constraint_row_2(
     surface: &dyn Surface,
     vel_seeds: &[SurfaceSeed],
@@ -315,12 +312,16 @@ pub fn constraint_row_2(
 /// The velocity-quadratic part of the second-order rhs (see
 /// [`constraint_row_2`]). Plane: identically zero (`∇²g = 0`, `g` linear in
 /// both `x` and the origin). Sphere/cylinder: `−2‖ẋ − v_c‖² + 2ṙ²`, projected
-/// perpendicular to the axis for the cylinder. Errors on kinds without a
-/// second-order form, and on inapplicable seeds.
+/// perpendicular to the axis for the cylinder. Cone/torus carry the extra
+/// terms of their non-constant curvature — differentiating `ġ = 0` once more
+/// and keeping everything quadratic in the first-order rates (`ẋ` and the
+/// field velocities), with the field accelerations' share left to the base
+/// row. Errors on kinds without a second-order form, and on inapplicable
+/// seeds.
 fn velocity_curvature(
     surface: &dyn Surface,
     vel_seeds: &[SurfaceSeed],
-    _x: &Point3,
+    x: &Point3,
     xdot: &Vec3,
 ) -> Result<f64, DiffError> {
     let kind = surface.surface_type();
@@ -347,8 +348,93 @@ fn velocity_curvature(
             let rel = xperp - vcperp;
             Ok(-2.0 * rel.norm_squared() + 2.0 * rdot * rdot)
         }
+        SurfaceKind::Cone => {
+            // g = ‖p‖² − τ h², τ = tan²α, u = x − apex, h = u·a, p = u − h a.
+            // With ẇ = ẋ − v_apex (relative rate), ḣ = ẇ·a, ṗ = ẇ − ḣ a:
+            //   g̈|quad = 2‖ẇ⊥‖² − τ̈ h² − 4 τ̇ h ḣ − 2 τ ḣ²,
+            // where τ̇ = 2 tanα sec²α · α̇ and (with α̈'s share in the base
+            // row) τ̈ = 2 sec²α (sec²α + 2 tan²α) · α̇².
+            let cone = downcast::<ConeSurface>(surface, kind)?;
+            let a = *cone.axis.as_ref();
+            let (v_apex, adot) = cone_field_velocity(kind, vel_seeds)?;
+            let w = *xdot - v_apex;
+            let hdot = w.dot(a);
+            let wperp = w - a * hdot;
+            let h = (*x - cone.apex).dot(a);
+            let t = cone.half_angle.tan();
+            let cos_a = cone.half_angle.cos();
+            let sec2 = 1.0 / (cos_a * cos_a);
+            let tau = t * t;
+            let tau_dot = 2.0 * t * sec2 * adot;
+            let tau_ddot = 2.0 * sec2 * (sec2 + 2.0 * tau) * adot * adot;
+            Ok(-2.0 * wperp.norm_squared()
+                + tau_ddot * h * h
+                + 4.0 * tau_dot * h * hdot
+                + 2.0 * tau * hdot * hdot)
+        }
+        SurfaceKind::Torus => {
+            // g = (ρ − R)² + h² − r², u = x − c, h = u·a, p = u − h a,
+            // ρ = ‖p‖. With ẇ = ẋ − v_c, ḣ = ẇ·a, ρ̇ = p̂·ẇ:
+            //   g̈|quad = 2(ρ̇ − Ṙ)² + 2(ρ − R)(‖ẇ⊥‖² − ρ̇²)/ρ + 2ḣ² − 2ṙ²,
+            // the middle term being ρ's own curvature (the non-constant ∇²g).
+            let torus = downcast::<TorusSurface>(surface, kind)?;
+            let a = *torus.axis.as_ref();
+            let (vc, big_rdot, rdot) = torus_field_velocity(kind, vel_seeds)?;
+            let rel = *x - torus.center;
+            let h = rel.dot(a);
+            let p = rel - a * h;
+            let rho = p.norm();
+            if rho < 1e-12 {
+                return Err(DiffError::UnsupportedConstraint(kind));
+            }
+            let phat = p / rho;
+            let w = *xdot - vc;
+            let hdot = w.dot(a);
+            let wperp = w - a * hdot;
+            let rho_dot = phat.dot(wperp);
+            let curv_rho = (wperp.norm_squared() - rho_dot * rho_dot) / rho;
+            Ok(-(2.0 * (rho_dot - big_rdot) * (rho_dot - big_rdot)
+                + 2.0 * (rho - torus.major_radius) * curv_rho
+                + 2.0 * hdot * hdot
+                - 2.0 * rdot * rdot))
+        }
         _ => Err(DiffError::UnsupportedConstraint(kind)),
     }
+}
+
+/// Sum the seeded (apex velocity, half-angle rate) of a cone's velocity
+/// seeds, rejecting inapplicable kinds.
+fn cone_field_velocity(kind: SurfaceKind, seeds: &[SurfaceSeed]) -> Result<(Vec3, f64), DiffError> {
+    let mut v_apex = Vec3::new(0.0, 0.0, 0.0);
+    let mut adot = 0.0;
+    for seed in seeds {
+        match *seed {
+            SurfaceSeed::Translate { velocity } => v_apex += velocity,
+            SurfaceSeed::ConeAngle { rate } => adot += rate,
+            other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+        }
+    }
+    Ok((v_apex, adot))
+}
+
+/// Sum the seeded (center velocity, major-radius rate, minor-radius rate) of
+/// a torus's velocity seeds, rejecting inapplicable kinds.
+fn torus_field_velocity(
+    kind: SurfaceKind,
+    seeds: &[SurfaceSeed],
+) -> Result<(Vec3, f64, f64), DiffError> {
+    let mut vc = Vec3::new(0.0, 0.0, 0.0);
+    let mut big_rdot = 0.0;
+    let mut rdot = 0.0;
+    for seed in seeds {
+        match *seed {
+            SurfaceSeed::Translate { velocity } => vc += velocity,
+            SurfaceSeed::TorusMajorRadius { rate } => big_rdot += rate,
+            SurfaceSeed::TorusMinorRadius { rate } => rdot += rate,
+            other => return Err(DiffError::UnsupportedSeed { kind, seed: other }),
+        }
+    }
+    Ok((vc, big_rdot, rdot))
 }
 
 /// Sum the seeded (center velocity, radius rate) of a sphere's velocity
@@ -823,5 +909,112 @@ mod tests {
         let xddot = solve_vertex_velocity(&rows2).unwrap();
         // Pole rides at exactly z = r (linear in r), so ẍ = 0.
         assert!(xddot.norm() < 1e-12, "xddot = {xddot:?}");
+    }
+
+    #[test]
+    fn cone_angle_acceleration_matches_closed_form() {
+        // A rim vertex on a fixed plane z = z0 and a cone (apex above, axis
+        // −ẑ) whose half-angle opens at constant rate α̇: the rim radius is
+        // ρ(α) = (apex_z − z0)·tan α, so with the angular slide frozen
+        //   ẋ = ρ'(α)·û = d·sec²α·α̇·û,  ẍ = ρ''(α)·û = d·2 sec²α tanα·α̇²·û,
+        // d = apex_z − z0. Nonlinear in α even with α̈ = 0 — exercising the
+        // cone's velocity-curvature term against an exact closed form.
+        use vcad_kernel_geom::ConeSurface;
+        use vcad_kernel_math::Dir3;
+        let apex_z = 20.0;
+        let z0 = 5.0;
+        let d = apex_z - z0;
+        let alpha = 0.25_f64.atan();
+        let adot = 1.0;
+        let cone = ConeSurface {
+            apex: Point3::new(0.0, 0.0, apex_z),
+            axis: Dir3::new_normalize(-Vec3::z()),
+            ref_dir: Dir3::new_normalize(Vec3::x()),
+            half_angle: alpha,
+        };
+        let plane = Plane::new(Point3::new(0.0, 0.0, z0), Vec3::x(), Vec3::y());
+        let u = 0.8_f64;
+        let uhat = Vec3::new(u.cos(), u.sin(), 0.0);
+        let rho = d * alpha.tan();
+        let x = Point3::new(rho * u.cos(), rho * u.sin(), z0);
+
+        let seed = [SurfaceSeed::ConeAngle { rate: adot }];
+        let rows1 = vec![
+            constraint_row(&plane, &[], &x).unwrap(),
+            constraint_row(&cone, &seed, &x).unwrap(),
+        ];
+        let xdot = solve_vertex_velocity(&rows1).unwrap();
+        let sec2 = 1.0 / (alpha.cos() * alpha.cos());
+        assert!(
+            (xdot - uhat * (d * sec2 * adot)).norm() < 1e-9,
+            "xdot = {xdot:?}"
+        );
+
+        let rows2 = vec![
+            constraint_row_2(&plane, &[], &[], &x, &xdot).unwrap(),
+            constraint_row_2(&cone, &seed, &[], &x, &xdot).unwrap(),
+        ];
+        let xddot = solve_vertex_velocity(&rows2).unwrap();
+        let expected = uhat * (d * 2.0 * sec2 * alpha.tan() * adot * adot);
+        assert!(
+            (xddot - expected).norm() < 1e-9,
+            "xddot = {xddot:?} vs expected {expected:?}"
+        );
+    }
+
+    #[test]
+    fn torus_minor_radius_acceleration_matches_nonlinear_field() {
+        // A point on the outer equator of a torus whose minor radius is a
+        // nonlinear function of θ: r(θ) = r0 + ṙθ + ½r̈θ². The point rides
+        // radially: x(θ) = (R + r(θ))·û, so ẋ = ṙ·û and ẍ = r̈·û — the
+        // torus analogue of the cylinder nonlinear-field test, pinned by two
+        // planes so only the radial DOF is live... the torus row alone pins
+        // the normal direction and the tangential DOFs are frozen, exactly
+        // like the cylinder case.
+        use vcad_kernel_geom::TorusSurface;
+        let torus = TorusSurface::new(7.0, 2.0);
+        let (rdot, rddot) = (0.6, 1.7);
+        let u = 0.9_f64;
+        let uhat = Vec3::new(u.cos(), u.sin(), 0.0);
+        let x = Point3::new(9.0 * u.cos(), 9.0 * u.sin(), 0.0); // ρ = R + r
+
+        let vel_seed = [SurfaceSeed::TorusMinorRadius { rate: rdot }];
+        let acc_seed = [SurfaceSeed::TorusMinorRadius { rate: rddot }];
+        let rows1 = vec![constraint_row(&torus, &vel_seed, &x).unwrap()];
+        let xdot = solve_vertex_velocity(&rows1).unwrap();
+        assert!((xdot - uhat * rdot).norm() < 1e-12, "xdot = {xdot:?}");
+
+        let rows2 = vec![constraint_row_2(&torus, &vel_seed, &acc_seed, &x, &xdot).unwrap()];
+        let xddot = solve_vertex_velocity(&rows2).unwrap();
+        assert!(
+            (xddot - uhat * rddot).norm() < 1e-10,
+            "xddot = {xddot:?} vs expected {:?}",
+            uhat * rddot
+        );
+    }
+
+    #[test]
+    fn torus_major_radius_acceleration_second_row_matches_fd() {
+        // Validate the torus second-order row's rhs directly against a central
+        // difference of the first-order rhs along the moving-point trajectory:
+        // for x(θ) riding the outer equator of a torus with R(θ) = R0 + Ṙθ,
+        // ∇g·ẍ must equal d/dθ[∇g·ẋ] − (∇̇g)·ẋ; equivalently the identity
+        // g(x(θ), θ) ≡ 0 gives ẍ = R̈ û = 0 here, so the solved acceleration
+        // must vanish even though the velocity-curvature and rhs terms are
+        // individually nonzero (they cancel exactly).
+        use vcad_kernel_geom::TorusSurface;
+        let torus = TorusSurface::new(7.0, 2.0);
+        let u = 1.7_f64;
+        let uhat = Vec3::new(u.cos(), u.sin(), 0.0);
+        let x = Point3::new(9.0 * u.cos(), 9.0 * u.sin(), 0.0);
+
+        let vel_seed = [SurfaceSeed::TorusMajorRadius { rate: 1.0 }];
+        let rows1 = vec![constraint_row(&torus, &vel_seed, &x).unwrap()];
+        let xdot = solve_vertex_velocity(&rows1).unwrap();
+        assert!((xdot - uhat).norm() < 1e-12, "xdot = {xdot:?}");
+
+        let rows2 = vec![constraint_row_2(&torus, &vel_seed, &[], &x, &xdot).unwrap()];
+        let xddot = solve_vertex_velocity(&rows2).unwrap();
+        assert!(xddot.norm() < 1e-10, "xddot = {xddot:?}, expected 0");
     }
 }

--- a/crates/vcad-kernel-diff/src/lib.rs
+++ b/crates/vcad-kernel-diff/src/lib.rs
@@ -54,7 +54,7 @@ pub use implicit::{
     tangency_rows, ConstraintRow,
 };
 pub use lbfgs::minimize_lbfgs;
-pub use lift::{lift_surface, DualSurface};
+pub use lift::{lift_surface, lift_surface_second, DualSurface, DualSurface2};
 pub use mass::{mass_properties, mass_properties_with_derivative, MassProperties};
 pub use optimize::{
     minimize, objective_gradient, objective_gradient_reverse, IterateRecord, MeshObjective,
@@ -100,15 +100,6 @@ pub enum DiffError {
     /// No implicit constraint form is implemented for this surface kind, so
     /// a topology vertex adjacent to it cannot be differentiated.
     UnsupportedConstraint(SurfaceKind),
-    /// No second-order (acceleration) form is implemented for this surface
-    /// kind yet. The volume second derivative supports plane/cylinder/sphere,
-    /// whose surface points are **linear** in the seeded fields (translation,
-    /// radius), so the node acceleration is just the first-order lift fed the
-    /// field accelerations. Cone/torus points are nonlinear in their shape
-    /// fields (half-angle, radii), so their acceleration carries an extra
-    /// `∂²x/∂field²·fielḋ²` term — a mechanical extension, deliberately not
-    /// shipped.
-    SecondOrderUnsupported(SurfaceKind),
     /// The implicit system at a topology vertex is inconsistent: dependent
     /// constraint rows disagree beyond tolerance. The vertex does not
     /// actually lie on a common intersection of its adjacent surfaces (or a
@@ -161,10 +152,6 @@ impl std::fmt::Display for DiffError {
             DiffError::UnsupportedConstraint(kind) => write!(
                 f,
                 "no implicit constraint form for surface kind {kind:?}; cannot differentiate an adjacent topology vertex"
-            ),
-            DiffError::SecondOrderUnsupported(kind) => write!(
-                f,
-                "no second-order form for surface kind {kind:?}; volume second derivative supports plane/cylinder/sphere"
             ),
             DiffError::InconsistentConstraints { residual } => write!(
                 f,

--- a/crates/vcad-kernel-diff/src/lift.rs
+++ b/crates/vcad-kernel-diff/src/lift.rs
@@ -145,6 +145,301 @@ pub fn lift_surface(
     }
 }
 
+/// Nested dual scalar: value, first tangent (`ẋ`), and second tangent (`ẍ`)
+/// in one pass, seeded as `((x, ẋ), (ẋ, ẍ))`.
+type Dd = Dual<Dual<f64>>;
+
+/// A concrete surface lifted to `Dual<Dual<f64>>` with first- **and**
+/// second-order θ-seeds applied — the exact second-order counterpart of
+/// [`DualSurface`]. Unlike the first-order lift there is no linearity
+/// assumption anywhere: a cone's `tan(half_angle)` or any other nonlinear
+/// field dependence differentiates through the nested duals exactly, so
+/// every surface kind is supported.
+#[derive(Debug, Clone)]
+pub enum DualSurface2 {
+    /// Lifted plane.
+    Plane(Box<Plane<Dd>>),
+    /// Lifted cylinder.
+    Cylinder(Box<CylinderSurface<Dd>>),
+    /// Lifted cone.
+    Cone(Box<ConeSurface<Dd>>),
+    /// Lifted sphere.
+    Sphere(Box<SphereSurface<Dd>>),
+    /// Lifted torus.
+    Torus(Box<TorusSurface<Dd>>),
+    /// Lifted bilinear patch.
+    Bilinear(Box<BilinearSurface<Dd>>),
+    /// Lifted B-spline surface.
+    BSpline(Box<BSplineSurface<Dd>>),
+}
+
+/// Add a field's first derivative `v` and second derivative `a` into a
+/// nested-dual scalar seeded `((f, ḟ), (ḟ, f̈))`.
+fn seed_scalar2(f: &mut Dd, v: f64, a: f64) {
+    f.real.dual += v;
+    f.dual.real += v;
+    f.dual.dual += a;
+}
+
+fn seed_point2(p: &mut tang::Point3<Dd>, v: Vec3, a: Vec3) {
+    seed_scalar2(&mut p.x, v.x, a.x);
+    seed_scalar2(&mut p.y, v.y, a.y);
+    seed_scalar2(&mut p.z, v.z, a.z);
+}
+
+/// Sum the translation velocities of a seed slice (zero if none), erroring
+/// on any seed not in `allowed`.
+fn collect2(
+    kind: SurfaceKind,
+    seeds: &[SurfaceSeed],
+    mut on_seed: impl FnMut(&SurfaceSeed) -> bool,
+) -> Result<(), DiffError> {
+    for seed in seeds {
+        if !on_seed(seed) {
+            return Err(DiffError::UnsupportedSeed { kind, seed: *seed });
+        }
+    }
+    Ok(())
+}
+
+/// Lift a stored surface to `Dual<Dual<f64>>`, seeding each θ-touched field
+/// with its first derivative (from `vel_seeds`) and second derivative (from
+/// `acc_seeds`). The two slices use the same [`SurfaceSeed`] vocabulary —
+/// a rate/velocity in `acc_seeds` is read as the field's `d²/dθ²` — so a
+/// first-order seeding lifts to second order by adding accelerations and
+/// nothing else (empty `acc_seeds` = fields linear in θ).
+pub fn lift_surface_second(
+    surface: &dyn Surface,
+    vel_seeds: &[SurfaceSeed],
+    acc_seeds: &[SurfaceSeed],
+) -> Result<DualSurface2, DiffError> {
+    let kind = surface.surface_type();
+    // Each arm folds both seed slices into (velocity, acceleration) per
+    // field, then writes them into the lifted struct via seed_scalar2 /
+    // seed_point2.
+    match kind {
+        SurfaceKind::Plane => {
+            let mut s = downcast::<Plane>(surface, kind)?.lift::<Dd>();
+            let mut v = Vec3::new(0.0, 0.0, 0.0);
+            let mut a = Vec3::new(0.0, 0.0, 0.0);
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            seed_point2(&mut s.origin, v, a);
+            Ok(DualSurface2::Plane(Box::new(s)))
+        }
+        SurfaceKind::Cylinder => {
+            let mut s = downcast::<CylinderSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            let (mut rv, mut ra) = (0.0, 0.0);
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                SurfaceSeed::CylinderRadius { rate } => {
+                    rv += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                SurfaceSeed::CylinderRadius { rate } => {
+                    ra += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            seed_point2(&mut s.center, v, a);
+            seed_scalar2(&mut s.radius, rv, ra);
+            Ok(DualSurface2::Cylinder(Box::new(s)))
+        }
+        SurfaceKind::Cone => {
+            let mut s = downcast::<ConeSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            let (mut av, mut aa) = (0.0, 0.0);
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                SurfaceSeed::ConeAngle { rate } => {
+                    av += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                SurfaceSeed::ConeAngle { rate } => {
+                    aa += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            seed_point2(&mut s.apex, v, a);
+            seed_scalar2(&mut s.half_angle, av, aa);
+            Ok(DualSurface2::Cone(Box::new(s)))
+        }
+        SurfaceKind::Sphere => {
+            let mut s = downcast::<SphereSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            let (mut rv, mut ra) = (0.0, 0.0);
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                SurfaceSeed::SphereRadius { rate } => {
+                    rv += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                SurfaceSeed::SphereRadius { rate } => {
+                    ra += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            seed_point2(&mut s.center, v, a);
+            seed_scalar2(&mut s.radius, rv, ra);
+            Ok(DualSurface2::Sphere(Box::new(s)))
+        }
+        SurfaceKind::Torus => {
+            let mut s = downcast::<TorusSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            let (mut mv, mut ma) = (0.0, 0.0);
+            let (mut nv, mut na) = (0.0, 0.0);
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                SurfaceSeed::TorusMajorRadius { rate } => {
+                    mv += rate;
+                    true
+                }
+                SurfaceSeed::TorusMinorRadius { rate } => {
+                    nv += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                SurfaceSeed::TorusMajorRadius { rate } => {
+                    ma += rate;
+                    true
+                }
+                SurfaceSeed::TorusMinorRadius { rate } => {
+                    na += rate;
+                    true
+                }
+                _ => false,
+            })?;
+            seed_point2(&mut s.center, v, a);
+            seed_scalar2(&mut s.major_radius, mv, ma);
+            seed_scalar2(&mut s.minor_radius, nv, na);
+            Ok(DualSurface2::Torus(Box::new(s)))
+        }
+        SurfaceKind::Bilinear => {
+            let mut s = downcast::<BilinearSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            for cp in [&mut s.p00, &mut s.p10, &mut s.p01, &mut s.p11] {
+                seed_point2(cp, v, a);
+            }
+            Ok(DualSurface2::Bilinear(Box::new(s)))
+        }
+        SurfaceKind::BSpline => {
+            let mut s = downcast::<BSplineSurface>(surface, kind)?.lift::<Dd>();
+            let (mut v, mut a) = (Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+            collect2(kind, vel_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    v += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            collect2(kind, acc_seeds, |seed| match *seed {
+                SurfaceSeed::Translate { velocity } => {
+                    a += velocity;
+                    true
+                }
+                _ => false,
+            })?;
+            for cp in &mut s.control_points {
+                seed_point2(cp, v, a);
+            }
+            Ok(DualSurface2::BSpline(Box::new(s)))
+        }
+    }
+}
+
+impl DualSurface2 {
+    /// Position `x(θ)`, velocity `dx/dθ`, and acceleration `d²x/dθ²` at a
+    /// frozen `(u, v)` — read off the value / first-tangent / second-tangent
+    /// slots of the nested-dual evaluation.
+    pub fn evaluate_with_acceleration(&self, uv: Point2) -> (Point3, Vec3, Vec3) {
+        let c = |x: f64| -> Dd { Dual::constant(Dual::constant(x)) };
+        let uv_d = tang::Point2::new(c(uv.x), c(uv.y));
+        let p = match self {
+            DualSurface2::Plane(s) => s.evaluate(uv_d),
+            DualSurface2::Cylinder(s) => s.evaluate(uv_d),
+            DualSurface2::Cone(s) => s.evaluate(uv_d),
+            DualSurface2::Sphere(s) => s.evaluate(uv_d),
+            DualSurface2::Torus(s) => s.evaluate(uv_d),
+            DualSurface2::Bilinear(s) => s.evaluate(uv_d),
+            DualSurface2::BSpline(s) => s.eval(uv.x, uv.y),
+        };
+        (
+            Point3::new(p.x.real.real, p.y.real.real, p.z.real.real),
+            Vec3::new(p.x.real.dual, p.y.real.dual, p.z.real.dual),
+            Vec3::new(p.x.dual.dual, p.y.dual.dual, p.z.dual.dual),
+        )
+    }
+}
+
 impl DualSurface {
     /// Evaluate at a frozen `(u, v)` (constants — the sample pattern does
     /// not move with θ), returning the dual-valued position.
@@ -296,5 +591,81 @@ mod tests {
         let lifted = lift_surface(&sph, &[]).unwrap();
         let (_, vel) = lifted.evaluate_with_velocity(Point2::new(0.7, 0.3));
         assert!(vel.norm() < 1e-15);
+    }
+
+    #[test]
+    fn cone_angle_second_order_lift_matches_fd_of_velocity() {
+        // ẍ of a cone surface point under a constant half-angle rate: the
+        // point is nonlinear in α (tan α), so ẍ ≠ 0 even with α̈ = 0. Oracle:
+        // central difference of the *first-order* lift's velocity at α ± h.
+        use vcad_kernel_math::Dir3;
+        let cone = ConeSurface {
+            apex: Point3::new(0.0, 0.0, 20.0),
+            axis: Dir3::new_normalize(-Vec3::z()),
+            ref_dir: Dir3::new_normalize(Vec3::x()),
+            half_angle: 0.25_f64.atan(),
+        };
+        let seed = [SurfaceSeed::ConeAngle { rate: 1.0 }];
+        let lifted2 = lift_surface_second(&cone, &seed, &[]).unwrap();
+        let h = 1e-6;
+        for &(u, v) in &[(0.0, 5.0), (1.3, 12.0), (4.7, 18.0)] {
+            let uv = Point2::new(u, v);
+            let (_, vel, acc) = lifted2.evaluate_with_acceleration(uv);
+            // First-order consistency.
+            let (_, vel1) = lift_surface(&cone, &seed)
+                .unwrap()
+                .evaluate_with_velocity(uv);
+            assert!((vel - vel1).norm() < 1e-13, "vel mismatch at ({u},{v})");
+            // FD of the velocity across α.
+            let vel_at = |da: f64| {
+                let bumped = ConeSurface {
+                    half_angle: cone.half_angle + da,
+                    ..cone.clone()
+                };
+                lift_surface(&bumped, &seed)
+                    .unwrap()
+                    .evaluate_with_velocity(uv)
+                    .1
+            };
+            let fd = (vel_at(h) - vel_at(-h)) / (2.0 * h);
+            assert!(
+                (acc - fd).norm() < 1e-4 * fd.norm().max(1.0),
+                "cone ẍ ({u},{v}): {acc:?} vs FD {fd:?}"
+            );
+            assert!(acc.norm() > 1e-3, "cone ẍ should be nonzero (tan α)");
+        }
+    }
+
+    #[test]
+    fn torus_nonlinear_minor_radius_second_order_lift() {
+        // r(θ) = θ² at θ0: velocity seeds carry ṙ = 2θ0, acceleration seeds
+        // r̈ = 2. Torus points are linear in r at frozen (u, v), so
+        // ẍ = r̈·∂x/∂r = 2·(cos v·û + sin v·ẑ), a unit direction scaled by 2.
+        let torus = TorusSurface::new(7.0, 2.25); // r = θ0², θ0 = 1.5
+        let theta0 = 1.5;
+        let vel = [SurfaceSeed::TorusMinorRadius { rate: 2.0 * theta0 }];
+        let acc = [SurfaceSeed::TorusMinorRadius { rate: 2.0 }];
+        let lifted2 = lift_surface_second(&torus, &vel, &acc).unwrap();
+        for &(u, v) in &[(0.0, 0.0), (1.1, 2.2), (3.4, 5.1)] {
+            let (_, _, a) = lifted2.evaluate_with_acceleration(Point2::new(u, v));
+            assert!(
+                (a.norm() - 2.0).abs() < 1e-12,
+                "torus ẍ norm {} at ({u},{v}), expected 2 (= r̈)",
+                a.norm()
+            );
+        }
+    }
+
+    #[test]
+    fn linear_seeding_second_order_lift_has_zero_acceleration() {
+        // Plane/cylinder/sphere points are linear in their seeded fields, so
+        // empty acceleration seeds ⇒ ẍ = 0 exactly — the invariant the old
+        // two-lift shortcut relied on, now a special case of the nested lift.
+        let cyl = CylinderSurface::new(5.0);
+        let lifted2 =
+            lift_surface_second(&cyl, &[SurfaceSeed::CylinderRadius { rate: 1.0 }], &[]).unwrap();
+        let (_, vel, acc) = lifted2.evaluate_with_acceleration(Point2::new(1.0, 3.0));
+        assert!((vel - Vec3::new(1.0_f64.cos(), 1.0_f64.sin(), 0.0)).norm() < 1e-15);
+        assert!(acc.norm() < 1e-15, "linear field ⇒ zero ẍ, got {acc:?}");
     }
 }

--- a/crates/vcad-kernel-diff/src/second_order.rs
+++ b/crates/vcad-kernel-diff/src/second_order.rs
@@ -26,20 +26,20 @@
 //!
 //! # Node accelerations
 //!
-//! - **Lift nodes** (`SurfaceUv`) on plane/cylinder/sphere: the surface point
-//!   `x(θ) = S(u, v; fields(θ))` is **linear** in the seeded fields
-//!   (translation, radius) at a frozen `(u, v)`, so `∂x/∂field` is a constant
-//!   map and `ẍ = (∂x/∂field)·field̈` — exactly the first-order lift
-//!   ([`crate::lift_surface`]) evaluated with the field *accelerations*
-//!   seeded where velocities normally go. No second-order lift is needed for
-//!   these kinds; cone/torus (nonlinear in half-angle / radii) are rejected
-//!   with [`DiffError::SecondOrderUnsupported`].
+//! - **Lift nodes** (`SurfaceUv`): the surface point `x(θ) = S(u, v;
+//!   fields(θ))` is evaluated through the nested-dual lift
+//!   ([`crate::lift_surface_second`]) with every seeded field packed as
+//!   `((f, ḟ), (ḟ, f̈))`, so `ẍ = ∂x/∂field·field̈ + ∂²x/∂field²·fielḋ ²`
+//!   comes out exactly for **every** surface kind — the linear kinds
+//!   (plane/cylinder/sphere, where the second term vanishes) and the
+//!   nonlinear ones (cone's `tan α`, torus radii) alike.
 //! - **Vertex / Boundary nodes** solve the second-order implicit system
 //!   ([`crate::constraint_row_2`]): the same row gradients as the velocity
 //!   solve, the frozen tangential completion reused verbatim, only the
-//!   right-hand side carries the curvature. Tangency-completion rows are
-//!   linear in `x` and the surface center, so their second-order form is the
-//!   first-order [`crate::tangency_rows`] fed the acceleration seeds.
+//!   right-hand side carries the curvature — including the cone/torus
+//!   non-constant `∇²g` terms. Tangency-completion rows are linear in `x`
+//!   and the surface center, so their second-order form is the first-order
+//!   [`crate::tangency_rows`] fed the acceleration seeds.
 //!
 //! What this computes, exactly: the volume second derivative with the node
 //! accelerations of plane/cylinder/sphere nodes carried in full. It is not a
@@ -50,7 +50,6 @@
 use std::collections::{BTreeSet, HashMap};
 
 use tang::Dual;
-use vcad_kernel_geom::SurfaceKind;
 use vcad_kernel_math::{Point2, Point3, Vec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::frozen::{refine_boundary_point, FrozenError, FrozenPlan, NodeRecipe};
@@ -59,8 +58,8 @@ use crate::seam::{
     assemble_vertex_rows, checked_index, incidence_context, vertex_incident_surfaces,
 };
 use crate::{
-    constraint_row, constraint_row_2, lift_surface, mesh_volume, solve_vertex_velocity,
-    tangency_rows, ConstraintRow, DiffError, DualSurface, ParamSeeding,
+    constraint_row, constraint_row_2, lift_surface_second, mesh_volume, solve_vertex_velocity,
+    tangency_rows, ConstraintRow, DiffError, DualSurface2, ParamSeeding,
 };
 
 /// A parameter's first- **and** second-order seeding: how θ moves each
@@ -164,9 +163,8 @@ fn assemble_vertex_rows_second(
 /// [`crate::evaluate_with_sensitivity`] (the same signature and anchor checks
 /// hold). The first-order path is identical to that function; the addition is
 /// the per-node acceleration `ẍ` (see the module docs for the kinematics).
-///
-/// `SurfaceUv` nodes are restricted to plane/cylinder/sphere; a lift node on
-/// a cone/torus errors with [`DiffError::SecondOrderUnsupported`].
+/// Every surface kind with an implicit form is supported — plane, cylinder,
+/// sphere, cone, and torus.
 pub fn evaluate_with_second_derivative(
     brep: &BRepSolid,
     plan: &FrozenPlan,
@@ -178,10 +176,9 @@ pub fn evaluate_with_second_derivative(
     let vel = &seeding.velocity;
     let acc = &seeding.acceleration;
 
-    // Lift each referenced face surface once per (velocity / acceleration)
-    // seeding — shared by every sample on the face.
-    let mut lifted_vel: HashMap<u32, DualSurface> = HashMap::new();
-    let mut lifted_acc: HashMap<u32, DualSurface> = HashMap::new();
+    // Lift each referenced face surface once to the nested-dual scalar with
+    // both seedings applied — shared by every sample on the face.
+    let mut lifted: HashMap<u32, DualSurface2> = HashMap::new();
 
     let anchor_check = |node: usize, p: &Point3, anchor: &Point3| -> Result<(), DiffError> {
         let d2 = (*p - *anchor).norm_squared();
@@ -228,28 +225,17 @@ pub fn evaluate_with_second_derivative(
                         .ok_or(FrozenError::RecipeOutOfRange)?;
                     topo.faces[face_id].surface_index
                 };
-                let kind = brep.geometry.surfaces[surface_index].surface_type();
-                // Only kinds whose points are linear in the seeded fields.
-                if !matches!(
-                    kind,
-                    SurfaceKind::Plane | SurfaceKind::Cylinder | SurfaceKind::Sphere
-                ) {
-                    return Err(DiffError::SecondOrderUnsupported(kind));
-                }
                 let uv = Point2::new(u, v);
-                if let std::collections::hash_map::Entry::Vacant(e) = lifted_vel.entry(face) {
+                if let std::collections::hash_map::Entry::Vacant(e) = lifted.entry(face) {
                     let surface = brep.geometry.surfaces[surface_index].as_ref();
-                    e.insert(lift_surface(surface, vel.get(surface_index))?);
+                    e.insert(lift_surface_second(
+                        surface,
+                        vel.get(surface_index),
+                        acc.get(surface_index),
+                    )?);
                 }
-                if let std::collections::hash_map::Entry::Vacant(e) = lifted_acc.entry(face) {
-                    let surface = brep.geometry.surfaces[surface_index].as_ref();
-                    e.insert(lift_surface(surface, acc.get(surface_index))?);
-                }
-                let (p, vx) = lifted_vel[&face].evaluate_with_velocity(uv);
+                let (p, vx, ax) = lifted[&face].evaluate_with_acceleration(uv);
                 anchor_check(i, &p, &plan.base_positions[i])?;
-                // x is linear in the fields ⇒ ẍ = (∂x/∂field)·field̈, which is
-                // the first-order lift evaluated with the acceleration seeds.
-                let (_, ax) = lifted_acc[&face].evaluate_with_velocity(uv);
                 positions.push(p);
                 velocities.push(vx);
                 accelerations.push(ax);

--- a/crates/vcad-kernel-diff/tests/m10_second_order.rs
+++ b/crates/vcad-kernel-diff/tests/m10_second_order.rs
@@ -288,6 +288,232 @@ fn m10_rounded_cube_second_derivative_matches_fd() {
     );
 }
 
+// ======================================== cone / torus second order (F1)
+
+const CONE_APEX_Z: f64 = 20.0;
+const CONE_H: f64 = 8.0;
+const CONE_SEGS: u32 = 24;
+
+/// θ = half-angle α about a fixed apex (the M7 cone-alpha model): both cap
+/// radii are `(APEX_Z − z)·tan α`, so every node position is **nonlinear**
+/// in α and the second-order machinery must produce nonzero accelerations.
+fn build_cone_alpha(alpha: f64) -> BRepSolid {
+    let t = alpha.tan();
+    vcad_kernel_primitives::make_cone(
+        CONE_APEX_Z * t,
+        (CONE_APEX_Z - CONE_H) * t,
+        CONE_H,
+        CONE_SEGS,
+    )
+}
+
+fn cone_alpha_seeding(brep: &BRepSolid) -> ParamSeeding {
+    let mut s = ParamSeeding::new();
+    let n = s.seed_where(
+        &brep.geometry,
+        |surf| surf.surface_type() == vcad_kernel_geom::SurfaceKind::Cone,
+        SurfaceSeed::ConeAngle { rate: 1.0 },
+    );
+    assert_eq!(n, 1, "expected exactly the cone lateral surface");
+    s
+}
+
+#[test]
+fn m10_cone_half_angle_second_derivative_matches_closed_form() {
+    let params = TessellationParams {
+        circle_segments: CONE_SEGS,
+        height_segments: 2,
+        ..Default::default()
+    };
+    let alpha0 = 0.25_f64.atan();
+    let (v, dv, ddv) = second_order_volume(&build_cone_alpha, &cone_alpha_seeding, alpha0, &params);
+
+    // Discrete closed form: V(α) = (h·k/3)·C·tan²α with k = ½N sin(2π/N) and
+    // C = z_a² + z_b² + z_a·z_b (z_a = 20, z_b = 12) — exactly quadratic in
+    // tan α, so d²V/dα² = (h·k/3)·C·(2 sec⁴α + 4 tan²α sec²α) is exact for
+    // the frozen mesh, a zero-discretization-error target like the boolean
+    // hole's.
+    let n = CONE_SEGS as f64;
+    let k = 0.5 * n * (2.0 * std::f64::consts::PI / n).sin();
+    let za = CONE_APEX_Z;
+    let zb = CONE_APEX_Z - CONE_H;
+    let c = za * za + zb * zb + za * zb;
+    let t = alpha0.tan();
+    let sec2 = 1.0 / (alpha0.cos() * alpha0.cos());
+    let v_exact = CONE_H * k / 3.0 * c * t * t;
+    let dv_exact = CONE_H * k / 3.0 * c * 2.0 * t * sec2;
+    let ddv_exact = CONE_H * k / 3.0 * c * (2.0 * sec2 * sec2 + 4.0 * t * t * sec2);
+
+    assert!((v - v_exact).abs() / v_exact < 1e-12, "V {v} vs {v_exact}");
+    assert!(
+        (dv - dv_exact).abs() / dv_exact.abs() < 1e-9,
+        "dV/dα {dv} vs {dv_exact}"
+    );
+    let rel = (ddv - ddv_exact).abs() / ddv_exact.abs();
+    eprintln!("cone d²V/dα²: analytic {ddv:.6} vs closed {ddv_exact:.6} (rel {rel:.3e})");
+    assert!(
+        rel <= 1e-9,
+        "cone d²V/dα² {ddv} vs closed form {ddv_exact} (rel {rel:.3e})"
+    );
+
+    // FD of the analytic dV/dα (fresh captures at α ± h).
+    let fd = fd_of_analytic_dv(
+        &build_cone_alpha,
+        &cone_alpha_seeding,
+        alpha0,
+        1e-6,
+        &params,
+    );
+    let rel_fd = (ddv - fd).abs() / ddv_exact.abs();
+    assert!(
+        rel_fd <= 1e-5,
+        "cone d²V/dα² {ddv} vs FD {fd} (rel {rel_fd:.3e})"
+    );
+
+    // The point of the extension: nodes are genuinely nonlinear in α, so the
+    // machinery must produce *nonzero* accelerations (unlike every previous
+    // linear-in-θ gate).
+    let brep = build_cone_alpha(alpha0);
+    let plan = capture_plan(&brep, &params).unwrap();
+    let seam = evaluate_with_second_derivative(
+        &brep,
+        &plan,
+        &SecondOrderSeeding::linear(cone_alpha_seeding(&brep)),
+    )
+    .unwrap();
+    let max_accel = seam
+        .accelerations
+        .iter()
+        .map(|a| a.norm())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        max_accel > 1.0,
+        "cone nodes must accelerate (tan α nonlinearity), max ‖ẍ‖ = {max_accel:.3e}"
+    );
+}
+
+const TORUS_R: f64 = 8.0;
+const TORUS_MINOR: f64 = 3.0;
+const TORUS_SEGS: u32 = 24;
+
+fn torus_params() -> TessellationParams {
+    TessellationParams {
+        circle_segments: TORUS_SEGS,
+        height_segments: 2,
+        latitude_segments: TORUS_SEGS,
+        ..Default::default()
+    }
+}
+
+fn torus_seeding(brep: &BRepSolid, seed: SurfaceSeed) -> ParamSeeding {
+    let mut s = ParamSeeding::new();
+    let n = s.seed_where(
+        &brep.geometry,
+        |surf| surf.surface_type() == vcad_kernel_geom::SurfaceKind::Torus,
+        seed,
+    );
+    assert_eq!(n, 1, "expected exactly the torus surface");
+    s
+}
+
+#[test]
+fn m10_torus_minor_radius_second_derivative() {
+    let params = torus_params();
+    let build = |r: f64| vcad_kernel_primitives::make_torus(TORUS_R, r, TORUS_SEGS);
+    let seeding =
+        |brep: &BRepSolid| torus_seeding(brep, SurfaceSeed::TorusMinorRadius { rate: 1.0 });
+    let (_, dv, ddv) = second_order_volume(&build, &seeding, TORUS_MINOR, &params);
+
+    // Continuum sanity band: V = 2π²R r² ⇒ d²V/dr² = 4π²R; the two
+    // N-gon polygonizations put the mesh a few percent under it.
+    let ddv_cont = 4.0 * std::f64::consts::PI.powi(2) * TORUS_R;
+    assert!(
+        (ddv - ddv_cont).abs() / ddv_cont < 0.05,
+        "torus d²V/dr² {ddv} vs continuum {ddv_cont}"
+    );
+
+    // Gate: FD of the analytic dV/dr (fresh captures at r ± h). The torus
+    // seam-loop boundary nodes re-capture with O(1e-8) correspondence jitter
+    // (measured: rel 1.2e-4 at h = 1e-6, jitter/2h-limited), so use h = 1e-4
+    // where the jitter clears — same reasoning as the rounded-cube gate. The
+    // truncation term is negligible (V is cubic in r, d³V/dr³ ≈ 2πk·6).
+    let fd = fd_of_analytic_dv(&build, &seeding, TORUS_MINOR, 1e-4, &params);
+    let rel = (ddv - fd).abs() / ddv.abs();
+    eprintln!("torus d²V/dr²: analytic {ddv:.6} vs FD {fd:.6} (rel {rel:.3e}), dV/dr {dv:.6}");
+    assert!(
+        rel <= 1e-5,
+        "torus d²V/dr² {ddv} vs FD {fd} (rel {rel:.3e})"
+    );
+}
+
+#[test]
+fn m10_torus_major_radius_second_derivative() {
+    let params = torus_params();
+    let build = |big_r: f64| vcad_kernel_primitives::make_torus(big_r, TORUS_MINOR, TORUS_SEGS);
+    let seeding =
+        |brep: &BRepSolid| torus_seeding(brep, SurfaceSeed::TorusMajorRadius { rate: 1.0 });
+    let (_, dv, ddv) = second_order_volume(&build, &seeding, TORUS_R, &params);
+
+    // V is linear in R (Pappus: cross-section area × centroid path), for the
+    // discrete swept mesh exactly as for the continuum ⇒ d²V/dR² = 0. The
+    // torus rows' velocity-curvature terms are individually nonzero here and
+    // must cancel exactly against the lift's ∂²x/∂R² = 0.
+    let fd = fd_of_analytic_dv(&build, &seeding, TORUS_R, 1e-6, &params);
+    eprintln!("torus d²V/dR²: analytic {ddv:.3e} vs FD {fd:.3e} (dV/dR {dv:.6})");
+    assert!(
+        ddv.abs() < 1e-6 * dv.abs(),
+        "d²V/dR² should vanish (V linear in R), got {ddv:.3e}"
+    );
+    assert!((ddv - fd).abs() < 1e-4, "analytic {ddv:.3e} vs FD {fd:.3e}");
+}
+
+#[test]
+fn m10_torus_nonlinear_field_chain_rule() {
+    // r(θ) = θ² at θ0 = √3: velocity seeding ṙ = 2θ0, acceleration seeding
+    // r̈ = 2. Chain rule on the same frozen plan:
+    //   d²V/dθ² = d²V/dr²·(2θ0)² + dV/dr·2,
+    // with d²V/dr² and dV/dr from the linear-seeding run — an internal
+    // consistency gate that exercises nonzero acceleration seeds through
+    // every torus node class (lift, boundary, seam vertex).
+    let params = torus_params();
+    let theta0 = TORUS_MINOR.sqrt();
+    let brep = vcad_kernel_primitives::make_torus(TORUS_R, TORUS_MINOR, TORUS_SEGS);
+    let plan = capture_plan(&brep, &params).expect("capture torus");
+
+    // Linear-in-r run: dV/dr and d²V/dr².
+    let lin = SecondOrderSeeding::linear(torus_seeding(
+        &brep,
+        SurfaceSeed::TorusMinorRadius { rate: 1.0 },
+    ));
+    let seam_lin = evaluate_with_second_derivative(&brep, &plan, &lin).expect("linear seam");
+    let (_, dv_dr, ddv_drr) = volume_with_second_derivative(&seam_lin);
+
+    // Nonlinear r(θ) = θ² run.
+    let nonlin = SecondOrderSeeding {
+        velocity: torus_seeding(&brep, SurfaceSeed::TorusMinorRadius { rate: 2.0 * theta0 }),
+        acceleration: torus_seeding(&brep, SurfaceSeed::TorusMinorRadius { rate: 2.0 }),
+    };
+    let seam_nl = evaluate_with_second_derivative(&brep, &plan, &nonlin).expect("nonlinear seam");
+    let (_, dv_dtheta, ddv_dthth) = volume_with_second_derivative(&seam_nl);
+
+    let dv_expected = dv_dr * 2.0 * theta0;
+    let ddv_expected = ddv_drr * (2.0 * theta0) * (2.0 * theta0) + dv_dr * 2.0;
+    let rel1 = (dv_dtheta - dv_expected).abs() / dv_expected.abs();
+    let rel2 = (ddv_dthth - ddv_expected).abs() / ddv_expected.abs();
+    eprintln!(
+        "torus chain rule: dV/dθ {dv_dtheta:.6} vs {dv_expected:.6} (rel {rel1:.3e}), \
+         d²V/dθ² {ddv_dthth:.6} vs {ddv_expected:.6} (rel {rel2:.3e})"
+    );
+    assert!(
+        rel1 <= 1e-12,
+        "first-order chain rule violated (rel {rel1:.3e})"
+    );
+    assert!(
+        rel2 <= 1e-12,
+        "second-order chain rule violated (rel {rel2:.3e})"
+    );
+}
+
 // ================================================= Gauss–Newton curvature
 
 // The M9 five-parameter model: fillet_all_edges(cube(sx,sy,sz), r) drilled by

--- a/crates/vcad-kernel-fillet/src/fillet_curved.rs
+++ b/crates/vcad-kernel-fillet/src/fillet_curved.rs
@@ -146,8 +146,8 @@ fn fillet_edges_detailed_inner(
     // pipeline below insets *every* face by `radius`, which is only valid
     // when every edge is filleted; for a proper subset it shrinks the whole
     // body. See `fillet_subset` for the geometrically correct construction.
-    if crate::fillet_subset::is_independent_plane_plane_set(brep, edge_ids) {
-        return crate::fillet_subset::fillet_independent_plane_edges(brep, edge_ids, radius);
+    if crate::fillet_subset::is_plane_plane_chain_set(brep, edge_ids, radius) {
+        return crate::fillet_subset::fillet_plane_chain_edges(brep, edge_ids, radius);
     }
 
     let faces = extract_faces(brep);

--- a/crates/vcad-kernel-fillet/src/fillet_subset.rs
+++ b/crates/vcad-kernel-fillet/src/fillet_subset.rs
@@ -1,4 +1,5 @@
-//! Correct per-edge fillet for an independent set of plane-plane edges.
+//! Correct per-edge fillet for a set of plane-plane edges: independent
+//! edges and **chains of adjacent edges joined by miter corners**.
 //!
 //! The shared-`trims` pipeline in [`crate::fillet_curved`] insets *every*
 //! face of the solid by `radius` — which is only correct when *every* edge
@@ -7,22 +8,33 @@
 //! non-watertight solid (a single-edge cube fillet came out at ~522 mm³
 //! instead of ~995 mm³).
 //!
-//! This module implements the geometrically correct construction for the
-//! case that matters to per-edge (differentiable) fillet radii: a set of
-//! **plane-plane** edges no two of which share a vertex (an *independent
-//! set*). For that case each selected edge is a self-contained rounding:
+//! This module implements the geometrically correct construction for
+//! **plane-plane** edges where each vertex is touched by at most **two**
+//! selected edges:
 //!
-//! * the two faces adjacent to the edge (its *side* faces) are inset only
-//!   along that edge,
-//! * a single quarter-cylinder blend replaces the edge,
-//! * the faces that merely *touch* an endpoint of the edge (its *cap*
-//!   faces) have that one corner rounded by the blend's terminating arc —
-//!   the cylinder ends flush against them, so no spherical corner patch is
-//!   required.
+//! * An edge endpoint touched by no other selected edge is a *cap* end:
+//!   the two faces adjacent to the edge (its *side* faces) are inset only
+//!   along that edge, a quarter-cylinder blend replaces the edge, and the
+//!   face that merely touches the endpoint (the *cap* face) has that one
+//!   corner rounded by the blend's terminating arc.
 //!
-//! Every face, cap arc and cylinder ring is generated from the same
-//! tangent-point / arc-sampling formulas, so coincident points quantize
-//! to a single welded vertex and the result is watertight.
+//! * An endpoint shared by **two** selected edges is a *miter corner*.
+//!   When the two blends have equal radius and the corner is mirror
+//!   symmetric — the edges share exactly one face `S`, and their other
+//!   faces `A`, `C` make equal dihedral angles with `S` (every prism-like
+//!   corner: boxes, L-brackets, top rims) — the two blend cylinders
+//!   intersect **exactly** in a planar curve on the bisector plane of the
+//!   two edge directions. The corner therefore needs no spherical patch:
+//!   each cylinder is trimmed at the miter plane, both trimmed ends share
+//!   the *same* sampled curve (welding is exact by construction), the
+//!   shared face's corner collapses to the curve's end on `S`, and faces
+//!   `A`/`C` corner at the curve's other end (which lies on `A ∩ C`, the
+//!   surviving third edge). Closed rings of edges (a box's top rim) are
+//!   chains whose every vertex is a miter.
+//!
+//! Every face, cap arc, miter curve and cylinder ring is generated from
+//! the same tangent-point / arc-sampling formulas, so coincident points
+//! quantize to a single welded vertex and the result is watertight.
 
 use std::collections::{HashMap, HashSet};
 use vcad_kernel_geom::{CylinderSurface, GeometryStore, Plane, SurfaceKind};
@@ -39,6 +51,12 @@ use crate::FilletResult;
 /// / side faces) and that the tessellated volume tracks the analytic
 /// closed form to well under 1e-6 relative.
 const ARC_SEGMENTS: usize = 128;
+
+/// Tolerance for the miter-symmetry test: the two non-shared faces must
+/// make equal dihedral angles with the shared face (compared via normal
+/// dot products) for the bisector-plane trim to be an exact intersection
+/// curve of both cylinders.
+const MITER_SYM_TOL: f64 = 1e-7;
 
 /// Precomputed geometry for one selected plane-plane edge.
 struct BlendGeom {
@@ -74,13 +92,22 @@ impl BlendGeom {
     fn tan_b_at(&self, v: VertexId) -> Point3 {
         self.center_at(v) + self.n_b * self.radius
     }
+    /// Unit edge direction pointing away from endpoint `v`.
+    fn dir_away_from(&self, v: VertexId) -> Vec3 {
+        if v == self.v_start {
+            self.axis
+        } else {
+            -self.axis
+        }
+    }
 }
 
-/// True when every `edge_id` names a plane-plane manifold edge and no two
-/// of the selected edges share a vertex. This is the domain the correct
-/// subset builder covers; callers fall back to the legacy pipeline
-/// otherwise.
-pub(crate) fn is_independent_plane_plane_set(brep: &BRepSolid, edge_ids: &[EdgeId]) -> bool {
+/// True when every `edge_id` names a plane-plane manifold edge, no vertex
+/// is touched by more than two of them, and every shared vertex is a
+/// symmetric trihedral miter corner (see the module docs). This is the
+/// domain the correct subset builder covers; callers fall back to the
+/// legacy pipeline otherwise.
+pub(crate) fn is_plane_plane_chain_set(brep: &BRepSolid, edge_ids: &[EdgeId], radius: f64) -> bool {
     if edge_ids.is_empty() {
         return false;
     }
@@ -89,8 +116,19 @@ pub(crate) fn is_independent_plane_plane_set(brep: &BRepSolid, edge_ids: &[EdgeI
         return false;
     }
     let edges = extract_edges(brep);
-    let mut seen_vertices: HashSet<VertexId> = HashSet::new();
+    let faces = extract_faces(brep);
+    let face_normal: HashMap<FaceId, Vec3> = faces.iter().map(|f| (f.face_id, f.normal)).collect();
+
+    // Faces incident to each vertex (for the trihedral test).
+    let mut faces_at_vertex: HashMap<VertexId, HashSet<FaceId>> = HashMap::new();
+    for f in &faces {
+        for &v in &f.vertex_ids {
+            faces_at_vertex.entry(v).or_default().insert(f.face_id);
+        }
+    }
+
     let mut matched = 0usize;
+    let mut at_vertex: HashMap<VertexId, Vec<&crate::topology::EdgeInfo>> = HashMap::new();
     for e in &edges {
         if !selected.contains(&e.edge_id) {
             continue;
@@ -101,16 +139,133 @@ pub(crate) fn is_independent_plane_plane_set(brep: &BRepSolid, edge_ids: &[EdgeI
         if sa != SurfaceKind::Plane || sb != SurfaceKind::Plane {
             return false;
         }
-        if !seen_vertices.insert(e.v_start) || !seen_vertices.insert(e.v_end) {
-            return false; // two selected edges share this vertex
+        at_vertex.entry(e.v_start).or_default().push(e);
+        at_vertex.entry(e.v_end).or_default().push(e);
+    }
+    if matched != edge_ids.len() {
+        return false;
+    }
+
+    for (&v, touching) in &at_vertex {
+        match touching.len() {
+            1 => {}
+            2 => {
+                let (e1, e2) = (touching[0], touching[1]);
+                // Exactly one shared face.
+                let f1: HashSet<FaceId> = [e1.face_a, e1.face_b].into_iter().collect();
+                let f2: HashSet<FaceId> = [e2.face_a, e2.face_b].into_iter().collect();
+                let shared: Vec<FaceId> = f1.intersection(&f2).copied().collect();
+                if shared.len() != 1 {
+                    return false;
+                }
+                let s = shared[0];
+                let a = if e1.face_a == s { e1.face_b } else { e1.face_a };
+                let c = if e2.face_a == s { e2.face_b } else { e2.face_a };
+                if a == c {
+                    return false;
+                }
+                // Trihedral corner: exactly the three faces S, A, C meet at v.
+                match faces_at_vertex.get(&v) {
+                    Some(fs)
+                        if fs.len() == 3
+                            && fs.contains(&s)
+                            && fs.contains(&a)
+                            && fs.contains(&c) => {}
+                    _ => return false,
+                }
+                // Mirror symmetry: equal dihedral angles against S.
+                let (ns, na, nc) = (face_normal[&s], face_normal[&a], face_normal[&c]);
+                if (na.dot(ns) - nc.dot(ns)).abs() > MITER_SYM_TOL {
+                    return false;
+                }
+                // Edge directions away from v must not be parallel (the
+                // miter plane's normal is their difference).
+                let d1 = edge_dir_away(brep, e1, v);
+                let d2 = edge_dir_away(brep, e2, v);
+                if (d1 - d2).norm() < 1e-9 {
+                    return false;
+                }
+                // Both edges must be long enough that the miter (which
+                // consumes up to ~radius of axial length) cannot cross the
+                // opposite end's trim.
+                for e in [e1, e2] {
+                    let len = (brep.topology.vertices[e.v_end].point
+                        - brep.topology.vertices[e.v_start].point)
+                        .norm();
+                    if len <= 2.0 * radius {
+                        return false;
+                    }
+                }
+            }
+            _ => return false,
         }
     }
-    matched == edge_ids.len()
+    true
 }
 
-/// Fillet an independent set of plane-plane edges. Precondition:
-/// [`is_independent_plane_plane_set`] returned `true` for `edge_ids`.
-pub(crate) fn fillet_independent_plane_edges(
+/// Unit direction of edge `e` pointing away from its endpoint `v`.
+fn edge_dir_away(brep: &BRepSolid, e: &crate::topology::EdgeInfo, v: VertexId) -> Vec3 {
+    let a = brep.topology.vertices[e.v_start].point;
+    let b = brep.topology.vertices[e.v_end].point;
+    let d = (b - a).normalize();
+    if v == e.v_start {
+        d
+    } else {
+        -d
+    }
+}
+
+/// A miter corner: the shared face and the trimmed-intersection curve both
+/// blend cylinders terminate on. `ring[0]` lies on `A ∩ C` (the surviving
+/// third edge of the corner); `ring[last]` lies on the shared face `S`.
+struct MiterCorner {
+    shared_face: FaceId,
+    ring: Vec<Point3>,
+}
+
+/// Sample the miter curve at vertex `v` from blend `b` (either blend works
+/// by symmetry): the blend's arc from its tangency on its non-shared face
+/// to its tangency on `shared`, with each sample slid along the axis onto
+/// the miter plane `{x : (x − v)·m = 0}`.
+fn sample_miter_ring(
+    b: &BlendGeom,
+    v: VertexId,
+    v_pos: Point3,
+    shared: FaceId,
+    m: Vec3,
+) -> Vec<Point3> {
+    let center = b.center_at(v);
+    let r = b.radius;
+    let (from, to) = if b.face_a == shared {
+        (b.tan_b_at(v), b.tan_a_at(v))
+    } else {
+        (b.tan_a_at(v), b.tan_b_at(v))
+    };
+    let u = (from - center) / r;
+    let mut w = b.axis.cross(u);
+    let wn = w.norm();
+    if wn < 1e-12 {
+        return vec![from, to];
+    }
+    w = w / wn;
+    let d = to - center;
+    let ang = d.dot(w).atan2(d.dot(u));
+    let am = b.axis.dot(m);
+    let mut pts = Vec::with_capacity(ARC_SEGMENTS + 1);
+    for i in 0..=ARC_SEGMENTS {
+        let t = ang * (i as f64 / ARC_SEGMENTS as f64);
+        let radial = u * t.cos() + w * t.sin();
+        let p0 = center + radial * r;
+        // Slide along the axis onto the miter plane.
+        let s = (v_pos - p0).dot(m) / am;
+        pts.push(p0 + b.axis * s);
+    }
+    pts
+}
+
+/// Fillet a chain set of plane-plane edges. Precondition:
+/// [`is_plane_plane_chain_set`] returned `true` for `edge_ids`.
+pub(crate) fn fillet_plane_chain_edges(
     brep: &BRepSolid,
     edge_ids: &[EdgeId],
     radius: f64,
@@ -164,12 +319,41 @@ pub(crate) fn fillet_independent_plane_edges(
         results.push(FilletResult::Success);
     }
 
-    // For each vertex, which selected edge touches it (independent set ⇒
-    // at most one).
-    let mut edge_at_vertex: HashMap<VertexId, EdgeId> = HashMap::new();
+    // Selected edges touching each vertex (1 = cap end, 2 = miter corner).
+    let mut edges_at_vertex: HashMap<VertexId, Vec<EdgeId>> = HashMap::new();
     for (&eid, b) in &blends {
-        edge_at_vertex.insert(b.v_start, eid);
-        edge_at_vertex.insert(b.v_end, eid);
+        edges_at_vertex.entry(b.v_start).or_default().push(eid);
+        edges_at_vertex.entry(b.v_end).or_default().push(eid);
+    }
+    for list in edges_at_vertex.values_mut() {
+        list.sort(); // determinism: the miter ring samples from the lower id
+    }
+
+    // Precompute every miter corner's shared face and trim curve. Both
+    // blends at the corner reference the SAME point list, so their welding
+    // along the miter is exact by construction.
+    let mut miters: HashMap<VertexId, MiterCorner> = HashMap::new();
+    for (&v, eids) in &edges_at_vertex {
+        if eids.len() != 2 {
+            continue;
+        }
+        let (b1, b2) = (&blends[&eids[0]], &blends[&eids[1]]);
+        let f1: HashSet<FaceId> = [b1.face_a, b1.face_b].into_iter().collect();
+        let shared = if f1.contains(&b2.face_a) {
+            b2.face_a
+        } else {
+            b2.face_b
+        };
+        let v_pos = topo.vertices[v].point;
+        let m = (b1.dir_away_from(v) - b2.dir_away_from(v)).normalize();
+        let ring = sample_miter_ring(b1, v, v_pos, shared, m);
+        miters.insert(
+            v,
+            MiterCorner {
+                shared_face: shared,
+                ring,
+            },
+        );
     }
 
     let mut new_topo = Topology::new();
@@ -185,12 +369,26 @@ pub(crate) fn fillet_independent_plane_edges(
         for i in 0..n {
             let v = face.vertex_ids[i];
             let pos = face.positions[i];
-            let Some(&eid) = edge_at_vertex.get(&v) else {
+            let Some(eids) = edges_at_vertex.get(&v) else {
                 loop_positions.push(pos);
                 continue;
             };
-            let b = &blends[&eid];
 
+            if let Some(corner) = miters.get(&v) {
+                // Miter corner: the shared face's corner collapses to the
+                // curve's end on S; the two non-shared side faces (and no
+                // others — the corner is trihedral) corner at the curve's
+                // end on A ∩ C.
+                if face.face_id == corner.shared_face {
+                    loop_positions.push(*corner.ring.last().unwrap());
+                } else {
+                    loop_positions.push(corner.ring[0]);
+                }
+                continue;
+            }
+
+            // Cap end: exactly one selected edge at this vertex.
+            let b = &blends[&eids[0]];
             if face.face_id == b.face_a {
                 loop_positions.push(b.tan_a_at(v)); // side face inset
             } else if face.face_id == b.face_b {
@@ -224,15 +422,37 @@ pub(crate) fn fillet_independent_plane_edges(
         );
     }
 
-    // 2. Emit the quarter-cylinder blend for every selected edge.
+    // 2. Emit the blend cylinder for every selected edge. Each end's ring
+    //    runs tangent-A → tangent-B: a cap end uses the quarter arc in the
+    //    endpoint plane, a mitered end uses the corner's trim curve
+    //    (oriented so it starts on this blend's face_a side).
     for b in blends.values() {
-        let ta_s = b.tan_a_at(b.v_start);
-        let tb_s = b.tan_b_at(b.v_start);
-        let ta_e = b.tan_a_at(b.v_end);
-        let tb_e = b.tan_b_at(b.v_end);
-
-        let ring_start = sample_arc(b.center_start, ta_s, tb_s, b.axis, ARC_SEGMENTS);
-        let ring_end = sample_arc(b.center_end, ta_e, tb_e, b.axis, ARC_SEGMENTS);
+        let ring_at = |v: VertexId, center: Point3, ta: Point3, tb: Point3| -> Vec<Point3> {
+            match miters.get(&v) {
+                Some(corner) => {
+                    // ring[0] is on A ∩ C (this blend's non-shared side),
+                    // ring[last] on the shared face.
+                    if b.face_a == corner.shared_face {
+                        corner.ring.iter().rev().copied().collect()
+                    } else {
+                        corner.ring.clone()
+                    }
+                }
+                None => sample_arc(center, ta, tb, b.axis, ARC_SEGMENTS),
+            }
+        };
+        let ring_start = ring_at(
+            b.v_start,
+            b.center_start,
+            b.tan_a_at(b.v_start),
+            b.tan_b_at(b.v_start),
+        );
+        let ring_end = ring_at(
+            b.v_end,
+            b.center_end,
+            b.tan_a_at(b.v_end),
+            b.tan_b_at(b.v_end),
+        );
 
         // Closed loop: start ring (ta_s → tb_s) then end ring reversed
         // (tb_e → ta_e). Winding chosen so the CCW face normal points
@@ -240,7 +460,7 @@ pub(crate) fn fillet_independent_plane_edges(
         let mut loop_positions = ring_start;
         loop_positions.extend(ring_end.into_iter().rev());
 
-        let ref_dir = (ta_s - b.center_start).normalize();
+        let ref_dir = (b.tan_a_at(b.v_start) - b.center_start).normalize();
         let cyl = CylinderSurface {
             center: b.center_start,
             axis: Dir3::new_normalize(b.axis),

--- a/crates/vcad-kernel-fillet/tests/miter_chain.rs
+++ b/crates/vcad-kernel-fillet/tests/miter_chain.rs
@@ -1,0 +1,165 @@
+//! Miter corners for adjacent-edge fillets — the follow-up the per-edge
+//! fillet fix named: two selected plane-plane edges sharing a vertex.
+//!
+//! Closed forms (cube of side `a`, radius `r`): each filleted edge removes
+//! a prism of cross-section `r² − πr²/4` along its length; where two
+//! filleted edges meet at a corner the removed prisms overlap in a region
+//! of volume `(5/3 − π/2)·r³` (∫₀ʳ (r − √(2rz − z²))² dz), which must be
+//! added back exactly once per miter corner:
+//!
+//! ```text
+//! V = a³ − c·Σlength + (5/3 − π/2)·r³·(#corners),   c = r²(1 − π/4)
+//! ```
+//!
+//! The discrete mesh uses 128-segment arcs, so the tessellated volume
+//! tracks these closed forms to ~1e-5 relative (the same band the
+//! independent-edge gates use). Watertightness is gated structurally:
+//! every undirected mesh edge must be shared by exactly two triangles.
+
+use std::collections::HashMap;
+use vcad_kernel_fillet::fillet_edges_detailed;
+use vcad_kernel_fillet::FilletResult;
+use vcad_kernel_math::Point3;
+use vcad_kernel_primitives::{make_cube, BRepSolid};
+use vcad_kernel_topo::EdgeId;
+
+const A: f64 = 10.0;
+const R: f64 = 1.5;
+
+/// Cross-section removed per unit length of a 90° edge fillet.
+fn c_edge() -> f64 {
+    R * R * (1.0 - std::f64::consts::PI / 4.0)
+}
+
+/// Overlap of two removed prisms at a 90° miter corner.
+fn c_corner() -> f64 {
+    (5.0 / 3.0 - std::f64::consts::PI / 2.0) * R * R * R
+}
+
+/// Find the cube edge whose endpoints match `p` and `q` (any order).
+fn edge_between(brep: &BRepSolid, p: Point3, q: Point3) -> EdgeId {
+    let topo = &brep.topology;
+    for (edge_id, edge) in &topo.edges {
+        let he1 = edge.half_edge;
+        let Some(he2) = topo.half_edges[he1].twin else {
+            continue;
+        };
+        let a = topo.vertices[topo.half_edges[he1].origin].point;
+        let b = topo.vertices[topo.half_edges[he2].origin].point;
+        let close = |x: Point3, y: Point3| (x - y).norm() < 1e-9;
+        if (close(a, p) && close(b, q)) || (close(a, q) && close(b, p)) {
+            return edge_id;
+        }
+    }
+    panic!("no edge between {p:?} and {q:?}");
+}
+
+fn mesh_volume(mesh: &vcad_kernel_tessellate::TriangleMesh) -> f64 {
+    let verts = &mesh.vertices;
+    let mut vol = 0.0;
+    for tri in mesh.indices.chunks(3) {
+        let (i0, i1, i2) = (
+            tri[0] as usize * 3,
+            tri[1] as usize * 3,
+            tri[2] as usize * 3,
+        );
+        let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
+        let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
+        let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
+        vol += v0[0] * (v1[1] * v2[2] - v2[1] * v1[2]) - v1[0] * (v0[1] * v2[2] - v2[1] * v0[2])
+            + v2[0] * (v0[1] * v1[2] - v1[1] * v0[2]);
+    }
+    (vol / 6.0).abs()
+}
+
+/// Structural watertightness: every undirected edge of the triangle mesh
+/// is shared by exactly two triangles (welded positions, so quantize).
+fn assert_watertight(mesh: &vcad_kernel_tessellate::TriangleMesh, label: &str) {
+    let key = |i: u32| -> [i64; 3] {
+        let b = i as usize * 3;
+        [
+            (mesh.vertices[b] as f64 * 1e6).round() as i64,
+            (mesh.vertices[b + 1] as f64 * 1e6).round() as i64,
+            (mesh.vertices[b + 2] as f64 * 1e6).round() as i64,
+        ]
+    };
+    let mut counts: HashMap<([i64; 3], [i64; 3]), i32> = HashMap::new();
+    for tri in mesh.indices.chunks(3) {
+        for e in 0..3 {
+            let (p, q) = (key(tri[e]), key(tri[(e + 1) % 3]));
+            if p == q {
+                continue; // degenerate sliver along a welded seam
+            }
+            let k = if p < q { (p, q) } else { (q, p) };
+            *counts.entry(k).or_insert(0) += 1;
+        }
+    }
+    let boundary = counts.values().filter(|&&c| c % 2 != 0).count();
+    assert_eq!(
+        boundary, 0,
+        "{label}: {boundary} boundary (odd-count) mesh edges — not watertight"
+    );
+}
+
+fn run_case(edges: &[EdgeId], cube: &BRepSolid, total_len: f64, corners: usize, label: &str) {
+    let (result, results) = fillet_edges_detailed(cube, edges, R);
+    assert_eq!(results.len(), edges.len(), "{label}: one result per edge");
+    for r in &results {
+        assert!(matches!(r, FilletResult::Success), "{label}: {r:?}");
+    }
+    let mesh = vcad_kernel_tessellate::tessellate_brep(&result, 64);
+    assert_watertight(&mesh, label);
+    let vol = mesh_volume(&mesh);
+    let expected = A * A * A - c_edge() * total_len + c_corner() * corners as f64;
+    let rel = (vol - expected).abs() / expected;
+    eprintln!("{label}: volume {vol:.6} vs closed form {expected:.6} (rel {rel:.3e})");
+    assert!(
+        rel <= 1e-4,
+        "{label}: volume {vol} vs closed form {expected} (rel {rel:.3e})"
+    );
+}
+
+#[test]
+fn two_adjacent_edges_meet_in_a_miter() {
+    // L-chain at the origin corner: edges along +X and +Y share (0,0,0).
+    let cube = make_cube(A, A, A);
+    let e_x = edge_between(&cube, Point3::new(0.0, 0.0, 0.0), Point3::new(A, 0.0, 0.0));
+    let e_y = edge_between(&cube, Point3::new(0.0, 0.0, 0.0), Point3::new(0.0, A, 0.0));
+    run_case(&[e_x, e_y], &cube, 2.0 * A, 1, "L-chain");
+}
+
+#[test]
+fn three_edge_open_chain() {
+    // U-chain around the bottom face: +X edge, then +Y, then the far X edge.
+    let cube = make_cube(A, A, A);
+    let e1 = edge_between(&cube, Point3::new(0.0, 0.0, 0.0), Point3::new(A, 0.0, 0.0));
+    let e2 = edge_between(&cube, Point3::new(A, 0.0, 0.0), Point3::new(A, A, 0.0));
+    let e3 = edge_between(&cube, Point3::new(A, A, 0.0), Point3::new(0.0, A, 0.0));
+    run_case(&[e1, e2, e3], &cube, 3.0 * A, 2, "U-chain");
+}
+
+#[test]
+fn closed_top_rim_ring() {
+    // All four top edges: a closed chain, every vertex a miter, no caps.
+    let cube = make_cube(A, A, A);
+    let corners = [
+        Point3::new(0.0, 0.0, A),
+        Point3::new(A, 0.0, A),
+        Point3::new(A, A, A),
+        Point3::new(0.0, A, A),
+    ];
+    let edges: Vec<EdgeId> = (0..4)
+        .map(|i| edge_between(&cube, corners[i], corners[(i + 1) % 4]))
+        .collect();
+    run_case(&edges, &cube, 4.0 * A, 4, "top rim");
+}
+
+#[test]
+fn independent_pair_still_works() {
+    // Regression: two opposite (non-adjacent) edges — the original
+    // independent-set path, now a chain set with zero miter corners.
+    let cube = make_cube(A, A, A);
+    let e1 = edge_between(&cube, Point3::new(0.0, 0.0, 0.0), Point3::new(A, 0.0, 0.0));
+    let e2 = edge_between(&cube, Point3::new(0.0, A, A), Point3::new(A, A, A));
+    run_case(&[e1, e2], &cube, 2.0 * A, 0, "opposite pair");
+}

--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -57,11 +57,13 @@
 //!   onto the collision-mesh nodes through the M5 pullback
 //!   ([`evaluate_with_pullback`](vcad_kernel_diff::evaluate_with_pullback)) —
 //!   future work, noted in `docs/differentiable-seam-m8.md`.
-//! - **Mass-property channel only.** θ is assumed to move geometry, hence mass
-//!   properties. If θ also moves a **joint anchor / mount frame**, that
-//!   sensitivity is *not* included here (the rollout applies mounts as fixed
-//!   transforms). The same FD-on-scalars pattern extends to anchor coordinates
-//!   when a model needs it.
+//! - **Anchor channel.** If θ also moves a **joint anchor / mount frame** (a
+//!   pivot hole whose position scales with the part), use
+//!   [`rollout_gradient_with_anchors`]: the anchor coordinates enter the
+//!   factorization as additional scalars — `∂J/∂anchor` by the same
+//!   central-FD-rollout pattern, `d(anchor)/dθ` by central FD on the caller's
+//!   anchor map (a pure function of θ, no geometry rebuild) — and the two
+//!   channels sum. [`rollout_gradient`] is the anchor-free special case.
 //! - **Determinism.** phyz's ABA + semi-implicit Euler are deterministic;
 //!   the FD estimate of `∂J/∂p` is only meaningful if the rollout closure is a
 //!   pure function of its mass-property input (fixed initial state, fixed
@@ -316,10 +318,74 @@ pub fn rollout_gradient(
     theta: &[f64],
     fd: &MassPropFdSteps,
 ) -> Result<(f64, Vec<f64>), DiffError> {
+    rollout_gradient_with_anchors(
+        bodies,
+        &|_theta: &[f64]| Vec::new(),
+        &|props: &[BodyMassProps], _anchors: &[f64]| rollout(props),
+        theta,
+        fd,
+        &AnchorFdSteps::default(),
+    )
+}
+
+/// Finite-difference step policy for the **anchor channel** of
+/// [`rollout_gradient_with_anchors`].
+///
+/// Two independent steps, because the two derivatives probe different maps:
+/// `value_abs` perturbs an anchor scalar inside the *rollout* (`∂J/∂a`,
+/// meters in the phyz frame), while `theta_rel`/`theta_min` step θ inside the
+/// caller's *anchor map* (`da/dθ`, a pure function — usually linear — so the
+/// step only needs to clear roundoff).
+#[derive(Debug, Clone, Copy)]
+pub struct AnchorFdSteps {
+    /// Absolute step (m) for each anchor scalar in the `∂J/∂a` rollouts.
+    pub value_abs: f64,
+    /// Relative step (of `|θ_k|`) for the `da/dθ_k` central difference.
+    pub theta_rel: f64,
+    /// Floor for the θ step.
+    pub theta_min: f64,
+}
+
+impl Default for AnchorFdSteps {
+    fn default() -> Self {
+        Self {
+            value_abs: 1e-7,
+            theta_rel: 1e-6,
+            theta_min: 1e-9,
+        }
+    }
+}
+
+/// [`rollout_gradient`] with the **anchor channel**: `(J, dJ/dθ)` where θ
+/// moves both the bodies' mass properties *and* joint anchor / mount-frame
+/// coordinates.
+///
+/// `anchor_map` maps θ to a flat vector of anchor scalars (layout is the
+/// caller's contract with its own `rollout` — e.g. `[pivot_x_m, pivot_y_m]`).
+/// The chain gains one term per anchor scalar:
+///
+/// ```text
+/// dJ/dθ = Σ_bodies ∂J/∂p·dp/dθ  +  Σ_anchors ∂J/∂a·da/dθ
+/// ```
+///
+/// with `∂J/∂a` from central-FD rollouts (like `∂J/∂p` — no CAD rebuild) and
+/// `da/dθ` from a central difference of `anchor_map` itself, which is a pure
+/// function of θ (no geometry, no remeshing; for the common linear anchor —
+/// a hole position proportional to a dimension — the FD is exact to
+/// roundoff). Everything in the [`rollout_gradient`] contract carries over;
+/// the rollout closure must be pure in *both* inputs.
+pub fn rollout_gradient_with_anchors(
+    bodies: &[DiffBody],
+    anchor_map: &impl Fn(&[f64]) -> Vec<f64>,
+    rollout: &impl Fn(&[BodyMassProps], &[f64]) -> f64,
+    theta: &[f64],
+    fd: &MassPropFdSteps,
+    anchor_fd: &AnchorFdSteps,
+) -> Result<(f64, Vec<f64>), DiffError> {
     let n = theta.len();
 
     // 1. Nominal mass properties per body (positions-only seam), and the
-    //    frozen plan / B-rep kept for the exact dp/dθ below.
+    //    frozen plan / B-rep kept for the exact dp/dθ below; nominal anchors.
     let mut breps = Vec::with_capacity(bodies.len());
     let mut plans = Vec::with_capacity(bodies.len());
     let mut nominal = Vec::with_capacity(bodies.len());
@@ -332,9 +398,10 @@ pub fn rollout_gradient(
         breps.push(brep);
         plans.push(plan);
     }
+    let anchors0 = anchor_map(theta);
 
-    // Primal objective at the nominal properties.
-    let j0 = rollout(&nominal);
+    // Primal objective at the nominal properties and anchors.
+    let j0 = rollout(&nominal, &anchors0);
 
     // 2. ∂J/∂p per body by central FD on the 10 mass-property scalars.
     //    Each body is perturbed independently; the others hold their nominal
@@ -349,12 +416,12 @@ pub fn rollout_gradient(
             let mut sp = nom.scalars();
             sp[j] += h;
             work[i] = BodyMassProps::from_scalars(sp);
-            let jp = rollout(&work);
+            let jp = rollout(&work, &anchors0);
 
             let mut sm = nom.scalars();
             sm[j] -= h;
             work[i] = BodyMassProps::from_scalars(sm);
-            let jm = rollout(&work);
+            let jm = rollout(&work, &anchors0);
 
             grad_p[j] = (jp - jm) / (2.0 * h);
         }
@@ -363,8 +430,21 @@ pub fn rollout_gradient(
         djdp.push(grad_p);
     }
 
+    // 2b. ∂J/∂a per anchor scalar, same central-FD-rollout pattern.
+    let mut djda = vec![0.0f64; anchors0.len()];
+    for (a, g) in djda.iter_mut().enumerate() {
+        let h = anchor_fd.value_abs;
+        let mut work = anchors0.clone();
+        work[a] = anchors0[a] + h;
+        let jp = rollout(&nominal, &work);
+        work[a] = anchors0[a] - h;
+        let jm = rollout(&nominal, &work);
+        *g = (jp - jm) / (2.0 * h);
+    }
+
     // 3 + 4. Exact dp/dθ from the seam, contracted with ∂J/∂p and summed
-    //         over bodies.
+    //         over bodies; then the anchor channel — da/dθ by central FD on
+    //         the (geometry-free) anchor map, contracted with ∂J/∂a.
     let mut gradient = vec![0.0f64; n];
     for (i, body) in bodies.iter().enumerate() {
         for (k, g) in gradient.iter_mut().enumerate() {
@@ -377,6 +457,25 @@ pub fn rollout_gradient(
                 acc += djdp[i][j] * dp[j];
             }
             *g += acc;
+        }
+    }
+    if !anchors0.is_empty() {
+        for (k, g) in gradient.iter_mut().enumerate() {
+            let h = (anchor_fd.theta_rel * theta[k].abs()).max(anchor_fd.theta_min);
+            let mut tp = theta.to_vec();
+            tp[k] += h;
+            let ap = anchor_map(&tp);
+            let mut tm = theta.to_vec();
+            tm[k] -= h;
+            let am = anchor_map(&tm);
+            debug_assert_eq!(
+                ap.len(),
+                anchors0.len(),
+                "anchor map length must be θ-invariant"
+            );
+            for (a, dj) in djda.iter().enumerate() {
+                *g += dj * (ap[a] - am[a]) / (2.0 * h);
+            }
         }
     }
 

--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -53,10 +53,12 @@
 //!   load, a ground penalty), contact forces depend on the *surface* — a
 //!   channel this gradient does not see. The rollout closure you pass **must**
 //!   build a contact-free model; if it does not, the returned gradient is
-//!   silently incomplete. Extending to contacts means pulling `∂J/∂x` back
-//!   onto the collision-mesh nodes through the M5 pullback
-//!   ([`evaluate_with_pullback`](vcad_kernel_diff::evaluate_with_pullback)) —
-//!   future work, noted in `docs/differentiable-seam-m8.md`.
+//!   silently incomplete. The **surface skin** is built: objective terms that
+//!   read the surface directly go through [`rollout_gradient_with_surface`]
+//!   (exact, one M5 pullback per body), and a future contact adjoint's
+//!   `∂J/∂x` plugs into [`surface_gradient`] unchanged. What remains
+//!   phyz-side is the adjoint itself — producing `∂J_dyn/∂x` when contact
+//!   forces act *during* the rollout.
 //! - **Anchor channel.** If θ also moves a **joint anchor / mount frame** (a
 //!   pivot hole whose position scales with the part), use
 //!   [`rollout_gradient_with_anchors`]: the anchor coordinates enter the
@@ -72,9 +74,10 @@
 use phyz::math::{Mat3, Vec3 as PVec3};
 use phyz::SpatialInertia;
 use vcad_kernel_diff::{
-    evaluate_with_sensitivity, mass_properties, mass_properties_with_derivative, DiffError,
-    MassProperties, ParamSeeding,
+    evaluate_with_pullback, evaluate_with_sensitivity, mass_properties,
+    mass_properties_with_derivative, DiffError, MassProperties, ParamSeeding,
 };
+use vcad_kernel_math::{Point3 as CadPoint3, Vec3 as CadVec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::frozen::capture_plan;
 use vcad_kernel_tessellate::TessellationParams;
@@ -476,6 +479,158 @@ pub fn rollout_gradient_with_anchors(
             for (a, dj) in djda.iter().enumerate() {
                 *g += dj * (ap[a] - am[a]) / (2.0 * h);
             }
+        }
+    }
+
+    Ok((j0, gradient))
+}
+
+/// A surface-dependent objective term on one body's frozen-plan mesh.
+///
+/// Given the seam node positions (mm, CAD frame) and the frozen triangles,
+/// return the term's value and its analytic node gradient `∂J_surf/∂x`
+/// (J-units per mm, one vector per node). This is the **contact skin** of the
+/// M8 factorization: any objective contribution that reads the *surface*
+/// rather than the mass properties — a ground-clearance penalty, a
+/// penetration term, or (when one exists) a contact adjoint's `∂J/∂x`.
+pub type SurfaceTerm<'a> = Box<dyn Fn(&[CadPoint3], &[[u32; 3]]) -> (f64, Vec<CadVec3>) + 'a>;
+
+/// Price a mesh cotangent through the CAD seam: given `∂J/∂x` on `body`'s
+/// frozen-plan nodes (mm frame), return the per-parameter `dJ/dθ`
+/// contribution.
+///
+/// One M5 pullback ([`evaluate_with_pullback`]) prices the whole cotangent;
+/// each parameter then costs only a seeding synthesis and a contraction —
+/// the reverse-mode economics the skin was designed around. This is the raw
+/// entry point a **contact adjoint** plugs into: whatever produces `∂J/∂x`
+/// on the collision surface (an analytic penalty today, a phyz contact
+/// adjoint when one exists), this function turns it into CAD-parameter
+/// sensitivities.
+pub fn surface_gradient(
+    body: &DiffBody,
+    theta: &[f64],
+    djdx: &[CadVec3],
+) -> Result<Vec<f64>, DiffError> {
+    let brep = (body.build)(theta);
+    let plan = capture_plan(&brep, &body.tess)?;
+    let cots = evaluate_with_pullback(&brep, &plan, djdx)?;
+    let mut out = Vec::with_capacity(theta.len());
+    for k in 0..theta.len() {
+        let seeding = (body.seeding_for)(&brep, theta, k)?;
+        out.push(cots.contract(&seeding));
+    }
+    Ok(out)
+}
+
+/// [`rollout_gradient`] with the **surface skin**: `(J, dJ/dθ)` for a
+/// composite objective
+///
+/// ```text
+/// J = J_dyn(mass props)  +  Σ_bodies J_surf(surface nodes)
+/// ```
+///
+/// where `J_dyn` is the contact-free rollout (mass-property channel, exactly
+/// as [`rollout_gradient`]) and each `J_surf` reads the body's tessellated
+/// surface directly. The gradient sums both channels:
+///
+/// ```text
+/// dJ/dθ = Σ ∂J/∂p·dp/dθ  +  Σ pullback(∂J_surf/∂x)·seeding
+/// ```
+///
+/// The surface channel is **exact** (analytic node gradient through the M5
+/// pullback — no FD anywhere in it) and costs one pullback per body
+/// regardless of the θ dimension.
+///
+/// `surface_terms` is parallel to `bodies`; `None` for bodies without a
+/// surface term. What this does **not** do: surface-dependent *dynamics*.
+/// If contact forces act during the rollout, `∂J_dyn/∂(surface)` needs a
+/// contact adjoint phyz does not currently expose; when one exists, its
+/// `∂J/∂x` enters through [`surface_gradient`] and the factorization is
+/// unchanged (documented in `docs/differentiable-seam-m8.md`).
+pub fn rollout_gradient_with_surface(
+    bodies: &[DiffBody],
+    surface_terms: &[Option<SurfaceTerm>],
+    rollout: &impl Fn(&[BodyMassProps]) -> f64,
+    theta: &[f64],
+    fd: &MassPropFdSteps,
+) -> Result<(f64, Vec<f64>), DiffError> {
+    assert_eq!(
+        surface_terms.len(),
+        bodies.len(),
+        "one surface-term slot per body"
+    );
+    let n = theta.len();
+
+    // 1. Nominal seam per body; keep positions for the surface terms and the
+    //    B-rep/plan for both channels' seam passes.
+    let mut breps = Vec::with_capacity(bodies.len());
+    let mut plans = Vec::with_capacity(bodies.len());
+    let mut nominal = Vec::with_capacity(bodies.len());
+    let mut j_surf = 0.0;
+    let mut cotangents = Vec::with_capacity(bodies.len());
+    for (body, term) in bodies.iter().zip(surface_terms) {
+        let brep = (body.build)(theta);
+        let plan = capture_plan(&brep, &body.tess)?;
+        let seam0 = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new())?;
+        let props = mass_properties(&seam0.positions, &seam0.triangles, body.seam_density());
+        nominal.push(BodyMassProps::from_seam(&props));
+        // Surface term: value into J, node gradient priced by one pullback.
+        cotangents.push(match term {
+            Some(t) => {
+                let (value, djdx) = t(&seam0.positions, &seam0.triangles);
+                j_surf += value;
+                Some(evaluate_with_pullback(&brep, &plan, &djdx)?)
+            }
+            None => None,
+        });
+        breps.push(brep);
+        plans.push(plan);
+    }
+
+    let j0 = rollout(&nominal) + j_surf;
+
+    // 2. ∂J_dyn/∂p per body by central FD (J_surf does not depend on p, so
+    //    perturbing the scalars probes exactly the dynamic term).
+    let mut djdp: Vec<[f64; 10]> = Vec::with_capacity(bodies.len());
+    for (i, nom) in nominal.iter().enumerate() {
+        let steps = fd.steps_for(nom);
+        let mut grad_p = [0.0f64; 10];
+        let mut work = nominal.clone();
+        for j in 0..10 {
+            let h = steps[j];
+            let mut sp = nom.scalars();
+            sp[j] += h;
+            work[i] = BodyMassProps::from_scalars(sp);
+            let jp = rollout(&work);
+
+            let mut sm = nom.scalars();
+            sm[j] -= h;
+            work[i] = BodyMassProps::from_scalars(sm);
+            let jm = rollout(&work);
+
+            grad_p[j] = (jp - jm) / (2.0 * h);
+        }
+        work[i] = *nom;
+        djdp.push(grad_p);
+    }
+
+    // 3. Per (body, parameter): the mass-property channel (forward seam) and
+    //    the surface channel (contraction of the body's one pullback).
+    let mut gradient = vec![0.0f64; n];
+    for (i, body) in bodies.iter().enumerate() {
+        for (k, g) in gradient.iter_mut().enumerate() {
+            let seeding = (body.seeding_for)(&breps[i], theta, k)?;
+            let seam_k = evaluate_with_sensitivity(&breps[i], &plans[i], &seeding)?;
+            let (_props, dprops) = mass_properties_with_derivative(&seam_k, body.seam_density());
+            let dp = BodyMassProps::deriv_scalars(&dprops);
+            let mut acc = 0.0;
+            for j in 0..10 {
+                acc += djdp[i][j] * dp[j];
+            }
+            if let Some(cots) = &cotangents[i] {
+                acc += cots.contract(&seeding);
+            }
+            *g += acc;
         }
     }
 

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -46,8 +46,9 @@ pub mod stl;
 mod world;
 
 pub use diff::{
-    nominal_mass_props, rollout_gradient, rollout_gradient_with_anchors, AnchorFdSteps,
-    BodyMassProps, DiffBody, MassPropFdSteps,
+    nominal_mass_props, rollout_gradient, rollout_gradient_with_anchors,
+    rollout_gradient_with_surface, surface_gradient, AnchorFdSteps, BodyMassProps, DiffBody,
+    MassPropFdSteps, SurfaceTerm,
 };
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -45,7 +45,10 @@ pub mod joints;
 pub mod stl;
 mod world;
 
-pub use diff::{nominal_mass_props, rollout_gradient, BodyMassProps, DiffBody, MassPropFdSteps};
+pub use diff::{
+    nominal_mass_props, rollout_gradient, rollout_gradient_with_anchors, AnchorFdSteps,
+    BodyMassProps, DiffBody, MassPropFdSteps,
+};
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};
 pub use world::{JointState, PhysicsWorld};

--- a/crates/vcad-kernel-physics/tests/m8_anchor_channel.rs
+++ b/crates/vcad-kernel-physics/tests/m8_anchor_channel.rs
@@ -1,0 +1,197 @@
+//! M8 anchor channel — `dJ/dθ` when θ moves a joint anchor / mount frame as
+//! well as the body's mass properties.
+//!
+//! The M8 note promised: "anchor coordinates slot in as more scalars" of the
+//! same factorization. These gates hold [`rollout_gradient_with_anchors`] to
+//! that:
+//!
+//! 1. **Anchor channel in isolation** (`1e-6`): a pendulum whose *geometry*
+//!    is θ-independent (empty seeding ⇒ zero mass-property channel) but whose
+//!    pivot offset is `a(θ) = θ·MM_TO_M` — the gradient must equal a full
+//!    rebuild-and-resimulate central FD, and must be far from zero.
+//! 2. **Both channels together** (`1e-4`): the cylinder radius drives the
+//!    mass properties *and* the pivot offset (`a = 2r`, a mount hole that
+//!    scales with the part). The summed gradient must match the end-to-end
+//!    FD, and must differ measurably from the mass-only gradient (the anchor
+//!    channel is load-bearing, not decorative).
+
+use phyz::math::{SpatialTransform, Vec3};
+use phyz::{aba_with_external_forces, ModelBuilder};
+use vcad_kernel_diff::{ParamSeeding, SurfaceSeed};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::{
+    nominal_mass_props, rollout_gradient, rollout_gradient_with_anchors, AnchorFdSteps,
+    BodyMassProps, DiffBody, MassPropFdSteps,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::TessellationParams;
+
+const DENSITY: f64 = 2700.0;
+const HEIGHT_MM: f64 = 8.0;
+const R0: f64 = 10.0;
+const MM_TO_M: f64 = 1e-3;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 64,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+/// Differentiable cylinder body: radius = θ[0] (mm).
+fn cylinder_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|theta: &[f64]| make_cylinder(theta[0], HEIGHT_MM, 64)),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            let n = s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            assert_eq!(n, 1, "expected exactly one cylinder surface");
+            Ok(s)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+/// θ-independent body (fixed 10 mm cylinder): the seeding is empty, so the
+/// mass-property channel contributes exactly zero and any gradient must come
+/// from the anchor channel alone.
+fn fixed_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|_theta: &[f64]| make_cylinder(R0, HEIGHT_MM, 64)),
+        seeding_for: Box::new(|_brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            Ok(ParamSeeding::new())
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+/// Gravity pendulum with a translated mount: the cylinder's axis is rotated
+/// to +X (as in the M8 pendulum) and the whole body is shifted +X by the
+/// anchor offset `anchors[0]` (m) before attaching to the revolute Z joint at
+/// the origin — a pivot hole whose position is a model parameter. Returns
+/// q(T).
+fn offset_pendulum_rollout(
+    props: &[BodyMassProps],
+    anchors: &[f64],
+    q0: f64,
+    t_final: f64,
+    dt: f64,
+) -> f64 {
+    let ry90 = phyz::math::Mat3::new(0.0, 0.0, 1.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0);
+    let mount = SpatialTransform::new(ry90, Vec3::new(anchors[0], 0.0, 0.0));
+    let si = props[0].to_spatial_inertia().transform(&mount);
+
+    let model = ModelBuilder::new()
+        .gravity(Vec3::new(-9.81, 0.0, 0.0))
+        .dt(dt)
+        .add_revolute_body("bob", -1, SpatialTransform::identity(), si)
+        .build();
+    let mut state = model.default_state();
+    state.q[0] = q0;
+    let steps = (t_final / dt).round() as usize;
+    for _ in 0..steps {
+        let qdd = aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * dt;
+        state.q[0] += state.v[0] * dt;
+    }
+    state.q[0]
+}
+
+const Q0: f64 = 0.4;
+const T_FINAL: f64 = 0.15;
+const DT: f64 = 1.0 / 960.0;
+
+#[test]
+fn anchor_channel_in_isolation_matches_end_to_end_fd() {
+    // Geometry fixed; θ moves only the pivot offset a(θ) = θ·MM_TO_M.
+    let bodies = [fixed_body()];
+    let anchor_map = |theta: &[f64]| vec![theta[0] * MM_TO_M];
+    let rollout = |p: &[BodyMassProps], a: &[f64]| offset_pendulum_rollout(p, a, Q0, T_FINAL, DT);
+
+    let (j, grad) = rollout_gradient_with_anchors(
+        &bodies,
+        &anchor_map,
+        &rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+        &AnchorFdSteps::default(),
+    )
+    .expect("gradient");
+
+    // End-to-end FD: same fixed geometry, anchors rebuilt at θ ± h.
+    let props = nominal_mass_props(&bodies, &[R0]).expect("props");
+    let j_at = |t: f64| rollout(&props, &anchor_map(&[t]));
+    let h = 1e-3;
+    let fd = (j_at(R0 + h) - j_at(R0 - h)) / (2.0 * h);
+    let rel = (grad[0] - fd).abs() / fd.abs().max(1e-12);
+    assert!(
+        rel <= 1e-6,
+        "anchor-only dq(T)/dθ: adapter {} vs end-to-end fd {fd} (rel {rel:.3e}); J = {j}",
+        grad[0]
+    );
+    // The channel must be live: moving the pivot 1 mm visibly changes q(T).
+    assert!(
+        grad[0].abs() > 1e-4,
+        "anchor sensitivity should be far from zero, got {}",
+        grad[0]
+    );
+}
+
+#[test]
+fn combined_mass_and_anchor_channels_match_end_to_end_fd() {
+    // θ = radius drives BOTH the mass properties and the pivot offset
+    // a(θ) = 2θ·MM_TO_M (a mount hole at twice the radius).
+    let bodies = [cylinder_body()];
+    let anchor_map = |theta: &[f64]| vec![2.0 * theta[0] * MM_TO_M];
+    let rollout = |p: &[BodyMassProps], a: &[f64]| offset_pendulum_rollout(p, a, Q0, T_FINAL, DT);
+
+    let (_j, grad) = rollout_gradient_with_anchors(
+        &bodies,
+        &anchor_map,
+        &rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+        &AnchorFdSteps::default(),
+    )
+    .expect("gradient");
+
+    // Full end-to-end FD: rebuild CAD, rebuild anchors, re-simulate.
+    let j_at = |t: f64| {
+        let props = nominal_mass_props(&bodies, &[t]).expect("props");
+        rollout(&props, &anchor_map(&[t]))
+    };
+    let h = 1e-3;
+    let fd = (j_at(R0 + h) - j_at(R0 - h)) / (2.0 * h);
+    let rel = (grad[0] - fd).abs() / fd.abs().max(1e-12);
+    assert!(
+        rel <= 1e-4,
+        "combined dq(T)/dr: adapter {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        grad[0]
+    );
+
+    // The anchor channel must contribute: dropping it (mass-only adapter with
+    // anchors frozen at their nominal value) must give a measurably different
+    // gradient.
+    let anchors0 = anchor_map(&[R0]);
+    let (_, mass_only) = rollout_gradient(
+        &bodies,
+        &|p: &[BodyMassProps]| rollout(p, &anchors0),
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("mass-only gradient");
+    let gap = (grad[0] - mass_only[0]).abs();
+    assert!(
+        gap > 1e-3 * grad[0].abs().max(1e-12),
+        "anchor channel should be load-bearing: combined {} vs mass-only {}",
+        grad[0],
+        mass_only[0]
+    );
+}

--- a/crates/vcad-kernel-physics/tests/m8_surface_skin.rs
+++ b/crates/vcad-kernel-physics/tests/m8_surface_skin.rs
@@ -1,0 +1,219 @@
+//! M8 surface skin — objectives that read the tessellated surface, priced
+//! through the M5 pullback and summed with the mass-property core.
+//!
+//! The M8 design note named this extension precisely: "the mass-property
+//! factorization is the smooth core, the surface pullback the contact skin."
+//! These gates hold [`rollout_gradient_with_surface`] and
+//! [`surface_gradient`] to it:
+//!
+//! 1. **Skin in isolation, machine precision**: with a constant rollout, a
+//!    volume surface term's `dJ/dr` must equal the N-gon prism closed form
+//!    `2·k·r·h` — the surface channel is exact (analytic node gradient →
+//!    pullback → contraction; no FD anywhere).
+//! 2. **Core + skin together** (`1e-4`, FD-limited by the core): flywheel
+//!    spin-up plus a radial surface penalty, against a full
+//!    rebuild-and-resimulate central FD; both channels asserted live.
+
+use vcad_kernel_diff::{evaluate_with_sensitivity, ParamSeeding, SurfaceSeed};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_physics::{
+    nominal_mass_props, rollout_gradient_with_surface, surface_gradient, BodyMassProps, DiffBody,
+    MassPropFdSteps, SurfaceTerm,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::frozen::capture_plan;
+use vcad_kernel_tessellate::TessellationParams;
+
+use phyz::math::{SpatialTransform, Vec3 as PVec3};
+use phyz::{aba_with_external_forces, ModelBuilder};
+
+const DENSITY: f64 = 2700.0;
+const HEIGHT_MM: f64 = 8.0;
+const R0: f64 = 10.0;
+const SEGS: u32 = 64;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: SEGS,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+fn cylinder_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|theta: &[f64]| make_cylinder(theta[0], HEIGHT_MM, SEGS)),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            let n = s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            assert_eq!(n, 1, "expected exactly one cylinder surface");
+            Ok(s)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+/// Torque-driven flywheel (as in the M8 gates): ω(T) = τT/I_zz exactly.
+fn flywheel_rollout(props: &[BodyMassProps]) -> f64 {
+    const TORQUE: f64 = 1e-4;
+    const T_FINAL: f64 = 0.2;
+    const DT: f64 = 1.0 / 480.0;
+    let si = props[0].to_spatial_inertia();
+    let model = ModelBuilder::new()
+        .gravity(PVec3::new(0.0, 0.0, -9.81))
+        .dt(DT)
+        .add_revolute_body("bob", -1, SpatialTransform::identity(), si)
+        .build();
+    let mut state = model.default_state();
+    let steps = (T_FINAL / DT).round() as usize;
+    for _ in 0..steps {
+        state.ctrl[0] = TORQUE;
+        let qdd = aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * DT;
+        state.q[0] += state.v[0] * DT;
+    }
+    state.v[0]
+}
+
+/// Mesh volume via the divergence theorem (the same signed sum the seam's
+/// mass-property integrals use), plus its exact node gradient.
+fn volume_term() -> SurfaceTerm<'static> {
+    Box::new(|positions: &[Point3], triangles: &[[u32; 3]]| {
+        let v = vcad_kernel_diff::mass_properties(positions, triangles, 1.0).volume;
+        let g = vcad_kernel_diff::volume_gradient(positions, triangles);
+        (v, g)
+    })
+}
+
+/// Radial second-moment surface penalty `P = λ·Σ_i (x_i² + y_i²)` with its
+/// exact node gradient `∂P/∂x_i = λ·(2x_i, 2y_i, 0)`.
+fn radial_penalty_term(lambda: f64) -> SurfaceTerm<'static> {
+    Box::new(move |positions: &[Point3], _triangles: &[[u32; 3]]| {
+        let mut p = 0.0;
+        let mut g = Vec::with_capacity(positions.len());
+        for x in positions {
+            p += lambda * (x.x * x.x + x.y * x.y);
+            g.push(Vec3::new(2.0 * lambda * x.x, 2.0 * lambda * x.y, 0.0));
+        }
+        (p, g)
+    })
+}
+
+#[test]
+fn surface_skin_in_isolation_is_exact() {
+    // Constant rollout ⇒ zero mass-property channel; J = V(mesh).
+    // N-gon prism: V = k r² h, k = ½N sin(2π/N) ⇒ dV/dr = 2 k r h.
+    let bodies = [cylinder_body()];
+    let terms = vec![Some(volume_term())];
+    let (j, grad) = rollout_gradient_with_surface(
+        &bodies,
+        &terms,
+        &|_p: &[BodyMassProps]| 0.0,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("gradient");
+
+    let n = SEGS as f64;
+    let k = 0.5 * n * (2.0 * std::f64::consts::PI / n).sin();
+    let v_exact = k * R0 * R0 * HEIGHT_MM;
+    let dv_exact = 2.0 * k * R0 * HEIGHT_MM;
+    assert!(
+        (j - v_exact).abs() / v_exact < 1e-12,
+        "J {j} vs V {v_exact}"
+    );
+    let rel = (grad[0] - dv_exact).abs() / dv_exact;
+    assert!(
+        rel <= 1e-9,
+        "skin dV/dr {} vs closed form {dv_exact} (rel {rel:.3e})",
+        grad[0]
+    );
+
+    // The raw skin entry point agrees: one pullback, same number.
+    let body = cylinder_body();
+    let brep = (body.build)(&[R0]);
+    let plan = capture_plan(&brep, &body.tess).expect("capture");
+    let seam = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new()).expect("seam");
+    let djdx = vcad_kernel_diff::volume_gradient(&seam.positions, &seam.triangles);
+    let skin = surface_gradient(&body, &[R0], &djdx).expect("skin");
+    let rel_raw = (skin[0] - dv_exact).abs() / dv_exact;
+    assert!(
+        rel_raw <= 1e-9,
+        "surface_gradient {} vs closed form {dv_exact} (rel {rel_raw:.3e})",
+        skin[0]
+    );
+}
+
+#[test]
+fn core_plus_skin_matches_end_to_end_fd() {
+    const LAMBDA: f64 = 1e-6; // scales the penalty near the spin-up magnitude
+    let bodies = [cylinder_body()];
+    let terms = vec![Some(radial_penalty_term(LAMBDA))];
+    let rollout = |p: &[BodyMassProps]| flywheel_rollout(p);
+
+    let (_j, grad) = rollout_gradient_with_surface(
+        &bodies,
+        &terms,
+        &rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("gradient");
+
+    // End-to-end FD: rebuild CAD, fresh capture, dynamic term + surface term.
+    let j_at = |r: f64| {
+        let props = nominal_mass_props(&bodies, &[r]).expect("props");
+        let body = cylinder_body();
+        let brep = (body.build)(&[r]);
+        let plan = capture_plan(&brep, &body.tess).expect("capture");
+        let seam = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new()).expect("seam");
+        let (p_surf, _) = radial_penalty_term(LAMBDA)(&seam.positions, &seam.triangles);
+        rollout(&props) + p_surf
+    };
+    let h = 1e-3;
+    let fd = (j_at(R0 + h) - j_at(R0 - h)) / (2.0 * h);
+    let rel = (grad[0] - fd).abs() / fd.abs().max(1e-12);
+    assert!(
+        rel <= 1e-4,
+        "core+skin dJ/dr: adapter {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        grad[0]
+    );
+
+    // Both channels must be load-bearing.
+    let (_, core_only) = rollout_gradient_with_surface(
+        &bodies,
+        &[None],
+        &rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("core-only");
+    let (_, skin_only) = rollout_gradient_with_surface(
+        &bodies,
+        &[Some(radial_penalty_term(LAMBDA))],
+        &|_p: &[BodyMassProps]| 0.0,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("skin-only");
+    assert!(
+        core_only[0].abs() > 1e-12 && skin_only[0].abs() > 1e-12,
+        "both channels should contribute: core {} skin {}",
+        core_only[0],
+        skin_only[0]
+    );
+    let sum_gap = (grad[0] - (core_only[0] + skin_only[0])).abs();
+    assert!(
+        sum_gap <= 1e-12 * grad[0].abs().max(1.0),
+        "channels must sum linearly: {} vs {} + {}",
+        grad[0],
+        core_only[0],
+        skin_only[0]
+    );
+}

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -2264,6 +2264,22 @@ fn tessellate_cylindrical_face(
         .map(|he| topo.vertices[topo.half_edges[he].origin].point)
         .collect();
 
+    // Ruled two-chain strip: a blend face whose end rings are angle-paired
+    // sample curves but not necessarily planar (a miter-trimmed fillet
+    // cylinder ends on a slanted intersection curve). The rectangular
+    // (u, v) grid below assumes constant-v ends and would overshoot the
+    // slanted trim; the ruled path connects the two chains column by
+    // column using the loop's own points verbatim, so the boundary welds
+    // exactly with both the planar neighbors and the twin blend.
+    if let Some(cyl) = surface
+        .as_any()
+        .downcast_ref::<vcad_kernel_geom::CylinderSurface>()
+    {
+        if let Some(mesh) = tessellate_ruled_two_chain(cyl, &verts, reversed) {
+            return mesh;
+        }
+    }
+
     let mut radius = None;
     let mut u_min = 0.0;
     let mut u_max = 2.0 * PI;
@@ -2552,6 +2568,146 @@ fn tessellate_cylindrical_face(
     }
 
     mesh
+}
+
+/// Ruled tessellation of a cylinder face bounded by two angle-paired sample
+/// chains (a fillet blend whose ends may be slanted miter-trim curves).
+///
+/// Detection is deliberately strict so only machine-generated blend loops
+/// take this path: the loop must have even length ≥ 8, split into two
+/// halves whose vertices pair up at **identical** cylinder angles
+/// (`|Δu| < 1e-9`, loop vertex `i` pairing with `L−1−i`), and at least one
+/// half must be non-planar in `v` (a slanted end) — constant-`v` faces keep
+/// the existing grid path unchanged. Returns `None` when any condition
+/// fails.
+///
+/// The emitted triangles use the loop's own points verbatim (no surface
+/// re-evaluation), so the strip's boundary welds exactly against the
+/// neighboring planar faces and against the twin blend sharing the miter
+/// curve.
+fn tessellate_ruled_two_chain(
+    cyl: &vcad_kernel_geom::CylinderSurface,
+    verts: &[Point3],
+    reversed: bool,
+) -> Option<TriangleMesh> {
+    let l = verts.len();
+    if l < 8 || !l.is_multiple_of(2) {
+        return None;
+    }
+    let half = l / 2;
+
+    let axis = *cyl.axis.as_ref();
+    let ref_dir = *cyl.ref_dir.as_ref();
+    let y_dir = axis.cross(ref_dir);
+    let angle_v = |p: &Point3| -> (f64, f64) {
+        let d = *p - cyl.center;
+        let v = d.dot(axis);
+        let u = d.dot(y_dir).atan2(d.dot(ref_dir));
+        (u, v)
+    };
+
+    // Pair columns: loop = [chain1 (0..half), chain2 reversed (half..l)],
+    // so column i couples verts[i] with verts[l − 1 − i].
+    let mut v_spread_1 = 0.0f64;
+    let mut v_spread_2 = 0.0f64;
+    let (mut v1_min, mut v1_max) = (f64::MAX, f64::MIN);
+    let (mut v2_min, mut v2_max) = (f64::MAX, f64::MIN);
+    for i in 0..half {
+        let (u_a, v_a) = angle_v(&verts[i]);
+        let (u_b, v_b) = angle_v(&verts[l - 1 - i]);
+        // Compare angles on the circle (handle the ±π wrap).
+        let mut du = u_a - u_b;
+        while du > PI {
+            du -= 2.0 * PI;
+        }
+        while du < -PI {
+            du += 2.0 * PI;
+        }
+        if du.abs() > 1e-9 {
+            return None;
+        }
+        v1_min = v1_min.min(v_a);
+        v1_max = v1_max.max(v_a);
+        v2_min = v2_min.min(v_b);
+        v2_max = v2_max.max(v_b);
+        v_spread_1 = v_spread_1.max(v1_max - v1_min);
+        v_spread_2 = v_spread_2.max(v2_max - v2_min);
+    }
+    // Both ends planar (constant v) → the existing grid path already
+    // handles this face; keep behavior identical.
+    if v_spread_1 < 1e-9 && v_spread_2 < 1e-9 {
+        return None;
+    }
+
+    let mut mesh = TriangleMesh::new();
+    let radial_normal = |p: &Point3| -> Vec3 {
+        let d = *p - cyl.center;
+        let radial = d - axis * d.dot(axis);
+        let n = radial.norm();
+        if n < 1e-12 {
+            axis
+        } else {
+            radial / n
+        }
+    };
+    // Vertex layout: column i contributes bottom (index 2i) and top (2i+1).
+    for i in 0..half {
+        for p in [&verts[i], &verts[l - 1 - i]] {
+            mesh.vertices
+                .extend_from_slice(&[p.x as f32, p.y as f32, p.z as f32]);
+            let n = radial_normal(p);
+            let (nx, ny, nz) = if reversed {
+                (-n.x as f32, -n.y as f32, -n.z as f32)
+            } else {
+                (n.x as f32, n.y as f32, n.z as f32)
+            };
+            mesh.normals.extend_from_slice(&[nx, ny, nz]);
+        }
+    }
+    for i in 0..half - 1 {
+        let bl = (2 * i) as u32;
+        let tl = bl + 1;
+        let br = bl + 2;
+        let tr = bl + 3;
+        mesh.indices.extend_from_slice(&[bl, br, tl]);
+        mesh.indices.extend_from_slice(&[br, tr, tl]);
+    }
+
+    // Orient the strip so triangle normals agree with the (possibly
+    // reversed) outward radial direction: check one non-degenerate
+    // triangle and flip the whole strip if needed.
+    for t in mesh.indices.chunks(3) {
+        let p = |i: u32| {
+            let b = i as usize * 3;
+            Point3::new(
+                mesh.vertices[b] as f64,
+                mesh.vertices[b + 1] as f64,
+                mesh.vertices[b + 2] as f64,
+            )
+        };
+        let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+        let n = (b - a).cross(c - a);
+        if n.norm() < 1e-12 {
+            continue;
+        }
+        let centroid = Point3::new(
+            (a.x + b.x + c.x) / 3.0,
+            (a.y + b.y + c.y) / 3.0,
+            (a.z + b.z + c.z) / 3.0,
+        );
+        let mut outward = radial_normal(&centroid);
+        if reversed {
+            outward = -outward;
+        }
+        if n.dot(outward) < 0.0 {
+            for tri in mesh.indices.chunks_mut(3) {
+                tri.swap(1, 2);
+            }
+        }
+        break;
+    }
+
+    Some(mesh)
 }
 
 /// Tessellate a spherical face.

--- a/docs/differentiable-seam-closeout.md
+++ b/docs/differentiable-seam-closeout.md
@@ -1,0 +1,173 @@
+# Differentiable seam — closeout: the named follow-ups
+
+M0–M10 (`differentiable-seam-m0-m2.md` … `-m10.md`) shipped the seam and its
+first consumer. Each milestone's design note also named what it deliberately
+did **not** build. This wave closes those follow-ups — every deferred item
+that is reachable from this repository — and records the two that remain
+deferred, with the reason.
+
+## What this wave ships
+
+### 1. Cone/torus second order (M10's only deliberate omission)
+
+M10 restricted `evaluate_with_second_derivative` to plane/cylinder/sphere,
+whose surface points are linear in their seeded fields. The restriction is
+gone, in both places it lived:
+
+- **Lift nodes** now go through a nested-dual surface lift
+  (`lift_surface_second`, `Dual<Dual<f64>>` with every seeded field packed
+  `((f, ḟ), (ḟ, f̈))`), so `ẍ = ∂x/∂field·field̈ + ∂²x/∂field²·fielḋ²` is
+  exact for **every** surface kind — the cone's `tan α` and the torus radii
+  nonlinearities included. The old two-first-order-lifts shortcut survives as
+  the special case where the second term vanishes; a unit gate asserts the
+  linear kinds still produce exactly zero acceleration under empty
+  acceleration seeds.
+- **Vertex/Boundary rows** (`constraint_row_2`) gained cone and torus
+  velocity-curvature arms in closed form. Differentiating each implicit
+  identity twice and keeping the terms quadratic in first-order rates:
+
+  ```text
+  cone:   curv = −2‖ẇ⊥‖² + τ̈ h² + 4 τ̇ h ḣ + 2 τ ḣ²,
+          τ = tan²α, τ̇ = 2 tanα sec²α·α̇, τ̈|α̈=0 = 2 sec²α(sec²α + 2tan²α)·α̇²
+  torus:  curv = −[ 2(ρ̇ − Ṙ)² + 2(ρ − R)(‖ẇ⊥‖² − ρ̇²)/ρ + 2ḣ² − 2ṙ² ]
+  ```
+
+  with `ẇ` the vertex rate relative to the apex/center. The torus middle term
+  is the non-constant `∇²g` the M10 note called "the mechanical extension".
+  `DiffError::SecondOrderUnsupported` no longer exists: every kind with an
+  implicit form has a second-order form.
+
+Gates: the fixed-apex cone's `d²V/dα²` against its **exact discrete closed
+form** `(h·k/3)·C·(2sec⁴α + 4tan²α sec²α)` at rel ≤ 1e-9, with node
+accelerations asserted **nonzero** (the first gate in the suite where the
+acceleration machinery is live rather than proving zeros); torus `d²V/dr²`
+against the continuum `4π²R` (5% polygonization band) and FD of the analytic
+`dV/dr`; torus `d²V/dR²` = 0 exactly (V linear in R — the curvature terms
+must cancel, and do); and an `r(θ) = θ²` chain-rule consistency gate at
+1e-12 that exercises nonzero acceleration seeds through every torus node
+class. Closed-form unit tests pin the new rows (cone rim: `ẍ = d·2sec²α tanα
+α̇²·û`; torus equator nonlinear-field and major-radius-cancellation cases).
+
+### 2. Physics adapter: anchor channel (M8 note)
+
+M8's factorization note promised "anchor coordinates slot in as more
+scalars". `rollout_gradient_with_anchors` delivers it:
+
+```text
+dJ/dθ = Σ_bodies ∂J/∂p·dp/dθ  +  Σ_anchors ∂J/∂a·da/dθ
+```
+
+`∂J/∂a` comes from the same central-FD-rollout pattern as `∂J/∂p` (no CAD
+rebuild); `da/dθ` from a central difference of the caller's **anchor map**,
+a pure function of θ with no geometry in it. `rollout_gradient` is now the
+anchor-free special case of the same implementation. Gates: the anchor
+channel in isolation (fixed geometry, pivot = θ) matches a full
+rebuild-and-resimulate FD at 1e-6; combined channels (radius drives mass
+props *and* a pivot at `2r`) at 1e-4, with the anchor contribution asserted
+load-bearing.
+
+### 3. Physics adapter: surface skin (M8 extension)
+
+The M8 note's sentence — "the mass-property factorization is the smooth
+core, the surface pullback the contact skin" — is now code:
+
+- `surface_gradient(body, θ, ∂J/∂x)` is the raw skin: a mesh cotangent on
+  the body's frozen-plan nodes in, per-parameter `dJ/dθ` out, via **one** M5
+  pullback plus a contraction per parameter. This is the exact entry point a
+  future phyz contact adjoint plugs into.
+- `rollout_gradient_with_surface` composes it with the smooth core for
+  objectives `J = J_dyn(mass props) + J_surf(surface nodes)` — ground
+  clearance, penetration, or any other penalty that reads the tessellated
+  surface. The surface channel is exact end to end (analytic node gradient →
+  pullback → contraction; no FD anywhere in it).
+
+Gates: the skin in isolation reproduces the N-gon prism closed form
+`dV/dr = 2krh` at 1e-9 through both entry points; flywheel spin-up + a
+radial surface penalty matches a rebuild-and-resimulate FD at 1e-4, with
+both channels asserted live and summing linearly.
+
+**Honest boundary, unchanged:** surface-dependent *dynamics* — contact
+forces acting during the rollout — need `∂J_dyn/∂x` from a phyz-side
+adjoint that does not exist at any vendored version. The skin is the seam
+it drops into; until then the contact-free contract on `rollout_gradient`
+stands.
+
+### 4. Document parameter gradient (M6's rejected stretch, unlocked)
+
+M6 rejected this as unreachable: the Rust document evaluator (`vcad-eval`)
+sat behind the excluded `loon` sibling. With the sibling in scope,
+`vcad_eval::diff::document_parameter_gradient` closes the product-level
+loop: a `.vcad` document's **named parameter** (the existing `parameters` +
+`bindings` sidecar) differentiates end to end —
+
+```text
+parameter → resolve bindings → evaluate_document → BRep per part
+          → synthesize_seeding (M6) → frozen-plan seam
+          → d(volume, mass, centroid, inertia)/dθ
+```
+
+— per solid part, with zero hand seeding. Probe evaluations are
+pre-validated (part count must hold at θ ± h), so a parameter value that
+crosses a part-count boundary errors instead of returning a wrong gradient.
+Gates: a parametric IR cylinder (radius bound to `"r"`) hits the N-gon
+closed form `dV/dr = 2krh` at 1e-9, mass scales by density, the centroid
+derivative vanishes, and `dI_zz/dr` matches a document-rebuild FD at 1e-6;
+a **loon-authored** document (`vcad_loon::eval_vcad` → bind → differentiate)
+reaches the same closed form — the exact path the M6 note deferred.
+
+### 5. Fillet miter corners (the per-edge fillet fix's named follow-up)
+
+Filleting **adjacent** edges — edges sharing a vertex — now works through
+the correct subset builder instead of falling back to the legacy
+inset-everything pipeline. The key geometric fact: at a vertex where two
+equal-radius blends meet over a shared face `S` with equal dihedral angles
+against `S` (every prism-like corner), the two blend cylinders intersect
+**exactly** in a planar curve on the bisector plane of the edge directions.
+So the corner is a *miter*, not a spherical patch:
+
+- both trimmed cylinder ends reference the **same** sampled curve, making
+  the weld exact by construction;
+- the shared face's corner collapses to the curve's end on `S`;
+- the two other faces corner at the opposite end, which lies on the
+  surviving third edge of the trihedral corner.
+
+Open chains, closed rings (a box's top rim: four edges, four miters, no
+caps), and the old independent sets all go through one generalized builder;
+anything outside the symmetric-chain domain still falls back to the legacy
+pipeline rather than producing wrong geometry.
+
+The tessellator gained a matching **ruled two-chain path** for cylinder
+faces whose end rings are angle-paired but not planar (the slanted miter
+trims — the old rectangular `(u, v)` grid overshot them and left an open
+seam). Detection is strict (exact angle pairing, non-constant `v`), so
+only blend faces take the new path; constant-`v` faces keep the existing
+grid bit for bit.
+
+Gates: L-chain, U-chain, and the closed top rim on a cube match the exact
+closed form `V = a³ − r²(1 − π/4)·Σlen + (5/3 − π/2)r³·(#corners)` to
+~1e-6 — the corner constant is `∫₀ʳ (r − √(2rz − z²))² dz`, the overlap of
+the two removed prisms — with structural watertightness asserted (every
+mesh edge shared by exactly two triangles).
+
+## What stays deferred, and why
+
+- **phyz inertia-parameter adjoint.** The FD factor `∂J/∂p` in the rollout
+  adapters would become analytic with a phyz-side parameter adjoint; phyz
+  lives in its own repository, outside this session's scope. The
+  factorization is already shaped for the swap.
+- **Contact-adjoint dynamics.** Same repository boundary: producing
+  `∂J_dyn/∂x` when contacts act during a rollout is phyz-side work. The
+  vcad-side seam for it (`surface_gradient`) ships in this wave.
+- **Cone-tangent-to-plane tangency rows** (M7 note): still waiting for a
+  gate model that produces one — consistent with `tangency_rows`'
+  documented "unknown kind = no tangency information" contract.
+- **Asymmetric / non-trihedral fillet corners** (unequal dihedral angles,
+  ≥3 blends at a vertex outside `fillet_all_edges`): the bisector-plane
+  identity that makes the miter exact does not hold there; those
+  selections fall back to the legacy pipeline. A sphere-patch corner for
+  the 3-blend case is the natural next construction.
+
+## Validation
+
+Full workspace suite (only the GTK-bound `vcad-desktop` excluded), clippy
+`-D warnings`, `cargo fmt --check` — green at every commit of the wave.


### PR DESCRIPTION
## What this is

M0–M10 shipped across #379–#385. Each milestone's design note also named what it deliberately did **not** build. This PR closes all of those follow-ups that live in this repository — five items, one commit each — and records the two that stay deferred (both phyz-side). Design note: `docs/differentiable-seam-closeout.md`.

## 1. Cone/torus second order (M10's only omission)

The lift moves to a nested-dual (`Dual<Dual<f64>>`) surface lift with fields packed `((f, f′), (f′, f″))`, so node accelerations are exact for **every** surface kind — the cone's `tan α` and torus radii nonlinearities included — subsuming the old linear-kinds-only shortcut. `constraint_row_2` gains cone/torus velocity-curvature arms in closed form (the non-constant `∇²g` terms). `DiffError::SecondOrderUnsupported` no longer exists.

Gates: cone `d²V/dα²` vs its exact discrete closed form at **≤1e-9** with node accelerations asserted *nonzero* (the machinery is live, not proving zeros); torus `d²V/dr²` vs continuum + FD; torus `d²V/dR²` = 0 exactly (curvature terms must cancel, and do); `r(θ) = θ²` chain rule at **1e-12**.

## 2 & 3. Physics adapter: anchor channel + surface skin (M8's two named extensions)

- **Anchors** ("more scalars in the same factorization"): `rollout_gradient_with_anchors` sums `Σ ∂J/∂p·dp/dθ + Σ ∂J/∂a·da/dθ`, with `∂J/∂a` from the same central-FD-rollout pattern and `da/dθ` from FD on the caller's geometry-free anchor map. Isolation gate 1e-6 vs rebuild-and-resimulate; combined channels 1e-4 with the anchor contribution asserted load-bearing.
- **Surface skin** ("the mass-property factorization is the smooth core, the surface pullback the contact skin"): `surface_gradient` is the raw skin — `∂J/∂x` on frozen-plan nodes in, `dJ/dθ` out via **one** M5 pullback — and the exact entry point a future phyz contact adjoint plugs into. `rollout_gradient_with_surface` composes it with the core for `J = J_dyn(mass props) + J_surf(surface)` objectives (clearance/penetration penalties). Skin-in-isolation hits the N-gon closed form at 1e-9; core+skin matches end-to-end FD at 1e-4, channels summing linearly. What it does *not* claim: contact forces during the rollout — that `∂J_dyn/∂x` is the phyz-side adjoint, documented.

## 4. Document parameter gradient (M6's rejected stretch, unlocked by loon)

`vcad_eval::diff::document_parameter_gradient`: a `.vcad` document's **named parameter** differentiates end to end — resolve bindings → `evaluate_document` → BRep per part → synthesized seeding → seam → `d(mass properties)/dθ` — zero hand seeding. Probes are pre-validated so a part-count-crossing parameter value errors instead of returning a wrong gradient. Gated against the N-gon closed form (1e-9), a document-rebuild FD on `dI_zz/dr` (1e-6), and a **loon-authored** document through `vcad_loon::eval_vcad` — the precise path the M6 note deferred.

## 5. Fillet miter corners (the per-edge fillet fix's follow-up)

Filleting **adjacent** edges now works. At a vertex where two equal-radius blends meet over a shared face with symmetric dihedrals (every prism-like corner), the two cylinders intersect *exactly* in a planar curve on the bisector plane — so the corner is a **miter**, not a sphere patch: both trimmed ends reference the same sampled curve (weld exact by construction), the shared face corners onto the curve's end, the other faces onto the surviving third edge. Open chains, closed rings (a box's **top rim**), and the old independent sets go through one generalized builder; anything outside the symmetric-chain domain still falls back to the legacy pipeline.

The tessellator gains a strict ruled two-chain path for the slanted miter trims (the rectangular `(u,v)` grid overshot them); constant-`v` faces keep the existing grid bit for bit.

Gates: L-chain, U-chain, and top rim match the exact closed form `V = a³ − r²(1−π/4)·Σlen + (5/3 − π/2)r³·#corners` to ~1e-6, with structural watertightness asserted (every mesh edge shared by exactly two triangles).

## Still deferred (and why)

phyz inertia-parameter adjoint and contact-adjoint dynamics — both live in the phyz repository, outside this session's scope; the vcad-side seams for both are now in place. Cone-tangent-to-plane tangency rows still await a gate model that produces one. Asymmetric/≥3-blend fillet corners fall back to the legacy pipeline; a sphere-patch corner is the natural next construction.

## Validation

Workspace suite (only GTK-bound `vcad-desktop` excluded): **2034 passed, 0 failed** (+21 new gates). Canonical clippy (`cargo clippy --workspace -- -D warnings`) clean, plus `--all-targets` clean on every touched crate; `cargo fmt --check` clean. CLAUDE.md's crate map updated (the seam is complete with two consumers); one changelog entry for the user-facing fillet fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP

---
_Generated by [Claude Code](https://claude.ai/code/session_01Puwd9LmMkq5JmAbLjjfqxP)_