### PR TITLE
Differentiable seam M11: phyz trajectory adjoint — exact ∂J/∂p + contact dynamics through the seam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,15 +112,18 @@ vcad/
 │   # Work-in-progress crates (built but not yet wired to any consumer):
 │   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
 │   #
-│   # - vcad-kernel-diff         # Differentiable seam, COMPLETE (M0–M10 + closeout):
+│   # - vcad-kernel-diff         # Differentiable seam, COMPLETE (M0–M11 + closeout):
 │   #                            # dx/dθ of frozen tessellations, mass-property QoIs,
 │   #                            # differentiable fillet radius, reverse-mode adjoint,
 │   #                            # seeding synthesis, cone/torus coverage incl. second
 │   #                            # order, L-BFGS optimizer
-│   #                            # (docs/differentiable-seam-m0-m2.md … -closeout.md).
+│   #                            # (docs/differentiable-seam-m0-m2.md … -m11.md).
 │   #                            # Consumers: vcad-kernel-physics::diff (rollout
 │   #                            # gradients — mass-property core, anchor channel,
-│   #                            # surface skin) and vcad-eval::diff
+│   #                            # surface skin; M11 adds exact ∂J/∂p via the
+│   #                            # phyz::diff trajectory adjoint and
+│   #                            # contact_rollout_gradient — contact dynamics
+│   #                            # priced through the seam) and vcad-eval::diff
 │   #                            # (document_parameter_gradient — d(mass props)/d(named
 │   #                            # .vcad parameter))
 ├── packages/                      # TypeScript workspace

--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -25,40 +25,39 @@
 //!   the polynomial mass-property integrals: every field's θ-derivative in
 //!   one pass, to machine precision. No remeshing, no topology risk.
 //!
-//! - **`∂J/∂p_body`** — *central finite differences on the mass-property
-//!   scalars themselves*. Each scalar is perturbed ±h and the rollout is
-//!   re-run (≈20 rollouts per body: 10 scalars × 2). This is cheap and
-//!   robust: no CAD rebuild, no re-tessellation, no boolean/fillet
-//!   combinatorics under perturbation — only the physics integrator re-runs,
-//!   on a body whose inertia scalar moved by a hair.
+//! - **`∂J/∂p_body`** — two implementations of the same factor:
+//!   - **Adjoint (exact)** — [`rollout_gradient_adjoint`] hands a structured
+//!     rollout ([`AdjointRolloutSpec`]) to the **phyz trajectory adjoint**
+//!     (`phyz::diff`), which prices all `10·n_bodies` sensitivities in one
+//!     backward pass (dual-number lanes through a scalar-generic ABA — no
+//!     finite differences). Requires the rollout in structured form:
+//!     single-DOF joints, open-loop control, final-state objective with an
+//!     analytic gradient.
+//!   - **Central FD (fallback)** — [`rollout_gradient`] takes an *opaque*
+//!     rollout closure and perturbs each mass-property scalar ±h
+//!     (≈20 rollouts per body). Still no CAD rebuild, no re-tessellation —
+//!     only the integrator re-runs. This remains the path for rollouts the
+//!     spec cannot express (arbitrary code, state feedback, multi-DOF
+//!     joints) or for phyz versions without the adjoint.
 //!
-//! ## Why finite differences for `∂J/∂p`, not a phyz adjoint
-//!
-//! phyz ships `phyz-diff`, but it differentiates a single dynamics step with
-//! respect to **state and control** (`∂(q',v')/∂(q,v,ctrl)`), not with respect
-//! to **model inertia parameters**. The factor M8 needs — sensitivity of the
-//! rollout objective to a body's mass/COM/inertia — is not exposed by phyz at
-//! any version currently vendored. So the live, and only, path for
-//! `∂J/∂p_body` is central FD on the mass-property scalars, exactly the
-//! fallback the seam design anticipated. If a future phyz grows a
-//! parameter-adjoint, it drops in behind this same factorization: replace the
-//! FD loop in [`rollout_gradient`] with the analytic `∂J/∂p` and the chain is
-//! unchanged.
+//!   Either way the factorization is unchanged; the M11 gates
+//!   (`m11_adjoint_rollout.rs`) hold the two implementations to each other
+//!   at 1e-5 and to a rebuild-and-resimulate FD at 1e-4.
 //!
 //! # Contract and boundaries
 //!
-//! - **Contact-free only.** The factorization is exact *because* geometry
-//!   reaches the dynamics solely through mass properties. The moment collision
-//!   geometry participates (a contact, a joint limit that bottoms out under
-//!   load, a ground penalty), contact forces depend on the *surface* — a
-//!   channel this gradient does not see. The rollout closure you pass **must**
-//!   build a contact-free model; if it does not, the returned gradient is
-//!   silently incomplete. The **surface skin** is built: objective terms that
-//!   read the surface directly go through [`rollout_gradient_with_surface`]
-//!   (exact, one M5 pullback per body), and a future contact adjoint's
-//!   `∂J/∂x` plugs into [`surface_gradient`] unchanged. What remains
-//!   phyz-side is the adjoint itself — producing `∂J_dyn/∂x` when contact
-//!   forces act *during* the rollout.
+//! - **Contact-free for the mass-property-only entry points.** The
+//!   factorization is exact *because* geometry reaches the dynamics solely
+//!   through mass properties. The rollout closure passed to
+//!   [`rollout_gradient`] / [`rollout_gradient_adjoint`] **must** build a
+//!   contact-free model; if it does not, the returned gradient is silently
+//!   incomplete. When contact forces *do* act during the rollout, use
+//!   [`contact_rollout_gradient`]: the phyz contact adjoint produces
+//!   `∂J_dyn/∂x` on the body's collision skin (the frozen-plan seam mesh)
+//!   under the differentiable per-vertex penalty contact model, and that
+//!   cotangent goes through the same M5 pullback as [`surface_gradient`].
+//!   Objective terms that merely *read* the surface (no contact dynamics)
+//!   still go through [`rollout_gradient_with_surface`].
 //! - **Anchor channel.** If θ also moves a **joint anchor / mount frame** (a
 //!   pivot hole whose position scales with the part), use
 //!   [`rollout_gradient_with_anchors`]: the anchor coordinates enter the
@@ -491,8 +490,9 @@ pub fn rollout_gradient_with_anchors(
 /// return the term's value and its analytic node gradient `∂J_surf/∂x`
 /// (J-units per mm, one vector per node). This is the **contact skin** of the
 /// M8 factorization: any objective contribution that reads the *surface*
-/// rather than the mass properties — a ground-clearance penalty, a
-/// penetration term, or (when one exists) a contact adjoint's `∂J/∂x`.
+/// rather than the mass properties — a ground-clearance penalty or a
+/// penetration term. (Contact *dynamics* have their own entry point:
+/// [`contact_rollout_gradient`].)
 pub type SurfaceTerm<'a> = Box<dyn Fn(&[CadPoint3], &[[u32; 3]]) -> (f64, Vec<CadVec3>) + 'a>;
 
 /// Price a mesh cotangent through the CAD seam: given `∂J/∂x` on `body`'s
@@ -503,9 +503,9 @@ pub type SurfaceTerm<'a> = Box<dyn Fn(&[CadPoint3], &[[u32; 3]]) -> (f64, Vec<Ca
 /// each parameter then costs only a seeding synthesis and a contraction —
 /// the reverse-mode economics the skin was designed around. This is the raw
 /// entry point a **contact adjoint** plugs into: whatever produces `∂J/∂x`
-/// on the collision surface (an analytic penalty today, a phyz contact
-/// adjoint when one exists), this function turns it into CAD-parameter
-/// sensitivities.
+/// on the collision surface (an analytic penalty, or the phyz contact
+/// adjoint that [`contact_rollout_gradient`] drives), this function turns it
+/// into CAD-parameter sensitivities.
 pub fn surface_gradient(
     body: &DiffBody,
     theta: &[f64],
@@ -543,10 +543,10 @@ pub fn surface_gradient(
 ///
 /// `surface_terms` is parallel to `bodies`; `None` for bodies without a
 /// surface term. What this does **not** do: surface-dependent *dynamics*.
-/// If contact forces act during the rollout, `∂J_dyn/∂(surface)` needs a
-/// contact adjoint phyz does not currently expose; when one exists, its
-/// `∂J/∂x` enters through [`surface_gradient`] and the factorization is
-/// unchanged (documented in `docs/differentiable-seam-m8.md`).
+/// If contact forces act during the rollout, use
+/// [`contact_rollout_gradient`], which obtains `∂J_dyn/∂x` from the phyz
+/// contact adjoint and feeds it through the same pullback (documented in
+/// `docs/differentiable-seam-m8.md` and `-m11.md`).
 pub fn rollout_gradient_with_surface(
     bodies: &[DiffBody],
     surface_terms: &[Option<SurfaceTerm>],
@@ -635,6 +635,260 @@ pub fn rollout_gradient_with_surface(
     }
 
     Ok((j0, gradient))
+}
+
+// ---------------------------------------------------------------------------
+// Adjoint-backed rollout gradients (phyz trajectory adjoint for ∂J/∂p)
+// ---------------------------------------------------------------------------
+
+/// A structured, adjoint-differentiable rollout description.
+///
+/// [`rollout_gradient`] takes an opaque closure and therefore has to probe
+/// `∂J/∂p` by finite differences (~20 re-simulations per body). This spec
+/// exposes the rollout's structure — model builder, initial state, open-loop
+/// control schedule, final-state objective with its analytic gradient — so
+/// the phyz **trajectory adjoint** ([`phyz::diff`]) can compute `∂J/∂p`
+/// exactly in one backward pass.
+///
+/// # Contract
+///
+/// - `build_model` must install body `i`'s inertia **exactly as**
+///   `props[i].to_spatial_inertia()` — i.e. in the CAD body frame. Mounting
+///   (rotating/offsetting the body relative to its joint) belongs in the
+///   joint's `parent_to_joint` and `axis`, *not* in a transformed inertia;
+///   a transformed inertia would silently decouple `∂J/∂p` from the seam's
+///   `dp/dθ`. Violations are detected and panic.
+/// - Joints: single-DOF (revolute/prismatic) + fixed, like phyz's adjoint.
+/// - `ctrl` is open-loop: it must not read the state.
+/// - The rollout the adjoint differentiates is phyz's semi-implicit Euler
+///   (`v' = v + dt·qdd`, `q' = q + dt·v'`) — the same integrator the m8
+///   test rollouts hand-roll, so the FD path and the adjoint path price the
+///   same trajectory.
+#[allow(clippy::type_complexity)]
+pub struct AdjointRolloutSpec<'a> {
+    /// Build the (contact-free unless used via
+    /// [`contact_rollout_gradient`]) phyz model at the given mass
+    /// properties. See the type-level contract.
+    pub build_model: Box<dyn Fn(&[BodyMassProps]) -> phyz::Model + 'a>,
+    /// Initial joint positions (length `nq`).
+    pub q0: Vec<f64>,
+    /// Initial joint velocities (length `nv`).
+    pub v0: Vec<f64>,
+    /// Number of integration steps.
+    pub steps: usize,
+    /// Open-loop control at step `t` (length `nv`).
+    pub ctrl: Box<dyn Fn(usize) -> phyz::math::DVec + 'a>,
+    /// Final-state objective `J = g(q_T, v_T)`.
+    pub objective_value: Box<dyn Fn(&[f64], &[f64]) -> f64 + 'a>,
+    /// Analytic objective gradient `(∂g/∂q_T, ∂g/∂v_T)`.
+    pub objective_gradient: Box<dyn Fn(&[f64], &[f64]) -> (Vec<f64>, Vec<f64>) + 'a>,
+}
+
+/// Check the [`AdjointRolloutSpec::build_model`] contract: the model's body
+/// inertias must be the props verbatim (CAD body frame, no mount transform
+/// baked in).
+fn assert_model_matches_props(model: &phyz::Model, props: &[BodyMassProps]) {
+    assert_eq!(
+        model.nbodies(),
+        props.len(),
+        "build_model must create exactly one phyz body per DiffBody"
+    );
+    for (i, (body, p)) in model.bodies.iter().zip(props).enumerate() {
+        let si = p.to_spatial_inertia();
+        let close = |a: f64, b: f64| (a - b).abs() <= 1e-9 * a.abs().max(b.abs()).max(1e-12);
+        let com_ok = close(body.inertia.com.x, si.com.x)
+            && close(body.inertia.com.y, si.com.y)
+            && close(body.inertia.com.z, si.com.z);
+        let mut inertia_ok = close(body.inertia.mass, si.mass);
+        for r in 0..3 {
+            for c in 0..3 {
+                inertia_ok &= close(body.inertia.inertia.get(r, c), si.inertia.get(r, c));
+            }
+        }
+        assert!(
+            com_ok && inertia_ok,
+            "build_model contract violation on body {i}: the phyz body's \
+             spatial inertia differs from props[{i}].to_spatial_inertia(). \
+             Mount transforms belong in the joint (parent_to_joint / axis), \
+             not in a transformed inertia."
+        );
+    }
+}
+
+/// Shared core of the adjoint-backed gradients: nominal seam pass per body,
+/// model build + contract check, one phyz adjoint pass, then the exact
+/// `∂J/∂p · dp/dθ` contraction (plus the surface-channel contraction when
+/// collision skins are present).
+fn adjoint_gradient_core(
+    bodies: &[DiffBody],
+    spec: &AdjointRolloutSpec,
+    contact: Option<(&ContactConfig, &[usize])>,
+    theta: &[f64],
+) -> Result<(f64, Vec<f64>), DiffError> {
+    let n = theta.len();
+
+    // 1. Nominal seam pass per body; keep B-reps/plans/positions.
+    let mut breps = Vec::with_capacity(bodies.len());
+    let mut plans = Vec::with_capacity(bodies.len());
+    let mut positions = Vec::with_capacity(bodies.len());
+    let mut nominal = Vec::with_capacity(bodies.len());
+    for body in bodies {
+        let brep = (body.build)(theta);
+        let plan = capture_plan(&brep, &body.tess)?;
+        let seam0 = evaluate_with_sensitivity(&brep, &plan, &ParamSeeding::new())?;
+        let props = mass_properties(&seam0.positions, &seam0.triangles, body.seam_density());
+        nominal.push(BodyMassProps::from_seam(&props));
+        positions.push(seam0.positions);
+        breps.push(brep);
+        plans.push(plan);
+    }
+
+    // 2. Build the model and hold it to the body-frame contract.
+    let model = (spec.build_model)(&nominal);
+    assert_model_matches_props(&model, &nominal);
+
+    // 3. Collision skins: the body's frozen-plan nodes, mm → m. The skin is
+    //    *exactly* the seam mesh, so the vertex cotangent that comes back is
+    //    already indexed by plan node.
+    let meshes: Vec<phyz::diff::CollisionMesh> = match contact {
+        Some((_, skinned)) => skinned
+            .iter()
+            .map(|&i| phyz::diff::CollisionMesh {
+                body: i,
+                vertices: positions[i]
+                    .iter()
+                    .map(|p| phyz::math::Vec3::new(p.x * MM_TO_M, p.y * MM_TO_M, p.z * MM_TO_M))
+                    .collect(),
+            })
+            .collect(),
+        None => Vec::new(),
+    };
+    let ground = contact.map(|(cfg, _)| phyz::diff::GroundContact {
+        height: cfg.ground_height_m,
+        stiffness: cfg.stiffness,
+        damping: cfg.damping,
+    });
+
+    // 4. One adjoint pass: J, exact ∂J/∂p per body, and (with contact) the
+    //    exact vertex cotangent ∂J/∂x per skinned body.
+    let objective = phyz::diff::FinalStateObjective {
+        value: &*spec.objective_value,
+        gradient: &*spec.objective_gradient,
+    };
+    let ctrl = &*spec.ctrl;
+    let rollout = phyz::diff::AdjointRollout {
+        model: &model,
+        contact: ground.map(|g| phyz::diff::ContactSetup {
+            ground: g,
+            meshes: &meshes,
+        }),
+        q0: spec.q0.clone(),
+        v0: spec.v0.clone(),
+        steps: spec.steps,
+        ctrl,
+    };
+    let adj = phyz::diff::adjoint_rollout_gradient(&rollout, &objective);
+
+    // 5. Mass-property channel: exact ∂J/∂p (adjoint) · exact dp/dθ (seam).
+    let mut gradient = vec![0.0f64; n];
+    for (i, body) in bodies.iter().enumerate() {
+        for (k, g) in gradient.iter_mut().enumerate() {
+            let seeding = (body.seeding_for)(&breps[i], theta, k)?;
+            let seam_k = evaluate_with_sensitivity(&breps[i], &plans[i], &seeding)?;
+            let (_props, dprops) = mass_properties_with_derivative(&seam_k, body.seam_density());
+            let dp = BodyMassProps::deriv_scalars(&dprops);
+            let acc: f64 = adj.d_inertia[i]
+                .iter()
+                .zip(&dp)
+                .map(|(djdp, dpj)| djdp * dpj)
+                .sum();
+            *g += acc;
+        }
+    }
+
+    // 6. Surface channel: the adjoint's ∂J/∂x (per metre, body frame) turns
+    //    into a per-mm cotangent on the frozen-plan nodes and goes through
+    //    one M5 pullback per skinned body — the exact seam the M8 note
+    //    promised the contact adjoint would drop into.
+    if let Some((_, skinned)) = contact {
+        for (mi, &i) in skinned.iter().enumerate() {
+            let djdx_mm: Vec<CadVec3> = adj.d_vertices[mi]
+                .iter()
+                .map(|g| CadVec3::new(g.x * MM_TO_M, g.y * MM_TO_M, g.z * MM_TO_M))
+                .collect();
+            let cots = evaluate_with_pullback(&breps[i], &plans[i], &djdx_mm)?;
+            for (k, g) in gradient.iter_mut().enumerate() {
+                let seeding = (bodies[i].seeding_for)(&breps[i], theta, k)?;
+                *g += cots.contract(&seeding);
+            }
+        }
+    }
+
+    Ok((adj.objective, gradient))
+}
+
+/// [`rollout_gradient`] with the finite-difference `∂J/∂p` factor replaced
+/// by the **phyz trajectory adjoint**: `(J, dJ/dθ)` where both factors of
+/// the M8 chain are exact —
+///
+/// ```text
+/// dJ/dθ = Σ_bodies  ∂J/∂p_body (adjoint, exact) · dp_body/dθ (seam, exact)
+/// ```
+///
+/// The FD-based [`rollout_gradient`] remains available as the fallback for
+/// rollouts that cannot be expressed as an [`AdjointRolloutSpec`] (closed
+/// over arbitrary code, state-feedback control, multi-DOF joints, or a phyz
+/// version without the adjoint).
+pub fn rollout_gradient_adjoint(
+    bodies: &[DiffBody],
+    spec: &AdjointRolloutSpec,
+    theta: &[f64],
+) -> Result<(f64, Vec<f64>), DiffError> {
+    adjoint_gradient_core(bodies, spec, None, theta)
+}
+
+/// Ground-plane contact configuration for [`contact_rollout_gradient`], in
+/// phyz (SI) units.
+#[derive(Debug, Clone, Copy)]
+pub struct ContactConfig {
+    /// World z of the ground plane (m).
+    pub ground_height_m: f64,
+    /// Penalty stiffness per vertex (N/m).
+    pub stiffness: f64,
+    /// Penalty damping per vertex (N·s/m).
+    pub damping: f64,
+}
+
+/// `(J, dJ/dθ)` for a rollout in which **contact forces act during the
+/// dynamics** — the boundary the M8 contract left open.
+///
+/// Each body listed in `skinned` collides with the ground plane through its
+/// own frozen-plan seam mesh (mm → m), under phyz's differentiable
+/// per-vertex penalty model. The phyz trajectory adjoint returns both
+/// `∂J/∂p` and the vertex cotangent `∂J/∂x`; the gradient sums the two
+/// channels the seam already knows how to price:
+///
+/// ```text
+/// dJ/dθ = Σ ∂J/∂p·dp/dθ  +  Σ pullback(∂J/∂x)·seeding
+/// ```
+///
+/// The surface channel goes through [`evaluate_with_pullback`] exactly as
+/// [`surface_gradient`] — this function *is* the contact adjoint plugged
+/// into that seam. Both factors of both channels are analytic; there is no
+/// finite difference anywhere in the chain.
+///
+/// The forward model being differentiated is phyz's diff rollout (vertex
+/// penalty contact, no friction, single-DOF joints, open-loop control) —
+/// see `phyz::diff` for the contract. It is **not** the GJK/EPA production
+/// contact pipeline.
+pub fn contact_rollout_gradient(
+    bodies: &[DiffBody],
+    spec: &AdjointRolloutSpec,
+    contact: &ContactConfig,
+    skinned: &[usize],
+    theta: &[f64],
+) -> Result<(f64, Vec<f64>), DiffError> {
+    adjoint_gradient_core(bodies, spec, Some((contact, skinned)), theta)
 }
 
 /// The nominal SI mass properties of each body at θ (positions-only seam).

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -46,9 +46,10 @@ pub mod stl;
 mod world;
 
 pub use diff::{
-    nominal_mass_props, rollout_gradient, rollout_gradient_with_anchors,
-    rollout_gradient_with_surface, surface_gradient, AnchorFdSteps, BodyMassProps, DiffBody,
-    MassPropFdSteps, SurfaceTerm,
+    contact_rollout_gradient, nominal_mass_props, rollout_gradient, rollout_gradient_adjoint,
+    rollout_gradient_with_anchors, rollout_gradient_with_surface, surface_gradient,
+    AdjointRolloutSpec, AnchorFdSteps, BodyMassProps, ContactConfig, DiffBody, MassPropFdSteps,
+    SurfaceTerm,
 };
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};

--- a/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
+++ b/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
@@ -1,0 +1,273 @@
+//! M11 — the phyz inertia-parameter adjoint replaces the FD `∂J/∂p` factor.
+//!
+//! The M8 chain `dJ/dθ = Σ ∂J/∂p·dp/dθ` had one inexact factor: `∂J/∂p` by
+//! central FD on the mass-property scalars (~20 rollouts per body). With the
+//! phyz trajectory adjoint both factors are analytic. Gates:
+//!
+//! 1. **Adjoint vs FD path** (`1e-5`): the same rollout priced by
+//!    `rollout_gradient_adjoint` and by the FD-based `rollout_gradient`
+//!    must agree to the FD path's own accuracy (its central differences sit
+//!    near the ~1e-5 relative sweet spot the step policy targets).
+//! 2. **End-to-end** (`1e-4`): the adjoint gradient against a *full*
+//!    rebuild-and-resimulate central FD — rebuild the CAD at `r ± h`,
+//!    convert to mass properties, re-simulate — the same bar as the M8
+//!    gates in `m8_rollout_gradient.rs`.
+//! 3. **Determinism**: two adjoint passes are bit-identical.
+//!
+//! Both rollouts are the M8 pair re-expressed as [`AdjointRolloutSpec`]s:
+//! the torque-driven flywheel (inertia channel isolated; `ω(T) = τT/I_zz`
+//! exactly) and a gravity pendulum (mass, COM, and inertia channels all
+//! live). The pendulum mounts the cylinder via the **joint axis** (revolute
+//! about body-X) rather than a transformed inertia, honouring the spec's
+//! body-frame contract.
+
+use phyz::math::{DVec, SpatialTransform, Vec3};
+use phyz::{Joint, JointType, Model, ModelBuilder};
+use vcad_kernel_diff::{ParamSeeding, SurfaceSeed};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::{
+    nominal_mass_props, rollout_gradient, rollout_gradient_adjoint, AdjointRolloutSpec,
+    BodyMassProps, DiffBody, MassPropFdSteps,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::TessellationParams;
+
+/// Aluminium-ish density (kg/m³).
+const DENSITY: f64 = 2700.0;
+/// Cylinder height (mm).
+const HEIGHT_MM: f64 = 8.0;
+/// Nominal radius (mm).
+const R0: f64 = 10.0;
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 64,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+fn cylinder_body<'a>() -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|theta: &[f64]| make_cylinder(theta[0], HEIGHT_MM, 64)),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            let n = s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            assert_eq!(n, 1, "expected exactly one cylinder surface");
+            Ok(s)
+        }),
+        density_kg_m3: DENSITY,
+        tess: tess(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Flywheel: revolute about Z, COM on the axis, constant torque, J = ω(T).
+// ---------------------------------------------------------------------------
+
+const TORQUE: f64 = 1e-4;
+const FLY_DT: f64 = 1.0 / 480.0;
+const FLY_STEPS: usize = 96; // 0.2 s
+
+fn flywheel_model(props: &[BodyMassProps]) -> Model {
+    ModelBuilder::new()
+        .gravity(Vec3::new(0.0, 0.0, -9.81))
+        .dt(FLY_DT)
+        .add_revolute_body(
+            "disc",
+            -1,
+            SpatialTransform::identity(),
+            props[0].to_spatial_inertia(),
+        )
+        .build()
+}
+
+fn flywheel_spec<'a>() -> AdjointRolloutSpec<'a> {
+    AdjointRolloutSpec {
+        build_model: Box::new(|p: &[BodyMassProps]| flywheel_model(p)),
+        q0: vec![0.0],
+        v0: vec![0.0],
+        steps: FLY_STEPS,
+        ctrl: Box::new(|_t| DVec::from_slice(&[TORQUE])),
+        objective_value: Box::new(|_q, v| v[0]),
+        objective_gradient: Box::new(|q, v| {
+            let mut gv = vec![0.0; v.len()];
+            gv[0] = 1.0;
+            (vec![0.0; q.len()], gv)
+        }),
+    }
+}
+
+/// The identical rollout as an opaque closure, for the FD path and the
+/// end-to-end oracle: same integrator (semi-implicit Euler), same steps.
+fn flywheel_rollout(props: &[BodyMassProps]) -> f64 {
+    let model = flywheel_model(props);
+    let mut state = model.default_state();
+    for _ in 0..FLY_STEPS {
+        state.ctrl[0] = TORQUE;
+        let qdd = phyz::aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * FLY_DT;
+        state.q[0] += state.v[0] * FLY_DT;
+    }
+    state.v[0]
+}
+
+// ---------------------------------------------------------------------------
+// Pendulum: revolute about body-X, gravity −Y; the CAD cylinder's COM at
+// (0, 0, h/2) gives a live lever arm without any inertia transform.
+// ---------------------------------------------------------------------------
+
+const PEND_DT: f64 = 1.0 / 960.0;
+const PEND_STEPS: usize = 144; // 0.15 s
+const Q0: f64 = 0.4;
+
+fn pendulum_model(props: &[BodyMassProps]) -> Model {
+    let joint = Joint {
+        joint_type: JointType::Revolute,
+        parent_to_joint: SpatialTransform::identity(),
+        axis: Vec3::new(1.0, 0.0, 0.0),
+        damping: 0.0,
+        limits: None,
+    };
+    ModelBuilder::new()
+        .gravity(Vec3::new(0.0, -9.81, 0.0))
+        .dt(PEND_DT)
+        .add_body("bob", -1, joint, props[0].to_spatial_inertia())
+        .build()
+}
+
+fn pendulum_spec<'a>() -> AdjointRolloutSpec<'a> {
+    AdjointRolloutSpec {
+        build_model: Box::new(|p: &[BodyMassProps]| pendulum_model(p)),
+        q0: vec![Q0],
+        v0: vec![0.0],
+        steps: PEND_STEPS,
+        ctrl: Box::new(|_t| DVec::from_slice(&[0.0])),
+        objective_value: Box::new(|q, _v| q[0]),
+        objective_gradient: Box::new(|q, v| {
+            let mut gq = vec![0.0; q.len()];
+            gq[0] = 1.0;
+            (gq, vec![0.0; v.len()])
+        }),
+    }
+}
+
+fn pendulum_rollout(props: &[BodyMassProps]) -> f64 {
+    let model = pendulum_model(props);
+    let mut state = model.default_state();
+    state.q[0] = Q0;
+    for _ in 0..PEND_STEPS {
+        let qdd = phyz::aba_with_external_forces(&model, &state, None);
+        state.v[0] += qdd[0] * PEND_DT;
+        state.q[0] += state.v[0] * PEND_DT;
+    }
+    state.q[0]
+}
+
+// ---------------------------------------------------------------------------
+// Gate 1 — adjoint vs the FD path (1e-5).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjoint_matches_fd_path() {
+    let bodies = [cylinder_body()];
+
+    let (j_adj, g_adj) =
+        rollout_gradient_adjoint(&bodies, &flywheel_spec(), &[R0]).expect("adjoint");
+    let (j_fd, g_fd) = rollout_gradient(
+        &bodies,
+        &flywheel_rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("fd path");
+    // Same integrator, same trajectory: the primal objectives agree to
+    // roundoff; the gradients to the FD path's own accuracy.
+    assert!(
+        (j_adj - j_fd).abs() <= 1e-12 * j_fd.abs(),
+        "flywheel J: adjoint {j_adj} vs fd-path {j_fd}"
+    );
+    let rel = (g_adj[0] - g_fd[0]).abs() / g_fd[0].abs();
+    assert!(
+        rel <= 1e-5,
+        "flywheel dJ/dr: adjoint {} vs fd-path {} (rel {rel:.3e})",
+        g_adj[0],
+        g_fd[0]
+    );
+
+    let (j_adj, g_adj) =
+        rollout_gradient_adjoint(&bodies, &pendulum_spec(), &[R0]).expect("adjoint");
+    let (j_fd, g_fd) = rollout_gradient(
+        &bodies,
+        &pendulum_rollout,
+        &[R0],
+        &MassPropFdSteps::default(),
+    )
+    .expect("fd path");
+    assert!(
+        (j_adj - j_fd).abs() <= 1e-12 * j_fd.abs().max(1.0),
+        "pendulum J: adjoint {j_adj} vs fd-path {j_fd}"
+    );
+    let rel = (g_adj[0] - g_fd[0]).abs() / g_fd[0].abs();
+    assert!(
+        rel <= 1e-5,
+        "pendulum dJ/dr: adjoint {} vs fd-path {} (rel {rel:.3e})",
+        g_adj[0],
+        g_fd[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2 — end-to-end rebuild-and-resimulate FD (1e-4), the M8 bar.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjoint_matches_end_to_end_fd() {
+    const GATE: f64 = 1e-4;
+    const H_THETA: f64 = 1e-3; // mm — same reasoning as the M8 gates.
+    let bodies = [cylinder_body()];
+
+    let e2e = |rollout: &dyn Fn(&[BodyMassProps]) -> f64| -> f64 {
+        let j_at = |r: f64| {
+            let props = nominal_mass_props(&bodies, &[r]).expect("props");
+            rollout(&props)
+        };
+        (j_at(R0 + H_THETA) - j_at(R0 - H_THETA)) / (2.0 * H_THETA)
+    };
+
+    let (_, g) = rollout_gradient_adjoint(&bodies, &flywheel_spec(), &[R0]).expect("adjoint");
+    let fd = e2e(&flywheel_rollout);
+    let rel = (g[0] - fd).abs() / fd.abs();
+    assert!(
+        rel <= GATE,
+        "flywheel dω/dr: adjoint {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        g[0]
+    );
+    assert!(g[0] < 0.0, "spin-up speed must fall as the disc grows");
+
+    let (_, g) = rollout_gradient_adjoint(&bodies, &pendulum_spec(), &[R0]).expect("adjoint");
+    let fd = e2e(&pendulum_rollout);
+    let rel = (g[0] - fd).abs() / fd.abs();
+    assert!(
+        rel <= GATE,
+        "pendulum dq(T)/dr: adjoint {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        g[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3 — determinism.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn adjoint_is_deterministic() {
+    let bodies = [cylinder_body()];
+    let (ja, ga) = rollout_gradient_adjoint(&bodies, &pendulum_spec(), &[R0]).expect("adjoint");
+    let (jb, gb) = rollout_gradient_adjoint(&bodies, &pendulum_spec(), &[R0]).expect("adjoint");
+    assert_eq!(ja, jb, "objective must be bit-identical");
+    assert_eq!(ga, gb, "gradient must be bit-identical");
+}

--- a/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
+++ b/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
@@ -1,0 +1,217 @@
+//! M11 — contact forces inside the rollout, priced end to end.
+//!
+//! This closes the last honest boundary of the M8 contract ("contact-free
+//! only"): a CAD parameter that changes the **collision surface** now
+//! differentiates through contact dynamics. The chain is
+//!
+//! ```text
+//! dJ/dθ = Σ ∂J/∂p·dp/dθ            (mass-property channel, both exact)
+//!       + Σ pullback(∂J/∂x)·seeding (surface channel: phyz contact adjoint
+//!                                    → M5 pullback, both exact)
+//! ```
+//!
+//! with `∂J/∂x` from the phyz trajectory adjoint under the differentiable
+//! per-vertex penalty contact model, on the body's own frozen-plan seam
+//! mesh.
+//!
+//! **The model:** the CAD cylinder (radius θ) lies on its side (a rotated
+//! mount frame on a vertical prismatic joint) resting on the ground plane;
+//! `J = q(T)`, the settled height. Growing the radius moves the contact
+//! line down the body (surface channel, `≈ +1e−3 m per mm` — the vertex at
+//! `y_body = r` drops by exactly `dθ`) *and* adds mass which sinks the body
+//! deeper into the penalty spring (mass channel, negative, ~2% of the
+//! total) — both channels are live and pull in opposite directions.
+//!
+//! Gates:
+//! 1. **End-to-end FD** (`1e-4`): full chain vs rebuild-and-resimulate
+//!    central FD at `θ ± h` — CAD rebuild, re-tessellation, re-simulation
+//!    with contact.
+//! 2. **Channel liveness**: the gradient sits near the surface channel's
+//!    `+1e−3` (so the FD agreement is not vacuous), and doubling the
+//!    density measurably shifts it (mass channel load-bearing).
+//! 3. **Determinism**: bit-identical across runs.
+//!
+//! The settled steady state keeps every active contact well inside its
+//! smooth branch (activation margins ~3e−5 m vs FD probe movements ~1e−6 m),
+//! so the central-difference oracle is clean; see the phyz-side gates for
+//! the transient-free argument.
+
+use phyz::math::{DVec, Mat3, SpatialTransform, Vec3};
+use phyz::{Joint, JointType, Model, ModelBuilder};
+use vcad_kernel_diff::{ParamSeeding, SurfaceSeed};
+use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::{
+    contact_rollout_gradient, AdjointRolloutSpec, BodyMassProps, ContactConfig, DiffBody,
+};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::TessellationParams;
+
+/// Aluminium-ish density (kg/m³).
+const DENSITY: f64 = 2700.0;
+/// Cylinder height (mm).
+const HEIGHT_MM: f64 = 8.0;
+/// Nominal radius (mm).
+const R0: f64 = 10.0;
+/// mm → m.
+const MM_TO_M: f64 = 1e-3;
+
+const DT: f64 = 1e-3;
+const STEPS: usize = 400; // 0.4 s — settled to ~e−44 of the transient.
+
+fn tess() -> TessellationParams {
+    TessellationParams {
+        circle_segments: 64,
+        height_segments: 2,
+        ..Default::default()
+    }
+}
+
+fn cylinder_body<'a>(density: f64) -> DiffBody<'a> {
+    DiffBody {
+        build: Box::new(|theta: &[f64]| make_cylinder(theta[0], HEIGHT_MM, 64)),
+        seeding_for: Box::new(|brep: &BRepSolid, _theta: &[f64], _k: usize| {
+            let mut s = ParamSeeding::new();
+            let n = s.seed_where(
+                &brep.geometry,
+                |surf| surf.as_any().downcast_ref::<CylinderSurface>().is_some(),
+                SurfaceSeed::CylinderRadius { rate: 1.0 },
+            );
+            assert_eq!(n, 1, "expected exactly one cylinder surface");
+            Ok(s)
+        }),
+        density_kg_m3: density,
+        tess: tess(),
+    }
+}
+
+/// The cylinder on its side: mount rotation `R_x(90°)` in `parent_to_joint`
+/// (body ẑ — the cylinder axis — maps to world ŷ), vertical prismatic
+/// motion via the axis expressed in the mounted joint frame. The body's
+/// spatial inertia is installed verbatim (CAD body frame), honouring the
+/// spec contract — the mount lives entirely in the joint.
+fn lying_cylinder_model(props: &[BodyMassProps]) -> Model {
+    // world→joint rotation R_x(90°); world +Z expressed in the joint frame
+    // is (0, −1, 0), which makes q a straight world-height coordinate.
+    let e_wj = Mat3::new(1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 1.0, 0.0);
+    let joint = Joint {
+        joint_type: JointType::Prismatic,
+        parent_to_joint: SpatialTransform::new(e_wj, Vec3::zeros()),
+        axis: Vec3::new(0.0, -1.0, 0.0),
+        damping: 0.0,
+        limits: None,
+    };
+    ModelBuilder::new()
+        .gravity(Vec3::new(0.0, 0.0, -9.81))
+        .dt(DT)
+        .add_body("roller", -1, joint, props[0].to_spatial_inertia())
+        .build()
+}
+
+fn spec<'a>() -> AdjointRolloutSpec<'a> {
+    AdjointRolloutSpec {
+        build_model: Box::new(|p: &[BodyMassProps]| lying_cylinder_model(p)),
+        q0: vec![0.0], // lowest surface line exactly touching the ground
+        v0: vec![0.0],
+        steps: STEPS,
+        ctrl: Box::new(|_t| DVec::from_slice(&[0.0])),
+        objective_value: Box::new(|q, _v| q[0]),
+        objective_gradient: Box::new(|q, v| {
+            let mut gq = vec![0.0; q.len()];
+            gq[0] = 1.0;
+            (gq, vec![0.0; v.len()])
+        }),
+    }
+}
+
+fn contact() -> ContactConfig {
+    ContactConfig {
+        // The lowest body point (y_body = r₀) sits at world z = −r₀ at q = 0.
+        ground_height_m: -R0 * MM_TO_M,
+        stiffness: 100.0, // N/m per vertex — ω·dt ≈ 0.2, ζ ≈ 0.5 with c below
+        damping: 0.5,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Gate 1 — full chain vs rebuild-and-resimulate FD (1e-4).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contact_chain_matches_end_to_end_fd() {
+    const GATE: f64 = 1e-4;
+    const H_THETA: f64 = 1e-3; // mm; moves contact vertices by 1e−6 m,
+                               // well inside the ~3e−5 m activation margins.
+
+    let bodies = [cylinder_body(DENSITY)];
+    let (j, grad) =
+        contact_rollout_gradient(&bodies, &spec(), &contact(), &[0], &[R0]).expect("gradient");
+
+    // The body must actually have settled into the spring (J < 0, order of
+    // the equilibrium penetration) — otherwise the gate isn't testing
+    // contact dynamics at all.
+    assert!(
+        j < -1e-5 && j > -1e-2,
+        "settled height J = {j} not in the expected penalty-equilibrium range"
+    );
+
+    // Rebuild-and-resimulate central difference of the same rollout.
+    let j_at = |r: f64| -> f64 {
+        let b = [cylinder_body(DENSITY)];
+        let (j, _) = contact_rollout_gradient(&b, &spec(), &contact(), &[0], &[r]).expect("probe");
+        j
+    };
+    let fd = (j_at(R0 + H_THETA) - j_at(R0 - H_THETA)) / (2.0 * H_THETA);
+    let rel = (grad[0] - fd).abs() / fd.abs();
+    assert!(
+        rel <= GATE,
+        "dJ/dr: chain {} vs end-to-end fd {fd} (rel {rel:.3e})",
+        grad[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2 — both channels load-bearing.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn both_channels_are_live() {
+    let bodies = [cylinder_body(DENSITY)];
+    let (_, grad) =
+        contact_rollout_gradient(&bodies, &spec(), &contact(), &[0], &[R0]).expect("gradient");
+
+    // Surface channel dominates: the contact line drops by exactly dθ as the
+    // radius grows, so dJ/dθ ≈ +1e−3 m/mm minus the (negative) mass term.
+    assert!(
+        grad[0] > 0.5e-3 && grad[0] < 1.05e-3,
+        "dJ/dr = {} not in the surface-dominated range (+1e−3 m/mm scale)",
+        grad[0]
+    );
+
+    // Mass channel: doubling the density must measurably lower the gradient
+    // (heavier body sinks further per unit of added mass — the ∂J/∂p·dp/dθ
+    // term is negative and scales with density).
+    let heavy = [cylinder_body(2.0 * DENSITY)];
+    let (_, grad_heavy) =
+        contact_rollout_gradient(&heavy, &spec(), &contact(), &[0], &[R0]).expect("gradient");
+    assert!(
+        grad_heavy[0] < grad[0] - 1e-5,
+        "mass channel not load-bearing: {} (2ρ) vs {} (ρ)",
+        grad_heavy[0],
+        grad[0]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Gate 3 — determinism.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contact_gradient_is_deterministic() {
+    let bodies = [cylinder_body(DENSITY)];
+    let (ja, ga) =
+        contact_rollout_gradient(&bodies, &spec(), &contact(), &[0], &[R0]).expect("gradient");
+    let (jb, gb) =
+        contact_rollout_gradient(&bodies, &spec(), &contact(), &[0], &[R0]).expect("gradient");
+    assert_eq!(ja, jb, "objective must be bit-identical");
+    assert_eq!(ga, gb, "gradient must be bit-identical");
+}

--- a/docs/differentiable-seam-closeout.md
+++ b/docs/differentiable-seam-closeout.md
@@ -151,13 +151,18 @@ mesh edge shared by exactly two triangles).
 
 ## What stays deferred, and why
 
-- **phyz inertia-parameter adjoint.** The FD factor `∂J/∂p` in the rollout
-  adapters would become analytic with a phyz-side parameter adjoint; phyz
-  lives in its own repository, outside this session's scope. The
-  factorization is already shaped for the swap.
-- **Contact-adjoint dynamics.** Same repository boundary: producing
-  `∂J_dyn/∂x` when contacts act during a rollout is phyz-side work. The
-  vcad-side seam for it (`surface_gradient`) ships in this wave.
+- ~~**phyz inertia-parameter adjoint.**~~ **Closed in M11**
+  (`differentiable-seam-m11.md`): `phyz::diff`'s trajectory adjoint computes
+  `∂J/∂p` exactly; `rollout_gradient_adjoint` swaps it in behind the
+  unchanged factorization, with the FD path kept as the fallback for
+  rollouts the structured spec cannot express.
+- ~~**Contact-adjoint dynamics.**~~ **Closed in M11**: the phyz contact
+  adjoint produces `∂J_dyn/∂x` on the body's frozen-plan seam mesh under a
+  differentiable per-vertex penalty contact model, and
+  `contact_rollout_gradient` prices it through the `surface_gradient`
+  pullback — the M8 "contact-free only" boundary no longer stands (for the
+  diff rollout's own forward model; the GJK/EPA production pipeline remains
+  non-differentiable).
 - **Cone-tangent-to-plane tangency rows** (M7 note): still waiting for a
   gate model that produces one — consistent with `tangency_rows`'
   documented "unknown kind = no tangency information" contract.

--- a/docs/differentiable-seam-m11.md
+++ b/docs/differentiable-seam-m11.md
@@ -1,0 +1,192 @@
+# Differentiable seam — M11 design note: the phyz-side adjoints
+
+M8 shipped the physics rollout gradient with one inexact factor and one
+honest boundary, and named both. The factor: `∂J/∂p` (sensitivity of the
+rollout objective to each body's ten mass-property scalars) came from central
+finite differences — ≈20 re-simulations per body — because phyz exposed no
+inertia-parameter sensitivity. The boundary: **contact-free only**, because
+producing `∂J_dyn/∂x` on a collision surface needed a phyz contact adjoint
+that did not exist; the closeout note carried both as "phyz lives in its own
+repository, outside this session's scope." M11 is the session with phyz in
+scope. Both items are closed, on both sides of the repo boundary.
+
+## What phyz gained: `phyz::diff`, an exact trajectory adjoint
+
+New module in the umbrella `phyz` crate (mirrored into the split `phyz-diff`
+crate as `phyz_diff::rollout`, per the tree's umbrella/split duplication
+convention). One backward pass over a semi-implicit Euler rollout with a
+final-state objective `J = g(q_T, v_T)` returns **both** sensitivities the
+CAD seam needs:
+
+- **`dJ/dπ`** per body — π = `[m, cx, cy, cz, Ixx, Iyy, Izz, Ixy, Ixz, Iyz]`
+  (COM-frame inertia, body-frame COM), deliberately packed in the same order
+  as vcad's `BodyMassProps::scalars()` so the gradient drops into the M8
+  factorization with no re-indexing.
+- **`∂J/∂x`** per collision-mesh vertex (body frame) — the contact cotangent,
+  when ground-contact forces act during the rollout.
+
+### Reverse over the trajectory, tangent within the step
+
+The driver is a discrete adjoint: `λ_t = ∂J/∂x_t` backpropagates through the
+step Jacobians. Semi-implicit Euler (`v' = v + dt·a`, `q' = q + dt·v'`,
+`a = ABA(q, v, u; π, V)`) gives, with `w := dt·λ_q' + λ_v'`:
+
+```text
+λ_q = λ_q' + dt·(∂a/∂q)ᵀw        λ_v = w + dt·(∂a/∂v)ᵀw
+dJ/dπ += dt·wᵀ·∂a/∂π            dJ/dV += dt·wᵀ·∂a/∂V
+```
+
+The within-step Jacobian columns are **exact**, not FD: tang's spatial
+algebra is generic over `tang::Scalar`, so ABA + forward kinematics + the
+contact law were written once over `T: Scalar` (the same move `phyz-diff`'s
+symbolic tracer made with `ExprId`) and instantiated at `tang::Dual<f64>`.
+One seeded dual lane per column; comparisons and clamps branch on the primal,
+so the tangent is the derivative of the branch the `f64` rollout actually
+takes.
+
+The π lanes seed the ten inertia scalars through the symmetric packing (one
+off-diagonal scalar seeds both matrix entries — the same convention a central
+difference on the packed scalars probes), so `dJ/dπ` is directly the
+derivative vcad's FD loop was estimating.
+
+### The vertex channel avoids a lane per vertex
+
+Vertices reach the dynamics only through each body's 6-component contact
+wrench. So instead of `3·N` dual lanes, the driver prices the wrench
+cotangent `χ_b = dt·wᵀ·∂a/∂(wrench_b)` once per contacting body (6 lanes
+through the full step, seeded on an additive external-wrench input) and
+contracts it against each vertex's **local** wrench Jacobian — 3 dual
+evaluations of just the penalty law, holding the state at its stored nominal.
+Cost per step: `O(nq + nv + 10·n_b + 6·n_b)` full dual steps plus `O(3·N)`
+local evaluations. Everything is plain `f64` arithmetic in a fixed order —
+two runs are bit-identical.
+
+### The contact model is a differentiable forward model of its own
+
+The adjoint does **not** differentiate the GJK/EPA production pipeline (a
+single deepest-point contact whose location is a combinatorial function of
+the mesh). Contact in `phyz::diff` is the standard differentiable-simulation
+choice: every collision-mesh vertex below the ground plane contributes an
+independent penalty wrench, `f_z = max(0, k·depth − c·v_z)` applied at the
+vertex. The force is a smooth function of the vertex position wherever the
+contact is active, the "contact set" is implicit in the smooth clamp (no
+fixed-contact-set contract needed — better than the v1 contract the brief
+allowed), and the gradient is the exact derivative of *this* forward model.
+Friction is deliberately absent: its `‖v_t‖` kink sits exactly at the
+sticking state a resting gate converges to.
+
+### phyz-side gates (`crates/phyz/tests/diff_adjoint.rs`)
+
+- **Flywheel closed form, 1e-12** (measured ~1e-15): semi-implicit Euler
+  gives `v_T = steps·dt·τ/I_zz` exactly, so `dJ/dI_zz = −steps·dt·τ/I_zz²`
+  is an exact discrete closed form; the other nine scalars are asserted
+  structurally dead.
+- **Gravity pendulum, all 10 π-scalars vs central FD at 1e-6**, with a
+  lopsided body (COM offset on all axes, dense inertia) and ≥4 channels
+  asserted live (mass, COM x/y, I_zz).
+- **Two-link 3D chain (mixed joint axes), all 20 π-scalars vs FD at 1e-6**,
+  ≥14 live — this is the gate that exercises the articulated-inertia
+  propagation a single body never touches. (The FD oracle's inertia step is
+  1e-6, not 1e-7: at 1e-7 the oracle's own roundoff sits at the gate —
+  measured rel 1.01e-6 — which is FD noise, not adjoint error.)
+- **Box settling on the plane, vertex gradient vs FD at 1e-4**, released at
+  rest exactly touching (the whole trajectory stays on one smooth branch),
+  plus closed-form anchors: `∂q_T/∂z = −1/4` per bottom vertex at
+  equilibrium (load shared by 4 vertices), top/tangential channels exactly
+  dead.
+- **Tilting paddle** (box offset on a revolute joint, resting tilted):
+  the same FD gate with a live rotation — frame conventions, torque arm,
+  rotational vertex velocity — including the x-channel that only exists
+  under tilt.
+- **Determinism**: bit-identical outputs across runs.
+
+### Contract (both repos)
+
+Single-DOF joints (revolute/prismatic) + fixed — the same domain as the
+symbolic tracer, and enough for every gate model the seam program has used;
+multi-DOF joints panic rather than misdifferentiate. Open-loop control (a
+state-feedback law would add `∂u/∂x` terms the driver does not model).
+Final-state objectives with caller-supplied analytic gradients.
+
+## What vcad gained: both M8 factors analytic, and the boundary closed
+
+### `rollout_gradient_adjoint` — the FD factor replaced (Task 1)
+
+`AdjointRolloutSpec` exposes the rollout's structure (model builder, initial
+state, open-loop control, objective + gradient); the adapter runs one seam
+pass per body for nominal props, one phyz adjoint pass for the exact
+`∂J/∂p`, and the usual per-(body, parameter) seam pass for the exact
+`dp/dθ`. The factorization — and every downstream consumer — is unchanged;
+`rollout_gradient` (FD) stays as the fallback for rollouts the spec cannot
+express (opaque closures, state feedback, multi-DOF joints, or a phyz
+without the adjoint).
+
+One new contract, enforced with a runtime check: `build_model` must install
+each body's inertia **verbatim** (`props[i].to_spatial_inertia()`, CAD body
+frame). Mounting belongs in the joint (`parent_to_joint`, `axis`) — the M8
+test's `si.transform(&mount)` idiom would silently decouple `∂J/∂p` from the
+seam's `dp/dθ`. The M11 pendulum shows the compliant form: revolute about
+body-X instead of a rotated inertia.
+
+Gates (`m11_adjoint_rollout.rs`), on the M8 flywheel + pendulum re-expressed
+as specs:
+
+- adjoint vs the FD path at 1e-5 — measured 1.2e-10 (flywheel),
+  4.9e-10 (pendulum); primal objectives agree to 1e-12 (same integrator,
+  same trajectory);
+- adjoint vs rebuild-and-resimulate end-to-end FD at 1e-4 (the M8 bar) —
+  measured 5.0e-8 and 1.2e-9;
+- determinism bit-identical.
+
+### `contact_rollout_gradient` — the last honest boundary (Task 2)
+
+The M8 contract said *contact-free only*, and the closeout note kept
+"contact-adjoint dynamics" deferred. Closed:
+
+```text
+dJ/dθ = Σ ∂J/∂p·dp/dθ            (mass channel — adjoint · seam, both exact)
+      + Σ pullback(∂J/∂x)·seeding (surface channel — contact adjoint · M5
+                                    pullback, both exact)
+```
+
+Each skinned body collides with the ground through **its own frozen-plan
+seam mesh** (mm → m), so the vertex cotangent the adjoint returns is already
+indexed by plan node; scaled back to per-mm it goes through
+`evaluate_with_pullback` exactly as `surface_gradient` promised a contact
+adjoint would. No finite difference anywhere in the chain.
+
+Gate model (`m11_contact_gradient.rs`): the CAD cylinder (radius θ) lying on
+its side — a rotated mount frame on a vertical prismatic joint — resting on
+the ground; `J = q(T)`, the settled height. Growing the radius moves the
+contact line down the body (surface channel: the `y_body = r` vertex drops
+by exactly dθ, so `+1e−3 m per mm`) *and* adds mass that sinks the body
+deeper into the penalty spring (mass channel, negative, a few percent of the
+total — measured `dJ/dr = 9.82e-4`, i.e. ~2% below the pure-surface `1e-3`) —
+two live channels pulling in opposite directions. Gates:
+
+- full chain vs rebuild-and-resimulate FD (CAD rebuild, re-tessellation,
+  re-simulation with contact) at 1e-4 — measured `dJ/dr = 9.8202e-4` vs FD,
+  rel **3.5e-7**;
+- channel liveness: the gradient sits in the surface-dominated range, and
+  doubling the density measurably lowers it (mass channel load-bearing);
+- determinism bit-identical.
+
+## Honest boundaries
+
+- The contact adjoint differentiates **phyz's diff rollout** (per-vertex
+  penalty against a ground plane, no friction), not the GJK/EPA production
+  pipeline of `PhysicsWorld`. A vcad gym rollout is not automatically
+  differentiable; the differentiable path is `contact_rollout_gradient`'s
+  own forward model, and its FD gates rebuild and re-simulate *that* model.
+- Single-DOF joints, open-loop control, final-state objectives (running
+  costs would be a mechanical extension of the λ recursion — nothing needs
+  them yet).
+- Force discontinuities at contact-activation instants (impact with nonzero
+  approach speed) are inherited from the penalty law's damping term: the
+  adjoint returns the exact derivative of the discrete trajectory, but that
+  derivative is only as meaningful as the trajectory is smooth in its
+  parameters. The gates pin the settled/steady regime where the law is
+  smooth; a bouncing objective would need a restitution-aware smoothing
+  neither repo has.
+- The FD path (`rollout_gradient`) stays, deliberately, for everything the
+  structured spec cannot express.


### PR DESCRIPTION
## What

Finishes the differentiable-seam program's two phyz-side follow-ups the closeout note deferred ("phyz lives in its own repository, outside this session's scope"):

**Depends on ecto/phyz#7** (`phyz::diff`, the exact trajectory adjoint) — CI here clones `ecto/phyz@main`, so it stays red until that PR merges. Merge order: phyz first.

### Task 1 — `rollout_gradient_adjoint`: the FD factor replaced

The M8 chain `dJ/dθ = Σ ∂J/∂p·dp/dθ` had one inexact factor: `∂J/∂p` by central FD on the mass-property scalars (~20 re-simulations per body). With the phyz trajectory adjoint (one backward pass, dual-number lanes through a scalar-generic ABA — π packed in `BodyMassProps::scalars()` order) both factors are now analytic. The rollout is described structurally (`AdjointRolloutSpec`: model builder, open-loop control, final-state objective + gradient), with a runtime-enforced contract that bodies carry their CAD body-frame inertia verbatim (mounting belongs in the joint, not a transformed inertia). The FD-based `rollout_gradient` stays as the documented fallback.

### Task 2 — `contact_rollout_gradient`: the last honest boundary closed

M8 was "contact-free only". Now: each skinned body collides with the ground through **its own frozen-plan seam mesh** (mm→m) under phyz's differentiable per-vertex penalty contact model; the adjoint's vertex cotangent `∂J/∂x` scales back to per-mm and goes through `evaluate_with_pullback` exactly as `surface_gradient` promised a contact adjoint would. Both channels — mass-property and surface — are analytic end to end.

Honest boundary, restated: the differentiable path is phyz's diff rollout (vertex penalty, no friction, single-DOF joints), not the GJK/EPA production pipeline.

## Gates

- `m11_adjoint_rollout.rs` — M8's flywheel + pendulum as specs: adjoint vs FD path at 1e-5 (measured 1.2e-10 / 4.9e-10), vs rebuild-and-resimulate end-to-end FD at 1e-4, the M8 bar (measured 5.0e-8 / 1.2e-9); determinism bit-identical.
- `m11_contact_gradient.rs` — CAD cylinder lying on its side on the ground, `J = q(T)`: full chain vs rebuild-and-resimulate FD at 1e-4 (measured rel **3.5e-7**); surface channel (+1e-3 m/mm, contact line moves with radius) and mass channel (negative, ~2%) asserted independently load-bearing; determinism bit-identical.
- phyz-side gates (in ecto/phyz#7): flywheel exact closed form 1e-12, pendulum + 3D two-link chain all-π vs FD 1e-6, box/paddle vertex gradients vs FD 1e-4 with closed-form anchors.

## Validation

`cargo test --workspace --exclude vcad-desktop` green (161 test targets), `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` clean (`--all-targets` clean on vcad-kernel-physics; the workspace `--all-targets` failures are pre-existing `vcad-ffi` test lints untouched here), `cargo fmt --all --check` clean.

Docs: `docs/differentiable-seam-m11.md` (design note), closeout deferred-list and CLAUDE.md crate map updated. Changelog skipped (kernel-internal capability, not user-facing app behavior). Still deferred, unchanged: cone-tangent-to-plane tangency rows (needs a gate model first) and the sphere-patch 3-blend fillet corner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)