### PR TITLE
perf: clash-detection broadphase + raster material tints

### DIFF
--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -287,12 +287,39 @@ pub fn evaluate_document(
         _ => 0.0,
     };
 
-    // Clash detection
+    // Clash detection. Broadphase first: blind pairwise `intersection`
+    // across all roots is O(n²) BRep booleans, which is fatal for
+    // many-root scenes (an imported chip die has ~90k roots). Compute
+    // each solid's AABB once, sort by min-x, and sweep — only pairs whose
+    // boxes overlap reach the kernel. AABB-disjoint pairs intersect to
+    // empty anyway, so skipping them is behavior-preserving.
     let mut clashes = Vec::new();
     let t_clash = clock.map(|c| c.now_ms());
     if !options.skip_clash_detection && solids.len() >= 2 {
-        for i in 0..solids.len() {
-            for j in (i + 1)..solids.len() {
+        let boxes: Vec<Option<([f64; 3], [f64; 3])>> = solids
+            .iter()
+            .map(|s| s.as_ref().map(|s| s.bounding_box()))
+            .collect();
+        let mut order: Vec<usize> = (0..solids.len()).filter(|&i| boxes[i].is_some()).collect();
+        order.sort_by(|&a, &b| {
+            let ax = boxes[a].as_ref().unwrap().0[0];
+            let bx = boxes[b].as_ref().unwrap().0[0];
+            ax.partial_cmp(&bx).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for (k, &i) in order.iter().enumerate() {
+            let (min_i, max_i) = boxes[i].as_ref().unwrap();
+            for &j in &order[k + 1..] {
+                let (min_j, max_j) = boxes[j].as_ref().unwrap();
+                if min_j[0] > max_i[0] {
+                    break; // sorted by min-x: no later j can overlap i
+                }
+                if min_j[1] > max_i[1]
+                    || max_j[1] < min_i[1]
+                    || min_j[2] > max_i[2]
+                    || max_j[2] < min_i[2]
+                {
+                    continue;
+                }
                 if let (Some(a), Some(b)) = (&solids[i], &solids[j]) {
                     let intersection = a.intersection(b);
                     if !intersection.is_empty() {

--- a/crates/vcad-eval/tests/clash_broadphase.rs
+++ b/crates/vcad-eval/tests/clash_broadphase.rs
@@ -1,0 +1,119 @@
+//! Regression tests for the clash-detection AABB broadphase: the sweep must
+//! still surface every genuinely overlapping pair, skip disjoint pairs
+//! without invoking the boolean kernel, and stay fast on many-root scenes
+//! (blind O(n²) pairwise booleans made a ~90k-root imported chip die
+//! unrenderable).
+
+use vcad_eval::{evaluate_document, EvalOptions};
+use vcad_ir::{CsgOp, Document, Node, NodeId, SceneEntry, Vec3};
+
+/// Document with one cube root per `(origin, size)` entry.
+fn doc_with_cubes(cubes: &[([f64; 3], f64)]) -> Document {
+    let mut doc = Document::new();
+    let mut id: NodeId = 1;
+    for &(origin, size) in cubes {
+        let cube = id;
+        doc.nodes.insert(
+            cube,
+            Node {
+                id: cube,
+                name: None,
+                op: CsgOp::Cube {
+                    size: Vec3::new(size, size, size),
+                },
+            },
+        );
+        let moved = id + 1;
+        id += 2;
+        doc.nodes.insert(
+            moved,
+            Node {
+                id: moved,
+                name: None,
+                op: CsgOp::Translate {
+                    child: cube,
+                    offset: Vec3::new(origin[0], origin[1], origin[2]),
+                },
+            },
+        );
+        doc.roots.push(SceneEntry {
+            root: moved,
+            material: "default".to_string(),
+            visible: None,
+        });
+    }
+    doc
+}
+
+fn clash_count(doc: &Document) -> usize {
+    let scene = evaluate_document(doc, &EvalOptions::default()).expect("evaluate");
+    scene.clashes.len()
+}
+
+#[test]
+fn overlapping_pair_still_detected() {
+    // Two 10-cubes offset by 5 on x: genuine overlap.
+    let doc = doc_with_cubes(&[([0.0, 0.0, 0.0], 10.0), ([5.0, 0.0, 0.0], 10.0)]);
+    assert_eq!(clash_count(&doc), 1);
+}
+
+#[test]
+fn overlap_found_regardless_of_root_order() {
+    // Same pair, reversed order — the sweep sorts by min-x, so ordering of
+    // roots must not matter.
+    let doc = doc_with_cubes(&[([5.0, 0.0, 0.0], 10.0), ([0.0, 0.0, 0.0], 10.0)]);
+    assert_eq!(clash_count(&doc), 1);
+}
+
+#[test]
+fn overlap_on_y_and_z_only_still_detected() {
+    // Identical x-extent (sweep axis), overlapping only via y/z checks.
+    let doc = doc_with_cubes(&[([0.0, 0.0, 0.0], 10.0), ([0.0, 4.0, 4.0], 10.0)]);
+    assert_eq!(clash_count(&doc), 1);
+}
+
+#[test]
+fn disjoint_roots_produce_no_clashes() {
+    let doc = doc_with_cubes(&[
+        ([0.0, 0.0, 0.0], 10.0),
+        ([100.0, 0.0, 0.0], 10.0),
+        ([0.0, 100.0, 0.0], 10.0),
+        ([0.0, 0.0, 100.0], 10.0),
+    ]);
+    assert_eq!(clash_count(&doc), 0);
+}
+
+#[test]
+fn three_way_overlap_reports_each_pair() {
+    // Three cubes chained: A∩B and B∩C overlap, A∩C do not.
+    let doc = doc_with_cubes(&[
+        ([0.0, 0.0, 0.0], 10.0),
+        ([7.0, 0.0, 0.0], 10.0),
+        ([14.0, 0.0, 0.0], 10.0),
+    ]);
+    assert_eq!(clash_count(&doc), 2);
+}
+
+#[test]
+fn many_disjoint_roots_evaluate_quickly() {
+    // 2,000 disjoint cubes = ~2M candidate pairs. With the broadphase this
+    // is pure AABB arithmetic; without it, ~2M BRep booleans (minutes).
+    // Keeping the wall-clock bound loose but real: fails hard on a
+    // regression to blind pairwise booleans.
+    let cubes: Vec<([f64; 3], f64)> = (0..2000)
+        .map(|i| {
+            let x = (i % 50) as f64 * 20.0;
+            let y = ((i / 50) % 50) as f64 * 20.0;
+            let z = (i / 2500) as f64 * 20.0;
+            ([x, y, z], 10.0)
+        })
+        .collect();
+    let doc = doc_with_cubes(&cubes);
+    let t0 = std::time::Instant::now();
+    assert_eq!(clash_count(&doc), 0);
+    assert!(
+        t0.elapsed() < std::time::Duration::from_secs(30),
+        "clash broadphase too slow: {:?}",
+        t0.elapsed()
+    );
+}

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -1427,15 +1427,28 @@ mod raster {
     /// with the same edge classification as the SVG path drawn on top
     /// (hidden lines removed). Errors are human-readable strings.
     pub fn render_jpeg_str(raw_vcad: &str, opts: &RasterOptions) -> Result<Vec<u8>, String> {
-        let solids: Vec<Solid> = evaluate_vcad(raw_vcad)?
-            .into_iter()
-            .map(|(s, _)| s)
-            .collect();
-        render_jpeg_solids(&solids, opts)
+        let tinted = evaluate_vcad(raw_vcad)?;
+        let solids: Vec<Solid> = tinted.iter().map(|(s, _)| s.clone()).collect();
+        let tints: Vec<Option<[f64; 3]>> = tinted.iter().map(|(_, t)| *t).collect();
+        render_jpeg_impl(&solids, &tints, opts)
     }
 
-    /// Render pre-evaluated solids to JPEG bytes. See [`render_jpeg_str`].
+    /// Render pre-evaluated solids to JPEG bytes, monochrome (no material
+    /// tints — mecheval reference images depend on this). See
+    /// [`render_jpeg_str`], which honours document material colours.
     pub fn render_jpeg_solids(solids: &[Solid], opts: &RasterOptions) -> Result<Vec<u8>, String> {
+        let no_tints: Vec<Option<[f64; 3]>> = vec![None; solids.len()];
+        render_jpeg_impl(solids, &no_tints, opts)
+    }
+
+    /// Shared raster implementation; `tints[i]`, when present, tints solid
+    /// `i`'s shading ramp exactly as the SVG path does. Untinted solids keep
+    /// the original two-stop monochrome shading, byte-for-byte.
+    fn render_jpeg_impl(
+        solids: &[Solid],
+        tints: &[Option<[f64; 3]>],
+        opts: &RasterOptions,
+    ) -> Result<Vec<u8>, String> {
         if solids.is_empty() {
             return Err("no solids produced".to_string());
         }
@@ -1451,11 +1464,9 @@ mod raster {
         let down = normalize(opts.view.down());
         let light = normalize(LIGHT);
 
-        // The raster path is monochrome (mecheval reference images) — no tints.
-        let no_tints: Vec<Option<[f64; 3]>> = vec![None; solids.len()];
         let arts = build_artifacts(
             solids,
-            &no_tints,
+            tints,
             cam,
             RASTER_SEGMENTS,
             &EdgeRules {
@@ -1529,19 +1540,24 @@ mod raster {
         // gives every face with the same normal the same colour, which
         // makes axis-aligned recesses invisible in axis-aligned views — a
         // mild depth cue (farther → darker) separates them.
-        for art in &arts {
+        for (ai, art) in arts.iter().enumerate() {
             let proj: Vec<(f64, f64, f64)> = art.verts.iter().map(|v| to_px(*v)).collect();
+            let tinted = tints.get(ai).copied().flatten().is_some();
             for (ti, t) in art.tris.iter().enumerate() {
                 if !art.visible[ti] {
                     continue;
                 }
                 let centroid_d = (proj[t[0]].2 + proj[t[1]].2 + proj[t[2]].2) / 3.0;
                 let cue = 0.78 + 0.22 * ((centroid_d - dmin) / dspan).clamp(0.0, 1.0);
-                let shade = mix_rgb(
-                    FILL_DARK,
-                    FILL_LIGHT,
-                    (lambertian(art.normals[ti], light) * cue).clamp(0.0, 1.0),
-                );
+                let lit = (lambertian(art.normals[ti], light) * cue).clamp(0.0, 1.0);
+                // Tinted parts sample their material ramp (same as the SVG
+                // path); untinted parts keep the original monochrome shade
+                // byte-for-byte (mecheval reference images).
+                let shade = if tinted {
+                    ramp_sample(&art.ramp, lit)
+                } else {
+                    mix_rgb(FILL_DARK, FILL_LIGHT, lit)
+                };
                 fill_triangle(
                     &mut rgb,
                     &mut zbuf,

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -231,8 +231,17 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<TintedSolid>, String> {
     // left in an undefined state. The JS caller is responsible for
     // catching the trap (WebAssembly.RuntimeError) and poisoning the
     // shared instance; see packages/mcp/src/tools/render.ts.
+    // A static renderer never displays clash meshes, and clash detection
+    // is O(n²) pairwise booleans across scene roots — fatal for many-root
+    // documents (an imported chip die has ~90k roots).
     let scene = catch_unwind(AssertUnwindSafe(|| {
-        evaluate_document(&parsed.document, &EvalOptions::default())
+        evaluate_document(
+            &parsed.document,
+            &EvalOptions {
+                skip_clash_detection: true,
+                ..Default::default()
+            },
+        )
     }))
     .map_err(|_| "eval panicked".to_string())?
     .map_err(|e| format!("eval: {}", e))?;


### PR DESCRIPTION
## What

Three renderer/eval fixes found by tracing why a large imported document never finished rendering:

1. **Clash detection broadphase** (`vcad-eval`): `evaluate_document` ran a blind O(n²) pairwise BRep `intersection` across all scene roots. On a many-root document this dominates everything — an imported chip die (~88k roots, zero actual overlaps) sat at 84% of profile samples inside `boolean_op`/`face_aabb` and would effectively never finish (3.8 **billion** kernel booleans). Now: per-root AABBs computed once, sorted by min-x, sweep-and-prune — only genuinely overlapping boxes reach the kernel. AABB-disjoint pairs intersect to empty anyway, so results are identical.
2. **`vcad-render` skips clash detection** — a static renderer never displays clash meshes (the flag existed, nothing set it).
3. **Raster path honors material tints** (`vcad-render --jpeg`): `render_jpeg_str` silently dropped document material colors — hardcoded monochrome. Tinted parts now sample the same tinted shading ramp as the SVG path. Untinted parts keep the original shade **byte-for-byte**, and `render_jpeg_solids` stays monochrome, so mecheval reference images are unchanged.

## Numbers

| scenario | before | after |
|---|---|---|
| 88k-root sky130 die (`vcad-render`) | never finishes | **5.2 s** |
| 2,000 disjoint roots (`evaluate_document`) | minutes | **0.23 s** |

## Testing

- New `clash_broadphase` integration suite: overlap still detected (incl. same-x-extent pairs and root-order independence), disjoint scenes produce zero clashes, per-pair counts, and a 2,000-root wall-clock regression bound.
- `cargo test -p vcad-eval -p vcad-render` green; clippy `-D warnings` clean (incl. `--all-features`).

Found while importing a real OpenLane/sky130 GDS via #387 — the two PRs are independent but this one is what makes big imported layouts actually render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)