### PR TITLE
feat(process): vcad-process — planar TCAD-lite process simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7417,6 +7417,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-process"
+version = "0.9.4"
+dependencies = [
+ "geo",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "vcad-gdsii",
+ "vcad-ir",
+]
+
+[[package]]
 name = "vcad-render"
 version = "0.9.3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/vcad-ecad-diff",
     "crates/vcad-ecad-diff-wasm",
     "crates/vcad-gdsii",
+    "crates/vcad-process",
     "crates/stepperoni",
     "crates/termview",
     "crates/vcad-embroidery",
@@ -130,6 +131,7 @@ default-members = [
     "crates/vcad-ecad-diff",
     "crates/vcad-ecad-diff-wasm",
     "crates/vcad-gdsii",
+    "crates/vcad-process",
     "crates/stepperoni",
     "crates/termview",
     "crates/vcad-embroidery",
@@ -223,6 +225,8 @@ vcad-embroidery = { path = "crates/vcad-embroidery", version = "0.9.4" }
 vcad-embroidery-pes = { path = "crates/vcad-embroidery-pes", version = "0.9.4" }
 vcad-embroidery-dst = { path = "crates/vcad-embroidery-dst", version = "0.9.4" }
 vcad-tool-derive = { path = "crates/vcad-tool-derive", version = "0.9.4" }
+vcad-gdsii = { path = "crates/vcad-gdsii", version = "0.9.4" }
+vcad-process = { path = "crates/vcad-process", version = "0.9.4" }
 
 # GPU stack — version-pin here, each consumer opts into the features it needs.
 wgpu = { version = "23" }

--- a/changelog/entries/2026-07-03-process-litho.json
+++ b/changelog/entries/2026-07-03-process-litho.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-03-process-litho",
+  "version": "0.9.4",
+  "date": "2026-07-03",
+  "category": "feat",
+  "title": "Photolithography steps in the process simulator",
+  "summary": "vcad-process recipes gain SpinResist, Expose, Develop, EtchThroughResist, and Strip: a physically honest resist loop that lands on the same geometry as the idealized PatternEtch.",
+  "features": ["process-sim", "photolithography", "resist", "cross-section"]
+}

--- a/changelog/entries/2026-07-03-process-sim.json
+++ b/changelog/entries/2026-07-03-process-sim.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-03-process-sim",
+  "version": "0.9.4",
+  "date": "2026-07-03",
+  "category": "feat",
+  "title": "Planar semiconductor process simulation",
+  "summary": "New vcad-process crate turns GDS masks plus a serializable process recipe (deposit, pattern etch, oxide growth, implant, CMP) into 3D film stacks and textbook process cross-sections.",
+  "features": ["process-sim", "gdsii", "chip-layout", "cross-section"]
+}

--- a/crates/vcad-process/Cargo.toml
+++ b/crates/vcad-process/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vcad-process"
+description = "Planar semiconductor process emulation: GDS masks + a process recipe → film-stack geometry"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+# Pure-Rust 2D polygon booleans (same version vcad-kernel-cam pins);
+# geo-clipper is deliberately avoided — it does not build for WASM.
+geo = "0.28"
+serde = { workspace = true }
+thiserror = { workspace = true }
+vcad-gdsii = { workspace = true }
+vcad-ir = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vcad-process/README.md
+++ b/crates/vcad-process/README.md
@@ -1,0 +1,92 @@
+# vcad-process
+
+Planar semiconductor process emulation — TCAD-lite. Takes **GDS masks +
+a process recipe** and produces the resulting film-stack geometry, both
+as a 3D stack and as the classic textbook process cross-section.
+
+```text
+GDS layout ──flatten──▶ per-layer masks (µm) ─┐
+                                              ├─▶ planar film simulator ─▶ vcad_ir::Document
+recipe (deposit/etch/grow/implant/CMP) ───────┘        (3D stack, cross-section)
+```
+
+## Recipe as plain data
+
+A `Recipe` is a substrate plus an ordered `Vec<ProcessStep>`; everything
+derives serde so recipes can live in JSON files next to the layouts:
+
+- `Deposit { material, thickness_um }` — blanket film over the current
+  top surface.
+- `PatternEtch { mask_layer, polarity, depth_um }` — etch the current
+  top film using a GDS layer as the mask. `Polarity::KeepMasked` keeps
+  film under mask polygons (subtractive patterning of a deposited film);
+  `Polarity::RemoveMasked` removes it there (opening windows). A depth
+  shallower than the film leaves a recessed remnant.
+- `GrowOxide { thickness_um }` — thermal oxidation: like a deposit, but
+  it consumes silicon from the film below. The classic rule of thumb is
+  **0.46 units of Si consumed per unit of oxide grown** (SiO₂ occupies
+  ~2.2× the volume of the Si it came from), so 46% of the oxide ends up
+  below the original surface and 54% above. Exposed as
+  `SI_CONSUMED_PER_OXIDE`.
+- `Implant { mask_layer, dopant, depth_um }` — doped region in the top
+  of the substrate under mask openings (v0: a thin colored slab inset
+  into the wafer).
+- `Planarize { to_um }` — CMP: clip everything above a height.
+
+## Mask engine
+
+Masks come from `vcad_gdsii::flatten` (f64 database units → µm),
+clipped to the region of interest and unioned per layer with the pure-
+Rust `geo` boolean ops (the same `geo = "0.28"` vcad-kernel-cam pins —
+no geo-clipper, which doesn't build for WASM). Etch = film footprint ∖
+mask or ∩ mask; all plan-view state is `geo::MultiPolygon<f64>` in µm.
+
+## Outputs
+
+Both emitters produce a `vcad_ir::Document` in the same sketch +
+extrude (+ union/difference for holes) style as the vcad-gdsii bridge,
+at the same **1 µm = 1 mm** view scale.
+
+- `simulate_3d(lib, top_cell, recipe, window)` — one part per surviving
+  film, bottom-up, with per-material colors (silicon gray-blue, SiO₂
+  pale gray, poly red, aluminum metallic, dopants green/orange).
+  `window: Option<[x0, y0, x1, y1]>` (µm) crops the die — pass one for
+  real layouts.
+- `cross_section(lib, top_cell, recipe, cut)` — the iconic deliverable:
+  intersect each film's footprint with a `CutLine` (axis-aligned, at
+  `position_um`, over `span`) to get exact 1D intervals, then emit one
+  thin slab (0.05 µm) per interval × film thickness. Etched-away
+  intervals are actually missing. Render with `--view front` for an
+  `Axis::X` cut (`--view side` for `Axis::Y`).
+
+## Planar v0 approximations (a.k.a. lies we tell on purpose)
+
+- **The top surface is a single scalar height**, not a height field.
+  Films deposit as flat slabs at the current top; a deposit over a
+  patterned film **bridges the etched gaps** instead of conforming into
+  them (no conformal/isotropic deposition, no step coverage).
+- Etches are perfectly anisotropic and vertical; `GrowOxide` is blanket
+  (no LOCOS bird's beak) and consumes from the current surface film
+  only.
+- Implants are uniform box profiles under mask polygons — no straggle,
+  no diffusion, no channeling, and they don't move during later thermal
+  steps (implant *before* oxidation will float inside the grown oxide;
+  sequence recipes accordingly).
+- No resist, exposure, or develop steps — `PatternEtch` is mask →
+  result in one step.
+
+Cross-section slabs get a hair of extra thickness per film
+(+0.002 µm/film) so coplanar front faces don't z-fight in orthographic
+renders; implant slabs sit 0.002 µm proud of the wafer in 3D for the
+same reason.
+
+## Example
+
+`examples/haiku_xsection.rs` runs a simplified sky130-ish flow (field
+oxide + active openings, implants, poly gate, ILD/CMP, li1, met1, met2)
+over a real GDS die and writes both a mid-die cross-section and a
+windowed 3D stack:
+
+```bash
+cargo run -p vcad-process --example haiku_xsection -- chip.gds out_dir
+```

--- a/crates/vcad-process/README.md
+++ b/crates/vcad-process/README.md
@@ -7,7 +7,7 @@ as a 3D stack and as the classic textbook process cross-section.
 ```text
 GDS layout ──flatten──▶ per-layer masks (µm) ─┐
                                               ├─▶ planar film simulator ─▶ vcad_ir::Document
-recipe (deposit/etch/grow/implant/CMP) ───────┘        (3D stack, cross-section)
+recipe (deposit/etch/grow/implant/CMP/litho) ─┘        (3D stack, cross-section)
 ```
 
 ## Recipe as plain data
@@ -33,6 +33,33 @@ derives serde so recipes can live in JSON files next to the layouts:
   into the wafer).
 - `Planarize { to_um }` — CMP: clip everything above a height.
 
+### Photolithography (resist) steps
+
+- `SpinResist { thickness_um, tone }` — spin-coat a blanket photoresist
+  film on the current top surface (`tone: Positive | Negative`).
+- `Expose { mask_layer, dose_mj_cm2 }` — expose the topmost resist film
+  through a GDS layer (a maskless stepper writing the same polygons is
+  equivalent). Pattern and dose are recorded on the film; exposure is
+  binary for now and the dose is pure bookkeeping — dose-to-clear
+  thresholding is future work. Multiple exposures union.
+- `Develop` — resolve the topmost exposed resist film: positive tone
+  removes the exposed regions, negative tone keeps only them. After
+  develop the resist footprint reflects the pattern.
+- `EtchThroughResist { depth_um }` — etch the topmost non-resist film
+  wherever resist is absent: the physically honest replacement for
+  `PatternEtch`'s idealized one-step mask, with the same
+  through/partial-etch semantics. `PatternEtch` remains available as
+  the shortcut, and the two land on identical geometry:
+
+  ```text
+  SpinResist(neg) → Expose(L) → Develop → EtchThroughResist(d) → Strip
+      ≡ PatternEtch { mask_layer: L, KeepMasked,   depth_um: d }
+  SpinResist(pos) → Expose(L) → Develop → EtchThroughResist(d) → Strip
+      ≡ PatternEtch { mask_layer: L, RemoveMasked, depth_um: d }
+  ```
+
+- `Strip` — remove all resist films.
+
 ## Mask engine
 
 Masks come from `vcad_gdsii::flatten` (f64 database units → µm),
@@ -49,7 +76,9 @@ at the same **1 µm = 1 mm** view scale.
 
 - `simulate_3d(lib, top_cell, recipe, window)` — one part per surviving
   film, bottom-up, with per-material colors (silicon gray-blue, SiO₂
-  pale gray, poly red, aluminum metallic, dopants green/orange).
+  pale gray, poly red, aluminum metallic, dopants green/orange, resist
+  the classic amber — resist films render like any other film while
+  they're on the wafer, and vanish after `Strip`).
   `window: Option<[x0, y0, x1, y1]>` (µm) crops the die — pass one for
   real layouts.
 - `cross_section(lib, top_cell, recipe, cut)` — the iconic deliverable:
@@ -72,8 +101,11 @@ at the same **1 µm = 1 mm** view scale.
   no diffusion, no channeling, and they don't move during later thermal
   steps (implant *before* oxidation will float inside the grown oxide;
   sequence recipes accordingly).
-- No resist, exposure, or develop steps — `PatternEtch` is mask →
-  result in one step.
+- Litho is binary: exposure dose is recorded but not modeled (no
+  dose-to-clear threshold, no PEB, no proximity effects), develop is a
+  perfect boolean, and resist doesn't reflow or erode during etch.
+  `PatternEtch` remains as the even-more-idealized mask → result
+  shortcut.
 
 Cross-section slabs get a hair of extra thickness per film
 (+0.002 µm/film) so coplanar front faces don't z-fight in orthographic

--- a/crates/vcad-process/examples/haiku_xsection.rs
+++ b/crates/vcad-process/examples/haiku_xsection.rs
@@ -1,0 +1,136 @@
+//! End-to-end PoC: run a simplified sky130-ish process flow over a real
+//! GDS die and emit both deliverables:
+//!
+//! - `haiku_xsection.vcad` — cross-section cut horizontally through the
+//!   die middle (y = 63.5 µm, x = 40..90 µm). Render with `--view front`.
+//! - `haiku_stack3d.vcad` — 3D film stack over a 20×20 µm window. Render
+//!   with `--view iso`.
+//!
+//! Usage: `haiku_xsection <in.gds> <out_dir>`
+//!
+//! Expects sky130-style layer numbers: diff=65, poly=66, li1=67,
+//! met1=68, met2=69.
+
+use vcad_gdsii::read_library;
+use vcad_process::{cross_section, simulate_3d, Axis, CutLine, Polarity, ProcessStep, Recipe};
+
+fn sky130ish_recipe() -> Recipe {
+    use ProcessStep::*;
+    Recipe {
+        substrate_material: "silicon".into(),
+        substrate_thickness_um: 0.8,
+        steps: vec![
+            // Field oxide, opened over active area, then dope the openings.
+            GrowOxide { thickness_um: 0.3 },
+            PatternEtch {
+                mask_layer: 65,
+                polarity: Polarity::RemoveMasked,
+                depth_um: 0.3,
+            },
+            Implant {
+                mask_layer: 65,
+                dopant: "ndiff".into(),
+                depth_um: 0.12,
+            },
+            // Poly gate.
+            Deposit {
+                material: "poly".into(),
+                thickness_um: 0.18,
+            },
+            PatternEtch {
+                mask_layer: 66,
+                polarity: Polarity::KeepMasked,
+                depth_um: 0.18,
+            },
+            // ILD + CMP, local interconnect.
+            Deposit {
+                material: "sio2".into(),
+                thickness_um: 0.45,
+            },
+            Planarize { to_um: 0.75 },
+            Deposit {
+                material: "li".into(),
+                thickness_um: 0.10,
+            },
+            PatternEtch {
+                mask_layer: 67,
+                polarity: Polarity::KeepMasked,
+                depth_um: 0.10,
+            },
+            // ILD2 + CMP, metal 1.
+            Deposit {
+                material: "sio2".into(),
+                thickness_um: 0.40,
+            },
+            Planarize { to_um: 1.20 },
+            Deposit {
+                material: "aluminum".into(),
+                thickness_um: 0.36,
+            },
+            PatternEtch {
+                mask_layer: 68,
+                polarity: Polarity::KeepMasked,
+                depth_um: 0.36,
+            },
+            // IMD + CMP, metal 2.
+            Deposit {
+                material: "sio2".into(),
+                thickness_um: 0.55,
+            },
+            Planarize { to_um: 2.05 },
+            Deposit {
+                material: "aluminum".into(),
+                thickness_um: 0.36,
+            },
+            PatternEtch {
+                mask_layer: 69,
+                polarity: Polarity::KeepMasked,
+                depth_um: 0.36,
+            },
+        ],
+    }
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let gds_path = args.next().expect("arg 1: in.gds");
+    let out_dir = std::path::PathBuf::from(args.next().expect("arg 2: out dir"));
+
+    let bytes = std::fs::read(&gds_path).expect("read gds");
+    let lib = read_library(&bytes).expect("parse gds");
+    let top = lib.cells.last().map(|c| c.name.clone()).expect("cells");
+    // Prefer a cell literally named like the design if present.
+    let top = lib
+        .cells
+        .iter()
+        .find(|c| c.name.contains("haiku"))
+        .map(|c| c.name.clone())
+        .unwrap_or(top);
+    let recipe = sky130ish_recipe();
+
+    // (a) Cross-section through the die middle.
+    let cut = CutLine {
+        axis: Axis::X,
+        position_um: 63.5,
+        span: [40.0, 90.0],
+    };
+    let section = cross_section(&lib, &top, &recipe, &cut).expect("cross section");
+    let section_path = out_dir.join("haiku_xsection.vcad");
+    std::fs::write(&section_path, section.to_json().expect("json")).expect("write");
+    println!(
+        "wrote {} ({} parts)",
+        section_path.display(),
+        section.roots.len()
+    );
+
+    // (b) 3D stack over a 20×20 µm window centered on the cut.
+    let window = [54.0, 53.5, 74.0, 73.5];
+    let stack = simulate_3d(&lib, &top, &recipe, Some(window)).expect("3d stack");
+    let stack_path = out_dir.join("haiku_stack3d.vcad");
+    std::fs::write(&stack_path, stack.to_json().expect("json")).expect("write");
+    println!(
+        "wrote {} ({} parts)",
+        stack_path.display(),
+        stack.roots.len()
+    );
+}

--- a/crates/vcad-process/src/bridge.rs
+++ b/crates/vcad-process/src/bridge.rs
@@ -247,6 +247,26 @@ pub fn cross_section(
     recipe: &Recipe,
     cut: &CutLine,
 ) -> Result<Document> {
+    cross_section_scaled(lib, top_cell, recipe, cut, 1.0)
+}
+
+/// [`cross_section`] with vertical exaggeration: every film's z-extent is
+/// multiplied by `z_scale` at emission. Real film stacks are ~7 µm tall on
+/// cuts hundreds of µm long — a ribbon at true aspect. `z_scale` in the
+/// 5–20 range gives the classic textbook proportions without touching the
+/// simulation itself (footprints and thickness math are unscaled).
+pub fn cross_section_scaled(
+    lib: &Library,
+    top_cell: &str,
+    recipe: &Recipe,
+    cut: &CutLine,
+    z_scale: f64,
+) -> Result<Document> {
+    if !(z_scale.is_finite() && z_scale > 0.0) {
+        return Err(ProcessError::BadRecipe(format!(
+            "z_scale must be positive and finite, got {z_scale}"
+        )));
+    }
     if !(cut.position_um.is_finite()
         && cut.span.iter().all(|v| v.is_finite())
         && cut.span[0] != cut.span[1])
@@ -311,7 +331,11 @@ pub fn cross_section(
                         },
                     ),
                 };
-                b.prism(&rect.to_polygon(), film.z_bottom_um, film.z_top_um)
+                b.prism(
+                    &rect.to_polygon(),
+                    film.z_bottom_um * z_scale,
+                    film.z_top_um * z_scale,
+                )
             })
             .collect();
         b.push_part(film, nodes);
@@ -494,5 +518,46 @@ mod tests {
             span: [0.0, 1.0],
         };
         assert!(cross_section(&lib, "top", &recipe, &cut).is_err());
+    }
+
+    #[test]
+    fn z_scale_exaggerates_only_vertical() {
+        let lib = sample_library();
+        let recipe = Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 2.0,
+            steps: vec![ProcessStep::Deposit {
+                material: "oxide".into(),
+                thickness_um: 0.5,
+            }],
+        };
+        let cut = CutLine {
+            axis: Axis::Y,
+            position_um: 4.0,
+            span: [0.0, 10.0],
+        };
+        let base = cross_section(&lib, "top", &recipe, &cut).unwrap();
+        let scaled = cross_section_scaled(&lib, "top", &recipe, &cut, 10.0).unwrap();
+
+        let max_extrude_z = |doc: &Document| -> f64 {
+            doc.nodes
+                .values()
+                .filter_map(|n| match &n.op {
+                    CsgOp::Extrude { direction, .. } => Some(direction.z),
+                    _ => None,
+                })
+                .fold(0.0, f64::max)
+        };
+        let (bz, sz) = (max_extrude_z(&base), max_extrude_z(&scaled));
+        assert!(
+            (sz - bz * 10.0).abs() < 1e-9,
+            "vertical not scaled: base {bz}, scaled {sz}"
+        );
+        // Horizontal footprint identical: same node count, same sketch xs.
+        assert_eq!(base.nodes.len(), scaled.nodes.len());
+
+        // Bad scales rejected.
+        assert!(cross_section_scaled(&lib, "top", &recipe, &cut, 0.0).is_err());
+        assert!(cross_section_scaled(&lib, "top", &recipe, &cut, f64::NAN).is_err());
     }
 }

--- a/crates/vcad-process/src/bridge.rs
+++ b/crates/vcad-process/src/bridge.rs
@@ -50,6 +50,7 @@ fn material_def(material: &str) -> MaterialDef {
         "silicon" => ([0.42, 0.50, 0.80], 0.1, 0.7), // gray-blue wafer
         "sio2" => ([0.88, 0.85, 0.55], 0.0, 0.9),    // pale sandy oxide
         "poly" => ([0.88, 0.24, 0.18], 0.1, 0.7),    // classic poly red
+        "resist" => ([0.97, 0.62, 0.12], 0.0, 0.5),  // classic resist amber
         "aluminum" => ([0.35, 0.82, 0.78], 0.9, 0.35), // bright metal teal
         "li" | "tungsten" => ([0.65, 0.32, 0.88], 0.6, 0.5), // local interconnect purple
         "ndiff" | "n+" => ([0.22, 0.78, 0.30], 0.1, 0.7), // n-type green
@@ -442,6 +443,44 @@ mod tests {
         };
         let doc = cross_section(&sample_library(), "top", &patterned_recipe(), &cut).unwrap();
         assert_eq!(doc.roots.len(), 1); // substrate only
+    }
+
+    #[test]
+    fn resist_films_render_while_present() {
+        // A stack frozen mid-litho (before Strip) must include the resist
+        // as its own amber-tinted part in both emitters.
+        let recipe = Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 1.0,
+            steps: vec![
+                ProcessStep::SpinResist {
+                    thickness_um: 1.0,
+                    tone: crate::recipe::ResistTone::Positive,
+                },
+                ProcessStep::Expose {
+                    mask_layer: 1,
+                    dose_mj_cm2: 150.0,
+                },
+                ProcessStep::Develop,
+            ],
+        };
+        let doc = simulate_3d(&sample_library(), "top", &recipe, None).unwrap();
+        let names: Vec<_> = doc
+            .roots
+            .iter()
+            .map(|r| doc.nodes[&r.root].name.clone().unwrap())
+            .collect();
+        assert!(names.iter().any(|n| n.contains("resist")));
+        let color = doc.materials["resist"].color;
+        assert!(color[0] > color[2], "resist should render amber, not blue");
+
+        let cut = CutLine {
+            axis: Axis::X,
+            position_um: 4.0,
+            span: [0.0, 10.0],
+        };
+        let section = cross_section(&sample_library(), "top", &recipe, &cut).unwrap();
+        assert!(section.materials.contains_key("resist"));
     }
 
     #[test]

--- a/crates/vcad-process/src/bridge.rs
+++ b/crates/vcad-process/src/bridge.rs
@@ -1,0 +1,459 @@
+//! Film stack → [`vcad_ir::Document`] emission.
+//!
+//! Both outputs use the same sketch + extrude representation the vcad-gdsii
+//! bridge produces, at the same view scale: **1 µm of layout = 1 mm of
+//! model** (dies are invisible at true scale).
+
+use geo::{Coord, MultiPolygon, Polygon, Rect};
+use vcad_gdsii::Library;
+use vcad_ir::{
+    CsgOp, Document, MaterialDef, Node, NodeId, SceneEntry, SketchSegment2D, Vec2, Vec3,
+};
+
+use crate::error::{ProcessError, Result};
+use crate::masks::{flatten_um, layout_bounds, masks_in_bounds};
+use crate::recipe::{Axis, CutLine, Recipe};
+use crate::section::footprint_intervals;
+use crate::sim::{simulate, Film, FilmKind};
+
+/// View scale: 1 µm of layout renders as 1 mm of model.
+const UM_TO_MM: f64 = 1.0;
+
+/// Half-thickness (µm) of the slab a cross-section is drawn as.
+const SECTION_HALF_UM: f64 = 0.025;
+
+/// Extra half-thickness (µm) added per film in a cross-section so
+/// stacked films never share a coplanar front face (z-fighting).
+const SECTION_BIAS_UM: f64 = 0.002;
+
+/// How far (µm) an implant slab pokes above the substrate top in the 3D
+/// view so its face wins the depth test against the substrate.
+const IMPLANT_PROUD_UM: f64 = 0.002;
+
+/// Cross-section band half-width (µm): masks are clipped to
+/// `position ± this` before simulation to keep the 2D booleans tiny.
+const SECTION_BAND_UM: f64 = 1.0;
+
+/// Polygons smaller than this (µm²) are dropped before emission.
+const MIN_AREA_UM2: f64 = 1e-9;
+
+/// Per-material display colors. Anything unknown falls back to a neutral
+/// teal so a recipe with exotic materials still renders.
+///
+/// The palette is deliberately more saturated than the physical
+/// materials: renderers in the vcad family key their tint strength off
+/// HSV saturation (achromatic parts fall back to a house monochrome
+/// ramp), and a cross-section is only useful if films are tellable
+/// apart.
+fn material_def(material: &str) -> MaterialDef {
+    let (color, metallic, roughness) = match material {
+        "silicon" => ([0.42, 0.50, 0.80], 0.1, 0.7), // gray-blue wafer
+        "sio2" => ([0.88, 0.85, 0.55], 0.0, 0.9),    // pale sandy oxide
+        "poly" => ([0.88, 0.24, 0.18], 0.1, 0.7),    // classic poly red
+        "aluminum" => ([0.35, 0.82, 0.78], 0.9, 0.35), // bright metal teal
+        "li" | "tungsten" => ([0.65, 0.32, 0.88], 0.6, 0.5), // local interconnect purple
+        "ndiff" | "n+" => ([0.22, 0.78, 0.30], 0.1, 0.7), // n-type green
+        "pdiff" | "p+" => ([0.95, 0.60, 0.15], 0.1, 0.7), // p-type orange
+        _ => ([0.30, 0.72, 0.74], 0.2, 0.6),
+    };
+    MaterialDef {
+        name: material.to_string(),
+        color,
+        metallic,
+        roughness,
+        ..Default::default()
+    }
+}
+
+/// Incremental document builder mirroring the vcad-gdsii bridge.
+struct Builder {
+    doc: Document,
+    next_id: NodeId,
+}
+
+impl Builder {
+    fn new() -> Self {
+        Self {
+            doc: Document::new(),
+            next_id: 1,
+        }
+    }
+
+    fn alloc(&mut self, name: Option<String>, op: CsgOp) -> NodeId {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.doc.nodes.insert(id, Node { id, name, op });
+        id
+    }
+
+    /// Sketch a closed ring at `z` (mm) and extrude it up by `height` mm.
+    fn ring_extrude(&mut self, ring: &geo::LineString<f64>, z_mm: f64, height_mm: f64) -> NodeId {
+        let segments: Vec<SketchSegment2D> = ring
+            .lines()
+            .filter(|l| l.start != l.end)
+            .map(|l| SketchSegment2D::Line {
+                start: Vec2::new(l.start.x * UM_TO_MM, l.start.y * UM_TO_MM),
+                end: Vec2::new(l.end.x * UM_TO_MM, l.end.y * UM_TO_MM),
+            })
+            .collect();
+        let sketch = self.alloc(
+            None,
+            CsgOp::Sketch2D {
+                origin: Vec3::new(0.0, 0.0, z_mm),
+                x_dir: Vec3::new(1.0, 0.0, 0.0),
+                y_dir: Vec3::new(0.0, 1.0, 0.0),
+                segments,
+            },
+        );
+        self.alloc(
+            None,
+            CsgOp::Extrude {
+                sketch,
+                direction: Vec3::new(0.0, 0.0, height_mm),
+                twist_angle: None,
+                scale_end: None,
+            },
+        )
+    }
+
+    /// One polygon (with holes) as a prism from `z0` to `z1` (µm).
+    fn prism(&mut self, polygon: &Polygon<f64>, z0_um: f64, z1_um: f64) -> NodeId {
+        let z_mm = z0_um * UM_TO_MM;
+        let h_mm = (z1_um - z0_um) * UM_TO_MM;
+        let body = self.ring_extrude(polygon.exterior(), z_mm, h_mm);
+        if polygon.interiors().is_empty() {
+            return body;
+        }
+        // Subtract holes; overshoot them vertically so the boolean never
+        // has to resolve coplanar top/bottom faces.
+        let overshoot = h_mm * 0.05;
+        let holes: Vec<NodeId> = polygon
+            .interiors()
+            .iter()
+            .map(|ring| self.ring_extrude(ring, z_mm - overshoot, h_mm + 2.0 * overshoot))
+            .collect();
+        let holes = self
+            .union_tree(holes)
+            .expect("non-empty interiors yield a node");
+        self.alloc(
+            None,
+            CsgOp::Difference {
+                left: body,
+                right: holes,
+            },
+        )
+    }
+
+    /// Balanced union so deep chains never overflow recursive consumers.
+    fn union_tree(&mut self, mut level: Vec<NodeId>) -> Option<NodeId> {
+        while level.len() > 1 {
+            let mut next = Vec::with_capacity(level.len().div_ceil(2));
+            let mut iter = level.into_iter();
+            while let Some(left) = iter.next() {
+                match iter.next() {
+                    Some(right) => next.push(self.alloc(None, CsgOp::Union { left, right })),
+                    None => next.push(left),
+                }
+            }
+            level = next;
+        }
+        level.pop()
+    }
+
+    /// Register `nodes` as one named part with the material for `film`.
+    fn push_part(&mut self, film: &Film, nodes: Vec<NodeId>) {
+        let Some(root) = self.union_tree(nodes) else {
+            return;
+        };
+        if let Some(node) = self.doc.nodes.get_mut(&root) {
+            node.name = Some(film.name.clone());
+        }
+        self.doc
+            .materials
+            .entry(film.material.clone())
+            .or_insert_with(|| material_def(&film.material));
+        self.doc.roots.push(SceneEntry {
+            root,
+            material: film.material.clone(),
+            visible: None,
+        });
+    }
+}
+
+fn window_rect(window: [f64; 4]) -> Result<Rect<f64>> {
+    let [x0, y0, x1, y1] = window;
+    if !(window.iter().all(|v| v.is_finite()) && x1 > x0 && y1 > y0) {
+        return Err(ProcessError::BadRecipe(format!(
+            "window must be finite [x0, y0, x1, y1] with positive extent, got {window:?}"
+        )));
+    }
+    Ok(Rect::new(Coord { x: x0, y: y0 }, Coord { x: x1, y: y1 }))
+}
+
+fn nonempty_polygons(footprint: &MultiPolygon<f64>) -> impl Iterator<Item = &Polygon<f64>> {
+    use geo::Area;
+    footprint
+        .iter()
+        .filter(|p| p.unsigned_area() > MIN_AREA_UM2)
+}
+
+/// Simulate `recipe` over the masks of `top_cell` and emit the 3D film
+/// stack as a document — one part per surviving film, bottom-up.
+///
+/// `window` optionally restricts the emitted die region to
+/// `[x0, y0, x1, y1]` in µm; without it the full layout bounding box is
+/// used (fine for test structures, slow for real dies).
+pub fn simulate_3d(
+    lib: &Library,
+    top_cell: &str,
+    recipe: &Recipe,
+    window: Option<[f64; 4]>,
+) -> Result<Document> {
+    let flat = flatten_um(lib, top_cell)?;
+    let bounds = match window {
+        Some(w) => window_rect(w)?,
+        None => layout_bounds(&flat)
+            .ok_or_else(|| ProcessError::BadRecipe("layout has no geometry".into()))?,
+    };
+    let masks = masks_in_bounds(&flat, bounds);
+    let films = simulate(recipe, &masks, bounds)?;
+
+    let mut b = Builder::new();
+    for film in &films {
+        // Nudge implant tops proud of the substrate so the doped slab is
+        // visible instead of z-fighting inside the wafer.
+        let z_top = match film.kind {
+            FilmKind::Implant => film.z_top_um + IMPLANT_PROUD_UM,
+            _ => film.z_top_um,
+        };
+        let nodes: Vec<NodeId> = nonempty_polygons(&film.footprint)
+            .map(|p| b.prism(p, film.z_bottom_um, z_top))
+            .collect();
+        b.push_part(film, nodes);
+    }
+    Ok(b.doc)
+}
+
+/// Simulate `recipe` and emit the classic textbook cross-section along
+/// `cut` — a thin slab per (film × surviving interval).
+///
+/// For an [`Axis::X`] cut render with `--view front`; for [`Axis::Y`],
+/// `--view side`. Each film's slab is drawn a hair thicker than the one
+/// below so coplanar slab faces never z-fight in the orthographic view.
+pub fn cross_section(
+    lib: &Library,
+    top_cell: &str,
+    recipe: &Recipe,
+    cut: &CutLine,
+) -> Result<Document> {
+    if !(cut.position_um.is_finite()
+        && cut.span.iter().all(|v| v.is_finite())
+        && cut.span[0] != cut.span[1])
+    {
+        return Err(ProcessError::BadRecipe(format!(
+            "cut line must have a finite position and a non-empty span, got {cut:?}"
+        )));
+    }
+    let flat = flatten_um(lib, top_cell)?;
+    // Only geometry within a thin band around the cut can affect it.
+    let (lo, hi) = (cut.span[0].min(cut.span[1]), cut.span[0].max(cut.span[1]));
+    let band = match cut.axis {
+        Axis::X => Rect::new(
+            Coord {
+                x: lo,
+                y: cut.position_um - SECTION_BAND_UM,
+            },
+            Coord {
+                x: hi,
+                y: cut.position_um + SECTION_BAND_UM,
+            },
+        ),
+        Axis::Y => Rect::new(
+            Coord {
+                x: cut.position_um - SECTION_BAND_UM,
+                y: lo,
+            },
+            Coord {
+                x: cut.position_um + SECTION_BAND_UM,
+                y: hi,
+            },
+        ),
+    };
+    let masks = masks_in_bounds(&flat, band);
+    let films = simulate(recipe, &masks, band)?;
+
+    let mut b = Builder::new();
+    for (index, film) in films.iter().enumerate() {
+        let half = SECTION_HALF_UM + index as f64 * SECTION_BIAS_UM;
+        let nodes: Vec<NodeId> = footprint_intervals(&film.footprint, cut)
+            .into_iter()
+            .map(|[a0, a1]| {
+                let rect = match cut.axis {
+                    Axis::X => Rect::new(
+                        Coord {
+                            x: a0,
+                            y: cut.position_um - half,
+                        },
+                        Coord {
+                            x: a1,
+                            y: cut.position_um + half,
+                        },
+                    ),
+                    Axis::Y => Rect::new(
+                        Coord {
+                            x: cut.position_um - half,
+                            y: a0,
+                        },
+                        Coord {
+                            x: cut.position_um + half,
+                            y: a1,
+                        },
+                    ),
+                };
+                b.prism(&rect.to_polygon(), film.z_bottom_um, film.z_top_um)
+            })
+            .collect();
+        b.push_part(film, nodes);
+    }
+    Ok(b.doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recipe::{Polarity, ProcessStep};
+    use vcad_gdsii::{Cell, Element, Library};
+
+    /// Layout: layer 1 square x 2..6, y 2..6 on a 10×10 die outline
+    /// (layer 0) so bounds are stable.
+    fn sample_library() -> Library {
+        let mut top = Cell::new("top");
+        top.elements.push(Element::Boundary {
+            layer: 0,
+            datatype: 0,
+            xy: vec![(0, 0), (10_000, 0), (10_000, 10_000), (0, 10_000), (0, 0)],
+        });
+        top.elements.push(Element::Boundary {
+            layer: 1,
+            datatype: 0,
+            xy: vec![
+                (2_000, 2_000),
+                (6_000, 2_000),
+                (6_000, 6_000),
+                (2_000, 6_000),
+                (2_000, 2_000),
+            ],
+        });
+        let mut lib = Library::new("process_test");
+        lib.cells = vec![top];
+        lib
+    }
+
+    fn patterned_recipe() -> Recipe {
+        Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 1.0,
+            steps: vec![
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.2,
+                },
+                ProcessStep::PatternEtch {
+                    mask_layer: 1,
+                    polarity: Polarity::KeepMasked,
+                    depth_um: 0.2,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn simulate_3d_emits_one_part_per_film() {
+        let doc = simulate_3d(&sample_library(), "top", &patterned_recipe(), None).unwrap();
+        // substrate + patterned poly.
+        assert_eq!(doc.roots.len(), 2);
+        let names: Vec<_> = doc
+            .roots
+            .iter()
+            .map(|r| doc.nodes[&r.root].name.clone().unwrap())
+            .collect();
+        assert!(names[0].contains("silicon"));
+        assert!(names[1].contains("poly"));
+        doc.to_json().unwrap();
+    }
+
+    #[test]
+    fn window_crops_the_stack() {
+        // Window that misses the poly square: only the substrate remains.
+        let doc = simulate_3d(
+            &sample_library(),
+            "top",
+            &patterned_recipe(),
+            Some([7.0, 7.0, 9.0, 9.0]),
+        )
+        .unwrap();
+        assert_eq!(doc.roots.len(), 1);
+    }
+
+    #[test]
+    fn cross_section_has_gaps_where_etched() {
+        let cut = CutLine {
+            axis: Axis::X,
+            position_um: 4.0,
+            span: [0.0, 10.0],
+        };
+        let doc = cross_section(&sample_library(), "top", &patterned_recipe(), &cut).unwrap();
+        assert_eq!(doc.roots.len(), 2);
+        // The poly part is a single 4 µm slab (one interval), not blanket:
+        // its sketch spans x = 2..6 mm at the 1 µm = 1 mm view scale.
+        let poly_root = doc.roots[1].root;
+        let mut xs: Vec<f64> = Vec::new();
+        fn collect_xs(doc: &Document, id: vcad_ir::NodeId, xs: &mut Vec<f64>) {
+            match &doc.nodes[&id].op {
+                CsgOp::Union { left, right } | CsgOp::Difference { left, right } => {
+                    collect_xs(doc, *left, xs);
+                    collect_xs(doc, *right, xs);
+                }
+                CsgOp::Extrude { sketch, .. } => collect_xs(doc, *sketch, xs),
+                CsgOp::Sketch2D { segments, .. } => {
+                    for s in segments {
+                        if let SketchSegment2D::Line { start, end } = s {
+                            xs.push(start.x);
+                            xs.push(end.x);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        collect_xs(&doc, poly_root, &mut xs);
+        let min = xs.iter().fold(f64::MAX, |a, &b| a.min(b));
+        let max = xs.iter().fold(f64::MIN, |a, &b| a.max(b));
+        assert!((min - 2.0).abs() < 1e-9, "poly slab starts at 2 µm");
+        assert!((max - 6.0).abs() < 1e-9, "poly slab ends at 6 µm");
+    }
+
+    #[test]
+    fn cross_section_missing_the_mask_has_no_poly() {
+        let cut = CutLine {
+            axis: Axis::X,
+            position_um: 8.0, // above the square
+            span: [0.0, 10.0],
+        };
+        let doc = cross_section(&sample_library(), "top", &patterned_recipe(), &cut).unwrap();
+        assert_eq!(doc.roots.len(), 1); // substrate only
+    }
+
+    #[test]
+    fn rejects_bad_window_and_cut() {
+        let lib = sample_library();
+        let recipe = patterned_recipe();
+        assert!(simulate_3d(&lib, "top", &recipe, Some([0.0, 0.0, -1.0, 1.0])).is_err());
+        let cut = CutLine {
+            axis: Axis::X,
+            position_um: f64::NAN,
+            span: [0.0, 1.0],
+        };
+        assert!(cross_section(&lib, "top", &recipe, &cut).is_err());
+    }
+}

--- a/crates/vcad-process/src/error.rs
+++ b/crates/vcad-process/src/error.rs
@@ -1,0 +1,22 @@
+//! Error type for process simulation.
+
+use thiserror::Error;
+
+/// Errors produced while simulating a process recipe.
+#[derive(Debug, Error)]
+pub enum ProcessError {
+    /// The underlying GDS library failed to flatten.
+    #[error("gds error: {0}")]
+    Gds(#[from] vcad_gdsii::GdsError),
+    /// A recipe step references a GDS layer with no geometry anywhere in
+    /// the layout — almost always a typo in the recipe.
+    #[error("recipe references GDS layer {0}, which has no geometry in the layout")]
+    UnknownMaskLayer(i16),
+    /// A recipe parameter is out of range (non-positive thickness, empty
+    /// span, NaN, …).
+    #[error("bad recipe: {0}")]
+    BadRecipe(String),
+}
+
+/// Convenience alias used throughout the crate.
+pub type Result<T> = std::result::Result<T, ProcessError>;

--- a/crates/vcad-process/src/lib.rs
+++ b/crates/vcad-process/src/lib.rs
@@ -2,7 +2,9 @@
 //! v0.
 //!
 //! Takes a GDSII layout (masks) plus a [`Recipe`] (deposit, etch, grow,
-//! implant, planarize) and produces geometry as [`vcad_ir::Document`]s:
+//! implant, planarize, plus a photolithography loop of spin / expose /
+//! develop / etch-through-resist / strip) and produces geometry as
+//! [`vcad_ir::Document`]s:
 //!
 //! - [`simulate_3d`] — the 3D film stack over a (windowed) die region.
 //! - [`cross_section`] — the classic textbook process cross-section along
@@ -23,5 +25,5 @@ mod bridge;
 
 pub use bridge::{cross_section, simulate_3d};
 pub use error::{ProcessError, Result};
-pub use recipe::{Axis, CutLine, Polarity, ProcessStep, Recipe, SI_CONSUMED_PER_OXIDE};
-pub use sim::{simulate, Film, FilmKind, Masks};
+pub use recipe::{Axis, CutLine, Polarity, ProcessStep, Recipe, ResistTone, SI_CONSUMED_PER_OXIDE};
+pub use sim::{simulate, Exposure, Film, FilmKind, Masks, ResistState};

--- a/crates/vcad-process/src/lib.rs
+++ b/crates/vcad-process/src/lib.rs
@@ -23,7 +23,7 @@ pub mod sim;
 
 mod bridge;
 
-pub use bridge::{cross_section, simulate_3d};
+pub use bridge::{cross_section, cross_section_scaled, simulate_3d};
 pub use error::{ProcessError, Result};
 pub use recipe::{Axis, CutLine, Polarity, ProcessStep, Recipe, ResistTone, SI_CONSUMED_PER_OXIDE};
 pub use sim::{simulate, Exposure, Film, FilmKind, Masks, ResistState};

--- a/crates/vcad-process/src/lib.rs
+++ b/crates/vcad-process/src/lib.rs
@@ -1,0 +1,27 @@
+//! Planar semiconductor process emulation — the digital twin of a fab,
+//! v0.
+//!
+//! Takes a GDSII layout (masks) plus a [`Recipe`] (deposit, etch, grow,
+//! implant, planarize) and produces geometry as [`vcad_ir::Document`]s:
+//!
+//! - [`simulate_3d`] — the 3D film stack over a (windowed) die region.
+//! - [`cross_section`] — the classic textbook process cross-section along
+//!   a cut line, with real gaps where material was etched away.
+//!
+//! See the crate README for the process model and its (deliberate)
+//! planar-v0 approximations.
+
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod masks;
+pub mod recipe;
+pub mod section;
+pub mod sim;
+
+mod bridge;
+
+pub use bridge::{cross_section, simulate_3d};
+pub use error::{ProcessError, Result};
+pub use recipe::{Axis, CutLine, Polarity, ProcessStep, Recipe, SI_CONSUMED_PER_OXIDE};
+pub use sim::{simulate, Film, FilmKind, Masks};

--- a/crates/vcad-process/src/masks.rs
+++ b/crates/vcad-process/src/masks.rs
@@ -1,0 +1,183 @@
+//! GDS layout → plan-view masks in µm.
+//!
+//! Bridges [`vcad_gdsii::flatten`] output (f64 database units) into the
+//! [`Masks`](crate::sim::Masks) the simulator consumes: polygons are
+//! scaled to µm, clipped to the region of interest, and unioned per layer
+//! so downstream booleans and interval extraction see disjoint geometry.
+
+use geo::{BooleanOps, Coord, LineString, MultiPolygon, Polygon, Rect};
+use vcad_gdsii::{flatten, LayerPolygons, Library};
+
+use crate::error::Result;
+use crate::sim::Masks;
+
+/// Flatten `top_cell` and return per-layer polygons scaled to µm.
+pub fn flatten_um(lib: &Library, top_cell: &str) -> Result<Vec<LayerPolygons>> {
+    let db_to_um = lib.db_unit_in_meters * 1e6;
+    let mut flat = flatten(lib, top_cell)?;
+    for layer in &mut flat {
+        for polygon in &mut layer.polygons {
+            for p in polygon.iter_mut() {
+                p[0] *= db_to_um;
+                p[1] *= db_to_um;
+            }
+        }
+    }
+    Ok(flat)
+}
+
+/// Bounding box of all flattened geometry, `Rect` in µm. `None` when the
+/// layout is empty.
+pub fn layout_bounds(flat: &[LayerPolygons]) -> Option<Rect<f64>> {
+    let mut min = [f64::INFINITY; 2];
+    let mut max = [f64::NEG_INFINITY; 2];
+    for layer in flat {
+        for polygon in &layer.polygons {
+            for p in polygon {
+                min[0] = min[0].min(p[0]);
+                min[1] = min[1].min(p[1]);
+                max[0] = max[0].max(p[0]);
+                max[1] = max[1].max(p[1]);
+            }
+        }
+    }
+    (min[0] <= max[0]).then(|| {
+        Rect::new(
+            Coord {
+                x: min[0],
+                y: min[1],
+            },
+            Coord {
+                x: max[0],
+                y: max[1],
+            },
+        )
+    })
+}
+
+fn ring(points: &[[f64; 2]]) -> LineString<f64> {
+    LineString::from(
+        points
+            .iter()
+            .map(|p| Coord { x: p[0], y: p[1] })
+            .collect::<Vec<_>>(),
+    )
+}
+
+/// Union a set of multipolygons as a balanced tree (a left fold makes the
+/// intermediate result grow with every step; pairing keeps both operands
+/// small).
+fn union_all(mut level: Vec<MultiPolygon<f64>>) -> MultiPolygon<f64> {
+    if level.is_empty() {
+        return MultiPolygon::new(Vec::new());
+    }
+    while level.len() > 1 {
+        let mut next = Vec::with_capacity(level.len().div_ceil(2));
+        let mut iter = level.into_iter();
+        while let Some(a) = iter.next() {
+            match iter.next() {
+                Some(b) => next.push(a.union(&b)),
+                None => next.push(a),
+            }
+        }
+        level = next;
+    }
+    level.pop().expect("non-empty level")
+}
+
+/// Build the simulator masks: every flattened layer, clipped to `bounds`
+/// and unioned into disjoint polygons.
+///
+/// Clipping first keeps the booleans small — a full die may carry tens of
+/// thousands of polygons per layer, but a cross-section band or a 3D
+/// window only intersects a handful.
+pub fn masks_in_bounds(flat: &[LayerPolygons], bounds: Rect<f64>) -> Masks {
+    let clip = MultiPolygon::new(vec![bounds.to_polygon()]);
+    flat.iter()
+        .map(|layer| {
+            let clipped: Vec<MultiPolygon<f64>> = layer
+                .polygons
+                .iter()
+                .filter(|polygon| polygon.len() >= 3)
+                .filter(|polygon| {
+                    // Cheap bbox rejection before the real boolean.
+                    let (mut lo, mut hi) = ([f64::INFINITY; 2], [f64::NEG_INFINITY; 2]);
+                    for p in polygon.iter() {
+                        lo[0] = lo[0].min(p[0]);
+                        lo[1] = lo[1].min(p[1]);
+                        hi[0] = hi[0].max(p[0]);
+                        hi[1] = hi[1].max(p[1]);
+                    }
+                    lo[0] <= bounds.max().x
+                        && hi[0] >= bounds.min().x
+                        && lo[1] <= bounds.max().y
+                        && hi[1] >= bounds.min().y
+                })
+                .map(|polygon| {
+                    MultiPolygon::new(vec![Polygon::new(ring(polygon), Vec::new())])
+                        .intersection(&clip)
+                })
+                .collect();
+            (layer.layer, union_all(clipped))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{coord, Area};
+
+    fn layer(layer: i16, polygons: Vec<Vec<[f64; 2]>>) -> LayerPolygons {
+        LayerPolygons { layer, polygons }
+    }
+
+    #[test]
+    fn masks_are_clipped_and_unioned() {
+        // Two overlapping unit squares → union area 1.75; clipped to a
+        // window covering only the left one → area 1.0 + sliver.
+        let flat = vec![layer(
+            1,
+            vec![
+                vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+                vec![[0.5, 0.0], [1.5, 0.0], [1.5, 0.75], [0.5, 0.75]],
+            ],
+        )];
+        let bounds = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 2.0, y: 2.0 });
+        let masks = masks_in_bounds(&flat, bounds);
+        let union = &masks[&1];
+        assert!((union.unsigned_area() - (1.0 + 0.5 * 0.75)).abs() < 1e-9);
+
+        let window = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 1.0, y: 2.0 });
+        let masks = masks_in_bounds(&flat, window);
+        assert!((masks[&1].unsigned_area() - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn far_away_polygons_are_rejected() {
+        let flat = vec![layer(
+            2,
+            vec![vec![
+                [100.0, 100.0],
+                [101.0, 100.0],
+                [101.0, 101.0],
+                [100.0, 101.0],
+            ]],
+        )];
+        let bounds = Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 10.0 });
+        let masks = masks_in_bounds(&flat, bounds);
+        assert!(masks[&2].0.is_empty());
+    }
+
+    #[test]
+    fn layout_bounds_covers_all_layers() {
+        let flat = vec![
+            layer(1, vec![vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]]),
+            layer(2, vec![vec![[-2.0, 3.0], [4.0, 3.0], [4.0, 5.0]]]),
+        ];
+        let b = layout_bounds(&flat).unwrap();
+        assert_eq!(b.min(), coord! { x: -2.0, y: 0.0 });
+        assert_eq!(b.max(), coord! { x: 4.0, y: 5.0 });
+        assert!(layout_bounds(&[]).is_none());
+    }
+}

--- a/crates/vcad-process/src/recipe.rs
+++ b/crates/vcad-process/src/recipe.rs
@@ -74,6 +74,52 @@ pub enum ProcessStep {
         /// above which all material is removed.
         to_um: f64,
     },
+    /// Spin-coat a blanket photoresist film over the current top surface.
+    SpinResist {
+        /// Resist film thickness in µm.
+        thickness_um: f64,
+        /// Resist tone: which regions survive [`ProcessStep::Develop`].
+        tone: ResistTone,
+    },
+    /// Expose the topmost resist film through a GDS layer. (A maskless
+    /// stepper writing the same polygons directly is equivalent — the
+    /// layer is simply where the light lands.) The pattern and dose are
+    /// recorded on the resist film; exposure is binary for now and the
+    /// dose is pure bookkeeping — dose-to-clear thresholding is future
+    /// work. Multiple exposures accumulate (their patterns union).
+    Expose {
+        /// GDS layer number whose polygons are the exposed regions.
+        mask_layer: i16,
+        /// Exposure dose in mJ/cm² (recorded, not yet modeled).
+        dose_mj_cm2: f64,
+    },
+    /// Develop the topmost exposed, undeveloped resist film:
+    /// [`ResistTone::Positive`] removes the exposed regions,
+    /// [`ResistTone::Negative`] keeps only the exposed regions. After
+    /// develop the resist footprint reflects the pattern.
+    Develop,
+    /// Etch the topmost non-resist film wherever resist is absent, to
+    /// `depth_um` — the physically honest replacement for
+    /// [`ProcessStep::PatternEtch`]'s idealized mask → result shortcut.
+    /// Same through/partial-etch semantics as `PatternEtch`.
+    EtchThroughResist {
+        /// Etch depth in µm. Depth ≥ film thickness clears the film in
+        /// the open regions; a shallower depth leaves a recessed remnant.
+        depth_um: f64,
+    },
+    /// Strip all resist films from the stack.
+    Strip,
+}
+
+/// Photoresist tone: which regions survive [`ProcessStep::Develop`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ResistTone {
+    /// Exposed regions dissolve in the developer and are removed — the
+    /// common case.
+    Positive,
+    /// Exposed regions cross-link and survive; everything unexposed is
+    /// removed.
+    Negative,
 }
 
 /// A full process flow: substrate plus ordered steps.
@@ -142,6 +188,39 @@ mod tests {
         assert_eq!(recipe, parsed);
         // Steps are tagged so recipe files read like a run sheet.
         assert!(json.contains("\"step\": \"GrowOxide\""));
+    }
+
+    #[test]
+    fn litho_steps_serde_round_trip() {
+        let recipe = Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 1.5,
+            steps: vec![
+                ProcessStep::SpinResist {
+                    thickness_um: 1.0,
+                    tone: ResistTone::Positive,
+                },
+                ProcessStep::Expose {
+                    mask_layer: 66,
+                    dose_mj_cm2: 150.0,
+                },
+                ProcessStep::Develop,
+                ProcessStep::EtchThroughResist { depth_um: 0.18 },
+                ProcessStep::Strip,
+                ProcessStep::SpinResist {
+                    thickness_um: 0.8,
+                    tone: ResistTone::Negative,
+                },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&recipe).unwrap();
+        let parsed: Recipe = serde_json::from_str(&json).unwrap();
+        assert_eq!(recipe, parsed);
+        // Same run-sheet tagging as the rest of the steps.
+        assert!(json.contains("\"step\": \"SpinResist\""));
+        assert!(json.contains("\"step\": \"Develop\""));
+        assert!(json.contains("\"tone\": \"Positive\""));
+        assert!(json.contains("\"tone\": \"Negative\""));
     }
 
     #[test]

--- a/crates/vcad-process/src/recipe.rs
+++ b/crates/vcad-process/src/recipe.rs
@@ -1,0 +1,158 @@
+//! Process recipes as plain, serializable data.
+//!
+//! A [`Recipe`] is a substrate plus an ordered list of [`ProcessStep`]s —
+//! the whole thing derives serde so recipes can live in JSON files next to
+//! the layouts they build.
+
+use serde::{Deserialize, Serialize};
+
+/// Fraction of silicon consumed per unit of thermally grown oxide.
+///
+/// Thermal oxidation converts silicon into SiO₂; the classic rule of thumb
+/// is that 0.46 units of silicon are consumed for every 1.0 unit of oxide
+/// grown (the Si lattice expands by ~2.2× when oxidized). [`super::sim`]
+/// lowers the surface film by `0.46 × thickness` and grows the oxide from
+/// that recessed level, so 54% of the oxide sits above the original
+/// surface and 46% below.
+pub const SI_CONSUMED_PER_OXIDE: f64 = 0.46;
+
+/// Which side of a photomask survives a patterned etch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Polarity {
+    /// Film survives where mask polygons are present (etch the field).
+    /// This is the usual subtractive patterning of a deposited film:
+    /// deposit blanket poly, keep it only under the poly mask.
+    KeepMasked,
+    /// Film is removed where mask polygons are present (etch the shapes).
+    /// E.g. opening the field oxide over active area.
+    RemoveMasked,
+}
+
+/// One step of a planar process flow.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "step")]
+pub enum ProcessStep {
+    /// Blanket-deposit a film of `material` over the current top surface.
+    /// Planar v0: the film is a flat slab starting at the current top.
+    Deposit {
+        /// Material name (drives the display color, e.g. `"sio2"`).
+        material: String,
+        /// Film thickness in µm.
+        thickness_um: f64,
+    },
+    /// Pattern-etch the current top film using a GDS layer as the mask.
+    PatternEtch {
+        /// GDS layer number whose polygons form the mask.
+        mask_layer: i16,
+        /// Whether masked or unmasked regions survive.
+        polarity: Polarity,
+        /// Etch depth in µm. Depth ≥ film thickness clears the film in
+        /// the etched regions; a shallower depth leaves a recessed film.
+        depth_um: f64,
+    },
+    /// Thermally grow oxide on the current top surface. Unlike
+    /// [`ProcessStep::Deposit`], growth consumes
+    /// [`SI_CONSUMED_PER_OXIDE`] × `thickness_um` of the film below.
+    GrowOxide {
+        /// Total oxide thickness in µm.
+        thickness_um: f64,
+    },
+    /// Implant dopant into the top of the substrate under mask openings.
+    /// Planar v0: a thin colored slab inset into the substrate wherever
+    /// the mask layer has polygons.
+    Implant {
+        /// GDS layer number whose polygons define the implanted regions.
+        mask_layer: i16,
+        /// Dopant name (drives the display color, e.g. `"ndiff"`).
+        dopant: String,
+        /// Junction depth in µm below the current substrate top.
+        depth_um: f64,
+    },
+    /// Chemical-mechanical planarization: clip everything above a height.
+    Planarize {
+        /// Height (µm, relative to the original substrate top at z = 0)
+        /// above which all material is removed.
+        to_um: f64,
+    },
+}
+
+/// A full process flow: substrate plus ordered steps.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Recipe {
+    /// Substrate material name (usually `"silicon"`).
+    pub substrate_material: String,
+    /// Substrate thickness in µm. The substrate top surface is z = 0;
+    /// the wafer body spans `-substrate_thickness_um .. 0`.
+    pub substrate_thickness_um: f64,
+    /// Process steps, executed in order.
+    pub steps: Vec<ProcessStep>,
+}
+
+/// Axis a [`CutLine`] runs parallel to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Axis {
+    /// Cut line parallel to the X axis (a "horizontal" cut at fixed Y).
+    X,
+    /// Cut line parallel to the Y axis (a "vertical" cut at fixed X).
+    Y,
+}
+
+/// A straight cut through the die for cross-section extraction.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct CutLine {
+    /// Axis the cut line runs parallel to.
+    pub axis: Axis,
+    /// Position of the line on the *other* axis, in µm (an [`Axis::X`]
+    /// cut sits at `y = position_um`).
+    pub position_um: f64,
+    /// Extent of the cut along its own axis, `[start, end]` in µm.
+    pub span: [f64; 2],
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recipe_serde_round_trip() {
+        let recipe = Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 1.5,
+            steps: vec![
+                ProcessStep::Implant {
+                    mask_layer: 65,
+                    dopant: "ndiff".into(),
+                    depth_um: 0.12,
+                },
+                ProcessStep::GrowOxide { thickness_um: 0.3 },
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.18,
+                },
+                ProcessStep::PatternEtch {
+                    mask_layer: 66,
+                    polarity: Polarity::KeepMasked,
+                    depth_um: 0.18,
+                },
+                ProcessStep::Planarize { to_um: 0.8 },
+            ],
+        };
+        let json = serde_json::to_string_pretty(&recipe).unwrap();
+        let parsed: Recipe = serde_json::from_str(&json).unwrap();
+        assert_eq!(recipe, parsed);
+        // Steps are tagged so recipe files read like a run sheet.
+        assert!(json.contains("\"step\": \"GrowOxide\""));
+    }
+
+    #[test]
+    fn cutline_serde_round_trip() {
+        let cut = CutLine {
+            axis: Axis::X,
+            position_um: 63.5,
+            span: [40.0, 90.0],
+        };
+        let json = serde_json::to_string(&cut).unwrap();
+        let parsed: CutLine = serde_json::from_str(&json).unwrap();
+        assert_eq!(cut, parsed);
+    }
+}

--- a/crates/vcad-process/src/section.rs
+++ b/crates/vcad-process/src/section.rs
@@ -1,0 +1,183 @@
+//! Cross-section interval extraction.
+//!
+//! Intersecting a film's plan-view footprint with a [`CutLine`] yields a
+//! set of 1D intervals along the cut — the spans where the film exists.
+//! Each `(interval × film z-range)` later becomes one rectangle of the
+//! textbook cross-section.
+
+use geo::{MultiPolygon, Polygon};
+
+use crate::recipe::{Axis, CutLine};
+
+/// Merge tolerance: crossings closer than this (µm) collapse.
+const EPS: f64 = 1e-9;
+
+/// Where an edge crosses the scan line, using the half-open rule
+/// (`lo <= pos < hi`) so vertices shared by two edges count once.
+fn edge_crossing(axis: Axis, pos: f64, a: geo::Coord<f64>, b: geo::Coord<f64>) -> Option<f64> {
+    // `across` is the coordinate the cut is fixed in; `along` is the
+    // coordinate we report. An Axis::X cut fixes y and reports x.
+    let (a_across, a_along, b_across, b_along) = match axis {
+        Axis::X => (a.y, a.x, b.y, b.x),
+        Axis::Y => (a.x, a.y, b.x, b.y),
+    };
+    let crosses = (a_across <= pos && pos < b_across) || (b_across <= pos && pos < a_across);
+    crosses.then(|| a_along + (pos - a_across) * (b_along - a_along) / (b_across - a_across))
+}
+
+/// Intervals of a single polygon (with holes) along the cut, via even-odd
+/// pairing of all ring crossings.
+fn polygon_intervals(polygon: &Polygon<f64>, cut: &CutLine) -> Vec<[f64; 2]> {
+    let mut crossings: Vec<f64> = Vec::new();
+    let rings = std::iter::once(polygon.exterior()).chain(polygon.interiors());
+    for ring in rings {
+        for line in ring.lines() {
+            if let Some(x) = edge_crossing(cut.axis, cut.position_um, line.start, line.end) {
+                crossings.push(x);
+            }
+        }
+    }
+    crossings.sort_by(f64::total_cmp);
+    crossings
+        .chunks_exact(2)
+        .filter(|pair| pair[1] - pair[0] > EPS)
+        .map(|pair| [pair[0], pair[1]])
+        .collect()
+}
+
+/// Union a set of intervals (sorted-merge).
+fn merge_intervals(mut intervals: Vec<[f64; 2]>) -> Vec<[f64; 2]> {
+    intervals.sort_by(|a, b| a[0].total_cmp(&b[0]));
+    let mut merged: Vec<[f64; 2]> = Vec::with_capacity(intervals.len());
+    for iv in intervals {
+        match merged.last_mut() {
+            Some(last) if iv[0] <= last[1] + EPS => last[1] = last[1].max(iv[1]),
+            _ => merged.push(iv),
+        }
+    }
+    merged
+}
+
+/// Intersect `footprint` with the cut line and return the surviving
+/// intervals along the cut, clipped to `cut.span`, sorted and disjoint.
+///
+/// Etched-away regions simply produce no interval — gaps in the returned
+/// list are gaps in the film.
+pub fn footprint_intervals(footprint: &MultiPolygon<f64>, cut: &CutLine) -> Vec<[f64; 2]> {
+    let (lo, hi) = (cut.span[0].min(cut.span[1]), cut.span[0].max(cut.span[1]));
+    let all: Vec<[f64; 2]> = footprint
+        .iter()
+        .flat_map(|p| polygon_intervals(p, cut))
+        .filter_map(|iv| {
+            let (a, b) = (iv[0].max(lo), iv[1].min(hi));
+            (b - a > EPS).then_some([a, b])
+        })
+        .collect();
+    merge_intervals(all)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{polygon, BooleanOps, MultiPolygon};
+
+    fn cut_x(position_um: f64, span: [f64; 2]) -> CutLine {
+        CutLine {
+            axis: Axis::X,
+            position_um,
+            span,
+        }
+    }
+
+    #[test]
+    fn square_crossing_the_cut_yields_exactly_its_interval() {
+        let square: MultiPolygon<f64> = MultiPolygon::new(vec![polygon![
+            (x: 2.0, y: 1.0),
+            (x: 7.0, y: 1.0),
+            (x: 7.0, y: 4.0),
+            (x: 2.0, y: 4.0),
+        ]]);
+        let intervals = footprint_intervals(&square, &cut_x(2.5, [0.0, 10.0]));
+        assert_eq!(intervals, vec![[2.0, 7.0]]);
+        // A cut that misses the square entirely yields nothing.
+        assert!(footprint_intervals(&square, &cut_x(5.0, [0.0, 10.0])).is_empty());
+        // The span clips the interval.
+        let clipped = footprint_intervals(&square, &cut_x(2.5, [3.0, 5.0]));
+        assert_eq!(clipped, vec![[3.0, 5.0]]);
+    }
+
+    #[test]
+    fn etch_subtraction_removes_the_interval() {
+        // Film across x = 0..10, etched (subtracted) over x = 4..6:
+        // the cut must report two intervals with a real gap.
+        let film: MultiPolygon<f64> = MultiPolygon::new(vec![polygon![
+            (x: 0.0, y: 0.0),
+            (x: 10.0, y: 0.0),
+            (x: 10.0, y: 2.0),
+            (x: 0.0, y: 2.0),
+        ]]);
+        let etched = film.difference(&MultiPolygon::new(vec![polygon![
+            (x: 4.0, y: -1.0),
+            (x: 6.0, y: -1.0),
+            (x: 6.0, y: 3.0),
+            (x: 4.0, y: 3.0),
+        ]]));
+        let intervals = footprint_intervals(&etched, &cut_x(1.0, [0.0, 10.0]));
+        assert_eq!(intervals.len(), 2);
+        assert!((intervals[0][0] - 0.0).abs() < 1e-9 && (intervals[0][1] - 4.0).abs() < 1e-9);
+        assert!((intervals[1][0] - 6.0).abs() < 1e-9 && (intervals[1][1] - 10.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn holes_produce_gaps() {
+        let with_hole: MultiPolygon<f64> = MultiPolygon::new(vec![Polygon::new(
+            polygon![
+                (x: 0.0, y: 0.0),
+                (x: 8.0, y: 0.0),
+                (x: 8.0, y: 8.0),
+                (x: 0.0, y: 8.0),
+            ]
+            .exterior()
+            .clone(),
+            vec![polygon![
+                (x: 3.0, y: 3.0),
+                (x: 5.0, y: 3.0),
+                (x: 5.0, y: 5.0),
+                (x: 3.0, y: 5.0),
+            ]
+            .exterior()
+            .clone()],
+        )]);
+        let intervals = footprint_intervals(&with_hole, &cut_x(4.0, [0.0, 8.0]));
+        assert_eq!(intervals, vec![[0.0, 3.0], [5.0, 8.0]]);
+    }
+
+    #[test]
+    fn vertical_cut_uses_y_axis() {
+        let square: MultiPolygon<f64> = MultiPolygon::new(vec![polygon![
+            (x: 1.0, y: 2.0),
+            (x: 3.0, y: 2.0),
+            (x: 3.0, y: 9.0),
+            (x: 1.0, y: 9.0),
+        ]]);
+        let cut = CutLine {
+            axis: Axis::Y,
+            position_um: 2.0,
+            span: [0.0, 10.0],
+        };
+        assert_eq!(footprint_intervals(&square, &cut), vec![[2.0, 9.0]]);
+    }
+
+    #[test]
+    fn overlapping_multipolygon_parts_merge() {
+        // Two disjoint parts and one adjacent — merged output is disjoint
+        // and sorted.
+        let mp = MultiPolygon::new(vec![
+            polygon![(x: 0.0, y: 0.0), (x: 2.0, y: 0.0), (x: 2.0, y: 2.0), (x: 0.0, y: 2.0)],
+            polygon![(x: 2.0, y: 0.0), (x: 4.0, y: 0.0), (x: 4.0, y: 2.0), (x: 2.0, y: 2.0)],
+            polygon![(x: 6.0, y: 0.0), (x: 7.0, y: 0.0), (x: 7.0, y: 2.0), (x: 6.0, y: 2.0)],
+        ]);
+        let intervals = footprint_intervals(&mp, &cut_x(1.0, [0.0, 10.0]));
+        assert_eq!(intervals, vec![[0.0, 4.0], [6.0, 7.0]]);
+    }
+}

--- a/crates/vcad-process/src/section.rs
+++ b/crates/vcad-process/src/section.rs
@@ -39,7 +39,9 @@ fn polygon_intervals(polygon: &Polygon<f64>, cut: &CutLine) -> Vec<[f64; 2]> {
     }
     crossings.sort_by(f64::total_cmp);
     crossings
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .filter(|pair| pair[1] - pair[0] > EPS)
         .map(|pair| [pair[0], pair[1]])
         .collect()

--- a/crates/vcad-process/src/sim.rs
+++ b/crates/vcad-process/src/sim.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use geo::{BooleanOps, MultiPolygon, Rect};
 
 use crate::error::{ProcessError, Result};
-use crate::recipe::{Polarity, ProcessStep, Recipe, SI_CONSUMED_PER_OXIDE};
+use crate::recipe::{Polarity, ProcessStep, Recipe, ResistTone, SI_CONSUMED_PER_OXIDE};
 
 /// Films thinner than this (µm) are dropped from the output.
 const MIN_THICKNESS_UM: f64 = 1e-9;
@@ -30,6 +30,33 @@ pub enum FilmKind {
     Grown,
     /// Doped region inset into the substrate ([`ProcessStep::Implant`]).
     Implant,
+    /// Spin-coated photoresist ([`ProcessStep::SpinResist`]).
+    Resist,
+}
+
+/// One recorded exposure shot on a resist film.
+#[derive(Debug, Clone)]
+pub struct Exposure {
+    /// GDS layer that patterned the shot.
+    pub mask_layer: i16,
+    /// Dose in mJ/cm². Recorded for bookkeeping only — dose-to-clear
+    /// thresholding is future work; exposure is binary for now.
+    pub dose_mj_cm2: f64,
+    /// Exposed plan-view pattern (mask polygons clipped to bounds), µm.
+    pub pattern: MultiPolygon<f64>,
+}
+
+/// Litho bookkeeping carried by resist films ([`FilmKind::Resist`]).
+#[derive(Debug, Clone)]
+pub struct ResistState {
+    /// Tone of the resist.
+    pub tone: ResistTone,
+    /// Exposures recorded so far, in order. [`ProcessStep::Develop`]
+    /// resolves their union.
+    pub exposures: Vec<Exposure>,
+    /// Whether the film has been developed (its footprint reflects the
+    /// exposure pattern).
+    pub developed: bool,
 }
 
 /// One surviving slab of material after running a recipe.
@@ -47,6 +74,9 @@ pub struct Film {
     pub z_top_um: f64,
     /// Plan-view extent of the film, in µm.
     pub footprint: MultiPolygon<f64>,
+    /// Litho state for resist films (`kind == FilmKind::Resist`);
+    /// `None` for everything else.
+    pub resist: Option<ResistState>,
 }
 
 impl Film {
@@ -61,6 +91,40 @@ pub type Masks = HashMap<i16, MultiPolygon<f64>>;
 
 fn bounds_polygon(bounds: Rect<f64>) -> MultiPolygon<f64> {
     MultiPolygon::new(vec![bounds.to_polygon()])
+}
+
+/// Etch `films[index]` down by `depth`: `keep` survives at full height,
+/// `removed` is where the etch bites. A depth reaching the film bottom
+/// clears the removed region entirely; a shallower etch leaves a
+/// recessed remnant there.
+fn etch_film(
+    films: &mut Vec<Film>,
+    index: usize,
+    keep: MultiPolygon<f64>,
+    removed: MultiPolygon<f64>,
+    depth: f64,
+) {
+    let film = &mut films[index];
+    let thickness = film.thickness_um();
+    if depth + MIN_THICKNESS_UM >= thickness {
+        // Etched through: the film only survives where kept.
+        film.footprint = keep;
+    } else {
+        // Partial etch: full-height film where kept, recessed remnant
+        // where etched.
+        let (name, material, kind) = (film.name.clone(), film.material.clone(), film.kind);
+        let (z_bottom, z_top) = (film.z_bottom_um, film.z_top_um - depth);
+        film.footprint = keep;
+        films.push(Film {
+            name: format!("{name}_recess"),
+            material,
+            kind,
+            z_bottom_um: z_bottom,
+            z_top_um: z_top,
+            footprint: removed,
+            resist: None,
+        });
+    }
 }
 
 fn positive(value: f64, what: &str) -> Result<f64> {
@@ -91,6 +155,7 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
         z_bottom_um: -recipe.substrate_thickness_um,
         z_top_um: 0.0,
         footprint: blanket.clone(),
+        resist: None,
     }];
     // Height of the (planar) top surface and index of the film forming it.
     let mut top_um = 0.0_f64;
@@ -117,6 +182,7 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
                     z_bottom_um: top_um,
                     z_top_um: top_um + t,
                     footprint: blanket.clone(),
+                    resist: None,
                 });
                 top_um += t;
                 surface = films.len() - 1;
@@ -137,6 +203,7 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
                     z_bottom_um: oxide_bottom,
                     z_top_um: oxide_bottom + t,
                     footprint: blanket.clone(),
+                    resist: None,
                 });
                 top_um = oxide_bottom + t;
                 surface = films.len() - 1;
@@ -148,35 +215,18 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
             } => {
                 let depth = positive(*depth_um, "etch depth")?;
                 let mask = mask(*mask_layer)?.intersection(&blanket);
-                let film = &mut films[surface];
-                let keep = match polarity {
-                    Polarity::KeepMasked => film.footprint.intersection(&mask),
-                    Polarity::RemoveMasked => film.footprint.difference(&mask),
+                let film = &films[surface];
+                let (keep, removed) = match polarity {
+                    Polarity::KeepMasked => (
+                        film.footprint.intersection(&mask),
+                        film.footprint.difference(&mask),
+                    ),
+                    Polarity::RemoveMasked => (
+                        film.footprint.difference(&mask),
+                        film.footprint.intersection(&mask),
+                    ),
                 };
-                let thickness = film.thickness_um();
-                if depth + MIN_THICKNESS_UM >= thickness {
-                    // Etched through: the film only survives where kept.
-                    film.footprint = keep;
-                } else {
-                    // Partial etch: full-height film where kept, recessed
-                    // remnant where etched.
-                    let removed = match polarity {
-                        Polarity::KeepMasked => film.footprint.difference(&mask),
-                        Polarity::RemoveMasked => film.footprint.intersection(&mask),
-                    };
-                    let (name, material, kind) =
-                        (film.name.clone(), film.material.clone(), film.kind);
-                    let (z_bottom, z_top) = (film.z_bottom_um, film.z_top_um - depth);
-                    film.footprint = keep;
-                    films.push(Film {
-                        name: format!("{name}_recess"),
-                        material,
-                        kind,
-                        z_bottom_um: z_bottom,
-                        z_top_um: z_top,
-                        footprint: removed,
-                    });
-                }
+                etch_film(&mut films, surface, keep, removed, depth);
                 // Planar approximation: `top_um` stays at the un-etched
                 // film top; the next deposit bridges over the etched gaps.
             }
@@ -195,6 +245,7 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
                     z_bottom_um: substrate_top - depth,
                     z_top_um: substrate_top,
                     footprint: mask,
+                    resist: None,
                 });
                 // Implants do not change the surface.
             }
@@ -211,6 +262,125 @@ pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec
                 // `surface` may now be a zero-thickness film; the next
                 // deposit lands on `top_um` either way, and etches of a
                 // fully clipped film are no-ops on an empty slab.
+            }
+            ProcessStep::SpinResist { thickness_um, tone } => {
+                let t = positive(*thickness_um, "resist thickness")?;
+                films.push(Film {
+                    name: format!("s{sn:02}_resist"),
+                    material: "resist".to_string(),
+                    kind: FilmKind::Resist,
+                    z_bottom_um: top_um,
+                    z_top_um: top_um + t,
+                    footprint: blanket.clone(),
+                    resist: Some(ResistState {
+                        tone: *tone,
+                        exposures: Vec::new(),
+                        developed: false,
+                    }),
+                });
+                top_um += t;
+                surface = films.len() - 1;
+            }
+            ProcessStep::Expose {
+                mask_layer,
+                dose_mj_cm2,
+            } => {
+                let dose = positive(*dose_mj_cm2, "exposure dose")?;
+                let pattern = mask(*mask_layer)?.intersection(&blanket);
+                let film = films
+                    .iter_mut()
+                    .rev()
+                    .find(|f| f.kind == FilmKind::Resist)
+                    .ok_or_else(|| {
+                        ProcessError::BadRecipe(
+                            "Expose requires a resist film; add a SpinResist step first".into(),
+                        )
+                    })?;
+                let state = film
+                    .resist
+                    .as_mut()
+                    .expect("resist films carry litho state");
+                state.exposures.push(Exposure {
+                    mask_layer: *mask_layer,
+                    dose_mj_cm2: dose,
+                    pattern,
+                });
+            }
+            ProcessStep::Develop => {
+                let film = films
+                    .iter_mut()
+                    .rev()
+                    .find(
+                        |f| matches!(&f.resist, Some(r) if !r.developed && !r.exposures.is_empty()),
+                    )
+                    .ok_or_else(|| {
+                        ProcessError::BadRecipe(
+                            "Develop requires an exposed, undeveloped resist film".into(),
+                        )
+                    })?;
+                let state = film.resist.as_mut().expect("matched a resist film");
+                let tone = state.tone;
+                let exposed = state
+                    .exposures
+                    .iter()
+                    .skip(1)
+                    .fold(state.exposures[0].pattern.clone(), |acc, e| {
+                        acc.union(&e.pattern)
+                    });
+                state.developed = true;
+                film.footprint = match tone {
+                    ResistTone::Positive => film.footprint.difference(&exposed),
+                    ResistTone::Negative => film.footprint.intersection(&exposed),
+                };
+                // Planar approximation: like PatternEtch, `top_um` stays
+                // at the resist top; the openings are gaps, not a new
+                // surface height.
+            }
+            ProcessStep::EtchThroughResist { depth_um } => {
+                let depth = positive(*depth_um, "etch depth")?;
+                let mut resists = films.iter().filter(|f| f.kind == FilmKind::Resist);
+                let Some(first) = resists.next() else {
+                    return Err(ProcessError::BadRecipe(
+                        "EtchThroughResist requires a resist film; \
+                         run SpinResist → Expose → Develop first"
+                            .into(),
+                    ));
+                };
+                // Everything under resist is protected; the union covers
+                // the (unusual) multi-resist case.
+                let protected =
+                    resists.fold(first.footprint.clone(), |acc, f| acc.union(&f.footprint));
+                // Target the film forming the surface under the resist:
+                // the topmost film that is neither resist nor an implant
+                // (implants live inside the substrate).
+                let target = films
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, f)| !matches!(f.kind, FilmKind::Resist | FilmKind::Implant))
+                    .max_by(|a, b| a.1.z_top_um.total_cmp(&b.1.z_top_um))
+                    .map(|(i, _)| i)
+                    .expect("the substrate always survives");
+                let film = &films[target];
+                let keep = film.footprint.intersection(&protected);
+                let removed = film.footprint.difference(&protected);
+                etch_film(&mut films, target, keep, removed, depth);
+                // Planar approximation as for PatternEtch: `top_um` is
+                // unchanged (and still includes the resist on top).
+            }
+            ProcessStep::Strip => {
+                films.retain(|f| f.kind != FilmKind::Resist);
+                // The surface reverts to the tallest remaining film
+                // (implants sit inside the substrate and never form the
+                // surface; ties go to the most recent film).
+                let (index, z_top) = films
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, f)| f.kind != FilmKind::Implant)
+                    .max_by(|a, b| a.1.z_top_um.total_cmp(&b.1.z_top_um))
+                    .map(|(i, f)| (i, f.z_top_um))
+                    .expect("the substrate always survives a strip");
+                surface = index;
+                top_um = z_top;
             }
         }
     }
@@ -420,5 +590,276 @@ mod tests {
             bounds(),
         );
         assert!(matches!(result, Err(ProcessError::UnknownMaskLayer(42))));
+    }
+
+    // --- photolithography ---
+
+    use crate::recipe::ResistTone;
+
+    /// Masks with the standard 4×4 test square on layer 1.
+    fn litho_masks() -> Masks {
+        let mut masks = Masks::new();
+        masks.insert(1, square_mask(2.0, 2.0, 6.0, 6.0));
+        masks
+    }
+
+    fn spin(tone: ResistTone) -> ProcessStep {
+        ProcessStep::SpinResist {
+            thickness_um: 1.0,
+            tone,
+        }
+    }
+
+    fn expose() -> ProcessStep {
+        ProcessStep::Expose {
+            mask_layer: 1,
+            dose_mj_cm2: 150.0,
+        }
+    }
+
+    #[test]
+    fn spin_resist_deposits_a_blanket_resist_film() {
+        let films = simulate(
+            &recipe(vec![spin(ResistTone::Positive)]),
+            &Masks::new(),
+            bounds(),
+        )
+        .unwrap();
+        assert_eq!(films.len(), 2);
+        let resist = &films[1];
+        assert_eq!(resist.kind, FilmKind::Resist);
+        assert_eq!(resist.material, "resist");
+        assert!((resist.z_bottom_um - 0.0).abs() < 1e-12);
+        assert!((resist.z_top_um - 1.0).abs() < 1e-12);
+        assert!((resist.footprint.unsigned_area() - 100.0).abs() < 1e-9);
+        let state = resist.resist.as_ref().unwrap();
+        assert_eq!(state.tone, ResistTone::Positive);
+        assert!(state.exposures.is_empty() && !state.developed);
+    }
+
+    #[test]
+    fn expose_records_pattern_and_dose_on_the_resist() {
+        let films = simulate(
+            &recipe(vec![spin(ResistTone::Positive), expose()]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        let state = films[1].resist.as_ref().unwrap();
+        assert_eq!(state.exposures.len(), 1);
+        let shot = &state.exposures[0];
+        assert_eq!(shot.mask_layer, 1);
+        assert!((shot.dose_mj_cm2 - 150.0).abs() < 1e-12);
+        assert!((shot.pattern.unsigned_area() - 16.0).abs() < 1e-9);
+        // Exposure alone does not change the footprint.
+        assert!((films[1].footprint.unsigned_area() - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn positive_develop_removes_exposed_regions() {
+        let films = simulate(
+            &recipe(vec![
+                spin(ResistTone::Positive),
+                expose(),
+                ProcessStep::Develop,
+            ]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        let resist = &films[1];
+        // 10×10 blanket minus the 4×4 exposed square.
+        assert!((resist.footprint.unsigned_area() - 84.0).abs() < 1e-9);
+        assert!(resist.resist.as_ref().unwrap().developed);
+    }
+
+    #[test]
+    fn negative_develop_keeps_only_exposed_regions() {
+        let films = simulate(
+            &recipe(vec![
+                spin(ResistTone::Negative),
+                expose(),
+                ProcessStep::Develop,
+            ]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        assert!((films[1].footprint.unsigned_area() - 16.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn litho_steps_out_of_order_error() {
+        // Expose with no resist on the wafer.
+        let result = simulate(&recipe(vec![expose()]), &litho_masks(), bounds());
+        assert!(matches!(result, Err(ProcessError::BadRecipe(_))));
+        // Develop with no exposed resist.
+        let result = simulate(
+            &recipe(vec![spin(ResistTone::Positive), ProcessStep::Develop]),
+            &litho_masks(),
+            bounds(),
+        );
+        assert!(matches!(result, Err(ProcessError::BadRecipe(_))));
+        // EtchThroughResist with no resist at all.
+        let result = simulate(
+            &recipe(vec![ProcessStep::EtchThroughResist { depth_um: 0.1 }]),
+            &litho_masks(),
+            bounds(),
+        );
+        assert!(matches!(result, Err(ProcessError::BadRecipe(_))));
+    }
+
+    #[test]
+    fn expose_missing_mask_layer_errors() {
+        let result = simulate(
+            &recipe(vec![
+                spin(ResistTone::Positive),
+                ProcessStep::Expose {
+                    mask_layer: 7,
+                    dose_mj_cm2: 100.0,
+                },
+            ]),
+            &litho_masks(),
+            bounds(),
+        );
+        assert!(matches!(result, Err(ProcessError::UnknownMaskLayer(7))));
+    }
+
+    #[test]
+    fn etch_through_resist_removes_only_where_resist_is_open() {
+        // Positive resist over blanket poly: develop opens the mask
+        // square, the etch bites only there.
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.2,
+                },
+                spin(ResistTone::Positive),
+                expose(),
+                ProcessStep::Develop,
+                ProcessStep::EtchThroughResist { depth_um: 0.2 },
+            ]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        let poly = films.iter().find(|f| f.material == "poly").unwrap();
+        assert!((poly.footprint.unsigned_area() - 84.0).abs() < 1e-9);
+        // The resist is still on the wafer until stripped.
+        assert!(films.iter().any(|f| f.kind == FilmKind::Resist));
+    }
+
+    #[test]
+    fn etch_through_resist_respects_depth() {
+        // A 0.1 µm etch into a 0.4 µm film leaves a recessed remnant in
+        // the open regions instead of clearing them.
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "sio2".into(),
+                    thickness_um: 0.4,
+                },
+                spin(ResistTone::Positive),
+                expose(),
+                ProcessStep::Develop,
+                ProcessStep::EtchThroughResist { depth_um: 0.1 },
+                ProcessStep::Strip,
+            ]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        let full = films.iter().find(|f| f.name == "s01_sio2").unwrap();
+        let recess = films.iter().find(|f| f.name.ends_with("_recess")).unwrap();
+        assert!((full.z_top_um - 0.4).abs() < 1e-12);
+        assert!((full.footprint.unsigned_area() - 84.0).abs() < 1e-9);
+        assert!((recess.z_top_um - 0.3).abs() < 1e-12);
+        assert!((recess.footprint.unsigned_area() - 16.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn strip_removes_resist_but_nothing_else() {
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.2,
+                },
+                spin(ResistTone::Positive),
+                expose(),
+                ProcessStep::Develop,
+                ProcessStep::Strip,
+                // The next deposit must land back on the poly top, not on
+                // the departed resist's top.
+                ProcessStep::Deposit {
+                    material: "aluminum".into(),
+                    thickness_um: 0.3,
+                },
+            ]),
+            &litho_masks(),
+            bounds(),
+        )
+        .unwrap();
+        assert!(films.iter().all(|f| f.kind != FilmKind::Resist));
+        assert!(films.iter().any(|f| f.material == "poly"));
+        let al = films.iter().find(|f| f.material == "aluminum").unwrap();
+        assert!((al.z_bottom_um - 0.2).abs() < 1e-12);
+        assert!((al.z_top_um - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn litho_sequence_matches_idealized_pattern_etch() {
+        // The whole point of the resist steps: spin → expose → develop →
+        // etch-through-resist → strip must land exactly where the
+        // one-step idealized PatternEtch lands, for both tones.
+        let masks = litho_masks();
+        for (tone, polarity) in [
+            (ResistTone::Negative, Polarity::KeepMasked),
+            (ResistTone::Positive, Polarity::RemoveMasked),
+        ] {
+            let litho = simulate(
+                &recipe(vec![
+                    ProcessStep::Deposit {
+                        material: "poly".into(),
+                        thickness_um: 0.2,
+                    },
+                    spin(tone),
+                    expose(),
+                    ProcessStep::Develop,
+                    ProcessStep::EtchThroughResist { depth_um: 0.2 },
+                    ProcessStep::Strip,
+                ]),
+                &masks,
+                bounds(),
+            )
+            .unwrap();
+            let ideal = simulate(
+                &recipe(vec![
+                    ProcessStep::Deposit {
+                        material: "poly".into(),
+                        thickness_um: 0.2,
+                    },
+                    ProcessStep::PatternEtch {
+                        mask_layer: 1,
+                        polarity,
+                        depth_um: 0.2,
+                    },
+                ]),
+                &masks,
+                bounds(),
+            )
+            .unwrap();
+            assert_eq!(litho.len(), ideal.len(), "film count differs ({tone:?})");
+            for (a, b) in litho.iter().zip(&ideal) {
+                assert_eq!(a.material, b.material);
+                assert_eq!(a.kind, b.kind);
+                assert!((a.z_bottom_um - b.z_bottom_um).abs() < 1e-12);
+                assert!((a.z_top_um - b.z_top_um).abs() < 1e-12);
+                let sym = a.footprint.difference(&b.footprint).unsigned_area()
+                    + b.footprint.difference(&a.footprint).unsigned_area();
+                assert!(sym < 1e-9, "{} footprint differs ({tone:?}): {sym}", a.name);
+            }
+        }
     }
 }

--- a/crates/vcad-process/src/sim.rs
+++ b/crates/vcad-process/src/sim.rs
@@ -1,0 +1,424 @@
+//! Planar film-stack simulator.
+//!
+//! Executes a [`Recipe`] against a set of 2D masks and produces the
+//! surviving [`Film`]s. Everything is planar (v0): each film lives at a
+//! fixed z range and the "current top surface" is a single scalar height,
+//! not a height field — deposits over a patterned film do not conform to
+//! the pattern. See the crate README for the full list of approximations.
+//!
+//! Units: µm in x/y/z. The substrate top is z = 0; the wafer body extends
+//! down to `-substrate_thickness_um`.
+
+use std::collections::HashMap;
+
+use geo::{BooleanOps, MultiPolygon, Rect};
+
+use crate::error::{ProcessError, Result};
+use crate::recipe::{Polarity, ProcessStep, Recipe, SI_CONSUMED_PER_OXIDE};
+
+/// Films thinner than this (µm) are dropped from the output.
+const MIN_THICKNESS_UM: f64 = 1e-9;
+
+/// How a film came to exist — drives labeling and rendering tweaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilmKind {
+    /// The wafer itself.
+    Substrate,
+    /// Blanket-deposited ([`ProcessStep::Deposit`]).
+    Deposited,
+    /// Thermally grown ([`ProcessStep::GrowOxide`]).
+    Grown,
+    /// Doped region inset into the substrate ([`ProcessStep::Implant`]).
+    Implant,
+}
+
+/// One surviving slab of material after running a recipe.
+#[derive(Debug, Clone)]
+pub struct Film {
+    /// Unique display label, e.g. `"s03_poly"`.
+    pub name: String,
+    /// Material name from the recipe (drives color).
+    pub material: String,
+    /// Provenance of the film.
+    pub kind: FilmKind,
+    /// Bottom of the film in µm (substrate top = 0).
+    pub z_bottom_um: f64,
+    /// Top of the film in µm.
+    pub z_top_um: f64,
+    /// Plan-view extent of the film, in µm.
+    pub footprint: MultiPolygon<f64>,
+}
+
+impl Film {
+    /// Film thickness in µm.
+    pub fn thickness_um(&self) -> f64 {
+        self.z_top_um - self.z_bottom_um
+    }
+}
+
+/// Masks for a recipe: GDS layer number → unioned plan-view polygons (µm).
+pub type Masks = HashMap<i16, MultiPolygon<f64>>;
+
+fn bounds_polygon(bounds: Rect<f64>) -> MultiPolygon<f64> {
+    MultiPolygon::new(vec![bounds.to_polygon()])
+}
+
+fn positive(value: f64, what: &str) -> Result<f64> {
+    if value.is_finite() && value > 0.0 {
+        Ok(value)
+    } else {
+        Err(ProcessError::BadRecipe(format!(
+            "{what} must be positive and finite, got {value}"
+        )))
+    }
+}
+
+/// Run `recipe` over `masks` within `bounds` and return the surviving
+/// films, bottom-up (substrate first).
+///
+/// `masks` must contain an entry for every GDS layer any step references
+/// (an empty [`MultiPolygon`] is fine — it means "no mask openings within
+/// bounds"); a missing entry is reported as
+/// [`ProcessError::UnknownMaskLayer`].
+pub fn simulate(recipe: &Recipe, masks: &Masks, bounds: Rect<f64>) -> Result<Vec<Film>> {
+    positive(recipe.substrate_thickness_um, "substrate thickness")?;
+    let blanket = bounds_polygon(bounds);
+
+    let mut films: Vec<Film> = vec![Film {
+        name: format!("s00_{}", recipe.substrate_material),
+        material: recipe.substrate_material.clone(),
+        kind: FilmKind::Substrate,
+        z_bottom_um: -recipe.substrate_thickness_um,
+        z_top_um: 0.0,
+        footprint: blanket.clone(),
+    }];
+    // Height of the (planar) top surface and index of the film forming it.
+    let mut top_um = 0.0_f64;
+    let mut surface = 0_usize;
+
+    let mask = |layer: i16| -> Result<&MultiPolygon<f64>> {
+        masks
+            .get(&layer)
+            .ok_or(ProcessError::UnknownMaskLayer(layer))
+    };
+
+    for (step_index, step) in recipe.steps.iter().enumerate() {
+        let sn = step_index + 1; // s00 is the substrate
+        match step {
+            ProcessStep::Deposit {
+                material,
+                thickness_um,
+            } => {
+                let t = positive(*thickness_um, "deposit thickness")?;
+                films.push(Film {
+                    name: format!("s{sn:02}_{material}"),
+                    material: material.clone(),
+                    kind: FilmKind::Deposited,
+                    z_bottom_um: top_um,
+                    z_top_um: top_um + t,
+                    footprint: blanket.clone(),
+                });
+                top_um += t;
+                surface = films.len() - 1;
+            }
+            ProcessStep::GrowOxide { thickness_um } => {
+                let t = positive(*thickness_um, "oxide thickness")?;
+                let consumed = SI_CONSUMED_PER_OXIDE * t;
+                let film = &mut films[surface];
+                let old_top = film.z_top_um;
+                // Consume the top of the surface film (clamped — growing
+                // more oxide than there is silicon just eats the film).
+                film.z_top_um = (old_top - consumed).max(film.z_bottom_um);
+                let oxide_bottom = film.z_top_um;
+                films.push(Film {
+                    name: format!("s{sn:02}_sio2"),
+                    material: "sio2".to_string(),
+                    kind: FilmKind::Grown,
+                    z_bottom_um: oxide_bottom,
+                    z_top_um: oxide_bottom + t,
+                    footprint: blanket.clone(),
+                });
+                top_um = oxide_bottom + t;
+                surface = films.len() - 1;
+            }
+            ProcessStep::PatternEtch {
+                mask_layer,
+                polarity,
+                depth_um,
+            } => {
+                let depth = positive(*depth_um, "etch depth")?;
+                let mask = mask(*mask_layer)?.intersection(&blanket);
+                let film = &mut films[surface];
+                let keep = match polarity {
+                    Polarity::KeepMasked => film.footprint.intersection(&mask),
+                    Polarity::RemoveMasked => film.footprint.difference(&mask),
+                };
+                let thickness = film.thickness_um();
+                if depth + MIN_THICKNESS_UM >= thickness {
+                    // Etched through: the film only survives where kept.
+                    film.footprint = keep;
+                } else {
+                    // Partial etch: full-height film where kept, recessed
+                    // remnant where etched.
+                    let removed = match polarity {
+                        Polarity::KeepMasked => film.footprint.difference(&mask),
+                        Polarity::RemoveMasked => film.footprint.intersection(&mask),
+                    };
+                    let (name, material, kind) =
+                        (film.name.clone(), film.material.clone(), film.kind);
+                    let (z_bottom, z_top) = (film.z_bottom_um, film.z_top_um - depth);
+                    film.footprint = keep;
+                    films.push(Film {
+                        name: format!("{name}_recess"),
+                        material,
+                        kind,
+                        z_bottom_um: z_bottom,
+                        z_top_um: z_top,
+                        footprint: removed,
+                    });
+                }
+                // Planar approximation: `top_um` stays at the un-etched
+                // film top; the next deposit bridges over the etched gaps.
+            }
+            ProcessStep::Implant {
+                mask_layer,
+                dopant,
+                depth_um,
+            } => {
+                let depth = positive(*depth_um, "implant depth")?;
+                let mask = mask(*mask_layer)?.intersection(&blanket);
+                let substrate_top = films[0].z_top_um;
+                films.push(Film {
+                    name: format!("s{sn:02}_{dopant}"),
+                    material: dopant.clone(),
+                    kind: FilmKind::Implant,
+                    z_bottom_um: substrate_top - depth,
+                    z_top_um: substrate_top,
+                    footprint: mask,
+                });
+                // Implants do not change the surface.
+            }
+            ProcessStep::Planarize { to_um } => {
+                if !to_um.is_finite() {
+                    return Err(ProcessError::BadRecipe(format!(
+                        "planarize height must be finite, got {to_um}"
+                    )));
+                }
+                for film in &mut films {
+                    film.z_top_um = film.z_top_um.min(*to_um);
+                }
+                top_um = top_um.min(*to_um);
+                // `surface` may now be a zero-thickness film; the next
+                // deposit lands on `top_um` either way, and etches of a
+                // fully clipped film are no-ops on an empty slab.
+            }
+        }
+    }
+
+    films.retain(|f| f.thickness_um() > MIN_THICKNESS_UM && !f.footprint.0.is_empty());
+    films.sort_by(|a, b| a.z_bottom_um.total_cmp(&b.z_bottom_um));
+    Ok(films)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::recipe::{Polarity, ProcessStep, Recipe};
+    use geo::{coord, polygon, Area};
+
+    fn bounds() -> Rect<f64> {
+        Rect::new(coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 10.0 })
+    }
+
+    fn square_mask(x0: f64, y0: f64, x1: f64, y1: f64) -> MultiPolygon<f64> {
+        MultiPolygon::new(vec![polygon![
+            (x: x0, y: y0),
+            (x: x1, y: y0),
+            (x: x1, y: y1),
+            (x: x0, y: y1),
+        ]])
+    }
+
+    fn recipe(steps: Vec<ProcessStep>) -> Recipe {
+        Recipe {
+            substrate_material: "silicon".into(),
+            substrate_thickness_um: 2.0,
+            steps,
+        }
+    }
+
+    #[test]
+    fn etch_removes_geometry() {
+        // Blanket film, then remove where the mask is: surviving area is
+        // bounds minus mask.
+        let mut masks = Masks::new();
+        masks.insert(1, square_mask(2.0, 2.0, 6.0, 6.0));
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.2,
+                },
+                ProcessStep::PatternEtch {
+                    mask_layer: 1,
+                    polarity: Polarity::RemoveMasked,
+                    depth_um: 0.2,
+                },
+            ]),
+            &masks,
+            bounds(),
+        )
+        .unwrap();
+        assert_eq!(films.len(), 2); // substrate + patterned poly
+        let poly = &films[1];
+        assert_eq!(poly.material, "poly");
+        // 10×10 field minus 4×4 mask hole.
+        assert!((poly.footprint.unsigned_area() - (100.0 - 16.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn keep_masked_inverts_the_etch() {
+        let mut masks = Masks::new();
+        masks.insert(1, square_mask(2.0, 2.0, 6.0, 6.0));
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "poly".into(),
+                    thickness_um: 0.2,
+                },
+                ProcessStep::PatternEtch {
+                    mask_layer: 1,
+                    polarity: Polarity::KeepMasked,
+                    depth_um: 0.2,
+                },
+            ]),
+            &masks,
+            bounds(),
+        )
+        .unwrap();
+        assert!((films[1].footprint.unsigned_area() - 16.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn partial_etch_leaves_a_recessed_film() {
+        let mut masks = Masks::new();
+        masks.insert(1, square_mask(0.0, 0.0, 5.0, 10.0));
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "sio2".into(),
+                    thickness_um: 0.4,
+                },
+                ProcessStep::PatternEtch {
+                    mask_layer: 1,
+                    polarity: Polarity::RemoveMasked,
+                    depth_um: 0.1,
+                },
+            ]),
+            &masks,
+            bounds(),
+        )
+        .unwrap();
+        // substrate + kept full film + recessed remnant.
+        assert_eq!(films.len(), 3);
+        let full = films.iter().find(|f| f.name == "s01_sio2").unwrap();
+        let recess = films.iter().find(|f| f.name.ends_with("_recess")).unwrap();
+        assert!((full.z_top_um - 0.4).abs() < 1e-12);
+        assert!((recess.z_top_um - 0.3).abs() < 1e-12);
+        assert!((recess.footprint.unsigned_area() - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn grow_oxide_consumes_silicon() {
+        let films = simulate(
+            &recipe(vec![ProcessStep::GrowOxide { thickness_um: 1.0 }]),
+            &Masks::new(),
+            bounds(),
+        )
+        .unwrap();
+        assert_eq!(films.len(), 2);
+        let substrate = &films[0];
+        let oxide = &films[1];
+        // 0.46 µm of Si consumed → substrate top drops to -0.46; oxide
+        // spans -0.46 .. +0.54 (total 1.0, 54% above the original surface).
+        assert!((substrate.z_top_um - (-0.46)).abs() < 1e-12);
+        assert!((oxide.z_bottom_um - (-0.46)).abs() < 1e-12);
+        assert!((oxide.z_top_um - 0.54).abs() < 1e-12);
+        assert_eq!(oxide.material, "sio2");
+    }
+
+    #[test]
+    fn planarize_clips_films() {
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "sio2".into(),
+                    thickness_um: 0.5,
+                },
+                ProcessStep::Deposit {
+                    material: "aluminum".into(),
+                    thickness_um: 0.4,
+                },
+                ProcessStep::Planarize { to_um: 0.7 },
+            ]),
+            &Masks::new(),
+            bounds(),
+        )
+        .unwrap();
+        let al = films.iter().find(|f| f.material == "aluminum").unwrap();
+        assert!((al.z_top_um - 0.7).abs() < 1e-12);
+        assert!((al.thickness_um() - 0.2).abs() < 1e-12);
+        // Planarizing below a film's bottom removes it entirely.
+        let films = simulate(
+            &recipe(vec![
+                ProcessStep::Deposit {
+                    material: "sio2".into(),
+                    thickness_um: 0.5,
+                },
+                ProcessStep::Deposit {
+                    material: "aluminum".into(),
+                    thickness_um: 0.4,
+                },
+                ProcessStep::Planarize { to_um: 0.5 },
+            ]),
+            &Masks::new(),
+            bounds(),
+        )
+        .unwrap();
+        assert!(films.iter().all(|f| f.material != "aluminum"));
+    }
+
+    #[test]
+    fn implant_insets_into_substrate() {
+        let mut masks = Masks::new();
+        masks.insert(65, square_mask(1.0, 1.0, 3.0, 3.0));
+        let films = simulate(
+            &recipe(vec![ProcessStep::Implant {
+                mask_layer: 65,
+                dopant: "ndiff".into(),
+                depth_um: 0.12,
+            }]),
+            &masks,
+            bounds(),
+        )
+        .unwrap();
+        let implant = films.iter().find(|f| f.kind == FilmKind::Implant).unwrap();
+        assert!((implant.z_bottom_um - (-0.12)).abs() < 1e-12);
+        assert!((implant.z_top_um - 0.0).abs() < 1e-12);
+        assert!((implant.footprint.unsigned_area() - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn missing_mask_layer_errors() {
+        let result = simulate(
+            &recipe(vec![ProcessStep::Implant {
+                mask_layer: 42,
+                dopant: "ndiff".into(),
+                depth_um: 0.1,
+            }]),
+            &Masks::new(),
+            bounds(),
+        );
+        assert!(matches!(result, Err(ProcessError::UnknownMaskLayer(42))));
+    }
+}


### PR DESCRIPTION
## What

New `vcad-process` crate: planar ("TCAD-lite") semiconductor process simulation — the digital twin of a fab, and M2 of the chip-design arc that produced vcad-gdsii (#387/#394).

- **Recipe as data** (serde): `Deposit`, `PatternEtch`, `GrowOxide` (0.46 Si-consumption rule), `Implant`, `Planarize` over a substrate.
- **Photolithography steps**: `SpinResist` (positive/negative tone), `Expose` (mask layer + dose), `Develop`, `EtchThroughResist`, `Strip` — with an equivalence test proving the full litho sequence reproduces the idealized `PatternEtch` film-by-film (both tones/polarities). Resist renders amber while present.
- **Mask engine** from `vcad-gdsii::flatten` + pure-Rust `geo` booleans, clipped to the region of interest before any boolean so full-die cuts stay cheap.
- **Outputs** as `vcad_ir::Document`: `simulate_3d` (windowed 3D film stack) and `cross_section` / `cross_section_scaled` (textbook cut with exact analytic interval extraction; etched-away intervals genuinely absent; optional vertical exaggeration).

Validated against a real librelane sky130 die (haiku_gen): the cross-section shows implant wells under field-oxide openings, poly, li1, met1/met2 with correct gaps.

## Testing

35 tests: interval extraction (holes → gaps, span clipping, Y cuts, merging), etch subtraction, GrowOxide consumption math, Planarize, implant inset, mask clipping/union, window crop, resist tone semantics, litho↔PatternEtch equivalence, z-scale emission, serde round-trips, bad-input rejection. Clippy `-D warnings` + fmt clean.

Known planar-v0 limitations documented in the README (scalar top surface — no conformal deposition, anisotropic etch only, box implants, blanket oxidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)