### PR TITLE
docs(plans): convergence strategy, domain atlas, and SCS closed-loop demo

### DIFF
--- a/docs/plans/2026-07-06-convergence-strategy.md
+++ b/docs/plans/2026-07-06-convergence-strategy.md
@@ -1,0 +1,180 @@
+# vcad — the loop is the product
+
+*Convergence audit and highest-leverage strategy. 2026-07-06.*
+
+## What the tree already says
+
+Nobody wrote this roadmap down, but the crate list did. Seven convergences,
+each with receipts in the repo:
+
+1. **MEMS / semiconductor devices** — `vcad-gdsii` + `vcad-process` (implant is
+   already a recipe step; that's TCAD, not photonics) + phyz + the
+   differentiable seam. Photonics and MEMS are siblings of the same layer-stack
+   substrate.
+2. **A robot factory, not a robot CAD** — `vcad-sim` (GPU batch), `batch_step`
+   MCP tools, `packages/training` with `modal/` and `lambda/` cloud-GPU dirs,
+   M11 gradients through contact dynamics. Design → train → deploy, morphology
+   and policy co-optimized.
+3. **Training a CAD model** — mecheval + leaderboard (frontier labs already
+   show up on it), `vcad-eval` as a canonical evaluator (an RL reward
+   function), a multimodal training-data pipeline with a self-grading oracle.
+4. **Designed materials** — atoms → homogenize → continuum → rollout, with
+   dJ/d(lattice constant) proven against finite differences. "Solve for the
+   material" joins "solve for the geometry."
+5. **Every machine that makes things gets a backend** — FDM slicer, CAM +
+   stock sim, sheet metal, wafers, three embroidery crates. One document, any
+   machine.
+6. **Agents that buy atoms** — quote/order/wallet, a shared cost model, DFM
+   packs per fab, `validate_for_fab` gates, an ACP-CM protocol draft.
+7. **vcad everywhere, agents as peers** — CRDT concurrent editing, the AI
+   contract in Rust, termview, spatial, wasmosis.
+
+The temptation is to rank these and pick a vertical. That's the wrong axis.
+
+## The leverage analysis
+
+Sort the assets by what *compounds* versus what merely *adds*:
+
+**Linear:** each new domain. Photonics, MEMS, embroidery — every one adds
+surface area, costs engineering, and alone competes as a niche tool against an
+entrenched incumbent (gdsfactory, Coventor, Wilcom). Domains are multipliers
+only if something else compounds them.
+
+**Compounding:**
+
+- **The single DAG.** Cross-domain value lives in the couplings, not the
+  domains — n domains, n² couplings. This is already the stated moat
+  ([cross-domain co-design](2026-06-23-cross-domain-codesign-vision.md)).
+- **Differentiability.** Gradients compose across domains (atoms → continuum →
+  rollout is proven). Every domain added makes intent-as-interface stronger.
+- **Verification.** Every domain feeds the same trust primitive — the Receipt.
+  Trust is what unlocks both commerce and training reward, so its value grows
+  superlinearly with domain count.
+- **The commerce rail.** Protocols compound by network effect. Whoever defines
+  how agents purchase fabrication takes a rate on the agent economy's physical
+  output.
+- **The data flywheel.** Every verified session, every eval run, every order
+  emits (design, spec, outcome) triples. Data moats outlive feature moats.
+
+These five stack into one loop:
+
+> **intent → design → proof → purchase → physical outcome → data → better
+> models → better designs.**
+
+The domains are not the product. **The loop is the product.** The highest
+leverage move is always the one that strengthens the loop, never the one that
+adds a domain for its own sake.
+
+## The point of view
+
+> A design isn't real because it renders. It's real because it ships with a
+> machine-checkable proof, survives a purchase order, and comes back from the
+> fab measuring what the proof said it would.
+
+## The highest-leverage bet: proof-carrying design
+
+Proof-carrying code (Necula, 1997) let untrusted code run because the code
+carried its own machine-checkable certificate. vcad's version: **a `.vcad`
+file travels with a machine-verifiable Receipt** — DRC clean under this fab
+pack, mass 41.3 g ± tolerance, resonance at 1550.0 nm, min-wall held, quote
+locked, every claim traceable to the oracle that checked it.
+
+This is the answer to the defining problem of the agent era: **slop**.
+Generative output becomes engineering exactly when it carries proof. The
+Receipt is:
+
+- what makes a fab accept an agent's purchase order,
+- what makes a human trust an agent's bracket,
+- what makes an eval a reward function,
+- the one primitive every current and future domain plugs into.
+
+The pieces exist but are siloed: `build_receipt`/`verify_receipt` (PCB),
+`verify_part` (mech), `validate_for_fab`, sheet-metal checks, DFM packs.
+The bet is to unify them: **one signed, versioned, fail-closed receipt schema
+across every domain**, with the `unverifiable ≠ clean` discipline the ecad
+stack already enforces.
+
+## The insight that makes it legendary: the order flow is the instrument
+
+Receipts today prove *simulated* properties. The legendary version closes
+sim2real — and the commerce rail is secretly the mechanism.
+
+Every agent-placed order returns a physical object that can be measured
+against its receipt. That makes each transaction a **paid experiment**: the
+customer funds the fabrication, the delivered part is ground truth, and the
+receipt-vs-caliper delta is calibration data for the kernel, the process
+models, and the trained models. Stripe never got physical feedback from a
+payment. vcad's take-rate transactions each return a measurable object.
+
+No lab can buy physical ground truth at this scale. The order flow collects
+it as a side effect of revenue. That's the flywheel's last gear, and nobody
+else is positioned to build it.
+
+## The three ownership moves (all open)
+
+Legendary infrastructure companies own a benchmark, a protocol, or an
+environment. vcad can own all three:
+
+1. **Own the benchmark** (the ImageNet move). mecheval → a multi-domain
+   physeval family (mech, pcb, photonics, materials). Frontier labs already
+   submit runs. When labs optimize against your benchmark, your representation
+   becomes the field's coordinate system.
+2. **Own the gym** (the Gym move). The verified environment — kernel + oracles
+   + render — is where models learn physical design. Publish it. Every lab
+   that trains in your world makes `.vcad` the native tongue of machine
+   engineering.
+3. **Own the protocol** (the Stripe move). ACP-CM becomes the rail agents use
+   to buy atoms, with the Receipt as its trust layer. Take rate on the
+   physical output of the agent economy.
+
+## The signature moment
+
+A prompt goes in: *"a mounting bracket for this board, under 50 g, ships this
+week."* No human opens a CAD window. The agent designs, the receipt certifies
+mass 41.3 g and min-bend legality, the order places against the receipt, the
+bracket arrives. On camera, a scale reads **41.3 g**. The caliper matches the
+drawing. The measurement posts back into the flywheel as ground truth.
+
+Then the second act: a specialist model, trained in the gym on flywheel data,
+tops the public leaderboard — above the frontier labs — at designing parts
+that survive this exact test. The loop, made visible.
+
+## Sequencing
+
+1. **Unify the Receipt.** One schema, signed, versioned, fail-closed, across
+   mech / pcb / sheet metal. Mostly consolidation of existing oracles; the
+   highest ratio of leverage to effort in the repo.
+2. **Close one physical loop publicly.** PCB (JLCPCB) or sheet metal
+   (SendCutSend) — both have APIs and the order tools exist. Publish the
+   receipt next to the caliper photo.
+3. **Generalize the eval.** mecheval patterns → per-domain leaderboards, each
+   graded by the same oracles that sign receipts.
+4. **Ship the flywheel.** Opt-in verified sessions → training data → specialist
+   model → beat frontier models on the public benchmark → publish everything.
+5. **Admit domains through the gate.** A new domain enters only if it plugs
+   into all five compounding layers: representable in the DAG, verifiable,
+   differentiable, purchasable, evaluable. Photonics passes all five and
+   should be next. Anything that passes fewer than four is a distraction,
+   however fun.
+
+## What kills it
+
+- **A wrong receipt.** A signed proof on top of a flaky boolean is worse than
+  no proof — it's a false instrument. Receipt integrity must stay fail-closed
+  (#343's `unverifiable ≠ clean` is the house rule; extend it everywhere), and
+  kernel robustness debt is receipt debt.
+- **Scope honesty.** A receipt proves manufacturability and simulated
+  properties — not fitness for purpose. Overclaiming is the liability that
+  ends the commerce rail. Say exactly what was checked, by which oracle, at
+  which version.
+- **Breadth without the gate.** Embroidery-style excursions that don't plug
+  into the loop burn the scarce resource — kernel-team attention.
+- **Losing the environment race.** Frontier labs will build in-house design
+  environments. The counter is to be open, be first, and be the benchmark
+  they report numbers on. A closed vcad loses this race; an open one referees
+  it.
+
+## One line
+
+**vcad is the compiler from intent to matter — and every build ships with its
+proof.**

--- a/docs/plans/2026-07-06-domain-atlas.md
+++ b/docs/plans/2026-07-06-domain-atlas.md
@@ -1,0 +1,197 @@
+# vcad domain atlas — now and future
+
+*Companion to [the convergence strategy](2026-07-06-convergence-strategy.md).
+Every domain, scored against the admission gate. 2026-07-06.*
+
+## How to read this
+
+**Domains vs. layers.** The Receipt, the gradients, the commerce rail, the
+eval, and the DAG are *layers* — they are not domains and never compete with
+one another. A domain is a kind of physical thing vcad can design. Layers
+compound; domains plug in.
+
+**The gate.** A domain is admitted when it plugs into all five layers:
+
+1. **Representable** — lives in the parametric DAG / IR
+2. **Verifiable** — has oracles that can sign receipt claims
+3. **Differentiable** — parameters priced through the seam
+4. **Purchasable** — a rail exists to make it real (vendor API, shuttle run,
+   or the user's own machine)
+5. **Evaluable** — mecheval-style tasks with a self-grading oracle
+
+Scores below: ✓ shipped/clearly reachable, ~ partial or manual, ✗ missing.
+
+---
+
+## Scorecard
+
+| domain | repr | verify | diff | purchase | eval | verdict |
+|---|---|---|---|---|---|---|
+| **Now** |
+| mechanical BRep | ✓ | ✓ | ✓ | ~ | ✓ | the substrate |
+| sheet metal | ✓ | ✓ | ✓ | ✓ SCS | ~ | first public loop |
+| electronics / PCB | ✓ | ✓ | ✓ | ~ (API denied) | ~ | deepest oracle stack |
+| 3D printing | ✓ | ~ | ✓ | ✓ (own Bambu) | ~ | private-loop volume |
+| CNC / CAM | ~ | ~ | ~ | ~ | ✗ | stocksim needs a consumer |
+| robotics / physics | ✓ | ✓ | ✓ | ~ | ~ | the wave-2 demo |
+| materials / atoms | ✓ | ✓ | ✓ | ✗ | ~ | longest horizon, real gradients |
+| wafer process + GDSII | ✓ | ~ | ~ | ~ | ✗ | substrate for photonics/MEMS/silicon |
+| electromagnetics | ~ | ~ | ✓ | ✓ (rides PCB) | ✗ | half-shipped, unnamed |
+| embroidery | ✓ | ~ | ✗ | ~ | ✗ | 2.5/5 — park it |
+| **Future** |
+| photonics (PIC) | ✓ | ✓ | ✓ | ✓ (ANT via SiEPIC) | ✓ | 5/5 — next admission |
+| MEMS | ✓ | ~ | ✓ | ✓ (MUMPs shuttles) | ✓ | photonics' sibling |
+| silicon / ASIC | ✓ | ✓ | ~ | ✓ (TinyTapeout/IHP) | ✓ | most legendary rail |
+| free-space optics | ~ | ✓ | ✓ | ~ (COTS + mounts) | ✓ | enters via optomech |
+| cable harness | ✓ | ✓ | ✓ | ~ | ✓ | the missing mechatronic glue |
+| injection molding | ✓ | ✓ | ✓ | ✓ (Protolabs-class) | ✓ | wave-3, capital-heavy |
+| textiles / soft goods | ~ | ~ | ~ | ~ | ✗ | embroidery's redemption arc |
+
+---
+
+## Now
+
+### Mechanical BRep (the substrate)
+Kernel, booleans, fillets, sketches/constraints, sweep/loft/shell, STEP,
+drafting/GD&T. Oracles: mass properties, mecheval grading, DFM. Gradients:
+the differentiable seam, complete M0–M11. Commerce: no direct CNC rail yet
+(quotes exist, ordering is manual). **Gap:** kernel robustness debt *is*
+receipt debt — boolean edge cases are now trust bugs, not just geometry bugs.
+
+### Sheet metal
+Flanges/bends/unfold, SCS shop profiles, cost model, nesting, sequencing,
+DXF + folded STEP. The chosen first public loop
+([demo spec](2026-07-06-scs-closed-loop-demo.md)). **Gap:** a sheet-metal
+mecheval task family.
+
+### Electronics / PCB
+The deepest oracle stack in the repo: DRC/ERC (fail-closed), DFM fab packs,
+impedance/SI/thermal/PDN, autorouter with negotiated congestion, Gerber +
+native KiCad export, the Receipt already exists here. **Purchase rail
+regression:** JLCPCB denied the API application. Options: PCBWay's API,
+Aisler, Seeed Fusion — or keep PCB ordering human-in-the-loop and let sheet
+metal carry the public loop. **Gap:** pick the replacement rail; pcbeval.
+
+### 3D printing
+Slicer + Bambu G-code. The only domain where the loop closes with **zero
+vendor dependency** — the user's printer is the effector. Cheapest physical
+ground truth per datum; this is the *volume* calibration loop while SCS is
+the *public* one. **Gap:** print-then-measure receipt flow; dimensional
+accuracy oracles per printer profile.
+
+### CNC / CAM
+Toolpaths exist, stocksim exists (octree SDF, marching cubes) with **no
+consumer** — the canonical gate violation from before the gate existed.
+Admit properly or leave parked: wire stocksim as the toolpath verification
+oracle (receipt claim: "stock minus toolpath ⊆ target + tolerance"), then a
+rail (Xometry-class API or SCS CNC).
+
+### Robotics / physics
+phyz, gym tools, GPU batch envs, URDF, cloud training dirs, contact-dynamics
+gradients. Verification is unusual: the receipt claim is *behavioral* ("this
+policy achieves the grasp in sim"). Purchase: parts are COTS + the other
+domains' rails — a robot is a cross-domain assembly, which is the point.
+**This is the wave-2 signature demo** (gripper: trained before its body
+existed).
+
+### Materials / atoms
+MD, ML potentials, homogenize → MaterialCard → continuum, cross-scale
+gradients proven. Purchase rail: none — you cannot order a lattice constant.
+Nearest real rail: **printed lattices/metamaterials** (homogenize a printed
+unit cell instead of a crystal, then the 3DP rail makes it). That converts
+this domain from "research demo" to "orderable material."
+
+### Wafer process + GDSII
+`vcad-process` (deposit/etch/grow/implant/litho) + `vcad-gdsii`
+(read/write/flatten/IR bridge). Not a user-facing domain — the **shared
+substrate** for photonics, MEMS, and silicon. Its oracles (cross-sections,
+film stacks) become receipt claims in all three.
+
+### Electromagnetics (half-shipped, unnamed)
+Already in the tree without a name: coils, motor windings, winding-factor
+math, impedance, RF calculators, diff-pair routing. Naming it a domain turns
+scattered tools into a receipt family (inductance, torque constant, Z₀).
+Future: antennas, filter synthesis, eventually a field solver. Rides the PCB
+rail — coils are copper.
+
+### Embroidery
+Three crates, machine formats (.dst/.pes). Scores 2.5/5: no gradients, no
+eval, no scaled rail (home machines only). **Park it** — it re-enters later
+as the output device of the textiles domain, not as its own domain.
+
+---
+
+## Future (in admission order)
+
+### Photonics — next
+Full case in the convergence discussion: `vcad-pic-pdk` / components /
+layout / sim / verify, S-matrix spectra through tang-expr, GDS via
+`vcad-gdsii`, 3D truth via `vcad-process`. Purchase rail is real: SiEPIC
+EBeam PDK → Applied Nanotools fab runs. Eval: "design a ring filter at
+1550 nm" self-grades from the simulated spectrum. 5/5.
+
+### MEMS
+Same substrate as photonics + one recipe step (release etch) + phyz for
+resonator/accelerometer behavior (needs modal analysis — a small eigenproblem,
+tang-la, same machinery as the glockenspiel stretch goal). Purchase rail:
+MEMSCAP MUMPs-class multi-user shuttles (manual ordering, real). Eval:
+"resonator at 32.768 kHz" — self-grading, brutal, wonderful.
+
+### Silicon / ASIC
+GDSII ✓, open-PDK DRC decks are importable rules, and the rail is the most
+legendary one available: **TinyTapeout on IHP shuttles, ~hundreds of dollars,
+agent-budget-sized**. "An agent taped out working silicon and the receipt
+predicted its behavior" is a milestone no one else is positioned to claim.
+Slow cadence (months per shuttle) — start one early so it's in flight while
+faster loops iterate.
+
+### Free-space optics + optomech
+Enters through the **parts engine**, not the physics: agents design mounts,
+cage plates, and baffles (SCS + 3DP rails, shipped) around COTS optics from a
+catalog. Then `vcad-kernel-raytrace` grows refraction + conic/asphere
+surfaces and the receipt gains spot size / focal length claims. Lens design
+was historically *the* gradient-optimization field — the seam will feel at
+home.
+
+### Cable harness
+The missing glue in every mechatronic assembly and the n² coupling story
+made literal: connects PCB (pinouts), enclosure (routing space), and
+assembly (lengths through the kinematic envelope). Oracles: continuity,
+gauge-vs-current (`size_trace_for_current` generalizes), bend radius, length
+through the moving mechanism. Rail: custom-harness vendors are semi-manual
+today — start with the receipt, let the rail mature.
+
+### Injection molding
+DFM pack pattern fits perfectly (draft angles, wall thickness, undercuts,
+sink); Protolabs-class APIs exist; wall thickness is a differentiable
+parameter. Wave 3 because tooling cost raises the stakes on receipt
+correctness — a wrong receipt on a $79 SCS order is a lesson; on a $8k mold
+it's a lawsuit.
+
+### Textiles / soft goods
+Sewing patterns are flat-pattern unfold on developable surfaces — shared math
+with `vcad-kernel-sheet`. Embroidery becomes the decoration pass. Speculative;
+gate honestly before admitting.
+
+---
+
+## Waves
+
+- **Wave 1 (now):** unify the Receipt; SCS public loop
+  (glockenspiel); 3DP private calibration loop; name the EM domain; wire
+  stocksim or park it.
+- **Wave 2:** photonics admission (full crate family); gripper demo
+  (robotics × sheet metal × training); harness receipts; pcbeval +
+  sheet-metal eval families; pick the PCB rail replacement.
+- **Wave 3:** MEMS; silicon tapeout (start the shuttle clock early);
+  optomech wedge into free-space optics; injection molding.
+- **Declined (examples to keep the gate honest):** architecture/AEC (rail
+  and eval both fail), garment fashion at scale (no oracle for "fits"),
+  food/bio (no substrate). Fun is not a gate criterion.
+
+## The rule, restated
+
+New domains enter through the gate, in whatever order the rails and demos
+make them ready — but **no domain enters ahead of the loop**. If a quarter's
+work strengthens a domain but not the Receipt, the flywheel, or a rail, it's
+the wrong quarter.

--- a/docs/plans/2026-07-06-scs-closed-loop-demo.md
+++ b/docs/plans/2026-07-06-scs-closed-loop-demo.md
@@ -1,0 +1,103 @@
+# The receipt you can hear — SCS closed-loop demo
+
+*First public prompt-to-part loop, per
+[the convergence strategy](2026-07-06-convergence-strategy.md) sequencing
+step 2. Vendor: SendCutSend (JLCPCB denied the API application; SCS export,
+shop profiles, and cost model are already in `vcad-kernel-sheet`). 2026-07-06.*
+
+## The pick: a laser-cut glockenspiel
+
+An eight-bar aluminum glockenspiel (C6–C7 major scale) on a folded
+sheet-metal stand, one SCS order. Every dimension is physics:
+
+- **Bar lengths** are solved from the target pitches — a free-free bar's
+  fundamental is closed-form, and `materials.rs` already carries the E and ρ
+  the formula needs.
+- **Mounting holes** sit exactly on the nodal lines of the fundamental mode
+  (0.2242 · L from each end) — the hole *positions* are a receipt claim.
+- **The frame** is a folded U-channel: bends, reliefs, unfold, DFM — the parts
+  of `vcad-kernel-sheet` a flat part wouldn't exercise.
+
+Why this beats a bracket: the receipt is **audible**. A phone spectrogram is a
+precision instrument anyone owns, pitch error in cents is objective and
+brutal, and "we compiled a C major scale into metal" needs no engineering
+literacy to land. Vibraphone bars are aluminum in real life — this is not a
+toy approximation.
+
+## The physics (all closed-form, all differentiable)
+
+Free-free transverse vibration of a rectangular bar:
+
+```
+f₁ = (4.730)² / (2π L²) · sqrt(E I / ρ A)   with I/A = t²/12
+   = 3.5608 · (t / L²) · sqrt(E / 12ρ)
+```
+
+For 6061 (E = 69 GPa, ρ = 2700 kg/m³ — values from
+`vcad-kernel-sheet/src/materials.rs`) at t = 3.175 mm (0.125″):
+f₁ ≈ 16.50 / L² (L in meters). Solving for the scale:
+
+| note | target Hz | bar length | nodal holes at |
+|------|-----------|-----------|----------------|
+| C6   | 1046.5    | 125.6 mm  | 28.2 mm from ends |
+| D6   | 1174.7    | 118.5 mm  | 26.6 mm |
+| E6   | 1318.5    | 111.9 mm  | 25.1 mm |
+| F6   | 1396.9    | 108.7 mm  | 24.4 mm |
+| G6   | 1568.0    | 102.6 mm  | 23.0 mm |
+| A6   | 1760.0    | 96.8 mm   | 21.7 mm |
+| B6   | 1975.5    | 91.4 mm   | 20.5 mm |
+| C7   | 2093.0    | 88.8 mm   | 19.9 mm |
+
+Bar width 25 mm (width doesn't move f₁ to first order — it cancels in I/A).
+Bars suspended on cord through the nodal holes; frame powder-coated, bars raw
+(coatings damp the ring).
+
+## The receipt
+
+| claim | oracle | instrument |
+|-------|--------|-----------|
+| f₁ per bar (Hz) | analytic beam model + materials.rs | phone FFT, error in cents |
+| total mass (g) | inspect_cad mass properties | kitchen scale |
+| bar lengths, hole positions | drawing dims | caliper |
+| frame bend angles 90° | bend model + springback | protractor |
+| DFM legal for SCS | sheet_metal_check, shop profile | the order is accepted |
+| cost estimate | sheet_metal_cost | the actual invoice |
+
+## The calibration act (the part that makes it strategy, not content)
+
+Predicted f₁ will be off by a few percent — E and ρ have alloy tolerance, and
+±0.1 mm on a 3.175 mm sheet is ±3 % on pitch, directly. **That error is the
+demo.** On camera:
+
+1. Predict from nominal dims → measure → show the delta (likely 20–60 cents).
+2. Caliper the *as-built* thickness, re-run the receipt with measured t.
+3. Residual collapses. The gap between step 1 and 3 is sim2real calibration
+   happening in public — the "order flow is the instrument" thesis, performed.
+
+## Pipeline exercised
+
+`create_cad_loon` (bars + frame) → `sheet_metal_check` (SCS profile) →
+`sheet_metal_unfold` → DXF export → `sheet_metal_cost` →
+`quote_manufacturing` → `place_order` (human-authorized per the wallet
+model) → wait for the box → measure → publish receipt vs. reality.
+
+## Stretch goal — where gradients earn their keep
+
+Bar lengths are closed-form; no gradient needed (say so honestly). But a
+free-free bar's second partial sits at a non-harmonic 2.76 · f₁. Real
+vibraphone bars are *undercut* to retune it to 4 · f₁. We can't vary
+thickness (2D cutting), but **in-plane width profiling** w(x) changes the
+variable-coefficient beam equation — EI(x) and ρA(x) no longer cancel — so
+the overtone ratio is tunable. No closed form exists; a 1-D FEM beam
+eigenproblem (tang-la) priced through the differentiable seam solves it.
+Gradient-tuned harmonic bars, cut flat: that's the flex for act two.
+
+## Runners-up (kept for later waves)
+
+- **Servo gripper** (cross-domain: sheet metal + kinematics + phyz + gym) —
+  "the robot was trained before its body existed." Wave-2 material; needs
+  assembly, a servo, and the training story told well.
+- **Balance sculpture** — center-of-mass receipt, balances only if the kernel
+  is right. Minimal fallback; single number, less wow.
+- **F405 enclosure** — practical, ties to `check_enclosure_fit` and the
+  existing example, but visually a box.


### PR DESCRIPTION
## What

Three strategy docs in `docs/plans/` capturing where the crate tree has been quietly converging, and the highest-leverage strategy that falls out of it.

- **[convergence-strategy](../blob/claude/inspiring-cannon-12f348/docs/plans/2026-07-06-convergence-strategy.md)** — the seven convergences already visible in the tree; the leverage analysis (domains are linear, the loop compounds); **proof-carrying design** as the single highest-leverage bet (one signed, fail-closed Receipt schema across every domain); the order flow as a sim2real instrument (every purchase returns physical ground truth); the three ownership moves — benchmark (mecheval → physeval), gym (publish the verified environment), protocol (ACP-CM).
- **[domain-atlas](../blob/claude/inspiring-cannon-12f348/docs/plans/2026-07-06-domain-atlas.md)** — 10 current + 7 future domains scored against a five-gate admission test (representable / verifiable / differentiable / purchasable / evaluable), with wave sequencing and a declined list to keep the gate honest.
- **[scs-closed-loop-demo](../blob/claude/inspiring-cannon-12f348/docs/plans/2026-07-06-scs-closed-loop-demo.md)** — the first public prompt-to-part loop via SendCutSend: an eight-bar aluminum glockenspiel whose receipt is audible. Bar lengths solved closed-form from target pitches using E/ρ already in `vcad-kernel-sheet/src/materials.rs`; mounting holes on the fundamental's nodal lines; verification by phone FFT; the as-built thickness recalibration as the on-camera sim2real act.

## Why

Sequencing context for future work: new domains (photonics next) enter through the gate, and no domain enters ahead of the loop. Wave-1 items (receipt unification, glockenspiel build, 3DP calibration loop, naming the EM domain, stocksim wiring) are being spun off as separate tasks.

Docs only — no code changes, no changelog entry per the changelog policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)