### PR TITLE
Use NUL byte separator in net-pair keys for robustness

### DIFF
--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -3758,7 +3758,7 @@ function parsePadClearance(
 
 /** Sorted, NUL-joined net-pair key so (A,B) and (B,A) collapse. */
 function netPairKey(a: string, b: string): string {
-  return a <= b ? `${a} ${b}` : `${b} ${a}`;
+  return a <= b ? `${a}\x00${b}` : `${b}\x00${a}`;
 }
 
 /** Run the lightweight pre-routing DRC subset against a freshly-placed board.
@@ -3811,7 +3811,7 @@ export async function summarizePlacementDrc(pcb: Pcb): Promise<PlacementDrc> {
   }
 
   const shorts: PlacementShort[] = [...shortPairs].map((key) => {
-    const [a, b] = key.split(" ") as [string, string];
+    const [a, b] = key.split("\x00") as [string, string];
     const refs = new Set<string>();
     for (const p of padPairs) {
       if (netPairKey(p.parsed.nets[0], p.parsed.nets[1]) === key) {


### PR DESCRIPTION
## Summary

Replace space-based separator with NUL byte (`\x00`) in net-pair key generation and parsing to prevent collisions when net names contain spaces.

## Changes

- **`netPairKey()` function**: Changed separator from space (`" "`) to NUL byte (`"\x00"`) when constructing sorted net-pair keys
- **`summarizePlacementDrc()` function**: Updated corresponding `split()` call to parse keys using NUL byte separator instead of space

## Details

The net-pair key function creates a canonical representation of net pairs (e.g., for short detection in placement DRC) by sorting the two net names and joining them with a separator. Using a space as separator could cause false collisions if net names themselves contain spaces—for example, nets named `"A B"` and `"C"` would produce the same key as nets `"A"` and `"B C"`.

Using NUL byte (`\x00`) as separator is more robust since it's an invalid character in net names and cannot appear in the input, guaranteeing unique key generation.

https://claude.ai/code/session_01YA5jekdT7TJkikGsaHp2Nr