### PR TITLE
fix(mcp): durable save_document + export_gerber blocked-verdict + error_kind telemetry

### DIFF
--- a/changelog/entries/2026-07-07-export-gerber-blocked-verdict.json
+++ b/changelog/entries/2026-07-07-export-gerber-blocked-verdict.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-export-gerber-blocked-verdict",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "export_gerber DRC block reports as a verdict, not an error",
+  "summary": "When the clean-DRC gate blocks a dirty board, export_gerber now returns the structured blocked verdict (reason, DRC summary, escape hatches) as a normal result instead of a tool error, matching validate_for_fab.",
+  "features": ["mcp", "pcb", "gerber", "drc"],
+  "mcpTools": ["export_gerber"]
+}

--- a/changelog/entries/2026-07-07-save-document-durable.json
+++ b/changelog/entries/2026-07-07-save-document-durable.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-save-document-durable",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "save_document works on the hosted MCP server",
+  "summary": "save_document/load_document now persist durably on mcp.vcad.io: signed-in saves land in your vcad.io account under the given name; anonymous saves return a private reopen key. Previously every hosted save failed.",
+  "features": ["mcp", "sessions", "durability"],
+  "mcpTools": ["save_document", "load_document"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -1325,7 +1325,11 @@ describe("ecad session flow", () => {
     // Deliberately NOT routed → MID's two pads sit in disjoint copper groups,
     // so DRC reports an UnconnectedNet error and the board is not fab-clean.
 
-    const blocked = out(await exportGerber({ document_id: id })); // require_clean_drc defaults true
+    const blockedResult = await exportGerber({ document_id: id }); // require_clean_drc defaults true
+    // The gate tripping is a verdict, not a tool failure — isError would make
+    // clients and telemetry read a working guard as a crash.
+    expect((blockedResult as { isError?: boolean }).isError).toBeUndefined();
+    const blocked = out(blockedResult);
     expect(blocked.success).toBe(false);
     expect(blocked.blocked).toBe(true);
     expect(blocked.drc.errors).toBeGreaterThan(0);

--- a/packages/mcp/src/__tests__/save-load-durable.test.ts
+++ b/packages/mcp/src/__tests__/save-load-durable.test.ts
@@ -1,0 +1,268 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Document } from "@vcad/ir";
+import { createServer } from "../server.js";
+import {
+  AnonSupabaseSessionStore,
+  setSessionFetch,
+} from "../session-store.js";
+import { documents, saveDocument, loadDocument, openDocument } from "../tools/session.js";
+
+/**
+ * Durable save_document / load_document — the hosted-deploy path.
+ *
+ * WHY: in production save_document wrote to the serverless filesystem, which
+ * is read-only — it failed on 100% of calls (4/4 in telemetry, across four
+ * builds). These tests drive the fixed behavior through the real CallTool
+ * handler with a fake PostgREST backend, exactly like checkpoint.test.ts:
+ * a signed-in save is a durable, name-keyed row in the caller's own documents
+ * table and survives a simulated redeploy; an anonymous save is keyed by an
+ * unguessable id (a name would be guessable across capability-keyed tenants).
+ */
+
+/** PostgREST stand-in serving both the user-owned `documents` table and the
+ *  anonymous `mcp_sessions` table. `rows` is the durable backend — it
+ *  survives a "redeploy" (cleared `documents` cache + fresh server). */
+function installFake() {
+  const rows = new Map<string, Record<string, unknown>>();
+  const eq = (sp: URLSearchParams, k: string): string | null => {
+    const v = sp.get(k);
+    return v && v.startsWith("eq.") ? v.slice(3) : null;
+  };
+  const keyOf = (url: URL): string =>
+    url.pathname.endsWith("/mcp_sessions")
+      ? `anon|${eq(url.searchParams, "document_id")}`
+      : `${eq(url.searchParams, "user_id")}|${eq(url.searchParams, "local_id")}`;
+  setSessionFetch((async (input: unknown, init: RequestInit = {}) => {
+    const url = new URL(String(input));
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && url.pathname.endsWith("/rpc/append_session_event")) {
+      return new Response(JSON.stringify({ ok: true, id: 1, seq: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (method === "POST") {
+      const body = JSON.parse(String(init.body)) as Array<
+        Record<string, unknown>
+      >;
+      for (const r of body) {
+        rows.set(
+          url.pathname.endsWith("/mcp_sessions")
+            ? `anon|${r.document_id}`
+            : `${r.user_id}|${r.local_id}`,
+          r,
+        );
+      }
+      return new Response(null, { status: 201 });
+    }
+    if (method === "GET") {
+      const row = rows.get(keyOf(url));
+      if (!row) return new Response("", { status: 406 });
+      return new Response(JSON.stringify({ content: row.content }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(null, { status: 204 });
+  }) as unknown as typeof fetch);
+  return { rows };
+}
+
+async function connect(
+  engine: Engine,
+  user: { sub: string; email: string } | null,
+) {
+  const server = await createServer(engine, { user });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function parse(result: unknown): Record<string, unknown> {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+function makeCubeDoc(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "test_cube",
+        op: { type: "Cube", size: { x: 10, y: 10, z: 10 } },
+      },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [{ root: 1, material: "default" }],
+  };
+}
+
+const USER = { sub: "user-save", email: "s@x.test" };
+
+describe("durable save_document / load_document (hosted deploy)", () => {
+  let engine: Engine;
+  let prevUrl: string | undefined;
+  let prevKey: string | undefined;
+
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  beforeEach(() => {
+    prevUrl = process.env.SUPABASE_URL;
+    prevKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    documents.clear();
+  });
+
+  afterEach(() => {
+    if (prevUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = prevUrl;
+    if (prevKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = prevKey;
+    setSessionFetch(((...a: Parameters<typeof fetch>) =>
+      fetch(...a)) as typeof fetch);
+  });
+
+  it("signed-in save is durable, name-keyed, and survives a redeploy", async () => {
+    const fake = installFake();
+
+    // Instance A: open a doc and save it by a human name.
+    const a = await connect(engine, USER);
+    const documentId = parse(
+      await a.client.callTool({
+        name: "open_document",
+        arguments: { initial: makeCubeDoc() },
+      }),
+    ).document_id as string;
+
+    const saved = parse(
+      await a.client.callTool({
+        name: "save_document",
+        arguments: { document_id: documentId, name: "My Part" },
+      }),
+    );
+    expect(saved.saved).toBe(true);
+    // Name normalizes to the deterministic slug used as the reopen handle.
+    expect(saved.name).toBe("my-part");
+    // No filesystem path in the durable result — the old fs write is exactly
+    // what failed on the read-only serverless filesystem.
+    expect(saved.path).toBeUndefined();
+    // The row landed in the CALLER's documents table under the saved: key.
+    expect(fake.rows.has(`${USER.sub}|mcp:saved:my-part`)).toBe(true);
+    await a.client.close();
+    await a.server.close();
+
+    // ── Redeploy: wipe warm caches, boot a fresh instance B on the same
+    // durable backend.
+    documents.clear();
+    const b = await connect(engine, USER);
+
+    // Load by either the original name or the slug — both normalize the same.
+    const loaded = parse(
+      await b.client.callTool({
+        name: "load_document",
+        arguments: { name: "My Part" },
+      }),
+    );
+    expect(loaded.document_id).toMatch(/^doc_/);
+    expect(loaded.parts).toBe(1);
+
+    const got = parse(
+      await b.client.callTool({
+        name: "get_document",
+        arguments: { document_id: loaded.document_id },
+      }),
+    );
+    expect(Object.keys(got.nodes as Record<string, unknown>)).toContain("1");
+
+    await b.client.close();
+    await b.server.close();
+  });
+
+  it("rejects an unusable save name instead of writing junk", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+    const documentId = parse(
+      await client.callTool({
+        name: "open_document",
+        arguments: { initial: makeCubeDoc() },
+      }),
+    ).document_id as string;
+
+    const res = (await client.callTool({
+      name: "save_document",
+      arguments: { document_id: documentId, name: "///" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/Invalid save name/);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("errors clearly when a named save doesn't exist", async () => {
+    installFake();
+    const { client, server } = await connect(engine, USER);
+    const res = (await client.callTool({
+      name: "load_document",
+      arguments: { name: "never-saved" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toMatch(/No saved document named "never-saved"/);
+    await client.close();
+    await server.close();
+  });
+
+  it("anonymous save mints an unguessable key, not a name-derived row", async () => {
+    const fake = installFake();
+    const store = new AnonSupabaseSessionStore({
+      supabaseUrl: "https://supa.test",
+      serviceRoleKey: "svc",
+    });
+
+    const open = openDocument({ initial: makeCubeDoc() });
+    const documentId = JSON.parse(open.content[0].text).document_id as string;
+
+    const saved = JSON.parse(
+      (await saveDocument({ document_id: documentId, name: "board" }, store))
+        .content[0].text,
+    ) as { saved: boolean; name: string };
+    expect(saved.saved).toBe(true);
+    // The reopen handle is saved_<slug>_<random> — never the bare name, which
+    // would be guessable across capability-keyed tenants.
+    expect(saved.name).toMatch(/^saved_board_[A-Za-z0-9_-]+$/);
+    expect(fake.rows.has(`anon|${saved.name}`)).toBe(true);
+    expect(fake.rows.has("anon|board")).toBe(false);
+
+    // Cold-cache load by the returned key round-trips the document.
+    documents.clear();
+    const loaded = JSON.parse(
+      (await loadDocument({ name: saved.name }, store)).content[0].text,
+    ) as { document_id: string; parts: number };
+    expect(loaded.document_id).toMatch(/^doc_/);
+    expect(loaded.parts).toBe(1);
+
+    // The bare name alone must NOT resolve for an anonymous caller.
+    const miss = await loadDocument({ name: "board" }, store);
+    expect(miss.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -23,6 +23,7 @@ import {
   loadDocument,
   documents,
 } from "../tools/session.js";
+import { InMemorySessionStore } from "../session-store.js";
 import {
   registryDispatchableNames,
   registryToolDescriptors,
@@ -217,11 +218,14 @@ describe("session persistence (save_document / load_document)", () => {
     rmSync(stateDir, { recursive: true, force: true });
   });
 
-  it("round-trips a session to disk and back", () => {
+  it("round-trips a session to disk and back", async () => {
     const open = openDocument({ initial: makeCubeDoc() });
     const { document_id } = JSON.parse(open.content[0].text);
 
-    const save = saveDocument({ document_id, name: "my-part" });
+    const save = await saveDocument(
+      { document_id, name: "my-part" },
+      new InMemorySessionStore(),
+    );
     const saved = JSON.parse(save.content[0].text);
     expect(saved.saved).toBe(true);
     expect(saved.name).toBe("my-part");
@@ -231,7 +235,10 @@ describe("session persistence (save_document / load_document)", () => {
     // Simulate a cold start: drop the in-process session.
     documents.clear();
 
-    const load = loadDocument({ name: "my-part" });
+    const load = await loadDocument(
+      { name: "my-part" },
+      new InMemorySessionStore(),
+    );
     expect(load.isError).toBeFalsy();
     const loaded = JSON.parse(load.content[0].text);
     expect(loaded.document_id).toMatch(/^doc_/);
@@ -245,8 +252,11 @@ describe("session persistence (save_document / load_document)", () => {
     expect(Object.keys(fetched.nodes)).toContain("1");
   });
 
-  it("load_document on a missing file returns an isError result", () => {
-    const load = loadDocument({ name: "does-not-exist" });
+  it("load_document on a missing file returns an isError result", async () => {
+    const load = await loadDocument(
+      { name: "does-not-exist" },
+      new InMemorySessionStore(),
+    );
     expect(load.isError).toBe(true);
     expect(load.content[0].text).toContain('No saved document named "does-not-exist"');
     expect(load.content[0].text).toContain(stateDir);

--- a/packages/mcp/src/notify.ts
+++ b/packages/mcp/src/notify.ts
@@ -77,7 +77,7 @@ function freshWindow(): Window {
 export function fireToolAlert(
   name: string,
   args: Record<string, unknown>,
-  result: { isError?: boolean },
+  result: { isError?: boolean; content?: Array<{ type?: string; text?: string }> },
 ): void {
   // The viewer polls get_preview_version on a timer to self-refresh; counting
   // it would swamp PostHog/Discord with non-user traffic. get_preview_glb is

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -960,17 +960,21 @@ export async function createServer(
       {
         name: "save_document",
         description:
-          "Persist a live session to disk as `<name>.vcad` under VCAD_MCP_STATE_DIR " +
-          "(or the working directory) so it survives a restart and can be reopened " +
-          "by name with load_document. Sessions are otherwise in-memory only.",
+          "Persist a live session under a name so it can be reopened with " +
+          "load_document. On the hosted server the save is durable: a signed-in " +
+          "user's save goes to their vcad.io account under the (normalized) name; " +
+          "an anonymous save returns an unguessable `saved_…` key to reopen with. " +
+          "On a local/stdio server it writes `<name>.vcad` under VCAD_MCP_STATE_DIR " +
+          "(or the working directory).",
         inputSchema: saveDocumentSchema,
       },
       {
         name: "load_document",
         description:
-          "Reopen a previously saved `<name>.vcad` into a fresh session and return " +
-          "its new document_id. The cheap way to resume a board/part across runs " +
-          "instead of rebuilding it.",
+          "Reopen a save_document save into a fresh session and return its new " +
+          "document_id. Pass the same name you saved under (or the `saved_…` key " +
+          "an anonymous save returned). The cheap way to resume a board/part " +
+          "across runs instead of rebuilding it.",
         inputSchema: loadDocumentSchema,
       },
       {
@@ -2428,11 +2432,11 @@ export async function createServer(
           break;
 
         case "save_document":
-          result = saveDocument(args);
+          result = await saveDocument(args, sessionStore);
           break;
 
         case "load_document":
-          result = loadDocument(args);
+          result = await loadDocument(args, sessionStore);
           break;
 
         case "continue_document":

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -21,6 +21,12 @@ import type { Document } from "@vcad/ir";
 import type { AuthUser } from "./oauth.js";
 
 export interface SessionStore {
+  /** Keying scope of the durable rows. "user": rows are scoped to the caller
+   *  (user_id, local_id), so human-chosen names are safe keys. "capability":
+   *  rows are keyed by the unguessable id ALONE, so name-derived keys would be
+   *  guessable across tenants — only random ids are safe. "memory": no durable
+   *  backend at all (stdio/local). save_document keys its named saves off this. */
+  readonly scope: "memory" | "user" | "capability";
   /** Fetch a session's Document, or null on miss. Never throws for
    *  not-found; transport/Supabase errors are logged and surfaced as null so
    *  an outage degrades to "cache only", not a tool failure. */
@@ -38,6 +44,7 @@ export interface SessionStore {
  * before), save/drop do nothing. Used for stdio and anonymous HTTP calls.
  */
 export class InMemorySessionStore implements SessionStore {
+  readonly scope = "memory" as const;
   async load(): Promise<Document | null> {
     return null;
   }
@@ -82,6 +89,7 @@ export interface SupabaseStoreConfig {
  * vcad.io — it isn't just a dead row.
  */
 export class SupabaseSessionStore implements SessionStore {
+  readonly scope = "user" as const;
   /**
    * Per-session monotonic version. The `version` column is int4, so a
    * timestamp can't be used (Date.now() overflows). A cold instance restarts
@@ -112,7 +120,7 @@ export class SupabaseSessionStore implements SessionStore {
   }
 
   /** `?user_id=eq.<caller>&local_id=eq.mcp:<id>` — the ownership-scoped key. */
-  private scope(documentId: string): string {
+  private scopeQuery(documentId: string): string {
     const uid = encodeURIComponent(this.cfg.userId);
     const lid = encodeURIComponent(this.localId(documentId));
     return `?user_id=eq.${uid}&local_id=eq.${lid}`;
@@ -121,7 +129,7 @@ export class SupabaseSessionStore implements SessionStore {
   async load(documentId: string): Promise<Document | null> {
     try {
       const res = await sessionFetch(
-        this.rowsUrl(`${this.scope(documentId)}&select=content&limit=1`),
+        this.rowsUrl(`${this.scopeQuery(documentId)}&select=content&limit=1`),
         {
           method: "GET",
           headers: this.headers({ Accept: "application/vnd.pgrst.object+json" }),
@@ -177,7 +185,7 @@ export class SupabaseSessionStore implements SessionStore {
 
   async drop(documentId: string): Promise<void> {
     try {
-      await sessionFetch(this.rowsUrl(this.scope(documentId)), {
+      await sessionFetch(this.rowsUrl(this.scopeQuery(documentId)), {
         method: "DELETE",
         headers: this.headers(),
       });
@@ -195,6 +203,7 @@ export class SupabaseSessionStore implements SessionStore {
  * cross-instance routing exactly like signed-in users do.
  */
 export class AnonSupabaseSessionStore implements SessionStore {
+  readonly scope = "capability" as const;
   constructor(private cfg: { supabaseUrl: string; serviceRoleKey: string }) {}
 
   private headers(extra: Record<string, string> = {}): Record<string, string> {

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -53,13 +53,35 @@ export function configureTelemetry(info: {
 const pending = new Set<Promise<void>>();
 
 /**
+ * Coarse error classification for triage, derived ONLY from known marker
+ * strings — never the raw error text, which can embed argument values or IR
+ * (the no-payload constraint above). "other" is the honest bucket for
+ * anything unrecognized; extend the markers when a new class shows up in a
+ * real incident.
+ */
+function classifyErrorKind(result: {
+  isError?: boolean;
+  content?: Array<{ type?: string; text?: string }>;
+}): string {
+  const text = result.content?.find((c) => typeof c.text === "string")?.text ?? "";
+  if (/Unknown document_id/.test(text)) return "unknown_document";
+  if (/Unknown checkpoint_id/.test(text)) return "unknown_checkpoint";
+  if (/kernel WASM not loaded|kernel_wasm/i.test(text)) return "kernel_unavailable";
+  if (/Document has no PCB/.test(text)) return "no_pcb";
+  if (/"document_safe"/.test(text)) return "validation";
+  if (/Invalid save name|No saved document named/.test(text)) return "save_load";
+  if (/^Error: /.test(text)) return "exception";
+  return "other";
+}
+
+/**
  * Capture one tool call to PostHog. Fire-and-forget — returns immediately and
  * never throws. A no-op when no API key is set.
  */
 export function captureToolCall(
   name: string,
   args: Record<string, unknown>,
-  result: { isError?: boolean },
+  result: { isError?: boolean; content?: Array<{ type?: string; text?: string }> },
 ): void {
   const docId =
     typeof args?.document_id === "string" && args.document_id
@@ -68,6 +90,7 @@ export function captureToolCall(
   captureEvent("mcp_tool_call", {
     tool: name,
     is_error: !!result.isError,
+    ...(result.isError ? { error_kind: classifyErrorKind(result) } : {}),
     ...(docId ? { document_id: docId } : {}),
   });
 }

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -4148,6 +4148,11 @@ export async function exportGerber(args: Record<string, unknown>) {
         verdict.status === "unverifiable"
           ? verdict.reason
           : `${verdict.summary.errors} DRC error(s) must be resolved before fabrication`;
+      // A blocked export is a VERDICT, not a tool failure — same posture as
+      // validate_for_fab's `verdict: "blocked"`. The tool ran, evaluated the
+      // gate, and reported a structured refusal with escape hatches; isError
+      // here would (and did) make every working gate trip read as a tool
+      // crash in clients and telemetry.
       return {
         content: [
           {
@@ -4165,7 +4170,6 @@ export async function exportGerber(args: Record<string, unknown>) {
             }),
           },
         ],
-        isError: true,
       };
     }
   }

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -318,22 +318,52 @@ export function closeDocument(args: Record<string, unknown>): {
 // ─── Durable persistence (save_document / load_document) ──────────────────────
 //
 // The session Map above is in-process only — a server restart or cold start
-// loses every board, and there is no way to reopen one by id. These two tools
-// add a file-backed persistence layer: `save_document` serializes a live
-// session to `<name>.vcad` under the state root, and `load_document` reads it
-// back into a fresh session.
+// loses every board, and there is no way to reopen one by name. These two
+// tools add a named persistence layer, routed by the session store's scope:
 //
-// The state root is VCAD_MCP_STATE_DIR (or process.cwd()), and `resolveWithinRoot`
-// both sanitizes `name` and confines reads/writes to that root, so a caller can
-// never escape it with `../` or an absolute path.
+// - "memory" (stdio/local): file-backed — `save_document` serializes the
+//   session to `<name>.vcad` under the state root and `load_document` reads it
+//   back. The state root is VCAD_MCP_STATE_DIR (or process.cwd()), and
+//   `resolveWithinRoot` sanitizes `name` and confines reads/writes to that
+//   root, so a caller can never escape it with `../` or an absolute path.
 //
-// This is the local/stdio persistence layer. The natural extension for the
-// hosted/multi-tenant deployment is durable storage in the Supabase `documents`
-// table keyed by the OAuth user, rather than the local filesystem.
+// - "user" (hosted, signed in): durable rows in the caller's own `documents`
+//   table under the `saved:<slug>` key (→ local_id `mcp:saved:<slug>`), so a
+//   plain human name is a safe, per-user key and the save also shows up at
+//   vcad.io. The hosted filesystem is read-only — writeFileSync there was why
+//   save_document failed 100% of the time in production.
+//
+// - "capability" (hosted, anonymous): rows are keyed by id ALONE, so a
+//   name-derived key would be guessable across tenants. The save is keyed by
+//   an unguessable `saved_…` id returned to the caller, which load_document
+//   accepts in place of a name.
 
 /** State root for saved `.vcad` files. VCAD_MCP_STATE_DIR or cwd. */
 function stateRoot(): string {
   return process.env.VCAD_MCP_STATE_DIR ?? process.cwd();
+}
+
+/** Normalize a human save name to the deterministic durable-key slug. Both
+ *  save and load apply this, so "My Part" and "my-part" reopen the same row. */
+function savedNameSlug(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+}
+
+/** Durable key for a user-scoped named save. The `saved:` prefix keeps names
+ *  out of the live-session id namespace (`doc_*` / `ckpt_*`). */
+function savedKey(slug: string): string {
+  return `saved:${slug}`;
+}
+
+/** True for the unguessable ids minted by anonymous saves — load_document
+ *  passes these through verbatim instead of slugging them. */
+function isCapabilitySavedId(name: string): boolean {
+  return /^saved_[A-Za-z0-9_-]+$/.test(name);
 }
 
 // ─── save_document ────────────────────────────────────────────────────────
@@ -348,28 +378,98 @@ export const saveDocumentSchema = {
     name: {
       type: "string" as const,
       description:
-        "Filename slug (no extension) to save under, relative to the server state directory " +
-        "(VCAD_MCP_STATE_DIR if set, otherwise the working directory). Written as <name>.vcad.",
+        "Name to save under and reopen with load_document. On the hosted " +
+        "server this is a durable per-user name (normalized to lowercase-and-" +
+        "dashes); on a local/stdio server it is a filename slug written as " +
+        "<name>.vcad under VCAD_MCP_STATE_DIR (or the working directory).",
     },
   },
   required: ["document_id", "name"],
 };
 
-export function saveDocument(args: Record<string, unknown>): {
+export async function saveDocument(
+  args: Record<string, unknown>,
+  store: SessionStore,
+): Promise<{
   content: Array<{ type: "text"; text: string }>;
-} {
+  isError?: boolean;
+}> {
   const id = String(args.document_id ?? "");
   const name = String(args.name ?? "");
   const doc = getSession(id);
-  // resolveWithinRoot sanitizes `name` (rejects absolute/.. /NUL/escape) and
-  // confines the write to the state root.
-  const path = resolveWithinRoot(`${name}.vcad`, stateRoot());
-  writeFileSync(path, JSON.stringify(doc));
+
+  // Local/stdio: file-backed, exactly as before. resolveWithinRoot sanitizes
+  // `name` (rejects absolute/.. /NUL/escape) and confines the write to the
+  // state root.
+  if (store.scope === "memory") {
+    const path = resolveWithinRoot(`${name}.vcad`, stateRoot());
+    writeFileSync(path, JSON.stringify(doc));
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ saved: true, name, path }),
+        },
+      ],
+    };
+  }
+
+  // Hosted: the serverless filesystem is read-only, so the save goes to the
+  // durable session store instead.
+  const slug = savedNameSlug(name);
+  if (!slug) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text:
+            `Invalid save name "${name}" — use letters, digits, dashes, or ` +
+            `underscores (e.g. "motor-mount-v2").`,
+        },
+      ],
+    };
+  }
+
+  // Frozen snapshot: later edits to the live session must not mutate the save.
+  const snapshot = JSON.parse(JSON.stringify(doc)) as Document;
+  // "user" rows are scoped per-caller, so the plain name is a safe key.
+  // "capability" rows are keyed by id alone, so a name would be guessable
+  // across tenants — mint an unguessable id instead (same posture as
+  // checkpoint ids) and hand it back as the reopen handle.
+  const key =
+    store.scope === "user"
+      ? savedKey(slug)
+      : `saved_${slug}_${randomBytes(9).toString("base64url")}`;
+  // Warm-cache so a same-instance load works even if the (best-effort)
+  // durable write degrades; the store row is what survives a redeploy.
+  documents.set(key, snapshot);
+  await store.save(key, snapshot, name.trim() || slug);
+
   return {
     content: [
       {
         type: "text",
-        text: JSON.stringify({ saved: true, name, path }),
+        text: JSON.stringify(
+          store.scope === "user"
+            ? {
+                saved: true,
+                name: slug,
+                hint:
+                  `Saved durably to your account — reopen anytime with ` +
+                  `load_document({name: "${slug}"}). It also appears in your ` +
+                  `documents at vcad.io.`,
+              }
+            : {
+                saved: true,
+                name: key,
+                hint:
+                  `Saved durably under an anonymous key — reopen with ` +
+                  `load_document({name: "${key}"}). Keep the key; anonymous ` +
+                  `saves can't be listed or recovered by plain name (sign in ` +
+                  `to save by name).`,
+              },
+        ),
       },
     ],
   };
@@ -383,46 +483,100 @@ export const loadDocumentSchema = {
     name: {
       type: "string" as const,
       description:
-        "Filename slug (no extension) to load, relative to the server state directory " +
-        "(VCAD_MCP_STATE_DIR if set, otherwise the working directory). Reads <name>.vcad.",
+        "The name passed to save_document (or the `saved_…` key an anonymous " +
+        "save returned). On a local/stdio server this reads <name>.vcad from " +
+        "the state directory.",
     },
   },
   required: ["name"],
 };
 
-export function loadDocument(args: Record<string, unknown>): {
+export async function loadDocument(
+  args: Record<string, unknown>,
+  store: SessionStore,
+): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
-} {
+}> {
   const name = String(args.name ?? "");
-  const root = stateRoot();
-  const path = resolveWithinRoot(`${name}.vcad`, root);
-  let raw: string;
-  try {
-    raw = readFileSync(path, "utf8");
-  } catch {
+
+  // Local/stdio: file-backed, exactly as before.
+  if (store.scope === "memory") {
+    const root = stateRoot();
+    const path = resolveWithinRoot(`${name}.vcad`, root);
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf8");
+    } catch {
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text",
+            text: `No saved document named "${name}" under ${root}`,
+          },
+        ],
+      };
+    }
     return {
-      isError: true,
       content: [
         {
           type: "text",
-          text: `No saved document named "${name}" under ${root}`,
+          text: JSON.stringify(openSavedSnapshot(JSON.parse(raw) as Document, name)),
         },
       ],
     };
   }
-  const doc = JSON.parse(raw) as Document;
-  const id = registerSession(doc);
+
+  // Hosted: resolve the save from the warm cache, then the durable store.
+  // An anonymous `saved_…` key passes through verbatim; a plain name resolves
+  // via the same slug normalization save_document applied.
+  const candidates: string[] = [];
+  if (isCapabilitySavedId(name)) candidates.push(name);
+  const slug = savedNameSlug(name);
+  if (slug) candidates.push(savedKey(slug));
+
+  for (const key of candidates) {
+    let snapshot = documents.get(key) ?? null;
+    if (!snapshot) snapshot = await store.load(key);
+    if (snapshot) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(openSavedSnapshot(snapshot, name)),
+          },
+        ],
+      };
+    }
+  }
+
   return {
+    isError: true,
     content: [
       {
         type: "text",
-        text: JSON.stringify({
-          document_id: id,
-          name,
-          parts: doc.roots?.length ?? 0,
-        }),
+        text:
+          `No saved document named "${name}". Save one first with ` +
+          `save_document(document_id, name). (Anonymous saves are reopened by ` +
+          `the exact \`saved_…\` key save_document returned; checkpoints use ` +
+          `branch_from, not load_document.)`,
       },
     ],
+  };
+}
+
+/** Open a saved snapshot as a fresh, independent session. The deep copy keeps
+ *  the saved row frozen — editing the loaded session never mutates the save. */
+function openSavedSnapshot(
+  snapshot: Document,
+  name: string,
+): Record<string, unknown> {
+  const copy = JSON.parse(JSON.stringify(snapshot)) as Document;
+  const id = registerSession(copy);
+  return {
+    document_id: id,
+    name,
+    parts: copy.roots?.length ?? 0,
   };
 }


### PR DESCRIPTION
## The live fire from 30 days of MCP telemetry

Triage of the ship-path failures (tools that fail at the end of a long agent session):

| tool | 30-day record | verdict |
|---|---|---|
| `save_document` | **4/4 failed, across 4 builds — never succeeded once** | real bug, fixed here |
| `export_gerber` | 7/9 "errors", all coinciding with the June 26 clean-DRC gate | working guard misreported as tool error, fixed here |
| `get_preview_glb` | 128 errors, all on builds `0e8335b`→`8d869cf` (June 25–26) | already fixed by `188ec6b`; 0/51 errors on current build — no action |

## save_document / load_document: durable on the hosted server

`save_document` wrote `<name>.vcad` via `writeFileSync` to `VCAD_MCP_STATE_DIR ?? process.cwd()` — read-only on the serverless deploy, so **every hosted save threw**. The session-store architecture already had the right durable path (checkpoints); saves now route by store scope:

- **`user`** (signed in): name-keyed row in the caller's own `documents` table (`local_id: mcp:saved:<slug>`) — per-user namespace, and the save shows up at vcad.io. Reopen with `load_document({name})`; names normalize deterministically ("My Part" ≡ "my-part").
- **`capability`** (anonymous): a plain name would be guessable across tenants (rows are keyed by id alone), so the save mints an unguessable `saved_<slug>_<rand>` key, returned as the reopen handle — same posture as checkpoint ids.
- **`memory`** (stdio/local): unchanged file-backed behavior.

Adding the `scope` discriminator surfaced a latent collision: it silently shadowed `SupabaseSessionStore`'s private `scope()` query builder (Vite flagged the duplicate member; `load()`/`drop()` would have broken). The query builder is now `scopeQuery()`.

## export_gerber: blocked is a verdict, not an error

The clean-DRC gate returned its structured refusal (`blocked:true`, reason, DRC summary, three escape hatches) with `isError:true` — so every working gate trip read as a tool crash in clients and error dashboards. It now returns the verdict as a normal result, matching `validate_for_fab`'s `verdict:"blocked"` posture. Payload unchanged.

## Telemetry: error_kind

This triage was slow because `mcp_tool_call` carries only `is_error`. Error events now also carry a coarse `error_kind` (`unknown_document`, `kernel_unavailable`, `validation`, `exception`, …) derived **only from known marker strings** — the "never send argument values or IR" constraint holds.

## Tests

- New `save-load-durable.test.ts`: e2e signed-in save → simulated redeploy → load-by-name on a cold instance; slug normalization; invalid-name rejection; anonymous key-not-name isolation (bare name must NOT resolve).
- `export_gerber` blocked test now asserts the result is not `isError`.
- Full `@vcad/mcp` suite: 29 files, 498 passed / 2 pre-existing skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)