### PR TITLE
feat(em): name the electromagnetics domain, emit receipt claims from EM calculators

### DIFF
--- a/changelog/entries/2026-07-07-em-domain-claims.json
+++ b/changelog/entries/2026-07-07-em-domain-claims.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-07-07-em-domain-claims",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "Electromagnetics named as a domain, calculators emit claims",
+  "summary": "Every EM calculator (coil, impedance, PDN, RF, winding, motor) now returns structured receipt claims — quantity, predicted value, unit, method, inputs — and the domain is documented end to end.",
+  "features": ["electromagnetics", "pcb", "receipt", "verification"],
+  "mcpTools": [
+    "calc_coil",
+    "size_coil",
+    "calc_impedance",
+    "size_impedance",
+    "size_pdn",
+    "calc_rf",
+    "winding_layout",
+    "calc_motor"
+  ]
+}

--- a/crates/vcad-ecad-sim/src/em.rs
+++ b/crates/vcad-ecad-sim/src/em.rs
@@ -1,0 +1,67 @@
+//! Electromagnetics — the named domain, in one place.
+//!
+//! vcad's EM capability grew up scattered: spiral-inductance math landed with
+//! the PCB-motor work, transmission-line impedance with the routing stack,
+//! the air-gap solver with motor co-design. This module names the collection
+//! **electromagnetics** and gives it a single front door. It re-exports the
+//! existing modules unchanged — no paths move, nothing is deprecated — so
+//! `vcad_ecad_sim::magnetics` and `vcad_ecad_sim::em::magnetics` are the same
+//! module.
+//!
+//! # What the domain can claim today
+//!
+//! Every solver here is a closed-form, first-order model. Each one makes a
+//! small set of quantitative *claims* — a predicted value for a named physical
+//! quantity, from named inputs, by a citable method:
+//!
+//! | quantity | symbol | unit | solver | method |
+//! |---|---|---|---|---|
+//! | spiral inductance | L | H | [`magnetics::coil_inductance_henry`] | modified Wheeler (Mohan et al. 1999) |
+//! | torque constant | Kt | N·m/A | [`magnetics::motor_torque_constant`] | kw·N·p·B·A_pole (first-order) |
+//! | back-EMF constant | Ke | V·s/rad | [`motor::evaluate_motor`] | Ke = Kt (SI) |
+//! | no-load speed | ω0 | rad/s | [`motor::evaluate_motor`] | V/Ke, linear DC model |
+//! | stall torque | Ts | N·m | [`motor::evaluate_motor`] | Kt·V/R, linear DC model |
+//! | air-gap flux density | B_gap | T | [`airgap::airgap_flux_density`] | MEC reluctance network |
+//! | characteristic impedance | Z0 | Ω | [`impedance`] | IPC-2141 / Hammerstad–Jensen |
+//! | differential impedance | Zdiff | Ω | [`impedance`] | 2·Z0·k edge-coupling factor |
+//! | effective permittivity | εr_eff | — | [`impedance`] | Hammerstad–Jensen |
+//! | propagation delay | td | ps | [`signal_integrity::propagation_delay`] | 3.336·√εr_eff ps/mm |
+//! | crosstalk | NEXT/FEXT | dB | [`signal_integrity::estimate_crosstalk`] | empirical 1/(1+(s/h)²) coupling |
+//!
+//! The MCP calculators (`calc_coil`, `calc_impedance`, `size_coil`,
+//! `size_impedance`, `winding_layout`) mirror these closed forms in
+//! TypeScript; `calc_motor` calls [`motor::evaluate_motor`] and
+//! [`airgap::airgap_flux_density`] through the kernel WASM; `calc_rf` (RLC
+//! resonance/Q) and `size_pdn` (IR-drop resistor mesh) are TS-side solvers
+//! with no Rust twin yet. Each calculator emits its predictions as **receipt
+//! claims** — *quantity, predicted value, unit, method, inputs* (see
+//! `packages/mcp/src/tools/em-claims.ts`). A claim is honest about being a
+//! model — first-order, no slotting/fringing/saturation, no field solver — so
+//! a future measurement or FEA pass can grade it rather than contradict it.
+//!
+//! # Differentiable by construction
+//!
+//! The geometry→performance leaves ([`magnetics`], the [`impedance`] Z0
+//! functions) are generic over `tang::Scalar`, so the same code that computes
+//! an `f64` builds a `tang_expr` graph and differentiates symbolically.
+//! `vcad-ecad-diff` consumes these leaves for motor plant/controller
+//! co-design; `size_impedance` solves trace geometry by gradient, not search.
+//!
+//! # Neighbors, deliberately outside the domain
+//!
+//! - [`crate::thermal`] — junction temperature and via thermal resistance:
+//!   thermal, not electromagnetic (though copper geometry feeds both).
+//! - [`crate::circuit`] — lumped-element MNA transient simulation: circuit
+//!   behavior over time, not field/geometry claims.
+//!
+//! # Future
+//!
+//! Antenna synthesis, filter synthesis, and eventually a field solver join
+//! here. The domain rides the PCB rail — coils are copper — so everything it
+//! designs is already purchasable as a board.
+
+pub use crate::airgap;
+pub use crate::impedance;
+pub use crate::magnetics;
+pub use crate::motor;
+pub use crate::signal_integrity;

--- a/crates/vcad-ecad-sim/src/lib.rs
+++ b/crates/vcad-ecad-sim/src/lib.rs
@@ -9,16 +9,23 @@
 //!
 //! # Modules
 //!
+//! The electromagnetic solvers are grouped under the [`em`] domain facade
+//! (see its module docs for the claim family and domain framing):
+//!
 //! - [`airgap`] — First-order air-gap flux density via a reluctance network (MEC)
-//! - [`circuit`] — Lumped-element transient circuit simulation (MNA network solver)
 //! - [`impedance`] — Characteristic impedance for microstrip and stripline geometries
 //! - [`magnetics`] — Scalar-generic spiral inductance + motor torque constant
 //! - [`motor`] — Analytical motor performance (Kt/Ke, no-load speed, stall torque, curve)
 //! - [`signal_integrity`] — Propagation delay, crosstalk estimation, length matching
+//!
+//! Neighbors outside the EM domain:
+//!
+//! - [`circuit`] — Lumped-element transient circuit simulation (MNA network solver)
 //! - [`thermal`] — Component junction temperature and via thermal resistance
 
 pub mod airgap;
 pub mod circuit;
+pub mod em;
 pub mod impedance;
 pub mod magnetics;
 pub mod motor;

--- a/packages/docs/content/guides/electronics/electromagnetics.mdx
+++ b/packages/docs/content/guides/electronics/electromagnetics.mdx
@@ -1,0 +1,53 @@
+---
+title: "Electromagnetics"
+description: "The EM domain: coils, motor windings, impedance, RF — and the claims they make"
+order: 6
+---
+
+vcad's electromagnetics capability grew up scattered across the PCB stack: spiral-inductance math arrived with PCB motors, transmission-line impedance with the routing tools, the air-gap solver with motor co-design. This page names the collection **electromagnetics** — a design domain in its own right, alongside PCB layout and mechanical modeling. Nothing moved and no tool was renamed; the domain is a lens, not a migration.
+
+Electromagnetics rides the PCB rail: everything the domain designs is copper, so it is fabricated the same way any board is. A planar inductor, a motor stator, a matched RF feed — each is traces, vias, and zones that `export_gerber` already knows how to ship.
+
+## The tools
+
+Eight calculators analyze or size EM structures. They are pure: they take parameters and return numbers, touching no board.
+
+| Tool | What it does |
+|---|---|
+| `calc_coil` | Planar spiral inductance (modified Wheeler), DC resistance, L/R time constant |
+| `size_coil` | Inverse: solve turn count for a target inductance, check it fits the annulus |
+| `calc_impedance` | Characteristic impedance Z0 for microstrip/stripline, single-ended or differential |
+| `size_impedance` | Inverse: solve trace width (and pair spacing) for a target Z0, snapped to the fab grid |
+| `size_pdn` | Size power-distribution copper so every load node meets its IR-drop budget |
+| `calc_rf` | RLC frequency response: resonance, Q, S11/return loss against a reference Z0 |
+| `winding_layout` | Polyphase motor winding plan: per-slot phase/polarity and the winding factor |
+| `calc_motor` | First-order motor performance: Kt, Ke, no-load speed, stall torque, speed–torque curve |
+
+Three realizers turn plans into copper on the session board: `add_coil` (one Archimedean spiral of traces), `add_coil_array` (a ring of coils with per-coil nets and chirality), and `add_motor_winding` (plan + place + interconnect + terminate a whole stator winding in one call).
+
+## The claim family
+
+Every calculator's output now includes a `claims` array. A claim is one quantitative prediction in a uniform shape:
+
+```json
+{
+  "domain": "em",
+  "quantity": "inductance",
+  "predicted": 862.674,
+  "unit": "nH",
+  "method": "wheeler-mohan-1999",
+  "inputs": { "turns": 10, "inner_radius": 2, "outer_radius": 6, "geometry": "circular" }
+}
+```
+
+The quantities the domain can claim today: inductance, DC resistance, characteristic and differential impedance, effective permittivity, propagation delay, IR drop, resonant frequency, Q factor, winding factor, torque constant, back-EMF constant, no-load speed, stall torque, and air-gap flux density.
+
+The `method` string names the closed-form model that produced the number — `wheeler-mohan-1999`, `ipc2141-microstrip`, `mec-reluctance`, `star-of-slots`, `first-order-dc-motor`, and friends. Every one is a first-order model: no slotting, fringing, saturation, or field solving. That honesty is the point — a claim states what was predicted, by what model, from what inputs, so a Receipt can ledger it and a later measurement or FEA pass can grade the prediction instead of contradicting a vague number.
+
+## Differentiable by construction
+
+The kernel-side leaves behind these calculators (`crates/vcad-ecad-sim`, module `em`) are generic over the `tang` scalar type, so the same code that evaluates a number also builds a symbolic expression graph and differentiates exactly. `size_impedance` solves trace geometry by gradient rather than search, and motor plant/controller co-design backpropagates through the torque-constant leaf.
+
+## What's next
+
+Antenna synthesis, filter synthesis, and eventually a field solver join the domain here. The claim family is designed to absorb them: a new solver adds new quantities and methods, and the Receipt machinery inherits them for free.

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -18,6 +18,7 @@ import {
   calcCoil,
   sizeCoil,
   calcRf,
+  calcMotor,
   addCoil,
   addCoilArray,
   windingLayout,
@@ -4788,5 +4789,130 @@ describe("layer-name validation at write boundaries", () => {
     expect(isErr(res)).toBe(true);
     expect(errText(res)).toContain("copper_layer");
     expect(errText(res)).toContain("did you mean 'FCu'");
+  });
+});
+
+describe("EM receipt claims", () => {
+  const stack = { dielectric_height: 0.2, copper_thickness: 0.035, dielectric_er: 4.3 };
+
+  it("calc_impedance claims Z0, er_eff, and delay with the model that computed them", async () => {
+    const r = out(await calcImpedance({ trace_width: 0.3, ...stack }));
+    expect(r.claims.map((c: any) => c.quantity)).toEqual([
+      "characteristic_impedance",
+      "effective_permittivity",
+      "propagation_delay",
+    ]);
+    for (const c of r.claims) {
+      expect(c.domain).toBe("em");
+      expect(c.method).toBe("ipc2141-microstrip");
+      expect(c.inputs.trace_width).toBe(0.3);
+    }
+    const z0 = r.claims.find((c: any) => c.quantity === "characteristic_impedance");
+    expect(z0.predicted).toBe(r.z0);
+    expect(z0.unit).toBe("ohm");
+  });
+
+  it("a differential pair adds a differential_impedance claim", async () => {
+    const r = out(
+      await calcImpedance({
+        trace_width: 0.15,
+        spacing: 0.15,
+        trace_type: "diff_microstrip",
+        ...stack,
+      }),
+    );
+    const diff = r.claims.find((c: any) => c.quantity === "differential_impedance");
+    expect(diff.predicted).toBe(r.z_diff);
+    expect(diff.method).toBe("edge-coupled-diff-pair");
+    expect(diff.inputs.spacing).toBe(0.15);
+  });
+
+  it("size_impedance claims describe the snapped geometry it recommends", () => {
+    const r = out(sizeImpedance({ trace_type: "microstrip", target_z0: 50, ...stack }));
+    const z0 = r.claims.find((c: any) => c.quantity === "characteristic_impedance");
+    expect(z0.predicted).toBe(r.measured.z0);
+    expect(z0.inputs.trace_width).toBe(r.width_mm);
+  });
+
+  it("calc_coil and size_coil claim inductance and DC resistance", () => {
+    const r = out(calcCoil({ inner_radius: 2, outer_radius: 6, turns: 10, trace_width: 0.2 }));
+    const ind = r.claims.find((c: any) => c.quantity === "inductance");
+    expect(ind.predicted).toBe(r.inductance_nh);
+    expect(ind.unit).toBe("nH");
+    expect(ind.method).toBe("wheeler-mohan-1999");
+    expect(r.claims.find((c: any) => c.quantity === "dc_resistance").predicted).toBe(
+      r.dc_resistance_ohm,
+    );
+
+    const s = out(
+      sizeCoil({ target_inductance_nh: 500, inner_radius: 2, outer_radius: 8, trace_width: 0.15 }),
+    );
+    const sInd = s.claims.find((c: any) => c.quantity === "inductance");
+    expect(sInd.predicted).toBe(s.achieved_inductance_nh);
+    expect(sInd.inputs.turns).toBe(s.turns);
+  });
+
+  it("calc_rf claims resonance and Q", () => {
+    const r = out(calcRf({ topology: "series_rlc", r_ohm: 50, l_henry: 10e-9, c_farad: 10e-12 }));
+    const f0 = r.claims.find((c: any) => c.quantity === "resonant_frequency");
+    expect(f0.predicted).toBe(r.resonance_hz);
+    expect(f0.unit).toBe("Hz");
+    expect(r.claims.find((c: any) => c.quantity === "q_factor").predicted).toBe(r.q_factor);
+  });
+
+  it("size_pdn claims one IR drop per budgeted node", async () => {
+    const r = out(
+      await sizePdn({
+        nodes: 2,
+        edges: [{ a: 0, b: 1, length: 10 }],
+        loads: [{ node: 1, current: 1.0 }],
+        targets: [{ node: 1, max_drop: 0.05 }],
+      }),
+    );
+    expect(r.claims).toHaveLength(1);
+    expect(r.claims[0].quantity).toBe("ir_drop");
+    expect(r.claims[0].predicted).toBe(r.measured_drops_v[0]);
+    expect(r.claims[0].inputs.node).toBe(1);
+  });
+
+  it("winding_layout claims the winding factor only for a feasible plan", () => {
+    const plan = out(windingLayout({ slots: 9, poles: 12 }));
+    const kw = plan.claims.find((c: any) => c.quantity === "winding_factor");
+    expect(kw.predicted).toBe(plan.windingFactor);
+    expect(kw.method).toBe("star-of-slots");
+    const bad = out(windingLayout({ slots: 9, poles: 12, layer: "single" }));
+    expect(bad.claims).toBeUndefined();
+  });
+
+  it("calc_motor claims Kt/Ke/speed/stall, plus B_gap when it computed it", async () => {
+    const r = out(
+      await calcMotor({
+        pole_pairs: 6,
+        turns_per_phase: 60,
+        winding_factor: 0.866,
+        inner_radius_mm: 5,
+        outer_radius_mm: 30,
+        phase_resistance_ohm: 0.5,
+        supply_voltage_v: 24,
+        magnet: {},
+      }),
+    );
+    const q = (name: string) => r.claims.find((c: any) => c.quantity === name);
+    expect(q("torque_constant").predicted).toBe(r.kt_nm_per_a);
+    expect(q("torque_constant").unit).toBe("N·m/A");
+    expect(q("back_emf_constant").predicted).toBe(r.ke_v_s_per_rad);
+    expect(q("no_load_speed").predicted).toBe(r.no_load_speed_rad_s);
+    expect(q("stall_torque").predicted).toBe(r.stall_torque_nm);
+    const b = q("airgap_flux_density");
+    expect(b.method).toBe("mec-reluctance");
+    expect(b.predicted).toBe(r.airgap_flux_tesla);
+    // Every claim in the family carries the uniform shape.
+    for (const c of r.claims) {
+      expect(c.domain).toBe("em");
+      expect(typeof c.predicted).toBe("number");
+      expect(typeof c.unit).toBe("string");
+      expect(typeof c.method).toBe("string");
+      expect(c.inputs).toBeTruthy();
+    }
   });
 });

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -63,6 +63,7 @@ import {
 } from "@vcad/engine";
 import type { Engine, NetlistResult, TriangleMesh, NetContinuity } from "@vcad/engine";
 import { registerSession, getSession, undoLastSnapshot, historyDepth } from "./session.js";
+import { emClaim } from "./em-claims.js";
 import type { NextAction } from "./next-actions.js";
 import { computeEnclosureFitForBoard } from "./enclosure.js";
 import { validatePcb, pcbValidationError } from "./pcb-validate.js";
@@ -4918,6 +4919,31 @@ export async function calcImpedance(args: Record<string, unknown>) {
   if (gate.kind === "incomplete") return ecadError(gate.message);
   applyRealizedGate(result, gate, { conductor: "trace", noun: "Impedance" });
 
+  // Receipt claims for the quantities predicted (method reflects the branch
+  // actually taken above — see em-claims.ts for the family).
+  const model = traceType === "stripline" ? "ipc2141-stripline" : "ipc2141-microstrip";
+  const claimInputs = {
+    trace_width: traceWidth,
+    copper_thickness: copperThickness,
+    dielectric_height: dielectricHeight,
+    dielectric_er: er,
+    trace_type: traceType,
+  };
+  const claims = [
+    emClaim("characteristic_impedance", result.z0 as number, "ohm", model, claimInputs),
+    emClaim("effective_permittivity", result.er_eff as number, "dimensionless", model, claimInputs),
+    emClaim("propagation_delay", result.delay_ps_per_mm as number, "ps/mm", model, claimInputs),
+  ];
+  if (result.z_diff !== undefined) {
+    claims.push(
+      emClaim("differential_impedance", result.z_diff as number, "ohm", "edge-coupled-diff-pair", {
+        ...claimInputs,
+        spacing,
+      }),
+    );
+  }
+  result.claims = claims;
+
   return {
     content: [
       {
@@ -5052,6 +5078,31 @@ export function sizeImpedance(args: Record<string, unknown>) {
     ...(reason ? { reason } : {}),
   };
 
+  // Receipt claims about the recommended (snapped) geometry.
+  const seModel = traceType.includes("stripline") ? "ipc2141-stripline" : "ipc2141-microstrip";
+  const claimInputs = {
+    trace_type: traceType,
+    trace_width: r4(wSnap),
+    ...(isDiff ? { spacing: r4(sSnap as number) } : {}),
+    copper_thickness: t,
+    dielectric_height: h,
+    dielectric_er: er,
+  };
+  payload.claims = [
+    emClaim("characteristic_impedance", r2(z0Meas), "ohm", seModel, claimInputs),
+    ...(isDiff
+      ? [
+          emClaim(
+            "differential_impedance",
+            r2(diffMeas as number),
+            "ohm",
+            "edge-coupled-diff-pair",
+            claimInputs,
+          ),
+        ]
+      : []),
+  ];
+
   return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
 }
 
@@ -5101,6 +5152,16 @@ export async function sizePdn(args: Record<string, unknown>) {
     });
     return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
   };
+  // One IR-drop receipt claim per budgeted node — same model regardless of
+  // which engine (TS solver or Rust adjoint) produced the widths.
+  const pdnClaims = (drops: number[], segments: number) =>
+    targets.map((tg, i) =>
+      emClaim("ir_drop", Math.round(drops[i]! * 1e6) / 1e6, "V", "dc-resistor-mesh", {
+        node: tg.node,
+        max_drop_v: tg.max_drop,
+        segments,
+      }),
+    );
 
   // Optionally route into the Rust kernel engine (implicit-function adjoint)
   // via WASM. Falls through to the TS solver if the artifact isn't available.
@@ -5137,6 +5198,7 @@ export async function sizePdn(args: Record<string, unknown>) {
         targets,
         converged: exact.converged,
         ...(overBudget.length ? { over_budget: overBudget } : {}),
+        claims: pdnClaims(drops, widths.length),
       });
     }
   }
@@ -5244,6 +5306,8 @@ export async function sizePdn(args: Record<string, unknown>) {
     fab_grid_mm: grid,
     ...(active.length ? { active_constraints: active } : {}),
     ...(overBudget.length ? { over_budget: overBudget } : {}),
+    // One IR-drop claim per budgeted node, at the sized copper widths.
+    claims: pdnClaims(measured, ne),
   });
 }
 
@@ -5291,6 +5355,20 @@ export function calcCoil(args: Record<string, unknown>) {
           // L/R time constant in microseconds.
           time_constant_us: r3((inductanceNh * 1e-9) / resistance / 1e-6),
           inputs: { inner_radius: innerR, outer_radius: outerR, trace_width: w, copper_thickness: t },
+          claims: [
+            emClaim("inductance", r3(inductanceNh), "nH", "wheeler-mohan-1999", {
+              turns,
+              inner_radius: innerR,
+              outer_radius: outerR,
+              geometry,
+            }),
+            emClaim("dc_resistance", r3(resistance), "ohm", "dc-trace-resistance", {
+              wire_length_mm: r3(wireLen),
+              trace_width: w,
+              copper_thickness: t,
+              resistivity: rho,
+            }),
+          ],
         }),
       },
     ],
@@ -5360,6 +5438,21 @@ export function sizeCoil(args: Record<string, unknown>) {
           max_turns_fit: maxTurnsFit,
           dc_resistance_ohm: r3(resistance),
           wire_length_mm: r3(wireLen),
+          // Claims describe the integer-turn coil actually recommended.
+          claims: [
+            emClaim("inductance", r3(achievedNh), "nH", "wheeler-mohan-1999", {
+              turns,
+              inner_radius: innerR,
+              outer_radius: outerR,
+              geometry,
+            }),
+            emClaim("dc_resistance", r3(resistance), "ohm", "dc-trace-resistance", {
+              wire_length_mm: r3(wireLen),
+              trace_width: w,
+              copper_thickness: t,
+              resistivity: rho,
+            }),
+          ],
         }),
       },
     ],
@@ -5454,6 +5547,24 @@ export function calcRf(args: Record<string, unknown>) {
           },
           z0_ohm: z0,
           samples,
+          claims: [
+            emClaim("resonant_frequency", Math.round(f0), "Hz", "rlc-analytic", {
+              topology,
+              r_ohm: r,
+              l_henry: l,
+              c_farad: c,
+            }),
+            ...(Number.isFinite(q)
+              ? [
+                  emClaim("q_factor", r3(q), "dimensionless", "rlc-analytic", {
+                    topology,
+                    r_ohm: r,
+                    l_henry: l,
+                    c_farad: c,
+                  }),
+                ]
+              : []),
+          ],
         }),
       },
     ],
@@ -5981,7 +6092,24 @@ export function windingLayout(args: Record<string, unknown>) {
     ...(neutralNet ? { neutralNet } : {}),
   };
 
-  return { content: [{ type: "text" as const, text: JSON.stringify(plan) }] };
+  // A winding factor is only a claim about a buildable winding.
+  const payload = {
+    ...plan,
+    ...(feasible
+      ? {
+          claims: [
+            emClaim("winding_factor", plan.windingFactor, "dimensionless", "star-of-slots", {
+              slots,
+              poles,
+              phases,
+              layer,
+            }),
+          ],
+        }
+      : {}),
+  };
+
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
 }
 
 // ============================================================================
@@ -8624,11 +8752,12 @@ export async function calcMotor(args: Record<string, unknown>) {
   // Resolve air-gap flux: explicit value, else compute from magnet geometry.
   let bGap = num(args.airgap_flux_tesla);
   let bGapSource: "supplied" | "computed" = "supplied";
+  let magnetSpec: Parameters<typeof airgapFluxDensity>[0] | undefined;
   if (!Number.isFinite(bGap)) {
     const m = (args.magnet ?? {}) as Record<string, unknown>;
     const mnum = (v: unknown, d: number) =>
       typeof v === "number" && Number.isFinite(v) ? (v as number) : d;
-    const computed = await airgapFluxDensity({
+    magnetSpec = {
       remanenceTesla: mnum(m.remanence_tesla, 1.2),
       magnetThicknessMm: mnum(m.magnet_thickness_mm, 3),
       recoilMuRel: mnum(m.recoil_mu_rel, 1.05),
@@ -8638,7 +8767,8 @@ export async function calcMotor(args: Record<string, unknown>) {
       ironMuRel: typeof m.iron_mu_rel === "number" ? (m.iron_mu_rel as number) : null,
       ironPathMm: mnum(m.iron_path_mm, 0),
       ironAreaMm2: mnum(m.iron_area_mm2, 1),
-    });
+    };
+    const computed = await airgapFluxDensity(magnetSpec);
     if (computed == null) {
       return fail(
         "air-gap flux is required: pass airgap_flux_tesla, or `magnet` params (ECAD WASM must be available to compute B_gap).",
@@ -8663,6 +8793,41 @@ export async function calcMotor(args: Record<string, unknown>) {
   }
 
   const r4 = (n: number) => Math.round(n * 1e4) / 1e4;
+  const motorInputs = {
+    pole_pairs: polePairs,
+    turns_per_phase: turnsPerPhase,
+    winding_factor: windingFactor,
+    inner_radius_mm: innerR,
+    outer_radius_mm: outerR,
+    phase_resistance_ohm: phaseR,
+    supply_voltage_v: supplyV,
+    airgap_flux_tesla: r4(bGap),
+  };
+  const claims = [
+    emClaim("torque_constant", r4(perf.ktNmPerA), "N·m/A", "first-order-dc-motor", motorInputs),
+    emClaim("back_emf_constant", r4(perf.keVSPerRad), "V·s/rad", "first-order-dc-motor", motorInputs),
+    emClaim("no_load_speed", r4(perf.noLoadSpeedRadS), "rad/s", "first-order-dc-motor", motorInputs),
+    emClaim("stall_torque", r4(perf.stallTorqueNm), "N·m", "first-order-dc-motor", motorInputs),
+  ];
+  if (bGapSource === "computed" && magnetSpec) {
+    claims.push(
+      emClaim("airgap_flux_density", r4(bGap), "T", "mec-reluctance", {
+        remanence_tesla: magnetSpec.remanenceTesla,
+        magnet_thickness_mm: magnetSpec.magnetThicknessMm,
+        recoil_mu_rel: magnetSpec.recoilMuRel,
+        airgap_mm: magnetSpec.airgapMm,
+        magnet_area_mm2: magnetSpec.magnetAreaMm2,
+        gap_area_mm2: magnetSpec.gapAreaMm2,
+        ...(magnetSpec.ironMuRel != null
+          ? {
+              iron_mu_rel: magnetSpec.ironMuRel,
+              iron_path_mm: magnetSpec.ironPathMm,
+              iron_area_mm2: magnetSpec.ironAreaMm2,
+            }
+          : {}),
+      }),
+    );
+  }
   return {
     content: [
       {
@@ -8682,6 +8847,7 @@ export async function calcMotor(args: Record<string, unknown>) {
             torque_nm: r4(p.torqueNm),
           })),
           note: "First-order steady-state estimate (no slotting/fringing/saturation/losses).",
+          claims,
         }),
       },
     ],

--- a/packages/mcp/src/tools/em-claims.ts
+++ b/packages/mcp/src/tools/em-claims.ts
@@ -1,0 +1,79 @@
+/**
+ * The electromagnetics (EM) receipt-claim family.
+ *
+ * Every EM calculator (calc_coil, calc_motor, calc_rf, calc_impedance,
+ * size_coil, size_impedance, size_pdn, winding_layout) predicts values for
+ * named physical quantities — inductance, torque constant, Z0, winding
+ * factor, resonance. A claim records one such prediction in a uniform,
+ * plainly serializable shape: what quantity, what value, by what method,
+ * from what inputs. That is exactly what a receipt needs to ledger the
+ * prediction and what a later measurement or FEA pass needs to grade it.
+ *
+ * Deliberately dependency-free: coordination with the unified-receipt work
+ * is by shape, not by import. Claims ride inside each tool's existing JSON
+ * payload under a `claims` key — additive, so no consumer breaks.
+ *
+ * Method identifiers are stable, citable strings (see `EmMethod`); a claim
+ * is honest about being a first-order closed-form model, so a higher-
+ * fidelity oracle can grade it rather than contradict it.
+ */
+
+/** Physical quantities the EM domain can currently claim. */
+export type EmQuantity =
+  | "inductance"
+  | "dc_resistance"
+  | "characteristic_impedance"
+  | "differential_impedance"
+  | "effective_permittivity"
+  | "propagation_delay"
+  | "ir_drop"
+  | "resonant_frequency"
+  | "q_factor"
+  | "winding_factor"
+  | "torque_constant"
+  | "back_emf_constant"
+  | "no_load_speed"
+  | "stall_torque"
+  | "airgap_flux_density";
+
+/** Stable identifiers for the closed-form models behind each claim. */
+export type EmMethod =
+  | "wheeler-mohan-1999" // modified-Wheeler planar spiral inductance
+  | "dc-trace-resistance" // R = ρ·L/(w·t)
+  | "ipc2141-microstrip" // Hammerstad–Jensen microstrip Z0 / εr_eff
+  | "ipc2141-stripline" // IPC-2141 stripline Z0
+  | "edge-coupled-diff-pair" // Zdiff = 2·Z0·k(s/h)
+  | "dc-resistor-mesh" // PDN Laplacian G·V = I
+  | "rlc-analytic" // series/parallel RLC frequency response
+  | "star-of-slots" // polyphase winding factor kw = kp·kd
+  | "mec-reluctance" // air-gap B via magnetic equivalent circuit
+  | "first-order-dc-motor"; // Kt/Ke, V = iR + Ke·ω envelope
+
+/**
+ * One quantitative prediction made by an EM calculator — the unit of the
+ * domain's receipt-claim family.
+ */
+export interface EmClaim {
+  /** Domain tag, so a mixed-domain receipt can group claims. */
+  domain: "em";
+  quantity: EmQuantity;
+  /** Predicted value, in `unit`. */
+  predicted: number;
+  /** Unit of `predicted` as the tool reports it (e.g. "nH", "ohm", "rad/s"). */
+  unit: string;
+  /** The model that produced the number. */
+  method: EmMethod;
+  /** Named inputs the prediction was computed from. */
+  inputs: Record<string, number | string>;
+}
+
+/** Build one claim. Skips nothing, validates nothing — callers own honesty. */
+export function emClaim(
+  quantity: EmQuantity,
+  predicted: number,
+  unit: string,
+  method: EmMethod,
+  inputs: Record<string, number | string>,
+): EmClaim {
+  return { domain: "em", quantity, predicted, unit, method, inputs };
+}


### PR DESCRIPTION
## Summary

Per the [domain atlas](https://github.com/ecto/vcad/pull/397) — "electromagnetics is half-shipped and unnamed" — this consolidates vcad's scattered EM tools into one named domain. Organizational only: no public API or MCP tool renames, no new physics.

**Naming** — `crates/vcad-ecad-sim` gains an `em` facade module that re-exports the existing `airgap` / `impedance` / `magnetics` / `motor` / `signal_integrity` modules unchanged, with module docs presenting EM as a domain: a claim table (quantity / unit / solver / method), the differentiable-leaf story, and what joins later (antennas, filter synthesis, a field solver). `thermal` and `circuit` are documented as deliberate neighbors outside the domain. A docs page (`guides/electronics/electromagnetics.mdx`) presents the same framing to users.

**Claim family** — `packages/mcp/src/tools/em-claims.ts` defines `EmClaim { domain: "em", quantity, predicted, unit, method, inputs }` as a plain serializable shape with zero imports, so the parallel receipt-unification work can adopt it by shape rather than by dependency. All eight EM calculators now return a `claims` array:

| tool | claims |
|---|---|
| `calc_coil` / `size_coil` | inductance (nH), DC resistance (Ω) |
| `calc_impedance` | Z0 (Ω), εr_eff, delay (ps/mm), Zdiff (Ω) |
| `size_impedance` | Z0 / Zdiff of the recommended snapped geometry |
| `size_pdn` | one IR drop (V) per budgeted node — identical from TS and Rust-adjoint engines |
| `calc_rf` | resonant frequency (Hz), Q |
| `winding_layout` | winding factor (feasible plans only) |
| `calc_motor` | Kt, Ke, no-load speed, stall torque (+ B_gap via mec-reluctance when computed) |

Method strings are stable, citable model ids (`wheeler-mohan-1999`, `ipc2141-microstrip`, `mec-reluctance`, `star-of-slots`, `first-order-dc-motor`, …) honest to the branch actually taken, so a later measurement or FEA pass grades the prediction instead of contradicting a bare number.

## Testing

- `cargo test -p vcad-ecad-sim` + `cargo clippy -p vcad-ecad-sim -- -D warnings` clean
- `packages/mcp`: full vitest suite 502 passed (28 files), including 8 new EM-claim tests; strict `tsc --noEmit` clean (build script only runs `--noCheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)