### PR TITLE
feat(cam): stocksim verification oracle — gouge/excess checks vs target part

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,8 @@ vcad/
 │   ├── vcad-kernel-raytrace/      # Direct BRep ray tracing
 │   ├── vcad-kernel-physics/       # phyz physics simulation
 │   ├── vcad-kernel-urdf/          # URDF robot description import
+│   ├── vcad-kernel-cam/           # 2.5D CAM toolpath generation + G-code post
+│   ├── vcad-kernel-stocksim/      # CAM stock sim (octree SDF) + toolpath verification oracle
 │   ├── vcad-kernel/               # Unified kernel API
 │   ├── vcad-kernel-wasm/          # WASM bindings for browser
 │   ├── vcad-ir/                   # Intermediate representation
@@ -110,8 +112,6 @@ vcad/
 │   └── vcad/                      # Legacy CSG library (manifold-based)
 │
 │   # Work-in-progress crates (built but not yet wired to any consumer):
-│   # - vcad-kernel-stocksim     # CAM stock sim (octree SDF, marching cubes); no consumers yet
-│   #
 │   # - vcad-kernel-diff         # Differentiable seam, COMPLETE (M0–M11 + closeout):
 │   #                            # dx/dθ of frozen tessellations, mass-property QoIs,
 │   #                            # differentiable fillet radius, reverse-mode adjoint,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7014,7 +7014,9 @@ dependencies = [
 name = "vcad-kernel"
 version = "0.9.4"
 dependencies = [
+ "serde_json",
  "vcad-kernel-booleans",
+ "vcad-kernel-cam",
  "vcad-kernel-constraints",
  "vcad-kernel-cost",
  "vcad-kernel-dfm",
@@ -7026,6 +7028,7 @@ dependencies = [
  "vcad-kernel-shell",
  "vcad-kernel-sketch",
  "vcad-kernel-step",
+ "vcad-kernel-stocksim",
  "vcad-kernel-sweep",
  "vcad-kernel-tessellate",
  "vcad-kernel-text",

--- a/crates/vcad-kernel-stocksim/src/lib.rs
+++ b/crates/vcad-kernel-stocksim/src/lib.rs
@@ -8,7 +8,10 @@
 //! # Features
 //!
 //! - SDF octree representation of stock
-//! - Swept volume subtraction for toolpath simulation
+//! - Swept volume subtraction for toolpath simulation, with per-tool cutter
+//!   envelopes (flat, ball, bull, and cone bottoms)
+//! - Verification oracle: gouge and excess checks against a target mesh
+//!   ([`verify_stock_against_mesh`])
 //! - Marching cubes mesh extraction for visualization
 //! - Collision detection for tool holders
 //!
@@ -29,11 +32,15 @@ mod collision;
 mod marching_cubes;
 mod octree;
 mod subtract;
+mod verify;
 
 pub use collision::{CollisionResult, CollisionType};
 pub use marching_cubes::MarchingCubes;
 pub use octree::{OctreeNode, Stock};
 pub use subtract::SweptVolume;
+pub use verify::{
+    verify_stock_against_mesh, CheckReport, StockVerification, VerifyOptions, ViolationSample,
+};
 
 use thiserror::Error;
 

--- a/crates/vcad-kernel-stocksim/src/octree.rs
+++ b/crates/vcad-kernel-stocksim/src/octree.rs
@@ -219,24 +219,32 @@ impl Stock {
         ]
     }
 
-    /// Subtract a sphere from the stock.
-    pub fn subtract_sphere(&mut self, center: [f64; 3], radius: f64) {
+    /// Subtract an arbitrary signed-distance region from the stock.
+    ///
+    /// The remaining material is `stock ∖ region`. `sdf` must be negative
+    /// inside the removal region, positive outside, and 1-Lipschitz (a true
+    /// signed distance or a conservative lower bound of one) — the octree
+    /// descent relies on the Lipschitz property to prune cells that provably
+    /// don't touch the region boundary.
+    pub fn subtract_sdf<F: Fn([f64; 3]) -> f64>(&mut self, sdf: F) {
         let bounds = self.bounds;
         let max_depth = self.max_depth;
         let old_root = std::mem::replace(&mut self.root, OctreeNode::Solid { inside: false });
-        self.root =
-            Self::subtract_sphere_node_impl(old_root, center, radius, &bounds, 0, max_depth);
+        self.root = Self::subtract_sdf_node_impl(old_root, &sdf, &bounds, 0, max_depth);
     }
 
-    fn subtract_sphere_node_impl(
+    fn subtract_sdf_node_impl<F: Fn([f64; 3]) -> f64>(
         node: OctreeNode,
-        center: [f64; 3],
-        radius: f64,
+        sdf: &F,
         bounds: &[f64; 6],
         depth: u8,
         max_depth: u8,
     ) -> OctreeNode {
-        // Check if sphere intersects this cell
+        // Already air: subtracting more changes nothing.
+        if matches!(node, OctreeNode::Solid { inside: false }) {
+            return node;
+        }
+
         let cell_center = [
             (bounds[0] + bounds[3]) / 2.0,
             (bounds[1] + bounds[4]) / 2.0,
@@ -247,34 +255,20 @@ impl Stock {
             (bounds[4] - bounds[1]) / 2.0,
             (bounds[5] - bounds[2]) / 2.0,
         ];
-
-        // Distance from sphere center to closest point on cell
-        let closest = [
-            center[0].clamp(bounds[0], bounds[3]),
-            center[1].clamp(bounds[1], bounds[4]),
-            center[2].clamp(bounds[2], bounds[5]),
-        ];
-        let dist_sq = (closest[0] - center[0]).powi(2)
-            + (closest[1] - center[1]).powi(2)
-            + (closest[2] - center[2]).powi(2);
-
-        // Cell diagonal
         let cell_diag = (half_size[0].powi(2) + half_size[1].powi(2) + half_size[2].powi(2)).sqrt();
 
-        // If sphere doesn't intersect cell, return unchanged
-        if dist_sq > (radius + cell_diag).powi(2) {
+        let d = sdf(cell_center);
+
+        // Region provably misses the cell: nothing to remove.
+        if d > cell_diag {
             return node;
         }
-
-        // If cell is entirely inside sphere, make it empty
-        let corner_dist_sq = (cell_center[0] - center[0]).powi(2)
-            + (cell_center[1] - center[1]).powi(2)
-            + (cell_center[2] - center[2]).powi(2);
-        if corner_dist_sq + cell_diag.powi(2) < radius.powi(2) {
+        // Cell provably swallowed by the region: all material removed.
+        if d < -cell_diag {
             return OctreeNode::Solid { inside: false };
         }
 
-        // If at max depth, create leaf with SDF
+        // At max depth, store the boolean result as a leaf SDF.
         if depth >= max_depth {
             let sdf_before = match &node {
                 OctreeNode::Leaf { sdf } => *sdf,
@@ -288,16 +282,11 @@ impl Stock {
                 OctreeNode::Branch { .. } => -cell_diag, // Assume some material
             };
 
-            // Sphere SDF at cell center
-            let sphere_sdf = ((cell_center[0] - center[0]).powi(2)
-                + (cell_center[1] - center[1]).powi(2)
-                + (cell_center[2] - center[2]).powi(2))
-            .sqrt()
-                - radius;
-
-            // Union of SDFs (max for subtraction)
-            let new_sdf = sdf_before.max(sphere_sdf);
-            return OctreeNode::Leaf { sdf: new_sdf };
+            // Subtraction is intersection with the region's complement, so
+            // the region SDF enters NEGATED: material = max(before, -d).
+            return OctreeNode::Leaf {
+                sdf: sdf_before.max(-d),
+            };
         }
 
         // Subdivide and recurse
@@ -318,17 +307,17 @@ impl Stock {
             }
         };
 
-        let new_children: [OctreeNode; 8] = std::array::from_fn(|i| {
-            let child_bounds = Self::child_bounds(bounds, i);
-            Self::subtract_sphere_node_impl(
-                children[i].clone(),
-                center,
-                radius,
-                &child_bounds,
-                depth + 1,
-                max_depth,
-            )
-        });
+        let new_children: Vec<OctreeNode> = children
+            .into_iter()
+            .enumerate()
+            .map(|(i, child)| {
+                let child_bounds = Self::child_bounds(bounds, i);
+                Self::subtract_sdf_node_impl(child, sdf, &child_bounds, depth + 1, max_depth)
+            })
+            .collect();
+        let new_children: [OctreeNode; 8] = new_children
+            .try_into()
+            .expect("octree branch always has 8 children");
 
         // Try to collapse if all children are same solid
         if let Some(inside) = Self::can_collapse(&new_children) {
@@ -338,6 +327,15 @@ impl Stock {
                 children: Box::new(new_children),
             }
         }
+    }
+
+    /// Subtract a sphere from the stock.
+    pub fn subtract_sphere(&mut self, center: [f64; 3], radius: f64) {
+        self.subtract_sdf(|p| {
+            ((p[0] - center[0]).powi(2) + (p[1] - center[1]).powi(2) + (p[2] - center[2]).powi(2))
+                .sqrt()
+                - radius
+        });
     }
 
     fn can_collapse(children: &[OctreeNode; 8]) -> Option<bool> {
@@ -358,103 +356,7 @@ impl Stock {
 
     /// Subtract a capsule (swept sphere) from the stock.
     pub fn subtract_capsule(&mut self, from: [f64; 3], to: [f64; 3], radius: f64) {
-        let bounds = self.bounds;
-        let max_depth = self.max_depth;
-        let old_root = std::mem::replace(&mut self.root, OctreeNode::Solid { inside: false });
-        self.root =
-            Self::subtract_capsule_node_impl(old_root, from, to, radius, &bounds, 0, max_depth);
-    }
-
-    fn subtract_capsule_node_impl(
-        node: OctreeNode,
-        from: [f64; 3],
-        to: [f64; 3],
-        radius: f64,
-        bounds: &[f64; 6],
-        depth: u8,
-        max_depth: u8,
-    ) -> OctreeNode {
-        let cell_center = [
-            (bounds[0] + bounds[3]) / 2.0,
-            (bounds[1] + bounds[4]) / 2.0,
-            (bounds[2] + bounds[5]) / 2.0,
-        ];
-        let half_size = [
-            (bounds[3] - bounds[0]) / 2.0,
-            (bounds[4] - bounds[1]) / 2.0,
-            (bounds[5] - bounds[2]) / 2.0,
-        ];
-        let cell_diag = (half_size[0].powi(2) + half_size[1].powi(2) + half_size[2].powi(2)).sqrt();
-
-        // Capsule SDF at cell center
-        let capsule_sdf = capsule_sdf(cell_center, from, to, radius);
-
-        // Quick reject: if capsule is far from cell
-        if capsule_sdf > cell_diag * 2.0 {
-            return node;
-        }
-
-        // Quick accept: if cell is entirely inside capsule
-        if capsule_sdf < -cell_diag {
-            return OctreeNode::Solid { inside: false };
-        }
-
-        // At max depth, compute SDF
-        if depth >= max_depth {
-            let sdf_before = match &node {
-                OctreeNode::Leaf { sdf } => *sdf,
-                OctreeNode::Solid { inside } => {
-                    if *inside {
-                        -cell_diag
-                    } else {
-                        cell_diag
-                    }
-                }
-                OctreeNode::Branch { .. } => -cell_diag,
-            };
-
-            let new_sdf = sdf_before.max(capsule_sdf);
-            return OctreeNode::Leaf { sdf: new_sdf };
-        }
-
-        // Subdivide
-        let children = match node {
-            OctreeNode::Branch { children } => *children,
-            _ => {
-                let child = node.clone();
-                [
-                    child.clone(),
-                    child.clone(),
-                    child.clone(),
-                    child.clone(),
-                    child.clone(),
-                    child.clone(),
-                    child.clone(),
-                    child,
-                ]
-            }
-        };
-
-        let new_children: [OctreeNode; 8] = std::array::from_fn(|i| {
-            let child_bounds = Self::child_bounds(bounds, i);
-            Self::subtract_capsule_node_impl(
-                children[i].clone(),
-                from,
-                to,
-                radius,
-                &child_bounds,
-                depth + 1,
-                max_depth,
-            )
-        });
-
-        if let Some(inside) = Self::can_collapse(&new_children) {
-            OctreeNode::Solid { inside }
-        } else {
-            OctreeNode::Branch {
-                children: Box::new(new_children),
-            }
-        }
+        self.subtract_sdf(|p| capsule_sdf(p, from, to, radius));
     }
 
     /// Convert stock to a triangle mesh using marching cubes.
@@ -537,6 +439,27 @@ mod tests {
         assert!(
             sdf > 0.0,
             "After subtracting sphere, center should be outside"
+        );
+    }
+
+    #[test]
+    fn test_subtract_sphere_boundary_cells() {
+        // Points inside the sphere but in partially-covered boundary cells
+        // must read as removed too — this exercises the leaf-level SDF
+        // (subtraction must negate the region SDF), not just the
+        // whole-cell quick-accept path.
+        let mut stock = Stock::from_box([0.0, 0.0, 0.0, 100.0, 100.0, 50.0], 5.0);
+        stock.subtract_sphere([50.0, 50.0, 25.0], 20.0);
+
+        let just_inside = stock.sdf_at(50.0, 50.0, 25.0 + 18.0);
+        assert!(
+            just_inside > 0.0,
+            "point 2mm inside the sphere surface should be removed, got {just_inside}"
+        );
+        let just_outside = stock.sdf_at(50.0, 50.0, 25.0 + 22.0);
+        assert!(
+            just_outside < 0.0,
+            "point 2mm outside the sphere surface should remain, got {just_outside}"
         );
     }
 

--- a/crates/vcad-kernel-stocksim/src/subtract.rs
+++ b/crates/vcad-kernel-stocksim/src/subtract.rs
@@ -4,6 +4,10 @@ use vcad_kernel_cam::{Tool, Toolpath, ToolpathSegment};
 
 use crate::Stock;
 
+/// Cutting length assumed above the tip (or cone shoulder) for tools that
+/// don't report a flute length: drills, V-bits, and face mills.
+const DEFAULT_CUT_LENGTH: f64 = 50.0;
+
 /// A swept volume representing tool motion.
 pub struct SweptVolume {
     /// Tool radius.
@@ -36,44 +40,228 @@ impl SweptVolume {
     }
 }
 
+/// SDF of a tool's cutter envelope with the tip at the origin, axis +Z.
+///
+/// Each variant is a 1-Lipschitz signed distance (or a conservative lower
+/// bound of one), as required by [`Stock::subtract_sdf`].
+enum ToolStamp {
+    /// Flat-bottomed cylinder (flat endmill, face mill).
+    Flat {
+        /// Cutter radius.
+        radius: f64,
+        /// Cutting length above the tip.
+        height: f64,
+    },
+    /// Hemispherical tip blended into a cylinder (ball endmill).
+    Ball {
+        /// Cutter radius.
+        radius: f64,
+        /// Cutting length above the tip.
+        height: f64,
+    },
+    /// Flat bottom with a rounded outer corner (bull endmill).
+    Bull {
+        /// Cutter radius.
+        radius: f64,
+        /// Corner radius, strictly between 0 and `radius`.
+        corner: f64,
+        /// Cutting length above the tip.
+        height: f64,
+    },
+    /// Cone tip opening into a cylinder (V-bit, drill).
+    Cone {
+        /// Cutter radius at the shoulder.
+        radius: f64,
+        /// Angle between the cone side and the tool axis, radians.
+        half_angle: f64,
+        /// Cutting length above the tip.
+        height: f64,
+    },
+}
+
+impl ToolStamp {
+    fn from_tool(tool: &Tool) -> Self {
+        let radius = tool.radius();
+        match tool {
+            Tool::FlatEndMill { flute_length, .. } => ToolStamp::Flat {
+                radius,
+                height: *flute_length,
+            },
+            Tool::BallEndMill { flute_length, .. } => ToolStamp::Ball {
+                radius,
+                height: *flute_length,
+            },
+            Tool::BullEndMill {
+                corner_radius,
+                flute_length,
+                ..
+            } => {
+                let corner = corner_radius.clamp(0.0, radius);
+                if corner <= 0.0 {
+                    ToolStamp::Flat {
+                        radius,
+                        height: *flute_length,
+                    }
+                } else if (radius - corner) < 1e-9 {
+                    ToolStamp::Ball {
+                        radius,
+                        height: *flute_length,
+                    }
+                } else {
+                    ToolStamp::Bull {
+                        radius,
+                        corner,
+                        height: *flute_length,
+                    }
+                }
+            }
+            Tool::VBit { angle, .. } => {
+                let half_angle = (angle.to_radians() / 2.0).clamp(0.02, 1.55);
+                ToolStamp::Cone {
+                    radius,
+                    half_angle,
+                    height: radius / half_angle.tan() + DEFAULT_CUT_LENGTH,
+                }
+            }
+            Tool::Drill { point_angle, .. } => {
+                let half_angle = (point_angle.to_radians() / 2.0).clamp(0.02, 1.55);
+                ToolStamp::Cone {
+                    radius,
+                    half_angle,
+                    height: radius / half_angle.tan() + DEFAULT_CUT_LENGTH,
+                }
+            }
+            Tool::FaceMill { .. } => ToolStamp::Flat {
+                radius,
+                height: DEFAULT_CUT_LENGTH,
+            },
+        }
+    }
+
+    /// Evaluate the stamp SDF at world point `p` for a tool tip at `tip`.
+    fn sdf(&self, p: [f64; 3], tip: [f64; 3]) -> f64 {
+        let dx = p[0] - tip[0];
+        let dy = p[1] - tip[1];
+        let z = p[2] - tip[2];
+        let q = (dx * dx + dy * dy).sqrt();
+        match *self {
+            ToolStamp::Flat { radius, height } => flat_cylinder_sdf(q, z, radius, height),
+            ToolStamp::Ball { radius, height } => {
+                let sphere = (q * q + (z - radius).powi(2)).sqrt() - radius;
+                let barrel = flat_cylinder_sdf(q, z - radius, radius, (height - radius).max(0.0));
+                sphere.min(barrel)
+            }
+            ToolStamp::Bull {
+                radius,
+                corner,
+                height,
+            } => {
+                let uq = q - (radius - corner);
+                let uz = z - corner;
+                if uq > 0.0 && uz < 0.0 {
+                    // Rounded outer corner: distance to the torus arc.
+                    (uq * uq + uz * uz).sqrt() - corner
+                } else {
+                    flat_cylinder_sdf(q, z, radius, height)
+                }
+            }
+            ToolStamp::Cone {
+                radius,
+                half_angle,
+                height,
+            } => {
+                // Signed distance to the cone side through the apex, capped
+                // by the cylinder wall and the top.
+                let side = q * half_angle.cos() - z * half_angle.sin();
+                side.max(q - radius).max(z - height)
+            }
+        }
+    }
+}
+
+/// Exact SDF of a finite cylinder with radius `r` spanning z ∈ [0, h], in
+/// radial/axial coordinates.
+fn flat_cylinder_sdf(q: f64, z: f64, r: f64, h: f64) -> f64 {
+    let dq = q - r;
+    let dz = (z - h / 2.0).abs() - h / 2.0;
+    let outside = (dq.max(0.0).powi(2) + dz.max(0.0).powi(2)).sqrt();
+    let inside = dq.max(dz).min(0.0);
+    outside + inside
+}
+
 impl Stock {
     /// Subtract a toolpath from the stock.
+    ///
+    /// Motion segments (rapids included — a rapid through material is a
+    /// crash, and simulating it as removal is what lets verification catch
+    /// it) are sampled at sub-cell spacing, and the tool's cutter envelope —
+    /// flat, ball, bull, or cone bottom depending on the tool type — is
+    /// subtracted at each sample. Toolpath coordinates are tool-tip
+    /// positions; the cutter extends upward (+Z) from the tip.
     ///
     /// # Arguments
     ///
     /// * `tool` - The cutting tool
     /// * `toolpath` - The toolpath to subtract
     pub fn subtract_toolpath(&mut self, tool: &Tool, toolpath: &Toolpath) {
-        let radius = tool.radius();
-        let mut current_pos = [0.0, 0.0, self.bounds()[5] + 10.0]; // Start above stock
+        let stamp = ToolStamp::from_tool(tool);
+        let spacing = self.stamp_spacing();
+        // Start above the stock so the approach move cuts nothing.
+        let mut current = [0.0, 0.0, self.bounds()[5] + 10.0];
 
         for segment in &toolpath.segments {
             match segment {
                 ToolpathSegment::Rapid { to } | ToolpathSegment::Linear { to, .. } => {
-                    // Only subtract for cutting moves that enter the stock
-                    let min_z = current_pos[2].min(to[2]);
-                    if min_z <= self.bounds()[5] {
-                        self.subtract_capsule(current_pos, *to, radius);
-                    }
-                    current_pos = *to;
+                    self.stamp_segment(&stamp, current, *to, spacing);
+                    current = *to;
                 }
                 ToolpathSegment::Arc {
                     to, center, dir, ..
                 } => {
-                    // Linearize arc into segments
-                    let arc_points = linearize_arc(current_pos, *to, *center, *dir);
-                    let mut prev = current_pos;
-                    for pt in arc_points {
-                        let min_z = prev[2].min(pt[2]);
-                        if min_z <= self.bounds()[5] {
-                            self.subtract_capsule(prev, pt, radius);
-                        }
+                    let mut prev = current;
+                    for pt in linearize_arc(current, *to, *center, *dir) {
+                        self.stamp_segment(&stamp, prev, pt, spacing);
                         prev = pt;
                     }
-                    current_pos = *to;
+                    current = *to;
                 }
                 _ => {} // Ignore non-motion segments
             }
+        }
+    }
+
+    /// Stamp spacing: half the finest leaf cell, so the scallop left
+    /// between consecutive stamps stays well below the sim resolution.
+    fn stamp_spacing(&self) -> f64 {
+        let b = self.bounds();
+        let cells = (1u32 << self.max_depth()) as f64;
+        let cell = ((b[3] - b[0]) / cells)
+            .max((b[4] - b[1]) / cells)
+            .max((b[5] - b[2]) / cells);
+        (cell * 0.5).max(1e-3)
+    }
+
+    /// Subtract the cutter envelope at samples along a linear move.
+    fn stamp_segment(&mut self, stamp: &ToolStamp, from: [f64; 3], to: [f64; 3], spacing: f64) {
+        // The cutter extends upward from the tip: a move whose tip stays
+        // above the stock top can't touch material.
+        let top = self.bounds()[5];
+        if from[2] > top && to[2] > top {
+            return;
+        }
+
+        let len =
+            ((to[0] - from[0]).powi(2) + (to[1] - from[1]).powi(2) + (to[2] - from[2]).powi(2))
+                .sqrt();
+        let n = ((len / spacing).ceil() as usize).max(1);
+        for i in 0..=n {
+            let t = i as f64 / n as f64;
+            let tip = [
+                from[0] + t * (to[0] - from[0]),
+                from[1] + t * (to[1] - from[1]),
+                from[2] + t * (to[2] - from[2]),
+            ];
+            self.subtract_sdf(|p| stamp.sdf(p, tip));
         }
     }
 }
@@ -172,17 +360,54 @@ mod tests {
     }
 
     #[test]
+    fn test_flat_stamp_cuts_flat_floor() {
+        let stamp = ToolStamp::from_tool(&Tool::FlatEndMill {
+            diameter: 6.0,
+            flute_length: 20.0,
+            flutes: 2,
+        });
+        let tip = [0.0, 0.0, 0.0];
+
+        // Inside the cutter, just above the tip.
+        assert!(stamp.sdf([0.0, 0.0, 0.5], tip) < 0.0);
+        assert!(stamp.sdf([2.9, 0.0, 0.5], tip) < 0.0);
+        // Below the tip: a flat endmill does NOT cut under its floor.
+        assert!(stamp.sdf([0.0, 0.0, -0.5], tip) > 0.0);
+        // Outside the radius.
+        assert!(stamp.sdf([3.5, 0.0, 5.0], tip) > 0.0);
+    }
+
+    #[test]
+    fn test_ball_stamp_tip_geometry() {
+        let stamp = ToolStamp::from_tool(&Tool::BallEndMill {
+            diameter: 6.0,
+            flute_length: 20.0,
+            flutes: 2,
+        });
+        let tip = [0.0, 0.0, 0.0];
+
+        // Sphere center sits at z = +r, so the tip itself is on the surface.
+        assert!(stamp.sdf([0.0, 0.0, 0.0], tip).abs() < 1e-9);
+        assert!(stamp.sdf([0.0, 0.0, 3.0], tip) < 0.0);
+        // At tip height the ball has zero radius: a point at q=2 is outside.
+        assert!(stamp.sdf([2.0, 0.0, 0.01], tip) > 0.0);
+        // Nothing below the tip.
+        assert!(stamp.sdf([0.0, 0.0, -0.5], tip) > 0.0);
+    }
+
+    #[test]
     fn test_stock_subtract_toolpath() {
         use vcad_kernel_cam::{CamSettings, Face};
 
-        let mut stock = Stock::from_box([0.0, 0.0, 0.0, 50.0, 50.0, 10.0], 2.0);
+        // CAM convention: stock top at Z=0, material below.
+        let mut stock = Stock::from_box([0.0, 0.0, -10.0, 50.0, 50.0, 0.0], 1.0);
         let tool = Tool::FlatEndMill {
             diameter: 6.0,
             flute_length: 20.0,
             flutes: 2,
         };
 
-        // Create a simple facing toolpath
+        // Face off the top 2mm.
         let face = Face::new(0.0, 0.0, 50.0, 50.0, 2.0);
         let settings = CamSettings {
             stepover: 4.0,
@@ -190,23 +415,31 @@ mod tests {
             feed_rate: 1000.0,
             plunge_rate: 300.0,
             spindle_rpm: 12000.0,
-            safe_z: 15.0,
-            retract_z: 20.0,
+            safe_z: 5.0,
+            retract_z: 10.0,
         };
         let toolpath = face.generate(&tool, &settings).unwrap();
 
-        // Subtract the toolpath
         stock.subtract_toolpath(&tool, &toolpath);
 
-        // After facing, the top surface should have material removed
-        let sdf_top = stock.sdf_at(25.0, 25.0, 9.0);
-        let sdf_below = stock.sdf_at(25.0, 25.0, 5.0);
-
-        // sdf_top should be higher (more outside) than sdf_below after facing
-        // (material removed from top)
+        // The faced layer is gone...
         assert!(
-            sdf_top > sdf_below || sdf_top > -1.0,
-            "Top should have less material after facing"
+            stock.sdf_at(25.0, 25.0, -1.0) > 0.0,
+            "faced layer should be removed at the center"
+        );
+        assert!(
+            stock.sdf_at(5.0, 5.0, -0.5) > 0.0,
+            "faced layer should be removed near the edges"
+        );
+        // ...and the floor below survives: a flat endmill leaves a flat
+        // floor instead of gouging a ball radius below the tip.
+        assert!(
+            stock.sdf_at(25.0, 25.0, -2.5) < 0.0,
+            "flat endmill must not gouge below the floor"
+        );
+        assert!(
+            stock.sdf_at(25.0, 25.0, -5.0) < 0.0,
+            "material well below the floor must remain"
         );
     }
 }

--- a/crates/vcad-kernel-stocksim/src/verify.rs
+++ b/crates/vcad-kernel-stocksim/src/verify.rs
@@ -1,0 +1,469 @@
+//! CAM verification oracle: grade a simulated stock against the target part.
+//!
+//! After a toolpath has been subtracted from a [`Stock`], the remaining
+//! material should match the target part. Two things can go wrong, and each
+//! gets its own check:
+//!
+//! * **Gouge** — the toolpath removed material the part needs. Detected as
+//!   samples inside the target (deeper than `tolerance`) where the stock
+//!   reads air.
+//! * **Excess** — the toolpath failed to remove material it was supposed
+//!   to. Detected as samples outside the target (farther than `allowance`)
+//!   where the stock still reads material.
+//!
+//! Sampling happens on a grid aligned with the octree leaf centers, where
+//! the stored SDF sign is most trustworthy. Violations thinner than one
+//! leaf cell can escape detection, so pick the stock resolution below the
+//! finest defect you care about.
+
+use serde::{Deserialize, Serialize};
+
+use crate::Stock;
+
+/// Cap on total grid samples; deeper octrees get strided sampling.
+const MAX_SAMPLES: usize = 1_000_000;
+
+/// Options for [`verify_stock_against_mesh`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VerifyOptions {
+    /// Maximum depth (mm) that material removal may intrude past the target
+    /// surface before it counts as a gouge.
+    pub tolerance: f64,
+    /// Maximum thickness (mm) of leftover material outside the target
+    /// (machining allowance) before it counts as excess.
+    pub allowance: f64,
+    /// Cap on example violation points reported per check.
+    pub max_examples: usize,
+}
+
+impl Default for VerifyOptions {
+    fn default() -> Self {
+        Self {
+            tolerance: 0.1,
+            allowance: 0.1,
+            max_examples: 16,
+        }
+    }
+}
+
+/// A sampled violation point.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ViolationSample {
+    /// World position of the sample (mm).
+    pub position: [f64; 3],
+    /// Distance from the target surface (mm): intrusion depth for gouges,
+    /// leftover thickness for excess.
+    pub depth: f64,
+}
+
+/// Outcome of one check (gouge or excess).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CheckReport {
+    /// True when no violations were found.
+    pub pass: bool,
+    /// Number of violating grid samples.
+    pub violation_count: usize,
+    /// Deepest violation found (mm); 0 when clean.
+    pub worst_depth: f64,
+    /// Up to `max_examples` violating points, deepest kept.
+    pub examples: Vec<ViolationSample>,
+}
+
+/// Structured result of stock-vs-target verification.
+///
+/// Plain serializable data so it can be embedded in higher-level reports
+/// (e.g. a build receipt claim).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StockVerification {
+    /// True when both checks pass.
+    pub pass: bool,
+    /// Material removed that the target needed.
+    pub gouge: CheckReport,
+    /// Material left that the toolpath should have removed.
+    pub excess: CheckReport,
+    /// Gouge tolerance requested (mm).
+    pub tolerance: f64,
+    /// Machining allowance requested (mm).
+    pub allowance: f64,
+    /// Extra margin added to both thresholds to absorb simulation
+    /// discretization error (mm).
+    pub sim_margin: f64,
+    /// Number of grid samples evaluated.
+    pub grid_samples: usize,
+    /// Grid cell size per axis (mm). Violations thinner than a cell can
+    /// escape detection.
+    pub cell_size: [f64; 3],
+}
+
+/// Verify a simulated stock against a target triangle mesh.
+///
+/// `vertices` and `indices` use the tessellation layout: flat `xyz` f32
+/// triples and triangle index triples (`TriangleMesh::vertices` /
+/// `TriangleMesh::indices`). The mesh must be closed, since containment is
+/// decided by ray casting.
+pub fn verify_stock_against_mesh(
+    stock: &Stock,
+    vertices: &[f32],
+    indices: &[u32],
+    opts: &VerifyOptions,
+) -> StockVerification {
+    let tris = collect_triangles(vertices, indices);
+    let b = stock.bounds();
+    let n = 1usize << stock.max_depth();
+    let cell = [
+        (b[3] - b[0]) / n as f64,
+        (b[4] - b[1]) / n as f64,
+        (b[5] - b[2]) / n as f64,
+    ];
+
+    // Stride the grid when the octree is deep enough that sampling every
+    // leaf would blow the budget.
+    let mut stride = 1usize;
+    while (n.div_ceil(stride)).pow(3) > MAX_SAMPLES {
+        stride += 1;
+    }
+
+    // Samples sit exactly on leaf centers, where the stored SDF sign is
+    // near-exact. The margin only needs to absorb the small model errors:
+    // stamp scallops, arc linearization, and target tessellation sag.
+    let max_cell = cell[0].max(cell[1]).max(cell[2]);
+    let sim_margin = 0.25 * max_cell + 0.01;
+    let gouge_threshold = opts.tolerance + sim_margin;
+    let excess_threshold = opts.allowance + sim_margin;
+
+    let mut gouge = CheckAccum::new(opts.max_examples);
+    let mut excess = CheckAccum::new(opts.max_examples);
+    let mut grid_samples = 0usize;
+
+    for i in (0..n).step_by(stride) {
+        let x = b[0] + (i as f64 + 0.5) * cell[0];
+        for j in (0..n).step_by(stride) {
+            let y = b[1] + (j as f64 + 0.5) * cell[1];
+            for k in (0..n).step_by(stride) {
+                let z = b[2] + (k as f64 + 0.5) * cell[2];
+                grid_samples += 1;
+
+                let p = [x, y, z];
+                let stock_sdf = stock.sdf_at(x, y, z);
+                let inside_target = point_in_triangles(p, &tris);
+
+                if inside_target && stock_sdf > 0.0 {
+                    // Target needs material here but the stock lost it.
+                    let d = distance_to_triangles(p, &tris);
+                    if d > gouge_threshold {
+                        gouge.add(p, d);
+                    }
+                } else if !inside_target && stock_sdf < 0.0 {
+                    // Stock kept material the target doesn't want.
+                    let d = distance_to_triangles(p, &tris);
+                    if d > excess_threshold {
+                        excess.add(p, d);
+                    }
+                }
+            }
+        }
+    }
+
+    let gouge = gouge.finish();
+    let excess = excess.finish();
+    StockVerification {
+        pass: gouge.pass && excess.pass,
+        gouge,
+        excess,
+        tolerance: opts.tolerance,
+        allowance: opts.allowance,
+        sim_margin,
+        grid_samples,
+        cell_size: cell,
+    }
+}
+
+/// Accumulator for one check, keeping the deepest examples.
+struct CheckAccum {
+    count: usize,
+    worst: f64,
+    examples: Vec<ViolationSample>,
+    cap: usize,
+}
+
+impl CheckAccum {
+    fn new(cap: usize) -> Self {
+        Self {
+            count: 0,
+            worst: 0.0,
+            examples: Vec::new(),
+            cap,
+        }
+    }
+
+    fn add(&mut self, position: [f64; 3], depth: f64) {
+        self.count += 1;
+        self.worst = self.worst.max(depth);
+        if self.examples.len() < self.cap {
+            self.examples.push(ViolationSample { position, depth });
+        } else if let Some((idx, shallowest)) = self
+            .examples
+            .iter()
+            .enumerate()
+            .min_by(|(_, a), (_, b)| a.depth.total_cmp(&b.depth))
+            .map(|(idx, s)| (idx, s.depth))
+        {
+            if depth > shallowest {
+                self.examples[idx] = ViolationSample { position, depth };
+            }
+        }
+    }
+
+    fn finish(self) -> CheckReport {
+        CheckReport {
+            pass: self.count == 0,
+            violation_count: self.count,
+            worst_depth: self.worst,
+            examples: self.examples,
+        }
+    }
+}
+
+type Triangle = [[f64; 3]; 3];
+
+fn collect_triangles(vertices: &[f32], indices: &[u32]) -> Vec<Triangle> {
+    indices
+        .chunks_exact(3)
+        .map(|tri| {
+            let v = |idx: u32| {
+                let i = idx as usize * 3;
+                [
+                    vertices[i] as f64,
+                    vertices[i + 1] as f64,
+                    vertices[i + 2] as f64,
+                ]
+            };
+            [v(tri[0]), v(tri[1]), v(tri[2])]
+        })
+        .collect()
+}
+
+/// Point containment by ray crossing count. The ray direction is slightly
+/// tilted so it doesn't hit shared edges or vertices exactly.
+fn point_in_triangles(p: [f64; 3], tris: &[Triangle]) -> bool {
+    let dir = [1.0, 1e-7, 1.3e-7];
+    let mut crossings = 0u32;
+    for tri in tris {
+        if ray_hits_triangle(p, dir, tri) {
+            crossings += 1;
+        }
+    }
+    crossings % 2 == 1
+}
+
+/// Möller–Trumbore ray-triangle intersection (t > 0 only).
+fn ray_hits_triangle(orig: [f64; 3], dir: [f64; 3], tri: &Triangle) -> bool {
+    let e1 = sub(tri[1], tri[0]);
+    let e2 = sub(tri[2], tri[0]);
+    let h = cross(dir, e2);
+    let a = dot(e1, h);
+    if a.abs() < 1e-12 {
+        return false;
+    }
+    let f = 1.0 / a;
+    let s = sub(orig, tri[0]);
+    let u = f * dot(s, h);
+    if !(0.0..=1.0).contains(&u) {
+        return false;
+    }
+    let q = cross(s, e1);
+    let v = f * dot(dir, q);
+    if v < 0.0 || u + v > 1.0 {
+        return false;
+    }
+    f * dot(e2, q) > 1e-9
+}
+
+fn distance_to_triangles(p: [f64; 3], tris: &[Triangle]) -> f64 {
+    tris.iter()
+        .map(|tri| {
+            let c = closest_point_on_triangle(p, tri[0], tri[1], tri[2]);
+            norm(sub(p, c))
+        })
+        .fold(f64::INFINITY, f64::min)
+}
+
+/// Closest point on a triangle to `p` (Ericson, Real-Time Collision
+/// Detection §5.1.5).
+fn closest_point_on_triangle(p: [f64; 3], a: [f64; 3], b: [f64; 3], c: [f64; 3]) -> [f64; 3] {
+    let ab = sub(b, a);
+    let ac = sub(c, a);
+    let ap = sub(p, a);
+    let d1 = dot(ab, ap);
+    let d2 = dot(ac, ap);
+    if d1 <= 0.0 && d2 <= 0.0 {
+        return a;
+    }
+
+    let bp = sub(p, b);
+    let d3 = dot(ab, bp);
+    let d4 = dot(ac, bp);
+    if d3 >= 0.0 && d4 <= d3 {
+        return b;
+    }
+
+    let vc = d1 * d4 - d3 * d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+        let v = d1 / (d1 - d3);
+        return add(a, scale(ab, v));
+    }
+
+    let cp = sub(p, c);
+    let d5 = dot(ab, cp);
+    let d6 = dot(ac, cp);
+    if d6 >= 0.0 && d5 <= d6 {
+        return c;
+    }
+
+    let vb = d5 * d2 - d1 * d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+        let w = d2 / (d2 - d6);
+        return add(a, scale(ac, w));
+    }
+
+    let va = d3 * d6 - d5 * d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+        let w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return add(b, scale(sub(c, b), w));
+    }
+
+    let denom = 1.0 / (va + vb + vc);
+    let v = vb * denom;
+    let w = vc * denom;
+    add(add(a, scale(ab, v)), scale(ac, w))
+}
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+fn add(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+fn scale(a: [f64; 3], s: f64) -> [f64; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+fn norm(a: [f64; 3]) -> f64 {
+    dot(a, a).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a closed 12-triangle box mesh in the tessellation layout.
+    fn box_mesh(min: [f64; 3], max: [f64; 3]) -> (Vec<f32>, Vec<u32>) {
+        let corners = [
+            [min[0], min[1], min[2]],
+            [max[0], min[1], min[2]],
+            [max[0], max[1], min[2]],
+            [min[0], max[1], min[2]],
+            [min[0], min[1], max[2]],
+            [max[0], min[1], max[2]],
+            [max[0], max[1], max[2]],
+            [min[0], max[1], max[2]],
+        ];
+        let vertices: Vec<f32> = corners
+            .iter()
+            .flat_map(|c| c.iter().map(|&v| v as f32))
+            .collect();
+        let quads: [[u32; 4]; 6] = [
+            [0, 3, 2, 1], // bottom
+            [4, 5, 6, 7], // top
+            [0, 1, 5, 4], // -y
+            [2, 3, 7, 6], // +y
+            [1, 2, 6, 5], // +x
+            [0, 4, 7, 3], // -x
+        ];
+        let indices: Vec<u32> = quads
+            .iter()
+            .flat_map(|q| [q[0], q[1], q[2], q[0], q[2], q[3]])
+            .collect();
+        (vertices, indices)
+    }
+
+    #[test]
+    fn test_untouched_stock_matching_target_passes() {
+        let stock = Stock::from_box([0.0, 0.0, 0.0, 10.0, 10.0, 10.0], 1.0);
+        let (verts, idx) = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
+
+        let result = verify_stock_against_mesh(&stock, &verts, &idx, &VerifyOptions::default());
+        assert!(result.pass, "identical stock and target: {result:?}");
+        assert_eq!(result.gouge.violation_count, 0);
+        assert_eq!(result.excess.violation_count, 0);
+        assert!(result.grid_samples > 0);
+    }
+
+    #[test]
+    fn test_subtracted_sphere_is_a_gouge() {
+        let mut stock = Stock::from_box([0.0, 0.0, 0.0, 10.0, 10.0, 10.0], 1.0);
+        stock.subtract_sphere([5.0, 5.0, 5.0], 3.0);
+        let (verts, idx) = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
+
+        let result = verify_stock_against_mesh(&stock, &verts, &idx, &VerifyOptions::default());
+        assert!(!result.gouge.pass, "hollowed core must be a gouge");
+        assert!(
+            result.gouge.worst_depth > 2.0,
+            "deepest gouge sample should approach the box center, got {}",
+            result.gouge.worst_depth
+        );
+        assert!(!result.gouge.examples.is_empty());
+        assert!(
+            result.excess.pass,
+            "nothing was left over: {:?}",
+            result.excess
+        );
+        assert!(!result.pass);
+    }
+
+    #[test]
+    fn test_unmachined_layer_is_excess() {
+        // Target stops at z=8 but the stock was never machined: the top
+        // 2mm is leftover material.
+        let stock = Stock::from_box([0.0, 0.0, 0.0, 10.0, 10.0, 10.0], 1.0);
+        let (verts, idx) = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 8.0]);
+
+        let result = verify_stock_against_mesh(&stock, &verts, &idx, &VerifyOptions::default());
+        assert!(result.gouge.pass);
+        assert!(!result.excess.pass, "unmachined top layer must be excess");
+        assert!(
+            result.excess.worst_depth > 1.0,
+            "leftover layer is ~2mm thick, got {}",
+            result.excess.worst_depth
+        );
+        assert!(!result.pass);
+    }
+
+    #[test]
+    fn test_verification_serde_round_trip() {
+        let mut stock = Stock::from_box([0.0, 0.0, 0.0, 10.0, 10.0, 10.0], 1.0);
+        stock.subtract_sphere([5.0, 5.0, 5.0], 3.0);
+        let (verts, idx) = box_mesh([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
+
+        let result = verify_stock_against_mesh(&stock, &verts, &idx, &VerifyOptions::default());
+        let json = serde_json::to_string(&result).unwrap();
+        let parsed: StockVerification = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.pass, result.pass);
+        assert_eq!(parsed.gouge.violation_count, result.gouge.violation_count);
+        assert_eq!(parsed.grid_samples, result.grid_samples);
+    }
+}

--- a/crates/vcad-kernel-stocksim/src/verify.rs
+++ b/crates/vcad-kernel-stocksim/src/verify.rs
@@ -228,7 +228,9 @@ type Triangle = [[f64; 3]; 3];
 
 fn collect_triangles(vertices: &[f32], indices: &[u32]) -> Vec<Triangle> {
     indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|tri| {
             let v = |idx: u32| {
                 let i = idx as usize * 3;

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -23,6 +23,11 @@ vcad-kernel-constraints = { workspace = true }
 vcad-kernel-text = { workspace = true }
 vcad-kernel-cost = { workspace = true }
 vcad-kernel-dfm = { workspace = true }
+vcad-kernel-cam = { workspace = true }
+vcad-kernel-stocksim = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [features]
 # Forwards the `no-builtin-font` flag from vcad-kernel-text so downstream

--- a/crates/vcad-kernel/src/cam_verify.rs
+++ b/crates/vcad-kernel/src/cam_verify.rs
@@ -1,0 +1,192 @@
+//! CAM verification oracle: simulate toolpaths against stock and grade the
+//! result against a target [`Solid`].
+//!
+//! This bridges `vcad-kernel-cam` (toolpath generation) and
+//! `vcad-kernel-stocksim` (octree material-removal simulation): run the
+//! toolpath through the stock, then check the two CAM invariants against
+//! the target part — **no gouge** (the toolpath never removed material the
+//! part needs) and **no excess** (the toolpath removed everything it was
+//! supposed to, within the machining allowance).
+//!
+//! The [`StockVerification`] result is plain serializable data, suitable
+//! for embedding in a build receipt.
+
+use vcad_kernel_cam::{Tool, Toolpath};
+use vcad_kernel_stocksim::{
+    verify_stock_against_mesh, Stock, StockSimError, StockVerification, VerifyOptions,
+};
+
+use crate::Solid;
+
+/// Simulate `passes` (tool + toolpath, in cutting order) against a stock
+/// block and verify the remaining material against `target`.
+///
+/// * `target` — the part the toolpaths are supposed to produce, in the same
+///   frame as the toolpath coordinates. CAM convention puts the stock top
+///   at Z = 0 with material below, so a target modeled at the origin
+///   usually needs to be translated down into the stock first.
+/// * `stock_bounds` — `[min_x, min_y, min_z, max_x, max_y, max_z]` of the
+///   stock block (mm).
+/// * `resolution` — simulation cell size (mm). Violations thinner than a
+///   cell can escape detection, so keep this below the finest defect that
+///   matters.
+/// * `passes` — each entry pairs the tool with the toolpath it cuts.
+pub fn verify_toolpaths(
+    target: &Solid,
+    stock_bounds: [f64; 6],
+    resolution: f64,
+    passes: &[(Tool, Toolpath)],
+    opts: &VerifyOptions,
+) -> Result<StockVerification, StockSimError> {
+    let dx = stock_bounds[3] - stock_bounds[0];
+    let dy = stock_bounds[4] - stock_bounds[1];
+    let dz = stock_bounds[5] - stock_bounds[2];
+    if dx <= 0.0 || dy <= 0.0 || dz <= 0.0 {
+        return Err(StockSimError::InvalidBounds(format!(
+            "stock must have positive extent, got {dx} x {dy} x {dz}"
+        )));
+    }
+    if resolution <= 0.0 || !resolution.is_finite() {
+        return Err(StockSimError::ResolutionTooSmall(resolution));
+    }
+
+    let mut stock = Stock::from_box(stock_bounds, resolution);
+    for (tool, toolpath) in passes {
+        stock.subtract_toolpath(tool, toolpath);
+    }
+
+    let mesh = target.to_mesh(32);
+    Ok(verify_stock_against_mesh(
+        &stock,
+        &mesh.vertices,
+        &mesh.indices,
+        opts,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_kernel_cam::{CamSettings, Face, ToolpathSegment};
+    use vcad_kernel_stocksim::StockVerification;
+
+    /// 50 x 50 x 10 stock, CAM convention: top at Z = 0, material below.
+    const STOCK: [f64; 6] = [0.0, 0.0, -10.0, 50.0, 50.0, 0.0];
+
+    /// The part: the stock with its top 2mm faced off.
+    fn target_block() -> Solid {
+        Solid::cube(50.0, 50.0, 8.0).translate(0.0, 0.0, -10.0)
+    }
+
+    fn flat_tool() -> Tool {
+        Tool::FlatEndMill {
+            diameter: 6.0,
+            flute_length: 20.0,
+            flutes: 2,
+        }
+    }
+
+    fn settings() -> CamSettings {
+        CamSettings {
+            stepover: 4.0,
+            stepdown: 2.0,
+            feed_rate: 1000.0,
+            plunge_rate: 300.0,
+            spindle_rpm: 12000.0,
+            safe_z: 5.0,
+            retract_z: 10.0,
+        }
+    }
+
+    fn facing_toolpath(depth: f64) -> Toolpath {
+        Face::new(0.0, 0.0, 50.0, 50.0, depth)
+            .generate(&flat_tool(), &settings())
+            .unwrap()
+    }
+
+    fn verify(passes: &[(Tool, Toolpath)]) -> StockVerification {
+        verify_toolpaths(
+            &target_block(),
+            STOCK,
+            1.0,
+            passes,
+            &VerifyOptions::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn facing_to_target_depth_passes() {
+        let result = verify(&[(flat_tool(), facing_toolpath(2.0))]);
+        assert!(result.gouge.pass, "no gouge expected: {:?}", result.gouge);
+        assert!(
+            result.excess.pass,
+            "no excess expected: {:?}",
+            result.excess
+        );
+        assert!(result.pass);
+    }
+
+    #[test]
+    fn gouging_toolpath_fails_gouge_check() {
+        // Correct facing, plus a rogue slot 3mm below the finished face.
+        let mut rogue = facing_toolpath(2.0);
+        rogue.push(ToolpathSegment::rapid(-10.0, 25.0, 5.0));
+        rogue.push(ToolpathSegment::linear(-10.0, 25.0, -5.0, 300.0));
+        rogue.push(ToolpathSegment::linear(60.0, 25.0, -5.0, 1000.0));
+
+        let result = verify(&[(flat_tool(), rogue)]);
+        assert!(!result.gouge.pass, "3mm slot into the part must be flagged");
+        assert!(
+            result.gouge.worst_depth > 1.5,
+            "slot cuts ~3mm past the target surface, got {}",
+            result.gouge.worst_depth
+        );
+        assert!(!result.gouge.examples.is_empty());
+        assert!(
+            result.excess.pass,
+            "facing still completed: {:?}",
+            result.excess
+        );
+        assert!(!result.pass);
+    }
+
+    #[test]
+    fn shallow_facing_fails_excess_check() {
+        // Faces only 1mm of the 2mm that must come off.
+        let result = verify(&[(flat_tool(), facing_toolpath(1.0))]);
+        assert!(result.gouge.pass, "no gouge expected: {:?}", result.gouge);
+        assert!(!result.excess.pass, "1mm of leftover stock must be flagged");
+        assert!(
+            result.excess.worst_depth > 0.4,
+            "leftover layer is ~1mm thick, got {}",
+            result.excess.worst_depth
+        );
+        assert!(!result.pass);
+    }
+
+    #[test]
+    fn rejects_degenerate_stock() {
+        let result = verify_toolpaths(
+            &target_block(),
+            [0.0, 0.0, 0.0, 50.0, 50.0, 0.0],
+            1.0,
+            &[],
+            &VerifyOptions::default(),
+        );
+        assert!(matches!(result, Err(StockSimError::InvalidBounds(_))));
+
+        let result = verify_toolpaths(&target_block(), STOCK, 0.0, &[], &VerifyOptions::default());
+        assert!(matches!(result, Err(StockSimError::ResolutionTooSmall(_))));
+    }
+
+    #[test]
+    fn verification_is_plain_serializable_data() {
+        let result = verify(&[(flat_tool(), facing_toolpath(2.0))]);
+        let json = serde_json::to_string(&result).unwrap();
+        let parsed: StockVerification = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.pass, result.pass);
+        assert_eq!(parsed.grid_samples, result.grid_samples);
+        assert_eq!(parsed.gouge.violation_count, result.gouge.violation_count);
+    }
+}

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -18,6 +18,7 @@
 use std::path::Path;
 
 pub use vcad_kernel_booleans;
+pub use vcad_kernel_cam;
 pub use vcad_kernel_constraints;
 pub use vcad_kernel_cost;
 pub use vcad_kernel_dfm;
@@ -29,10 +30,14 @@ pub use vcad_kernel_sheet;
 pub use vcad_kernel_shell;
 pub use vcad_kernel_sketch;
 pub use vcad_kernel_step;
+pub use vcad_kernel_stocksim;
 pub use vcad_kernel_sweep;
 pub use vcad_kernel_tessellate;
 pub use vcad_kernel_text;
 pub use vcad_kernel_topo;
+
+pub mod cam_verify;
+pub use cam_verify::verify_toolpaths;
 
 pub mod sheet_fold;
 pub use sheet_fold::folded_sheet_solid;


### PR DESCRIPTION
## Summary

Wires `vcad-kernel-stocksim` into its first consumer — a CAM verification oracle — per the domain atlas (PR #397), which called the crate "the canonical gate violation" (built, zero consumers) and said: wire it as the CAM verification oracle or park it.

Verdict: the octree-SDF representation holds up; no parking needed. But the integration surfaced two latent simulation bugs that would have made any oracle built on it lie, both fixed here.

## The oracle

`vcad_kernel::verify_toolpaths(target, stock_bounds, resolution, &[(Tool, Toolpath)], &VerifyOptions)` simulates the passes against a stock block and grades the remaining material against the target `Solid` with two checks:

- **Gouge** — material removed that the part needs: samples inside the target (deeper than `tolerance`) where the stock reads air.
- **Excess** — material the toolpath failed to remove: samples outside the target (beyond `allowance`) where stock material remains.

The result (`StockVerification { pass, gouge, excess, sim_margin, cell_size, … }`, with capped worst-first example points) is plain serde data, ready to become a Receipt claim later.

Core lives in `vcad-kernel-stocksim/src/verify.rs` (`verify_stock_against_mesh`, takes a tessellation-layout mesh); the facade in `vcad-kernel/src/cam_verify.rs` follows the `sheet_fold` re-export pattern. `vcad_kernel_cam` and `vcad_kernel_stocksim` are now re-exported from the unified API.

Sampling runs on a grid aligned with the octree leaf centers — exactly where the stored SDF sign is near-exact, since subtraction evaluates the removal SDF at that same point. That keeps `sim_margin` small (0.25·cell + ε) and makes the checks deterministic instead of tessellation-noise-sensitive. Rapids are simulated as cutting: a rapid through material is a crash, and the oracle should flag it.

## Latent stocksim bugs fixed

1. **Tool model**: `subtract_toolpath` modeled every tool as a sphere-swept capsule *centered at the tool tip* — a correct flat-endmill facing pass would read as a full-radius gouge below the floor, and adjacent passes under-removed. Replaced with per-tool cutter-envelope SDFs (flat / ball / bull / cone bottoms, tip at origin, +Z axis) stamped at half-cell spacing along motion segments. The unused-but-exported `SweptVolume` helper is untouched.
2. **Subtraction sign**: leaf cells computed `max(before, region_sdf)` instead of `max(before, -region_sdf)`, so material was only ever removed via the whole-cell quick-accept path and boundary cells were systematically under-removed. `subtract_sphere`/`subtract_capsule` are now thin wrappers over a new generic `Stock::subtract_sdf` (any 1-Lipschitz SDF), which removes the duplicated recursion along with the bug. Regression test included (`test_subtract_sphere_boundary_cells`).

## Tests

- Facing a 50×50×10 stock down 2 mm to a 50×50×8 target: passes both checks.
- Same facing plus a rogue slot 3 mm below the finished face: fails gouge (worst depth ≈ 2.9 mm), excess stays clean.
- Facing only 1 mm of the required 2 mm: fails excess only.
- Degenerate stock bounds / resolution rejected; serde round-trip of the full result.
- Known sensitivity limit documented in the result itself: violations thinner than one grid cell can escape detection (`cell_size` is reported so callers can budget resolution).

`cargo test --workspace --exclude vcad-desktop`, `cargo clippy --workspace --exclude vcad-desktop -- -D warnings`, and `cargo fmt --all --check` all pass. (With the stricter `--all-targets`, pre-existing test-code lints in termview/stepperoni/vcad-kernel go red — untouched here.)

## Not in scope

WASM bindings / MCP tool / receipt claim for the oracle, and exercising `Roughing3D` dropcutter paths against it — natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
