### PR TITLE
Geo-block sanctioned jurisdictions on vcad.io + mcp.vcad.io (HTTP 451)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ npm run tauri:dev          # launches desktop window against the dev server
 npm run tauri:build        # produces a signed/unsigned installer
 ```
 
+## Export controls
+
+The hosted services (vcad.io and mcp.vcad.io) are not available in
+jurisdictions subject to U.S. sanctions and export controls — currently
+Russia, Belarus, Iran, Cuba, North Korea, Syria, and the Crimea, Sevastopol,
+Donetsk, and Luhansk regions of Ukraine. Users must comply with all
+applicable export laws. The open-source code in this repository is not
+affected and remains available to everyone. Details in
+[docs/export-controls.md](docs/export-controls.md).
+
 ## License
 
 Copyright © 2026 Municipal Robotics Corporation

--- a/docs/export-controls.md
+++ b/docs/export-controls.md
@@ -1,0 +1,35 @@
+# Export controls and sanctions
+
+vcad's **hosted services** — the web app at [vcad.io](https://vcad.io) and the
+MCP server at `mcp.vcad.io` — are operated by a U.S. person and are therefore
+subject to U.S. export controls and sanctions. They are **not available** in:
+
+- **Russia** — the OFAC determination of June 12, 2024 under Executive Order
+  14071 (effective September 12, 2024) prohibits supplying IT support and
+  cloud-based services for design and manufacturing software (CAD is
+  explicitly named) to any person located in the Russian Federation.
+- **Belarus** — parallel BIS Export Administration Regulations restrictions
+  (15 C.F.R. § 746.8).
+- **Iran, Cuba, North Korea, Syria** — comprehensively sanctioned under the
+  respective OFAC country programs.
+- **The Crimea, Sevastopol, Donetsk, and Luhansk regions of Ukraine** —
+  embargoed under Executive Orders 13685 and 14065. Blocked best-effort by
+  region where geolocation provides one; the rest of Ukraine is unaffected.
+
+Requests from these jurisdictions receive **HTTP 451** (Unavailable For Legal
+Reasons). The block list lives in [`shared/geo-block.ts`](../shared/geo-block.ts)
+and is enforced by Vercel Edge Middleware on both deployments, plus a
+request-layer check in the MCP server.
+
+## The open-source code is not affected
+
+This repository is published open-source software, which is not subject to
+the EAR (15 C.F.R. §§ 734.3(b)(3), 734.7). Anyone may clone, build, and run
+vcad locally under the [Apache License 2.0](../LICENSE).
+
+## Your responsibility
+
+By using the hosted services you represent that you are not located in any of
+the jurisdictions above and are not on a U.S. restricted-party list. You are
+responsible for complying with all export control and sanctions laws that
+apply to you.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,16 @@
+/**
+ * Vercel Edge Middleware for the vcad.io web app (repo-root deploy config).
+ *
+ * Blocks the entire hosted surface for embargoed jurisdictions — see
+ * shared/geo-block.ts for the block list and the legal citations. A copy of
+ * this wrapper exists at packages/app/middleware.ts so the block applies
+ * regardless of which directory the Vercel project uses as its root; both
+ * import the same shared module.
+ */
+
+import { isRequestGeoBlocked, geoBlockResponse } from "./shared/geo-block";
+
+export default function middleware(request: Request): Response | undefined {
+  if (isRequestGeoBlocked(request)) return geoBlockResponse();
+  return undefined; // fall through to the app
+}

--- a/packages/app/middleware.ts
+++ b/packages/app/middleware.ts
@@ -1,0 +1,16 @@
+/**
+ * Vercel Edge Middleware for the vcad.io web app (packages/app deploy config).
+ *
+ * Blocks the entire hosted surface for embargoed jurisdictions — see
+ * shared/geo-block.ts for the block list and the legal citations. A copy of
+ * this wrapper exists at the repo root so the block applies regardless of
+ * which directory the Vercel project uses as its root; both import the same
+ * shared module.
+ */
+
+import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block";
+
+export default function middleware(request: Request): Response | undefined {
+  if (isRequestGeoBlocked(request)) return geoBlockResponse();
+  return undefined; // fall through to the app
+}

--- a/packages/app/src/components/LegalPage.tsx
+++ b/packages/app/src/components/LegalPage.tsx
@@ -9,7 +9,7 @@ interface LegalContent {
 
 const CONTACT_EMAIL = "info@muni.works";
 const COMPANY = "Municipal Robotics Corporation";
-const LAST_UPDATED = "April 23, 2026";
+const LAST_UPDATED = "July 7, 2026";
 
 const PRIVACY: LegalContent = {
   title: "Privacy Policy",
@@ -99,6 +99,13 @@ const TERMS: LegalContent = {
       body: [
         "Don't use vcad to break the law, infringe others' rights, transmit malware, or attempt to access accounts or data that aren't yours. Don't abuse our AI features to generate content that would violate our providers' policies.",
         "We may suspend accounts that violate these terms.",
+      ],
+    },
+    {
+      heading: "Export controls and sanctions",
+      body: [
+        "The hosted service is not available in jurisdictions subject to comprehensive U.S. sanctions or to the OFAC determination under Executive Order 14071 covering IT support and cloud-based services for design and manufacturing software — currently Russia, Belarus, Iran, Cuba, North Korea, Syria, and the Crimea, Sevastopol, Donetsk, and Luhansk regions of Ukraine.",
+        "You may not use the hosted service if you are located in any of those jurisdictions or listed on a U.S. restricted-party list, and you are responsible for complying with all applicable export control and sanctions laws. The open-source code remains available on GitHub under the Apache License 2.0.",
       ],
     },
     {

--- a/packages/mcp/src/__tests__/geo-block.test.ts
+++ b/packages/mcp/src/__tests__/geo-block.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the shared export-control geo-block module (shared/geo-block.ts).
+ *
+ * Lives here (rather than next to the module) because packages/mcp already
+ * has vitest wired up and src/__tests__ is excluded from the tsc build, so
+ * the cross-package relative import never reaches the compiler output.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  BLOCKED_COUNTRIES,
+  GEO_BLOCK_BODY,
+  GEO_BLOCK_STATUS,
+  geoBlockResponse,
+  isGeoBlocked,
+  isRequestGeoBlocked,
+} from "../../../../shared/geo-block";
+
+describe("isGeoBlocked", () => {
+  it("blocks every listed country", () => {
+    for (const cc of ["RU", "BY", "IR", "CU", "KP", "SY"]) {
+      expect(isGeoBlocked(cc), cc).toBe(true);
+    }
+  });
+
+  it("is case- and whitespace-insensitive on the country code", () => {
+    expect(isGeoBlocked("ru")).toBe(true);
+    expect(isGeoBlocked(" RU ")).toBe(true);
+  });
+
+  it("allows US and other unlisted countries", () => {
+    expect(isGeoBlocked("US")).toBe(false);
+    expect(isGeoBlocked("DE")).toBe(false);
+    expect(isGeoBlocked("JP")).toBe(false);
+  });
+
+  it("fails open when the country header is missing", () => {
+    expect(isGeoBlocked(null)).toBe(false);
+    expect(isGeoBlocked(undefined)).toBe(false);
+    expect(isGeoBlocked("")).toBe(false);
+  });
+
+  it("allows Ukraine generally (e.g. Kyiv)", () => {
+    expect(isGeoBlocked("UA")).toBe(false);
+    expect(isGeoBlocked("UA", "30")).toBe(false); // Kyiv city
+    expect(isGeoBlocked("UA", null)).toBe(false); // region header missing
+  });
+
+  it("blocks the occupied Ukrainian regions", () => {
+    expect(isGeoBlocked("UA", "43")).toBe(true); // Crimea
+    expect(isGeoBlocked("UA", "40")).toBe(true); // Sevastopol
+    expect(isGeoBlocked("UA", "14")).toBe(true); // Donetsk
+    expect(isGeoBlocked("UA", "09")).toBe(true); // Luhansk
+  });
+
+  it("accepts the full ISO 3166-2 'UA-43' region form", () => {
+    expect(isGeoBlocked("UA", "UA-43")).toBe(true);
+    expect(isGeoBlocked("ua", "ua-40")).toBe(true);
+  });
+
+  it("does not apply UA region codes to other countries", () => {
+    // "43" is only meaningful as a subdivision of UA.
+    expect(isGeoBlocked("US", "43")).toBe(false);
+  });
+});
+
+describe("isRequestGeoBlocked", () => {
+  const req = (headers: Record<string, string>) =>
+    new Request("https://vcad.io/", { headers });
+
+  it("blocks based on the x-vercel-ip-country header", () => {
+    expect(isRequestGeoBlocked(req({ "x-vercel-ip-country": "RU" }))).toBe(
+      true,
+    );
+    expect(isRequestGeoBlocked(req({ "x-vercel-ip-country": "US" }))).toBe(
+      false,
+    );
+  });
+
+  it("combines country and region headers", () => {
+    expect(
+      isRequestGeoBlocked(
+        req({
+          "x-vercel-ip-country": "UA",
+          "x-vercel-ip-country-region": "43",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isRequestGeoBlocked(
+        req({
+          "x-vercel-ip-country": "UA",
+          "x-vercel-ip-country-region": "30",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("fails open with no geo headers at all", () => {
+    expect(isRequestGeoBlocked(req({}))).toBe(false);
+  });
+
+  it("honors request.geo when the platform provides it", () => {
+    const r = req({}) as Request & { geo?: { country?: string } };
+    r.geo = { country: "RU" };
+    expect(isRequestGeoBlocked(r)).toBe(true);
+  });
+});
+
+describe("geoBlockResponse", () => {
+  it("returns HTTP 451 with the shared JSON body", async () => {
+    const res = geoBlockResponse();
+    expect(res.status).toBe(GEO_BLOCK_STATUS);
+    expect(res.status).toBe(451);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    const body = await res.text();
+    expect(body).toBe(GEO_BLOCK_BODY);
+    const parsed = JSON.parse(body) as { message: string };
+    expect(parsed.message).toContain("export controls");
+    expect(parsed.message).toContain("github.com/ecto/vcad");
+  });
+});
+
+describe("block list", () => {
+  it("matches the jurisdictions in the OFAC/BIS citations", () => {
+    expect([...BLOCKED_COUNTRIES].sort()).toEqual([
+      "BY",
+      "CU",
+      "IR",
+      "KP",
+      "RU",
+      "SY",
+    ]);
+  });
+});

--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -61,6 +61,24 @@ npx esbuild@latest entry.ts \
   --outfile="$OUT/functions/mcp.func/index.mjs" \
   --banner:js="import { createRequire as __vcadCreateRequire } from 'module'; const require = __vcadCreateRequire(import.meta.url);"
 
+# ── 3b. Bundle edge middleware (export-control geo-block) ───
+# Build Output API deploys don't get Vercel's automatic middleware.ts
+# detection, so the geo-block middleware is bundled explicitly as an edge
+# function and wired in via a `middlewarePath` route below.
+mkdir -p "$OUT/functions/_middleware.func"
+npx esbuild@latest middleware.ts \
+  --bundle \
+  --platform=browser \
+  --format=esm \
+  --outfile="$OUT/functions/_middleware.func/index.js"
+
+cat > "$OUT/functions/_middleware.func/.vc-config.json" << 'EOF'
+{
+  "runtime": "edge",
+  "entrypoint": "index.js"
+}
+EOF
+
 # ── 4. Copy WASM binary next to the bundle ───────────────────
 cp "$REPO_ROOT/packages/kernel-wasm/vcad_kernel_wasm_bg.wasm" \
    "$OUT/functions/mcp.func/"
@@ -91,6 +109,11 @@ cat > "$OUT/config.json" << 'EOF'
 {
   "version": 3,
   "routes": [
+    {
+      "src": "/.*",
+      "middlewarePath": "_middleware",
+      "continue": true
+    },
     {
       "src": "^/$",
       "status": 308,

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -30,6 +30,11 @@ import { Engine } from "@vcad/engine";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { readFileSync } from "node:fs";
+import {
+  isGeoBlocked,
+  GEO_BLOCK_BODY,
+  GEO_BLOCK_STATUS,
+} from "../../shared/geo-block";
 
 // The serverless function filesystem is read-only (/var/task), so the
 // filesystem-touching tools (export_cad, import_step, export_gerber)
@@ -77,6 +82,23 @@ export default async function handler(
     "Access-Control-Expose-Headers",
     "mcp-session-id, mcp-protocol-version",
   );
+
+  // U.S. export-control / sanctions geo-block (see shared/geo-block.ts).
+  // Defense-in-depth behind the edge middleware in .vercel/output — every
+  // route dests to this one function, so this check alone covers the whole
+  // surface even if a request reaches it without traversing the middleware.
+  const ipCountry = req.headers["x-vercel-ip-country"];
+  const ipRegion = req.headers["x-vercel-ip-country-region"];
+  if (
+    isGeoBlocked(
+      Array.isArray(ipCountry) ? ipCountry[0] : ipCountry,
+      Array.isArray(ipRegion) ? ipRegion[0] : ipRegion,
+    )
+  ) {
+    res.writeHead(GEO_BLOCK_STATUS, { "Content-Type": "application/json" });
+    res.end(GEO_BLOCK_BODY);
+    return;
+  }
 
   const url = new URL(req.url ?? "/", `https://${req.headers.host ?? "mcp.vcad.io"}`);
 

--- a/services/mcp/middleware.ts
+++ b/services/mcp/middleware.ts
@@ -1,0 +1,19 @@
+/**
+ * Edge middleware for mcp.vcad.io — U.S. export-control / sanctions block.
+ *
+ * This deploy uses the Build Output API (build.sh writes .vercel/output
+ * directly), so Vercel's automatic middleware.ts detection does not apply.
+ * build.sh bundles this file into functions/_middleware.func (edge runtime)
+ * and routes every request through it via a `middlewarePath` route with
+ * `continue: true`. Block list + citations live in shared/geo-block.ts.
+ *
+ * The request handler in entry.ts runs the same check as defense-in-depth.
+ */
+
+import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block";
+
+export default function middleware(request: Request): Response {
+  if (isRequestGeoBlocked(request)) return geoBlockResponse();
+  // Build Output API middleware signals "continue to routing" explicitly.
+  return new Response(null, { headers: { "x-middleware-next": "1" } });
+}

--- a/services/mcp/vercel.json
+++ b/services/mcp/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "installCommand": "cd ../.. && npm ci --ignore-scripts",
   "buildCommand": "bash build.sh",
-  "ignoreCommand": "cd ../.. && git diff --quiet HEAD^ HEAD -- services/mcp packages/ir packages/core packages/engine packages/mcp packages/kernel-wasm",
+  "ignoreCommand": "cd ../.. && git diff --quiet HEAD^ HEAD -- services/mcp shared packages/ir packages/core packages/engine packages/mcp packages/kernel-wasm",
   "framework": null
 }

--- a/shared/geo-block.ts
+++ b/shared/geo-block.ts
@@ -1,0 +1,110 @@
+/**
+ * U.S. export-control / sanctions geo-block — single source of truth.
+ *
+ * vcad's hosted surfaces (vcad.io, mcp.vcad.io) are operated by a U.S.
+ * person and may not be supplied to the jurisdictions below:
+ *
+ * - RU — OFAC determination of 2024-06-12 under E.O. 14071 (effective
+ *   2024-09-12): prohibits supplying "IT support and cloud-based services
+ *   for … design and manufacturing software" (CAD is explicitly named) to
+ *   any person located in the Russian Federation.
+ * - BY — parallel BIS EAR restrictions (15 C.F.R. § 746.8, Russia/Belarus).
+ * - IR, CU, KP, SY — comprehensively sanctioned (OFAC country programs).
+ * - Crimea, Sevastopol, Donetsk, Luhansk (so-called DNR/LNR) regions of
+ *   Ukraine — embargoed under E.O. 13685 and E.O. 14065. Blocked
+ *   best-effort via the region header when the platform provides one.
+ *
+ * This module is imported by every deploy's edge middleware and by the MCP
+ * server's request handler — keep it dependency-free and runtime-agnostic
+ * (it runs on the Edge runtime and on Node). The public GitHub repo is NOT
+ * affected: published open-source software is not subject to the EAR
+ * (15 C.F.R. §§ 734.3(b)(3), 734.7).
+ */
+
+/** ISO 3166-1 alpha-2 country codes for which the hosted service is blocked. */
+export const BLOCKED_COUNTRIES: ReadonlySet<string> = new Set([
+  "RU",
+  "BY",
+  "IR",
+  "CU",
+  "KP",
+  "SY",
+]);
+
+/**
+ * Blocked ISO 3166-2:UA subdivision codes (the part after "UA-"):
+ * 43 = Crimea, 40 = Sevastopol, 14 = Donetsk oblast, 09 = Luhansk oblast.
+ */
+export const BLOCKED_UA_REGIONS: ReadonlySet<string> = new Set([
+  "43",
+  "40",
+  "14",
+  "09",
+]);
+
+/** HTTP status for blocked requests (RFC 7725 — Unavailable For Legal Reasons). */
+export const GEO_BLOCK_STATUS = 451;
+
+/** Human-readable message returned to blocked requests. */
+export const GEO_BLOCK_MESSAGE =
+  "vcad's hosted service is unavailable in your region due to U.S. export controls and sanctions. " +
+  "The open-source code remains available at github.com/ecto/vcad.";
+
+/** JSON body returned with the 451. */
+export const GEO_BLOCK_BODY = JSON.stringify({
+  error: "unavailable_for_legal_reasons",
+  message: GEO_BLOCK_MESSAGE,
+});
+
+/**
+ * Decide whether a request from `country` (ISO 3166-1 alpha-2, e.g. "RU")
+ * and optional `region` (ISO 3166-2 subdivision — either "43" or "UA-43"
+ * form) must be blocked.
+ *
+ * Fails open: a missing/empty country header allows the request. Geo headers
+ * are absent in local dev and some internal invocations, and blocking those
+ * would take the service down for everyone — IP geolocation is best-effort
+ * screening, not the sole compliance control.
+ */
+export function isGeoBlocked(
+  country: string | null | undefined,
+  region?: string | null,
+): boolean {
+  if (!country) return false;
+  const cc = country.trim().toUpperCase();
+  if (BLOCKED_COUNTRIES.has(cc)) return true;
+  if (cc === "UA" && region) {
+    const sub = region.trim().toUpperCase().replace(/^UA-/, "");
+    if (BLOCKED_UA_REGIONS.has(sub)) return true;
+  }
+  return false;
+}
+
+/** Vercel attaches `geo` to the request in some runtimes; honor it when present. */
+interface GeoRequest extends Request {
+  geo?: { country?: string; countryRegion?: string };
+}
+
+/**
+ * Extract geo from a fetch `Request` (Vercel's `x-vercel-ip-country` /
+ * `x-vercel-ip-country-region` headers, falling back to `request.geo` where
+ * the platform provides it) and run the block check.
+ */
+export function isRequestGeoBlocked(request: Request): boolean {
+  const geo = (request as GeoRequest).geo;
+  const country =
+    request.headers.get("x-vercel-ip-country") ?? geo?.country ?? null;
+  const region =
+    request.headers.get("x-vercel-ip-country-region") ??
+    geo?.countryRegion ??
+    null;
+  return isGeoBlocked(country, region);
+}
+
+/** The 451 response served to blocked requests (Edge runtime / fetch API). */
+export function geoBlockResponse(): Response {
+  return new Response(GEO_BLOCK_BODY, {
+    status: GEO_BLOCK_STATUS,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
## Why

Since **2024-09-12**, the OFAC determination under **E.O. 14071** prohibits supplying "IT support and cloud-based services for … design and manufacturing software" (CAD is explicitly named) to any person located in the Russian Federation. PostHog shows real RU usage of the hosted surfaces (9 users / ~750 events in the last 90 days, most recent 2026-06-28). This PR blocks the hosted services for embargoed jurisdictions; the open-source repo is unaffected (published open source is not subject to the EAR, 15 C.F.R. §§ 734.3(b)(3), 734.7).

## What

**Block list** (one shared module, `shared/geo-block.ts`, with legal citations): `RU`, `BY`, `IR`, `CU`, `KP`, `SY`, plus best-effort UA regions `43` (Crimea), `40` (Sevastopol), `14` (Donetsk), `09` (Luhansk) via `x-vercel-ip-country-region`. Blocked requests get **HTTP 451** with a short JSON body pointing at the GitHub repo. Missing geo headers **fail open** (local dev / internal invocations).

**Web app (vcad.io)** — Vercel Edge Middleware reading `x-vercel-ip-country` / `x-vercel-ip-country-region` (falls back to `request.geo` where present). Two vercel.json candidates exist for the app project (repo root and `packages/app`), so an identical thin wrapper sits at both roots — whichever root the Vercel project uses picks it up; both import the shared module. The whole surface is blocked uniformly, including `/privacy|terms|security`.

**MCP server (mcp.vcad.io)** — this deploy uses the Build Output API, so automatic `middleware.ts` detection doesn't apply. `build.sh` now bundles `services/mcp/middleware.ts` into `functions/_middleware.func` (edge runtime) and prepends a `middlewarePath` + `continue: true` route. Defense-in-depth: `entry.ts` runs the same check at the request layer, which alone covers every route since all routes dest to the single function. `shared/` was added to the deploy `ignoreCommand` so block-list changes trigger redeploys.

**Docs/legal** — new `docs/export-controls.md`, a README section, and an "Export controls and sanctions" section in the Terms page (`LegalPage.tsx`, last-updated bumped to July 7, 2026).

**Tests** — `packages/mcp/src/__tests__/geo-block.test.ts` (14 passing): RU blocked, UA-Kyiv allowed, UA-Crimea blocked (both `43` and `UA-43` forms), US allowed, missing header allowed, header/`request.geo` extraction, 451 response shape.

## Notes

- ⚠️ **Takes effect on next deploy** of each Vercel project (Cam deploys manually). Both the app project and the MCP project need a deploy.
- No changelog entry per `CLAUDE.md` conventions (compliance/infra, not product behavior).
- Not deployed or verified against live Vercel — the middleware path was smoke-tested with esbuild bundling; the Build Output API `middlewarePath` route should be sanity-checked on a preview deploy before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)