### PR TITLE
feat(3dp): print-then-measure calibration loop — predict_print / record_measurement

### DIFF
--- a/changelog/entries/2026-07-07-3dp-print-then-measure.json
+++ b/changelog/entries/2026-07-07-3dp-print-then-measure.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-3dp-print-then-measure",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "3D-print calibration loop: predict, print, measure",
+  "summary": "predict_print snapshots a design's measurables (bbox, mass, feature dims); record_measurement joins caliper/scale readings into a delta report with axis scales, hole undersize, and printer-profile suggestions.",
+  "features": ["3d-printing", "calibration", "verification", "mcp"],
+  "mcpTools": ["predict_print", "record_measurement"]
+}

--- a/docs/plans/2026-07-07-3dp-print-then-measure.md
+++ b/docs/plans/2026-07-07-3dp-print-then-measure.md
@@ -1,0 +1,194 @@
+# 3D printing: the print-then-measure calibration loop
+
+*The 3DP slice of [the domain atlas](2026-07-06-domain-atlas.md): "the only
+domain where the loop closes with zero vendor dependency — the user's printer
+is the effector. Cheapest physical ground truth per datum." Gap named there:
+**print-then-measure receipt flow; dimensional accuracy oracles per printer
+profile.** This doc designs and ships the minimal version. 2026-07-07.*
+
+## Why this loop
+
+Every other rail (SCS, PCB fabs) puts a vendor between the design and the
+ground truth. A Bambu on the desk doesn't. That makes 3DP the **volume**
+source of sim2real data: every print is a chance to capture a
+`(predicted, measured)` pair for near-zero cost, and those pairs are exactly
+what the Receipt needs to stop being a promise and start being a track
+record.
+
+The loop, minimally:
+
+```
+design ──► predict_print ──► slice + print (human + Bambu) ──► calipers/scale ──► record_measurement ──► delta report
+              │                                                                        │
+              └── prediction snapshot (stored with the session) ───────────────────────┘
+```
+
+Deliberately **not** in scope: printer integration beyond what
+`vcad-slicer`/`vcad-slicer-bambu` already do. The human carries the part to
+the printer. The value is the captured pairs, not automation of the carry.
+
+## The two artifacts
+
+Both are small JSON documents. Pure computation lives in
+`@vcad/core` (`packages/core/src/utils/print-calibration.ts`) — no I/O, no
+kernel, no MCP — mirroring the receipt engine's layering. The MCP tools wrap
+it; example scripts write the JSON to disk alongside the document.
+
+### 1. `PrintPrediction` — recorded *before* printing
+
+Produced by the `predict_print` MCP tool from an open session document:
+
+```jsonc
+{
+  "version": 1,
+  "document_id": "abc123",
+  "doc_fingerprint": "fnv1a-128 hex of the canonicalized document IR",
+  "created_at": "2026-07-07T…",
+  "material": { "name": "PLA", "density_kg_m3": 1240 },
+  "volume_mm3": 21847.3,          // kernel-evaluated, not hand math
+  "bbox_mm": { "x": 80, "y": 32, "z": 12 },
+  "assumptions": [
+    "mass assumes 100% infill (solid) — print the coupon solid or ignore the mass row",
+    "dimensions are model-space; no shrinkage compensation applied"
+  ],
+  "measurables": [
+    { "id": "bbox_x", "label": "Overall length (X)", "kind": "dimension",
+      "axis": "X", "feature": "overall", "predicted": 80, "unit": "mm" },
+    { "id": "hole_3mm", "label": "Small hole diameter", "kind": "diameter",
+      "axis": "XY", "feature": "hole", "predicted": 3, "unit": "mm" },
+    { "id": "mass", "label": "Part mass", "kind": "mass",
+      "predicted": 27.09, "unit": "g", "tolerance": 1.35 }
+  ]
+}
+```
+
+Measurables come from two sources, merged:
+
+- **Auto** (computed by the tool from the evaluated kernel mesh): `bbox_x/y/z`
+  and `mass` (when a density is known — from the `material_density_kg_m3` arg
+  or the document's material table).
+- **Declared** (passed by the caller): named features the mesh can't name —
+  step heights, hole diameters, wall thicknesses. For the calibration coupon
+  these are *derived from the same parameters that built the geometry*, the
+  f405 pattern: prediction and part can't drift apart by construction.
+
+`doc_fingerprint` hashes the canonicalized document IR with the receipt's
+existing `hashHex`/`canonicalize` (fnv1a-128), so `record_measurement` can
+detect "you edited the design after predicting" and flag the pairing stale.
+
+### 2. `CalibrationReport` — the receipt-vs-reality delta
+
+Produced by `record_measurement` from a prediction + measured values:
+
+```jsonc
+{
+  "version": 1,
+  "doc_fingerprint": "…", "stale": false,
+  "context": { "printer": "Bambu X1C", "material": "PLA Basic black",
+               "process": "0.2mm layers, 100% infill" },
+  "rows": [
+    { "id": "bbox_x", "kind": "dimension", "axis": "X",
+      "predicted": 80, "measured": 79.82, "unit": "mm",
+      "delta": -0.18, "delta_pct": -0.225,
+      "tolerance": 0.16, "within_tolerance": false }
+  ],
+  "missing": ["step_z_12"],        // predicted but not measured
+  "unknown": [],                   // measured but never predicted
+  "aggregates": {
+    "axis_scales": [                // least-squares measured ≈ scale·predicted
+      { "axis": "X", "n": 3, "scale": 0.99775 },
+      { "axis": "Y", "n": 2, "scale": 0.99810 },
+      { "axis": "Z", "n": 5, "scale": 1.00120 }
+    ],
+    "hole_offset_mm": -0.14,        // mean(measured−predicted), holes only
+    "wall_offset_mm": 0.06,         // …thin walls only (flow signature)
+    "mass": { "predicted_g": 27.09, "measured_g": 26.4, "delta_pct": -2.5 }
+  },
+  "suggestions": [
+    "XY prints ~0.21% small — set shrinkage/scale compensation to 100.21%",
+    "holes print 0.14mm undersize — enable hole compensation or drill to size"
+  ],
+  "verdict": "attention",           // pass | attention | fail
+  "summary": "9/12 within tolerance; XY scale 99.78%; holes −0.14mm"
+}
+```
+
+The aggregates are the point. Raw deltas are data; **axis scale factors,
+hole undersize, and wall offset are the actual knobs** a printer profile
+exposes (shrinkage compensation, hole compensation, flow ratio). One coupon
+print yields the numbers to turn. Accumulating reports per
+(printer, material) is the future "dimensional accuracy oracle per printer
+profile" — out of scope here, but the `context` block is shaped so the
+aggregation needs no schema change.
+
+Default tolerances when a measurable doesn't carry one:
+`±max(0.1mm, 0.2% of nominal)` for dimensions/diameters (a well-tuned FDM
+machine's realistic envelope), `±5%` for mass (infill/flow variance).
+Verdict: `pass` (all rows within tolerance), `fail` (any row out by more
+than 3× its tolerance, or a majority out), else `attention`.
+
+## Tool contracts
+
+New MCP pack `print` (opt-out like the others, in `TOOL_PACKS`):
+
+- **`predict_print`** `{ document_id, material_density_kg_m3?, material_name?,
+  measurables? }` → the `PrintPrediction`, returned inline AND cached
+  in-process keyed by `document_id` (same warm-instance lifetime as sessions
+  and the artifact registry — see `session.ts`). Small payload; the caller
+  is expected to keep it (the example writes it to disk next to the doc).
+- **`record_measurement`** `{ document_id?, measurements, printer?, material?,
+  process?, prediction? }` → the `CalibrationReport`, inline. `measurements`
+  is `{ id: value }`. The prediction is resolved from the inline `prediction`
+  arg first, then the warm cache — the inline path makes the tool usable
+  even after a cold serverless restart, and is how the example's
+  `record.mjs` replays a prediction file. Reports are also appended to the
+  warm cache for the session.
+
+Storage stays deliberately simple, per the artifact-store precedent: inline
+JSON + warm-instance cache + files-on-disk in the example. No new tables.
+When the unified Receipt grows a claims spine, `CalibrationReport` becomes a
+signed claim ("as-built within tolerance of as-designed") — the shapes here
+were chosen so that's an envelope change, not a rewrite.
+
+## The canonical coupon — `examples/calibration-coupon/`
+
+One plate, printable in ~1h, spanning the failure modes that matter:
+
+| Feature | Measurable(s) | What it calibrates |
+|---|---|---|
+| base plate 80×32×4 | `bbox_x`, `bbox_y` | XY scale (long spans) |
+| 4-step staircase, tops at Z 6/8/10/12 | `step_z_6…12` | Z scale at multiple heights |
+| through-holes Ø3/Ø5/Ø8 | `hole_3mm…8mm` | hole undersize vs size |
+| boss Ø6 | `boss_6mm` | outer vs inner diameter asymmetry |
+| thin fins 0.8/1.2/2.0 | `fin_0_8…2_0` | flow / wall accuracy |
+| whole part | `mass` | density × volume vs scale |
+
+Geometry rules: rectilinear unions with parts sunk 1 mm into the base (no
+coincident-face union seams), plain cylinder differences through a flat
+plate (the best-tested boolean path in the kernel), no fillets, no text.
+`geometry.mjs` exports both the document and `measurables()` derived from
+the same `PARAMS`.
+
+Scripts, following the f405-enclosure pattern (import MCP tools from
+`packages/mcp/dist`):
+
+- `build.mjs` — evaluate, `predict_print`, export STL, write
+  `out/prediction.json` + `out/measurements.template.json` (the guided
+  worksheet: every measurable with its label and a `null` to fill in).
+- `record.mjs <measurements.json>` — `record_measurement`, write
+  `out/calibration-report.json`, print the delta table.
+
+The worksheet **is** the "guided measurement step": each row tells the human
+what to measure and where ("Step 2 top face height off the bed"), in
+measurement order. No app UI in v1.
+
+## Follow-ups (not this change)
+
+- Aggregate reports per (printer, material) into a persistent calibration
+  profile; feed compensation back into slicer settings (`smart_defaults`).
+- Auto-derive hole/wall measurables from `vcad-slicer`'s BRep
+  `analyze_for_printing` (it already detects holes and wall thicknesses).
+- Infill-aware mass prediction via `vcad-kernel-cost`'s
+  `estimate_fdm_from_volume` when the print won't be solid.
+- `vcad measure` CLI subcommand wrapping the same core engine.
+- Receipt unification: emit the report as a signed receipt claim.

--- a/examples/calibration-coupon/README.md
+++ b/examples/calibration-coupon/README.md
@@ -1,0 +1,90 @@
+# Calibration coupon — print-then-measure, zero vendors
+
+The canonical part for vcad's **3DP private calibration loop** (see
+[the design doc](../../docs/plans/2026-07-07-3dp-print-then-measure.md) and
+[the domain atlas](../../docs/plans/2026-07-06-domain-atlas.md)): your own
+printer is the effector, calipers and a kitchen scale are the oracle, and
+every print captures a `(predicted, measured)` pair — the cheapest physical
+ground truth vcad can buy.
+
+One 80×32 mm plate, ~1 hour of print time, spanning the FDM failure modes
+that matter:
+
+| Feature | Measurables | What it calibrates |
+|---|---|---|
+| base plate 80×32×4 | `bbox_x`, `bbox_y` | XY scale over long spans |
+| 4-step staircase, tops at Z 6/8/10/12 | `step_z_6…12`, `bbox_z` | Z scale at several heights |
+| through-holes Ø3/Ø5/Ø8 | `hole_3mm/5mm/8mm` | hole undersize vs size |
+| boss Ø6 | `boss_6mm` | outer vs inner diameter asymmetry |
+| fins 0.8/1.2/2.0 mm | `fin_0_8/1_2/2` | thin-wall accuracy / flow |
+| the whole part | `mass` | volume × density vs the scale |
+
+[`geometry.mjs`](geometry.mjs) is the single source of truth: the same
+`PARAMS` build the document **and** the declared measurables, so prediction
+and part cannot drift apart.
+
+## 1. Build and predict
+
+```bash
+# From the repo root (fresh worktree? run `npm ci` first):
+npm run build --workspaces
+node examples/calibration-coupon/build.mjs
+```
+
+Outputs land in `out/`:
+
+- `coupon.stl` — slice and print. **Use 100% infill** or the mass row is
+  meaningless (every dimensional row still works).
+- `coupon.vcad` — editable parametric source.
+- `prediction.json` — the pre-print snapshot from `predict_print`:
+  kernel-evaluated bbox/volume/mass plus the 11 declared feature
+  measurables, fingerprinted against the exact document that made them.
+- `measurements.template.json` — the guided worksheet.
+
+## 2. Print, then measure
+
+Print `coupon.stl` (PLA assumed; any rigid filament works — adjust
+`density_kg_m3` in `geometry.mjs` if you predict mass for something else).
+Then:
+
+```bash
+cp out/measurements.template.json out/measurements.json
+$EDITOR out/measurements.json
+```
+
+Each entry in `guide` tells you what to measure and where ("Ø3 through-hole
+diameter (caliper inside jaws, front row) — predicted 3mm"); put your
+numbers in `measurements`. Leave anything you didn't measure as `null` —
+a partial worksheet is still data.
+
+## 3. Record the delta
+
+```bash
+node examples/calibration-coupon/record.mjs
+```
+
+This joins your numbers against `prediction.json` via the same
+`record_measurement` tool the MCP server exposes, prints the delta table,
+and writes `out/calibration-report.json` — the receipt-vs-reality artifact,
+stored alongside the document. Beyond per-feature deltas it reports the
+aggregates a printer profile can act on:
+
+```
+X scale: 99.80%   Z scale: 100.29%   hole offset: -0.12mm   wall offset: +0.07mm
+→ XY prints small by 0.21% — set shrinkage/scale compensation to 100.21%
+→ holes print 0.12mm undersize — enable hole compensation or drill/ream to size
+```
+
+Axis scale fits use only span-like features (plate, steps); holes and walls
+are excluded because their systematic offsets (undersize, over-extrusion)
+would masquerade as shrinkage — they get their own aggregates instead.
+
+## MCP flow (no scripts)
+
+The same loop is available to any MCP agent against a live session:
+
+1. `predict_print { document_id, material_density_kg_m3: 1240, measurables: […] }`
+2. …human prints and measures…
+3. `record_measurement { document_id, measurements: { bbox_x: 79.84, … },
+   printer: "Bambu X1C" }` — or pass the saved `prediction` inline if the
+   session is gone.

--- a/examples/calibration-coupon/build.mjs
+++ b/examples/calibration-coupon/build.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Build the calibration coupon: evaluate the geometry, snapshot the
+ * pre-print prediction (predict_print), and ship everything a print
+ * session needs — the STL, the prediction, and the measurement worksheet.
+ *
+ * Run from the repo root after building the workspace:
+ *   npm run build --workspaces
+ *   node examples/calibration-coupon/build.mjs
+ *
+ * Outputs land in examples/calibration-coupon/out/:
+ *   coupon.stl                  — slice this, print it (100% infill!)
+ *   coupon.vcad                 — editable parametric source
+ *   prediction.json             — what the design claims (predict_print)
+ *   measurements.template.json  — the guided worksheet: copy to
+ *                                 measurements.json, fill with calipers +
+ *                                 scale, then run record.mjs
+ */
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+
+import { Engine } from "@vcad/engine";
+import { openDocument } from "../../packages/mcp/dist/tools/session.js";
+import { predictPrint } from "../../packages/mcp/dist/tools/print-check.js";
+import { exportCad } from "../../packages/mcp/dist/tools/export.js";
+
+import { couponDocument, measurables, PARAMS } from "./geometry.mjs";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OUT = join(HERE, "out");
+mkdirSync(OUT, { recursive: true });
+process.env.VCAD_MCP_EXPORT_DIR = OUT;
+
+const parse = (r) => JSON.parse(r.content[0].text);
+const log = (...a) => console.log(...a);
+const rule = () => log("─".repeat(64));
+
+async function main() {
+  const engine = await Engine.init();
+
+  rule();
+  log("  vcad calibration coupon — print-then-measure, zero vendors");
+  rule();
+
+  // 1. The part.
+  const doc = couponDocument();
+  const { document_id } = parse(openDocument({ initial: doc }));
+  log(`\n[1] Coupon: ${PARAMS.base.x}×${PARAMS.base.y}mm plate — ` +
+    `${PARAMS.stepHeights.length} Z steps, Ø${PARAMS.holes.map((h) => h.d).join("/Ø")} holes, ` +
+    `Ø${PARAMS.boss.d} boss, ${PARAMS.fins.map((f) => f.t).join("/")}mm fins`);
+
+  // 2. The prediction — what the design claims, before any plastic moves.
+  const prediction = parse(
+    predictPrint(
+      {
+        document_id,
+        material_density_kg_m3: PARAMS.density_kg_m3,
+        material_name: "PLA",
+        measurables: measurables(),
+      },
+      engine,
+    ),
+  );
+  log(`\n[2] Prediction: ${prediction.measurables.length} measurables — ` +
+    `bbox ${prediction.bbox_mm.x}×${prediction.bbox_mm.y}×${prediction.bbox_mm.z}mm, ` +
+    `${prediction.volume_mm3.toFixed(0)}mm³, ` +
+    `${prediction.measurables.find((m) => m.id === "mass")?.predicted.toFixed(1)}g solid PLA`);
+  for (const a of prediction.assumptions) log(`    · ${a}`);
+
+  // 3. Ship: STL for the slicer, source, prediction, worksheet.
+  const stl = parse(exportCad({ ir: doc, filename: "coupon.stl" }, engine));
+  writeFileSync(join(OUT, "coupon.vcad"), JSON.stringify(doc, null, 2));
+  writeFileSync(join(OUT, "prediction.json"), JSON.stringify(prediction, null, 2));
+
+  const worksheet = {
+    printer: "",
+    material: "",
+    process: "",
+    guide: Object.fromEntries(
+      prediction.measurables.map((m) => [
+        m.id,
+        `${m.label} — predicted ${m.predicted}${m.unit}`,
+      ]),
+    ),
+    measurements: Object.fromEntries(prediction.measurables.map((m) => [m.id, null])),
+  };
+  writeFileSync(
+    join(OUT, "measurements.template.json"),
+    JSON.stringify(worksheet, null, 2),
+  );
+
+  log(`\n[3] Shipped → examples/calibration-coupon/out/`);
+  log(`    coupon.stl (${(stl.bytes / 1024).toFixed(0)} KB) — print at 100% infill`);
+  log(`    prediction.json + measurements.template.json`);
+  rule();
+  log("  Next: print coupon.stl, then");
+  log("    cp out/measurements.template.json out/measurements.json");
+  log("    (fill it in with calipers + scale)");
+  log("    node examples/calibration-coupon/record.mjs");
+  rule();
+}
+
+main().catch((e) => {
+  console.error("FAILED:", e);
+  process.exit(1);
+});

--- a/examples/calibration-coupon/geometry.mjs
+++ b/examples/calibration-coupon/geometry.mjs
@@ -1,0 +1,175 @@
+/**
+ * The vcad calibration coupon — a single printable plate that spans the FDM
+ * failure modes worth measuring: XY spans, Z heights at several altitudes,
+ * hole undersize across sizes, boss OD, thin-wall flow, and mass.
+ *
+ * This file is the single source of truth: the SAME `PARAMS` build both the
+ * document geometry and the declared measurables, so the prediction and the
+ * part cannot drift apart (the f405-enclosure pattern).
+ *
+ * Geometry rules (kernel-friendliness): rectilinear unions with every added
+ * body sunk `PARAMS.sink` into the base (no coincident-face union seams),
+ * plain cylinder differences through a flat plate — the best-tested boolean
+ * path in the kernel. No fillets, no text.
+ */
+
+export const PARAMS = {
+  base: { x: 80, y: 32, z: 4 },
+  /** How deep added bodies embed into the base (avoids coincident faces). */
+  sink: 1,
+  /** Step heights above the base top; tops land at base.z + h. */
+  stepHeights: [2, 4, 6, 8],
+  step: { width: 12, depth: 12, y: 18, x0: 4, pitch: 16 },
+  holes: [
+    { d: 3, x: 10, y: 8 },
+    { d: 5, x: 24, y: 8 },
+    { d: 8, x: 40, y: 8 },
+  ],
+  boss: { d: 6, height: 6, x: 72, y: 24 },
+  fins: [
+    { t: 0.8, x: 56 },
+    { t: 1.2, x: 64 },
+    { t: 2.0, x: 72 },
+  ],
+  fin: { length: 10, height: 8, y: 3 },
+  segments: 64,
+  /** PLA. Print the coupon at 100% infill or ignore the mass row. */
+  density_kg_m3: 1240,
+};
+
+const fmt = (n) => String(n).replace(".", "_");
+
+/** Build the coupon as a vcad IR document (one solid part). */
+export function couponDocument() {
+  const p = PARAMS;
+  const nodes = {};
+  let nextId = 1;
+  const add = (name, op) => {
+    const id = nextId++;
+    nodes[String(id)] = { id, name, op };
+    return id;
+  };
+
+  let solid = add("Base plate", {
+    type: "Cube",
+    size: { x: p.base.x, y: p.base.y, z: p.base.z },
+  });
+  const union = (id, name) =>
+    (solid = add(name, { type: "Union", left: solid, right: id }));
+
+  // Staircase along the back row — Z accuracy at several heights.
+  p.stepHeights.forEach((h, i) => {
+    const cube = add(`Step ${i + 1} body`, {
+      type: "Cube",
+      size: { x: p.step.width, y: p.step.depth, z: h + p.sink },
+    });
+    const placed = add(`Step ${i + 1}`, {
+      type: "Translate",
+      child: cube,
+      offset: { x: p.step.x0 + i * p.step.pitch, y: p.step.y, z: p.base.z - p.sink },
+    });
+    union(placed, `+ step ${i + 1}`);
+  });
+
+  // Boss — outer diameter, the mirror image of the holes.
+  const bossBody = add("Boss body", {
+    type: "Cylinder",
+    radius: p.boss.d / 2,
+    height: p.boss.height + p.sink,
+    segments: p.segments,
+  });
+  const boss = add("Boss", {
+    type: "Translate",
+    child: bossBody,
+    offset: { x: p.boss.x, y: p.boss.y, z: p.base.z - p.sink },
+  });
+  union(boss, "+ boss");
+
+  // Thin fins — wall accuracy / flow.
+  p.fins.forEach((f, i) => {
+    const wall = add(`Fin ${f.t}mm body`, {
+      type: "Cube",
+      size: { x: f.t, y: p.fin.length, z: p.fin.height + p.sink },
+    });
+    const placed = add(`Fin ${f.t}mm`, {
+      type: "Translate",
+      child: wall,
+      offset: { x: f.x - f.t / 2, y: p.fin.y, z: p.base.z - p.sink },
+    });
+    union(placed, `+ fin ${i + 1}`);
+  });
+
+  // Through-holes — drilled last, through the finished union.
+  for (const h of p.holes) {
+    const drill = add(`Hole Ø${h.d} body`, {
+      type: "Cylinder",
+      radius: h.d / 2,
+      height: p.base.z + 2 * p.sink,
+      segments: p.segments,
+    });
+    const placed = add(`Hole Ø${h.d}`, {
+      type: "Translate",
+      child: drill,
+      offset: { x: h.x, y: h.y, z: -p.sink },
+    });
+    solid = add(`− hole Ø${h.d}`, { type: "Difference", left: solid, right: placed });
+  }
+
+  nodes[String(solid)].name = "Calibration coupon";
+
+  return {
+    version: "0.1",
+    nodes,
+    materials: {
+      pla: {
+        name: "pla",
+        color: [0.9, 0.55, 0.15],
+        metallic: 0.0,
+        roughness: 0.6,
+        density: p.density_kg_m3,
+      },
+    },
+    part_materials: {},
+    roots: [{ root: solid, material: "pla" }],
+  };
+}
+
+/** The declared measurables — derived from the same PARAMS as the geometry.
+ *  (bbox_x/y/z and mass are added automatically by predict_print.) */
+export function measurables() {
+  const p = PARAMS;
+  return [
+    ...p.stepHeights.map((h, i) => ({
+      id: `step_z_${p.base.z + h}`,
+      label: `Step ${i + 1} top height off the bed (caliper as depth/height gauge)`,
+      kind: "dimension",
+      axis: "Z",
+      feature: "step",
+      predicted: p.base.z + h,
+    })),
+    ...p.holes.map((h) => ({
+      id: `hole_${fmt(h.d)}mm`,
+      label: `Ø${h.d} through-hole diameter (caliper inside jaws, front row)`,
+      kind: "diameter",
+      axis: "XY",
+      feature: "hole",
+      predicted: h.d,
+    })),
+    {
+      id: `boss_${fmt(PARAMS.boss.d)}mm`,
+      label: `Ø${p.boss.d} boss outer diameter (caliper outside jaws, back-right)`,
+      kind: "diameter",
+      axis: "XY",
+      feature: "boss",
+      predicted: p.boss.d,
+    },
+    ...p.fins.map((f) => ({
+      id: `fin_${fmt(f.t)}`,
+      label: `${f.t}mm fin wall thickness (caliper outside jaws, right edge)`,
+      kind: "dimension",
+      axis: "X",
+      feature: "wall",
+      predicted: f.t,
+    })),
+  ];
+}

--- a/examples/calibration-coupon/record.mjs
+++ b/examples/calibration-coupon/record.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * Record the as-built measurements of a printed coupon and emit the
+ * receipt-vs-reality delta report.
+ *
+ * Usage (after build.mjs, a print, and a session with calipers + scale):
+ *   cp out/measurements.template.json out/measurements.json
+ *   $EDITOR out/measurements.json         # fill in the numbers you measured
+ *   node examples/calibration-coupon/record.mjs [path/to/measurements.json]
+ *
+ * Reads out/prediction.json (from build.mjs), joins it with your numbers via
+ * the same record_measurement tool the MCP server exposes, prints the delta
+ * table, and writes out/calibration-report.json — the (predicted, measured)
+ * pair, stored alongside the document.
+ */
+
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
+
+import { recordMeasurement } from "../../packages/mcp/dist/tools/print-check.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const OUT = join(HERE, "out");
+
+const measurementsPath = process.argv[2] ?? join(OUT, "measurements.json");
+const prediction = JSON.parse(readFileSync(join(OUT, "prediction.json"), "utf8"));
+const worksheet = JSON.parse(readFileSync(measurementsPath, "utf8"));
+
+// Nulls are unmeasured rows — drop them; the report lists them as missing.
+const measurements = Object.fromEntries(
+  Object.entries(worksheet.measurements ?? {}).filter(
+    ([, v]) => typeof v === "number" && Number.isFinite(v),
+  ),
+);
+if (Object.keys(measurements).length === 0) {
+  console.error(
+    `No measurements filled in at ${measurementsPath} — ` +
+      `copy out/measurements.template.json to out/measurements.json and add your numbers.`,
+  );
+  process.exit(1);
+}
+
+const report = JSON.parse(
+  recordMeasurement({
+    measurements,
+    prediction,
+    ...(worksheet.printer && { printer: worksheet.printer }),
+    ...(worksheet.material && { material: worksheet.material }),
+    ...(worksheet.process && { process: worksheet.process }),
+  }).content[0].text,
+);
+
+writeFileSync(join(OUT, "calibration-report.json"), JSON.stringify(report, null, 2));
+
+// ── Console delta table ───────────────────────────────────────────────────
+const rule = () => console.log("─".repeat(72));
+rule();
+console.log("  calibration report — predicted vs measured");
+rule();
+const pad = (s, n) => String(s).padEnd(n);
+console.log(
+  pad("  id", 16) + pad("predicted", 11) + pad("measured", 11) + pad("delta", 10) + "verdict",
+);
+for (const r of report.rows) {
+  const mark = r.within_tolerance ? "ok" : "OUT";
+  console.log(
+    pad(`  ${r.id}`, 16) +
+      pad(`${r.predicted}${r.unit}`, 11) +
+      pad(`${r.measured}${r.unit}`, 11) +
+      pad(`${r.delta > 0 ? "+" : ""}${r.delta}`, 10) +
+      mark,
+  );
+}
+if (report.missing.length > 0) console.log(`  (unmeasured: ${report.missing.join(", ")})`);
+rule();
+for (const s of report.aggregates.axis_scales) {
+  console.log(`  ${s.axis} scale: ${(s.scale * 100).toFixed(2)}% (n=${s.n})`);
+}
+if (report.aggregates.hole_offset_mm !== undefined) {
+  console.log(`  hole offset: ${report.aggregates.hole_offset_mm}mm`);
+}
+if (report.aggregates.wall_offset_mm !== undefined) {
+  console.log(`  wall offset: ${report.aggregates.wall_offset_mm}mm`);
+}
+for (const s of report.suggestions) console.log(`  → ${s}`);
+rule();
+console.log(`  ${report.verdict.toUpperCase()} — ${report.summary}`);
+console.log(`  report: examples/calibration-coupon/out/calibration-report.json`);
+rule();
+
+process.exit(report.verdict === "fail" ? 1 : 0);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,25 @@
 // Receipt — re-runnable PCB audit ledger (browser-safe engine)
 export * from "./utils/receipt/index.js";
 
+// Print-then-measure calibration — 3DP receipt-vs-reality delta engine
+export {
+  buildCalibrationReport,
+  fingerprintDocument,
+  defaultTolerance,
+} from "./utils/print-calibration.js";
+export type {
+  Measurable,
+  MeasurableKind,
+  MeasurableAxis,
+  MeasurableFeature,
+  PrintPrediction,
+  MeasurementContext,
+  DeltaRow,
+  AxisScale,
+  CalibrationReport,
+  CalibrationVerdict,
+} from "./utils/print-calibration.js";
+
 // Types
 export type {
   PrimitiveKind,

--- a/packages/core/src/utils/__tests__/print-calibration.test.ts
+++ b/packages/core/src/utils/__tests__/print-calibration.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCalibrationReport,
+  defaultTolerance,
+  fingerprintDocument,
+  type PrintPrediction,
+} from "../print-calibration.js";
+
+/** A coupon-shaped prediction: XY spans, Z steps, holes, walls, mass. */
+function prediction(): PrintPrediction {
+  return {
+    version: 1,
+    document_id: "doc1",
+    doc_fingerprint: fingerprintDocument({ nodes: { "1": { op: "Cube" } } }),
+    created_at: "2026-07-07T00:00:00.000Z",
+    material: { name: "PLA", density_kg_m3: 1240 },
+    volume_mm3: 20000,
+    bbox_mm: { x: 80, y: 32, z: 12 },
+    assumptions: ["mass assumes 100% infill"],
+    measurables: [
+      { id: "bbox_x", label: "Overall X", kind: "dimension", axis: "X", feature: "overall", predicted: 80, unit: "mm" },
+      { id: "bbox_y", label: "Overall Y", kind: "dimension", axis: "Y", feature: "overall", predicted: 32, unit: "mm" },
+      { id: "step_z_6", label: "Step 1 height", kind: "dimension", axis: "Z", feature: "step", predicted: 6, unit: "mm" },
+      { id: "step_z_12", label: "Step 4 height", kind: "dimension", axis: "Z", feature: "step", predicted: 12, unit: "mm" },
+      { id: "hole_3mm", label: "Small hole", kind: "diameter", axis: "XY", feature: "hole", predicted: 3, unit: "mm" },
+      { id: "hole_8mm", label: "Large hole", kind: "diameter", axis: "XY", feature: "hole", predicted: 8, unit: "mm" },
+      { id: "fin_1_2", label: "Middle fin", kind: "dimension", axis: "X", feature: "wall", predicted: 1.2, unit: "mm" },
+      { id: "mass", label: "Part mass", kind: "mass", predicted: 24.8, unit: "g" },
+    ],
+  };
+}
+
+describe("buildCalibrationReport", () => {
+  it("joins measurements to measurables and computes signed deltas", () => {
+    const report = buildCalibrationReport(prediction(), {
+      bbox_x: 79.82,
+      bbox_y: 31.94,
+      step_z_6: 6.02,
+      step_z_12: 12.05,
+      hole_3mm: 2.85,
+      hole_8mm: 7.88,
+      fin_1_2: 1.26,
+      mass: 24.1,
+    });
+
+    const bx = report.rows.find((r) => r.id === "bbox_x")!;
+    expect(bx.delta).toBeCloseTo(-0.18, 6);
+    expect(bx.delta_pct).toBeCloseTo(-0.225, 3);
+    expect(report.missing).toEqual([]);
+    expect(report.unknown).toEqual([]);
+    expect(report.fingerprintAlgo).toBe("fnv1a-128");
+  });
+
+  it("fits per-axis scale factors by least squares", () => {
+    // Everything exactly 0.5% small in XY, exact in Z.
+    const p = prediction();
+    const report = buildCalibrationReport(p, {
+      bbox_x: 80 * 0.995,
+      bbox_y: 32 * 0.995,
+      step_z_6: 6,
+      step_z_12: 12,
+      hole_3mm: 3 * 0.995,
+      hole_8mm: 8 * 0.995,
+      fin_1_2: 1.2 * 0.995,
+      mass: 24.8,
+    });
+    const x = report.aggregates.axis_scales.find((s) => s.axis === "X")!;
+    const z = report.aggregates.axis_scales.find((s) => s.axis === "Z")!;
+    expect(x.scale).toBeCloseTo(0.995, 4);
+    expect(z.scale).toBeCloseTo(1.0, 4);
+    // Holes and walls never enter the scale fits — their systematic offsets
+    // (undersize, flow) would masquerade as shrinkage. The only XY-axis rows
+    // here are holes, so no XY fit is emitted, and the X fit excludes the fin.
+    expect(report.aggregates.axis_scales.find((s) => s.axis === "XY")).toBeUndefined();
+    expect(x.n).toBe(1);
+    // 0.5% off should surface a shrinkage-compensation suggestion.
+    expect(report.suggestions.some((s) => s.includes("shrinkage/scale compensation"))).toBe(true);
+  });
+
+  it("aggregates hole undersize and wall offset separately", () => {
+    const report = buildCalibrationReport(prediction(), {
+      hole_3mm: 2.8, // −0.2
+      hole_8mm: 7.9, // −0.1
+      fin_1_2: 1.3, // +0.1 (walls fat = flow high)
+    });
+    expect(report.aggregates.hole_offset_mm).toBeCloseTo(-0.15, 6);
+    expect(report.aggregates.wall_offset_mm).toBeCloseTo(0.1, 6);
+    expect(report.suggestions.some((s) => s.includes("undersize"))).toBe(true);
+    expect(report.suggestions.some((s) => s.includes("flow ratio"))).toBe(true);
+  });
+
+  it("tracks missing and unknown measurement ids without failing", () => {
+    const report = buildCalibrationReport(prediction(), {
+      bbox_x: 79.9,
+      typo_id: 5.0,
+    });
+    expect(report.missing).toContain("mass");
+    expect(report.missing).toContain("hole_3mm");
+    expect(report.unknown).toEqual(["typo_id"]);
+    expect(report.rows).toHaveLength(1);
+  });
+
+  it("verdicts: pass when all within tolerance, fail on gross error", () => {
+    const perfect = buildCalibrationReport(prediction(), {
+      bbox_x: 80.02,
+      bbox_y: 32.01,
+      step_z_6: 6.01,
+      step_z_12: 11.98,
+      hole_3mm: 3.02,
+      hole_8mm: 7.95,
+      fin_1_2: 1.21,
+      mass: 24.9,
+    });
+    expect(perfect.verdict).toBe("pass");
+
+    // bbox_x tolerance is max(0.1, 0.2%·80)=0.16; 3mm off is >3× — gross.
+    const gross = buildCalibrationReport(prediction(), { bbox_x: 77.0 });
+    expect(gross.verdict).toBe("fail");
+  });
+
+  it("flags a stale pairing when the document changed after prediction", () => {
+    const p = prediction();
+    const report = buildCalibrationReport(
+      p,
+      { bbox_x: 79.9 },
+      { current_doc_fingerprint: fingerprintDocument({ nodes: { "1": { op: "Sphere" } } }) },
+    );
+    expect(report.stale).toBe(true);
+    expect(report.summary).toContain("STALE");
+  });
+
+  it("mass rows use the 5% default tolerance and skip axis fits", () => {
+    expect(defaultTolerance("mass", 24.8)).toBeCloseTo(1.24, 6);
+    expect(defaultTolerance("dimension", 80)).toBeCloseTo(0.16, 6);
+    expect(defaultTolerance("dimension", 3)).toBeCloseTo(0.1, 6); // floor
+
+    const report = buildCalibrationReport(prediction(), { mass: 23.9 });
+    expect(report.aggregates.mass).toEqual({
+      predicted_g: 24.8,
+      measured_g: 23.9,
+      delta_pct: expect.closeTo(-3.629, 3),
+    });
+    expect(report.aggregates.axis_scales).toEqual([]);
+    expect(report.rows[0]!.within_tolerance).toBe(true);
+  });
+
+  it("fingerprintDocument is key-order independent", () => {
+    expect(fingerprintDocument({ a: 1, b: { c: 2, d: 3 } })).toBe(
+      fingerprintDocument({ b: { d: 3, c: 2 }, a: 1 }),
+    );
+    expect(fingerprintDocument({ a: 1 })).not.toBe(fingerprintDocument({ a: 2 }));
+  });
+});

--- a/packages/core/src/utils/print-calibration.ts
+++ b/packages/core/src/utils/print-calibration.ts
@@ -1,0 +1,356 @@
+/**
+ * Print-then-measure calibration — the 3DP receipt-vs-reality delta engine.
+ *
+ * The user's own printer is the one fab rail with zero vendor dependency, so
+ * every print can capture a (predicted, measured) pair for near-zero cost.
+ * This module owns the pure computation of that loop: a `PrintPrediction`
+ * snapshot taken before printing, a set of caliper/scale measurements taken
+ * after, and the `CalibrationReport` that joins them — per-feature deltas
+ * plus the aggregates a printer profile can actually act on (axis scale
+ * factors, hole undersize, wall/flow offset).
+ *
+ * No I/O, no kernel, no MCP — same layering as the receipt engine next door.
+ * The MCP tools (`predict_print`, `record_measurement`) and the
+ * examples/calibration-coupon scripts wrap this.
+ *
+ * Design doc: docs/plans/2026-07-07-3dp-print-then-measure.md
+ */
+
+import { hashHex, HASH_ALGO } from "./receipt/hash.js";
+
+/** What kind of physical quantity a measurable is. */
+export type MeasurableKind = "dimension" | "diameter" | "mass";
+
+/** Print-frame axis a linear measurable lies along ("XY" = in-plane, e.g. a
+ *  hole diameter — holes and bosses deform isotropically in the layer plane). */
+export type MeasurableAxis = "X" | "Y" | "Z" | "XY";
+
+/** Aggregation bucket for a measurable — which calibration signature it
+ *  feeds. `hole` and `wall` power the offset aggregates; `overall`/`step`/
+ *  `boss` participate only in the axis scale fits. */
+export type MeasurableFeature =
+  | "overall"
+  | "step"
+  | "hole"
+  | "boss"
+  | "wall";
+
+/** One thing the human will measure on the printed part. */
+export interface Measurable {
+  /** Stable id joining prediction to measurement (e.g. "hole_3mm"). */
+  id: string;
+  /** Human instruction — what to measure and where. */
+  label: string;
+  kind: MeasurableKind;
+  /** Required for dimensions/diameters; meaningless for mass. */
+  axis?: MeasurableAxis;
+  feature?: MeasurableFeature;
+  /** Design-intent value in `unit`. */
+  predicted: number;
+  unit: "mm" | "g";
+  /** ± tolerance in `unit`; defaulted per kind when omitted. */
+  tolerance?: number;
+}
+
+/** The pre-print snapshot of everything the design claims to be. */
+export interface PrintPrediction {
+  version: 1;
+  document_id?: string;
+  /** fnv1a-128 of the canonicalized document IR — staleness detection. */
+  doc_fingerprint: string;
+  created_at: string;
+  material?: { name?: string; density_kg_m3?: number };
+  /** Kernel-evaluated solid volume. */
+  volume_mm3: number;
+  bbox_mm: { x: number; y: number; z: number };
+  /** Honest caveats ("mass assumes 100% infill", …). */
+  assumptions: string[];
+  measurables: Measurable[];
+}
+
+/** Where and how the physical part was made and measured. */
+export interface MeasurementContext {
+  printer?: string;
+  material?: string;
+  /** Free-form process notes: layer height, infill, temperature… */
+  process?: string;
+  measured_at?: string;
+}
+
+/** One joined (predicted, measured) row of the report. */
+export interface DeltaRow {
+  id: string;
+  label: string;
+  kind: MeasurableKind;
+  axis?: MeasurableAxis;
+  feature?: MeasurableFeature;
+  predicted: number;
+  measured: number;
+  unit: "mm" | "g";
+  /** measured − predicted. */
+  delta: number;
+  /** 100 · delta / predicted. */
+  delta_pct: number;
+  tolerance: number;
+  within_tolerance: boolean;
+}
+
+/** Least-squares fit measured ≈ scale·predicted over one axis's dimensions. */
+export interface AxisScale {
+  axis: MeasurableAxis;
+  /** Number of rows in the fit. */
+  n: number;
+  scale: number;
+}
+
+export type CalibrationVerdict = "pass" | "attention" | "fail";
+
+/** The receipt-vs-reality delta artifact. */
+export interface CalibrationReport {
+  version: 1;
+  document_id?: string;
+  doc_fingerprint: string;
+  /** True when the document changed between prediction and recording. */
+  stale: boolean;
+  prediction_created_at: string;
+  recorded_at: string;
+  context: MeasurementContext;
+  rows: DeltaRow[];
+  /** Measurable ids the human never measured. */
+  missing: string[];
+  /** Measurement ids that match no measurable. */
+  unknown: string[];
+  aggregates: {
+    axis_scales: AxisScale[];
+    /** Mean(measured − predicted) over hole diameters, mm. */
+    hole_offset_mm?: number;
+    /** Mean(measured − predicted) over thin walls, mm. */
+    wall_offset_mm?: number;
+    mass?: { predicted_g: number; measured_g: number; delta_pct: number };
+  };
+  /** Printer-profile corrections derived from the aggregates. */
+  suggestions: string[];
+  verdict: CalibrationVerdict;
+  summary: string;
+  fingerprintAlgo: string;
+}
+
+/** Recursively sort object keys so serialization is order-independent. */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = canonicalize((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Content fingerprint of a document IR (or any JSON value). Deterministic
+ *  across key order; used to pair a measurement with the exact design it
+ *  measured. */
+export function fingerprintDocument(doc: unknown): string {
+  return hashHex(JSON.stringify(canonicalize(doc)));
+}
+
+/** Default ± tolerance for a measurable that doesn't declare one:
+ *  dimensions/diameters get a well-tuned-FDM envelope, mass gets 5%. */
+export function defaultTolerance(kind: MeasurableKind, predicted: number): number {
+  if (kind === "mass") return Math.abs(predicted) * 0.05;
+  return Math.max(0.1, Math.abs(predicted) * 0.002);
+}
+
+const round = (n: number, places = 4): number => {
+  const p = 10 ** places;
+  return Math.round(n * p) / p;
+};
+
+/** Least-squares scale through the origin: minimizes Σ(measured − s·predicted)². */
+function fitScale(pairs: Array<{ predicted: number; measured: number }>): number {
+  let num = 0;
+  let den = 0;
+  for (const p of pairs) {
+    num += p.measured * p.predicted;
+    den += p.predicted * p.predicted;
+  }
+  return den > 0 ? num / den : 1;
+}
+
+function mean(xs: number[]): number {
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+/** Join a prediction with measured values into the delta report.
+ *
+ *  `measurements` maps measurable id → measured value in the measurable's
+ *  own unit. Ids present in only one side land in `missing`/`unknown`
+ *  rather than failing — a partial worksheet is still data. */
+export function buildCalibrationReport(
+  prediction: PrintPrediction,
+  measurements: Record<string, number>,
+  options?: {
+    context?: MeasurementContext;
+    /** Fingerprint of the document as it exists NOW (for staleness). */
+    current_doc_fingerprint?: string;
+    recorded_at?: string;
+  },
+): CalibrationReport {
+  const context = options?.context ?? {};
+  const recordedAt = options?.recorded_at ?? new Date().toISOString();
+
+  const rows: DeltaRow[] = [];
+  const missing: string[] = [];
+  const seen = new Set<string>();
+
+  for (const m of prediction.measurables) {
+    seen.add(m.id);
+    const value = measurements[m.id];
+    if (value === undefined || value === null || !Number.isFinite(value)) {
+      missing.push(m.id);
+      continue;
+    }
+    const tolerance = m.tolerance ?? defaultTolerance(m.kind, m.predicted);
+    const delta = value - m.predicted;
+    rows.push({
+      id: m.id,
+      label: m.label,
+      kind: m.kind,
+      ...(m.axis !== undefined && { axis: m.axis }),
+      ...(m.feature !== undefined && { feature: m.feature }),
+      predicted: m.predicted,
+      measured: value,
+      unit: m.unit,
+      delta: round(delta),
+      delta_pct: m.predicted !== 0 ? round((100 * delta) / m.predicted) : 0,
+      tolerance: round(tolerance),
+      within_tolerance: Math.abs(delta) <= tolerance,
+    });
+  }
+
+  const unknown = Object.keys(measurements).filter((id) => !seen.has(id));
+
+  // ── Aggregates ────────────────────────────────────────────────────────
+  // Axis scale fits use only span-like rows (overall, steps, undeclared).
+  // Holes, bosses, and thin walls carry systematic process offsets
+  // (undersize, over-extrusion) that have their own aggregates below —
+  // letting them into the fit would misread flow error as shrinkage.
+  const scaleExcluded: ReadonlySet<string> = new Set(["hole", "boss", "wall"]);
+  const axisScales: AxisScale[] = [];
+  for (const axis of ["X", "Y", "Z", "XY"] as const) {
+    const pairs = rows.filter(
+      (r) =>
+        r.kind !== "mass" &&
+        r.axis === axis &&
+        r.predicted > 0 &&
+        (r.feature === undefined || !scaleExcluded.has(r.feature)),
+    );
+    if (pairs.length === 0) continue;
+    axisScales.push({ axis, n: pairs.length, scale: round(fitScale(pairs), 5) });
+  }
+
+  const holeDeltas = rows
+    .filter((r) => r.feature === "hole" && r.kind === "diameter")
+    .map((r) => r.delta);
+  const wallDeltas = rows
+    .filter((r) => r.feature === "wall")
+    .map((r) => r.delta);
+  const massRow = rows.find((r) => r.kind === "mass");
+
+  const aggregates: CalibrationReport["aggregates"] = { axis_scales: axisScales };
+  if (holeDeltas.length > 0) aggregates.hole_offset_mm = round(mean(holeDeltas));
+  if (wallDeltas.length > 0) aggregates.wall_offset_mm = round(mean(wallDeltas));
+  if (massRow) {
+    aggregates.mass = {
+      predicted_g: massRow.predicted,
+      measured_g: massRow.measured,
+      delta_pct: massRow.delta_pct,
+    };
+  }
+
+  // ── Suggestions — the aggregates translated into profile knobs ────────
+  const suggestions: string[] = [];
+  const inPlane = axisScales.filter((s) => s.axis === "X" || s.axis === "Y" || s.axis === "XY");
+  if (inPlane.length > 0) {
+    const s = mean(inPlane.map((a) => a.scale));
+    if (Math.abs(s - 1) > 0.001) {
+      const comp = round(100 / s, 2);
+      suggestions.push(
+        `XY prints ${s < 1 ? "small" : "large"} by ${round(Math.abs(1 - s) * 100, 2)}% — ` +
+          `set shrinkage/scale compensation to ${comp}%`,
+      );
+    }
+  }
+  const zScale = axisScales.find((s) => s.axis === "Z");
+  if (zScale && Math.abs(zScale.scale - 1) > 0.001) {
+    suggestions.push(
+      `Z prints ${zScale.scale < 1 ? "short" : "tall"} by ${round(Math.abs(1 - zScale.scale) * 100, 2)}% — ` +
+        `check first-layer squish and Z scale compensation`,
+    );
+  }
+  if (aggregates.hole_offset_mm !== undefined && aggregates.hole_offset_mm < -0.05) {
+    suggestions.push(
+      `holes print ${round(-aggregates.hole_offset_mm, 2)}mm undersize — ` +
+        `enable hole compensation or drill/ream to size`,
+    );
+  }
+  if (aggregates.wall_offset_mm !== undefined && Math.abs(aggregates.wall_offset_mm) > 0.05) {
+    suggestions.push(
+      `thin walls print ${round(Math.abs(aggregates.wall_offset_mm), 2)}mm ` +
+        `${aggregates.wall_offset_mm > 0 ? "thick — lower" : "thin — raise"} the flow ratio`,
+    );
+  }
+  if (massRow && !massRow.within_tolerance) {
+    suggestions.push(
+      `mass is ${round(Math.abs(massRow.delta_pct), 1)}% ${massRow.delta > 0 ? "over" : "under"} ` +
+        `prediction — check infill density and material density (assumed ` +
+        `${prediction.material?.density_kg_m3 ?? "unknown"} kg/m³)`,
+    );
+  }
+
+  // ── Verdict ───────────────────────────────────────────────────────────
+  const out = rows.filter((r) => !r.within_tolerance);
+  const gross = rows.some(
+    (r) => Math.abs(r.delta) > 3 * r.tolerance && r.tolerance > 0,
+  );
+  let verdict: CalibrationVerdict = "pass";
+  if (out.length > 0) verdict = "attention";
+  if (gross || (rows.length > 0 && out.length > rows.length / 2)) verdict = "fail";
+
+  const stale =
+    options?.current_doc_fingerprint !== undefined &&
+    options.current_doc_fingerprint !== prediction.doc_fingerprint;
+
+  const bits: string[] = [
+    `${rows.length - out.length}/${rows.length} within tolerance`,
+  ];
+  for (const s of inPlane.length > 0
+    ? [`XY scale ${round(mean(inPlane.map((a) => a.scale)) * 100, 2)}%`]
+    : []) {
+    bits.push(s);
+  }
+  if (zScale) bits.push(`Z scale ${round(zScale.scale * 100, 2)}%`);
+  if (aggregates.hole_offset_mm !== undefined) {
+    bits.push(`holes ${aggregates.hole_offset_mm > 0 ? "+" : ""}${round(aggregates.hole_offset_mm, 2)}mm`);
+  }
+  if (stale) bits.push("STALE — design changed after prediction");
+
+  return {
+    version: 1,
+    ...(prediction.document_id !== undefined && { document_id: prediction.document_id }),
+    doc_fingerprint: prediction.doc_fingerprint,
+    stale,
+    prediction_created_at: prediction.created_at,
+    recorded_at: recordedAt,
+    context,
+    rows,
+    missing,
+    unknown,
+    aggregates,
+    suggestions,
+    verdict,
+    summary: bits.join("; "),
+    fingerprintAlgo: HASH_ALGO,
+  };
+}

--- a/packages/mcp/src/__tests__/print-check.test.ts
+++ b/packages/mcp/src/__tests__/print-check.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for the 3DP print-then-measure loop: predict_print (pre-print
+ * snapshot of the design's measurables) and record_measurement (as-built
+ * capture → receipt-vs-reality delta report).
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import {
+  predictPrint,
+  recordMeasurement,
+  clearPrintCheckState,
+} from "../tools/print-check.js";
+import { openDocument, documents } from "../tools/session.js";
+
+let engine: Engine;
+
+/** 20×10×5 plate — volume 1000 mm³, so PLA (1240 kg/m³) mass is 1.24 g. */
+function makePlateDoc(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "Plate",
+        op: { type: "Cube", size: { x: 20, y: 10, z: 5 } },
+      },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [{ root: 1, material: "default" }],
+  };
+}
+
+function openWith(doc: Document): string {
+  const open = openDocument({ initial: doc });
+  return JSON.parse(open.content[0].text).document_id as string;
+}
+
+const parse = (r: { content: Array<{ type: "text"; text: string }> }) =>
+  JSON.parse(r.content[0].text);
+
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+beforeEach(() => {
+  documents.clear();
+  clearPrintCheckState();
+});
+
+describe("predict_print", () => {
+  it("snapshots kernel bbox and density-derived mass as measurables", () => {
+    const documentId = openWith(makePlateDoc());
+    const prediction = parse(
+      predictPrint(
+        { document_id: documentId, material_density_kg_m3: 1240, material_name: "PLA" },
+        engine,
+      ),
+    );
+
+    expect(prediction.version).toBe(1);
+    expect(prediction.bbox_mm).toEqual({ x: 20, y: 10, z: 5 });
+    expect(prediction.volume_mm3).toBeCloseTo(1000, 3);
+    expect(prediction.material).toEqual({ name: "PLA", density_kg_m3: 1240 });
+    expect(prediction.doc_fingerprint).toMatch(/^[0-9a-f]{32}$/);
+
+    const ids = prediction.measurables.map((m: { id: string }) => m.id);
+    expect(ids).toEqual(["bbox_x", "bbox_y", "bbox_z", "mass"]);
+    const mass = prediction.measurables.find((m: { id: string }) => m.id === "mass");
+    expect(mass.predicted).toBeCloseTo(1.24, 3);
+    expect(mass.unit).toBe("g");
+    // The 100%-infill caveat must be spelled out.
+    expect(prediction.assumptions.join(" ")).toContain("100% infill");
+  });
+
+  it("merges declared measurables, letting them win id collisions", () => {
+    const documentId = openWith(makePlateDoc());
+    const prediction = parse(
+      predictPrint(
+        {
+          document_id: documentId,
+          measurables: [
+            {
+              id: "hole_3mm",
+              label: "Small hole diameter",
+              kind: "diameter",
+              axis: "XY",
+              feature: "hole",
+              predicted: 3,
+            },
+            { id: "bbox_x", label: "Custom X", kind: "dimension", axis: "X", predicted: 19.5 },
+          ],
+        },
+        engine,
+      ),
+    );
+    const ids = prediction.measurables.map((m: { id: string }) => m.id);
+    expect(ids).toContain("hole_3mm");
+    // Declared bbox_x replaced the auto one.
+    const bx = prediction.measurables.filter((m: { id: string }) => m.id === "bbox_x");
+    expect(bx).toHaveLength(1);
+    expect(bx[0].predicted).toBe(19.5);
+    // No density anywhere → no mass measurable.
+    expect(ids).not.toContain("mass");
+    const hole = prediction.measurables.find((m: { id: string }) => m.id === "hole_3mm");
+    expect(hole.unit).toBe("mm"); // defaulted from kind
+  });
+
+  it("rejects malformed declared measurables", () => {
+    const documentId = openWith(makePlateDoc());
+    expect(() =>
+      predictPrint(
+        {
+          document_id: documentId,
+          measurables: [{ id: "x", label: "X", kind: "distance", predicted: 1 }],
+        },
+        engine,
+      ),
+    ).toThrow(/kind must be one of/);
+  });
+});
+
+describe("record_measurement", () => {
+  it("joins measurements against the cached prediction and reports deltas", () => {
+    const documentId = openWith(makePlateDoc());
+    predictPrint({ document_id: documentId, material_density_kg_m3: 1240 }, engine);
+
+    const report = parse(
+      recordMeasurement({
+        document_id: documentId,
+        measurements: { bbox_x: 19.9, bbox_y: 9.95, bbox_z: 5.05, mass: 1.2 },
+        printer: "Bambu X1C",
+        material: "PLA Basic black",
+        process: "0.2mm layers, 100% infill",
+      }),
+    );
+
+    expect(report.version).toBe(1);
+    expect(report.stale).toBe(false);
+    expect(report.context.printer).toBe("Bambu X1C");
+    expect(report.rows).toHaveLength(4);
+    const bx = report.rows.find((r: { id: string }) => r.id === "bbox_x");
+    expect(bx.delta).toBeCloseTo(-0.1, 6);
+    expect(report.aggregates.mass.measured_g).toBe(1.2);
+    expect(["pass", "attention", "fail"]).toContain(report.verdict);
+  });
+
+  it("flags a stale report when the document changed after prediction", () => {
+    const documentId = openWith(makePlateDoc());
+    predictPrint({ document_id: documentId }, engine);
+
+    // Mutate the session document in place — same id, different content.
+    const doc = documents.get(documentId)!;
+    (doc.nodes["1"]!.op as { size: { x: number } }).size.x = 25;
+
+    const report = parse(
+      recordMeasurement({ document_id: documentId, measurements: { bbox_x: 19.9 } }),
+    );
+    expect(report.stale).toBe(true);
+    expect(report.summary).toContain("STALE");
+  });
+
+  it("replays an inline prediction with no session state at all", () => {
+    const documentId = openWith(makePlateDoc());
+    const prediction = parse(
+      predictPrint({ document_id: documentId, material_density_kg_m3: 1240 }, engine),
+    );
+
+    // Simulate a cold instance: both registries wiped.
+    documents.clear();
+    clearPrintCheckState();
+
+    const report = parse(
+      recordMeasurement({
+        measurements: { bbox_x: 19.8, mass: 1.19 },
+        prediction,
+      }),
+    );
+    expect(report.rows).toHaveLength(2);
+    expect(report.missing).toContain("bbox_y");
+    // Session is gone → staleness is unknowable, not asserted.
+    expect(report.stale).toBe(false);
+  });
+
+  it("errors helpfully when there is no prediction to measure against", () => {
+    const documentId = openWith(makePlateDoc());
+    expect(() =>
+      recordMeasurement({ document_id: documentId, measurements: { bbox_x: 19.9 } }),
+    ).toThrow(/predict_print first|prediction/);
+    expect(() => recordMeasurement({ measurements: { bbox_x: 19.9 } })).toThrow(
+      /document_id.*prediction|prediction/,
+    );
+  });
+
+  it("rejects empty or non-numeric measurement sets", () => {
+    const documentId = openWith(makePlateDoc());
+    predictPrint({ document_id: documentId }, engine);
+    expect(() =>
+      recordMeasurement({ document_id: documentId, measurements: {} }),
+    ).toThrow(/empty/);
+    expect(() =>
+      recordMeasurement({
+        document_id: documentId,
+        measurements: { bbox_x: "abc" },
+      }),
+    ).toThrow(/finite number/);
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -17,6 +17,12 @@ import type { Document } from "@vcad/ir";
 import { exportCad, exportCadSchema } from "./tools/export.js";
 import { inspectCad, inspectCadSchema } from "./tools/inspect.js";
 import {
+  predictPrint,
+  predictPrintSchema,
+  recordMeasurement,
+  recordMeasurementSchema,
+} from "./tools/print-check.js";
+import {
   renderView,
   renderViewSchema,
   renderPcb,
@@ -710,6 +716,9 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "build_receipt",
     "verify_receipt",
   ],
+  // The 3DP print-then-measure calibration loop (predict before printing,
+  // record calipers/scale after — see docs/plans/2026-07-07-3dp-print-then-measure.md).
+  print: ["predict_print", "record_measurement"],
   // Mecheval self-grading oracle. The benchmark harness already excludes
   // these during scored runs; hosts that don't want the benchmark
   // vocabulary at all can drop the pack.
@@ -1141,6 +1150,19 @@ export async function createServer(
         description:
           "Inspect an open session document to get aggregate geometry properties: volume, surface area, bounding box, center of mass, triangle count, and mass (if material density is known). For per-part inspection use the chat-surface `inspect_part` / `describe_scene` tools (deferred from this MCP surface in v1).",
         inputSchema: inspectCadSchema,
+      },
+      // ── Print-then-measure calibration loop (3DP) ───────────────
+      {
+        name: "predict_print",
+        description:
+          "Snapshot the design's predicted measurables BEFORE 3D-printing it: kernel-evaluated bbox and mass (at a filament density), plus caller-declared feature dimensions (step heights, hole diameters, wall thicknesses) with design-intent values. Returns a PrintPrediction — save it; after printing, record_measurement joins caliper/scale readings against it. The prediction doubles as the guided measurement worksheet (each measurable carries a human instruction label).",
+        inputSchema: predictPrintSchema,
+      },
+      {
+        name: "record_measurement",
+        description:
+          "Record as-built measurements (caliper dimensions, scale mass) of a printed part against its predict_print snapshot and emit the receipt-vs-reality delta report: per-feature deltas with tolerances, per-axis scale factors (X/Y/Z shrinkage), hole undersize and thin-wall flow offsets, and concrete printer-profile suggestions. Accepts the prediction inline (from a saved prediction.json) when the session's warm instance is gone. Partial measurements are fine.",
+        inputSchema: recordMeasurementSchema,
       },
       // ── Verify-and-iterate loop: eyes + oracle ──────────────────
       {
@@ -2123,6 +2145,12 @@ export async function createServer(
 
         case "inspect_cad":
           result = inspectCad(args, engine);
+          break;
+        case "predict_print":
+          result = predictPrint(args, engine);
+          break;
+        case "record_measurement":
+          result = recordMeasurement(args);
           break;
 
         case "quote_manufacturing":

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Engine, TriangleMesh } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
 import { getSession } from "./session.js";
 
 export const inspectCadSchema = {
@@ -29,7 +30,7 @@ interface BoundingBox {
 }
 
 /** Per-part mass information. */
-interface PartMassInfo {
+export interface PartMassInfo {
   name: string;
   volume_mm3: number;
   material: string;
@@ -37,7 +38,7 @@ interface PartMassInfo {
   mass_g?: number;
 }
 
-interface InspectResult {
+export interface InspectResult {
   volume_mm3: number;
   surface_area_mm2: number;
   bounding_box: BoundingBox;
@@ -200,14 +201,10 @@ function computeMeshProperties(mesh: TriangleMesh): {
   };
 }
 
-export function inspectCad(
-  input: unknown,
-  engine: Engine,
-): { content: Array<{ type: "text"; text: string }> } {
-  const args = (input ?? {}) as Record<string, unknown>;
-  const documentId = String(args.document_id ?? "");
-  const ir = getSession(documentId);
-
+/** Evaluate a document and aggregate its geometry properties. Shared by
+ *  `inspect_cad` and `predict_print` (which snapshots the same numbers as
+ *  pre-print measurables). */
+export function computeInspection(ir: Document, engine: Engine): InspectResult {
   // Evaluate the document
   const scene = engine.evaluate(ir);
 
@@ -330,6 +327,19 @@ export function inspectCad(
     result.mass_g = Math.round(totalMass * 1000) / 1000;
     result.part_masses = partMasses;
   }
+
+  return result;
+}
+
+export function inspectCad(
+  input: unknown,
+  engine: Engine,
+): { content: Array<{ type: "text"; text: string }> } {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const documentId = String(args.document_id ?? "");
+  const ir = getSession(documentId);
+
+  const result = computeInspection(ir, engine);
 
   return {
     content: [

--- a/packages/mcp/src/tools/print-check.ts
+++ b/packages/mcp/src/tools/print-check.ts
@@ -1,0 +1,382 @@
+/**
+ * predict_print / record_measurement — the 3DP print-then-measure loop.
+ *
+ * The one fab rail with zero vendor dependency: the user's own printer is the
+ * effector, the human carries the part, calipers and a kitchen scale are the
+ * oracle. `predict_print` snapshots what the design CLAIMS (bbox, mass at a
+ * density, caller-declared feature dimensions) before printing;
+ * `record_measurement` joins the as-built numbers against that snapshot and
+ * emits the receipt-vs-reality delta report — per-feature deltas plus the
+ * aggregates a printer profile can act on (axis scales, hole undersize, flow).
+ *
+ * Pure math lives in @vcad/core's print-calibration module; this file is the
+ * MCP plumbing. Predictions and reports ride the same warm-instance lifetime
+ * as sessions (see session.ts) — `record_measurement` therefore also accepts
+ * the full prediction inline, so a cold instance (or a prediction.json saved
+ * to disk, as examples/calibration-coupon does) can replay it.
+ *
+ * Design doc: docs/plans/2026-07-07-3dp-print-then-measure.md
+ */
+
+import type { Engine } from "@vcad/engine";
+import {
+  buildCalibrationReport,
+  fingerprintDocument,
+  type CalibrationReport,
+  type Measurable,
+  type MeasurableAxis,
+  type MeasurableFeature,
+  type MeasurableKind,
+  type MeasurementContext,
+  type PrintPrediction,
+} from "@vcad/core";
+import { getSession } from "./session.js";
+import { computeInspection } from "./inspect.js";
+
+const MEASURABLE_KINDS: readonly MeasurableKind[] = ["dimension", "diameter", "mass"];
+const MEASURABLE_AXES: readonly MeasurableAxis[] = ["X", "Y", "Z", "XY"];
+const MEASURABLE_FEATURES: readonly MeasurableFeature[] = [
+  "overall",
+  "step",
+  "hole",
+  "boss",
+  "wall",
+];
+
+// Warm-instance registries, keyed by document_id — same lifetime model as the
+// in-memory session map and the artifact store. NOT durable across cold
+// serverless instances; the inline `prediction` arg on record_measurement is
+// the durable path.
+const predictions = new Map<string, PrintPrediction>();
+const reports = new Map<string, CalibrationReport[]>();
+
+/** Test/reset hook — mirrors the session map's lifecycle helpers. */
+export function clearPrintCheckState(): void {
+  predictions.clear();
+  reports.clear();
+}
+
+export const predictPrintSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description: "Session id from open_document.",
+    },
+    material_density_kg_m3: {
+      type: "number" as const,
+      description:
+        "Filament density for the mass prediction (e.g. PLA 1240, PETG 1270, ABS 1050). Falls back to the document's material densities when omitted; without either, no mass measurable is emitted.",
+    },
+    material_name: {
+      type: "string" as const,
+      description: "Material label recorded in the prediction (e.g. \"PLA\").",
+    },
+    measurables: {
+      type: "array" as const,
+      description:
+        "Named features the human will measure, with design-intent values — step heights, hole diameters, wall thicknesses. Merged with the auto measurables (bbox_x/y/z, mass). Derive `predicted` from the same parameters that built the geometry so prediction and part cannot drift.",
+      items: {
+        type: "object" as const,
+        properties: {
+          id: { type: "string" as const, description: "Stable id, e.g. \"hole_3mm\"." },
+          label: {
+            type: "string" as const,
+            description: "Measurement instruction, e.g. \"Small hole diameter (front-left)\".",
+          },
+          kind: { type: "string" as const, enum: [...MEASURABLE_KINDS] },
+          axis: {
+            type: "string" as const,
+            enum: [...MEASURABLE_AXES],
+            description: "Print-frame axis; \"XY\" for in-plane diameters.",
+          },
+          feature: {
+            type: "string" as const,
+            enum: [...MEASURABLE_FEATURES],
+            description: "Aggregation bucket (hole/wall feed the offset aggregates).",
+          },
+          predicted: { type: "number" as const, description: "Design-intent value." },
+          unit: { type: "string" as const, enum: ["mm", "g"] },
+          tolerance: {
+            type: "number" as const,
+            description: "± tolerance; defaults to max(0.1mm, 0.2%) for dimensions, 5% for mass.",
+          },
+        },
+        required: ["id", "label", "kind", "predicted"],
+      },
+    },
+  },
+  required: ["document_id"],
+};
+
+export const recordMeasurementSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description:
+        "Session id the prediction was taken from. Optional when a full `prediction` is passed inline.",
+    },
+    measurements: {
+      type: "object" as const,
+      description:
+        "Measured values keyed by measurable id, in each measurable's own unit (mm or g), e.g. {\"bbox_x\": 79.82, \"hole_3mm\": 2.85, \"mass\": 26.4}. A partial set is fine — unmeasured ids are reported as missing, not errors.",
+      additionalProperties: { type: "number" as const },
+    },
+    printer: {
+      type: "string" as const,
+      description: "Which machine printed the part (e.g. \"Bambu X1C\").",
+    },
+    material: {
+      type: "string" as const,
+      description: "Filament actually used (e.g. \"PLA Basic, black\").",
+    },
+    process: {
+      type: "string" as const,
+      description: "Free-form process notes: layer height, infill, temperatures.",
+    },
+    prediction: {
+      type: "object" as const,
+      description:
+        "A full PrintPrediction (as returned by predict_print) to measure against. Overrides the cached prediction — use this to replay a prediction.json after the session's warm instance recycled.",
+    },
+  },
+  required: ["measurements"],
+};
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+const jsonResult = (value: unknown): ToolResult => ({
+  content: [{ type: "text", text: JSON.stringify(value, null, 2) }],
+});
+
+function parseMeasurables(raw: unknown): Measurable[] {
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) throw new Error("measurables must be an array");
+  return raw.map((entry, i) => {
+    const m = entry as Record<string, unknown>;
+    const id = String(m.id ?? "");
+    const label = String(m.label ?? "");
+    const kind = m.kind as MeasurableKind;
+    const predicted = Number(m.predicted);
+    if (!id || !label) throw new Error(`measurables[${i}]: id and label are required`);
+    if (!MEASURABLE_KINDS.includes(kind)) {
+      throw new Error(`measurables[${i}]: kind must be one of ${MEASURABLE_KINDS.join(", ")}`);
+    }
+    if (!Number.isFinite(predicted)) {
+      throw new Error(`measurables[${i}]: predicted must be a finite number`);
+    }
+    if (m.axis !== undefined && !MEASURABLE_AXES.includes(m.axis as MeasurableAxis)) {
+      throw new Error(`measurables[${i}]: axis must be one of ${MEASURABLE_AXES.join(", ")}`);
+    }
+    if (
+      m.feature !== undefined &&
+      !MEASURABLE_FEATURES.includes(m.feature as MeasurableFeature)
+    ) {
+      throw new Error(
+        `measurables[${i}]: feature must be one of ${MEASURABLE_FEATURES.join(", ")}`,
+      );
+    }
+    const unit = m.unit === undefined ? (kind === "mass" ? "g" : "mm") : m.unit;
+    if (unit !== "mm" && unit !== "g") {
+      throw new Error(`measurables[${i}]: unit must be "mm" or "g"`);
+    }
+    return {
+      id,
+      label,
+      kind,
+      ...(m.axis !== undefined && { axis: m.axis as MeasurableAxis }),
+      ...(m.feature !== undefined && { feature: m.feature as MeasurableFeature }),
+      predicted,
+      unit,
+      ...(m.tolerance !== undefined && { tolerance: Number(m.tolerance) }),
+    };
+  });
+}
+
+/** Snapshot the design's predicted measurables before printing. */
+export function predictPrint(input: unknown, engine: Engine): ToolResult {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const documentId = String(args.document_id ?? "");
+  const ir = getSession(documentId);
+
+  const inspection = computeInspection(ir, engine);
+  const bbox = inspection.bounding_box;
+  const size = {
+    x: Math.round((bbox.max.x - bbox.min.x) * 1000) / 1000,
+    y: Math.round((bbox.max.y - bbox.min.y) * 1000) / 1000,
+    z: Math.round((bbox.max.z - bbox.min.z) * 1000) / 1000,
+  };
+
+  const declared = parseMeasurables(args.measurables);
+
+  const auto: Measurable[] = [
+    {
+      id: "bbox_x",
+      label: "Overall length along X (widest span, caliper jaws)",
+      kind: "dimension",
+      axis: "X",
+      feature: "overall",
+      predicted: size.x,
+      unit: "mm",
+    },
+    {
+      id: "bbox_y",
+      label: "Overall depth along Y (widest span, caliper jaws)",
+      kind: "dimension",
+      axis: "Y",
+      feature: "overall",
+      predicted: size.y,
+      unit: "mm",
+    },
+    {
+      id: "bbox_z",
+      label: "Overall height along Z (tallest point off the bed)",
+      kind: "dimension",
+      axis: "Z",
+      feature: "overall",
+      predicted: size.z,
+      unit: "mm",
+    },
+  ];
+
+  const assumptions: string[] = [
+    "dimensions are model-space; no shrinkage compensation applied",
+  ];
+
+  // Mass: explicit density arg wins; else use the document's per-part
+  // densities when inspect_cad already resolved them.
+  const densityArg = args.material_density_kg_m3;
+  let massG: number | undefined;
+  let density: number | undefined;
+  if (densityArg !== undefined) {
+    density = Number(densityArg);
+    if (!Number.isFinite(density) || density <= 0) {
+      throw new Error("material_density_kg_m3 must be a positive number");
+    }
+    massG = Math.round(((inspection.volume_mm3 / 1e9) * density) * 1e6) / 1000;
+    assumptions.push(
+      `mass assumes 100% infill (solid) at ${density} kg/m³ — print solid or ignore the mass row`,
+    );
+  } else if (inspection.mass_g !== undefined) {
+    massG = inspection.mass_g;
+    density = inspection.part_masses?.[0]?.density_kg_m3;
+    assumptions.push(
+      "mass assumes 100% infill (solid) at the document's material densities — print solid or ignore the mass row",
+    );
+  }
+  if (massG !== undefined) {
+    auto.push({
+      id: "mass",
+      label: "Part mass on a scale, grams",
+      kind: "mass",
+      predicted: massG,
+      unit: "g",
+    });
+  }
+
+  // Declared measurables win on id collision — the caller knows the design.
+  const declaredIds = new Set(declared.map((m) => m.id));
+  const measurables = [...auto.filter((m) => !declaredIds.has(m.id)), ...declared];
+
+  const materialName = args.material_name !== undefined ? String(args.material_name) : undefined;
+  const prediction: PrintPrediction = {
+    version: 1,
+    document_id: documentId,
+    doc_fingerprint: fingerprintDocument(ir),
+    created_at: new Date().toISOString(),
+    ...((materialName !== undefined || density !== undefined) && {
+      material: {
+        ...(materialName !== undefined && { name: materialName }),
+        ...(density !== undefined && { density_kg_m3: density }),
+      },
+    }),
+    volume_mm3: inspection.volume_mm3,
+    bbox_mm: size,
+    assumptions,
+    measurables,
+  };
+
+  predictions.set(documentId, prediction);
+  return jsonResult(prediction);
+}
+
+/** Record as-built measurements and emit the receipt-vs-reality delta. */
+export function recordMeasurement(input: unknown): ToolResult {
+  const args = (input ?? {}) as Record<string, unknown>;
+  const documentId = args.document_id !== undefined ? String(args.document_id) : undefined;
+
+  let prediction: PrintPrediction | undefined;
+  if (args.prediction !== undefined && args.prediction !== null) {
+    const p = args.prediction as PrintPrediction;
+    if (!Array.isArray(p.measurables) || typeof p.doc_fingerprint !== "string") {
+      throw new Error(
+        "prediction must be a PrintPrediction as returned by predict_print (measurables + doc_fingerprint)",
+      );
+    }
+    prediction = p;
+  } else if (documentId !== undefined) {
+    prediction = predictions.get(documentId);
+  }
+  if (!prediction) {
+    throw new Error(
+      documentId
+        ? `No prediction recorded for document ${documentId} on this instance. ` +
+          `Run predict_print first, or pass the saved prediction JSON inline via the \`prediction\` arg.`
+        : "Pass document_id (after predict_print) or a full `prediction` object.",
+    );
+  }
+
+  const rawMeasurements = args.measurements;
+  if (
+    rawMeasurements === null ||
+    typeof rawMeasurements !== "object" ||
+    Array.isArray(rawMeasurements)
+  ) {
+    throw new Error("measurements must be an object of {measurable_id: number}");
+  }
+  const measurements: Record<string, number> = {};
+  for (const [id, value] of Object.entries(rawMeasurements as Record<string, unknown>)) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) {
+      throw new Error(`measurements.${id} must be a finite number (got ${String(value)})`);
+    }
+    measurements[id] = n;
+  }
+  if (Object.keys(measurements).length === 0) {
+    throw new Error("measurements is empty — nothing to record");
+  }
+
+  const context: MeasurementContext = {
+    ...(args.printer !== undefined && { printer: String(args.printer) }),
+    ...(args.material !== undefined && { material: String(args.material) }),
+    ...(args.process !== undefined && { process: String(args.process) }),
+    measured_at: new Date().toISOString(),
+  };
+
+  // Staleness: only checkable when the session is still open here.
+  let currentFingerprint: string | undefined;
+  const sessionId = documentId ?? prediction.document_id;
+  if (sessionId !== undefined) {
+    try {
+      currentFingerprint = fingerprintDocument(getSession(sessionId));
+    } catch {
+      // Session gone (cold instance / closed) — report without staleness info.
+    }
+  }
+
+  const report = buildCalibrationReport(prediction, measurements, {
+    context,
+    ...(currentFingerprint !== undefined && {
+      current_doc_fingerprint: currentFingerprint,
+    }),
+  });
+
+  if (sessionId !== undefined) {
+    const list = reports.get(sessionId) ?? [];
+    list.push(report);
+    reports.set(sessionId, list);
+  }
+
+  return jsonResult(report);
+}


### PR DESCRIPTION
The 3DP slice of the domain atlas (#397): the one fab rail with **zero vendor dependency** — the user's own printer is the effector — making it the volume source of `(predicted, measured)` sim2real pairs. This ships the minimal loop:

```
design → predict_print → slice + print (human + Bambu) → calipers/scale → record_measurement → delta report
```

Design doc: [docs/plans/2026-07-07-3dp-print-then-measure.md](../blob/feat/3dp-print-then-measure/docs/plans/2026-07-07-3dp-print-then-measure.md)

## What's here

**`@vcad/core` — pure delta engine** (`packages/core/src/utils/print-calibration.ts`)
- `PrintPrediction` (pre-print snapshot) and `CalibrationReport` (receipt-vs-reality) types + `buildCalibrationReport()`. No I/O, no kernel, no MCP — same layering as the receipt engine next door, whose `hashHex` it reuses to fingerprint the document and detect a stale pairing (design edited between predict and record).
- Per-feature deltas with FDM-envelope default tolerances (±max(0.1mm, 0.2%) for dimensions, ±5% for mass), and the aggregates a printer profile can actually act on: per-axis least-squares scale fits, mean hole undersize, thin-wall flow offset, and concrete suggestions ("set shrinkage compensation to 100.21%").
- One judgment call worth reviewing: **axis scale fits exclude hole/boss/wall features.** Their systematic offsets (undersize, over-extrusion) masquerade as shrinkage — the smoke run measured 0.47% phantom shrinkage before the exclusion vs the true 0.21% after. Those features get dedicated aggregates instead.

**MCP `print` pack** (`packages/mcp/src/tools/print-check.ts`)
- `predict_print` — snapshots kernel-evaluated bbox/volume/mass (at a filament density) plus caller-declared feature measurables, each carrying a human measurement instruction, so the prediction doubles as the guided worksheet. Declared measurables derive from the same parameters that built the geometry (the f405 pattern).
- `record_measurement` — joins caliper/scale readings into the report. Predictions ride the warm-instance cache (same lifetime as sessions/artifacts), and the tool also accepts the prediction inline so a saved `prediction.json` replays after a cold serverless start.
- `inspect.ts`: extracted `computeInspection()` for reuse — behavior unchanged.

**Canonical coupon** (`examples/calibration-coupon/`)
- 80×32mm plate, ~1h print: Z staircase (tops at 6/8/10/12), Ø3/5/8 through-holes, Ø6 boss, 0.8/1.2/2.0mm fins, mass row. Kernel-friendly geometry: rectilinear unions with bodies sunk 1mm into the base (no coincident-face seams), plain cylinder differences through a flat plate.
- `build.mjs` ships STL + `prediction.json` + the measurement worksheet; `record.mjs` emits the delta report to `out/calibration-report.json` — JSON stored alongside the doc.

## Not in scope (per the design doc)

Printer integration beyond the existing slicer crates — the human carries the part. Follow-ups named in the doc: per-(printer, material) profile aggregation feeding `smart_defaults`, auto-measurables from `vcad-slicer`'s BRep analysis, infill-aware mass via `vcad-kernel-cost`, receipt-claim envelope when the unified Receipt lands.

## Testing

- `packages/core`: 127/127 (8 new for the delta engine — scale fits, aggregates, staleness, verdicts, missing/unknown handling)
- `packages/mcp`: 502 passed, 2 pre-existing skips (8 new for the tools — auto+declared measurable merge, inline-prediction cold replay, stale detection, input validation)
- Example runs end to end; coupon geometry verified visually via `render_view` (staircase, holes, boss, fins all as designed) and by hand-checked volume (13369mm³ kernel vs ≈13.3k analytic)
- Full workspace build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)