### PR TITLE
Silence middleware TS2835 in Vercel builds (.js import extensions)

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,7 +8,7 @@
  * import the same shared module.
  */
 
-import { isRequestGeoBlocked, geoBlockResponse } from "./shared/geo-block";
+import { isRequestGeoBlocked, geoBlockResponse } from "./shared/geo-block.js";
 
 export default function middleware(request: Request): Response | undefined {
   if (isRequestGeoBlocked(request)) return geoBlockResponse();

--- a/packages/app/middleware.ts
+++ b/packages/app/middleware.ts
@@ -8,7 +8,7 @@
  * shared module.
  */
 
-import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block";
+import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block.js";
 
 export default function middleware(request: Request): Response | undefined {
   if (isRequestGeoBlocked(request)) return geoBlockResponse();

--- a/packages/mcp/src/__tests__/geo-block.test.ts
+++ b/packages/mcp/src/__tests__/geo-block.test.ts
@@ -14,7 +14,7 @@ import {
   geoBlockResponse,
   isGeoBlocked,
   isRequestGeoBlocked,
-} from "../../../../shared/geo-block";
+} from "../../../../shared/geo-block.js";
 
 describe("isGeoBlocked", () => {
   it("blocks every listed country", () => {

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -34,7 +34,7 @@ import {
   isGeoBlocked,
   GEO_BLOCK_BODY,
   GEO_BLOCK_STATUS,
-} from "../../shared/geo-block";
+} from "../../shared/geo-block.js";
 
 // The serverless function filesystem is read-only (/var/task), so the
 // filesystem-touching tools (export_cad, import_step, export_gerber)

--- a/services/mcp/middleware.ts
+++ b/services/mcp/middleware.ts
@@ -10,7 +10,7 @@
  * The request handler in entry.ts runs the same check as defense-in-depth.
  */
 
-import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block";
+import { isRequestGeoBlocked, geoBlockResponse } from "../../shared/geo-block.js";
 
 export default function middleware(request: Request): Response {
   if (isRequestGeoBlocked(request)) return geoBlockResponse();


### PR DESCRIPTION
## Why

Since #403, every Vercel build of both projects (`vcad` and `vcad-mcp`) logs a non-fatal TypeScript error from the geo-block middleware:

```
middleware.ts(11,55): error TS2835: Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean '../../shared/geo-block.js'?
```

The block itself works in production (Vercel bundles middleware with esbuild, which resolves the specifier regardless; RU-node probes confirmed the 451s) — but the noise appears on every deploy and would turn fatal if Vercel ever hardens that typecheck.

## What

Add the `.js` extension to all five `shared/geo-block` import sites: the three middleware files (repo root, `packages/app`, `services/mcp`), plus `services/mcp/entry.ts` and the vitest suite for consistency. esbuild, Vercel's middleware compiler, and vitest all resolve `.js` → `.ts`. 5 lines, specifiers only.

## Verification

- Reproduced TS2835 on the old specifier with `tsc --noEmit --module node16 --moduleResolution node16` inside the ESM package (exact same error/position as the Vercel log); the new specifier typechecks clean.
- All three middlewares smoke-bundle with esbuild.
- `geo-block.test.ts`: 14/14 passing.

## Notes

- The log line disappears on the **next deploy** of each project.
- No changelog entry (build-noise fix, per CLAUDE.md conventions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)