### PR TITLE
Add copper provenance to make route_nets idempotent

### DIFF
--- a/changelog/entries/2026-07-07-route-nets-idempotent.json
+++ b/changelog/entries/2026-07-07-route-nets-idempotent.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-route-nets-idempotent",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "route_nets is idempotent and respects hand-placed copper",
+  "summary": "Re-running route_nets rips up only its own prior copper (traces/vias now carry provenance), so a re-route replaces the route instead of stacking shorts — and add_trace/add_via/coil copper survives.",
+  "features": ["pcb", "autorouter", "drc"],
+  "mcpTools": ["route_nets", "add_trace", "add_via"]
+}

--- a/crates/vcad-ecad-export/src/excellon.rs
+++ b/crates/vcad-ecad-export/src/excellon.rs
@@ -225,6 +225,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".into(),
+                source: None,
             }],
             zones: vec![],
             keepouts: vec![],

--- a/crates/vcad-ecad-export/src/gerber.rs
+++ b/crates/vcad-ecad-export/src/gerber.rs
@@ -879,6 +879,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "1".into(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![Via {
@@ -888,6 +889,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".into(),
+                source: None,
             }],
             zones: vec![Zone {
                 outline: vec![

--- a/crates/vcad-ecad-pcb/src/copper_pour.rs
+++ b/crates/vcad-ecad-pcb/src/copper_pour.rs
@@ -362,6 +362,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "1".to_string(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![],

--- a/crates/vcad-ecad-pcb/src/critique.rs
+++ b/crates/vcad-ecad-pcb/src/critique.rs
@@ -162,6 +162,7 @@ mod tests {
             width: 0.25,
             layer,
             net: net.into(),
+            source: None,
         }
     }
 
@@ -181,6 +182,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "SIG".into(),
+                source: None,
             }],
         );
         let c = critique_net(&pcb, "SIG");

--- a/crates/vcad-ecad-pcb/src/dfm.rs
+++ b/crates/vcad-ecad-pcb/src/dfm.rs
@@ -1579,6 +1579,7 @@ mod tests {
             width: 0.3,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         let report = check_dfm(&pcb, PcbFabProfile::Jlcpcb, None).unwrap();
         assert_eq!(report.profile, "jlcpcb");
@@ -1601,6 +1602,7 @@ mod tests {
             width: 0.08,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         // 2) A via with a 0.1mm drill — below JLC 0.2mm min drill, and a
         //    0.05mm annular ring (0.2 dia / 0.1 drill) below 0.13mm.
@@ -1611,6 +1613,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "SIG".into(),
+            source: None,
         });
 
         let report = check_dfm(&pcb, PcbFabProfile::Jlcpcb, None).unwrap();
@@ -1648,6 +1651,7 @@ mod tests {
             width: 0.15,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         let report = check_dfm(&pcb, PcbFabProfile::Jlcpcb, None).unwrap();
         assert_eq!(report.copper_weight_oz, 2.0);
@@ -1691,6 +1695,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "SIG".into(),
+            source: None,
         });
 
         let jlc = check_dfm(&pcb, PcbFabProfile::Jlcpcb, None).unwrap();
@@ -1765,6 +1770,7 @@ mod tests {
             width: 0.3,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         pcb.traces.push(Trace {
             start: Vec2::new(20.0, 20.0),
@@ -1772,6 +1778,7 @@ mod tests {
             width: 0.3,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         let report = check_dfm(&pcb, PcbFabProfile::Jlcpcb, None).unwrap();
         let at = find(&report, "acid_trap");
@@ -1789,6 +1796,7 @@ mod tests {
             width: 0.08,
             layer: PcbLayer::FCu,
             net: "SIG".into(),
+            source: None,
         });
         // A bespoke pack that allows 0.05mm traces.
         let custom = r#"

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -2190,6 +2190,7 @@ mod tests {
                     width: 0.25,
                     layer: PcbLayer::FCu,
                     net: "1".to_string(),
+                    source: None,
                 },
                 Trace {
                     start: Vec2::new(20.0, 50.0),
@@ -2197,6 +2198,7 @@ mod tests {
                     width: 0.25,
                     layer: PcbLayer::FCu,
                     net: "2".to_string(),
+                    source: None,
                 },
             ],
             trace_arcs: vec![],
@@ -2207,6 +2209,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".to_string(),
+                source: None,
             }],
             zones: vec![],
             keepouts: vec![],
@@ -2251,6 +2254,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "2".to_string(),
+                source: None,
             });
 
             let shorts: Vec<_> = check_drc(&pcb)
@@ -2294,6 +2298,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "3".to_string(),
+            source: None,
         });
         let shorts: Vec<_> = check_drc(&pcb)
             .into_iter()
@@ -2342,6 +2347,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "3".to_string(),
+            source: None,
         });
         let shorts: Vec<_> = check_drc(&pcb)
             .into_iter()
@@ -2375,6 +2381,7 @@ mod tests {
             width: 0.1, // below 0.25 minimum
             layer: PcbLayer::FCu,
             net: "1".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2442,6 +2449,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "2".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2466,6 +2474,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "1".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2490,6 +2499,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "2".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2514,6 +2524,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "1".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2540,6 +2551,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "1".to_string(),
+            source: None,
         });
         pcb.traces.push(Trace {
             start: Vec2::new(20.0, 40.3),
@@ -2547,6 +2559,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "2".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -2618,6 +2631,7 @@ mod tests {
             width: 0.2,
             layer: PcbLayer::FCu,
             net: net.into(),
+            source: None,
         };
         pcb.traces.push(leg(40.0, "USB_P"));
         pcb.traces.push(leg(40.3, "USB_N"));
@@ -2670,6 +2684,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: net.to_string(),
+            source: None,
         }
     }
 
@@ -3006,6 +3021,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "1".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -3216,6 +3232,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "1".to_string(),
+            source: None,
         });
 
         let violations = check_drc(&pcb);
@@ -3284,6 +3301,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "2".to_string(),
+            source: None,
         });
         let v = check_drc(&pcb);
         let d = v.iter().find(|v| v.rule == DrcRuleType::MinDrill).unwrap();
@@ -3407,6 +3425,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "3V3".to_string(),
+                source: None,
             },
             Trace {
                 start: Vec2::new(35.0, 40.0),
@@ -3414,6 +3433,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "3V3".to_string(),
+                source: None,
             },
         ];
 
@@ -3462,6 +3482,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "3V3".to_string(),
+            source: None,
         }];
 
         let c = analyze_net_continuity(&pcb, "3V3");
@@ -3627,6 +3648,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::In1Cu,
             net: "3".to_string(),
+            source: None,
         });
         let after: Vec<_> = check_drc(&pcb)
             .into_iter()
@@ -3803,6 +3825,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "3".to_string(),
+            source: None,
         });
 
         let unstitched = check_drc(&pcb)

--- a/crates/vcad-ecad-pcb/src/ratsnest.rs
+++ b/crates/vcad-ecad-pcb/src/ratsnest.rs
@@ -423,6 +423,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "VCC".into(),
+            source: None,
         });
 
         let netlist = Netlist {

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1492,6 +1492,7 @@ mod tests {
                 width: t.width,
                 layer: t.layer,
                 net: t.net.clone(),
+                source: None,
             });
         }
         for v in &r.vias {
@@ -1502,6 +1503,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: v.net.clone(),
+                source: None,
             });
         }
     }

--- a/crates/vcad-ecad-pcb/src/router/diff_pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/diff_pair.rs
@@ -417,6 +417,7 @@ mod tests {
                     width: 0.2,
                     layer: PcbLayer::FCu,
                     net: leg.net.clone(),
+                    source: None,
                 });
             }
         }

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -471,6 +471,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: net.into(),
+            source: None,
         }
     }
 

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -202,6 +202,7 @@ mod pcb_route_tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: net.into(),
+            source: None,
         }
     }
 

--- a/crates/vcad-ecad-pcb/src/session.rs
+++ b/crates/vcad-ecad-pcb/src/session.rs
@@ -377,6 +377,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: net.into(),
+            source: None,
         }
     }
 

--- a/crates/vcad-ecad-pcb/src/spatial.rs
+++ b/crates/vcad-ecad-pcb/src/spatial.rs
@@ -753,6 +753,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "1".to_string(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![Via {
@@ -762,6 +763,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".to_string(),
+                source: None,
             }],
             zones: vec![],
             keepouts: vec![],

--- a/crates/vcad-ecad-pcb/src/teardrop.rs
+++ b/crates/vcad-ecad-pcb/src/teardrop.rs
@@ -267,6 +267,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "N".into(),
+            source: None,
         };
         let trace = Trace {
             start: Vec2::new(20.0, 20.0),
@@ -274,6 +275,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "N".into(),
+            source: None,
         };
         let tds = generate_teardrops(&board(vec![], vec![trace], vec![via]));
         assert_eq!(tds.len(), 1, "one endpoint lands on the via");
@@ -293,6 +295,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "OTHER".into(),
+            source: None,
         };
         let trace = Trace {
             start: Vec2::new(20.0, 20.0),
@@ -300,6 +303,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "N".into(),
+            source: None,
         };
         let tds = generate_teardrops(&board(vec![], vec![trace], vec![via]));
         assert!(tds.is_empty(), "a different-net via gets no teardrop");
@@ -315,6 +319,7 @@ mod tests {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "N".into(),
+            source: None,
         };
         let trace = Trace {
             start: Vec2::new(20.0, 20.0),
@@ -322,6 +327,7 @@ mod tests {
             width: 0.25,
             layer: PcbLayer::FCu,
             net: "N".into(),
+            source: None,
         };
         assert!(generate_teardrops(&board(vec![], vec![trace], vec![via])).is_empty());
     }

--- a/crates/vcad-ecad-symbols/src/kicad_pcb.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_pcb.rs
@@ -686,6 +686,7 @@ fn parse_trace(node: &SExpr<'_>, net_map: &HashMap<u32, String>) -> Option<Trace
         width,
         layer,
         net,
+        source: None,
     })
 }
 
@@ -710,6 +711,7 @@ fn parse_via(node: &SExpr<'_>, net_map: &HashMap<u32, String>) -> Option<Via> {
         start_layer,
         end_layer,
         net,
+        source: None,
     })
 }
 

--- a/crates/vcad-ecad-symbols/src/kicad_write.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_write.rs
@@ -1234,6 +1234,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "VCC".into(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![Via {
@@ -1243,6 +1244,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "VCC".into(),
+                source: None,
             }],
             zones: vec![Zone {
                 outline: vec![

--- a/crates/vcad-eval/src/pcb_preview.rs
+++ b/crates/vcad-eval/src/pcb_preview.rs
@@ -757,6 +757,7 @@ mod tests {
             end: Vec2::new(20.0, 5.0),
             width: 0.25,
             layer: PcbLayer::FCu,
+            source: None,
         };
         let pcb = board_with(
             vec![chip("R1", 10.0, 10.0), chip("R2", 25.0, 20.0)],

--- a/crates/vcad-ir/src/ecad.rs
+++ b/crates/vcad-ir/src/ecad.rs
@@ -733,6 +733,24 @@ fn default_true() -> bool {
 // Traces and Vias
 // ============================================================================
 
+/// Provenance of a piece of copper: who placed it.
+///
+/// The autorouter treats its own output as disposable — re-running `route_nets`
+/// rips up `Autoroute` copper on the nets it routes and lays it fresh — while
+/// `Manual` copper (hand-placed traces/vias, coils) is preserved. Copper with
+/// no recorded source (documents from before provenance existed) is treated as
+/// autorouted, matching the rip-up behavior those documents already had.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(rename_all = "lowercase")]
+pub enum CopperSource {
+    /// Placed by the autorouter (`route_nets` / diff-pair routing).
+    Autoroute,
+    /// Hand-placed by a user or agent (`add_trace`, `add_via`, coil tools).
+    Manual,
+}
+
 /// A straight routed copper trace segment.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
@@ -748,6 +766,11 @@ pub struct Trace {
     pub layer: PcbLayer,
     /// Net this trace belongs to.
     pub net: NetId,
+    /// Who placed this copper. Absent on pre-provenance documents (treated as
+    /// autorouted, i.e. rippable by `route_nets`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub source: Option<CopperSource>,
 }
 
 /// An arc routed copper trace segment.
@@ -792,6 +815,11 @@ pub struct Via {
     pub end_layer: PcbLayer,
     /// Net this via belongs to.
     pub net: NetId,
+    /// Who placed this via. Absent on pre-provenance documents (treated as
+    /// autorouted, i.e. rippable by `route_nets`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub source: Option<CopperSource>,
 }
 
 // ============================================================================
@@ -1068,6 +1096,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "1".to_string(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![Via {
@@ -1077,6 +1106,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".to_string(),
+                source: None,
             }],
             zones: vec![Zone {
                 outline: vec![

--- a/crates/vcad-render/examples/pcb_preview.rs
+++ b/crates/vcad-render/examples/pcb_preview.rs
@@ -216,6 +216,7 @@ fn trace(net: &str, layer: PcbLayer, x1: f64, y1: f64, x2: f64, y2: f64, w: f64)
         width: w,
         layer,
         net: net.to_string(),
+        source: None,
     }
 }
 
@@ -265,6 +266,7 @@ fn sample_board() -> Pcb {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "GND".to_string(),
+            source: None,
         },
         Via {
             position: Vec2::new(27.7, 14.31),
@@ -273,6 +275,7 @@ fn sample_board() -> Pcb {
             start_layer: PcbLayer::FCu,
             end_layer: PcbLayer::BCu,
             net: "GND".to_string(),
+            source: None,
         },
     ];
 
@@ -537,6 +540,7 @@ fn complex_board() -> Pcb {
             width: 0.16,
             layer: PcbLayer::FCu,
             net: net.clone(),
+            source: None,
         });
         if n.is_multiple_of(3) {
             vias.push(Via {
@@ -546,6 +550,7 @@ fn complex_board() -> Pcb {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: net.clone(),
+                source: None,
             });
             let end2 = Vec2::new(end.x + d.x * 4.5, end.y + d.y * 4.5);
             traces.push(Trace {
@@ -554,6 +559,7 @@ fn complex_board() -> Pcb {
                 width: 0.25,
                 layer: PcbLayer::BCu,
                 net,
+                source: None,
             });
         }
     }
@@ -652,6 +658,7 @@ fn inner_layers_board() -> Pcb {
             width: 0.6,
             layer: *layer,
             net: format!("L{i}"),
+            source: None,
         });
     }
     Pcb {

--- a/crates/vcad-render/src/pcb.rs
+++ b/crates/vcad-render/src/pcb.rs
@@ -1609,6 +1609,7 @@ mod tests {
                 width: 0.25,
                 layer: PcbLayer::FCu,
                 net: "1".to_string(),
+                source: None,
             }],
             trace_arcs: vec![],
             vias: vec![Via {
@@ -1618,6 +1619,7 @@ mod tests {
                 start_layer: PcbLayer::FCu,
                 end_layer: PcbLayer::BCu,
                 net: "1".to_string(),
+                source: None,
             }],
             zones: vec![],
             keepouts: vec![],

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -177,6 +177,17 @@ c: [number, number, number],
 periodic?: [boolean, boolean, boolean], };
 
 /**
+ * Provenance of a piece of copper: who placed it.
+ *
+ * The autorouter treats its own output as disposable — re-running `route_nets`
+ * rips up `Autoroute` copper on the nets it routes and lays it fresh — while
+ * `Manual` copper (hand-placed traces/vias, coils) is preserved. Copper with
+ * no recorded source (documents from before provenance existed) is treated as
+ * autorouted, matching the rip-up behavior those documents already had.
+ */
+export type CopperSource = "autoroute" | "manual";
+
+/**
  * CSG operation — the core building block of the IR DAG.
  *
  * Each variant is either a leaf primitive or a combining/transform operation
@@ -2603,7 +2614,12 @@ layer: PcbLayer,
 /**
  * Net this trace belongs to.
  */
-net: string, };
+net: string, 
+/**
+ * Who placed this copper. Absent on pre-provenance documents (treated as
+ * autorouted, i.e. rippable by `route_nets`).
+ */
+source?: CopperSource, };
 
 /**
  * An arc routed copper trace segment.
@@ -2750,7 +2766,12 @@ endLayer: PcbLayer,
 /**
  * Net this via belongs to.
  */
-net: string, };
+net: string, 
+/**
+ * Who placed this via. Absent on pre-provenance documents (treated as
+ * autorouted, i.e. rippable by `route_nets`).
+ */
+source?: CopperSource, };
 
 /**
  * Vignette effect settings.

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -803,15 +803,15 @@ describe("route_nets locked_nets", () => {
     expect(hasDetour(getPcbBoard(getSession(id)))).toBe(true);
   });
 
-  it("rips up the same net when it is not locked (control)", async () => {
+  it("preserves manual add_trace copper even when the net is NOT locked", async () => {
     const created = out(
       await createSchematic({
-        components: [resistor("R1", 0), resistor("R2", 20)],
-        nets: { MID: ["R1.2", "R2.1"] },
+        components: [resistor("R1", 0), resistor("R2", 20), resistor("R3", 40)],
+        nets: { MID: ["R1.2", "R2.1"], NETB: ["R2.2", "R3.1"] },
       }),
     );
     const id = created.document_id;
-    await placeComponents({ document_id: id, board_width: 40, board_height: 20 });
+    await placeComponents({ document_id: id, board_width: 60, board_height: 20 });
     await addTrace({
       document_id: id,
       net: "MID",
@@ -823,11 +823,80 @@ describe("route_nets locked_nets", () => {
     });
     expect(hasDetour(getPcbBoard(getSession(id)))).toBe(true);
 
+    // No locked_nets: provenance alone protects the hand-placed copper. The
+    // net is preserved wholesale (the kernel can't route "around" existing
+    // copper) and reported so the caller knows it was skipped.
+    const res = out(await routeNets({ document_id: id }));
+    expect(res.success).toBe(true);
+    expect(res.manual_nets_preserved).toEqual(["MID"]);
+    expect(res.traces_removed ?? 0).toBe(0);
+    expect((res.warnings ?? []).join(" ")).toContain("MID");
+    const board = getPcbBoard(getSession(id));
+    expect(hasDetour(board)).toBe(true);
+    // Other nets still route normally around the preserved copper.
+    expect(board.traces.some((t) => t.net === "NETB")).toBe(true);
+  });
+
+  it("rips up untagged (pre-provenance) copper on an unlocked net (control)", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    await placeComponents({ document_id: id, board_width: 40, board_height: 20 });
+    // Inject a raw trace with no `source` — the shape of a document saved
+    // before copper provenance existed. Legacy copper stays disposable, so a
+    // re-route replaces it instead of stacking on top of it.
+    getPcbBoard(getSession(id)).traces.push({
+      start: { x: 1, y: 9 },
+      end: { x: 1, y: 1 },
+      width: 0.25,
+      layer: "FCu",
+      net: "MID",
+    });
+    expect(hasDetour(getPcbBoard(getSession(id)))).toBe(true);
+
     const res = out(await routeNets({ document_id: id }));
     expect(res.traces_removed).toBeGreaterThan(0);
     expect(hasDetour(getPcbBoard(getSession(id)))).toBe(false);
   });
+
+  it("keeps a manual via while re-routing the net's traces", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    await placeComponents({ document_id: id, board_width: 40, board_height: 20 });
+    out(await routeNets({ document_id: id }));
+    out(
+      await addVia({
+        document_id: id,
+        net: "MID",
+        position: { x: 2, y: 2 },
+      }),
+    );
+
+    // A via alone doesn't block re-routing (the ratsnest only counts traces),
+    // so the net is re-owned: autorouted copper replaced, manual via kept.
+    const res = out(await routeNets({ document_id: id }));
+    expect(res.success).toBe(true);
+    expect(res.traces_removed).toBeGreaterThan(0);
+    expect(res.manual_nets_preserved).toBeUndefined();
+    const board = getPcbBoard(getSession(id));
+    expect(
+      board.vias.some(
+        (v) => v.net === "MID" && v.source === "manual" && v.position.x === 2,
+      ),
+    ).toBe(true);
+    expect(board.traces.some((t) => t.net === "MID")).toBe(true);
+  });
 });
+
 
 describe("route_nets strategy", () => {
   const mkBoard = async () => {
@@ -2143,13 +2212,15 @@ describe("explicit netlist (nets as data)", () => {
 });
 
 describe("route_nets idempotency", () => {
-  // The exact board from the field bug report. Before the fix, routing an
-  // already-routed board a second time stacked copper: the kernel ratsnest
-  // skips nets that already have a trace, so the second route_all came back
-  // empty, the no-kernel fallback in routeNets misfired, and it chained naive
-  // straight segments over the clean route — turning a handful of inherent
-  // violations into dozens of shorts. The fix rips up the target nets' copper
-  // before routing, so re-running replaces the route instead of adding to it.
+  // The exact board from the field bug report (issue #277). Before the fix,
+  // routing an already-routed board a second time stacked copper: the kernel
+  // ratsnest skips nets that already have a trace, so the second route_all
+  // came back empty, the no-kernel fallback in routeNets misfired, and it
+  // chained naive straight segments over the clean route — turning a handful
+  // of inherent violations into dozens of shorts. The fix rips up the target
+  // nets' *autorouted* copper before routing (hand-placed copper is
+  // provenance-tagged and preserved), so re-running replaces the route
+  // instead of adding to it.
   const soic8 = (ref: string, x: number) => ({
     ref,
     value: "U",
@@ -2208,6 +2279,10 @@ describe("route_nets idempotency", () => {
     return id;
   };
 
+  /** Segment identity — stacked copper shows up as exact duplicates. */
+  const segKey = (t: { net: string; layer: string; start: Vec2; end: Vec2 }) =>
+    `${t.net}|${t.layer}|${t.start.x},${t.start.y}->${t.end.x},${t.end.y}`;
+
   it("a second route_nets does not stack copper or add violations", async () => {
     const id = await buildBoard();
 
@@ -2218,20 +2293,62 @@ describe("route_nets idempotency", () => {
     const vias1 = board1.vias.length;
     const drc1 = out(await runDrc({ document_id: id }));
     expect(traces1).toBeGreaterThan(0);
+    // A single pass never stacks copper on itself — the duplicate-free
+    // baseline the re-route must hold.
+    const keys1 = board1.traces.map(segKey);
+    expect(new Set(keys1).size).toBe(keys1.length);
 
     // Second route — must rip up and re-lay the same copper, not append a second
     // set. After the rip-up the board is pads-only again, exactly as it was
     // before the first route, so the deterministic router reproduces it byte
     // for byte.
-    out(await routeNets({ document_id: id }));
+    const r2 = out(await routeNets({ document_id: id }));
     const board2 = getPcbBoard(getSession(id));
     const drc2 = out(await runDrc({ document_id: id }));
 
+    // The rip-up is visible in the result, not silent.
+    expect(r2.traces_removed).toBeGreaterThan(0);
     expect(board2.traces.length).toBe(traces1);
     expect(board2.vias.length).toBe(vias1);
+    // No two identical segments — the stacked-copper signature.
+    const keys2 = board2.traces.map(segKey);
+    expect(new Set(keys2).size).toBe(keys2.length);
+    // Every piece of autorouted copper carries its provenance, so the next
+    // re-route knows it is disposable.
+    expect(board2.traces.every((t) => t.source === "autoroute")).toBe(true);
+    expect(board2.vias.every((v) => v.source === "autoroute")).toBe(true);
     expect(drc2.violations).toBe(drc1.violations);
     // The headline symptom: the re-route must never introduce shorts.
     expect(drc2.byRule.Short ?? 0).toBe(0);
+  });
+
+  it("a scoped re-route of one net leaves the other nets' copper untouched", async () => {
+    const id = await buildBoard();
+    out(await routeNets({ document_id: id }));
+
+    const before = getPcbBoard(getSession(id));
+    const othersBefore = before.traces.filter((t) => t.net !== "SIG2").map(segKey).sort();
+    const sig2Before = before.traces.filter((t) => t.net === "SIG2").length;
+    expect(sig2Before).toBeGreaterThan(0);
+
+    const r = out(await routeNets({ document_id: id, nets: ["SIG2"] }));
+    expect(r.success).toBe(true);
+    expect(r.traces_removed).toBeGreaterThan(0);
+
+    const after = getPcbBoard(getSession(id));
+    // SIG2 was replaced (still routed, no duplicate segments), not doubled.
+    // The scoped pass routes against different obstacles than the original
+    // negotiated pass, so the exact path may differ — but stacking would at
+    // least double the segment count.
+    const sig2After = after.traces.filter((t) => t.net === "SIG2");
+    expect(sig2After.length).toBeGreaterThan(0);
+    expect(sig2After.length).toBeLessThan(sig2Before * 2);
+    const sig2Keys = sig2After.map(segKey);
+    expect(new Set(sig2Keys).size).toBe(sig2Keys.length);
+    // Copper on every other net is byte-identical.
+    expect(after.traces.filter((t) => t.net !== "SIG2").map(segKey).sort()).toEqual(
+      othersBefore,
+    );
   });
 
   it("routing three times in a row stays flat — no monotonic copper growth", async () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1424,11 +1424,15 @@ export async function createServer(
         name: "route_nets",
         description:
           "Route electrical nets on the PCB with copper traces. Connects pads " +
-          "belonging to the same net. A net with a copper-pour zone (a plane) " +
-          "is connected by stitching each pad to the plane with a via instead " +
-          "of tracing it — those nets come back in `plane_stitched`. " +
-          "`locked_nets` preserves hand-placed copper from rip-up. Mutates the " +
-          "session document (pass document_id).",
+          "belonging to the same net. Idempotent: re-running rips up the " +
+          "previously autorouted copper on the target nets before routing, so " +
+          "a second call replaces the route instead of stacking shorts. " +
+          "Hand-placed copper (add_trace / add_via / coils) is preserved " +
+          "automatically; `locked_nets` additionally protects whole nets. A " +
+          "net with a copper-pour zone (a plane) is connected by stitching " +
+          "each pad to the plane with a via instead of tracing it — those " +
+          "nets come back in `plane_stitched`. Mutates the session document " +
+          "(pass document_id).",
         inputSchema: routeNetsSchema,
       },
       {
@@ -1542,7 +1546,8 @@ export async function createServer(
           "Lay an explicit copper trace: a polyline of segments on a layer, " +
           "assigned to a net. The general-purpose routing primitive — use it " +
           "for coil interconnect, buses, and hand-routes that route_nets " +
-          "(pad-driven) won't make. Mutates the session document.",
+          "(pad-driven) won't make. Tagged as manual copper, so route_nets " +
+          "preserves it instead of ripping it up. Mutates the session document.",
         inputSchema: addTraceSchema,
       },
       {

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -901,11 +901,14 @@ export const routeNetsSchema = {
       items: { type: "string" as const },
       description:
         "Net IDs to route (empty = route all). Re-running is safe and " +
-        "self-cleaning: routing rips up the prior copper on each net first and " +
-        "lays a complete fresh route, so trace counts don't grow across " +
-        "iterations. After a set_placement move, nets whose pads no longer sit " +
-        "under their copper are detected as stale and re-routed too (even if not " +
-        "listed here); the result reports `traces_removed`/`vias_removed` and " +
+        "self-cleaning: routing rips up the prior *autorouted* copper on each " +
+        "net first and lays a complete fresh route, so trace counts don't grow " +
+        "across iterations. Hand-placed copper (add_trace / add_via / coil " +
+        "tools) is never ripped: a net carrying a manual trace is preserved " +
+        "wholesale and reported in `manual_nets_preserved`. After a " +
+        "set_placement move, nets whose pads no longer sit under their copper " +
+        "are detected as stale and re-routed too (even if not listed here); " +
+        "the result reports `traces_removed`/`vias_removed` and " +
         "`stale_nets_cleared` so the cleanup is visible.",
     },
     locked_nets: {
@@ -913,10 +916,12 @@ export const routeNetsSchema = {
       items: { type: "string" as const },
       description:
         "Nets whose existing copper is preserved — never ripped up or " +
-        "re-routed by this call. Use for hand-routed traces/vias (e.g. a " +
-        "manual via bridge, or a stitched plane net) that the autorouter's " +
-        "self-cleaning would otherwise delete. Copper on these nets survives " +
-        "across route_nets passes; the kernel still routes every other net.",
+        "re-routed by this call. Copper on these nets survives across " +
+        "route_nets passes; the kernel still routes every other net. Nets " +
+        "carrying hand-placed traces (add_trace / coil tools) get this " +
+        "protection automatically via copper provenance, so locking is only " +
+        "needed for copper the tools didn't tag (e.g. imported or injected " +
+        "boards).",
     },
     strategy: {
       type: "string" as const,
@@ -940,7 +945,7 @@ export const routeNetsSchema = {
     receipt: {
       type: "boolean" as const,
       description:
-        "When true, wrap the route in a before/after DRC and return a `receipt` verdict (what it fixed, what it introduced incl. shorts, with each violation attributed to footprint vs routing) — instead of just a document_id. Routing is not idempotent; this surfaces a re-route that silently shorts the board.",
+        "When true, wrap the route in a before/after DRC and return a `receipt` verdict (what it fixed, what it introduced incl. shorts, with each violation attributed to footprint vs routing) — instead of just a document_id. Re-routing rips up the prior autorouted copper first (idempotent by construction); the receipt proves it, surfacing any re-route that would short the board.",
     },
   },
   required: [],
@@ -2963,8 +2968,8 @@ export async function routeNets(args: Record<string, unknown>) {
 
   const width = traceWidth || pcb.rules.defaultRules.traceWidth;
 
-  // Receipt: snapshot DRC before the (non-idempotent) route so the after-diff
-  // can attribute exactly what this call fixed and what it introduced.
+  // Receipt: snapshot DRC before the route so the after-diff can attribute
+  // exactly what this call fixed and what it introduced.
   const wantReceipt = Boolean(args.receipt);
   const beforeSnap = wantReceipt ? await drcPcb(pcb, "full", 500) : null;
 
@@ -3013,13 +3018,32 @@ export async function routeNets(args: Record<string, unknown>) {
     targetNets.add(net);
   }
 
+  // Copper provenance (issue #277): only *autorouted* copper is disposable.
+  // Traces carrying `source: "manual"` (add_trace / add_via / coil tools) are
+  // hand-placed work the router must not destroy. A net with a manual trace
+  // can't be partially re-routed either — the kernel's ratsnest treats any
+  // existing trace as "already routed" and skips the net, so ripping just its
+  // autorouted segments would strand it with no way to close it again.
+  // Such nets are therefore preserved wholesale (implicitly locked) and
+  // reported in `manual_nets_preserved`; delete the manual copper
+  // (delete_trace / delete_via) to hand the net back to the autorouter.
+  // Copper with no `source` (pre-provenance documents, or injected directly)
+  // is treated as autorouted — exactly the rip-up those documents already got.
+  // Manual *vias* alone don't block re-routing (the ratsnest ignores vias);
+  // they simply survive the rip-up while the net's traces are re-laid.
+  const manualNets = new Set<string>();
+  for (const t of pcb.traces) {
+    if (t.source === "manual" && targetNets.has(t.net)) manualNets.add(t.net);
+  }
+  for (const n of manualNets) targetNets.delete(n);
+
   let tracesRemoved = 0;
   let viasRemoved = 0;
   if (targetNets.size > 0) {
     const beforeT = pcb.traces.length;
     const beforeV = pcb.vias.length;
-    pcb.traces = pcb.traces.filter((t) => !targetNets.has(t.net));
-    pcb.vias = pcb.vias.filter((v) => !targetNets.has(v.net));
+    pcb.traces = pcb.traces.filter((t) => !targetNets.has(t.net) || t.source === "manual");
+    pcb.vias = pcb.vias.filter((v) => !targetNets.has(v.net) || v.source === "manual");
     tracesRemoved = beforeT - pcb.traces.length;
     viasRemoved = beforeV - pcb.vias.length;
   }
@@ -3051,18 +3075,20 @@ export async function routeNets(args: Record<string, unknown>) {
   // re-reading the board.
   const realizedWidths: Record<string, number> = {};
   // Nets the kernel should route: the effective set minus any the caller
-  // locked. A locked net is neither ripped up (above) nor re-routed here, so
-  // its hand-placed copper stays exactly as authored. An empty effectiveFilter
-  // means "route everything", so to subtract locked nets we make the all-set
-  // explicit; with no locked nets it stays empty (behavior unchanged).
+  // locked and minus nets preserved for their manual copper. A preserved net
+  // is neither ripped up (above) nor re-routed here, so its hand-placed
+  // copper stays exactly as authored. An empty effectiveFilter means "route
+  // everything", so to subtract preserved nets we make the all-set explicit;
+  // with nothing preserved it stays empty (behavior unchanged).
+  const preservedNets = new Set<string>([...lockedNets, ...manualNets]);
   let routeFilter = effectiveFilter;
-  if (lockedNets.size > 0) {
+  if (preservedNets.size > 0) {
     if (effectiveFilter.length > 0) {
-      routeFilter = effectiveFilter.filter((n) => !lockedNets.has(n));
+      routeFilter = effectiveFilter.filter((n) => !preservedNets.has(n));
     } else {
       const allRoutable = new Set<string>();
       for (const [net, conns] of netConnections) {
-        if (conns.length >= 2 && !lockedNets.has(net)) allRoutable.add(net);
+        if (conns.length >= 2 && !preservedNets.has(net)) allRoutable.add(net);
       }
       routeFilter = [...allRoutable];
     }
@@ -3098,6 +3124,7 @@ export async function routeNets(args: Record<string, unknown>) {
         // valid PcbLayer value.
         layer: t.layer as PcbLayer,
         net: t.net,
+        source: "autoroute",
       });
       realizedWidths[t.net] = Math.max(realizedWidths[t.net] ?? 0, t.width);
       tracesAdded++;
@@ -3110,6 +3137,7 @@ export async function routeNets(args: Record<string, unknown>) {
         startLayer: "FCu",
         endLayer: "BCu",
         net: v.net,
+        source: "autoroute",
       });
       viasAdded++;
     }
@@ -3130,7 +3158,7 @@ export async function routeNets(args: Record<string, unknown>) {
     const universe =
       routeFilter.length > 0
         ? routeFilter
-        : [...netConnections.keys()].filter((n) => !lockedNets.has(n));
+        : [...netConnections.keys()].filter((n) => !preservedNets.has(n));
     const tiers = [...new Set(universe.map(tierOf))].sort((a, b) => a - b);
     for (const tier of tiers) {
       const nets = universe.filter((n) => tierOf(n) === tier);
@@ -3153,7 +3181,8 @@ export async function routeNets(args: Record<string, unknown>) {
     // behavior; flagged because it may cross copper).
     for (const [netId, conns] of netConnections) {
       if (conns.length < 2) continue;
-      if (lockedNets.has(netId)) continue; // never reroute a locked net
+      // Never reroute a locked net or one preserved for its manual copper.
+      if (preservedNets.has(netId)) continue;
       if (effectiveFilter.length > 0 && !effectiveFilter.includes(netId)) continue;
       const positions = conns.map((c) => {
         const fp = pcb.footprints.find((f) => f.ref === c.component_ref)!;
@@ -3167,6 +3196,7 @@ export async function routeNets(args: Record<string, unknown>) {
           width,
           layer: "FCu",
           net: netId,
+          source: "autoroute",
         });
         tracesAdded++;
       }
@@ -3214,11 +3244,19 @@ export async function routeNets(args: Record<string, unknown>) {
   }
   // Stale nets the caller didn't ask for but we ripped up and re-routed because a
   // pad had moved out from under their copper. Surface them so a scoped re-route
-  // is honest about the extra cleanup it did.
-  const staleCleared = [...staleNets].filter((n) => !netsFilter.includes(n));
+  // is honest about the extra cleanup it did. Nets preserved for manual copper
+  // were NOT actually cleared, so they don't belong in this message.
+  const staleCleared = [...staleNets].filter(
+    (n) => !netsFilter.includes(n) && !manualNets.has(n),
+  );
   if (netsFilter.length > 0 && staleCleared.length > 0) {
     warnings.push(
       `ripped up orphaned copper on ${staleCleared.length} net(s) whose pads moved after the last route and re-routed them: ${staleCleared.join(", ")}`,
+    );
+  }
+  if (manualNets.size > 0) {
+    warnings.push(
+      `${manualNets.size} net(s) carry hand-placed copper (add_trace / add_via / coil tools) and were preserved as-is — neither ripped up nor re-routed: ${[...manualNets].sort().join(", ")}. Delete that copper (delete_trace / delete_via) first if route_nets should re-own the net`,
     );
   }
 
@@ -3269,6 +3307,9 @@ export async function routeNets(args: Record<string, unknown>) {
           ...(viasRemoved > 0 ? { vias_removed: viasRemoved } : {}),
           ...(staleCleared.length > 0 ? { stale_nets_cleared: staleCleared } : {}),
           ...(lockedNets.size > 0 ? { locked_nets: [...lockedNets] } : {}),
+          ...(manualNets.size > 0
+            ? { manual_nets_preserved: [...manualNets].sort() }
+            : {}),
           ...(planeStitched.length > 0 ? { plane_stitched: planeStitched } : {}),
           ...(Object.keys(realizedWidths).length > 0
             ? { track_widths_mm: realizedWidths }
@@ -3582,6 +3623,8 @@ export async function routeDiffPair(args: Record<string, unknown>) {
         width,
         layer: "FCu",
         net: leg.net,
+        // Router output: rippable by a route_nets re-route of these nets.
+        source: "autoroute",
       });
       added++;
     }
@@ -5583,7 +5626,14 @@ export function addCoil(args: Record<string, unknown>) {
     for (let li = 0; li < layersIn.length; li++) {
       const lyr = layersIn[li] as PcbLayer;
       for (let i = 0; i + 1 < pts.length; i++) {
-        pcb.traces.push({ start: pts[i], end: pts[i + 1], width: traceWidth, layer: lyr, net });
+        pcb.traces.push({
+          start: pts[i],
+          end: pts[i + 1],
+          width: traceWidth,
+          layer: lyr,
+          net,
+          source: "manual",
+        });
         totalTraces++;
       }
       totalLengthMm += perLayerLen;
@@ -5601,6 +5651,7 @@ export function addCoil(args: Record<string, unknown>) {
           startLayer: lyr,
           endLayer: layersIn[li + 1] as PcbLayer,
           net,
+          source: "manual",
         });
         stitchVias.push({ position: stitchPt, startLayer: lyr, endLayer: layersIn[li + 1] as PcbLayer });
       }
@@ -5651,6 +5702,7 @@ export function addCoil(args: Record<string, unknown>) {
       width: traceWidth,
       layer,
       net,
+      source: "manual",
     });
     tracesAdded++;
     lengthMm += Math.hypot(pts[i + 1].x - pts[i].x, pts[i + 1].y - pts[i].y);
@@ -5668,6 +5720,7 @@ export function addCoil(args: Record<string, unknown>) {
       startLayer: layer,
       endLayer: viaTo,
       net,
+      source: "manual" as const,
     };
     pcb.vias.push(v);
     via = { position: v.position, startLayer: layer, endLayer: viaTo };
@@ -7054,7 +7107,9 @@ export function addTrace(args: Record<string, unknown>) {
   for (let i = 0; i + 1 < points.length; i++) {
     const start = { x: round3(points[i].x), y: round3(points[i].y) };
     const end = { x: round3(points[i + 1].x), y: round3(points[i + 1].y) };
-    const trace: Trace = { start, end, width, layer, net };
+    // Tagged manual: route_nets preserves this copper instead of ripping it
+    // up on a re-route (issue #277).
+    const trace: Trace = { start, end, width, layer, net, source: "manual" };
     pcb.traces.push(trace);
     tracesAdded++;
     lengthMm += Math.hypot(end.x - start.x, end.y - start.y);
@@ -7137,7 +7192,8 @@ export function addVia(args: Record<string, unknown>) {
   }
 
   const pos = { x: round3(position.x), y: round3(position.y) };
-  const via: Via = { position: pos, diameter, drill, startLayer, endLayer, net };
+  // Tagged manual: survives route_nets rip-up (issue #277).
+  const via: Via = { position: pos, diameter, drill, startLayer, endLayer, net, source: "manual" };
   pcb.vias.push(via);
 
   return {
@@ -8279,6 +8335,7 @@ export function addViaArray(args: Record<string, unknown>) {
       startLayer,
       endLayer,
       net,
+      source: "manual",
     });
   }
 
@@ -8459,6 +8516,7 @@ export function addMotorWinding(args: Record<string, unknown>) {
       startLayer: copperLayer,
       endLayer: returnLayer,
       net: coil.net,
+      source: "manual",
     });
     vias++;
     coilTerminals.set(coil.slot, {
@@ -8484,6 +8542,7 @@ export function addMotorWinding(args: Record<string, unknown>) {
         width: traceWidth,
         layer: returnLayer,
         net: netName,
+        source: "manual",
       });
       interconnectTraces++;
       prevEnd = term.outer;
@@ -8504,6 +8563,7 @@ export function addMotorWinding(args: Record<string, unknown>) {
         width: traceWidth,
         layer: returnLayer,
         net: netName,
+        source: "manual",
       });
       interconnectTraces++;
     }
@@ -8525,6 +8585,7 @@ export function addMotorWinding(args: Record<string, unknown>) {
         width: traceWidth,
         layer: returnLayer,
         net: a,
+        source: "manual",
       });
       interconnectTraces++;
       pcb.netTies.push({


### PR DESCRIPTION
## Summary

This change adds copper provenance tracking to PCB traces and vias, enabling `route_nets` to be truly idempotent. The autorouter now distinguishes between hand-placed copper (from `add_trace`, `add_via`, coil tools) and its own autorouted output, ripping up only the latter on re-route. This fixes the field bug where re-running `route_nets` would stack copper and introduce shorts.

## Key Changes

**Data Model (IR & Rust)**
- Added `CopperSource` enum (`Autoroute` | `Manual`) to `Trace` and `Via` structs
- Source is optional (defaults to autorouted for pre-provenance documents)
- Serialized with `#[serde(default, skip_serializing_if = "Option::is_none")]` for backward compatibility

**Autorouter Behavior**
- `route_nets` now tags all its output with `source: "autoroute"`
- `add_trace`, `add_via`, and coil tools tag their output with `source: "manual"`
- On re-route, only autorouted copper is ripped up; manual copper is preserved
- Nets carrying manual traces are implicitly locked and reported in `manual_nets_preserved`
- Manual vias alone don't block re-routing (ratsnest ignores vias); they survive the rip-up while traces are re-laid

**API & Documentation**
- Updated `route_nets` schema descriptions to clarify idempotency and manual copper preservation
- Added `manual_nets_preserved` field to route result (alongside existing `locked_nets`)
- Updated `add_trace` and `add_via` descriptions to note provenance tagging
- Added warning message when nets are preserved for manual copper, instructing users to delete that copper if they want the autorouter to re-own the net

**Testing**
- Renamed and refactored idempotency tests to distinguish between manual and legacy (pre-provenance) copper
- Added test for scoped re-route of a single net (verifies other nets' copper is untouched)
- Added test for manual via preservation during trace re-route
- Added helper `segKey()` to detect stacked copper (exact duplicate segments)
- Verified no duplicate segments after re-route and that all autorouted copper carries provenance

**Diff-Pair Routing**
- Tagged diff-pair output with `source: "autoroute"` for consistency

## Implementation Details

The fix leverages the kernel's ratsnest behavior: it treats any existing trace as "already routed" and skips the net. This means a net with manual traces cannot be partially re-routed (ripping just autorouted segments would strand it). The solution preserves such nets wholesale and reports them so callers know they were skipped. Copper with no `source` field (documents from before this change) is treated as autorouted, matching the rip-up behavior those documents already experienced.

The provenance field is optional and skipped during serialization when absent, ensuring documents remain compatible with older versions while new versions correctly handle both tagged and untagged copper.

https://claude.ai/code/session_01Qgdy82a3TJT2cs5EuhKewD