### PR TITLE
fix(pcb): judge rotated footprint pads at their true positions

### DIFF
--- a/changelog/entries/2026-07-07-rotated-pad-drc.json
+++ b/changelog/entries/2026-07-07-rotated-pad-drc.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-rotated-pad-drc",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "DRC judges rotated footprint pads at their true positions",
+  "summary": "Pad copper on rotated footprints was checked at unrotated phantom positions, so traces routed to reported pad coordinates failed DRC as false shorts/clearance; DRC, DFM, and connectivity now use the rotated transform.",
+  "features": ["pcb", "drc", "dfm", "routing"],
+  "mcpTools": ["run_drc", "dfm_check", "get_pad_positions", "add_trace"]
+}

--- a/crates/vcad-ecad-pcb/src/component_mesh.rs
+++ b/crates/vcad-ecad-pcb/src/component_mesh.rs
@@ -575,10 +575,6 @@ fn pad_extent(shape: &PadShape) -> (f64, f64, f64, f64) {
 /// slightly inset from the pad, proud of the copper — under a studio IBL the
 /// metallic tin reads as a reflowed joint against the matte board.
 fn add_pad_solder(fp: &Footprint, zb: f32, z_dir: f32, out: &mut Vec<ComponentMesh>) {
-    let fp_rot = (fp.rotation as f32).to_radians();
-    let cos_f = fp_rot.cos();
-    let sin_f = fp_rot.sin();
-
     for pad in &fp.pads {
         if pad.pad_type != PadType::SMD {
             continue;
@@ -587,9 +583,8 @@ fn add_pad_solder(fp: &Footprint, zb: f32, z_dir: f32, out: &mut Vec<ComponentMe
         if pw < 1e-3 || ph < 1e-3 {
             continue;
         }
-        // Pad world position = footprint position + footprint-rotated pad offset.
-        let px = fp.position.x + pad.position.x * cos_f as f64 - pad.position.y * sin_f as f64;
-        let py = fp.position.y + pad.position.x * sin_f as f64 + pad.position.y * cos_f as f64;
+        let world = crate::geometry::pad_world_position(fp, pad);
+        let (px, py) = (world.x, world.y);
         let pad_rot = ((fp.rotation + pad.rotation) as f32).to_radians();
         // Shift the joint to the pad-local bbox center (nonzero only for an
         // off-origin Custom polygon), rotated into world by the pad rotation.

--- a/crates/vcad-ecad-pcb/src/copper_pour.rs
+++ b/crates/vcad-ecad-pcb/src/copper_pour.rs
@@ -128,15 +128,11 @@ fn collect_clearance_regions(pcb: &Pcb, zone: &Zone) -> Vec<Poly> {
     let spoke = zone.thermal_spoke_width.unwrap_or(DEFAULT_SPOKE_WIDTH);
     for footprint in &pcb.footprints {
         let fr = footprint.rotation.to_radians();
-        let (fc, fs) = (fr.cos(), fr.sin());
         for pad in &footprint.pads {
             if !pad.layers.contains(&zone.layer) {
                 continue;
             }
-            let world = Vec2::new(
-                footprint.position.x + pad.position.x * fc - pad.position.y * fs,
-                footprint.position.y + pad.position.x * fs + pad.position.y * fc,
-            );
+            let world = crate::geometry::pad_world_position(footprint, pad);
             let ang = fr + pad.rotation.to_radians();
             let (hw, hh) = pad_half_extents(pad);
             let same_net = pad.net.as_deref() == Some(zone.net.as_str());

--- a/crates/vcad-ecad-pcb/src/dfm.rs
+++ b/crates/vcad-ecad-pcb/src/dfm.rs
@@ -538,10 +538,7 @@ fn pad_min_dimension(pad: &Pad) -> f64 {
 
 /// Absolute board-frame center of a pad on its footprint.
 fn pad_center(fp: &vcad_ir::ecad::Footprint, pad: &Pad) -> Vec2 {
-    Vec2::new(
-        fp.position.x + pad.position.x,
-        fp.position.y + pad.position.y,
-    )
+    crate::geometry::pad_world_position(fp, pad)
 }
 
 /// Assemble a "minimum metric" rule result (smaller is worse).

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -443,10 +443,7 @@ fn check_pad_clearance(
             let Some(net) = pad.net.as_deref() else {
                 continue;
             };
-            let center = Vec2::new(
-                fp.position.x + pad.position.x,
-                fp.position.y + pad.position.y,
-            );
+            let center = crate::geometry::pad_world_position(fp, pad);
             let rot = (fp.rotation + pad.rotation).to_radians();
             boxes.push(PadBox {
                 center,
@@ -582,10 +579,7 @@ fn check_min_drill(pcb: &Pcb, violations: &mut Vec<DrcViolation>) {
         for pad in &footprint.pads {
             if let Some(drill) = &pad.drill {
                 if drill.diameter < min_drill - 1e-6 {
-                    let abs_pos = Vec2::new(
-                        footprint.position.x + pad.position.x,
-                        footprint.position.y + pad.position.y,
-                    );
+                    let abs_pos = crate::geometry::pad_world_position(footprint, pad);
                     violations.push(DrcViolation {
                         rule: DrcRuleType::MinDrill,
                         severity: DrcSeverity::Error,
@@ -692,10 +686,7 @@ fn check_hole_to_hole(pcb: &Pcb, violations: &mut Vec<DrcViolation>) {
         let generated = fp_is_generated(footprint);
         for pad in &footprint.pads {
             if let Some(drill) = &pad.drill {
-                let abs_pos = Vec2::new(
-                    footprint.position.x + pad.position.x,
-                    footprint.position.y + pad.position.y,
-                );
+                let abs_pos = crate::geometry::pad_world_position(footprint, pad);
                 holes.push(Hole {
                     pos: abs_pos,
                     radius: drill.diameter / 2.0,
@@ -781,10 +772,7 @@ fn check_annular_ring(pcb: &Pcb, violations: &mut Vec<DrcViolation>) {
                 let pad_min_dim = pad_min_dimension(pad);
                 let ring = (pad_min_dim - drill.diameter) / 2.0;
                 if ring < min_ring - 1e-6 {
-                    let abs_pos = Vec2::new(
-                        footprint.position.x + pad.position.x,
-                        footprint.position.y + pad.position.y,
-                    );
+                    let abs_pos = crate::geometry::pad_world_position(footprint, pad);
                     violations.push(DrcViolation {
                         rule: DrcRuleType::AnnularRing,
                         severity: DrcSeverity::Error,
@@ -873,10 +861,7 @@ fn check_keepout(pcb: &Pcb, violations: &mut Vec<DrcViolation>) {
                 let mut hit = false;
                 let mut hit_pos = fp.position;
                 for pad in &fp.pads {
-                    let pad_pos = Vec2::new(
-                        fp.position.x + pad.position.x,
-                        fp.position.y + pad.position.y,
-                    );
+                    let pad_pos = crate::geometry::pad_world_position(fp, pad);
                     if point_in_polygon(pad_pos, &keepout.outline) {
                         hit = true;
                         hit_pos = pad_pos;
@@ -1226,10 +1211,7 @@ fn build_conn_nodes(pcb: &Pcb) -> Vec<ConnNode> {
 
     for fp in &pcb.footprints {
         for pad in &fp.pads {
-            let center = Vec2::new(
-                fp.position.x + pad.position.x,
-                fp.position.y + pad.position.y,
-            );
+            let center = crate::geometry::pad_world_position(fp, pad);
             let rot = (fp.rotation + pad.rotation).to_radians();
             let mut layers = 0u16;
             for &l in &pad.layers {
@@ -2363,6 +2345,105 @@ mod tests {
             violations.is_empty(),
             "expected no violations, got: {:?}",
             violations
+        );
+    }
+
+    /// One-pad SMD footprint for the rotated-placement regression tests.
+    fn one_pad_footprint(
+        reference: &str,
+        position: Vec2,
+        rotation: f64,
+        pad_local: Vec2,
+        net: &str,
+    ) -> Footprint {
+        Footprint {
+            reference: reference.to_string(),
+            value: "X".to_string(),
+            footprint_name: "TEST_1PAD".to_string(),
+            position,
+            rotation,
+            front: true,
+            pads: vec![Pad {
+                number: "1".to_string(),
+                pad_type: PadType::SMD,
+                shape: PadShape::Rect {
+                    width: 1.2,
+                    height: 1.2,
+                },
+                position: pad_local,
+                rotation: 0.0,
+                drill: None,
+                net: Some(net.to_string()),
+                layers: vec![PcbLayer::FCu],
+            }],
+            graphics: vec![],
+            model_3d: None,
+            properties: std::collections::HashMap::new(),
+        }
+    }
+
+    /// DRC must judge pad copper at the ROTATED world position — the position
+    /// `get_pad_positions` reports and the Gerber writer exports. Regression
+    /// for the pad transform dropping the footprint rotation: J1's pad sits at
+    /// local (+5, 0) on a 180°-rotated footprint, so its real copper is at
+    /// (65, 60); the unrotated phantom position (75, 60) would sit dead on
+    /// R1's foreign-net pad and produced a bogus clearance/short.
+    #[test]
+    fn rotated_footprint_pads_are_judged_at_rotated_positions() {
+        let mut pcb = clean_pcb();
+        pcb.footprints.push(one_pad_footprint(
+            "J1",
+            Vec2::new(70.0, 60.0),
+            180.0,
+            Vec2::new(5.0, 0.0),
+            "1",
+        ));
+        pcb.footprints.push(one_pad_footprint(
+            "R1",
+            Vec2::new(75.0, 60.0),
+            0.0,
+            Vec2::new(0.0, 0.0),
+            "2",
+        ));
+        let conflicts: Vec<_> = check_drc(&pcb)
+            .into_iter()
+            .filter(|v| matches!(v.rule, DrcRuleType::Clearance | DrcRuleType::Short))
+            .collect();
+        assert!(
+            conflicts.is_empty(),
+            "rotated pad copper is 10mm from R1 — a violation means DRC placed \
+             it at the unrotated phantom position: {:?}",
+            conflicts
+        );
+    }
+
+    /// Positive control for the test above: when the ROTATED position really
+    /// does land on a foreign-net pad, DRC must still flag it.
+    #[test]
+    fn rotated_footprint_real_pad_overlap_is_still_flagged() {
+        let mut pcb = clean_pcb();
+        // 180° rotation puts J1's pad at (80 − 5, 60) = (75, 60) — on R1.
+        pcb.footprints.push(one_pad_footprint(
+            "J1",
+            Vec2::new(80.0, 60.0),
+            180.0,
+            Vec2::new(5.0, 0.0),
+            "1",
+        ));
+        pcb.footprints.push(one_pad_footprint(
+            "R1",
+            Vec2::new(75.0, 60.0),
+            0.0,
+            Vec2::new(0.0, 0.0),
+            "2",
+        ));
+        let conflicts: Vec<_> = check_drc(&pcb)
+            .into_iter()
+            .filter(|v| matches!(v.rule, DrcRuleType::Clearance | DrcRuleType::Short))
+            .collect();
+        assert!(
+            !conflicts.is_empty(),
+            "overlapping foreign-net pads at the rotated position must be flagged"
         );
     }
 

--- a/crates/vcad-ecad-pcb/src/geometry.rs
+++ b/crates/vcad-ecad-pcb/src/geometry.rs
@@ -70,6 +70,22 @@ pub fn pad_radius(shape: &PadShape) -> f64 {
     }
 }
 
+/// Absolute board-frame center of a pad: the footprint origin plus the pad's
+/// local offset rotated by the footprint rotation (degrees, CCW).
+///
+/// This is the canonical pad placement transform — the same one the Gerber /
+/// Excellon writers and the TypeScript `get_pad_positions` MCP tool apply:
+/// `world = fp + R(θ)·pad`. Every consumer that positions pad copper must go
+/// through it; adding `fp.position + pad.position` without the rotation
+/// misplaces every pad on a rotated footprint.
+pub fn pad_world_position(fp: &vcad_ir::ecad::Footprint, pad: &vcad_ir::ecad::Pad) -> Vec2 {
+    let (sin_r, cos_r) = fp.rotation.to_radians().sin_cos();
+    Vec2::new(
+        fp.position.x + pad.position.x * cos_r - pad.position.y * sin_r,
+        fp.position.y + pad.position.x * sin_r + pad.position.y * cos_r,
+    )
+}
+
 // ============================================================================
 // Coordinate conversion
 // ============================================================================
@@ -112,18 +128,13 @@ pub fn copper_layer_index(layer: PcbLayer) -> usize {
 
 /// Compute bounding box of a footprint's pads: `(min, max)`.
 pub fn footprint_bounds(fp: &vcad_ir::ecad::Footprint) -> (Vec2, Vec2) {
-    let fp_rot = fp.rotation.to_radians();
-    let cos_r = fp_rot.cos();
-    let sin_r = fp_rot.sin();
-
     let mut min_x = f64::MAX;
     let mut min_y = f64::MAX;
     let mut max_x = f64::MIN;
     let mut max_y = f64::MIN;
 
     for pad in &fp.pads {
-        let wx = fp.position.x + pad.position.x * cos_r - pad.position.y * sin_r;
-        let wy = fp.position.y + pad.position.x * sin_r + pad.position.y * cos_r;
+        let Vec2 { x: wx, y: wy } = pad_world_position(fp, pad);
         let (pw, ph) = pad_dimensions(&pad.shape);
         let r = pw.max(ph) / 2.0;
 
@@ -144,6 +155,70 @@ pub fn footprint_bounds(fp: &vcad_ir::ecad::Footprint) -> (Vec2, Vec2) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use vcad_ir::ecad::{Footprint, Pad, PadType};
+
+    fn rotated_fixture() -> Footprint {
+        Footprint {
+            reference: "J1".to_string(),
+            value: "CONN".to_string(),
+            footprint_name: "JST_XH_4".to_string(),
+            position: Vec2::new(10.0, 20.0),
+            rotation: 190.0,
+            front: true,
+            pads: vec![
+                Pad {
+                    number: "1".to_string(),
+                    pad_type: PadType::THT,
+                    shape: PadShape::Circle { diameter: 1.7 },
+                    position: Vec2::new(7.62, 0.0),
+                    rotation: 0.0,
+                    drill: None,
+                    net: Some("1".to_string()),
+                    layers: vec![PcbLayer::FCu],
+                },
+                Pad {
+                    number: "2".to_string(),
+                    pad_type: PadType::THT,
+                    shape: PadShape::Circle { diameter: 1.7 },
+                    position: Vec2::new(2.54, -1.27),
+                    rotation: 0.0,
+                    drill: None,
+                    net: Some("2".to_string()),
+                    layers: vec![PcbLayer::FCu],
+                },
+            ],
+            graphics: vec![],
+            model_3d: None,
+            properties: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Cross-language regression: these constants are also asserted by the
+    /// TypeScript `get_pad_positions` test ("agrees with the Rust
+    /// pad_world_position transform") in
+    /// `packages/mcp/src/__tests__/ecad.test.ts`. Both sides pin the same
+    /// footprint fixture (origin (10, 20), rotation 190°) to the same world
+    /// coordinates, so the Rust copper pipeline and the TS reporting tool
+    /// cannot silently drift apart. If you change one, change both.
+    #[test]
+    fn pad_world_position_rotated_matches_ts_tool() {
+        let fp = rotated_fixture();
+        let a = pad_world_position(&fp, &fp.pads[0]);
+        assert!((a.x - 2.495764922046975).abs() < 1e-9, "a.x = {}", a.x);
+        assert!((a.y - 18.67680088617799).abs() < 1e-9, "a.y = {}", a.y);
+        let b = pad_world_position(&fp, &fp.pads[1]);
+        assert!((b.x - 7.27805512171199).abs() < 1e-9, "b.x = {}", b.x);
+        assert!((b.y - 20.8096394750515).abs() < 1e-9, "b.y = {}", b.y);
+    }
+
+    #[test]
+    fn pad_world_position_zero_rotation_is_plain_offset() {
+        let mut fp = rotated_fixture();
+        fp.rotation = 0.0;
+        let a = pad_world_position(&fp, &fp.pads[0]);
+        assert!((a.x - 17.62).abs() < 1e-12);
+        assert!((a.y - 20.0).abs() < 1e-12);
+    }
 
     #[test]
     fn layer_z_fcu() {

--- a/crates/vcad-ecad-pcb/src/ratsnest.rs
+++ b/crates/vcad-ecad-pcb/src/ratsnest.rs
@@ -60,14 +60,9 @@ pub fn compute_ratsnest(pcb: &Pcb, netlist: &Netlist) -> Vec<RatsnestLine> {
     // Build pad position lookup: "REF:NUM" -> world position
     let mut pad_positions = std::collections::HashMap::new();
     for fp in &pcb.footprints {
-        let fp_rot = fp.rotation.to_radians();
-        let cos_r = fp_rot.cos();
-        let sin_r = fp_rot.sin();
         for pad in &fp.pads {
             let key = format!("{}:{}", fp.reference, pad.number);
-            let wx = fp.position.x + pad.position.x * cos_r - pad.position.y * sin_r;
-            let wy = fp.position.y + pad.position.x * sin_r + pad.position.y * cos_r;
-            pad_positions.insert(key, Vec2::new(wx, wy));
+            pad_positions.insert(key, crate::geometry::pad_world_position(fp, pad));
         }
     }
 

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1184,7 +1184,6 @@ fn stitch_planes(
     let copper = copper_layers(pcb);
 
     for fp in &pcb.footprints {
-        let (s, c) = fp.rotation.to_radians().sin_cos();
         for pad in &fp.pads {
             let Some(net) = pad.net.as_ref().filter(|n| !n.is_empty()) else {
                 continue;
@@ -1203,10 +1202,7 @@ fn stitch_planes(
             let Some(pad_layer) = pad.layers.iter().copied().find(|l| l.is_copper()) else {
                 continue;
             };
-            let pad_pt = Vec2::new(
-                fp.position.x + pad.position.x * c - pad.position.y * s,
-                fp.position.y + pad.position.x * s + pad.position.y * c,
-            );
+            let pad_pt = crate::geometry::pad_world_position(fp, pad);
             // A fine-pitch pad can't take an at-pad drill — force the dog-bone.
             // Pitch is the nearest neighbour's spacing in the footprint's own
             // frame (rotation/translation preserve relative distances).

--- a/crates/vcad-ecad-pcb/src/router/diff_pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/diff_pair.rs
@@ -71,14 +71,9 @@ fn fan_to_pads(segments: &mut Vec<(Vec2, Vec2)>, start_pad: Vec2, end_pad: Vec2)
 fn pad_positions_for_net(pcb: &Pcb, net: &str) -> Vec<Vec2> {
     let mut out = Vec::new();
     for fp in &pcb.footprints {
-        let fr = fp.rotation.to_radians();
-        let (fc, fs) = (fr.cos(), fr.sin());
         for pad in &fp.pads {
             if pad.net.as_deref() == Some(net) {
-                out.push(Vec2::new(
-                    fp.position.x + pad.position.x * fc - pad.position.y * fs,
-                    fp.position.y + pad.position.x * fs + pad.position.y * fc,
-                ));
+                out.push(crate::geometry::pad_world_position(fp, pad));
             }
         }
     }

--- a/crates/vcad-ecad-pcb/src/spatial.rs
+++ b/crates/vcad-ecad-pcb/src/spatial.rs
@@ -465,9 +465,8 @@ pub(crate) fn copper_elements(pcb: &Pcb) -> Vec<CopperElement> {
     // Footprint pads.
     for footprint in &pcb.footprints {
         for pad in &footprint.pads {
-            let abs_x = footprint.position.x + pad.position.x;
-            let abs_y = footprint.position.y + pad.position.y;
-            let center = Vec2::new(abs_x, abs_y);
+            let center = crate::geometry::pad_world_position(footprint, pad);
+            let (abs_x, abs_y) = (center.x, center.y);
             let net = pad.net.clone().unwrap_or_default();
             // Total pad rotation = footprint rotation + pad-local rotation.
             let rot = (footprint.rotation + pad.rotation).to_radians();
@@ -781,6 +780,116 @@ mod tests {
     fn default_index() {
         let index = SpatialIndex::default();
         assert!(index.is_empty());
+    }
+
+    /// Pads of a rotated footprint must be indexed at their rotated world
+    /// position (footprint origin + rotation-transformed pad offset) — the
+    /// same transform the Gerber writer and the `get_pad_positions` MCP tool
+    /// apply. Regression for copper_elements composing the offset without
+    /// rotating it, which put every pad of a rotated footprint at a phantom
+    /// location and made agent-routed traces to the reported positions fail
+    /// DRC.
+    #[test]
+    fn rotated_footprint_pads_index_at_rotated_positions() {
+        let footprint = Footprint {
+            reference: "R1".to_string(),
+            value: "10k".to_string(),
+            footprint_name: "R_0805".to_string(),
+            position: Vec2::new(25.0, 40.0),
+            rotation: 90.0,
+            front: true,
+            pads: vec![
+                Pad {
+                    number: "1".to_string(),
+                    pad_type: PadType::SMD,
+                    shape: PadShape::Rect {
+                        width: 1.0,
+                        height: 1.2,
+                    },
+                    position: Vec2::new(-1.0, 0.0),
+                    rotation: 0.0,
+                    drill: None,
+                    net: Some("1".to_string()),
+                    layers: vec![PcbLayer::FCu],
+                },
+                Pad {
+                    number: "2".to_string(),
+                    pad_type: PadType::SMD,
+                    shape: PadShape::Rect {
+                        width: 1.0,
+                        height: 1.2,
+                    },
+                    position: Vec2::new(1.0, 0.0),
+                    rotation: 0.0,
+                    drill: None,
+                    net: Some("2".to_string()),
+                    layers: vec![PcbLayer::FCu],
+                },
+            ],
+            graphics: vec![],
+            model_3d: None,
+            properties: std::collections::HashMap::new(),
+        };
+        let pcb = Pcb {
+            outline: BoardOutline {
+                vertices: vec![
+                    Vec2::new(0.0, 0.0),
+                    Vec2::new(100.0, 0.0),
+                    Vec2::new(100.0, 80.0),
+                    Vec2::new(0.0, 80.0),
+                ],
+                cutouts: vec![],
+                thickness: 1.6,
+            },
+            stackup: LayerStackup { layers: vec![] },
+            nets: vec![],
+            rules: DesignRules {
+                default_rules: NetClassRules {
+                    name: "Default".to_string(),
+                    trace_width: 0.25,
+                    clearance: 0.2,
+                    via_diameter: 0.8,
+                    via_drill: 0.4,
+                    diff_pair_gap: None,
+                    diff_pair_width: None,
+                },
+                class_rules: vec![],
+                net_class_assignments: std::collections::HashMap::new(),
+                edge_clearance: 0.5,
+                hole_to_hole: 0.5,
+                min_annular_ring: 0.15,
+                min_drill: 0.2,
+            },
+            footprints: vec![footprint],
+            traces: vec![],
+            trace_arcs: vec![],
+            vias: vec![],
+            zones: vec![],
+            keepouts: vec![],
+            net_ties: vec![],
+        };
+
+        let elements = copper_elements(&pcb);
+        assert_eq!(elements.len(), 2);
+        // 90° CCW: local (x, y) → world (fp.x − y, fp.y + x).
+        // Pad 1 local (−1, 0) → (25, 39); pad 2 local (1, 0) → (25, 41).
+        for (net, expect) in [("1", Vec2::new(25.0, 39.0)), ("2", Vec2::new(25.0, 41.0))] {
+            let el = elements.iter().find(|e| e.net == net).unwrap();
+            let CopperGeom::Rect { center, .. } = el.geom else {
+                panic!("expected rect pad geom");
+            };
+            assert!(
+                approx(center.x, expect.x) && approx(center.y, expect.y),
+                "pad on net {net} indexed at ({}, {}), expected ({}, {})",
+                center.x,
+                center.y,
+                expect.x,
+                expect.y
+            );
+            // The broadphase bbox must cover the rotated center too.
+            assert!(el.min[0] <= expect.x && expect.x <= el.max[0]);
+            assert!(el.min[1] <= expect.y && expect.y <= el.max[1]);
+        }
     }
 
     // ------------------------------------------------------------------

--- a/crates/vcad-ecad-pcb/src/teardrop.rs
+++ b/crates/vcad-ecad-pcb/src/teardrop.rs
@@ -59,14 +59,9 @@ pub fn generate_teardrops(pcb: &Pcb) -> Vec<Teardrop> {
         });
     }
     for fp in &pcb.footprints {
-        let fr = fp.rotation.to_radians();
-        let (fc, fs) = (fr.cos(), fr.sin());
         for pad in &fp.pads {
             let Some(net) = pad.net.clone() else { continue };
-            let world = Vec2::new(
-                fp.position.x + pad.position.x * fc - pad.position.y * fs,
-                fp.position.y + pad.position.x * fs + pad.position.y * fc,
-            );
+            let world = crate::geometry::pad_world_position(fp, pad);
             let (hw, hh) = pad_half_extents(pad);
             lands.push(Land {
                 center: world,

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -454,6 +454,37 @@ describe("get_pad_positions", () => {
     }
   });
 
+  it("agrees with the Rust pad_world_position transform on a rotated footprint", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0)],
+      }),
+    );
+    const id = created.document_id;
+    await placeComponents({ document_id: id, board_width: 40, board_height: 20 });
+
+    // Pin the placed footprint to the exact fixture the Rust kernel test
+    // `pad_world_position_rotated_matches_ts_tool` asserts in
+    // crates/vcad-ecad-pcb/src/geometry.rs. Both sides hardcode the same
+    // world coordinates (origin (10, 20), rotation 190°), so the Rust copper
+    // pipeline (DRC / routing / pours) and this reporting tool cannot drift
+    // apart on the pad transform. If you change one side, change both.
+    const board = getPcbBoard(getSession(id));
+    const fp = board.footprints.find((f) => f.ref === "R1")!;
+    fp.position = { x: 10, y: 20 };
+    fp.rotation = 190;
+    fp.pads[0]!.position = { x: 7.62, y: 0 };
+    fp.pads[1]!.position = { x: 2.54, y: -1.27 };
+
+    const res = out(await getPadPositions({ document_id: id, ref: "R1" }));
+    const pads = res.pads as PadPos[];
+    expect(pads.length).toBe(2);
+    expect(pads[0]!.x).toBeCloseTo(2.496, 3);
+    expect(pads[0]!.y).toBeCloseTo(18.677, 3);
+    expect(pads[1]!.x).toBeCloseTo(7.278, 3);
+    expect(pads[1]!.y).toBeCloseTo(20.81, 3);
+  });
+
   it("filters by net and by ref", async () => {
     const created = out(
       await createSchematic({


### PR DESCRIPTION
## What

PCB copper checks (DRC, DFM, connectivity) computed a pad's board-frame position as `fp.position + pad.position` **without** rotating the pad offset by the footprint rotation. Gerber/Excellon export and the `get_pad_positions` MCP tool **do** apply the rotation, so for any footprint with `rotation != 0` the copper pipeline placed pads at a phantom, unrotated location.

**Symptom:** an agent queries `get_pad_positions`, routes a trace to a reported pad coordinate, runs `run_drc` — and it fails as a false short / clearance violation, because DRC was judging the pad's copper somewhere else.

## Fix

- New `geometry::pad_world_position(fp, pad)` — the single canonical transform `world = fp + R(θ)·pad` (degrees CCW), matching the TS tool and the Gerber writer.
- Routed **every** pad placement in `vcad-ecad-pcb` through it: the buggy sites (`spatial::copper_elements`, six `drc.rs` sites, `dfm::pad_center`) **and** the previously-correct hand-rolled copies (ratsnest, copper_pour, teardrop, both routers, component_mesh) — so the transform now lives in exactly one place and can't drift again.

## Audit scope

The bug was confined to the `vcad-ecad-pcb` clearance/DRC/DFM path. **Already correct** (verified, unchanged): Gerber + Excellon writers (`vcad-ecad-export`), `render_pcb` (`vcad-render`), and the TS `get_pad_positions`. So exports always matched the reporting tool — only DRC/DFM/connectivity disagreed, which is exactly the observed failure.

## Tests (red/green verified)

I temporarily neutered the helper's rotation to confirm the new tests actually fail under the old behavior — all went red, then green with the fix.

- **Cross-language pinning:** a Rust test (`geometry.rs`) and a TS test (`ecad.test.ts`) assert the **same hardcoded world coordinates** for a 190°-rotated fixture, so the Rust pipeline and the TS reporting tool cannot silently drift apart.
- `spatial.rs`: `copper_elements` indexes rotated pads at rotated positions (center + broadphase bbox).
- `drc.rs`: reproduces the false-short shape (phantom position lands dead on a foreign-net pad → must be clean) plus a positive control (a **real** rotated overlap is still flagged).

All green: 170 `vcad-ecad-pcb` tests, dependent crates (`vcad-ecad-export`/`-verify`, `vcad-eval`, `vcad-render`), 200 mcp TS tests; clippy + fmt clean on the changed crate.

## Reviewer notes

Three unrelated issues spotted along the way were **not** fixed here (spun off as separate tasks):
- `packages/mcp/src/tools/ecad.ts` contains literal NUL bytes (a `netPairKey` separator), so plain `grep` treats the whole file as binary and silently returns no matches — use `rg -a`.
- Pre-existing workspace clippy failure in `vcad-ir` (`to_loon.rs:837` `3.14159` trips `approx_constant` on the current toolchain).
- `vcad-eval` 3D preview component boxes also ignore footprint rotation (cosmetic, not copper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)