### PR TITLE
fix(mcp): diff_stripline impedance uses the stripline model (cherry-pick #412)

### DIFF
--- a/changelog/entries/2026-07-07-diff-stripline-model-fix.json
+++ b/changelog/entries/2026-07-07-diff-stripline-model-fix.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-diff-stripline-model-fix",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "diff_stripline impedance now uses the stripline model",
+  "summary": "calc_impedance computed differential-stripline Z0 with the microstrip formula and microstrip coupling constants, disagreeing with size_impedance; both now share the stripline model per the Rust reference.",
+  "features": ["electromagnetics", "pcb", "impedance"],
+  "mcpTools": ["calc_impedance", "size_impedance"]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -5037,3 +5037,54 @@ describe("EM receipt claims", () => {
     }
   });
 });
+
+describe("diff_stripline model consistency (calc_impedance vs size_impedance)", () => {
+  const stack = { dielectric_height: 0.4, copper_thickness: 0.035, dielectric_er: 4.3 };
+
+  it("diff_stripline computes its base Z0 with the stripline formula", async () => {
+    const diff = out(
+      await calcImpedance({ trace_type: "diff_stripline", trace_width: 0.15, spacing: 0.2, ...stack }),
+    );
+    const se = out(
+      await calcImpedance({ trace_type: "stripline", trace_width: 0.15, ...stack }),
+    );
+    // Same base Z0 as plain stripline — NOT the microstrip formula.
+    expect(diff.z0).toBeCloseTo(se.z0, 6);
+    // Fully embedded in the dielectric → er_eff == er (and the delay follows).
+    expect(diff.er_eff).toBeCloseTo(4.3, 6);
+    // Claims name the model actually used.
+    const z0claim = diff.claims.find((c: any) => c.quantity === "characteristic_impedance");
+    expect(z0claim.method).toBe("ipc2141-stripline");
+  });
+
+  it("size_impedance(diff_stripline) geometry is reproduced by calc_impedance — same model", async () => {
+    const sized = out(
+      sizeImpedance({ trace_type: "diff_stripline", target_z0: 50, target_diff_z0: 90, ...stack }),
+    );
+    expect(sized.within_tolerance).toBe(true);
+    const calc = out(
+      await calcImpedance({
+        trace_type: "diff_stripline",
+        trace_width: sized.width_mm,
+        spacing: sized.spacing_mm,
+        ...stack,
+      }),
+    );
+    expect(calc.z0).toBeCloseTo(sized.measured.z0, 1);
+    expect(calc.z_diff).toBeCloseTo(sized.measured.diff_z0, 1);
+  });
+
+  it("stripline and microstrip diff pairs use their own coupling constants", async () => {
+    // Same s/h for both families; compare the implied coupling k = z_diff / (2·z0).
+    const geo = { trace_width: 0.15, spacing: 0.4, ...stack }; // s/h = 1
+    const micro = out(await calcImpedance({ trace_type: "diff_microstrip", ...geo }));
+    const strip = out(await calcImpedance({ trace_type: "diff_stripline", ...geo }));
+    const kMicro = micro.z_diff / (2 * micro.z0);
+    const kStrip = strip.z_diff / (2 * strip.z0);
+    // Analytic constants at s/h = 1: microstrip 1 − 0.48·e^−0.96, stripline 1 − 0.347·e^−2.9.
+    expect(kMicro).toBeCloseTo(1 - 0.48 * Math.exp(-0.96), 2);
+    expect(kStrip).toBeCloseTo(1 - 0.347 * Math.exp(-2.9), 2);
+    // Stripline couples less at the same spacing — the pair sits closer to 2·Z0.
+    expect(kStrip).toBeGreaterThan(kMicro);
+  });
+});

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -4655,9 +4655,13 @@ function striplineZ0(w: number, t: number, h: number, er: number): number {
   return (60 / Math.sqrt(er)) * Math.log((4 * h) / (0.67 * Math.PI * (0.8 * w + t)));
 }
 
-/** Edge-coupling factor for a differential pair; zDiff = 2·z0·k. ↑ in spacing. */
-function diffCouplingK(spacing: number, h: number): number {
-  return 1 - 0.48 * Math.exp((-0.96 * spacing) / h);
+/** Edge-coupling factor for a differential pair; zDiff = 2·z0·k. ↑ in spacing.
+ *  Empirical constants per family, matching the Rust reference
+ *  (vcad-ecad-sim/src/impedance.rs): microstrip (0.48, 0.96),
+ *  stripline (0.347, 2.9). */
+function diffCouplingK(traceType: string, spacing: number, h: number): number {
+  const [a, b] = traceType.includes("stripline") ? [0.347, 2.9] : [0.48, 0.96];
+  return 1 - a * Math.exp((-b * spacing) / h);
 }
 
 /** Single-ended z0 for a trace type (microstrip family vs stripline family). */
@@ -4924,22 +4928,18 @@ export async function calcImpedance(args: Record<string, unknown>) {
   const w = traceWidth;
   const t = copperThickness;
 
-  let z0: number;
-  let erEff: number;
-
-  if (traceType === "stripline") {
-    z0 = striplineZ0(w, t, h, er);
-    erEff = er;
-  } else {
-    z0 = microstripZ0(w, t, h, er);
-    erEff = microstripErEff(w, t, h, er);
-  }
+  // Route by family so diff_stripline gets the stripline formula — the same
+  // dispatch sizeImpedance uses, so the two tools always agree on a geometry.
+  const isStriplineFamily = traceType.includes("stripline");
+  const z0 = singleEndedZ0(traceType, w, t, h, er);
+  // Stripline is fully embedded in the dielectric, so er_eff == er.
+  const erEff = isStriplineFamily ? er : microstripErEff(w, t, h, er);
   const delayPsPerMm = 3.336 * Math.sqrt(erEff);
 
   // Differential pair calculations
   let zDiff: number | undefined;
   if (spacing > 0 && (traceType === "diff_microstrip" || traceType === "diff_stripline")) {
-    zDiff = 2 * z0 * diffCouplingK(spacing, h);
+    zDiff = 2 * z0 * diffCouplingK(traceType, spacing, h);
   }
 
   const result: Record<string, unknown> = {
@@ -4968,7 +4968,7 @@ export async function calcImpedance(args: Record<string, unknown>) {
 
   // Receipt claims for the quantities predicted (method reflects the branch
   // actually taken above — see em-claims.ts for the family).
-  const model = traceType === "stripline" ? "ipc2141-stripline" : "ipc2141-microstrip";
+  const model = isStriplineFamily ? "ipc2141-stripline" : "ipc2141-microstrip";
   const claimInputs = {
     trace_width: traceWidth,
     copper_thickness: copperThickness,
@@ -5053,7 +5053,7 @@ export function sizeImpedance(args: Record<string, unknown>) {
   const residual = isDiff
     ? (x: number[]) => [
         seZ0(x[0]!) - targetZ0,
-        2 * seZ0(x[0]!) * diffCouplingK(x[1]!, h) - (targetDiff as number),
+        2 * seZ0(x[0]!) * diffCouplingK(traceType, x[1]!, h) - (targetDiff as number),
       ]
     : (x: number[]) => [seZ0(x[0]!) - targetZ0];
   const lo = isDiff ? [minW, minS] : [minW];
@@ -5066,7 +5066,7 @@ export function sizeImpedance(args: Record<string, unknown>) {
   const wSnap = snap(cont[0]!, minW, maxW);
   const sSnap = isDiff ? snap(cont[1]!, minS, maxS) : undefined;
   const z0Meas = seZ0(wSnap);
-  const diffMeas = isDiff ? 2 * z0Meas * diffCouplingK(sSnap as number, h) : undefined;
+  const diffMeas = isDiff ? 2 * z0Meas * diffCouplingK(traceType, sSnap as number, h) : undefined;
 
   const within = (meas: number, target: number) =>
     Math.abs(meas - target) <= (tolPct / 100) * target;


### PR DESCRIPTION
## Summary

Cherry-pick of #412 onto `main`. #412 was stacked on `feat/em-domain` and got merged into that branch after #400 had already landed on main — so the fix never reached main. This is `ff1fd55a` cherry-picked cleanly (no conflicts, identical diff).

Original fix, in short:

1. `calc_impedance` computed `diff_stripline`'s single-ended Z0 with the *microstrip* formula (exact `=== "stripline"` branch), disagreeing with `size_impedance`'s `singleEndedZ0` dispatch. Both now share the same dispatch; `er_eff = er` for the fully-embedded stripline family; receipt claims name the model actually used (`ipc2141-stripline`).
2. `diffCouplingK` hardcoded microstrip edge-coupling constants (0.48, 0.96) for both families; stripline pairs now use (0.347, 2.9), matching `crates/vcad-ecad-sim/src/impedance.rs`.

## Testing

Re-validated at current main: full `packages/mcp` suite 526 passed (28 files) including the three regression tests from #412; strict `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)