### PR TITLE
Fix get_document to return full IR body, offload oversized docs

### DIFF
--- a/changelog/entries/2026-07-07-get-document-ir-body.json
+++ b/changelog/entries/2026-07-07-get-document-ir-body.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-get-document-ir-body",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "fix",
+  "title": "get_document returns the full IR body",
+  "summary": "The MCP get_document tool now reliably returns the full IR Document JSON; oversized documents offload to the artifact store with a sha256 manifest instead of being stubbed.",
+  "features": ["mcp"],
+  "mcpTools": ["get_document"]
+}

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -28,6 +28,7 @@ import {
   registryToolDescriptors,
   dispatchRegistryTool,
 } from "../tools/registry-dispatch.js";
+import { getArtifactFile, clearArtifacts } from "../tools/artifact-store.js";
 import { slimPreviewForInlineUi } from "../server.js";
 import {
   createRobotEnv,
@@ -39,6 +40,7 @@ import {
 import { existsSync, unlinkSync, mkdtempSync, rmSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
 
 /** Minimal Document with one cube part — replaces what createCadDocument
  *  used to build for downstream tests. */
@@ -130,6 +132,83 @@ describe("session lifecycle", () => {
   it("close_document on unknown id reports closed: false", () => {
     const out = closeDocument({ document_id: "doc_missing" });
     expect(JSON.parse(out.content[0].text).closed).toBe(false);
+  });
+});
+
+describe("get_document returns the IR body (issue #278)", () => {
+  // Regression: get_document is documented to "Return the full IR Document
+  // JSON" but callers observed only a {document_id} stub — useless for
+  // snapshotting board state or handing the document to another connection.
+
+  let prevCap: string | undefined;
+
+  beforeEach(() => {
+    prevCap = process.env.MCP_MAX_INLINE_ARTIFACT_BYTES;
+    clearArtifacts();
+  });
+
+  afterEach(() => {
+    if (prevCap === undefined) delete process.env.MCP_MAX_INLINE_ARTIFACT_BYTES;
+    else process.env.MCP_MAX_INLINE_ARTIFACT_BYTES = prevCap;
+    clearArtifacts();
+  });
+
+  it("a small document comes back with its parts and nodes inline", () => {
+    const open = openDocument({ initial: makeCubeDoc() });
+    const { document_id } = JSON.parse(open.content[0].text);
+
+    const result = getDocumentTool({ document_id });
+    const doc = JSON.parse(result.content[0].text);
+
+    // The IR body — not a {document_id} stub.
+    expect(Object.keys(doc)).not.toEqual(["document_id"]);
+    expect(doc.nodes["1"].op.type).toBe("Cube");
+    expect(doc.roots).toHaveLength(1);
+    expect(doc.version).toBe("0.1");
+  });
+
+  it("an oversized document offloads to the artifact store with a verifiable manifest", () => {
+    // Tighten the inline cap so the offload branch triggers without building
+    // a 64 KiB doc (remote.test.ts covers the default cap value).
+    process.env.MCP_MAX_INLINE_ARTIFACT_BYTES = "2048";
+
+    const big = makeCubeDoc();
+    for (let i = 2; i <= 60; i++) {
+      big.nodes[String(i)] = {
+        id: i,
+        name: `padding_cube_${i}`,
+        op: { type: "Cube", size: { x: i, y: i, z: i } },
+      };
+      big.roots.push({ root: i, material: "default" });
+    }
+    expect(JSON.stringify(big).length).toBeGreaterThan(2048);
+
+    const open = openDocument({ initial: big });
+    const { document_id } = JSON.parse(open.content[0].text);
+
+    const result = getDocumentTool({ document_id });
+    const handle = JSON.parse(result.content[0].text);
+
+    // Compact handle, not the IR — but with enough to act on.
+    expect(handle.document_id).toBe(document_id);
+    expect(handle.parts).toBe(60);
+    expect(handle.nodes).toBe(60);
+    expect(handle.artifact_id).toMatch(/^art_/);
+    expect(handle.artifact_url).toContain(`/artifacts/${handle.artifact_id}`);
+    expect(handle.manifest).toHaveLength(1);
+    expect(handle.manifest[0].file).toBe(`${document_id}.vcad`);
+
+    // The stored bytes ARE the full IR, and the manifest sha256 verifies them.
+    const stored = getArtifactFile(handle.artifact_id, `${document_id}.vcad`);
+    expect(stored).not.toBeNull();
+    const sha = createHash("sha256").update(stored!.buf).digest("hex");
+    expect(sha).toBe(handle.manifest[0].sha256);
+    const roundTripped = JSON.parse(stored!.buf.toString("utf8")) as Document;
+    expect(Object.keys(roundTripped.nodes)).toHaveLength(60);
+    expect(roundTripped.roots).toHaveLength(60);
+
+    // The session stays live — the handle is a snapshot, not a close.
+    expect(documents.has(document_id)).toBe(true);
   });
 });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -946,7 +946,7 @@ export async function createServer(
       {
         name: "get_document",
         description:
-          "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`.",
+          "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`. Very large documents come back as a compact artifact handle instead ({document_id, artifact_url, manifest with sha256, …}) — download the full IR at `artifact_url`.",
         inputSchema: getDocumentSchema,
         // Widget-callable: the viewer's "Open in vcad.io" button fetches
         // the IR through this tool to build the deep link.

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -14,6 +14,8 @@ import { writeFileSync, readFileSync } from "node:fs";
 import { randomBytes } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveWithinRoot } from "./safe-path.js";
+import { storeArtifact } from "./artifact-store.js";
+import { maxInlineArtifactBytes } from "./remote.js";
 import type { SessionStore } from "../session-store.js";
 import type { AuthUser } from "../oauth.js";
 
@@ -281,8 +283,40 @@ export function getDocumentTool(args: Record<string, unknown>): {
 } {
   const id = String(args.document_id ?? "");
   const doc = getSession(id);
+  const inline = JSON.stringify(doc);
+  // A routed PCB or imported assembly serializes far past the tool-output
+  // token budget. Same byte-cap idiom as export_gerber / import_step: under
+  // the cap the full IR returns inline (the documented contract); over it the
+  // IR moves to the artifact store and the result is a compact handle whose
+  // manifest sha256 lets any consumer verify the downloaded snapshot.
+  const cap = maxInlineArtifactBytes();
+  if (Buffer.byteLength(inline, "utf8") > cap) {
+    const handle = storeArtifact([{ name: `${id}.vcad`, content: inline }]);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            document_id: id,
+            parts: doc.roots?.length ?? 0,
+            nodes: Object.keys(doc.nodes ?? {}).length,
+            bytes: handle.bytes,
+            artifact_id: handle.artifact_id,
+            artifact_url: handle.artifact_url,
+            manifest: handle.manifest,
+            expires_at: handle.expires_at,
+            note:
+              `Document IR is ${handle.bytes} bytes — over the ${cap}-byte inline ` +
+              "limit, so the full IR was written to the artifact store. Download " +
+              "it at artifact_url (sha256 in the manifest verifies the snapshot); " +
+              "the session stays live via document_id.",
+          }),
+        },
+      ],
+    };
+  }
   return {
-    content: [{ type: "text", text: JSON.stringify(doc) }],
+    content: [{ type: "text", text: inline }],
   };
 }
 


### PR DESCRIPTION
## Summary

The `get_document` MCP tool now reliably returns the full IR Document JSON as documented. Previously, callers received only a `{document_id}` stub, making it impossible to snapshot board state or hand the document to another connection. Oversized documents (exceeding a configurable byte limit) are now offloaded to the artifact store with a compact handle and sha256-verified manifest.

## Changes

- **session.ts**: Modified `getDocumentTool()` to:
  - Serialize the document to JSON and check its byte length against `maxInlineArtifactBytes()`
  - Return the full IR inline for documents under the cap (the documented contract)
  - For oversized documents, store the IR in the artifact store and return a compact handle containing:
    - `document_id`, `parts`, `nodes` counts for quick reference
    - `artifact_id` and `artifact_url` for download
    - `manifest` with sha256 hash for verification
    - Explanatory `note` about the offload
  - Session remains live via `document_id` (the handle is a snapshot, not a close)

- **server.ts**: Updated `get_document` tool description to document the artifact handle behavior for large documents

- **tools.test.ts**: Added comprehensive regression tests:
  - Small documents return full IR inline with all nodes and parts
  - Oversized documents return a compact handle with verifiable manifest
  - Manifest sha256 correctly verifies the stored IR bytes
  - Session stays live after offload

- **changelog**: Added entry documenting the fix

## Implementation Details

The byte-cap idiom matches existing patterns in `export_gerber` and `import_step` tools. The `maxInlineArtifactBytes()` function (from `remote.js`) provides a configurable limit (default 64 KiB, overridable via `MCP_MAX_INLINE_ARTIFACT_BYTES` env var). The manifest sha256 allows any consumer to verify the downloaded snapshot without re-computing the hash.

https://claude.ai/code/session_01A15Eq1ABrLNkw9c4HuvhGr