### PR TITLE
STEP import: support revolution, extrusion, and offset surfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tang",
 ]
@@ -7280,6 +7280,7 @@ dependencies = [
  "vcad-kernel-math",
  "vcad-kernel-nurbs",
  "vcad-kernel-primitives",
+ "vcad-kernel-tessellate",
  "vcad-kernel-topo",
 ]
 

--- a/changelog/entries/2026-07-07-step-swept-offset-surfaces.json
+++ b/changelog/entries/2026-07-07-step-swept-offset-surfaces.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-07-step-swept-offset-surfaces",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "STEP import: revolution, extrusion, offset surfaces",
+  "summary": "SURFACE_OF_REVOLUTION, SURFACE_OF_LINEAR_EXTRUSION, and OFFSET_SURFACE now import — analytic when exact, NURBS otherwise — so SolidWorks/Fusion/Catia exports stop losing faces.",
+  "features": ["step-import", "brep-kernel", "nurbs"]
+}

--- a/crates/vcad-kernel-nurbs/src/lib.rs
+++ b/crates/vcad-kernel-nurbs/src/lib.rs
@@ -624,6 +624,49 @@ impl NurbsCurve {
         Self::new(pts, knots, 2)
     }
 
+    /// Create a NURBS circle lying in the plane spanned by `x_dir` / `y_dir`.
+    ///
+    /// The parameter domain is `[0, 2π]` and coincides with the STEP circle
+    /// angle convention at the quadrant points (rational quadratic arcs
+    /// reparameterize nonlinearly between them, so intermediate parameters
+    /// are only approximately the geometric angle).
+    pub fn circle_in_frame(center: Point3, x_dir: Dir3, y_dir: Dir3, radius: f64) -> Self {
+        use std::f64::consts::{FRAC_1_SQRT_2, TAU};
+        let w = FRAC_1_SQRT_2;
+        let x = *x_dir.as_ref();
+        let y = *y_dir.as_ref();
+        let p = |a: f64, b: f64| center + x * (radius * a) + y * (radius * b);
+
+        let pts = vec![
+            WeightedPoint::new(p(1.0, 0.0), 1.0),
+            WeightedPoint::new(p(1.0, 1.0), w),
+            WeightedPoint::new(p(0.0, 1.0), 1.0),
+            WeightedPoint::new(p(-1.0, 1.0), w),
+            WeightedPoint::new(p(-1.0, 0.0), 1.0),
+            WeightedPoint::new(p(-1.0, -1.0), w),
+            WeightedPoint::new(p(0.0, -1.0), 1.0),
+            WeightedPoint::new(p(1.0, -1.0), w),
+            WeightedPoint::new(p(1.0, 0.0), 1.0),
+        ];
+
+        let knots = vec![
+            0.0,
+            0.0,
+            0.0,
+            0.25 * TAU,
+            0.25 * TAU,
+            0.5 * TAU,
+            0.5 * TAU,
+            0.75 * TAU,
+            0.75 * TAU,
+            TAU,
+            TAU,
+            TAU,
+        ];
+
+        Self::new(pts, knots, 2)
+    }
+
     /// Insert a knot using Boehm's algorithm (rational version).
     pub fn insert_knot(&self, t: f64) -> Self {
         let n = self.control_points.len() - 1;
@@ -786,6 +829,104 @@ impl NurbsSurface {
         (
             (self.knots_u[self.degree_u], self.knots_u[self.n_u]),
             (self.knots_v[self.degree_v], self.knots_v[self.n_v]),
+        )
+    }
+
+    /// Create an exact surface of revolution: the full 360° sweep of
+    /// `profile` about the axis through `axis_point` along `axis_dir`.
+    ///
+    /// Uses the standard 9-control-point rational quadratic circle
+    /// construction (Piegl & Tiller, *The NURBS Book*, §8.3): each profile
+    /// control point is swept into 9 weighted control points around the
+    /// axis, which reproduces the surface of revolution exactly.
+    ///
+    /// The `u` parameter is the sweep angle with domain `[0, 2π]` (matching
+    /// the STEP `SURFACE_OF_REVOLUTION` convention of `u` = angle); `v` is
+    /// the profile curve parameter (its knot vector is reused verbatim), so
+    /// the surface normal `∂u × ∂v` points the same way as the STEP surface
+    /// normal.
+    pub fn revolution(profile: &NurbsCurve, axis_point: Point3, axis_dir: Dir3) -> Self {
+        use std::f64::consts::{FRAC_1_SQRT_2, FRAC_PI_4, SQRT_2, TAU};
+        const N_U: usize = 9;
+
+        let a = *axis_dir.as_ref();
+        let mut pts = Vec::with_capacity(profile.control_points.len() * N_U);
+        for wp in &profile.control_points {
+            let rel = wp.point - axis_point;
+            let foot = axis_point + a * rel.dot(a);
+            let radial = wp.point - foot;
+            let r = radial.norm();
+            let (x, y) = if r > 1e-14 {
+                let x = radial / r;
+                (x, a.cross(x))
+            } else {
+                // Control point on the axis: all 9 swept points coincide.
+                (Vec3::zeros(), Vec3::zeros())
+            };
+            for i in 0..N_U {
+                let theta = FRAC_PI_4 * i as f64;
+                // Even indices lie on the swept circle; odd indices are the
+                // tangent-intersection corners at distance r·√2 with weight
+                // scaled by cos(45°).
+                let (scale, w) = if i % 2 == 0 {
+                    (r, wp.weight)
+                } else {
+                    (r * SQRT_2, wp.weight * FRAC_1_SQRT_2)
+                };
+                let p = foot + (x * theta.cos() + y * theta.sin()) * scale;
+                pts.push(WeightedPoint::new(p, w));
+            }
+        }
+
+        let knots_u = vec![
+            0.0,
+            0.0,
+            0.0,
+            0.25 * TAU,
+            0.25 * TAU,
+            0.5 * TAU,
+            0.5 * TAU,
+            0.75 * TAU,
+            0.75 * TAU,
+            TAU,
+            TAU,
+            TAU,
+        ];
+
+        Self::new(
+            pts,
+            N_U,
+            profile.control_points.len(),
+            knots_u,
+            profile.knots.clone(),
+            2,
+            profile.degree,
+        )
+    }
+
+    /// Create an exact extruded (translational sweep) surface: `profile`
+    /// swept along `direction`.
+    ///
+    /// The `u` parameter is the profile curve parameter (knot vector reused
+    /// verbatim, matching the STEP `SURFACE_OF_LINEAR_EXTRUSION` convention
+    /// of `u` = curve parameter); `v ∈ [0, 1]` sweeps from the profile to
+    /// `profile + direction`, so the surface normal `∂u × ∂v` matches the
+    /// STEP normal `C'(u) × direction`.
+    pub fn extrusion(profile: &NurbsCurve, direction: Vec3) -> Self {
+        let n_u = profile.control_points.len();
+        let mut pts = Vec::with_capacity(n_u * 2);
+        pts.extend_from_slice(&profile.control_points);
+        for wp in &profile.control_points {
+            pts.push(WeightedPoint::new(wp.point + direction, wp.weight));
+        }
+        Self::new(
+            pts,
+            n_u,
+            2,
+            profile.knots.clone(),
+            vec![0.0, 0.0, 1.0, 1.0],
+            profile.degree,
+            1,
         )
     }
 }
@@ -1251,6 +1392,138 @@ mod tests {
 
         let n = surf.normal(Point2::new(0.5, 0.5));
         assert!((n.as_ref().z.abs() - 1.0).abs() < 1e-6);
+    }
+
+    // ---- Revolution / extrusion tests ----
+
+    #[test]
+    fn test_circle_in_frame_arbitrary_plane() {
+        // Circle in the XZ plane (normal = Y), radius 4, centered at (10, 2, 0)
+        let center = Point3::new(10.0, 2.0, 0.0);
+        let x = Dir3::new_normalize(Vec3::x());
+        let y = Dir3::new_normalize(Vec3::z());
+        let circle = NurbsCurve::circle_in_frame(center, x, y, 4.0);
+
+        let (t_min, t_max) = circle.parameter_domain();
+        assert!((t_max - std::f64::consts::TAU).abs() < 1e-12);
+        for i in 0..=32 {
+            let t = t_min + (t_max - t_min) * i as f64 / 32.0;
+            let p = circle.eval(t);
+            let d = p - center;
+            assert!(d.y.abs() < 1e-10, "point should stay in plane: {}", d.y);
+            assert!(
+                (d.norm() - 4.0).abs() < 1e-8,
+                "radius at t={}: {}",
+                t,
+                d.norm()
+            );
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_parallel_line_is_cylinder() {
+        // Segment at x=5 from z=0 to z=8, revolved about the Z axis.
+        let profile = NurbsCurve::new(
+            vec![
+                WeightedPoint::unweighted(Point3::new(5.0, 0.0, 0.0)),
+                WeightedPoint::unweighted(Point3::new(5.0, 0.0, 8.0)),
+            ],
+            vec![0.0, 0.0, 1.0, 1.0],
+            1,
+        );
+        let surf =
+            NurbsSurface::revolution(&profile, Point3::origin(), Dir3::new_normalize(Vec3::z()));
+
+        let ((u0, u1), (v0, v1)) = surf.parameter_domain();
+        for i in 0..=16 {
+            for j in 0..=8 {
+                let u = u0 + (u1 - u0) * i as f64 / 16.0;
+                let v = v0 + (v1 - v0) * j as f64 / 8.0;
+                let p = surf.eval(u, v);
+                let r = (p.x * p.x + p.y * p.y).sqrt();
+                assert!((r - 5.0).abs() < 1e-8, "radius at ({u},{v}): {r}");
+                assert!((-1e-9..=8.0 + 1e-9).contains(&p.z), "z: {}", p.z);
+            }
+        }
+        // v sweeps the profile: v=0 at z=0, v=1 at z=8
+        assert!(surf.eval(0.0, 0.0).z.abs() < 1e-9);
+        assert!((surf.eval(0.0, 1.0).z - 8.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_revolution_normal_orientation() {
+        use vcad_kernel_geom::Surface;
+        // Profile line going UP parallel to +Z at x=5: STEP normal
+        // (du × dv) must point radially outward.
+        let profile = NurbsCurve::new(
+            vec![
+                WeightedPoint::unweighted(Point3::new(5.0, 0.0, 0.0)),
+                WeightedPoint::unweighted(Point3::new(5.0, 0.0, 8.0)),
+            ],
+            vec![0.0, 0.0, 1.0, 1.0],
+            1,
+        );
+        let surf =
+            NurbsSurface::revolution(&profile, Point3::origin(), Dir3::new_normalize(Vec3::z()));
+        let n = surf.normal(Point2::new(0.1, 0.5));
+        let p = surf.eval(0.1, 0.5);
+        let outward = Vec3::new(p.x, p.y, 0.0).normalize();
+        assert!(
+            n.as_ref().dot(outward) > 0.9,
+            "normal should be outward: {:?}",
+            n
+        );
+    }
+
+    #[test]
+    fn test_revolution_of_offset_circle_is_torus() {
+        // Circle of radius 2 centered at (10, 0, 0) in the XZ plane,
+        // revolved about Z: torus R=10, r=2.
+        let profile = NurbsCurve::circle_in_frame(
+            Point3::new(10.0, 0.0, 0.0),
+            Dir3::new_normalize(Vec3::x()),
+            Dir3::new_normalize(Vec3::z()),
+            2.0,
+        );
+        let surf =
+            NurbsSurface::revolution(&profile, Point3::origin(), Dir3::new_normalize(Vec3::z()));
+
+        let ((u0, u1), (v0, v1)) = surf.parameter_domain();
+        for i in 0..=12 {
+            for j in 0..=12 {
+                let u = u0 + (u1 - u0) * i as f64 / 12.0;
+                let v = v0 + (v1 - v0) * j as f64 / 12.0;
+                let p = surf.eval(u, v);
+                // Torus implicit: (sqrt(x²+y²) - R)² + z² = r²
+                let ring = (p.x * p.x + p.y * p.y).sqrt() - 10.0;
+                let dist = (ring * ring + p.z * p.z).sqrt();
+                assert!((dist - 2.0).abs() < 1e-8, "torus dist at ({u},{v}): {dist}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_extrusion_of_circle_is_cylinder() {
+        let profile = NurbsCurve::circle_in_frame(
+            Point3::origin(),
+            Dir3::new_normalize(Vec3::x()),
+            Dir3::new_normalize(Vec3::y()),
+            3.0,
+        );
+        let surf = NurbsSurface::extrusion(&profile, Vec3::new(0.0, 0.0, 12.0));
+
+        let ((u0, u1), (v0, v1)) = surf.parameter_domain();
+        for i in 0..=16 {
+            for j in 0..=4 {
+                let u = u0 + (u1 - u0) * i as f64 / 16.0;
+                let v = v0 + (v1 - v0) * j as f64 / 4.0;
+                let p = surf.eval(u, v);
+                let r = (p.x * p.x + p.y * p.y).sqrt();
+                assert!((r - 3.0).abs() < 1e-8, "radius at ({u},{v}): {r}");
+            }
+        }
+        assert!(surf.eval(0.0, 0.0).z.abs() < 1e-9);
+        assert!((surf.eval(0.0, 1.0).z - 12.0).abs() < 1e-9);
     }
 
     // ---- Knot utilities tests ----

--- a/crates/vcad-kernel-step/Cargo.toml
+++ b/crates/vcad-kernel-step/Cargo.toml
@@ -17,3 +17,4 @@ thiserror.workspace = true
 
 [dev-dependencies]
 vcad-kernel-booleans = { path = "../vcad-kernel-booleans" }
+vcad-kernel-tessellate = { path = "../vcad-kernel-tessellate" }

--- a/crates/vcad-kernel-step/src/entities/surfaces.rs
+++ b/crates/vcad-kernel-step/src/entities/surfaces.rs
@@ -1,16 +1,18 @@
-//! Surface entities: planes, cylinders, cones, spheres, B-splines.
+//! Surface entities: planes, cylinders, cones, spheres, B-splines, and
+//! swept/offset surfaces (revolution, linear extrusion, offset).
 
 use super::{
-    parse_any_axis_placement, parse_cartesian_point, write_cartesian_point, AxisPlacement,
-    EntityArgs,
+    curves::{parse_curve, StepCurve},
+    parse_any_axis_placement, parse_cartesian_point, parse_vector, write_cartesian_point,
+    AxisPlacement, EntityArgs,
 };
 use crate::error::StepError;
 use stepperoni::{StepFile, StepValue};
 use vcad_kernel_geom::{
     BilinearSurface, ConeSurface, CylinderSurface, Plane, SphereSurface, Surface, TorusSurface,
 };
-use vcad_kernel_math::Point3;
-use vcad_kernel_nurbs::BSplineSurface;
+use vcad_kernel_math::{Dir3, Point3, Vec3};
+use vcad_kernel_nurbs::{BSplineSurface, NurbsCurve, NurbsSurface, WeightedPoint};
 
 /// Cap the expanded knot-vector length to defend against adversarial STEP
 /// inputs whose per-knot multiplicities sum to a huge number; without this,
@@ -22,6 +24,19 @@ const MAX_KNOT_MULTIPLICITY: usize = 10_000;
 /// Largest B-spline surface grid we will accept from a STEP file; beyond this
 /// the memory / compute cost to build the surface is attacker-profitable DoS.
 const MAX_BSPLINE_GRID: usize = 1_000_000;
+/// Maximum surface-in-surface nesting depth (OFFSET_SURFACE referencing
+/// another surface). Guards against reference cycles in malicious files
+/// (`#1 = OFFSET_SURFACE('', #1, ...)`) that would otherwise recurse forever.
+const MAX_SURFACE_RECURSION_DEPTH: usize = 8;
+/// Grid resolution (per direction) for the sampled NURBS fallback used when
+/// an OFFSET_SURFACE base has no exact analytic offset.
+const OFFSET_FIT_SAMPLES: usize = 24;
+/// Tolerance for direction classification (parallel/perpendicular tests on
+/// unit vectors).
+const DIR_EPS: f64 = 1e-9;
+/// Tolerance for positional coincidence (points on axis, coplanarity).
+/// Geometry is conventionally in millimeters.
+const POS_EPS: f64 = 1e-8;
 
 /// A surface parsed from STEP.
 #[derive(Debug, Clone)]
@@ -38,6 +53,9 @@ pub enum StepSurface {
     Torus(TorusSurface),
     /// A B-spline surface.
     BSpline(BSplineSurface),
+    /// A rational NURBS surface (produced by converting swept surfaces —
+    /// revolution / linear extrusion — that have no analytic equivalent).
+    Nurbs(NurbsSurface),
 }
 
 impl StepSurface {
@@ -50,7 +68,39 @@ impl StepSurface {
             StepSurface::Sphere(s) => Box::new(s),
             StepSurface::Torus(t) => Box::new(t),
             StepSurface::BSpline(b) => Box::new(b),
+            StepSurface::Nurbs(n) => Box::new(n),
         }
+    }
+
+    /// Convert a boxed Surface trait object back into a typed variant.
+    ///
+    /// Used to re-wrap the result of `Surface::offset()` (which returns a
+    /// trait object) into the enum. Returns `None` for surface types with
+    /// no corresponding variant.
+    fn from_box(surface: Box<dyn Surface>) -> Option<StepSurface> {
+        let any = surface.as_any();
+        if let Some(p) = any.downcast_ref::<Plane>() {
+            return Some(StepSurface::Plane(p.clone()));
+        }
+        if let Some(c) = any.downcast_ref::<CylinderSurface>() {
+            return Some(StepSurface::Cylinder(c.clone()));
+        }
+        if let Some(c) = any.downcast_ref::<ConeSurface>() {
+            return Some(StepSurface::Cone(c.clone()));
+        }
+        if let Some(s) = any.downcast_ref::<SphereSurface>() {
+            return Some(StepSurface::Sphere(s.clone()));
+        }
+        if let Some(t) = any.downcast_ref::<TorusSurface>() {
+            return Some(StepSurface::Torus(t.clone()));
+        }
+        if let Some(b) = any.downcast_ref::<BSplineSurface>() {
+            return Some(StepSurface::BSpline(b.clone()));
+        }
+        if let Some(n) = any.downcast_ref::<NurbsSurface>() {
+            return Some(StepSurface::Nurbs(n.clone()));
+        }
+        None
     }
 }
 
@@ -501,17 +551,64 @@ pub fn bilinear_planar_to_placement(bilinear: &BilinearSurface) -> AxisPlacement
     plane_to_placement(&plane)
 }
 
-/// Parse any supported surface entity.
+/// Parse any supported surface entity (reserved for callers that don't
+/// consume face `same_sense` flags).
+///
+/// Convenience wrapper around [`parse_surface_oriented`] that discards the
+/// normal-orientation flag. Prefer the oriented variant when the caller
+/// honors face `same_sense` flags (the reader does).
+#[allow(dead_code)]
 pub fn parse_surface(file: &StepFile, id: u64) -> Result<StepSurface, StepError> {
+    parse_surface_oriented(file, id).map(|(surface, _)| surface)
+}
+
+/// Parse any supported surface entity, returning the surface together with a
+/// normal-orientation flag.
+///
+/// The flag is `true` when the returned surface's natural normal points
+/// opposite to the STEP surface normal (`∂u × ∂v` of the STEP
+/// parameterization). This happens when a swept surface maps onto an
+/// analytic type whose normal convention is structural — e.g. a
+/// `SURFACE_OF_REVOLUTION` of a line running *anti-parallel* to the axis is
+/// still a cylinder, but the STEP normal points inward while
+/// [`CylinderSurface`]'s normal always points outward. Callers that consume
+/// `ADVANCED_FACE.same_sense` must XOR it with this flag.
+pub fn parse_surface_oriented(file: &StepFile, id: u64) -> Result<(StepSurface, bool), StepError> {
+    parse_surface_inner(file, id, 0)
+}
+
+fn parse_surface_inner(
+    file: &StepFile,
+    id: u64,
+    depth: usize,
+) -> Result<(StepSurface, bool), StepError> {
+    if depth > MAX_SURFACE_RECURSION_DEPTH {
+        return Err(StepError::UnsupportedEntity(format!(
+            "surface #{} exceeds nesting depth {} (reference cycle?)",
+            id, MAX_SURFACE_RECURSION_DEPTH
+        )));
+    }
     let entity = file.get(id).ok_or(StepError::MissingEntity(id))?;
 
     match entity.type_name.as_str() {
-        "PLANE" => Ok(StepSurface::Plane(parse_plane(file, id)?)),
-        "CYLINDRICAL_SURFACE" => Ok(StepSurface::Cylinder(parse_cylindrical_surface(file, id)?)),
-        "CONICAL_SURFACE" => Ok(StepSurface::Cone(parse_conical_surface(file, id)?)),
-        "SPHERICAL_SURFACE" => Ok(StepSurface::Sphere(parse_spherical_surface(file, id)?)),
-        "TOROIDAL_SURFACE" => Ok(StepSurface::Torus(parse_toroidal_surface(file, id)?)),
-        "B_SPLINE_SURFACE_WITH_KNOTS" => Ok(StepSurface::BSpline(parse_bspline_surface(file, id)?)),
+        "PLANE" => Ok((StepSurface::Plane(parse_plane(file, id)?), false)),
+        "CYLINDRICAL_SURFACE" => Ok((
+            StepSurface::Cylinder(parse_cylindrical_surface(file, id)?),
+            false,
+        )),
+        "CONICAL_SURFACE" => Ok((StepSurface::Cone(parse_conical_surface(file, id)?), false)),
+        "SPHERICAL_SURFACE" => Ok((
+            StepSurface::Sphere(parse_spherical_surface(file, id)?),
+            false,
+        )),
+        "TOROIDAL_SURFACE" => Ok((StepSurface::Torus(parse_toroidal_surface(file, id)?), false)),
+        "B_SPLINE_SURFACE_WITH_KNOTS" => Ok((
+            StepSurface::BSpline(parse_bspline_surface(file, id)?),
+            false,
+        )),
+        "SURFACE_OF_REVOLUTION" => parse_surface_of_revolution(file, id),
+        "SURFACE_OF_LINEAR_EXTRUSION" => parse_surface_of_linear_extrusion(file, id),
+        "OFFSET_SURFACE" => parse_offset_surface(file, id, depth),
         // Complex entities often have BOUNDED_SURFACE as first type
         "BOUNDED_SURFACE" | "B_SPLINE_SURFACE" => {
             // Check if it's a complex entity with B-spline data
@@ -520,13 +617,625 @@ pub fn parse_surface(file: &StepFile, id: u64) -> Result<StepSurface, StepError>
                     if type_name == "B_SPLINE_SURFACE_WITH_KNOTS" || type_name == "B_SPLINE_SURFACE")
             });
             if has_bspline {
-                Ok(StepSurface::BSpline(parse_bspline_surface(file, id)?))
+                Ok((
+                    StepSurface::BSpline(parse_bspline_surface(file, id)?),
+                    false,
+                ))
             } else {
                 Err(StepError::UnsupportedEntity(entity.type_name.clone()))
             }
         }
         other => Err(StepError::UnsupportedEntity(other.to_string())),
     }
+}
+
+// =============================================================================
+// Swept surfaces (revolution / linear extrusion) and offset surfaces
+// =============================================================================
+
+/// Parse a SURFACE_OF_REVOLUTION entity.
+///
+/// STEP syntax: `SURFACE_OF_REVOLUTION(name, swept_curve, axis_position)`
+///
+/// The swept curve is revolved a full turn about the axis. Analytic special
+/// cases map to analytic surfaces (the rest of the kernel — booleans,
+/// fillets — works best on those):
+/// - line parallel to the axis → cylinder
+/// - line perpendicular to the axis → plane
+/// - line intersecting the axis obliquely → cone
+/// - circle coplanar with the axis and centered on it → sphere
+/// - circle coplanar with the axis, off it → torus
+///
+/// Everything else (B-spline profiles, skew lines, tilted circles) converts
+/// to an exact rational NURBS surface of revolution.
+///
+/// Returns the surface and a flag that is `true` when the surface's natural
+/// normal is opposite the STEP `∂u × ∂v` normal (see
+/// [`parse_surface_oriented`]).
+pub fn parse_surface_of_revolution(
+    file: &StepFile,
+    id: u64,
+) -> Result<(StepSurface, bool), StepError> {
+    let entity = file.get(id).ok_or(StepError::MissingEntity(id))?;
+    if entity.type_name != "SURFACE_OF_REVOLUTION" {
+        return Err(StepError::type_mismatch(
+            "SURFACE_OF_REVOLUTION",
+            &entity.type_name,
+        ));
+    }
+    let curve_id = entity.entity_ref(1)?;
+    let axis_id = entity.entity_ref(2)?;
+    let curve = parse_curve(file, curve_id)?;
+    let placement = parse_any_axis_placement(file, axis_id)?;
+    let axis_point = placement.location;
+    let axis = placement.z_axis();
+    let a = *axis.as_ref();
+
+    let analytic = match curve.resolve() {
+        StepCurve::Line(line) => revolve_line(&curve, line, axis_point, a, id)?,
+        StepCurve::Circle(circle) => revolve_circle(&curve, circle, axis_point, a, id)?,
+        _ => None,
+    };
+    if let Some(result) = analytic {
+        return Ok(result);
+    }
+
+    let (profile, flipped) = profile_to_nurbs(&curve, id)?;
+    Ok((
+        StepSurface::Nurbs(NurbsSurface::revolution(&profile, axis_point, axis)),
+        flipped,
+    ))
+}
+
+/// Classify the revolution of a line about an axis.
+///
+/// Returns `Ok(None)` when the result is not an analytic surface (a skew
+/// line sweeps a hyperboloid of one sheet) so the caller falls back to the
+/// NURBS construction.
+fn revolve_line(
+    curve: &StepCurve,
+    line: &vcad_kernel_geom::Line3d,
+    axis_point: Point3,
+    a: Vec3,
+    id: u64,
+) -> Result<Option<(StepSurface, bool)>, StepError> {
+    let dir_norm = line.direction.norm();
+    if dir_norm < 1e-12 {
+        return Err(StepError::UnsupportedEntity(format!(
+            "SURFACE_OF_REVOLUTION #{id}: zero-length line direction"
+        )));
+    }
+    // Effective traversal direction (trimmed-curve sense flips it).
+    let d = line.direction * (curve_sense_sign(curve) / dir_norm);
+    let d_cross_a = d.cross(a);
+
+    if d_cross_a.norm() < DIR_EPS {
+        // Line parallel to the axis → cylinder.
+        let rel = line.origin - axis_point;
+        let radial = rel - a * rel.dot(a);
+        let radius = radial.norm();
+        if radius < POS_EPS {
+            return Err(StepError::UnsupportedEntity(format!(
+                "SURFACE_OF_REVOLUTION #{id}: revolving a line lying on the axis"
+            )));
+        }
+        let cylinder = CylinderSurface {
+            center: axis_point,
+            axis: Dir3::new_normalize(a),
+            ref_dir: Dir3::new_normalize(radial),
+            radius,
+        };
+        // The STEP normal (∂angle × ∂curve) points radially outward when
+        // the line runs along +axis, inward when anti-parallel;
+        // CylinderSurface's normal is always outward.
+        let flipped = d.dot(a) < 0.0;
+        return Ok(Some((StepSurface::Cylinder(cylinder), flipped)));
+    }
+
+    if d.dot(a).abs() < DIR_EPS {
+        // Line perpendicular to the axis: every point of the line sits at
+        // the same height along the axis, so the sweep is a plane.
+        let h = (line.origin - axis_point).dot(a);
+        let origin = axis_point + a * h;
+        // STEP normal ∝ -axis·(d · ρ); sample a point where the line is off
+        // the axis to fix the sign.
+        let mut sign = 0.0;
+        for t in curve_sample_ts(curve) {
+            let rho = curve.evaluate(t) - origin;
+            let dp = d.dot(rho);
+            if dp.abs() > POS_EPS {
+                sign = dp.signum();
+                break;
+            }
+        }
+        if sign == 0.0 {
+            return Err(StepError::UnsupportedEntity(format!(
+                "SURFACE_OF_REVOLUTION #{id}: degenerate planar revolution"
+            )));
+        }
+        let normal = a * (-sign);
+        // x along the line, y completes the frame so that x × y = normal.
+        let plane = Plane::new(origin, d, normal.cross(d));
+        return Ok(Some((StepSurface::Plane(plane), false)));
+    }
+
+    // Oblique line: only analytic (a cone) when it intersects the axis;
+    // a skew line sweeps a hyperboloid of one sheet.
+    let line_axis_dist = ((line.origin - axis_point).dot(d_cross_a) / d_cross_a.norm()).abs();
+    if line_axis_dist > POS_EPS {
+        return Ok(None);
+    }
+
+    // Apex = intersection of the line with the axis.
+    let w = axis_point - line.origin;
+    let t_apex = w.cross(a).dot(d_cross_a) / d_cross_a.dot(d_cross_a);
+    let apex = line.origin + d * t_apex;
+
+    // Sample a profile point away from the apex to pick the nappe.
+    let mut sample = None;
+    for t in curve_sample_ts(curve) {
+        let p = curve.evaluate(t);
+        if (p - apex).norm() > 1e-6 {
+            sample = Some(p);
+            break;
+        }
+    }
+    let sample = sample.ok_or_else(|| {
+        StepError::UnsupportedEntity(format!(
+            "SURFACE_OF_REVOLUTION #{id}: degenerate conical revolution"
+        ))
+    })?;
+    let rel = sample - apex;
+    let cone_axis = if rel.dot(a) >= 0.0 { a } else { -a };
+    let axial = rel.dot(cone_axis);
+    let radial = rel - cone_axis * axial;
+    let half_angle = radial.norm().atan2(axial);
+    let cone = ConeSurface {
+        apex,
+        axis: Dir3::new_normalize(cone_axis),
+        ref_dir: Dir3::new_normalize(radial),
+        half_angle,
+    };
+    // Compare the STEP normal with the cone's outward normal at the sample.
+    let n_cone = radial.normalize() * half_angle.cos() - cone_axis * half_angle.sin();
+    let n_step = revolution_step_normal(sample, d, axis_point, a);
+    let flipped = n_step.dot(n_cone) < 0.0;
+    Ok(Some((StepSurface::Cone(cone), flipped)))
+}
+
+/// Classify the revolution of a circle about an axis.
+///
+/// Returns `Ok(None)` when the result is not an analytic surface (the
+/// circle is tilted out of the axis plane, or the sweep self-intersects).
+fn revolve_circle(
+    curve: &StepCurve,
+    circle: &vcad_kernel_geom::Circle3d,
+    axis_point: Point3,
+    a: Vec3,
+    id: u64,
+) -> Result<Option<(StepSurface, bool)>, StepError> {
+    if circle.radius < POS_EPS {
+        return Err(StepError::UnsupportedEntity(format!(
+            "SURFACE_OF_REVOLUTION #{id}: revolving a degenerate circle"
+        )));
+    }
+    let n_c = *circle.normal.as_ref();
+    // Analytic only when the axis lies in the circle's plane: the axis
+    // direction is perpendicular to the circle normal, and the axis point
+    // is in the plane.
+    let coplanar =
+        n_c.dot(a).abs() < DIR_EPS && (axis_point - circle.center).dot(n_c).abs() < POS_EPS;
+    if !coplanar {
+        return Ok(None);
+    }
+
+    let rel = circle.center - axis_point;
+    let axial = rel.dot(a);
+    let radial = rel - a * axial;
+    let major = radial.norm();
+
+    if major < POS_EPS {
+        // Circle centered on the axis → sphere.
+        let sphere = SphereSurface {
+            center: circle.center,
+            radius: circle.radius,
+            ref_dir: Dir3::new_normalize(perpendicular_dir(a)),
+            axis: Dir3::new_normalize(a),
+        };
+        let flipped = revolved_circle_flipped(curve, axis_point, a, circle.center);
+        return Ok(Some((StepSurface::Sphere(sphere), flipped)));
+    }
+    if major <= circle.radius + POS_EPS {
+        // The tube crosses the axis (lemon/apple shape) — a self-intersecting
+        // torus, which TorusSurface does not model. Use the NURBS fallback.
+        return Ok(None);
+    }
+
+    let torus = TorusSurface {
+        center: axis_point + a * axial,
+        axis: Dir3::new_normalize(a),
+        ref_dir: Dir3::new_normalize(radial),
+        major_radius: major,
+        minor_radius: circle.radius,
+    };
+    // At the profile's angular position the tube center is the circle
+    // center, so the torus's natural normal there is `p - circle.center`.
+    let flipped = revolved_circle_flipped(curve, axis_point, a, circle.center);
+    Ok(Some((StepSurface::Torus(torus), flipped)))
+}
+
+/// Whether the natural (outward-from-`natural_center`) normal of a revolved
+/// circle disagrees with the STEP `∂u × ∂v` normal.
+fn revolved_circle_flipped(
+    curve: &StepCurve,
+    axis_point: Point3,
+    a: Vec3,
+    natural_center: Point3,
+) -> bool {
+    for t in curve_sample_ts(curve) {
+        let p = curve.evaluate(t);
+        // Skip samples on the axis: the sweep direction degenerates there.
+        let rel = p - axis_point;
+        let rho = rel - a * rel.dot(a);
+        if rho.norm() < 1e-6 {
+            continue;
+        }
+        let n_step = revolution_step_normal(p, curve_tangent(curve, t), axis_point, a);
+        let n_natural = p - natural_center;
+        if n_step.norm() < 1e-12 || n_natural.norm() < 1e-12 {
+            continue;
+        }
+        return n_step.dot(n_natural) < 0.0;
+    }
+    false
+}
+
+/// The (unnormalized) STEP surface normal of a surface of revolution at a
+/// point on the profile: `∂σ/∂u × ∂σ/∂v = (axis × ρ) × C'(v)`, where `ρ` is
+/// the radial offset of the point from the axis.
+fn revolution_step_normal(point: Point3, tangent: Vec3, axis_point: Point3, a: Vec3) -> Vec3 {
+    let rel = point - axis_point;
+    let rho = rel - a * rel.dot(a);
+    a.cross(rho).cross(tangent)
+}
+
+/// Parse a SURFACE_OF_LINEAR_EXTRUSION entity.
+///
+/// STEP syntax: `SURFACE_OF_LINEAR_EXTRUSION(name, swept_curve, extrusion_axis)`
+/// where `extrusion_axis` is a VECTOR (direction with magnitude).
+///
+/// Analytic special cases:
+/// - line → plane
+/// - circle extruded along its normal → cylinder
+///
+/// Everything else converts to an exact NURBS extrusion surface.
+///
+/// Returns the surface and a flag that is `true` when the surface's natural
+/// normal is opposite the STEP `C'(u) × V` normal (see
+/// [`parse_surface_oriented`]).
+pub fn parse_surface_of_linear_extrusion(
+    file: &StepFile,
+    id: u64,
+) -> Result<(StepSurface, bool), StepError> {
+    let entity = file.get(id).ok_or(StepError::MissingEntity(id))?;
+    if entity.type_name != "SURFACE_OF_LINEAR_EXTRUSION" {
+        return Err(StepError::type_mismatch(
+            "SURFACE_OF_LINEAR_EXTRUSION",
+            &entity.type_name,
+        ));
+    }
+    let curve_id = entity.entity_ref(1)?;
+    let vec_id = entity.entity_ref(2)?;
+    let curve = parse_curve(file, curve_id)?;
+    let v = parse_vector(file, vec_id)?;
+    let v_norm = v.norm();
+    if v_norm < 1e-12 {
+        return Err(StepError::UnsupportedEntity(format!(
+            "SURFACE_OF_LINEAR_EXTRUSION #{id}: zero-length extrusion vector"
+        )));
+    }
+    let sense = curve_sense_sign(&curve);
+
+    match curve.resolve() {
+        StepCurve::Line(line) => {
+            let dir_norm = line.direction.norm();
+            if dir_norm < 1e-12 {
+                return Err(StepError::UnsupportedEntity(format!(
+                    "SURFACE_OF_LINEAR_EXTRUSION #{id}: zero-length line direction"
+                )));
+            }
+            let d = line.direction * (sense / dir_norm);
+            let n = d.cross(v);
+            if n.norm() < DIR_EPS * v_norm {
+                return Err(StepError::UnsupportedEntity(format!(
+                    "SURFACE_OF_LINEAR_EXTRUSION #{id}: extruding a line along itself"
+                )));
+            }
+            // Plane whose normal is the STEP normal C'(u) × V.
+            let normal = n.normalize();
+            let plane = Plane::new(line.origin, d, normal.cross(d));
+            Ok((StepSurface::Plane(plane), false))
+        }
+        StepCurve::Circle(circle) => {
+            let n_c = *circle.normal.as_ref();
+            if n_c.cross(v).norm() < DIR_EPS * v_norm {
+                // Extruded along its own normal → cylinder.
+                let cylinder = CylinderSurface {
+                    center: circle.center,
+                    axis: circle.normal,
+                    ref_dir: circle.x_dir,
+                    radius: circle.radius,
+                };
+                // STEP normal C'(u) × V is outward for a CCW circle extruded
+                // along its normal, inward when the vector (or traversal)
+                // runs the other way.
+                let flipped = v.dot(n_c) * sense < 0.0;
+                Ok((StepSurface::Cylinder(cylinder), flipped))
+            } else {
+                let (profile, flipped) = profile_to_nurbs(&curve, id)?;
+                Ok((
+                    StepSurface::Nurbs(NurbsSurface::extrusion(&profile, v)),
+                    flipped,
+                ))
+            }
+        }
+        _ => {
+            let (profile, flipped) = profile_to_nurbs(&curve, id)?;
+            Ok((
+                StepSurface::Nurbs(NurbsSurface::extrusion(&profile, v)),
+                flipped,
+            ))
+        }
+    }
+}
+
+/// Parse an OFFSET_SURFACE entity.
+///
+/// STEP syntax: `OFFSET_SURFACE(name, basis_surface, distance, self_intersect)`
+///
+/// The offset distance is measured along the basis surface's STEP normal.
+/// Analytic bases offset exactly via [`Surface::offset`] (a plane shifts its
+/// origin, cylinder/sphere change radius, a cone shifts its apex, a torus
+/// changes its minor radius). B-spline/NURBS bases fall back to a sampled
+/// B-spline fit of the offset points.
+fn parse_offset_surface(
+    file: &StepFile,
+    id: u64,
+    depth: usize,
+) -> Result<(StepSurface, bool), StepError> {
+    let entity = file.get(id).ok_or(StepError::MissingEntity(id))?;
+    if entity.type_name != "OFFSET_SURFACE" {
+        return Err(StepError::type_mismatch(
+            "OFFSET_SURFACE",
+            &entity.type_name,
+        ));
+    }
+    let basis_id = entity.entity_ref(1)?;
+    let distance = entity.real(2)?;
+    if !distance.is_finite() {
+        return Err(StepError::UnsupportedEntity(format!(
+            "OFFSET_SURFACE #{id}: non-finite offset distance"
+        )));
+    }
+    let (base, base_flipped) = parse_surface_inner(file, basis_id, depth + 1)?;
+    // The STEP distance is measured along the STEP basis normal; when our
+    // base surface's natural normal is flipped relative to it, negate.
+    let d = if base_flipped { -distance } else { distance };
+
+    match base {
+        StepSurface::BSpline(_) | StepSurface::Nurbs(_) => {
+            let boxed = base.into_box();
+            let fitted = fit_offset_surface(boxed.as_ref(), d, id)?;
+            Ok((StepSurface::BSpline(fitted), base_flipped))
+        }
+        analytic => {
+            let offset = analytic.into_box().offset(d).ok_or_else(|| {
+                StepError::UnsupportedEntity(format!(
+                    "OFFSET_SURFACE #{id}: offset by {distance} degenerates the base surface"
+                ))
+            })?;
+            let surface = StepSurface::from_box(offset).ok_or_else(|| {
+                StepError::UnsupportedEntity(format!(
+                    "OFFSET_SURFACE #{id}: unsupported offset result type"
+                ))
+            })?;
+            Ok((surface, base_flipped))
+        }
+    }
+}
+
+/// Approximate the offset of a surface with a bicubic B-spline fit.
+///
+/// Samples a grid of `base(u,v) + d·n(u,v)` points and uses them as control
+/// points of a clamped uniform bicubic patch. The control points are not
+/// interpolated, so this is an approximation — it is only used when the base
+/// has no exact analytic offset (B-spline/NURBS bases).
+fn fit_offset_surface(
+    base: &dyn Surface,
+    distance: f64,
+    id: u64,
+) -> Result<BSplineSurface, StepError> {
+    let ((u0, u1), (v0, v1)) = base.domain();
+    if !(u1 - u0).is_finite() || !(v1 - v0).is_finite() {
+        return Err(StepError::UnsupportedEntity(format!(
+            "OFFSET_SURFACE #{id}: base surface has an unbounded domain"
+        )));
+    }
+    let n = OFFSET_FIT_SAMPLES;
+    let mut pts = Vec::with_capacity((n + 1) * (n + 1));
+    for j in 0..=n {
+        let v = v0 + (v1 - v0) * j as f64 / n as f64;
+        for i in 0..=n {
+            let u = u0 + (u1 - u0) * i as f64 / n as f64;
+            let uv = vcad_kernel_math::Point2::new(u, v);
+            let p = base.evaluate(uv) + *base.normal(uv).as_ref() * distance;
+            if !p.x.is_finite() || !p.y.is_finite() || !p.z.is_finite() {
+                return Err(StepError::UnsupportedEntity(format!(
+                    "OFFSET_SURFACE #{id}: offset sampling produced non-finite points"
+                )));
+            }
+            pts.push(p);
+        }
+    }
+    let knots = clamped_uniform_knots(n + 1, 3);
+    Ok(BSplineSurface::new(
+        pts,
+        n + 1,
+        n + 1,
+        knots.clone(),
+        knots,
+        3,
+        3,
+    ))
+}
+
+/// Clamped uniform knot vector for `n_pts` control points at `degree`.
+fn clamped_uniform_knots(n_pts: usize, degree: usize) -> Vec<f64> {
+    let m = n_pts + degree + 1;
+    let mut knots = vec![0.0; m];
+    let n_internal = m - 2 * (degree + 1);
+    for i in 0..=degree {
+        knots[i] = 0.0;
+        knots[m - 1 - i] = 1.0;
+    }
+    for i in 1..=n_internal {
+        knots[degree + i] = i as f64 / (n_internal + 1) as f64;
+    }
+    knots
+}
+
+/// Convert a parsed STEP curve into a NURBS profile curve for sweeping,
+/// along with a flag that is `true` when the profile's parameter direction
+/// runs against the effective (sense-adjusted) traversal — in that case the
+/// swept surface's constructed normal is opposite the STEP normal.
+///
+/// Lines become degree-1 segments over their trim range (or one
+/// direction-vector length when untrimmed); circles become exact rational
+/// quadratics (full circle — the face's bounds trim it in 3D); B-splines
+/// convert with unit weights.
+fn profile_to_nurbs(curve: &StepCurve, id: u64) -> Result<(NurbsCurve, bool), StepError> {
+    let sense_flipped = curve_sense_sign(curve) < 0.0;
+    match curve.resolve() {
+        StepCurve::Line(line) => {
+            let len = line.direction.norm();
+            if len < 1e-12 {
+                return Err(StepError::UnsupportedEntity(format!(
+                    "swept surface #{id}: zero-length line direction"
+                )));
+            }
+            let (t0, t1) = match curve {
+                StepCurve::Trimmed(tc) => (tc.trim1, tc.trim2),
+                _ => (0.0, len),
+            };
+            let p0 = curve.evaluate(t0);
+            let p1 = curve.evaluate(t1);
+            if (p1 - p0).norm() < 1e-12 {
+                return Err(StepError::UnsupportedEntity(format!(
+                    "swept surface #{id}: degenerate line profile"
+                )));
+            }
+            let profile = NurbsCurve::new(
+                vec![WeightedPoint::unweighted(p0), WeightedPoint::unweighted(p1)],
+                vec![0.0, 0.0, 1.0, 1.0],
+                1,
+            );
+            // Direction is baked from the trim order, so no flip.
+            Ok((profile, false))
+        }
+        StepCurve::Circle(circle) => Ok((
+            NurbsCurve::circle_in_frame(circle.center, circle.x_dir, circle.y_dir, circle.radius),
+            sense_flipped,
+        )),
+        StepCurve::BSpline(bspline) => {
+            let profile = NurbsCurve::new(
+                bspline
+                    .control_points
+                    .iter()
+                    .map(|p| WeightedPoint::unweighted(*p))
+                    .collect(),
+                bspline.knots.clone(),
+                bspline.degree,
+            );
+            Ok((profile, sense_flipped))
+        }
+        // `resolve()` never returns a Trimmed variant.
+        StepCurve::Trimmed(_) => Err(StepError::UnsupportedEntity(format!(
+            "swept surface #{id}: unresolvable trimmed profile"
+        ))),
+    }
+}
+
+/// Tangent (direction of increasing parameter) of a STEP curve at `t`, in
+/// the effective traversal direction: trimmed-curve `sense_agreement = false`
+/// flips the sign relative to the basis parameterization.
+fn curve_tangent(curve: &StepCurve, t: f64) -> Vec3 {
+    match curve {
+        StepCurve::Line(line) => line.direction,
+        StepCurve::Circle(circle) => {
+            ((*circle.y_dir.as_ref()) * t.cos() - (*circle.x_dir.as_ref()) * t.sin())
+                * circle.radius
+        }
+        StepCurve::BSpline(bspline) => bspline.tangent(t),
+        StepCurve::Trimmed(tc) => {
+            let tangent = curve_tangent(&tc.basis, t);
+            if tc.sense_agreement {
+                tangent
+            } else {
+                -tangent
+            }
+        }
+    }
+}
+
+/// Product of `sense_agreement` signs through any trimmed-curve wrappers:
+/// -1.0 when the effective traversal runs against the basis parameterization.
+fn curve_sense_sign(curve: &StepCurve) -> f64 {
+    match curve {
+        StepCurve::Trimmed(tc) => {
+            (if tc.sense_agreement { 1.0 } else { -1.0 }) * curve_sense_sign(&tc.basis)
+        }
+        _ => 1.0,
+    }
+}
+
+/// Candidate parameter values on a curve for orientation sampling, in the
+/// curve's own (basis) parameterization. Trimmed curves sample inside the
+/// trim range, since that is where the face actually lies.
+fn curve_sample_ts(curve: &StepCurve) -> Vec<f64> {
+    use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI};
+    match curve {
+        StepCurve::Trimmed(tc) => {
+            let (t1, t2) = (tc.trim1, tc.trim2);
+            vec![
+                0.5 * (t1 + t2),
+                t1 + 0.75 * (t2 - t1),
+                t1 + 0.25 * (t2 - t1),
+            ]
+        }
+        StepCurve::Line(line) => {
+            let len = line.direction.norm().max(1.0);
+            vec![0.5 * len, len, -len, 2.0 * len]
+        }
+        StepCurve::Circle(_) => vec![FRAC_PI_4, FRAC_PI_2, 0.75 * PI],
+        StepCurve::BSpline(bspline) => {
+            let (t0, t1) = bspline.parameter_domain();
+            vec![
+                0.5 * (t0 + t1),
+                t0 + 0.75 * (t1 - t0),
+                t0 + 0.25 * (t1 - t0),
+            ]
+        }
+    }
+}
+
+/// Any unit vector perpendicular to `v` (for building reference frames).
+fn perpendicular_dir(v: Vec3) -> Vec3 {
+    let arbitrary = if v.x.abs() < 0.9 {
+        Vec3::x()
+    } else {
+        Vec3::y()
+    };
+    (arbitrary - v * arbitrary.dot(v)).normalize()
 }
 
 /// Create an AxisPlacement from a Plane for writing.
@@ -746,6 +1455,508 @@ END-ISO-10303-21;
         let sphere = parse_spherical_surface(&file, 5).unwrap();
         assert!((sphere.radius - 7.5).abs() < 1e-10);
         assert!((sphere.center.x - 1.0).abs() < 1e-10);
+    }
+
+    const FIXTURE_HEADER: &str = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n";
+    const FIXTURE_FOOTER: &str = "ENDSEC;\nEND-ISO-10303-21;\n";
+
+    fn fixture(body: &str) -> StepFile {
+        parse_step(&format!("{FIXTURE_HEADER}{body}{FIXTURE_FOOTER}"))
+    }
+
+    #[test]
+    fn test_revolution_of_parallel_line_is_cylinder() {
+        // Line at x=10 running along +Z, revolved about the Z axis.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_revolution(&file, 8).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Cylinder(c) => {
+                assert!((c.radius - 10.0).abs() < 1e-10);
+                assert!((c.axis.as_ref().z.abs() - 1.0).abs() < 1e-10);
+                assert!(c.center.x.abs() < 1e-10 && c.center.y.abs() < 1e-10);
+            }
+            other => panic!("expected cylinder, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_antiparallel_line_flips_sense() {
+        // Same cylinder but the line runs along -Z: the STEP normal points
+        // inward while CylinderSurface's normal is outward.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 20.0));
+#2 = DIRECTION('', (0.0, 0.0, -1.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_revolution(&file, 8).unwrap();
+        assert!(flipped, "anti-parallel line should flip the sense");
+        assert!(matches!(surface, StepSurface::Cylinder(_)));
+    }
+
+    #[test]
+    fn test_revolution_of_perpendicular_line_is_plane() {
+        // Radial line at height z=5 pointing outward (+X), revolved about Z.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (2.0, 0.0, 5.0));
+#2 = DIRECTION('', (1.0, 0.0, 0.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_revolution(&file, 8).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Plane(p) => {
+                assert!((p.origin.z - 5.0).abs() < 1e-10);
+                // Outward-pointing line → STEP normal is -axis.
+                assert!((p.normal_dir.as_ref().z + 1.0).abs() < 1e-10);
+            }
+            other => panic!("expected plane, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_intersecting_line_is_cone() {
+        // Line from (10,0,0) toward the apex at (0,0,20), revolved about Z.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = DIRECTION('', (-0.4472135954999579, 0.0, 0.8944271909999159));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, _flipped) = parse_surface_of_revolution(&file, 8).unwrap();
+        match surface {
+            StepSurface::Cone(c) => {
+                assert!(c.apex.x.abs() < 1e-8);
+                assert!((c.apex.z - 20.0).abs() < 1e-8);
+                // half-angle = atan(10/20)
+                assert!((c.half_angle - (0.5f64).atan()).abs() < 1e-8);
+            }
+            other => panic!("expected cone, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_skew_line_is_nurbs_hyperboloid() {
+        // Line offset from the axis and tilted: sweeps a hyperboloid of one
+        // sheet, which has no analytic type — expect the NURBS fallback.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 5.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.7071067811865476, 0.7071067811865476));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, _) = parse_surface_of_revolution(&file, 8).unwrap();
+        assert!(matches!(surface, StepSurface::Nurbs(_)));
+    }
+
+    #[test]
+    fn test_revolution_of_offset_circle_is_torus() {
+        // Circle r=3 centered at (10,0,0) in the XZ plane, revolved about Z.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, -1.0, 0.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CIRCLE('', #4, 3.0);
+#6 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#7 = DIRECTION('', (0.0, 0.0, 1.0));
+#8 = AXIS1_PLACEMENT('', #6, #7);
+#9 = SURFACE_OF_REVOLUTION('', #5, #8);
+",
+        );
+        let (surface, _) = parse_surface_of_revolution(&file, 9).unwrap();
+        match surface {
+            StepSurface::Torus(t) => {
+                assert!((t.major_radius - 10.0).abs() < 1e-10);
+                assert!((t.minor_radius - 3.0).abs() < 1e-10);
+                assert!(t.center.x.abs() < 1e-10 && t.center.z.abs() < 1e-10);
+            }
+            other => panic!("expected torus, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_centered_circle_is_sphere() {
+        // Circle r=7 centered on the Z axis in the XZ plane → sphere.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 4.0));
+#2 = DIRECTION('', (0.0, -1.0, 0.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CIRCLE('', #4, 7.0);
+#6 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#7 = DIRECTION('', (0.0, 0.0, 1.0));
+#8 = AXIS1_PLACEMENT('', #6, #7);
+#9 = SURFACE_OF_REVOLUTION('', #5, #8);
+",
+        );
+        let (surface, _) = parse_surface_of_revolution(&file, 9).unwrap();
+        match surface {
+            StepSurface::Sphere(s) => {
+                assert!((s.radius - 7.0).abs() < 1e-10);
+                assert!((s.center.z - 4.0).abs() < 1e-10);
+            }
+            other => panic!("expected sphere, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_revolution_of_bspline_profile_is_nurbs() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = CARTESIAN_POINT('', (12.0, 0.0, 10.0));
+#3 = CARTESIAN_POINT('', (10.0, 0.0, 20.0));
+#4 = B_SPLINE_CURVE_WITH_KNOTS('', 2, (#1, #2, #3),
+     .UNSPECIFIED., .F., .F.,
+     (3, 3), (0.0, 1.0), .UNSPECIFIED.);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_revolution(&file, 8).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Nurbs(n) => {
+                // u=0 slice must reproduce the profile: at v ends, radius 10
+                let p0 = n.eval(0.0, 0.0);
+                assert!((p0.x - 10.0).abs() < 1e-8 && p0.z.abs() < 1e-8);
+                let p1 = n.eval(0.0, 1.0);
+                assert!((p1.x - 10.0).abs() < 1e-8 && (p1.z - 20.0).abs() < 1e-8);
+                // Half a turn: profile start rotated to (-10, 0, 0)
+                let half = n.eval(std::f64::consts::PI, 0.0);
+                assert!((half.x + 10.0).abs() < 1e-8, "x at half turn: {}", half.x);
+            }
+            other => panic!("expected NURBS, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extrusion_of_line_is_plane() {
+        // Line along X extruded along Z → XZ-ish plane with normal -Y
+        // (d × v = X × Z = -Y).
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 3.0, 0.0));
+#2 = DIRECTION('', (1.0, 0.0, 0.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = DIRECTION('', (0.0, 0.0, 1.0));
+#6 = VECTOR('', #5, 15.0);
+#7 = SURFACE_OF_LINEAR_EXTRUSION('', #4, #6);
+",
+        );
+        let (surface, flipped) = parse_surface_of_linear_extrusion(&file, 7).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Plane(p) => {
+                assert!((p.origin.y - 3.0).abs() < 1e-10);
+                assert!((p.normal_dir.as_ref().y + 1.0).abs() < 1e-10);
+            }
+            other => panic!("expected plane, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extrusion_of_circle_is_cylinder() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (1.0, 2.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CIRCLE('', #4, 6.0);
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = VECTOR('', #6, 30.0);
+#8 = SURFACE_OF_LINEAR_EXTRUSION('', #5, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_linear_extrusion(&file, 8).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Cylinder(c) => {
+                assert!((c.radius - 6.0).abs() < 1e-10);
+                assert!((c.center.x - 1.0).abs() < 1e-10);
+                assert!((c.axis.as_ref().z - 1.0).abs() < 1e-10);
+            }
+            other => panic!("expected cylinder, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extrusion_of_circle_against_normal_flips_sense() {
+        // Extruding a CCW circle against its normal flips the STEP normal
+        // inward.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 10.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CIRCLE('', #4, 6.0);
+#6 = DIRECTION('', (0.0, 0.0, -1.0));
+#7 = VECTOR('', #6, 10.0);
+#8 = SURFACE_OF_LINEAR_EXTRUSION('', #5, #7);
+",
+        );
+        let (surface, flipped) = parse_surface_of_linear_extrusion(&file, 8).unwrap();
+        assert!(flipped);
+        assert!(matches!(surface, StepSurface::Cylinder(_)));
+    }
+
+    #[test]
+    fn test_extrusion_of_tilted_circle_is_nurbs() {
+        // Circle extruded obliquely (not along its normal) → oblique
+        // cylinder, no analytic type.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CIRCLE('', #4, 6.0);
+#6 = DIRECTION('', (0.7071067811865476, 0.0, 0.7071067811865476));
+#7 = VECTOR('', #6, 10.0);
+#8 = SURFACE_OF_LINEAR_EXTRUSION('', #5, #7);
+",
+        );
+        let (surface, _) = parse_surface_of_linear_extrusion(&file, 8).unwrap();
+        match surface {
+            StepSurface::Nurbs(n) => {
+                // v=0 edge is the base circle; v=1 is translated by the vector
+                let p0 = n.eval(0.0, 0.0);
+                assert!((p0.x - 6.0).abs() < 1e-8 && p0.z.abs() < 1e-8);
+                let p1 = n.eval(0.0, 1.0);
+                let shift = 10.0 * std::f64::consts::FRAC_1_SQRT_2;
+                assert!((p1.x - 6.0 - shift).abs() < 1e-8);
+                assert!((p1.z - shift).abs() < 1e-8);
+            }
+            other => panic!("expected NURBS, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_extrusion_of_bspline_is_nurbs() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = CARTESIAN_POINT('', (5.0, 8.0, 0.0));
+#3 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#4 = B_SPLINE_CURVE_WITH_KNOTS('', 2, (#1, #2, #3),
+     .UNSPECIFIED., .F., .F.,
+     (3, 3), (0.0, 1.0), .UNSPECIFIED.);
+#5 = DIRECTION('', (0.0, 0.0, 1.0));
+#6 = VECTOR('', #5, 20.0);
+#7 = SURFACE_OF_LINEAR_EXTRUSION('', #4, #6);
+",
+        );
+        let (surface, _) = parse_surface_of_linear_extrusion(&file, 7).unwrap();
+        match surface {
+            StepSurface::Nurbs(n) => {
+                let p0 = n.eval(0.0, 0.0);
+                assert!(p0.x.abs() < 1e-8 && p0.z.abs() < 1e-8);
+                let p1 = n.eval(1.0, 1.0);
+                assert!((p1.x - 10.0).abs() < 1e-8 && (p1.z - 20.0).abs() < 1e-8);
+            }
+            other => panic!("expected NURBS, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_of_cylinder_grows_radius() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CYLINDRICAL_SURFACE('', #4, 8.0);
+#6 = OFFSET_SURFACE('', #5, 2.0, .F.);
+",
+        );
+        let (surface, flipped) = parse_surface_oriented(&file, 6).unwrap();
+        assert!(!flipped);
+        match surface {
+            StepSurface::Cylinder(c) => assert!((c.radius - 10.0).abs() < 1e-10),
+            other => panic!("expected cylinder, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_of_plane_shifts_origin() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 5.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = PLANE('', #4);
+#6 = OFFSET_SURFACE('', #5, -3.0, .F.);
+",
+        );
+        let (surface, _) = parse_surface_oriented(&file, 6).unwrap();
+        match surface {
+            StepSurface::Plane(p) => assert!((p.origin.z - 2.0).abs() < 1e-10),
+            other => panic!("expected plane, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_of_sphere_and_torus() {
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = SPHERICAL_SURFACE('', #4, 5.0);
+#6 = OFFSET_SURFACE('', #5, 1.5, .F.);
+#7 = TOROIDAL_SURFACE('', #4, 10.0, 3.0);
+#8 = OFFSET_SURFACE('', #7, -1.0, .F.);
+",
+        );
+        let (sphere, _) = parse_surface_oriented(&file, 6).unwrap();
+        match sphere {
+            StepSurface::Sphere(s) => assert!((s.radius - 6.5).abs() < 1e-10),
+            other => panic!("expected sphere, got {:?}", other),
+        }
+        let (torus, _) = parse_surface_oriented(&file, 8).unwrap();
+        match torus {
+            StepSurface::Torus(t) => {
+                assert!((t.major_radius - 10.0).abs() < 1e-10);
+                assert!((t.minor_radius - 2.0).abs() < 1e-10);
+            }
+            other => panic!("expected torus, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_degenerate_is_unsupported() {
+        // Offsetting a radius-8 cylinder inward by 8 collapses it.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = DIRECTION('', (1.0, 0.0, 0.0));
+#4 = AXIS2_PLACEMENT_3D('', #1, #2, #3);
+#5 = CYLINDRICAL_SURFACE('', #4, 8.0);
+#6 = OFFSET_SURFACE('', #5, -8.0, .F.);
+",
+        );
+        assert!(matches!(
+            parse_surface_oriented(&file, 6),
+            Err(StepError::UnsupportedEntity(_))
+        ));
+    }
+
+    #[test]
+    fn test_offset_of_flipped_swept_base_negates_distance() {
+        // Base: revolution of an anti-parallel line → cylinder r=10 with a
+        // flipped sense (STEP normal points inward). An offset of +2 along
+        // the STEP normal must therefore SHRINK the radius to 8.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 20.0));
+#2 = DIRECTION('', (0.0, 0.0, -1.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+#9 = OFFSET_SURFACE('', #8, 2.0, .F.);
+",
+        );
+        let (surface, flipped) = parse_surface_oriented(&file, 9).unwrap();
+        assert!(flipped, "offset inherits the base's flipped sense");
+        match surface {
+            StepSurface::Cylinder(c) => assert!((c.radius - 8.0).abs() < 1e-10),
+            other => panic!("expected cylinder, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_of_bspline_fits_nurbs() {
+        // A flat bilinear B-spline patch at z=0 offset by 2 should sit at
+        // z≈2 everywhere (flat base → the fit is exact up to fp error).
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#2 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#3 = CARTESIAN_POINT('', (0.0, 10.0, 0.0));
+#4 = CARTESIAN_POINT('', (10.0, 10.0, 0.0));
+#5 = B_SPLINE_SURFACE_WITH_KNOTS('', 1, 1, ((#1, #2), (#3, #4)),
+     .UNSPECIFIED., .F., .F., .F.,
+     (2, 2), (2, 2), (0.0, 1.0), (0.0, 1.0), .UNSPECIFIED.);
+#6 = OFFSET_SURFACE('', #5, 2.0, .F.);
+",
+        );
+        let (surface, _) = parse_surface_oriented(&file, 6).unwrap();
+        match surface {
+            StepSurface::BSpline(b) => {
+                use vcad_kernel_geom::Surface as _;
+                let ((u0, u1), (v0, v1)) = b.domain();
+                for i in 0..=8 {
+                    for j in 0..=8 {
+                        let u = u0 + (u1 - u0) * i as f64 / 8.0;
+                        let v = v0 + (v1 - v0) * j as f64 / 8.0;
+                        let p = b.eval(u, v);
+                        assert!((p.z - 2.0).abs() < 1e-8, "z at ({u},{v}): {}", p.z);
+                    }
+                }
+            }
+            other => panic!("expected B-spline fit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_offset_surface_cycle_is_rejected() {
+        // Self-referential offset must hit the depth cap, not recurse forever.
+        let file = fixture("#1 = OFFSET_SURFACE('', #1, 2.0, .F.);\n");
+        assert!(matches!(
+            parse_surface_oriented(&file, 1),
+            Err(StepError::UnsupportedEntity(_))
+        ));
+    }
+
+    #[test]
+    fn test_parse_surface_dispatches_new_types() {
+        // The untyped entry point must route the new entities too.
+        let file = fixture(
+            "#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = DIRECTION('', (0.0, 0.0, 1.0));
+#3 = VECTOR('', #2, 1.0);
+#4 = LINE('', #1, #3);
+#5 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#6 = DIRECTION('', (0.0, 0.0, 1.0));
+#7 = AXIS1_PLACEMENT('', #5, #6);
+#8 = SURFACE_OF_REVOLUTION('', #4, #7);
+",
+        );
+        let surface = parse_surface(&file, 8).unwrap();
+        assert!(matches!(surface, StepSurface::Cylinder(_)));
     }
 
     #[test]

--- a/crates/vcad-kernel-step/src/reader.rs
+++ b/crates/vcad-kernel-step/src/reader.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use crate::entities::{
     curves::{parse_curve, StepCurve},
     parse_advanced_face, parse_edge_curve, parse_edge_loop, parse_manifold_solid_brep,
-    parse_oriented_edge, parse_shell, parse_surface, parse_vertex_point,
+    parse_oriented_edge, parse_shell, parse_surface_oriented, parse_vertex_point,
 };
 use crate::error::StepError;
 use stepperoni::{Parser, StepFile};
@@ -104,8 +104,10 @@ pub(crate) struct StepReader<'a> {
     edge_map: HashMap<u64, EdgeId>,
     /// Maps (STEP edge ID, orientation) to vcad HalfEdgeId.
     half_edge_map: HashMap<(u64, bool), HalfEdgeId>,
-    /// Maps STEP surface ID to vcad geometry store index.
-    surface_map: HashMap<u64, usize>,
+    /// Maps STEP surface ID to vcad geometry store index, plus a flag that
+    /// is true when the stored surface's natural normal is flipped relative
+    /// to the STEP surface normal (see `parse_surface_oriented`).
+    surface_map: HashMap<u64, (usize, bool)>,
     /// For subdivided curved edges: maps (STEP edge ID, orientation) to
     /// an ordered chain of half-edge IDs that replace the single original.
     subdivided_edges: HashMap<(u64, bool), Vec<HalfEdgeId>>,
@@ -172,10 +174,11 @@ impl<'a> StepReader<'a> {
 
             // Parse and store surface - skip face if surface type unsupported
             if !self.surface_map.contains_key(&step_face.surface_id) {
-                match parse_surface(self.file, step_face.surface_id) {
-                    Ok(surface) => {
+                match parse_surface_oriented(self.file, step_face.surface_id) {
+                    Ok((surface, sense_flipped)) => {
                         let idx = geom.add_surface(surface.into_box());
-                        self.surface_map.insert(step_face.surface_id, idx);
+                        self.surface_map
+                            .insert(step_face.surface_id, (idx, sense_flipped));
                     }
                     Err(StepError::UnsupportedEntity(_)) => {
                         // Skip this face - surface type not supported
@@ -294,7 +297,7 @@ impl<'a> StepReader<'a> {
                 continue;
             }
             let step_face = parse_advanced_face(self.file, face_id)?;
-            let surface_idx = self.surface_map[&step_face.surface_id];
+            let (surface_idx, sense_flipped) = self.surface_map[&step_face.surface_id];
 
             let mut outer_loop: Option<LoopId> = None;
             let mut inner_loops = Vec::new();
@@ -353,7 +356,10 @@ impl<'a> StepReader<'a> {
                 None => continue,
             };
 
-            let orientation = if step_face.same_sense {
+            // `same_sense` is expressed against the STEP surface normal;
+            // XOR with the parse-time flag when our surface's natural
+            // normal points the other way.
+            let orientation = if step_face.same_sense != sense_flipped {
                 Orientation::Forward
             } else {
                 Orientation::Reversed

--- a/crates/vcad-kernel-step/tests/extended_surfaces.rs
+++ b/crates/vcad-kernel-step/tests/extended_surfaces.rs
@@ -1,0 +1,251 @@
+//! End-to-end import of the extended surface entities that real
+//! SolidWorks/Fusion/Catia exports rely on: SURFACE_OF_REVOLUTION,
+//! SURFACE_OF_LINEAR_EXTRUSION, and OFFSET_SURFACE.
+//!
+//! Each fixture is a complete hand-written solid whose lateral face uses one
+//! of the new entities. Before these were supported, the reader silently
+//! skipped the face and the imported solid came back with a hole in it.
+//! The tests check the full pipeline: import → solid → tessellate, with a
+//! sane mesh volume and bounding box.
+
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_step::read_step_from_buffer;
+use vcad_kernel_tessellate::{tessellate_brep, tessellate_solid, TessellationParams, TriangleMesh};
+
+/// A closed cylinder-shaped solid (r=10, h=20, axis Z): two planar caps and
+/// one lateral face whose surface is substituted per fixture. The seam edge
+/// curve is substituted alongside it (`<SEAM>`), since the vase fixture
+/// sweeps a B-spline profile that doubles as its seam edge.
+const CYLINDER_TEMPLATE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''), '2;1');
+FILE_NAME('fixture.step', '2024-01-01', (''), (''), '', '', '');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));
+ENDSEC;
+DATA;
+/* seam vertices */
+#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = CARTESIAN_POINT('', (10.0, 0.0, 20.0));
+#3 = VERTEX_POINT('', #1);
+#4 = VERTEX_POINT('', #2);
+
+/* rim circles */
+#10 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#11 = DIRECTION('', (0.0, 0.0, 1.0));
+#12 = DIRECTION('', (1.0, 0.0, 0.0));
+#13 = AXIS2_PLACEMENT_3D('', #10, #11, #12);
+#14 = CIRCLE('', #13, 10.0);
+#15 = CARTESIAN_POINT('', (0.0, 0.0, 20.0));
+#16 = AXIS2_PLACEMENT_3D('', #15, #11, #12);
+#17 = CIRCLE('', #16, 10.0);
+
+/* seam line */
+#18 = VECTOR('', #11, 20.0);
+#19 = LINE('', #1, #18);
+
+/* edges */
+#20 = EDGE_CURVE('', #3, #3, #14, .T.);
+#21 = EDGE_CURVE('', #4, #4, #17, .T.);
+#22 = EDGE_CURVE('', #3, #4, <SEAM>, .T.);
+
+/* lateral face: bottom rim, up the seam, top rim reversed, down the seam */
+#23 = ORIENTED_EDGE('', *, *, #20, .T.);
+#24 = ORIENTED_EDGE('', *, *, #22, .T.);
+#25 = ORIENTED_EDGE('', *, *, #21, .F.);
+#26 = ORIENTED_EDGE('', *, *, #22, .F.);
+#27 = EDGE_LOOP('', (#23, #24, #25, #26));
+#28 = FACE_OUTER_BOUND('', #27, .T.);
+#29 = ADVANCED_FACE('', (#28), #40, .T.);
+
+/* bottom cap (normal -Z) */
+#30 = DIRECTION('', (0.0, 0.0, -1.0));
+#31 = AXIS2_PLACEMENT_3D('', #10, #30, #12);
+#32 = PLANE('', #31);
+#33 = ORIENTED_EDGE('', *, *, #20, .F.);
+#34 = EDGE_LOOP('', (#33));
+#35 = FACE_OUTER_BOUND('', #34, .T.);
+#36 = ADVANCED_FACE('', (#35), #32, .T.);
+
+/* top cap (normal +Z) */
+#37 = AXIS2_PLACEMENT_3D('', #15, #11, #12);
+#38 = PLANE('', #37);
+#39 = ORIENTED_EDGE('', *, *, #21, .T.);
+#41 = EDGE_LOOP('', (#39));
+#42 = FACE_OUTER_BOUND('', #41, .T.);
+#43 = ADVANCED_FACE('', (#42), #38, .T.);
+
+/* lateral surface (fixture-specific, defines #40) */
+<LATERAL>
+
+#44 = CLOSED_SHELL('', (#29, #36, #43));
+#45 = MANIFOLD_SOLID_BREP('part', #44);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn build_fixture(seam_curve: &str, lateral: &str) -> String {
+    CYLINDER_TEMPLATE
+        .replace("<SEAM>", seam_curve)
+        .replace("<LATERAL>", lateral)
+}
+
+/// Signed mesh volume via the divergence theorem.
+fn mesh_volume(mesh: &TriangleMesh) -> f64 {
+    let pt = |i: u32| {
+        let i = i as usize * 3;
+        [
+            mesh.vertices[i] as f64,
+            mesh.vertices[i + 1] as f64,
+            mesh.vertices[i + 2] as f64,
+        ]
+    };
+    let mut vol = 0.0;
+    for tri in mesh.indices.chunks(3) {
+        let a = pt(tri[0]);
+        let b = pt(tri[1]);
+        let c = pt(tri[2]);
+        vol += a[0] * (b[1] * c[2] - b[2] * c[1])
+            + a[1] * (b[2] * c[0] - b[0] * c[2])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]);
+    }
+    vol / 6.0
+}
+
+/// Axis-aligned bounding box of a mesh as (min, max).
+fn mesh_bbox(mesh: &TriangleMesh) -> ([f64; 3], [f64; 3]) {
+    let mut min = [f64::MAX; 3];
+    let mut max = [f64::MIN; 3];
+    for v in mesh.vertices.chunks(3) {
+        for k in 0..3 {
+            min[k] = min[k].min(v[k] as f64);
+            max[k] = max[k].max(v[k] as f64);
+        }
+    }
+    (min, max)
+}
+
+/// Import the fixture and require all 3 faces to survive (no silent skips).
+fn import_solid(step_text: &str) -> BRepSolid {
+    let mut solids = read_step_from_buffer(step_text.as_bytes()).expect("import should succeed");
+    assert_eq!(solids.len(), 1);
+    let solid = solids.remove(0);
+    assert_eq!(
+        solid.topology.faces.len(),
+        3,
+        "no face may be skipped as unsupported"
+    );
+    solid
+}
+
+/// Tessellate through the app path (`tessellate_brep` is what the facade
+/// crate's `to_mesh` uses) — appropriate for analytic surfaces.
+fn app_mesh(solid: &BRepSolid) -> TriangleMesh {
+    let mesh = tessellate_brep(solid, 32);
+    assert!(
+        mesh.num_triangles() > 0,
+        "tessellation produced no triangles"
+    );
+    mesh
+}
+
+fn assert_cylinder_metrics(mesh: &TriangleMesh) {
+    // Ideal cylinder: V = π r² h with r=10, h=20. Rim circles are sampled
+    // polygons, so allow the volume to come in under the analytic value.
+    let ideal = std::f64::consts::PI * 100.0 * 20.0;
+    let vol = mesh_volume(mesh);
+    assert!(
+        vol > 0.85 * ideal && vol < 1.02 * ideal,
+        "volume {vol} not within tolerance of ideal {ideal}"
+    );
+    let (min, max) = mesh_bbox(mesh);
+    for k in 0..2 {
+        assert!(
+            (-10.5..=-9.0).contains(&min[k]),
+            "bbox min[{k}] = {}",
+            min[k]
+        );
+        assert!((9.0..=10.5).contains(&max[k]), "bbox max[{k}] = {}", max[k]);
+    }
+    assert!(min[2].abs() < 1e-3, "bbox z min = {}", min[2]);
+    assert!((max[2] - 20.0).abs() < 1e-3, "bbox z max = {}", max[2]);
+}
+
+#[test]
+fn import_surface_of_revolution_cylinder() {
+    // Lateral face: the seam line (parallel to the axis) revolved about Z.
+    // Must map to an analytic cylinder and import as a closed solid.
+    let step = build_fixture(
+        "#19",
+        "#46 = AXIS1_PLACEMENT('', #10, #11);
+#40 = SURFACE_OF_REVOLUTION('', #19, #46);",
+    );
+    let mesh = app_mesh(&import_solid(&step));
+    assert_cylinder_metrics(&mesh);
+}
+
+#[test]
+fn import_surface_of_linear_extrusion_cylinder() {
+    // Lateral face: the bottom rim circle extruded 20mm along +Z.
+    let step = build_fixture("#19", "#40 = SURFACE_OF_LINEAR_EXTRUSION('', #14, #18);");
+    let mesh = app_mesh(&import_solid(&step));
+    assert_cylinder_metrics(&mesh);
+}
+
+#[test]
+fn import_offset_surface_cylinder() {
+    // Lateral face: a radius-8 cylindrical surface offset outward by 2mm.
+    let step = build_fixture(
+        "#19",
+        "#46 = CYLINDRICAL_SURFACE('', #13, 8.0);
+#40 = OFFSET_SURFACE('', #46, 2.0, .F.);",
+    );
+    let mesh = app_mesh(&import_solid(&step));
+    assert_cylinder_metrics(&mesh);
+}
+
+#[test]
+fn import_surface_of_revolution_bspline_vase() {
+    // Lateral face: a quadratic B-spline profile (bulging from r=10 to r=12
+    // at mid-height) revolved about Z — exercises the exact rational NURBS
+    // revolution fallback end to end. The profile doubles as the seam edge.
+    let lateral = "#50 = CARTESIAN_POINT('', (12.0, 0.0, 10.0));
+#51 = B_SPLINE_CURVE_WITH_KNOTS('', 2, (#1, #50, #2),
+     .UNSPECIFIED., .F., .F.,
+     (3, 3), (0.0, 1.0), .UNSPECIFIED.);
+#52 = AXIS1_PLACEMENT('', #10, #11);
+#40 = SURFACE_OF_REVOLUTION('', #51, #52);";
+    let step = build_fixture("#51", lateral);
+    let solid = import_solid(&step);
+    // Use the per-face-faithful path: `tessellate_solid` evaluates B-spline
+    // faces on the surface itself (`tessellate_brep`, the display path,
+    // still flattens B-spline faces to their boundary loop — a pre-existing
+    // limitation that applies to all imported B-spline surfaces alike).
+    let mesh = tessellate_solid(&solid, &TessellationParams::from_segments(32));
+    assert!(mesh.num_triangles() > 0);
+
+    // Exact solid of revolution: V = π ∫ r(z)² dz with
+    // r(t) = 10 + 4t(1-t), z = 20t  →  V = π·20·(100 + 80/6 + 16/30)
+    let ideal = std::f64::consts::PI * 20.0 * (100.0 + 80.0 / 6.0 + 16.0 / 30.0);
+    let vol = mesh_volume(&mesh);
+    assert!(
+        vol > 0.85 * ideal && vol < 1.03 * ideal,
+        "volume {vol} not within tolerance of ideal {ideal}"
+    );
+
+    let (min, max) = mesh_bbox(&mesh);
+    // Max radius 11 at mid-height.
+    for k in 0..2 {
+        assert!(
+            (-11.5..=-10.0).contains(&min[k]),
+            "bbox min[{k}] = {}",
+            min[k]
+        );
+        assert!(
+            (10.0..=11.5).contains(&max[k]),
+            "bbox max[{k}] = {}",
+            max[k]
+        );
+    }
+    assert!(min[2].abs() < 1e-3, "bbox z min = {}", min[2]);
+    assert!((max[2] - 20.0).abs() < 1e-3, "bbox z max = {}", max[2]);
+}


### PR DESCRIPTION
## Summary

Add comprehensive support for three swept/offset surface entities in STEP import: `SURFACE_OF_REVOLUTION`, `SURFACE_OF_LINEAR_EXTRUSION`, and `OFFSET_SURFACE`. These are commonly used by CAD systems (SolidWorks, Fusion, Catia) to represent lateral faces of revolved and extruded features. Previously, the reader silently skipped these entities, resulting in incomplete solids with missing faces.

## Key Changes

**Surface parsing (`vcad-kernel-step/src/entities/surfaces.rs`):**
- Refactored `parse_surface()` → `parse_surface_oriented()` to return both the surface and a normal-orientation flag. This flag indicates when the surface's natural normal is opposite the STEP `∂u × ∂v` normal (e.g., a cylinder swept from an anti-parallel line). Callers that consume `ADVANCED_FACE.same_sense` XOR this flag to get the correct face orientation.
- Added `StepSurface::Nurbs` variant for rational NURBS surfaces produced by swept surfaces with no analytic equivalent.
- Implemented `parse_surface_of_revolution()` with analytic special cases:
  - Line parallel to axis → `CylinderSurface`
  - Line perpendicular to axis → `Plane`
  - Line intersecting axis obliquely → `ConeSurface`
  - Circle coplanar with axis, centered on it → `SphereSurface`
  - Circle coplanar with axis, off-axis → `TorusSurface`
  - Everything else → exact rational NURBS surface of revolution
- Implemented `parse_surface_of_linear_extrusion()` with analytic special cases:
  - Line → `Plane`
  - Circle extruded along its normal → `CylinderSurface`
  - Everything else → exact NURBS extrusion surface
- Implemented `parse_offset_surface()` with recursion depth guard (max 8 levels) to prevent infinite loops from reference cycles in malicious files. Analytic bases offset exactly via `Surface::offset()`; B-spline/NURBS bases fall back to a sampled bicubic B-spline fit.
- Added helper functions for orientation classification: `revolve_line()`, `revolve_circle()`, `revolved_circle_flipped()`, `revolution_step_normal()`, `profile_to_nurbs()`, `curve_tangent()`, `curve_sense_sign()`, `curve_sample_ts()`, `perpendicular_dir()`, `fit_offset_surface()`, `clamped_uniform_knots()`.
- Added tolerance constants: `DIR_EPS` (1e-9) for direction classification, `POS_EPS` (1e-8) for positional coincidence.

**NURBS surface construction (`vcad-kernel-nurbs/src/lib.rs`):**
- Added `NurbsCurve::circle_in_frame()` to construct exact rational quadratic circles in arbitrary planes (used as profiles for swept surfaces).
- Added `NurbsSurface::revolution()` using the standard 9-control-point rational quadratic circle construction (Piegl & Tiller, *The NURBS Book*, §8.3). Each profile control point sweeps into 9 weighted points around the axis, reproducing the surface of revolution exactly. Parameter `u` is sweep angle `[0, 2π]`, `v` is profile parameter.
- Added `NurbsSurface::extrusion()` for translational sweep surfaces. Parameter `u` is profile parameter, `v ∈ [0, 1]` sweeps from profile to `profile + direction`.

**Reader integration (`vcad-kernel-step/src/reader.rs`):**
- Updated to use `parse_surface_oriented()` and XOR the returned normal-orientation flag with `ADVANCED_FACE.same_sense` to correctly orient faces.

**Tests:**
- Added comprehensive unit tests in `surfaces.rs` covering revolution of parallel/anti-parallel lines, perpendicular lines, oblique lines, circles on/off axis, and offset surfaces.
- Added end-

https://claude.ai/code/session_01Py42X5jefBiHWH5AeLGEZi