### PR TITLE
feat(app): first-run template gallery + activation funnel telemetry

### DIFF
--- a/changelog/entries/2026-07-07-first-run-template-gallery.json
+++ b/changelog/entries/2026-07-07-first-run-template-gallery.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-07-first-run-template-gallery",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "First visit opens the template gallery",
+  "summary": "First-time visitors now land on the example gallery instead of a blank canvas — one click opens a real, editable part. Returning users with documents go straight to their work.",
+  "features": ["onboarding", "examples", "app"]
+}

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -333,7 +333,12 @@ export function App() {
   const statusBarVisible = useUiStore((s) => s.statusBarVisible);
   const selPart = selIds.size === 1 ? partIndex.get(Array.from(selIds)[0]!) : undefined;
   const hasSelectedEmbroideryPart = selPart != null && isEmbroideryPatternPart(selPart);
+  // First-run template gallery: only surfaces when boot found no existing
+  // document (fresh profile). Once the user has any saved document, boot
+  // resolves to it and the gallery never shows again.
+  const firstVisit = useBootStore((s) => s.firstVisit);
   const showOnboarding =
+    firstVisit &&
     !welcomeModalDismissed &&
     !welcomeHiddenThisSession &&
     parts.length === 0 &&

--- a/packages/app/src/components/CommandPalette.tsx
+++ b/packages/app/src/components/CommandPalette.tsx
@@ -44,6 +44,7 @@ import { useLocaleStore } from "@/stores/locale-store";
 import { useAppCommands } from "@/hooks/useAppCommands";
 import { cn } from "@/lib/utils";
 import { examples, exampleToVcadFile, type Example } from "@/data/examples";
+import { analytics } from "@/lib/analytics";
 
 const ICONS: Record<string, typeof Cube> = {
   Cube,
@@ -339,6 +340,7 @@ export function CommandPalette({ open, onOpenChange, onAboutOpen }: CommandPalet
   // quadruped) get routed through the global event handler in App.tsx,
   // which knows how to call the engine's URDF importer.
   const handleOpenExample = useCallback((example: Example) => {
+    analytics.templateOpened(example.id);
     if (example.urdf) {
       window.dispatchEvent(
         new CustomEvent("vcad:load-example", { detail: { urdf: example.urdf } }),

--- a/packages/app/src/components/DocTitle.tsx
+++ b/packages/app/src/components/DocTitle.tsx
@@ -18,6 +18,7 @@ import { useElectronicsStore } from "@/stores/electronics-store";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { invoke, isTauri } from "@/lib/tauri";
+import { analytics } from "@/lib/analytics";
 import { useCapabilities } from "@/lib/capabilities";
 
 /**
@@ -288,7 +289,13 @@ export function DocTitle({ macOverlay }: { macOverlay?: boolean }) {
 
       {/* Scope breadcrumb — only shows when out of doc root */}
       {sketchActive && (
-        <ScopeCrumb onExit={() => requestSketchExit()}>
+        <ScopeCrumb
+          onExit={() => {
+            // Immediate exit only happens for an empty sketch; with segments
+            // the confirmation in FeatureTree fires the abandon event instead.
+            if (requestSketchExit()) analytics.sketchAbandoned("empty");
+          }}
+        >
           Sketch <span className="text-text-muted">on</span>{" "}
           {getSketchPlaneName(sketchPlane)}
         </ScopeCrumb>

--- a/packages/app/src/components/FaceSelectionOverlay.tsx
+++ b/packages/app/src/components/FaceSelectionOverlay.tsx
@@ -2,6 +2,7 @@ import { useSketchStore, useDocumentStore } from "@vcad/core";
 import { Crosshair } from "@phosphor-icons/react/dist/ssr/Crosshair";
 import { X } from "@phosphor-icons/react/dist/ssr/X";
 import { Button } from "@/components/ui/button";
+import { analytics } from "@/lib/analytics";
 
 export function FaceSelectionOverlay() {
   const faceSelectionMode = useSketchStore((s) => s.faceSelectionMode);
@@ -40,7 +41,10 @@ export function FaceSelectionOverlay() {
           <Button
             variant="ghost"
             size="icon-sm"
-            onClick={cancelFaceSelection}
+            onClick={() => {
+              cancelFaceSelection();
+              analytics.sketchAbandoned("face_selection");
+            }}
           >
             <X size={16} />
           </Button>

--- a/packages/app/src/components/FeatureTree.tsx
+++ b/packages/app/src/components/FeatureTree.tsx
@@ -58,6 +58,7 @@ import { useEmbroideryStore } from "@/stores/embroidery-store";
 import type { PrimitiveKind, PartInfo, BooleanPartInfo, PrimitivePartInfo, SweepPartInfo, ExtrudePartInfo, RevolvePartInfo, FilletPartInfo, ChamferPartInfo, ShellPartInfo } from "@vcad/core";
 import type { PartInstance, Joint, JointKind } from "@vcad/ir";
 import { cn } from "@/lib/utils";
+import { analytics } from "@/lib/analytics";
 import { MoleculeTreeSection } from "./MoleculeTree";
 import { getPartSummary } from "./tree/part-summary";
 import { InlineCubeDimensions, InlineCylinderDimensions, InlineSphereDimensions, InlineExtrudeDimensions, InlineRevolveDimensions, InlineFilletDimensions, InlineChamferDimensions, InlineShellDimensions, InlineSweepProperties } from "./tree/InlineDimensions";
@@ -199,7 +200,10 @@ function SketchTreeSection() {
           type="button"
           onClick={() => {
             const exited = requestExit();
-            if (exited) addToast(t("tree.sketch.cancelled"), "info");
+            if (exited) {
+              analytics.sketchAbandoned("empty");
+              addToast(t("tree.sketch.cancelled"), "info");
+            }
           }}
           className="px-2 py-1 text-xs text-text-muted hover:text-text hover:bg-hover/60"
           title={t("tree.sketch.cancel_tooltip")}
@@ -222,6 +226,7 @@ function SketchTreeSection() {
               type="button"
               onClick={() => {
                 confirmExit();
+                analytics.sketchAbandoned("discarded");
                 addToast(t("tree.sketch.discarded"), "info");
               }}
               className="flex-1 rounded-md px-2 py-1.5 text-xs font-medium bg-red-600 hover:bg-red-700 text-white transition-colors"

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -31,6 +31,7 @@ import { UpgradeModal } from "@/components/UpgradeModal";
 import { cn } from "@/lib/utils";
 import { downloadBlob } from "@/lib/download";
 import { examples } from "@/data/examples";
+import { analytics } from "@/lib/analytics";
 import { SignInButton, UserMenu, triggerSync, useAuthStore } from "@vcad/auth";
 import { useChangelogStore } from "@/stores/changelog-store";
 import { useNotificationStore } from "@/stores/notification-store";
@@ -436,6 +437,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
       useNotificationStore.getState().addToast("Nothing to export", "info");
       return;
     }
+    analytics.exportStarted(format);
     try {
       const blob = await runJob(
         { verb: `Exporting ${format.toUpperCase()}` },
@@ -445,6 +447,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
           : exportStepBlob(scene),
       );
       downloadBlob(blob, `model.${format}`);
+      analytics.exportCompleted(format);
     } catch (err) {
       useNotificationStore
         .getState()
@@ -459,6 +462,7 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
   // bundle (e.g. Unitree G1 / Go2) that the loader pipes through the
   // engine's URDF importer.
   const handleLoadExampleEntry = (ex: (typeof examples)[number]) => {
+    analytics.templateOpened(ex.id);
     if (ex.urdf) {
       window.dispatchEvent(
         new CustomEvent("vcad:load-example", { detail: { urdf: ex.urdf } }),

--- a/packages/app/src/components/InlineOnboarding.tsx
+++ b/packages/app/src/components/InlineOnboarding.tsx
@@ -21,6 +21,7 @@ import { useOnboardingStore } from "@/stores/onboarding-store";
 import { examples, exampleToVcadFile } from "@/data/examples";
 import type { Example } from "@/data/examples";
 import { MOLECULE_DEMOS, useMoleculeStore } from "@/stores/molecule-store";
+import { analytics } from "@/lib/analytics";
 
 interface InlineOnboardingProps {
   visible: boolean;
@@ -82,6 +83,7 @@ export function InlineOnboarding({ visible }: InlineOnboardingProps) {
 
   function handleOpenExample(example: Example) {
     incrementProjectsCreated();
+    analytics.templateOpened(example.id);
     if (example.urdf) {
       window.dispatchEvent(
         new CustomEvent("vcad:load-example", { detail: { urdf: example.urdf } }),
@@ -94,6 +96,7 @@ export function InlineOnboarding({ visible }: InlineOnboardingProps) {
 
   function handleOpenMolecule(id: string) {
     incrementProjectsCreated();
+    analytics.templateOpened(id);
     useMoleculeStore.getState().loadDemo(id);
     hide();
   }

--- a/packages/app/src/components/SketchPropertyPanel.tsx
+++ b/packages/app/src/components/SketchPropertyPanel.tsx
@@ -513,6 +513,7 @@ export function SketchPropertyPanel() {
           const partId = addRevolve(plane, origin, segments, origin, axisDir, pendingOperation.angleDeg);
           if (partId) {
             select(partId);
+            analytics.sketchCompleted(constraints.length);
             addToast("Created Revolve", "success");
           } else {
             addToast("Revolve failed", "error");
@@ -541,6 +542,7 @@ export function SketchPropertyPanel() {
           const partId = addSweep(plane, origin, segments, path);
           if (partId) {
             select(partId);
+            analytics.sketchCompleted(constraints.length);
             addToast("Created Sweep", "success");
           } else {
             addToast("Sweep failed", "error");
@@ -559,6 +561,7 @@ export function SketchPropertyPanel() {
             );
             if (partId) {
               select(partId);
+              analytics.sketchCompleted(constraints.length);
               addToast("Created Loft", "success");
             }
           } else {

--- a/packages/app/src/components/SketchPropertyPanel.tsx
+++ b/packages/app/src/components/SketchPropertyPanel.tsx
@@ -468,8 +468,12 @@ export function SketchPropertyPanel() {
     if (!active) return;
     function handleCommit() {
       if (!pendingOperation) {
-        // No pending op — just exit.
-        exitSketchMode();
+        // No pending op — just exit. Any drawn segments are dropped, so this
+        // is an abandon from the funnel's perspective, not a completion.
+        const status = exitSketchMode();
+        analytics.sketchAbandoned(
+          status === "has_segments" ? "no_operation" : "empty",
+        );
         return;
       }
       if (!hasSegments && pendingOperation.kind !== "loft") {

--- a/packages/app/src/hooks/useAppCommands.ts
+++ b/packages/app/src/hooks/useAppCommands.ts
@@ -77,6 +77,7 @@ export function useAppCommands({
         useNotificationStore.getState().addToast("Nothing to export", "info");
         return;
       }
+      analytics.exportStarted(format);
       try {
         const blob =
           format === "stl"
@@ -85,6 +86,7 @@ export function useAppCommands({
               ? exportGltfBlob(scene)
               : exportStepBlob(scene);
         downloadBlob(blob, `model.${format}`);
+        analytics.exportCompleted(format);
       } catch (err) {
         useNotificationStore
           .getState()
@@ -470,6 +472,7 @@ export function useAppCommands({
         action: () => {
           const ok = useSketchStore.getState().requestExit();
           if (ok) {
+            analytics.sketchAbandoned("empty");
             useNotificationStore.getState().addToast("Sketch cancelled", "info");
           }
           onDismiss();
@@ -488,6 +491,7 @@ export function useAppCommands({
     return registry.map((cmd) => ({
       ...cmd,
       action: () => {
+        analytics.firstCommand(cmd.id);
         analytics.commandExecuted({
           id: cmd.id,
           category: cmd.category,

--- a/packages/app/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/app/src/hooks/useKeyboardShortcuts.ts
@@ -6,6 +6,7 @@ import { useNotificationStore } from "../stores/notification-store";
 import { useLogStore } from "../stores/log-store";
 import { useChangelogStore } from "../stores/changelog-store";
 import { ensureNotRecording } from "@/lib/recording-guard";
+import { analytics } from "@/lib/analytics";
 
 // Track last Escape time for double-tap emergency exit
 let lastEscapeTime = 0;
@@ -409,8 +410,15 @@ export function useKeyboardShortcuts() {
         // Double-tap: force exit from any sketch state
         if (isDoubleTap) {
           if (active || faceSelectionMode || pendingExit) {
-            exitSketchMode();
+            const status = exitSketchMode();
             cancelFaceSelection();
+            analytics.sketchAbandoned(
+              !active
+                ? "face_selection"
+                : status === "has_segments"
+                  ? "discarded"
+                  : "empty",
+            );
             useNotificationStore.getState().addToast("Sketch cancelled", "info");
             useUiStore.getState().setFocusZone("viewport");
             return;
@@ -420,6 +428,7 @@ export function useKeyboardShortcuts() {
         // Cancel face selection mode
         if (faceSelectionMode) {
           cancelFaceSelection();
+          analytics.sketchAbandoned("face_selection");
           useNotificationStore.getState().addToast("Face selection cancelled", "info");
           useUiStore.getState().setFocusZone("viewport");
           return;
@@ -441,6 +450,7 @@ export function useKeyboardShortcuts() {
           // Request exit - returns true if exited immediately (empty sketch)
           const exited = requestExit();
           if (exited) {
+            analytics.sketchAbandoned("empty");
             useNotificationStore.getState().addToast("Sketch cancelled", "info");
           }
           // If not exited, confirmation dialog will show in SketchConfirmationCorner

--- a/packages/app/src/hooks/useToolDefinitions.tsx
+++ b/packages/app/src/hooks/useToolDefinitions.tsx
@@ -665,9 +665,11 @@ export function useToolDefinitions(): {
         iconColor: color("build"),
         onClick: () => {
           if (!scene) return;
+          analytics.exportStarted("stl");
           const blob = exportStlBlob(scene);
           downloadBlob(blob, "model.stl");
           analytics.documentExported("stl");
+          analytics.exportCompleted("stl");
           useNotificationStore.getState().addToast("Exported model.stl", "success");
         },
       },
@@ -681,9 +683,11 @@ export function useToolDefinitions(): {
         iconColor: color("build"),
         onClick: () => {
           if (!scene) return;
+          analytics.exportStarted("glb");
           const blob = exportGltfBlob(scene);
           downloadBlob(blob, "model.glb");
           analytics.documentExported("glb");
+          analytics.exportCompleted("glb");
           useNotificationStore.getState().addToast("Exported model.glb", "success");
         },
       },
@@ -697,10 +701,12 @@ export function useToolDefinitions(): {
         iconColor: color("build"),
         onClick: () => {
           if (!scene) return;
+          analytics.exportStarted("step");
           try {
             const blob = exportStepBlob(scene);
             downloadBlob(blob, "model.step");
             analytics.documentExported("step");
+            analytics.exportCompleted("step");
             useNotificationStore
               .getState()
               .addToast("Exported model.step", "success");
@@ -730,6 +736,7 @@ export function useToolDefinitions(): {
             const boardIds = getPcbNodeIds(doc);
             const pcb = boardIds.length > 0 ? getNodePcb(doc, boardIds[0]!) : null;
             if (!pcb) return;
+            analytics.exportStarted("gerber");
             const files = await exportFabFiles(pcb);
             if (!files || files.length === 0) {
               useNotificationStore
@@ -742,6 +749,7 @@ export function useToolDefinitions(): {
             const blob = new Blob([zipSync(entries)], { type: "application/zip" });
             downloadBlob(blob, "gerbers.zip");
             analytics.documentExported("gerber");
+            analytics.exportCompleted("gerber");
             useNotificationStore
               .getState()
               .addToast(`Exported gerbers.zip (${files.length} files)`, "success");

--- a/packages/app/src/lib/analytics.ts
+++ b/packages/app/src/lib/analytics.ts
@@ -12,6 +12,17 @@ export const analytics = {
     ph?.capture("document_saved", { method }),
   documentExported: (format: "stl" | "glb" | "step" | "dxf" | "gerber") =>
     ph?.capture("document_exported", { format }),
+  // Export funnel — started fires at the moment the user triggers an export,
+  // completed only on success. A started without a completed is a failed or
+  // aborted export, which document_exported alone (success-only) can't show.
+  exportStarted: (format: "stl" | "glb" | "step" | "dxf" | "gerber") =>
+    ph?.capture("export_started", { format }),
+  exportCompleted: (format: "stl" | "glb" | "step" | "dxf" | "gerber") =>
+    ph?.capture("export_completed", { format }),
+
+  // Activation funnel — which starting template (example part or molecule
+  // demo) a user opened, from the first-run gallery, ⌘K palette, or menu.
+  templateOpened: (id: string) => ph?.capture("template_opened", { template_id: id }),
 
   // Feature usage
   primitiveAdded: (kind: "cube" | "cylinder" | "sphere" | "cone") =>
@@ -21,6 +32,13 @@ export const analytics = {
   sketchStarted: () => ph?.capture("sketch_started"),
   sketchCompleted: (constraintCount: number) =>
     ph?.capture("sketch_completed", { constraint_count: constraintCount }),
+  // Sketch mode exited without committing an operation. Reasons: "empty"
+  // (nothing drawn), "discarded" (drawn segments thrown away), "no_operation"
+  // (finished with segments but no extrude/revolve/… pending), or
+  // "face_selection" (bailed at the pick-a-face step before sketching).
+  sketchAbandoned: (
+    reason: "empty" | "discarded" | "no_operation" | "face_selection",
+  ) => ph?.capture("sketch_abandoned", { reason }),
   extrudeApplied: () => ph?.capture("extrude_applied"),
 
   // Auth events
@@ -43,6 +61,20 @@ export const analytics = {
   // (token) or accountless (inline) handoff.
   continueHandoff: (host: string, mode: "token" | "inline") =>
     ph?.capture("continue_handoff", { host, mode }),
+
+  // The very first command this browser profile ever executes — the key
+  // activation step. localStorage-guarded so it fires once per user, not
+  // once per session; the flag is only set when the event actually sends.
+  firstCommand: (id: string) => {
+    if (!ph) return;
+    try {
+      if (localStorage.getItem("vcad_first_command") != null) return;
+      localStorage.setItem("vcad_first_command", "1");
+    } catch {
+      return; // storage unavailable — skip rather than fire every command
+    }
+    ph.capture("first_command", { command_id: id });
+  },
 
   // Command registry — fired for every action triggered through
   // useAppCommands, regardless of which surface invoked it. Lets us see

--- a/packages/app/src/lib/bootstrap.ts
+++ b/packages/app/src/lib/bootstrap.ts
@@ -342,6 +342,10 @@ function applyDocumentData(data: DocumentBootData): void {
   }
 
   if (data.kind === "new") {
+    // No document found anywhere — a first visit (an untouched blank doc is
+    // never autosaved, so this stays true until the user actually keeps
+    // something). The app uses it to surface the template gallery.
+    useBootStore.getState().setFirstVisit(true);
     docStore.newDocument(data.id, data.name);
     return;
   }

--- a/packages/app/src/stores/boot-store.ts
+++ b/packages/app/src/stores/boot-store.ts
@@ -13,11 +13,16 @@ export interface BootState {
   bytesTotal: number;
   slowNetwork: boolean;
   error: string | null;
+  /** True when boot found no existing document anywhere (URL, route,
+   * last-opened slot, IDB) — a fresh profile. Drives the first-run
+   * template gallery. */
+  firstVisit: boolean;
 
   setPhase: (p: BootPhase) => void;
   setFetchProgress: (received: number, total: number) => void;
   setSlowNetwork: (s: boolean) => void;
   setError: (e: string) => void;
+  setFirstVisit: (v: boolean) => void;
 }
 
 export const useBootStore = create<BootState>((set) => ({
@@ -26,10 +31,12 @@ export const useBootStore = create<BootState>((set) => ({
   bytesTotal: 0,
   slowNetwork: false,
   error: null,
+  firstVisit: false,
 
   setPhase: (phase) => set({ phase }),
   setFetchProgress: (bytesReceived, bytesTotal) =>
     set({ bytesReceived, bytesTotal }),
   setSlowNetwork: (slowNetwork) => set({ slowNetwork }),
   setError: (error) => set({ error }),
+  setFirstVisit: (firstVisit) => set({ firstVisit }),
 }));


### PR DESCRIPTION
## Why

30-day telemetry: ~517 human visitors, 49 executed a command, 36 added a primitive, 10 started a sketch, 2 completed one, 3 exported. ~90% of visitors never touch the app. This PR makes the first-run land on the example gallery instead of a blank canvas, and adds the funnel events needed to see where the rest drop off.

## First-run template gallery

- Boot now sets a `firstVisit` flag on the boot store when no document exists anywhere (URL doc, `/~id` route, last-opened slot, IndexedDB). `showOnboarding` in `App.tsx` requires it.
- Fresh visitors get the existing `InlineOnboarding` welcome overlay — hero grid of example parts plus the molecule demos — one click from a real, picked-apart part.
- An untouched blank doc is never autosaved, so the gallery keeps returning until the visitor actually keeps something. Once any saved document exists, boot resolves to it and the gallery never shows again (previously it re-appeared on every empty canvas).
- Dismissal unchanged: X hides for the session, "don't show again" persists. No dialog redesign.

## Funnel telemetry (snake_case, `lib/analytics.ts`)

- `template_opened` (`template_id`) — gallery examples + molecule demos, ⌘K palette examples, File ▸ Examples menu.
- `first_command` (`command_id`) — once per user, `localStorage`-guarded (`vcad_first_command`); flag only set when the event actually sends so a pre-PostHog command can't swallow it. Lives in the `useAppCommands` shim next to `command_executed`.
- `export_started` / `export_completed` — around every export path (toolbar STL/GLB/STEP/Gerbers, header menu, palette commands — the latter two previously logged nothing). `document_exported` untouched; started-without-completed now surfaces failed exports.
- `sketch_abandoned` (`reason`: `empty` | `discarded` | `no_operation` | `face_selection`) — at every exit path that drops a sketch: Esc/double-Esc, palette cancel, FeatureTree ×/Discard, header breadcrumb ×, face-selection cancels, finish-with-no-operation.
- Fix: `sketch_completed` previously only fired for extrude commits; revolve/sweep/loft success paths now emit it too, so completions stop reading as silent exits.

## Verification

- `npm run build -w @vcad/app` (tsc -b + vite) clean; all 47 app tests pass; `npm run changelog:build` validates the new entry.
- Dev server + Chromium click-through: fresh profile shows the gallery after boot; picking **Bracket** loads the part and dismisses it; opening a template alone persists nothing (gallery returns next visit); adding a box via the palette autosaves; reload boots straight into the saved doc with no gallery; X-dismiss works and the gallery returns while the user still has no documents.

Changelog entry: `changelog/entries/2026-07-07-first-run-template-gallery.json` (feat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuDZsvq3TSmwMAKQnVUffA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuDZsvq3TSmwMAKQnVUffA)_