### PR TITLE
Add copper query and net tie authoring tools for PCB routing

### DIFF
--- a/changelog/entries/2026-07-07-copper-query-and-net-ties.json
+++ b/changelog/entries/2026-07-07-copper-query-and-net-ties.json
@@ -1,0 +1,17 @@
+{
+  "id": "2026-07-07-copper-query-and-net-ties",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "Query board copper and author net ties from MCP",
+  "summary": "New get_copper lists traces/vias/zones with delete-compatible indices, and add_net_tie/delete_net_tie declare intentional net junctions (wye neutrals, split grounds, shunt taps) without offline JSON surgery.",
+  "features": [
+    "ecad",
+    "pcb"
+  ],
+  "mcpTools": [
+    "get_copper",
+    "add_net_tie",
+    "delete_net_tie"
+  ]
+}

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -36,6 +36,9 @@ import {
   deleteZone,
   deleteTrace,
   deleteVia,
+  getCopper,
+  addNetTie,
+  deleteNetTie,
   undo,
   setDesignRules,
   sizeTraceForCurrent,
@@ -4595,6 +4598,326 @@ describe("delete_zone / delete_trace / delete_via", () => {
     const dv = out(await deleteVia({ document_id: id, index: 0 }));
     expect(dv.deleted).toMatchObject({ kind: "via", net: "MID" });
     expect(getPcbBoard(getSession(id)).vias).toHaveLength(0);
+  });
+});
+
+describe("get_copper", () => {
+  /** Board with two traces (MID/AUX), one via, and a back-side GND pour. */
+  async function boardWithCopper(): Promise<string> {
+    const id = await boardWithTwoResistors();
+    out(
+      await addTrace({
+        document_id: id,
+        net: "MID",
+        points: [
+          { x: 10, y: 10 },
+          { x: 20, y: 10 },
+        ],
+      }),
+    );
+    out(
+      await addTrace({
+        document_id: id,
+        net: "AUX",
+        layer: "BCu",
+        points: [
+          { x: 30, y: 30 },
+          { x: 40, y: 30 },
+        ],
+      }),
+    );
+    out(await addVia({ document_id: id, net: "MID", position: { x: 20, y: 10 } }));
+    out(await addZone({ document_id: id, net: "GND", layer: "BCu", fill_board: true }));
+    return id;
+  }
+
+  it("returns every element with delete-compatible kind + index", async () => {
+    const id = await boardWithCopper();
+    const res = out(await getCopper({ document_id: id }));
+    expect(res.success).toBe(true);
+    expect(res.total).toBe(4);
+    expect(res.count).toBe(4);
+    expect(res.next_offset).toBeUndefined();
+    expect(res.total_by_kind).toEqual({ trace: 2, via: 1, zone: 1 });
+
+    // Deterministic order: traces, arcs, vias, zones — index order within each.
+    expect(res.elements.map((e: { kind: string }) => e.kind)).toEqual([
+      "trace",
+      "trace",
+      "via",
+      "zone",
+    ]);
+    expect(res.elements[0]).toMatchObject({
+      kind: "trace",
+      index: 0,
+      net: "MID",
+      layer: "FCu",
+      start: { x: 10, y: 10 },
+      end: { x: 20, y: 10 },
+      source: "manual",
+    });
+    expect(res.elements[2]).toMatchObject({
+      kind: "via",
+      index: 0,
+      net: "MID",
+      layers: ["FCu", "BCu"],
+      position: { x: 20, y: 10 },
+    });
+    // Zones report bbox + vertex count, not the (possibly huge) outline.
+    expect(res.elements[3]).toMatchObject({ kind: "zone", index: 0, net: "GND", layer: "BCu" });
+    expect(res.elements[3].bbox).toEqual({ min: { x: 0, y: 0 }, max: { x: 50, y: 50 } });
+    expect(res.elements[3].vertices).toBeGreaterThanOrEqual(3);
+    expect(res.elements[3].outline).toBeUndefined();
+  });
+
+  it("filters by kind, net, layer, and bbox", async () => {
+    const id = await boardWithCopper();
+
+    const vias = out(await getCopper({ document_id: id, kind: "via" }));
+    expect(vias.total).toBe(1);
+    expect(vias.elements[0].kind).toBe("via");
+
+    const mid = out(await getCopper({ document_id: id, net: "MID" }));
+    expect(mid.total).toBe(2); // FCu trace + via
+    expect(mid.elements.every((e: { net: string }) => e.net === "MID")).toBe(true);
+
+    // BCu: the AUX trace, the pour — and the via, whose barrel spans FCu→BCu.
+    const bcu = out(await getCopper({ document_id: id, layer: "BCu" }));
+    expect(bcu.total).toBe(3);
+    expect(bcu.elements.map((e: { kind: string }) => e.kind).sort()).toEqual([
+      "trace",
+      "via",
+      "zone",
+    ]);
+
+    // Spatial: only the MID trace's neighborhood, kind-scoped so the
+    // board-spanning pour doesn't match.
+    const near = out(
+      await getCopper({ document_id: id, kind: "trace", bbox: { x: 5, y: 5, w: 10, h: 10 } }),
+    );
+    expect(near.total).toBe(1);
+    expect(near.elements[0]).toMatchObject({ kind: "trace", net: "MID" });
+
+    // Empty match is a success with total 0, not an error.
+    const none = out(await getCopper({ document_id: id, net: "GHOST" }));
+    expect(none.total).toBe(0);
+    expect(none.elements).toEqual([]);
+  });
+
+  it("query indices drive surgical deletes", async () => {
+    const id = await boardWithCopper();
+    const aux = out(await getCopper({ document_id: id, kind: "trace", net: "AUX" }));
+    expect(aux.total).toBe(1);
+    const del = out(await deleteTrace({ document_id: id, index: aux.elements[0].index }));
+    expect(del.deleted).toMatchObject({ kind: "trace", net: "AUX" });
+    expect(out(await getCopper({ document_id: id, kind: "trace" })).total).toBe(1);
+  });
+
+  it("paginates with offset and reports the uncapped total", async () => {
+    const id = await boardWithTwoResistors();
+    for (let i = 0; i < 5; i++) {
+      out(await addVia({ document_id: id, net: "MID", position: { x: 10 + i * 5, y: 40 } }));
+    }
+    const p1 = out(await getCopper({ document_id: id, kind: "via", limit: 2 }));
+    expect(p1.total).toBe(5);
+    expect(p1.count).toBe(2);
+    expect(p1.next_offset).toBe(2);
+    expect(p1.elements.map((e: { index: number }) => e.index)).toEqual([0, 1]);
+
+    const p2 = out(await getCopper({ document_id: id, kind: "via", limit: 2, offset: 4 }));
+    expect(p2.count).toBe(1);
+    expect(p2.elements[0].index).toBe(4);
+    expect(p2.next_offset).toBeUndefined();
+  });
+
+  it("rejects a bad kind, a malformed layer, and a bad bbox", async () => {
+    const id = await boardWithTwoResistors();
+    expect(isErr(await getCopper({ document_id: id, kind: "wire" }))).toBe(true);
+    expect(isErr(await getCopper({ document_id: id, layer: "F.Cu" }))).toBe(true);
+    expect(isErr(await getCopper({ document_id: id, bbox: { x: 0, y: 0 } }))).toBe(true);
+  });
+});
+
+describe("add_net_tie / delete_net_tie", () => {
+  /** Board whose netlist has four nets (one pad each) and no routing. */
+  async function boardWithFourNets(): Promise<string> {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { PHA: ["R1.1"], PHB: ["R1.2"], GND: ["R2.1"], AGND: ["R2.2"] },
+      }),
+    );
+    const id = created.document_id as string;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+    return id;
+  }
+
+  it("authors a board-wide tie and returns the updated tie list", async () => {
+    const id = await boardWithFourNets();
+    const res = out(await addNetTie({ document_id: id, nets: ["GND", "AGND"] }));
+    expect(res.success).toBe(true);
+    expect(res.tie).toMatchObject({ index: 0, nets: ["GND", "AGND"], scope: "board_wide" });
+    expect(res.net_ties).toEqual([res.tie]);
+    expect(res.net_ties_total).toBe(1);
+    expect(res.changed).toEqual([
+      { action: "added", kind: "netTie", index: 0, net: "GND+AGND" },
+    ]);
+
+    const board = getPcbBoard(getSession(id));
+    expect(board.netTies).toHaveLength(1);
+    expect(board.netTies![0]).toEqual({ nets: ["GND", "AGND"] });
+  });
+
+  it("authors a region-scoped tie with position + radius", async () => {
+    const id = await boardWithFourNets();
+    const res = out(
+      await addNetTie({
+        document_id: id,
+        nets: ["PHA", "PHB", "GND"],
+        position: { x: 25, y: 25 },
+        radius: 3,
+      }),
+    );
+    expect(res.tie).toMatchObject({
+      scope: "region",
+      position: { x: 25, y: 25 },
+      radius: 3,
+    });
+    const board = getPcbBoard(getSession(id));
+    expect(board.netTies![0].position).toEqual({ x: 25, y: 25 });
+    expect(board.netTies![0].radius).toBe(3);
+  });
+
+  it("rejects unknown nets, < 2 distinct nets, and a half-scoped region", async () => {
+    const id = await boardWithFourNets();
+    // Unknown net — the error names it so the typo is findable.
+    const bad = await addNetTie({ document_id: id, nets: ["GND", "GROUND"] });
+    expect(isErr(bad)).toBe(true);
+    expect((bad as { content: Array<{ text: string }> }).content[0].text).toContain("GROUND");
+
+    expect(isErr(await addNetTie({ document_id: id, nets: ["GND"] }))).toBe(true);
+    // Duplicates collapse — still one distinct net.
+    expect(isErr(await addNetTie({ document_id: id, nets: ["GND", "GND"] }))).toBe(true);
+    // position without radius (or vice versa) would silently become a
+    // board-wide exemption in the kernel — rejected outright.
+    expect(
+      isErr(await addNetTie({ document_id: id, nets: ["GND", "AGND"], position: { x: 1, y: 1 } })),
+    ).toBe(true);
+    expect(isErr(await addNetTie({ document_id: id, nets: ["GND", "AGND"], radius: 2 }))).toBe(true);
+    expect(
+      isErr(
+        await addNetTie({
+          document_id: id,
+          nets: ["GND", "AGND"],
+          position: { x: 1, y: 1 },
+          radius: 0,
+        }),
+      ),
+    ).toBe(true);
+    expect(getPcbBoard(getSession(id)).netTies ?? []).toHaveLength(0);
+  });
+
+  it("deletes by index, by net set, and by position; guards a mismatched index", async () => {
+    const id = await boardWithFourNets();
+    out(await addNetTie({ document_id: id, nets: ["GND", "AGND"] }));
+    out(
+      await addNetTie({
+        document_id: id,
+        nets: ["PHA", "PHB"],
+        position: { x: 10, y: 10 },
+        radius: 2,
+      }),
+    );
+    out(
+      await addNetTie({
+        document_id: id,
+        nets: ["PHB", "PHA"],
+        position: { x: 40, y: 40 },
+        radius: 2,
+      }),
+    );
+
+    // Net-set match alone is ambiguous across the two PHA/PHB junctions…
+    expect(isErr(await deleteNetTie({ document_id: id, nets: ["PHA", "PHB"] }))).toBe(true);
+    // …position disambiguates (order-insensitive net match).
+    const byPos = out(
+      await deleteNetTie({ document_id: id, nets: ["PHB", "PHA"], position: { x: 40, y: 40 } }),
+    );
+    expect(byPos.deleted).toMatchObject({ index: 2, nets: ["PHB", "PHA"] });
+    expect(byPos.net_ties_total).toBe(2);
+    expect(byPos.changed).toEqual([
+      { action: "removed", kind: "netTie", index: 2, net: "PHB+PHA" },
+    ]);
+
+    // Index + mismatched nets is a guard, not a delete.
+    expect(isErr(await deleteNetTie({ document_id: id, index: 0, nets: ["PHA", "PHB"] }))).toBe(
+      true,
+    );
+    // No selector at all → error; out-of-range index → error.
+    expect(isErr(await deleteNetTie({ document_id: id }))).toBe(true);
+    expect(isErr(await deleteNetTie({ document_id: id, index: 9 }))).toBe(true);
+
+    const bySet = out(await deleteNetTie({ document_id: id, nets: ["AGND", "GND"] }));
+    expect(bySet.deleted.nets).toEqual(["GND", "AGND"]);
+    const byIndex = out(await deleteNetTie({ document_id: id, index: 0 }));
+    expect(byIndex.net_ties_total).toBe(0);
+    expect(getPcbBoard(getSession(id)).netTies).toHaveLength(0);
+  });
+
+  it("a region-scoped tie exempts the junction short in DRC; deleting it re-arms", async () => {
+    const id = await boardWithFourNets();
+    // Pin the floorplan to the top edge so no pad sits near the junction the
+    // test builds — only the deliberate crossing may short.
+    out(
+      await setPlacement({
+        document_id: id,
+        placements: [
+          { ref: "R1", x: 10, y: 45 },
+          { ref: "R2", x: 35, y: 45 },
+        ],
+      }),
+    );
+    // A PHB stub ending ON the PHA trace — a T-junction at (20, 25), the
+    // shape of a real tie point (shunt tap, star chord meeting the neutral).
+    out(
+      await addTrace({
+        document_id: id,
+        net: "PHA",
+        points: [
+          { x: 10, y: 25 },
+          { x: 30, y: 25 },
+        ],
+      }),
+    );
+    out(
+      await addTrace({
+        document_id: id,
+        net: "PHB",
+        points: [
+          { x: 20, y: 15 },
+          { x: 20, y: 25 },
+        ],
+      }),
+    );
+
+    const before = out(await runDrc({ document_id: id }));
+    expect(before.byRule?.Short ?? 0).toBeGreaterThan(0);
+
+    out(
+      await addNetTie({
+        document_id: id,
+        nets: ["PHA", "PHB"],
+        position: { x: 20, y: 25 },
+        radius: 3,
+      }),
+    );
+    const tied = out(await runDrc({ document_id: id }));
+    expect(tied.byRule?.Short ?? 0).toBe(0);
+
+    // Take the tie back — the same copper is a short again (fail-closed).
+    out(await deleteNetTie({ document_id: id, nets: ["PHA", "PHB"] }));
+    const rearmed = out(await runDrc({ document_id: id }));
+    expect(rearmed.byRule?.Short ?? 0).toBeGreaterThan(0);
   });
 });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -240,6 +240,12 @@ import {
   deleteTraceSchema,
   deleteVia,
   deleteViaSchema,
+  getCopper,
+  getCopperSchema,
+  addNetTie,
+  addNetTieSchema,
+  deleteNetTie,
+  deleteNetTieSchema,
   undo,
   undoSchema,
   setDesignRules,
@@ -511,6 +517,10 @@ const SWITCH_DOC_WRITERS = new Set<string>([
   "delete_zone",
   "delete_trace",
   "delete_via",
+  // Net ties are DRC data, not copper — invisible in the render, but they
+  // change what run_drc accepts, so they must persist (and be undoable).
+  "add_net_tie",
+  "delete_net_tie",
   "undo",
   "set_stackup",
   "set_placement",
@@ -674,6 +684,7 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "route_nets",
     "get_pad_positions",
     "describe_pcb",
+    "get_copper",
     "add_trace",
     "add_via",
     "add_via_array",
@@ -684,6 +695,8 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "delete_zone",
     "delete_trace",
     "delete_via",
+    "add_net_tie",
+    "delete_net_tie",
     "set_design_rules",
     "size_trace_for_current",
     "add_coil",
@@ -755,7 +768,7 @@ function buildInstructions(kernelPrompt: string | null): string {
     "- Ship with `export_cad` (STL/GLB/STEP) or `open_in_browser` (vcad.io deep link).",
     "- Fix in place: when geometry is wrong, prefer `update` on the offending node over deleting parts and starting over.",
     "",
-    "PCB workflow: `create_schematic` (declare connectivity as data via `nets`) → `place_components` → `route_nets` / `add_coil` / `add_coil_array` → `run_drc` → `validate_for_fab` → `export_gerber`. All take the `document_id` from create_schematic and mutate that session — never re-send the document. `validate_for_fab` is the single 'is this board ready?' gate (DRC + renderability + Gerber serialization + blockers, all fail-closed); `export_gerber` enforces a clean DRC by default and blocks a dirty board. `board_from_solid` turns a solid part (e.g. an enclosure or stator disc in a CAD session) into an outline polygon for `place_components`. For motors, plan the winding first with `winding_layout` (slots + poles → per-coil phase/polarity/winding-factor, as data — it touches no board), then realize it with `add_coil_array`. `run_drc` returns a summary by default (counts by rule + net-pair, worst clearance, a capped sample); pass `detail:'full'` for every violation.",
+    "PCB workflow: `create_schematic` (declare connectivity as data via `nets`) → `place_components` → `route_nets` / `add_coil` / `add_coil_array` → `run_drc` → `validate_for_fab` → `export_gerber`. All take the `document_id` from create_schematic and mutate that session — never re-send the document. `validate_for_fab` is the single 'is this board ready?' gate (DRC + renderability + Gerber serialization + blockers, all fail-closed); `export_gerber` enforces a clean DRC by default and blocks a dirty board. `board_from_solid` turns a solid part (e.g. an enclosure or stator disc in a CAD session) into an outline polygon for `place_components`. For motors, plan the winding first with `winding_layout` (slots + poles → per-coil phase/polarity/winding-factor, as data — it touches no board), then realize it with `add_coil_array`. `run_drc` returns a summary by default (counts by rule + net-pair, worst clearance, a capped sample); pass `detail:'full'` for every violation. Surgical copper edits: `get_copper` lists existing traces/vias/zones (filtered by layer/net/bbox/kind) with the same indices `delete_trace`/`delete_via`/`delete_zone` accept — discover, then delete, without exporting the document. Where two nets must touch on purpose (wye neutral, split ground, shunt tap), declare it with `add_net_tie` — prefer a region-scoped tie (position+radius) so DRC stays honest away from the junction; `delete_net_tie` takes it back.",
   ].join("\n");
   if (!kernelPrompt) return header;
   const sections = new Map<string, string>();
@@ -1654,6 +1667,45 @@ export async function createServer(
         inputSchema: deleteViaSchema,
       },
       {
+        name: "get_copper",
+        description:
+          "Query the board's routed copper — traces, trace arcs, vias, zones — " +
+          "with optional `layer`/`net`/`bbox`/`kind` filters. Each element comes " +
+          "back with its `kind` + `index`: exactly the addressing delete_trace / " +
+          "delete_via / delete_zone accept, so a query can drive a surgical " +
+          "delete without exporting the document. describe_pcb aggregates " +
+          "counts; this returns the elements themselves (geometry, width, net, " +
+          "layer), capped at 200 per page with `offset` pagination and a `total`. " +
+          "Read-only.",
+        inputSchema: getCopperSchema,
+      },
+      {
+        name: "add_net_tie",
+        description:
+          "Declare an intentional junction between >= 2 nets (a net-tie) so DRC " +
+          "treats them as one node where they meet — required for wye/star motor " +
+          "neutrals, split grounds (GND+AGND), and current-sense shunt taps, " +
+          "which are otherwise reported as shorts. With `position`+`radius` the " +
+          "tie is region-scoped: clearance/short checks are exempt only for " +
+          "contacts inside the region, and connectivity accepts nets joined " +
+          "through copper when each has a tie-covered contact there — a stray " +
+          "crossing of the same nets elsewhere still fires. Without them the " +
+          "exemption is board-wide (prefer scoped: it keeps DRC honest away " +
+          "from the junction). Nets must exist on the board. Returns the " +
+          "updated tie list with indices. Mutates the session document.",
+        inputSchema: addNetTieSchema,
+      },
+      {
+        name: "delete_net_tie",
+        description:
+          "Remove a net tie by `index`, or by matching `nets` (set equality, " +
+          "order-insensitive) and/or `position` — the take-back for a bad " +
+          "add_net_tie. Any junction copper stays on the board; DRC will report " +
+          "it as a short again. Returns the deleted tie and the updated tie " +
+          "list. Mutates the session document.",
+        inputSchema: deleteNetTieSchema,
+      },
+      {
         name: "undo",
         description:
           "Rewind the most recent mutation on a session — the snapshot taken " +
@@ -2443,6 +2495,18 @@ export async function createServer(
 
         case "delete_via":
           result = deleteVia(args);
+          break;
+
+        case "get_copper":
+          result = getCopper(args);
+          break;
+
+        case "add_net_tie":
+          result = addNetTie(args);
+          break;
+
+        case "delete_net_tie":
+          result = deleteNetTie(args);
           break;
 
         case "undo":

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -25,6 +25,7 @@ import type {
   PadType,
   PcbLayer,
   Trace,
+  TraceArc,
   Via,
   Zone,
   Vec2,
@@ -7833,10 +7834,12 @@ export function addZone(args: Record<string, unknown>) {
 // `changed` diff of what left the board, mirroring the other mutators. For a
 // "take back the very last thing I did" the `undo` tool is the broader hammer.
 
-/** A removed (or, for undo, re-added) board element, for the `changed` diff. */
+/** A removed (or, for undo, re-added) board element, for the `changed` diff.
+ *  For `netTie` entries `net` is the joined nets as "A+B+C" (a tie has no
+ *  single net of its own). */
 interface PcbElementChange {
   action: "removed" | "added";
-  kind: "zone" | "trace" | "traceArc" | "via";
+  kind: "zone" | "trace" | "traceArc" | "via" | "netTie";
   index: number;
   net: string;
   layer?: string;
@@ -7986,6 +7989,582 @@ export function deleteVia(args: Record<string, unknown>) {
 }
 
 // ============================================================================
+// get_copper — read/query routed copper (the discovery side of the algebra)
+// ============================================================================
+//
+// add_trace/add_via/add_zone write copper and delete_trace/delete_via/
+// delete_zone remove it by index — but nothing let an agent SEE what copper
+// exists: describe_pcb only aggregates counts, so finding "the trace shorting
+// GND to PHA near the star point" meant exporting the whole document. This is
+// the read companion: filter by layer/net/bbox/kind and get each element back
+// with the same `index` (per-collection, add order) the delete_* tools accept.
+
+/** The queryable copper collections, in report order. */
+type CopperKind = "trace" | "traceArc" | "via" | "zone";
+const COPPER_KINDS: readonly CopperKind[] = ["trace", "traceArc", "via", "zone"];
+
+/** Axis-aligned bbox as {min, max}. */
+interface Bbox {
+  min: Vec2;
+  max: Vec2;
+}
+
+/** Conservative bounding box of a copper element (copper extent included). */
+function copperElementBbox(kind: CopperKind, el: Trace | TraceArc | Via | Zone): Bbox {
+  switch (kind) {
+    case "trace": {
+      const t = el as Trace;
+      const r = t.width / 2;
+      return {
+        min: { x: Math.min(t.start.x, t.end.x) - r, y: Math.min(t.start.y, t.end.y) - r },
+        max: { x: Math.max(t.start.x, t.end.x) + r, y: Math.max(t.start.y, t.end.y) + r },
+      };
+    }
+    case "traceArc": {
+      // Full-circle bound — conservative (a quarter arc reports the whole
+      // circle's box), but never misses copper on a bbox query.
+      const a = el as TraceArc;
+      const r = a.radius + a.width / 2;
+      return {
+        min: { x: a.center.x - r, y: a.center.y - r },
+        max: { x: a.center.x + r, y: a.center.y + r },
+      };
+    }
+    case "via": {
+      const v = el as Via;
+      const r = v.diameter / 2;
+      return {
+        min: { x: v.position.x - r, y: v.position.y - r },
+        max: { x: v.position.x + r, y: v.position.y + r },
+      };
+    }
+    case "zone": {
+      const z = el as Zone;
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      for (const p of z.outline) {
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+      return { min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
+    }
+  }
+}
+
+/** True when a via's barrel spans `layer` (start/end plus every copper layer
+ *  between, by stackup order) — a through via FCu→BCu carries In1Cu too. */
+function viaSpansLayer(via: Via, layer: PcbLayer): boolean {
+  const lo = COPPER_LAYERS.indexOf(via.startLayer);
+  const hi = COPPER_LAYERS.indexOf(via.endLayer);
+  const at = COPPER_LAYERS.indexOf(layer);
+  if (lo < 0 || hi < 0 || at < 0) return via.startLayer === layer || via.endLayer === layer;
+  return at >= Math.min(lo, hi) && at <= Math.max(lo, hi);
+}
+
+/** Hard cap on elements per get_copper page — keeps a dense board's response
+ *  bounded; the caller pages with `offset` (the result carries `total`). */
+const GET_COPPER_CAP = 200;
+
+/** JSON Schema for get_copper tool. */
+export const getCopperSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    kind: {
+      type: "string" as const,
+      description:
+        "Restrict to one collection: 'trace', 'traceArc', 'via', or 'zone'. " +
+        "Omit for all four.",
+    },
+    layer: {
+      type: "string" as const,
+      description:
+        "Copper-layer filter (e.g. 'FCu', 'BCu', 'In1Cu'). Traces/arcs/zones " +
+        "match their own layer; a via matches every layer its barrel spans.",
+    },
+    net: { type: "string" as const, description: "Net filter (exact id, e.g. 'GND')." },
+    bbox: {
+      type: "object" as const,
+      description:
+        "Spatial filter, board-local mm: keep elements whose bounding box " +
+        "overlaps the rectangle x..x+w, y..y+h (conservative for arcs).",
+      properties: {
+        x: { type: "number" as const },
+        y: { type: "number" as const },
+        w: { type: "number" as const },
+        h: { type: "number" as const },
+      },
+      required: ["x", "y", "w", "h"],
+    },
+    offset: {
+      type: "number" as const,
+      description: "Skip this many matches (pagination; default 0).",
+    },
+    limit: {
+      type: "number" as const,
+      description: `Max elements returned (default and cap ${GET_COPPER_CAP}).`,
+    },
+  },
+  required: ["document_id"],
+};
+
+/**
+ * Query the board's routed copper — traces, trace arcs, vias, zones — with
+ * optional layer/net/bbox/kind filters. Each element is returned with its
+ * `kind` and `index`: the exact addressing delete_trace / delete_via /
+ * delete_zone accept, so a query result can drive a surgical delete without
+ * ever exporting the document. Read-only.
+ */
+export function getCopper(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = ecadError;
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+
+  let kinds: readonly CopperKind[] = COPPER_KINDS;
+  if (args.kind != null) {
+    const k = String(args.kind);
+    if (!COPPER_KINDS.includes(k as CopperKind)) {
+      return fail(`kind '${k}' is not valid; legal: ${COPPER_KINDS.join(", ")}`);
+    }
+    kinds = [k as CopperKind];
+  }
+
+  let wantLayer: PcbLayer | undefined;
+  if (args.layer != null) {
+    const layerRes = validateCopperLayer(args.layer);
+    if ("error" in layerRes) return fail(layerRes.error);
+    wantLayer = layerRes.layer;
+  }
+  const wantNet = args.net != null ? String(args.net) : undefined;
+
+  let queryBox: Bbox | undefined;
+  if (args.bbox != null) {
+    const b = args.bbox as Record<string, unknown>;
+    if (
+      typeof b.x !== "number" || typeof b.y !== "number" ||
+      typeof b.w !== "number" || typeof b.h !== "number"
+    ) {
+      return fail("bbox must be {x, y, w, h} in board-local mm");
+    }
+    if ((b.w as number) < 0 || (b.h as number) < 0) return fail("bbox w and h must be >= 0");
+    queryBox = {
+      min: { x: b.x as number, y: b.y as number },
+      max: { x: (b.x as number) + (b.w as number), y: (b.y as number) + (b.h as number) },
+    };
+  }
+
+  const offset = typeof args.offset === "number" ? Math.max(0, Math.floor(args.offset)) : 0;
+  const limit =
+    typeof args.limit === "number"
+      ? Math.min(GET_COPPER_CAP, Math.max(1, Math.floor(args.limit)))
+      : GET_COPPER_CAP;
+
+  const overlaps = (a: Bbox, b: Bbox): boolean =>
+    a.min.x <= b.max.x && a.max.x >= b.min.x && a.min.y <= b.max.y && a.max.y >= b.min.y;
+
+  const layerMatches = (kind: CopperKind, el: Trace | TraceArc | Via | Zone): boolean => {
+    if (wantLayer === undefined) return true;
+    if (kind === "via") return viaSpansLayer(el as Via, wantLayer);
+    return (el as Trace | TraceArc | Zone).layer === wantLayer;
+  };
+
+  const rv = (v: Vec2): Vec2 => ({ x: round3(v.x), y: round3(v.y) });
+  const rbox = (b: Bbox): Bbox => ({ min: rv(b.min), max: rv(b.max) });
+
+  /** The reported view of one element — identity first, geometry after. */
+  const describe = (
+    kind: CopperKind,
+    index: number,
+    el: Trace | TraceArc | Via | Zone,
+  ): Record<string, unknown> => {
+    switch (kind) {
+      case "trace": {
+        const t = el as Trace;
+        return {
+          kind, index, net: t.net, layer: t.layer,
+          start: rv(t.start), end: rv(t.end), width: t.width,
+          ...(t.source ? { source: t.source } : {}),
+        };
+      }
+      case "traceArc": {
+        const a = el as TraceArc;
+        return {
+          kind, index, net: a.net, layer: a.layer,
+          center: rv(a.center), radius: round3(a.radius),
+          start_angle: a.startAngle, end_angle: a.endAngle, width: a.width,
+        };
+      }
+      case "via": {
+        const v = el as Via;
+        return {
+          kind, index, net: v.net, layers: [v.startLayer, v.endLayer],
+          position: rv(v.position), diameter: v.diameter, drill: v.drill,
+          ...(v.source ? { source: v.source } : {}),
+        };
+      }
+      case "zone": {
+        // A pour's outline can run to hundreds of vertices (board fills) —
+        // report its bbox + vertex count; the index is enough to delete it.
+        const z = el as Zone;
+        return {
+          kind, index, net: z.net, layer: z.layer,
+          bbox: rbox(copperElementBbox("zone", z)), vertices: z.outline.length,
+          ...(z.holes && z.holes.length > 0 ? { holes: z.holes.length } : {}),
+          clearance: z.clearance, priority: z.priority ?? 0,
+        };
+      }
+    }
+  };
+
+  const collections: Record<CopperKind, Array<Trace | TraceArc | Via | Zone>> = {
+    trace: pcb.traces,
+    traceArc: pcb.traceArcs ?? [],
+    via: pcb.vias,
+    zone: pcb.zones,
+  };
+
+  // Match in deterministic order (traces, arcs, vias, zones; index order
+  // within each) so offset-paging never skips or repeats an element.
+  const matched: Array<{ kind: CopperKind; index: number; el: Trace | TraceArc | Via | Zone }> = [];
+  const totalByKind: Partial<Record<CopperKind, number>> = {};
+  for (const kind of kinds) {
+    collections[kind].forEach((el, index) => {
+      if (wantNet !== undefined && el.net !== wantNet) return;
+      if (!layerMatches(kind, el)) return;
+      if (queryBox && !overlaps(copperElementBbox(kind, el), queryBox)) return;
+      matched.push({ kind, index, el });
+      totalByKind[kind] = (totalByKind[kind] ?? 0) + 1;
+    });
+  }
+
+  const page = matched.slice(offset, offset + limit);
+  const elements = page.map((m) => describe(m.kind, m.index, m.el));
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          total: matched.length,
+          total_by_kind: totalByKind,
+          count: elements.length,
+          offset,
+          ...(offset + elements.length < matched.length
+            ? { next_offset: offset + elements.length }
+            : {}),
+          elements,
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// add_net_tie / delete_net_tie — intentional net junctions
+// ============================================================================
+//
+// Wye motor windings, split grounds joined at one stitch, and current-sense
+// shunts all REQUIRE two named nets to touch on purpose — without a declared
+// tie, DRC correctly reports the junction as a short. Until now only the
+// add_motor_winding realizer could author a NetTie; an agent hand-building a
+// wye had to do offline JSON surgery on the saved .vcad. These tools complete
+// the algebra: author and remove ties on the live session.
+
+/** Tolerance for matching a tie by position in delete_net_tie, mm. */
+const TIE_POSITION_TOL = 1e-3;
+
+/** The reported view of one net tie: the stored fields plus its index (the
+ *  addressing delete_net_tie accepts) and the DRC scope it resolves to. */
+function describeNetTie(tie: NetTie, index: number): Record<string, unknown> {
+  return {
+    index,
+    nets: tie.nets,
+    ...(tie.position ? { position: tie.position } : {}),
+    ...(tie.radius !== undefined ? { radius: tie.radius } : {}),
+    scope: tie.position && tie.radius !== undefined ? "region" : "board_wide",
+  };
+}
+
+/** The full tie list, as returned by both tie tools after a mutation. */
+function netTieList(pcb: Pcb): Array<Record<string, unknown>> {
+  return (pcb.netTies ?? []).map((t, i) => describeNetTie(t, i));
+}
+
+/** JSON Schema for add_net_tie tool. */
+export const addNetTieSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    nets: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description:
+        "Names of the nets joined at this tie (>= 2, all must exist on the " +
+        "board) — e.g. the three phases + neutral of a wye, or GND + AGND.",
+    },
+    position: {
+      ...vec2Schema,
+      description:
+        "Center of the allowed join region, board-local mm. Give WITH `radius` " +
+        "to scope the exemption; omit both for a board-wide tie.",
+    },
+    radius: {
+      type: "number" as const,
+      description:
+        "Radius of the allowed join region, mm (> 0). Requires `position`. " +
+        "Size it to cover the junction copper with margin (~1 trace width): " +
+        "DRC judges each contact at an estimated contact point (e.g. a trace " +
+        "midpoint), not the exact geometric touch.",
+    },
+  },
+  required: ["document_id", "nets"],
+};
+
+/**
+ * Declare an intentional junction between two or more nets (a net-tie) so DRC
+ * treats them as one electrical node where they meet — the primitive behind
+ * wye/star neutral points, split-ground stitches, and current-sense shunt
+ * taps. Region-scoped (position+radius) ties exempt clearance/short checks
+ * only for contacts inside the region — and connectivity: nets joined through
+ * copper are legal when each has a tie-covered contact there (a stray crossing
+ * of the same nets elsewhere still fires). Region-less ties exempt the pair
+ * board-wide. Mutates the session document.
+ */
+export function addNetTie(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = ecadError;
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+
+  const rawNets = Array.isArray(args.nets) ? (args.nets as unknown[]) : undefined;
+  if (!rawNets) return fail("nets is required — the >= 2 net names this tie joins");
+  const nets: string[] = [];
+  for (const n of rawNets) {
+    const name = String(n ?? "").trim();
+    if (!name) return fail("every entry in nets must be a non-empty net name");
+    if (!nets.includes(name)) nets.push(name);
+  }
+  if (nets.length < 2) return fail("a net tie joins at least 2 distinct nets");
+
+  // A tie on a net that doesn't exist is a typo, not an intention — and it
+  // would silently exempt nothing. Validate against the board's netlist.
+  const known = new Set(pcb.nets.map((n) => n.id));
+  const unknown = nets.filter((n) => !known.has(n));
+  if (unknown.length > 0) {
+    const names = pcb.nets.map((n) => n.id);
+    const shown = names.slice(0, 30).join(", ");
+    return fail(
+      `unknown net${unknown.length > 1 ? "s" : ""} ${unknown.map((n) => `'${n}'`).join(", ")} — ` +
+        `board nets: ${shown}${names.length > 30 ? `, … (${names.length} total)` : ""}`,
+    );
+  }
+
+  // The kernel only forms a scoped region when BOTH position and radius are
+  // present (NetTieGroups in drc.rs); one without the other would silently
+  // degrade to a board-wide exemption. Fail closed instead.
+  const hasPosition = args.position != null;
+  const hasRadius = args.radius != null;
+  if (hasPosition !== hasRadius) {
+    return fail(
+      "position and radius must be given together — one without the other " +
+        "would silently become a board-wide exemption. Pass both to scope the " +
+        "tie to a region, or neither for an explicit board-wide tie.",
+    );
+  }
+  let position: Vec2 | undefined;
+  let radius: number | undefined;
+  if (hasPosition) {
+    const p = args.position as Record<string, unknown>;
+    if (typeof p.x !== "number" || typeof p.y !== "number") {
+      return fail("position must be {x, y} in board-local mm");
+    }
+    radius = args.radius as number;
+    if (typeof radius !== "number" || !(radius > 0)) return fail("radius must be > 0 mm");
+    position = { x: round3(p.x as number), y: round3(p.y as number) };
+    radius = round3(radius);
+  }
+
+  pcb.netTies = pcb.netTies ?? [];
+  const tie: NetTie = {
+    nets,
+    ...(position ? { position } : {}),
+    ...(radius !== undefined ? { radius } : {}),
+  };
+  pcb.netTies.push(tie);
+  const index = pcb.netTies.length - 1;
+
+  const change: PcbElementChange = {
+    action: "added",
+    kind: "netTie",
+    index,
+    net: nets.join("+"),
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          tie: describeNetTie(tie, index),
+          net_ties: netTieList(pcb),
+          net_ties_total: pcb.netTies.length,
+          changed: [change],
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+/** JSON Schema for delete_net_tie tool. */
+export const deleteNetTieSchema = {
+  type: "object" as const,
+  properties: {
+    ...docInputProperties,
+    index: {
+      type: "number" as const,
+      description:
+        "Zero-based position in pcb.netTies (as reported by add_net_tie / get_document).",
+    },
+    nets: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description:
+        "Match ties joining exactly this net set (order-insensitive). With " +
+        "`index`, a guard; without it, identifies the tie when exactly one matches.",
+    },
+    position: {
+      ...vec2Schema,
+      description:
+        `Match region-scoped ties centered here (±${TIE_POSITION_TOL} mm) — ` +
+        "disambiguates when the same net set is tied at several junctions " +
+        "(e.g. the three X–Y ties of a delta winding).",
+    },
+  },
+  required: ["document_id"],
+};
+
+/** Remove a net tie by `index`, or by matching `nets` (set equality) and/or
+ *  `position` — the take-back for a bad add_net_tie. The junction's copper (if
+ *  any) stays; DRC will report it as a short again. Mutates the session. */
+export function deleteNetTie(args: Record<string, unknown>) {
+  const ctx = resolveDocInput(args);
+  const pcb = getDocPcb(ctx.doc);
+  const fail = ecadError;
+  if (!pcb) {
+    return fail(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+  const ties = pcb.netTies ?? [];
+  if (ties.length === 0) return fail("board has no net ties to delete");
+
+  let wantNets: string[] | undefined;
+  if (args.nets != null) {
+    if (!Array.isArray(args.nets)) return fail("nets must be an array of net names");
+    wantNets = (args.nets as unknown[]).map((n) => String(n ?? "").trim()).sort();
+  }
+  let wantPos: Vec2 | undefined;
+  if (args.position != null) {
+    const p = args.position as Record<string, unknown>;
+    if (typeof p.x !== "number" || typeof p.y !== "number") {
+      return fail("position must be {x, y} in board-local mm");
+    }
+    wantPos = { x: p.x as number, y: p.y as number };
+  }
+
+  const matchesFilter = (tie: NetTie): boolean => {
+    if (wantNets) {
+      const have = [...tie.nets].sort();
+      if (have.length !== wantNets.length || have.some((n, i) => n !== wantNets![i])) return false;
+    }
+    if (wantPos) {
+      if (!tie.position) return false;
+      if (
+        Math.abs(tie.position.x - wantPos.x) > TIE_POSITION_TOL ||
+        Math.abs(tie.position.y - wantPos.y) > TIE_POSITION_TOL
+      ) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  let index: number;
+  if (typeof args.index === "number") {
+    index = args.index as number;
+    if (!Number.isInteger(index) || index < 0 || index >= ties.length) {
+      return fail(`index ${index} out of range — board has ${ties.length} net ties (0..${ties.length - 1})`);
+    }
+    // A nets/position given alongside the index is a guard against deleting
+    // the wrong tie — confirm the indexed tie actually matches.
+    if (!matchesFilter(ties[index]!)) {
+      return fail(
+        `net tie at index ${index} joins [${ties[index]!.nets.join(", ")}]` +
+          `${ties[index]!.position ? ` at (${ties[index]!.position!.x}, ${ties[index]!.position!.y})` : ""}, ` +
+          "not the nets/position you specified",
+      );
+    }
+  } else if (wantNets || wantPos) {
+    const matches = ties.flatMap((t, i) => (matchesFilter(t) ? [i] : []));
+    const sel = [
+      wantNets ? `[${wantNets.join(", ")}]` : undefined,
+      wantPos ? `(${wantPos.x}, ${wantPos.y})` : undefined,
+    ]
+      .filter(Boolean)
+      .join(" at ");
+    if (matches.length === 0) return fail(`no net tie matches ${sel}`);
+    if (matches.length > 1) {
+      return fail(
+        `${matches.length} net ties match ${sel} (indices ${matches.join(", ")}) — pass \`index\` or \`position\` to pick one`,
+      );
+    }
+    index = matches[0]!;
+  } else {
+    return fail(
+      `pass \`index\` (0..${ties.length - 1}), \`nets\`, or \`position\` to identify the tie to delete`,
+    );
+  }
+
+  const [removed] = ties.splice(index, 1);
+  const change: PcbElementChange = {
+    action: "removed",
+    kind: "netTie",
+    index,
+    net: removed!.nets.join("+"),
+  };
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          deleted: describeNetTie(removed!, index),
+          net_ties: netTieList(pcb),
+          net_ties_total: ties.length,
+          changed: [change],
+          ...docResultPayload(ctx),
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
 // undo — rewind the last mutation on a session (snapshot stack)
 // ============================================================================
 
@@ -8028,11 +8607,16 @@ function diffElementArray(
 /** Board-element diff between two PCBs (or null when neither has a board). */
 function diffPcbElements(before: Pcb | null, after: Pcb | null): PcbElementChange[] {
   if (!before || !after) return [];
+  // Ties carry no single `net` — view them with the joined names so the
+  // generic differ (which keys on full JSON and reads `.net`) can report them.
+  const tieView = (ties?: NetTie[]) =>
+    (ties ?? []).map((t) => ({ ...t, net: t.nets.join("+") }));
   return [
     ...diffElementArray("zone", before.zones ?? [], after.zones ?? []),
     ...diffElementArray("trace", before.traces ?? [], after.traces ?? []),
     ...diffElementArray("traceArc", (before.traceArcs ?? []) as never, (after.traceArcs ?? []) as never),
     ...diffElementArray("via", before.vias ?? [], after.vias ?? []),
+    ...diffElementArray("netTie", tieView(before.netTies) as never, tieView(after.netTies) as never),
   ];
 }
 


### PR DESCRIPTION
## Summary

Adds three new MCP tools for PCB copper inspection and net tie management, completing the read/write algebra for routed copper and intentional net junctions.

## Key Changes

- **`get_copper` tool** — Query the board's routed copper (traces, trace arcs, vias, zones) with optional filters by layer, net, bounding box, and kind. Returns each element with its `index` (compatible with delete tools) and geometry, enabling surgical edits without exporting the document. Supports pagination with `offset`/`limit` (capped at 200 elements per page).

- **`add_net_tie` tool** — Declare intentional junctions between two or more nets (e.g., wye motor neutral points, split-ground stitches, current-sense shunt taps). Supports both board-wide ties and region-scoped ties (position + radius). Validates that all nets exist on the board and rejects half-scoped regions (position without radius or vice versa).

- **`delete_net_tie` tool** — Remove a net tie by index, by matching net set (order-insensitive), or by position (±0.001 mm tolerance). Supports guards: passing `nets` or `position` alongside `index` confirms the indexed tie matches before deletion.

- **Net tie diffing** — Extended `PcbElementChange` to include `"netTie"` kind and updated `diffPcbElements` to track tie mutations in the `changed` diff (ties report their joined nets as `"A+B+C"` since they have no single net).

- **Copper element bounding boxes** — Added `copperElementBbox` helper to compute conservative axis-aligned bounds for traces, trace arcs, vias, and zones (full-circle bound for arcs to avoid missing copper on bbox queries).

- **Via layer spanning** — Added `viaSpansLayer` to check if a via's barrel spans a given copper layer (e.g., a through via FCu→BCu carries In1Cu).

- **Schema and validation** — Added JSON schemas for all three tools with comprehensive property descriptions. Validation includes layer name normalization, net existence checks, and bbox geometry validation.

- **Test coverage** — Added comprehensive tests for `get_copper` (filtering, pagination, index-driven deletes), `add_net_tie` (board-wide and region-scoped ties, validation), and `delete_net_tie` (index/net/position matching, guards, DRC integration). Includes an end-to-end test showing that a region-scoped tie exempts a junction short in DRC, and deleting it re-arms the violation.

- **Server integration** — Registered all three tools in the MCP server, marked `add_net_tie` and `delete_net_tie` as document writers (they mutate the session and must persist/be undoable), and updated the PCB workflow blurb in the server instructions.

## Implementation Details

- Copper queries iterate collections in deterministic order (traces, arcs, vias, zones; index order within each) to ensure offset-paging never skips or repeats elements.
- Zone outlines can run to hundreds of vertices on dense boards; `get_copper` reports bbox + vertex count instead of the full outline to keep responses bounded.
- Net ties are DRC data (not copper geometry) but change what `run_drc` accepts, so they must persist and be undoable like other mutations.
- Tie positions are rounded to 0.001 mm on write; `delete_net_tie` position matching uses the same ±0.001 mm tolerance, so echoing a position from `add_net_tie`'s result always matches.
- `add_net_tie` fails closed on a half-scoped region: the kernel's `NetTieGroups` only forms a region when both position and radius are present, so passing one without the other would silently degrade to a board-wide exemption.

https://claude.ai/code/session_0149H9KjqeyjkVWEihNjMvJS