### PR TITLE
Add induction motor mode, fringing derate, and self-start check

### DIFF
--- a/changelog/entries/2026-07-07-motor-induction-selfstart.json
+++ b/changelog/entries/2026-07-07-motor-induction-selfstart.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-motor-induction-selfstart",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "Induction motors, fringing derate, and will-it-spin check",
+  "summary": "calc_motor gains a thin-sheet induction mode (drag-cup / PCB rotors) and a Carter-like fringing derate for PM flux; new check_self_start gates starting torque against bearing friction.",
+  "features": ["electromagnetics", "motor", "receipt", "verification"],
+  "mcpTools": ["calc_motor", "check_self_start"]
+}

--- a/crates/vcad-ecad-sim/src/airgap.rs
+++ b/crates/vcad-ecad-sim/src/airgap.rs
@@ -146,6 +146,35 @@ pub fn airgap_flux_density(spec: &AirGapSpec) -> f64 {
     phi_g / (a_g * 1e-6)
 }
 
+/// First-order Carter-like fringing derate for the MEC gap field.
+///
+/// [`airgap_flux_density`] assumes flux crosses the gap straight — no
+/// spreading at the pole edges. Real flux fringes outward by roughly one gap
+/// length per pole edge (the classical straight-line-plus-quarter-circle
+/// fringe-tube estimate), so the same total flux crosses an effectively wider
+/// pole and the density *under* the pole face drops. Modeling the widening in
+/// the one dimension that matters (across the pole width `w`, gap `g`):
+///
+/// ```text
+///   B_derated = B_raw · w / (w + 2g)  =  B_raw · ρ / (ρ + 2),   ρ = w/g
+/// ```
+///
+/// This is the fringing analogue of Carter's slotting coefficient — a pure
+/// geometry ratio, first-order in `g/w`. It is honest only while the pole is
+/// wide compared to the gap (`ρ ≳ 2`); below that the fringe tubes overlap
+/// and the closed form under-predicts the field, so treat small-`ρ` results
+/// as a lower bound. Returns 1.0 (no derate) for a non-positive gap and 0.0
+/// for a non-positive pole width.
+pub fn fringing_derate(pole_width_mm: f64, airgap_mm: f64) -> f64 {
+    if airgap_mm <= 0.0 {
+        return 1.0;
+    }
+    if pole_width_mm <= 0.0 {
+        return 0.0;
+    }
+    pole_width_mm / (pole_width_mm + 2.0 * airgap_mm)
+}
+
 /// Coarse coreless / air-cored air-gap flux density (tesla) — **no back-iron**.
 ///
 /// With no soft-iron return path the field is set directly by the coil MMF
@@ -260,6 +289,21 @@ mod tests {
             b_iron > 0.95 * b_ideal,
             "iron drop should be small: {b_iron}"
         );
+    }
+
+    #[test]
+    fn fringing_derate_behaves_like_a_carter_factor() {
+        // Wide pole, small gap: barely any derate.
+        assert!(fringing_derate(20.0, 0.5) > 0.95);
+        // ρ = w/g = 2 → w/(w+2g) = 0.5.
+        assert!((fringing_derate(2.0, 1.0) - 0.5).abs() < 1e-12);
+        // Monotonic: bigger gap, more fringing, lower B.
+        assert!(fringing_derate(10.0, 2.0) < fringing_derate(10.0, 1.0));
+        // Degenerate guards.
+        assert_eq!(fringing_derate(10.0, 0.0), 1.0);
+        assert_eq!(fringing_derate(0.0, 1.0), 0.0);
+        // Always a derate, never a boost.
+        assert!(fringing_derate(5.0, 1.0) < 1.0);
     }
 
     #[test]

--- a/crates/vcad-ecad-sim/src/em.rs
+++ b/crates/vcad-ecad-sim/src/em.rs
@@ -22,6 +22,9 @@
 //! | no-load speed | ω0 | rad/s | [`motor::evaluate_motor`] | V/Ke, linear DC model |
 //! | stall torque | Ts | N·m | [`motor::evaluate_motor`] | Kt·V/R, linear DC model |
 //! | air-gap flux density | B_gap | T | [`airgap::airgap_flux_density`] | MEC reluctance network |
+//! | fringing derate | k_f | — | [`airgap::fringing_derate`] | Carter-like w/(w+2g) pole-edge fringe |
+//! | induction gap field | B1 | T | [`induction::evaluate_thin_sheet_induction`] | rotating-MMF fundamental, μ0·F1/g |
+//! | torque per unit slip | K | N·m | [`induction::evaluate_thin_sheet_induction`] | thin-sheet eddy torque, Russell–Norsworthy end effect |
 //! | characteristic impedance | Z0 | Ω | [`impedance`] | IPC-2141 / Hammerstad–Jensen |
 //! | differential impedance | Zdiff | Ω | [`impedance`] | 2·Z0·k edge-coupling factor |
 //! | effective permittivity | εr_eff | — | [`impedance`] | Hammerstad–Jensen |
@@ -30,10 +33,12 @@
 //!
 //! The MCP calculators (`calc_coil`, `calc_impedance`, `size_coil`,
 //! `size_impedance`, `winding_layout`) mirror these closed forms in
-//! TypeScript; `calc_motor` calls [`motor::evaluate_motor`] and
-//! [`airgap::airgap_flux_density`] through the kernel WASM; `calc_rf` (RLC
-//! resonance/Q) and `size_pdn` (IR-drop resistor mesh) are TS-side solvers
-//! with no Rust twin yet. Each calculator emits its predictions as **receipt
+//! TypeScript; `calc_motor` (PM mode) calls [`motor::evaluate_motor`] and
+//! [`airgap::airgap_flux_density`] through the kernel WASM, and mirrors the
+//! [`airgap::fringing_derate`] and [`induction`] closed forms in TypeScript
+//! (induction mode); `calc_rf` (RLC resonance/Q), `size_pdn` (IR-drop
+//! resistor mesh), and `check_self_start` (torque-vs-bearing-friction margin,
+//! mechanical rather than EM) are TS-side solvers with no Rust twin yet. Each calculator emits its predictions as **receipt
 //! claims** — *quantity, predicted value, unit, method, inputs* (see
 //! `packages/mcp/src/tools/em-claims.ts`). A claim is honest about being a
 //! model — first-order, no slotting/fringing/saturation, no field solver — so
@@ -62,6 +67,7 @@
 
 pub use crate::airgap;
 pub use crate::impedance;
+pub use crate::induction;
 pub use crate::magnetics;
 pub use crate::motor;
 pub use crate::signal_integrity;

--- a/crates/vcad-ecad-sim/src/induction.rs
+++ b/crates/vcad-ecad-sim/src/induction.rs
@@ -1,0 +1,283 @@
+//! Thin-sheet axial induction machine model (drag-cup / PCB-cage rotors).
+//!
+//! [`crate::motor`] models PM machines: torque comes from magnet flux crossing
+//! the gap (Kt/Ke). An axial *induction* machine has no magnets — the stator's
+//! rotating MMF induces eddy currents in a thin conductive rotor sheet (a
+//! drag-cup wall, a copper-clad PCB disc), and torque comes from those currents
+//! reacting against the travelling field. This module gives that machine the
+//! same closed-form, first-order treatment.
+//!
+//! # Model (read the limits)
+//!
+//! **Stator field.** A balanced m=3 phase winding with `N` series turns per
+//! phase, winding factor `kw`, and `p` pole pairs carrying peak current `I_pk`
+//! produces a rotating MMF fundamental of amplitude
+//!
+//! ```text
+//!   F1 = (3/2) · (4/π) · (kw·N / (2p)) · I_pk        [A·turns]
+//! ```
+//!
+//! Driving that MMF across the total non-ferromagnetic gap `g` (mechanical air
+//! gaps + rotor sheet + any PCB/adhesive in the flux path — everything that is
+//! not iron) gives the fundamental gap field
+//!
+//! ```text
+//!   B1 = μ0 · F1 / g                                  [T]
+//! ```
+//!
+//! **Rotor torque.** The rotor is a thin sheet characterized only by its
+//! surface conductance `σs = σ · t` (S) — e.g. two 2 oz copper layers:
+//! `5.8e7 S/m × 0.14e-3 m ≈ 8120 S`. At slip `s` the field sweeps past the
+//! sheet at slip speed `s·ωsync` (mechanical, `ωsync = ωe/p`), inducing a
+//! current density `J = σs·(v × B)`; integrating `r × (J × B)` over the active
+//! annulus `r1..r2` with the θ-average `⟨B²⟩ = B1²/2` gives a torque *linear*
+//! in slip:
+//!
+//! ```text
+//!   T(s) = k_ee · π · σs · s · (ωe/p) · B1² · (r2⁴ − r1⁴) / 4   [N·m]
+//! ```
+//!
+//! `k_ee` is the Russell–Norsworthy end-effect factor (≈ 0.5–0.8, default
+//! 0.65): the eddy-current return paths close *outside* the active annulus
+//! through sheet resistance the ideal integral ignores, so real torque is a
+//! constant fraction of the ideal value.
+//!
+//! **Honesty.** First-order only: linear-in-slip torque (no peak/breakdown —
+//! valid while the sheet's skin depth at slip frequency exceeds its thickness,
+//! true for thin sheets at small `s·f`), no stator leakage or magnetizing
+//! reactance (B1 is impressed, not solved from a T-equivalent circuit), no
+//! slotting, no saturation, no temperature dependence of σ. Use it for
+//! will-it-spin sizing of drag-cup and PCB-rotor machines, not as an FEA
+//! substitute.
+//!
+//! Reference for the end-effect treatment: Russell & Norsworthy, "Eddy
+//! currents and wall losses in screened-rotor induction motors", Proc. IEE,
+//! 1958.
+
+use serde::{Deserialize, Serialize};
+use std::f64::consts::PI;
+
+/// Permeability of free space, T·m/A.
+const MU0: f64 = 4.0 * PI * 1e-7;
+
+/// Inputs for the thin-sheet axial induction model.
+///
+/// Lengths in millimetres, current in amps RMS, conductance in siemens.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThinSheetInductionSpec {
+    /// Pole pairs `p` (electrical periods per mechanical revolution).
+    pub pole_pairs: f64,
+    /// Series turns per phase `N`.
+    pub turns_per_phase: f64,
+    /// Winding factor `kw` (distribution × pitch).
+    pub winding_factor: f64,
+    /// Phase current, amps RMS (balanced 3-phase drive assumed).
+    pub phase_current_a_rms: f64,
+    /// Electrical drive frequency, Hz.
+    pub electrical_freq_hz: f64,
+    /// Total non-ferromagnetic flux path `g`, mm — every air gap plus the
+    /// rotor sheet and any PCB substrate the flux crosses between back-irons.
+    pub effective_gap_mm: f64,
+    /// Rotor sheet surface conductance `σs = σ·thickness`, siemens.
+    pub sheet_conductance_s: f64,
+    /// Inner radius of the active (field-swept) annulus, mm.
+    pub inner_radius_mm: f64,
+    /// Outer radius of the active annulus, mm.
+    pub outer_radius_mm: f64,
+    /// Russell–Norsworthy end-effect factor `k_ee` (0..1]. Fraction of the
+    /// ideal torque that survives the eddy-current return paths closing
+    /// outside the active annulus. Typical 0.5–0.8; 0.65 is a sane default.
+    pub end_effect_factor: f64,
+}
+
+/// Closed-form performance of a [`ThinSheetInductionSpec`].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThinSheetInductionPerformance {
+    /// Fundamental air-gap flux density amplitude `B1`, tesla.
+    pub b1_tesla: f64,
+    /// Torque per unit slip `K` (with end effect applied): `T(s) = K·s`, N·m.
+    pub torque_per_unit_slip_nm: f64,
+    /// Locked-rotor torque `T(s=1)` with end effect applied, N·m. Equal to
+    /// `torque_per_unit_slip_nm` in this linear model.
+    pub locked_rotor_torque_nm: f64,
+    /// Locked-rotor torque *before* the end-effect factor, N·m — the ideal
+    /// annulus integral, for grading against the factored value.
+    pub locked_rotor_torque_raw_nm: f64,
+    /// Synchronous mechanical speed, RPM (`60·f/p`).
+    pub sync_rpm: f64,
+    /// Rotor sheet dissipation at locked rotor, W. At `s = 1` all air-gap
+    /// power is dissipated in the sheet: `P = T(1) · ωsync` (end effect
+    /// applied). Stator copper loss is *not* included — the model has no
+    /// phase resistance input.
+    pub copper_loss_w: f64,
+}
+
+/// Evaluate the thin-sheet axial induction closed form.
+///
+/// Returns all-zero performance (rather than NaN/inf) when any input that
+/// would break the closed form is non-positive: pole pairs, turns, winding
+/// factor, current, frequency, gap, conductance, or a non-annulus
+/// (`r2 <= r1`). The end-effect factor is clamped to (0, 1].
+pub fn evaluate_thin_sheet_induction(
+    spec: &ThinSheetInductionSpec,
+) -> ThinSheetInductionPerformance {
+    let zero = ThinSheetInductionPerformance {
+        b1_tesla: 0.0,
+        torque_per_unit_slip_nm: 0.0,
+        locked_rotor_torque_nm: 0.0,
+        locked_rotor_torque_raw_nm: 0.0,
+        sync_rpm: 0.0,
+        copper_loss_w: 0.0,
+    };
+    let p = spec.pole_pairs;
+    if p <= 0.0
+        || spec.turns_per_phase <= 0.0
+        || spec.winding_factor <= 0.0
+        || spec.phase_current_a_rms <= 0.0
+        || spec.electrical_freq_hz <= 0.0
+        || spec.effective_gap_mm <= 0.0
+        || spec.sheet_conductance_s <= 0.0
+        || spec.outer_radius_mm <= spec.inner_radius_mm
+        || spec.inner_radius_mm < 0.0
+    {
+        return zero;
+    }
+    let k_ee = if spec.end_effect_factor > 0.0 {
+        spec.end_effect_factor.min(1.0)
+    } else {
+        return zero;
+    };
+
+    // Rotating MMF fundamental (3-phase): F1 = (3/2)·(4/π)·(kw·N/(2p))·I_pk.
+    let i_pk = spec.phase_current_a_rms * std::f64::consts::SQRT_2;
+    let f1 = 1.5 * (4.0 / PI) * (spec.winding_factor * spec.turns_per_phase / (2.0 * p)) * i_pk;
+    let g_m = spec.effective_gap_mm * 1e-3;
+    let b1 = MU0 * f1 / g_m;
+
+    // Ideal linear slip torque: T(s) = π·σs·s·(ωe/p)·B1²·(r2⁴ − r1⁴)/4.
+    let omega_e = 2.0 * PI * spec.electrical_freq_hz;
+    let omega_sync = omega_e / p;
+    let r1_m = spec.inner_radius_mm * 1e-3;
+    let r2_m = spec.outer_radius_mm * 1e-3;
+    let annulus = (r2_m.powi(4) - r1_m.powi(4)) / 4.0;
+    let k_raw = PI * spec.sheet_conductance_s * omega_sync * b1 * b1 * annulus;
+    let k = k_ee * k_raw;
+
+    ThinSheetInductionPerformance {
+        b1_tesla: b1,
+        torque_per_unit_slip_nm: k,
+        locked_rotor_torque_nm: k,
+        locked_rotor_torque_raw_nm: k_raw,
+        sync_rpm: 60.0 * spec.electrical_freq_hz / p,
+        // s = 1: air-gap power T·ωsync all burns in the sheet.
+        copper_loss_w: k * omega_sync,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The validation reference from the tool spec: N=30, kw=0.866, p=3,
+    /// I=1.5 A rms, f=100 Hz, g=4.7 mm, σs=8120 S, r1=15.3, r2=28.5,
+    /// end effect 0.65.
+    fn reference_spec() -> ThinSheetInductionSpec {
+        ThinSheetInductionSpec {
+            pole_pairs: 3.0,
+            turns_per_phase: 30.0,
+            winding_factor: 0.866,
+            phase_current_a_rms: 1.5,
+            electrical_freq_hz: 100.0,
+            effective_gap_mm: 4.7,
+            sheet_conductance_s: 8120.0,
+            inner_radius_mm: 15.3,
+            outer_radius_mm: 28.5,
+            end_effect_factor: 0.65,
+        }
+    }
+
+    #[test]
+    fn reference_b1_is_about_4_7_mt() {
+        let perf = evaluate_thin_sheet_induction(&reference_spec());
+        assert!(
+            (perf.b1_tesla - 4.7e-3).abs() < 0.1e-3,
+            "B1 {} T should be ≈ 4.7 mT",
+            perf.b1_tesla
+        );
+    }
+
+    #[test]
+    fn reference_locked_rotor_raw_is_about_18_unm() {
+        let perf = evaluate_thin_sheet_induction(&reference_spec());
+        assert!(
+            (perf.locked_rotor_torque_raw_nm - 17.8e-6).abs() < 0.5e-6,
+            "raw locked-rotor {} N·m should be ≈ 17.8 µN·m",
+            perf.locked_rotor_torque_raw_nm
+        );
+        // End effect scales the delivered torque.
+        assert!(
+            (perf.locked_rotor_torque_nm - 0.65 * perf.locked_rotor_torque_raw_nm).abs() < 1e-12
+        );
+    }
+
+    #[test]
+    fn reference_sync_speed_is_2000_rpm() {
+        let perf = evaluate_thin_sheet_induction(&reference_spec());
+        assert!((perf.sync_rpm - 2000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn torque_is_linear_in_slip_and_loss_matches_airgap_power() {
+        let perf = evaluate_thin_sheet_induction(&reference_spec());
+        assert_eq!(perf.torque_per_unit_slip_nm, perf.locked_rotor_torque_nm);
+        let omega_sync = 2.0 * PI * 100.0 / 3.0;
+        assert!(
+            (perf.copper_loss_w - perf.locked_rotor_torque_nm * omega_sync).abs() < 1e-12,
+            "locked-rotor sheet loss should be T·ωsync"
+        );
+    }
+
+    #[test]
+    fn torque_scales_with_conductance_and_current_squared() {
+        let base = evaluate_thin_sheet_induction(&reference_spec());
+        let mut spec = reference_spec();
+        spec.sheet_conductance_s *= 2.0;
+        let thick = evaluate_thin_sheet_induction(&spec);
+        assert!((thick.locked_rotor_torque_nm / base.locked_rotor_torque_nm - 2.0).abs() < 1e-9);
+
+        let mut spec = reference_spec();
+        spec.phase_current_a_rms *= 2.0;
+        let hot = evaluate_thin_sheet_induction(&spec);
+        // B1 ∝ I, T ∝ B1² → 4×.
+        assert!((hot.locked_rotor_torque_nm / base.locked_rotor_torque_nm - 4.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn bigger_gap_weakens_field_and_torque() {
+        let base = evaluate_thin_sheet_induction(&reference_spec());
+        let mut spec = reference_spec();
+        spec.effective_gap_mm *= 2.0;
+        let far = evaluate_thin_sheet_induction(&spec);
+        assert!((far.b1_tesla / base.b1_tesla - 0.5).abs() < 1e-9);
+        assert!((far.locked_rotor_torque_nm / base.locked_rotor_torque_nm - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn non_physical_inputs_collapse_to_zero() {
+        for mutate in [
+            (|s: &mut ThinSheetInductionSpec| s.pole_pairs = 0.0) as fn(&mut _),
+            |s: &mut ThinSheetInductionSpec| s.effective_gap_mm = 0.0,
+            |s: &mut ThinSheetInductionSpec| s.sheet_conductance_s = -1.0,
+            |s: &mut ThinSheetInductionSpec| s.outer_radius_mm = s.inner_radius_mm,
+            |s: &mut ThinSheetInductionSpec| s.end_effect_factor = 0.0,
+        ] {
+            let mut spec = reference_spec();
+            mutate(&mut spec);
+            let perf = evaluate_thin_sheet_induction(&spec);
+            assert_eq!(perf.locked_rotor_torque_nm, 0.0);
+            assert_eq!(perf.b1_tesla, 0.0);
+        }
+    }
+}

--- a/crates/vcad-ecad-sim/src/lib.rs
+++ b/crates/vcad-ecad-sim/src/lib.rs
@@ -14,8 +14,9 @@
 //!
 //! - [`airgap`] — First-order air-gap flux density via a reluctance network (MEC)
 //! - [`impedance`] — Characteristic impedance for microstrip and stripline geometries
+//! - [`induction`] — Thin-sheet axial induction machine (drag-cup / PCB-cage rotors)
 //! - [`magnetics`] — Scalar-generic spiral inductance + motor torque constant
-//! - [`motor`] — Analytical motor performance (Kt/Ke, no-load speed, stall torque, curve)
+//! - [`motor`] — Analytical PM motor performance (Kt/Ke, no-load speed, stall torque, curve)
 //! - [`signal_integrity`] — Propagation delay, crosstalk estimation, length matching
 //!
 //! Neighbors outside the EM domain:
@@ -27,15 +28,19 @@ pub mod airgap;
 pub mod circuit;
 pub mod em;
 pub mod impedance;
+pub mod induction;
 pub mod magnetics;
 pub mod motor;
 pub mod signal_integrity;
 pub mod thermal;
 
-pub use airgap::{aircored_airgap_flux_density, airgap_flux_density, AirGapSpec};
+pub use airgap::{aircored_airgap_flux_density, airgap_flux_density, fringing_derate, AirGapSpec};
 pub use impedance::{
     diff_microstrip_impedance, diff_stripline_impedance, microstrip_impedance, stripline_impedance,
     ImpedanceResult,
+};
+pub use induction::{
+    evaluate_thin_sheet_induction, ThinSheetInductionPerformance, ThinSheetInductionSpec,
 };
 pub use motor::{evaluate_motor, MotorPerformance, MotorSpec, OperatingPoint};
 pub use signal_integrity::{

--- a/packages/docs/content/guides/electronics/electromagnetics.mdx
+++ b/packages/docs/content/guides/electronics/electromagnetics.mdx
@@ -10,7 +10,7 @@ Electromagnetics rides the PCB rail: everything the domain designs is copper, so
 
 ## The tools
 
-Eight calculators analyze or size EM structures. They are pure: they take parameters and return numbers, touching no board.
+Nine calculators analyze or size EM structures. They are pure: they take parameters and return numbers, touching no board.
 
 | Tool | What it does |
 |---|---|
@@ -21,7 +21,8 @@ Eight calculators analyze or size EM structures. They are pure: they take parame
 | `size_pdn` | Size power-distribution copper so every load node meets its IR-drop budget |
 | `calc_rf` | RLC frequency response: resonance, Q, S11/return loss against a reference Z0 |
 | `winding_layout` | Polyphase motor winding plan: per-slot phase/polarity and the winding factor |
-| `calc_motor` | First-order motor performance: Kt, Ke, no-load speed, stall torque, speed–torque curve |
+| `calc_motor` | First-order motor performance. PM mode: Kt, Ke, no-load speed, stall torque, speed–torque curve, optional pole-edge fringing derate. Induction mode: thin-sheet axial rotor (drag-cup / PCB cage) — gap field B1, torque-per-unit-slip, locked-rotor torque, sync speed |
+| `check_self_start` | Will it spin? Starting torque vs friction (direct estimate or the built-in bearing-drag catalog), fail-closed with margin |
 
 Three realizers turn plans into copper on the session board: `add_coil` (one Archimedean spiral of traces), `add_coil_array` (a ring of coils with per-coil nets and chirality), and `add_motor_winding` (plan + place + interconnect + terminate a whole stator winding in one call).
 
@@ -40,9 +41,9 @@ Every calculator's output now includes a `claims` array. A claim is one quantita
 }
 ```
 
-The quantities the domain can claim today: inductance, DC resistance, characteristic and differential impedance, effective permittivity, propagation delay, IR drop, resonant frequency, Q factor, winding factor, torque constant, back-EMF constant, no-load speed, stall torque, and air-gap flux density.
+The quantities the domain can claim today: inductance, DC resistance, characteristic and differential impedance, effective permittivity, propagation delay, IR drop, resonant frequency, Q factor, winding factor, torque constant, back-EMF constant, no-load speed, stall torque, air-gap flux density, torque per unit slip, locked-rotor torque, synchronous speed, rotor copper loss, friction torque, and starting margin.
 
-The `method` string names the closed-form model that produced the number — `wheeler-mohan-1999`, `ipc2141-microstrip`, `mec-reluctance`, `star-of-slots`, `first-order-dc-motor`, and friends. Every one is a first-order model: no slotting, fringing, saturation, or field solving. That honesty is the point — a claim states what was predicted, by what model, from what inputs, so a Receipt can ledger it and a later measurement or FEA pass can grade the prediction instead of contradicting a vague number.
+The `method` string names the closed-form model that produced the number — `wheeler-mohan-1999`, `ipc2141-microstrip`, `mec-reluctance`, `mec-fringing-derate`, `star-of-slots`, `first-order-dc-motor`, `thin-sheet-induction`, and friends. Every one is a first-order model: no slotting, fringing, saturation, or field solving. That honesty is the point — a claim states what was predicted, by what model, from what inputs, so a Receipt can ledger it and a later measurement or FEA pass can grade the prediction instead of contradicting a vague number.
 
 ## Differentiable by construction
 

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -19,6 +19,7 @@ import {
   sizeCoil,
   calcRf,
   calcMotor,
+  checkSelfStart,
   addCoil,
   addCoilArray,
   windingLayout,
@@ -5275,6 +5276,304 @@ describe("EM receipt claims", () => {
       expect(typeof c.method).toBe("string");
       expect(c.inputs).toBeTruthy();
     }
+  });
+
+  it("calc_motor induction mode claims B1, slip torque, sync speed, and rotor loss", async () => {
+    const r = out(
+      await calcMotor({
+        mode: "induction",
+        pole_pairs: 3,
+        turns_per_phase: 30,
+        winding_factor: 0.866,
+        phase_current_a: 1.5,
+        electrical_freq_hz: 100,
+        effective_gap_mm: 4.7,
+        sheet_conductance_s: 8120,
+        inner_radius_mm: 15.3,
+        outer_radius_mm: 28.5,
+      }),
+    );
+    const quantities = r.claims.map((c: any) => c.quantity);
+    expect(quantities).toEqual([
+      "airgap_flux_density",
+      "torque_per_unit_slip",
+      "locked_rotor_torque",
+      "synchronous_speed",
+      "rotor_copper_loss",
+    ]);
+    for (const c of r.claims) {
+      expect(c.domain).toBe("em");
+      expect(c.method).toBe("thin-sheet-induction");
+      expect(c.inputs.sheet_conductance_s).toBe(8120);
+      expect(c.inputs.end_effect_factor).toBe(0.65);
+    }
+    const lr = r.claims.find((c: any) => c.quantity === "locked_rotor_torque");
+    expect(lr.predicted).toBe(r.locked_rotor_torque_nm);
+    expect(lr.unit).toBe("N·m");
+  });
+
+  it("calc_motor PM fringing derate claims both the raw MEC B and the derated B", async () => {
+    const r = out(
+      await calcMotor({
+        pole_pairs: 6,
+        turns_per_phase: 60,
+        winding_factor: 0.866,
+        inner_radius_mm: 5,
+        outer_radius_mm: 30,
+        phase_resistance_ohm: 0.5,
+        supply_voltage_v: 24,
+        magnet: { airgap_mm: 1, pole_width_mm: 10 },
+      }),
+    );
+    const bClaims = r.claims.filter((c: any) => c.quantity === "airgap_flux_density");
+    expect(bClaims.map((c: any) => c.method)).toEqual(["mec-reluctance", "mec-fringing-derate"]);
+    expect(bClaims[0].predicted).toBe(r.airgap_flux_raw_tesla);
+    expect(bClaims[1].predicted).toBe(r.airgap_flux_tesla);
+    expect(bClaims[1].inputs.pole_width_mm).toBe(10);
+  });
+
+  it("check_self_start claims the catalog friction estimate and the margin", () => {
+    const r = out(
+      checkSelfStart({
+        available_torque_nm: 5e-3,
+        bearings: { type: "608-2RS", preload: "light", count: 2 },
+      }),
+    );
+    const friction = r.claims.find((c: any) => c.quantity === "friction_torque");
+    expect(friction.method).toBe("bearing-friction-catalog");
+    expect(friction.predicted).toBeCloseTo(4e-3, 9);
+    const margin = r.claims.find((c: any) => c.quantity === "start_margin");
+    expect(margin.method).toBe("torque-friction-margin");
+    expect(margin.predicted).toBe(r.margin);
+    // A direct friction estimate is the caller's number, not a prediction.
+    const direct = out(checkSelfStart({ available_torque_nm: 1e-3, friction_torque_nm: 2e-3 }));
+    expect(direct.claims.map((c: any) => c.quantity)).toEqual(["start_margin"]);
+  });
+});
+
+describe("calc_motor induction mode (thin-sheet axial rotor)", () => {
+  // The validation reference from the tool spec: N=30, kw=0.866, p=3,
+  // I=1.5 A rms, f=100 Hz, g=4.7 mm, σs=8120 S (2×2oz copper), r1=15.3,
+  // r2=28.5 → B1 ≈ 4.7 mT, locked-rotor ≈ 18 µN·m before end effect.
+  const reference = {
+    mode: "induction",
+    pole_pairs: 3,
+    turns_per_phase: 30,
+    winding_factor: 0.866,
+    phase_current_a: 1.5,
+    electrical_freq_hz: 100,
+    effective_gap_mm: 4.7,
+    sheet_conductance_s: 8120,
+    inner_radius_mm: 15.3,
+    outer_radius_mm: 28.5,
+  };
+
+  it("pins the reference machine: B1 ≈ 4.7 mT, raw locked-rotor ≈ 18 µN·m, 2000 rpm sync", async () => {
+    const r = out(await calcMotor(reference));
+    expect(r.success).toBe(true);
+    expect(r.mode).toBe("induction");
+    expect(r.b1_tesla).toBeCloseTo(4.69e-3, 4);
+    expect(r.locked_rotor_torque_raw_nm).toBeCloseTo(17.8e-6, 7);
+    // Default Russell–Norsworthy end effect 0.65 scales the delivered torque.
+    expect(r.end_effect_factor).toBe(0.65);
+    expect(r.locked_rotor_torque_nm).toBeCloseTo(0.65 * r.locked_rotor_torque_raw_nm, 9);
+    expect(r.torque_per_unit_slip_nm).toBe(r.locked_rotor_torque_nm);
+    expect(r.sync_rpm).toBe(2000);
+    // Locked-rotor sheet loss is the air-gap power T·ωsync.
+    const omegaSync = (2 * Math.PI * 100) / 3;
+    expect(r.copper_loss_w).toBeCloseTo(r.locked_rotor_torque_nm * omegaSync, 7);
+  });
+
+  it("honors an explicit end_effect_factor", async () => {
+    const r = out(await calcMotor({ ...reference, end_effect_factor: 1 }));
+    expect(r.locked_rotor_torque_nm).toBe(r.locked_rotor_torque_raw_nm);
+  });
+
+  it("torque scales with conductance and current squared, field inversely with gap", async () => {
+    const base = out(await calcMotor(reference));
+    const thick = out(await calcMotor({ ...reference, sheet_conductance_s: 16240 }));
+    expect(thick.locked_rotor_torque_nm / base.locked_rotor_torque_nm).toBeCloseTo(2, 4);
+    const hot = out(await calcMotor({ ...reference, phase_current_a: 3 }));
+    expect(hot.locked_rotor_torque_nm / base.locked_rotor_torque_nm).toBeCloseTo(4, 4);
+    const far = out(await calcMotor({ ...reference, effective_gap_mm: 9.4 }));
+    expect(far.b1_tesla / base.b1_tesla).toBeCloseTo(0.5, 4);
+  });
+
+  it("rejects missing or non-physical induction inputs", async () => {
+    for (const bad of [
+      { ...reference, phase_current_a: undefined },
+      { ...reference, electrical_freq_hz: 0 },
+      { ...reference, effective_gap_mm: -1 },
+      { ...reference, sheet_conductance_s: undefined },
+      { ...reference, end_effect_factor: 1.5 },
+      { ...reference, mode: "linear" },
+    ]) {
+      expect(isErr(await calcMotor(bad as Record<string, unknown>))).toBe(true);
+    }
+  });
+
+  it("PM mode still requires its electrical inputs", async () => {
+    const res = await calcMotor({
+      pole_pairs: 6,
+      turns_per_phase: 60,
+      inner_radius_mm: 5,
+      outer_radius_mm: 30,
+    });
+    expect(isErr(res)).toBe(true);
+  });
+});
+
+describe("calc_motor PM fringing derate", () => {
+  const base = {
+    pole_pairs: 6,
+    turns_per_phase: 60,
+    winding_factor: 0.866,
+    inner_radius_mm: 5,
+    outer_radius_mm: 30,
+    phase_resistance_ohm: 0.5,
+    supply_voltage_v: 24,
+  };
+
+  it("reports raw and derated B and uses the derated value for Kt", async () => {
+    const plain = out(await calcMotor({ ...base, magnet: { airgap_mm: 1 } }));
+    const derated = out(
+      await calcMotor({ ...base, magnet: { airgap_mm: 1, pole_width_mm: 10 } }),
+    );
+    // w/(w+2g) = 10/12.
+    expect(derated.fringing_derate).toBeCloseTo(10 / 12, 3);
+    expect(derated.airgap_flux_raw_tesla).toBe(plain.airgap_flux_tesla);
+    expect(derated.airgap_flux_tesla).toBeCloseTo(
+      plain.airgap_flux_tesla * (10 / 12),
+      3,
+    );
+    // Kt scales linearly with the gap flux.
+    expect(derated.kt_nm_per_a / plain.kt_nm_per_a).toBeCloseTo(10 / 12, 2);
+    // Without pole_width_mm nothing changes and no derate fields appear.
+    expect(plain.fringing_derate).toBeUndefined();
+    expect(plain.airgap_flux_raw_tesla).toBeUndefined();
+  });
+
+  it("a wide pole barely derates; derate shrinks as the gap grows", async () => {
+    const wide = out(await calcMotor({ ...base, magnet: { airgap_mm: 0.5, pole_width_mm: 40 } }));
+    expect(wide.fringing_derate).toBeGreaterThan(0.95);
+    const bigGap = out(await calcMotor({ ...base, magnet: { airgap_mm: 3, pole_width_mm: 10 } }));
+    expect(bigGap.fringing_derate).toBeLessThan(wide.fringing_derate);
+  });
+
+  it("rejects a non-positive pole width", async () => {
+    expect(isErr(await calcMotor({ ...base, magnet: { pole_width_mm: 0 } }))).toBe(true);
+  });
+});
+
+describe("check_self_start", () => {
+  it("608-2RS light pair lands at the documented 1–4 mN·m and gates fail-closed", () => {
+    const r = out(
+      checkSelfStart({
+        available_torque_nm: 2e-3, // 2 mN·m available
+        bearings: { type: "608-2RS", preload: "light", count: 2 },
+      }),
+    );
+    expect(r.friction_torque_mnm).toEqual({ min: 1, max: 4 });
+    // Beats the optimistic end, not the worst case → fail-closed no-start.
+    expect(r.starts).toBe(false);
+    expect(r.starts_best_case).toBe(true);
+    expect(r.margin).toBeCloseTo(0.5, 6);
+
+    const strong = out(
+      checkSelfStart({
+        available_torque_nm: 12e-3,
+        bearings: { type: "608-2RS", preload: "light", count: 2 },
+      }),
+    );
+    expect(strong.starts).toBe(true);
+    expect(strong.margin).toBeCloseTo(3, 6);
+  });
+
+  it("computes available torque from Kt·I when not given directly", () => {
+    const r = out(
+      checkSelfStart({
+        kt_nm_per_a: 0.004,
+        current_a: 1.5,
+        bearings: { type: "608-ZZ", count: 2 },
+      }),
+    );
+    expect(r.available_torque_nm).toBeCloseTo(0.006, 9);
+    expect(r.available_torque_source).toBe("kt_times_current");
+    expect(r.starts).toBe(true);
+  });
+
+  it("shielded and miniature presets are far freer than sealed 608s", () => {
+    const sealed = out(
+      checkSelfStart({ available_torque_nm: 1e-3, bearings: { type: "608-2RS", count: 2 } }),
+    );
+    const shielded = out(
+      checkSelfStart({ available_torque_nm: 1e-3, bearings: { type: "608-ZZ", count: 2 } }),
+    );
+    expect(shielded.friction_torque_mnm.max).toBeLessThan(sealed.friction_torque_mnm.max);
+    expect(shielded.starts).toBe(true);
+    for (const type of ["625", "688"]) {
+      const r = out(checkSelfStart({ available_torque_nm: 1e-3, bearings: { type, count: 2 } }));
+      expect(r.starts).toBe(true);
+      expect(r.bearings.per_bearing_mnm.max).toBeLessThanOrEqual(0.6);
+    }
+  });
+
+  it("medium preload and more bearings scale the range", () => {
+    const light = out(
+      checkSelfStart({ available_torque_nm: 1, bearings: { type: "608-2RS", preload: "light", count: 2 } }),
+    );
+    const medium = out(
+      checkSelfStart({ available_torque_nm: 1, bearings: { type: "608-2RS", preload: "medium", count: 2 } }),
+    );
+    expect(medium.friction_torque_mnm.max).toBeGreaterThan(light.friction_torque_mnm.max);
+    const quad = out(
+      checkSelfStart({ available_torque_nm: 1, bearings: { type: "608-2RS", preload: "light", count: 4 } }),
+    );
+    expect(quad.friction_torque_mnm.max).toBeCloseTo(2 * light.friction_torque_mnm.max, 9);
+  });
+
+  it("a direct friction estimate overrides the catalog", () => {
+    const r = out(
+      checkSelfStart({
+        available_torque_nm: 3e-3,
+        friction_torque_nm: 2e-3,
+        bearings: { type: "608-2RS", count: 2 },
+      }),
+    );
+    expect(r.friction_source).toBe("direct");
+    expect(r.friction_torque_mnm).toEqual({ min: 2, max: 2 });
+    expect(r.starts).toBe(true);
+    expect(r.margin).toBeCloseTo(1.5, 6);
+  });
+
+  it("an induction locked-rotor µN·m machine does NOT start on sealed bearings", () => {
+    // The reference thin-sheet machine: ~11.6 µN·m delivered locked-rotor
+    // torque vs a pair of 608-2RS at 1–4 mN·m — two orders of magnitude short.
+    const r = out(
+      checkSelfStart({
+        available_torque_nm: 11.6e-6,
+        bearings: { type: "608-2RS", preload: "light", count: 2 },
+      }),
+    );
+    expect(r.starts).toBe(false);
+    expect(r.starts_best_case).toBe(false);
+    expect(r.margin).toBeLessThan(0.01);
+  });
+
+  it("rejects bad inputs", () => {
+    expect(isErr(checkSelfStart({}))).toBe(true);
+    expect(isErr(checkSelfStart({ available_torque_nm: -1 }))).toBe(true);
+    expect(isErr(checkSelfStart({ kt_nm_per_a: 0.01 }))).toBe(true);
+    expect(
+      isErr(checkSelfStart({ available_torque_nm: 1, bearings: { type: "6900" } })),
+    ).toBe(true);
+    expect(
+      isErr(checkSelfStart({ available_torque_nm: 1, bearings: { type: "625", preload: "heavy" } })),
+    ).toBe(true);
+    expect(
+      isErr(checkSelfStart({ available_torque_nm: 1, bearings: { count: 1.5 } })),
+    ).toBe(true);
+    expect(isErr(checkSelfStart({ available_torque_nm: 1, friction_torque_nm: 0 }))).toBe(true);
   });
 });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -252,6 +252,8 @@ import {
   addMotorWindingSchema,
   calcMotor,
   calcMotorSchema,
+  checkSelfStart,
+  checkSelfStartSchema,
   searchElectronicParts,
   searchElectronicPartsSchema,
   resolvePart,
@@ -708,6 +710,7 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "size_coil",
     "calc_rf",
     "calc_motor",
+    "check_self_start",
     "search_electronic_parts",
     "list_footprints",
     "search_footprints",
@@ -1706,12 +1709,27 @@ export async function createServer(
       {
         name: "calc_motor",
         description:
-          "Evaluate motor performance AS DATA: torque constant Kt, back-EMF " +
-          "constant Ke, no-load speed, stall torque, and a speed–torque " +
-          "curve. Supply air-gap flux directly or compute it from magnet " +
-          "geometry via the first-order MEC field model. Pure: no board, no " +
-          "mutation. First-order steady state (no slotting/fringing/losses).",
+          "Evaluate motor performance AS DATA. mode:'pm' (default): torque " +
+          "constant Kt, back-EMF constant Ke, no-load speed, stall torque, " +
+          "and a speed–torque curve; supply air-gap flux directly or compute " +
+          "it from magnet geometry via the first-order MEC field model, with " +
+          "an optional Carter-like fringing derate (magnet.pole_width_mm). " +
+          "mode:'induction': thin-sheet axial induction rotor (drag-cup / " +
+          "PCB cage) — gap field B1, torque-per-unit-slip, locked-rotor " +
+          "torque, sync speed, rotor sheet loss. Pure: no board, no " +
+          "mutation. First-order steady state.",
         inputSchema: calcMotorSchema,
+      },
+      {
+        name: "check_self_start",
+        description:
+          "Will it spin? Starting torque (direct, or Kt·I; induction: the " +
+          "locked-rotor torque from calc_motor) vs a friction estimate " +
+          "(direct, or the built-in bearing catalog: 608-2RS/608-ZZ/625/688 " +
+          "× light/medium preload × count). Returns starts (fail-closed vs " +
+          "worst-case friction), best-case verdict, and the margin. Pure " +
+          "calc, no document.",
+        inputSchema: checkSelfStartSchema,
       },
       {
         name: "render_pcb",
@@ -2467,6 +2485,10 @@ export async function createServer(
 
         case "calc_motor":
           result = await calcMotor(args);
+          break;
+
+        case "check_self_start":
+          result = checkSelfStart(args);
           break;
 
         case "render_pcb":

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -9371,45 +9371,183 @@ function padApproxRadius(pad: Pad): number {
 export const calcMotorSchema = {
   type: "object" as const,
   properties: {
+    mode: {
+      type: "string" as const,
+      description:
+        "'pm' (default): permanent-magnet machine — Kt/Ke from air-gap flux; " +
+        "requires inner/outer radius, phase_resistance_ohm, supply_voltage_v. " +
+        "'induction': thin-sheet axial induction rotor (drag-cup / PCB cage) — " +
+        "torque from eddy currents; requires phase_current_a, electrical_freq_hz, " +
+        "effective_gap_mm, sheet_conductance_s, inner/outer radius.",
+    },
     pole_pairs: { type: "number" as const, description: "Pole pairs p (electrical periods per mechanical rev)." },
     turns_per_phase: { type: "number" as const, description: "Series turns per phase N." },
     winding_factor: { type: "number" as const, description: "Winding factor kw (default 0.95). Use the value from winding_layout for accuracy." },
-    inner_radius_mm: { type: "number" as const, description: "Inner (bore) stator radius, mm." },
-    outer_radius_mm: { type: "number" as const, description: "Outer stator radius, mm." },
-    phase_resistance_ohm: { type: "number" as const, description: "Per-phase resistance, ohms (e.g. the add_coil DC estimate)." },
-    supply_voltage_v: { type: "number" as const, description: "DC bus / supply voltage, volts." },
+    inner_radius_mm: { type: "number" as const, description: "Inner (bore) stator radius, mm. In induction mode: inner radius of the active annulus the field sweeps." },
+    outer_radius_mm: { type: "number" as const, description: "Outer stator radius, mm. In induction mode: outer radius of the active annulus." },
+    phase_resistance_ohm: { type: "number" as const, description: "Per-phase resistance, ohms (e.g. the add_coil DC estimate). PM mode only (required)." },
+    supply_voltage_v: { type: "number" as const, description: "DC bus / supply voltage, volts. PM mode only (required)." },
     airgap_flux_tesla: {
       type: "number" as const,
-      description: "Air-gap flux density B_gap (T). Omit to COMPUTE it from `magnet` via the MEC model.",
+      description: "PM mode: air-gap flux density B_gap (T). Omit to COMPUTE it from `magnet` via the MEC model.",
     },
     magnet: {
       type: "object" as const,
       description:
-        "Optional magnet/geometry to compute B_gap when airgap_flux_tesla is omitted (NdFeB defaults). Fields: remanence_tesla, magnet_thickness_mm, airgap_mm, recoil_mu_rel, magnet_area_mm2, gap_area_mm2, iron_mu_rel.",
+        "PM mode: optional magnet/geometry to compute B_gap when airgap_flux_tesla is omitted (NdFeB defaults). " +
+        "Fields: remanence_tesla, magnet_thickness_mm, airgap_mm, recoil_mu_rel, magnet_area_mm2, gap_area_mm2, iron_mu_rel. " +
+        "Add pole_width_mm (magnet pole face width across the fringing direction) to also apply the first-order " +
+        "Carter-like fringing derate w/(w+2g) — the tool then reports raw AND derated B and uses the derated value for Kt.",
+    },
+    phase_current_a: { type: "number" as const, description: "Induction mode (required): phase current, A RMS (balanced 3-phase drive)." },
+    electrical_freq_hz: { type: "number" as const, description: "Induction mode (required): electrical drive frequency, Hz." },
+    effective_gap_mm: {
+      type: "number" as const,
+      description:
+        "Induction mode (required): TOTAL non-ferromagnetic flux path, mm — all air gaps plus the rotor sheet " +
+        "and any PCB substrate between back-irons (e.g. 4.7 for a PCB-stator sandwich).",
+    },
+    sheet_conductance_s: {
+      type: "number" as const,
+      description:
+        "Induction mode (required): rotor sheet surface conductance σs = σ·thickness, siemens. " +
+        "E.g. 2×2oz copper: 5.8e7 S/m × 0.14e-3 m ≈ 8120 S.",
+    },
+    end_effect_factor: {
+      type: "number" as const,
+      description:
+        "Induction mode: Russell–Norsworthy end-effect factor (0..1] — fraction of ideal torque surviving the " +
+        "eddy return paths outside the active annulus. Default 0.65.",
     },
   },
-  required: [
-    "pole_pairs",
-    "turns_per_phase",
-    "inner_radius_mm",
-    "outer_radius_mm",
-    "phase_resistance_ohm",
-    "supply_voltage_v",
-  ],
+  required: ["pole_pairs", "turns_per_phase"],
 };
 
+/** Round to 6 significant digits — micro-newton-metre torques survive, noise doesn't. */
+const sig6 = (v: number) => (v === 0 || !Number.isFinite(v) ? v : Number(v.toPrecision(6)));
+
 /**
- * Evaluate a motor's headline performance — torque constant, back-EMF constant,
- * no-load speed, stall torque, and a speed–torque curve — from its magnetics +
- * electrical parameters. Pure analysis (no board, no mutation). The air-gap flux
- * is either supplied directly or computed from magnet geometry via the
- * first-order MEC reluctance model. First-order steady state: no slotting,
- * fringing, saturation, or losses.
+ * Thin-sheet axial induction branch of calc_motor. A TypeScript mirror of the
+ * `vcad_ecad_sim::induction` closed form (same pattern as calc_coil /
+ * calc_impedance mirroring their Rust twins):
+ *
+ *   F1 = (3/2)·(4/π)·(kw·N/(2p))·I_pk      rotating MMF fundamental
+ *   B1 = μ0·F1/g                           g = total non-ferromagnetic path
+ *   T(s) = k_ee·π·σs·s·(ωe/p)·B1²·(r2⁴−r1⁴)/4   linear-in-slip eddy torque
+ *
+ * k_ee is the Russell–Norsworthy end-effect factor (eddy return paths close
+ * outside the active annulus). First-order: no breakdown peak, no magnetizing/
+ * leakage reactance, no stator copper loss (no resistance input).
+ */
+function calcMotorInduction(
+  args: Record<string, unknown>,
+  polePairs: number,
+  turnsPerPhase: number,
+  windingFactor: number,
+  innerR: number,
+  outerR: number,
+) {
+  const fail = ecadError;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : NaN);
+  const iRms = num(args.phase_current_a);
+  const freqHz = num(args.electrical_freq_hz);
+  const gapMm = num(args.effective_gap_mm);
+  const sigmaS = num(args.sheet_conductance_s);
+  const endEffect = Number.isFinite(num(args.end_effect_factor))
+    ? num(args.end_effect_factor)
+    : 0.65;
+
+  if (!(iRms > 0)) return fail("induction mode: phase_current_a (A rms) must be > 0");
+  if (!(freqHz > 0)) return fail("induction mode: electrical_freq_hz must be > 0");
+  if (!(gapMm > 0)) return fail("induction mode: effective_gap_mm must be > 0");
+  if (!(sigmaS > 0)) return fail("induction mode: sheet_conductance_s must be > 0");
+  if (!(endEffect > 0 && endEffect <= 1)) {
+    return fail("induction mode: end_effect_factor must be in (0, 1]");
+  }
+
+  // Rotating MMF fundamental of a balanced 3-phase winding.
+  const iPk = iRms * Math.SQRT2;
+  const f1 = 1.5 * (4 / Math.PI) * ((windingFactor * turnsPerPhase) / (2 * polePairs)) * iPk;
+  const b1 = (MU0 * f1) / (gapMm * 1e-3);
+
+  const omegaSync = (2 * Math.PI * freqHz) / polePairs; // mechanical rad/s
+  const annulusM4 = (Math.pow(outerR * 1e-3, 4) - Math.pow(innerR * 1e-3, 4)) / 4;
+  const torquePerSlipRaw = Math.PI * sigmaS * omegaSync * b1 * b1 * annulusM4;
+  const torquePerSlip = endEffect * torquePerSlipRaw;
+  const syncRpm = (60 * freqHz) / polePairs;
+  // Locked rotor (s = 1): all air-gap power T·ωsync dissipates in the sheet.
+  const copperLossW = torquePerSlip * omegaSync;
+
+  const inductionInputs = {
+    pole_pairs: polePairs,
+    turns_per_phase: turnsPerPhase,
+    winding_factor: windingFactor,
+    phase_current_a: iRms,
+    electrical_freq_hz: freqHz,
+    effective_gap_mm: gapMm,
+    sheet_conductance_s: sigmaS,
+    inner_radius_mm: innerR,
+    outer_radius_mm: outerR,
+    end_effect_factor: endEffect,
+  };
+  const claim = (q: Parameters<typeof emClaim>[0], v: number, unit: string) =>
+    emClaim(q, sig6(v), unit, "thin-sheet-induction", inductionInputs);
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          mode: "induction",
+          b1_tesla: sig6(b1),
+          torque_per_unit_slip_nm: sig6(torquePerSlip),
+          locked_rotor_torque_nm: sig6(torquePerSlip),
+          locked_rotor_torque_raw_nm: sig6(torquePerSlipRaw),
+          sync_rpm: sig6(syncRpm),
+          copper_loss_w: sig6(copperLossW),
+          end_effect_factor: endEffect,
+          note:
+            "First-order thin-sheet induction model: torque linear in slip (T(s) = K·s, " +
+            "no breakdown peak), B1 impressed by the winding MMF (no magnetizing/leakage " +
+            "reactance, no slotting/saturation), Russell–Norsworthy end-effect factor " +
+            "applied to torque. copper_loss_w is the ROTOR sheet dissipation at locked " +
+            "rotor (T·ωsync); stator copper loss is not modeled (no resistance input). " +
+            "Feed locked_rotor_torque_nm to check_self_start to answer 'will it spin?'.",
+          claims: [
+            claim("airgap_flux_density", b1, "T"),
+            claim("torque_per_unit_slip", torquePerSlip, "N·m"),
+            claim("locked_rotor_torque", torquePerSlip, "N·m"),
+            claim("synchronous_speed", syncRpm, "rpm"),
+            claim("rotor_copper_loss", copperLossW, "W"),
+          ],
+        }),
+      },
+    ],
+  };
+}
+
+/**
+ * Evaluate a motor's headline performance AS DATA — pure analysis, no board,
+ * no mutation. Two machine models behind one tool:
+ *
+ * - `mode: "pm"` (default) — torque constant, back-EMF constant, no-load
+ *   speed, stall torque, and a speed–torque curve from magnetics + electrical
+ *   parameters. Air-gap flux is supplied directly or computed from magnet
+ *   geometry via the first-order MEC reluctance model; pass
+ *   `magnet.pole_width_mm` to additionally apply a Carter-like fringing
+ *   derate (raw and derated B both reported).
+ * - `mode: "induction"` — thin-sheet axial induction rotor (drag-cup / PCB
+ *   cage): fundamental gap field B1, torque-per-unit-slip, locked-rotor
+ *   torque, synchronous speed, rotor sheet loss.
  */
 export async function calcMotor(args: Record<string, unknown>) {
   const fail = ecadError;
 
   const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : NaN);
+  const mode = typeof args.mode === "string" ? args.mode : "pm";
+  if (mode !== "pm" && mode !== "induction") {
+    return fail("mode must be 'pm' (default) or 'induction'");
+  }
   const polePairs = num(args.pole_pairs);
   const turnsPerPhase = num(args.turns_per_phase);
   const windingFactor = Number.isFinite(num(args.winding_factor)) ? num(args.winding_factor) : 0.95;
@@ -9421,6 +9559,11 @@ export async function calcMotor(args: Record<string, unknown>) {
   if (!(polePairs > 0)) return fail("pole_pairs must be > 0");
   if (!(turnsPerPhase > 0)) return fail("turns_per_phase must be > 0");
   if (!(outerR > innerR && innerR >= 0)) return fail("outer_radius_mm must be > inner_radius_mm >= 0");
+
+  if (mode === "induction") {
+    return calcMotorInduction(args, polePairs, turnsPerPhase, windingFactor, innerR, outerR);
+  }
+
   if (!(phaseR > 0)) return fail("phase_resistance_ohm must be > 0");
   if (!(supplyV > 0)) return fail("supply_voltage_v must be > 0");
 
@@ -9428,6 +9571,8 @@ export async function calcMotor(args: Record<string, unknown>) {
   let bGap = num(args.airgap_flux_tesla);
   let bGapSource: "supplied" | "computed" = "supplied";
   let magnetSpec: Parameters<typeof airgapFluxDensity>[0] | undefined;
+  // Optional first-order fringing derate on the MEC flux (see below).
+  let fringing: { poleWidthMm: number; derate: number; bRawTesla: number } | undefined;
   if (!Number.isFinite(bGap)) {
     const m = (args.magnet ?? {}) as Record<string, unknown>;
     const mnum = (v: unknown, d: number) =>
@@ -9451,6 +9596,18 @@ export async function calcMotor(args: Record<string, unknown>) {
     }
     bGap = computed;
     bGapSource = "computed";
+
+    // Carter-like pole-edge fringing derate (mirrors
+    // vcad_ecad_sim::airgap::fringing_derate): flux fringes outward ~one gap
+    // length per pole edge, so B under the pole drops by w/(w+2g). First-order,
+    // honest only for pole width ≳ 2× gap. Opt-in via magnet.pole_width_mm.
+    if (m.pole_width_mm !== undefined) {
+      const poleW = num(m.pole_width_mm);
+      if (!(poleW > 0)) return fail("magnet.pole_width_mm must be > 0");
+      const derate = poleW / (poleW + 2 * magnetSpec.airgapMm);
+      fringing = { poleWidthMm: poleW, derate, bRawTesla: bGap };
+      bGap *= derate;
+    }
   }
 
   const perf = await evaluateMotor({
@@ -9485,23 +9642,41 @@ export async function calcMotor(args: Record<string, unknown>) {
     emClaim("stall_torque", r4(perf.stallTorqueNm), "N·m", "first-order-dc-motor", motorInputs),
   ];
   if (bGapSource === "computed" && magnetSpec) {
+    const mecInputs = {
+      remanence_tesla: magnetSpec.remanenceTesla,
+      magnet_thickness_mm: magnetSpec.magnetThicknessMm,
+      recoil_mu_rel: magnetSpec.recoilMuRel,
+      airgap_mm: magnetSpec.airgapMm,
+      magnet_area_mm2: magnetSpec.magnetAreaMm2,
+      gap_area_mm2: magnetSpec.gapAreaMm2,
+      ...(magnetSpec.ironMuRel != null
+        ? {
+            iron_mu_rel: magnetSpec.ironMuRel,
+            iron_path_mm: magnetSpec.ironPathMm,
+            iron_area_mm2: magnetSpec.ironAreaMm2,
+          }
+        : {}),
+    };
+    // The raw MEC prediction stays a claim of its own even when derated —
+    // a fringing-aware FEA pass grades the derate, not the network.
     claims.push(
-      emClaim("airgap_flux_density", r4(bGap), "T", "mec-reluctance", {
-        remanence_tesla: magnetSpec.remanenceTesla,
-        magnet_thickness_mm: magnetSpec.magnetThicknessMm,
-        recoil_mu_rel: magnetSpec.recoilMuRel,
-        airgap_mm: magnetSpec.airgapMm,
-        magnet_area_mm2: magnetSpec.magnetAreaMm2,
-        gap_area_mm2: magnetSpec.gapAreaMm2,
-        ...(magnetSpec.ironMuRel != null
-          ? {
-              iron_mu_rel: magnetSpec.ironMuRel,
-              iron_path_mm: magnetSpec.ironPathMm,
-              iron_area_mm2: magnetSpec.ironAreaMm2,
-            }
-          : {}),
-      }),
+      emClaim(
+        "airgap_flux_density",
+        r4(fringing ? fringing.bRawTesla : bGap),
+        "T",
+        "mec-reluctance",
+        mecInputs,
+      ),
     );
+    if (fringing) {
+      claims.push(
+        emClaim("airgap_flux_density", r4(bGap), "T", "mec-fringing-derate", {
+          ...mecInputs,
+          pole_width_mm: fringing.poleWidthMm,
+          fringing_derate: r4(fringing.derate),
+        }),
+      );
+    }
   }
   return {
     content: [
@@ -9509,8 +9684,20 @@ export async function calcMotor(args: Record<string, unknown>) {
         type: "text" as const,
         text: JSON.stringify({
           success: true,
+          mode: "pm",
           airgap_flux_tesla: r4(bGap),
           airgap_flux_source: bGapSource,
+          ...(fringing
+            ? {
+                airgap_flux_raw_tesla: r4(fringing.bRawTesla),
+                fringing_derate: r4(fringing.derate),
+                fringing_note:
+                  "Carter-like first-order derate: B under the pole drops by " +
+                  "w/(w+2g) as flux fringes ~one gap length past each pole edge. " +
+                  "Kt/Ke and the curve use the DERATED flux. Honest for pole " +
+                  "width ≳ 2× gap; below that treat it as a lower bound.",
+              }
+            : {}),
           winding_factor: windingFactor,
           kt_nm_per_a: r4(perf.ktNmPerA),
           ke_v_s_per_rad: r4(perf.keVSPerRad),
@@ -9521,8 +9708,204 @@ export async function calcMotor(args: Record<string, unknown>) {
             speed_rad_s: r4(p.speedRadS),
             torque_nm: r4(p.torqueNm),
           })),
-          note: "First-order steady-state estimate (no slotting/fringing/saturation/losses).",
+          note: fringing
+            ? "First-order steady-state estimate (no slotting/saturation/losses; " +
+              "pole-edge fringing derated via magnet.pole_width_mm)."
+            : "First-order steady-state estimate (no slotting/fringing/saturation/losses; " +
+              "pass magnet.pole_width_mm to derate for fringing).",
           claims,
+        }),
+      },
+    ],
+  };
+}
+
+// ============================================================================
+// check_self_start — will it spin? starting torque vs bearing friction
+// ============================================================================
+
+/**
+ * Documented typical running-friction torque per bearing, mN·m, by preset and
+ * preload class. Low-speed drag in small deep-groove bearings is dominated by
+ * seal contact and grease churning, so seal type matters more than load:
+ *
+ * - `608-2RS` (8×22×7, contact rubber seals): the lip drag dominates —
+ *   0.5–2 mN·m each at light preload (a pair lands at the oft-quoted
+ *   1–4 mN·m), roughly double under medium preload.
+ * - `608-ZZ` (8×22×7, non-contact metal shields): no lip contact, an order
+ *   of magnitude freer.
+ * - `625` (5×16×5) and `688` (8×16×5 thin-section): miniature bearings,
+ *   figures for the common shielded (ZZ-type, non-contact) variants.
+ *
+ * Ranges are catalog-typical for greased bearings at room temperature; a
+ * cold, over-greased, or axially pinched bearing can exceed the top end.
+ */
+const BEARING_FRICTION_MNM: Record<
+  string,
+  Record<"light" | "medium", { min: number; max: number }>
+> = {
+  "608-2RS": {
+    light: { min: 0.5, max: 2.0 },
+    medium: { min: 1.0, max: 4.0 },
+  },
+  "608-ZZ": {
+    light: { min: 0.05, max: 0.3 },
+    medium: { min: 0.15, max: 0.8 },
+  },
+  "625": {
+    light: { min: 0.03, max: 0.2 },
+    medium: { min: 0.1, max: 0.5 },
+  },
+  "688": {
+    light: { min: 0.03, max: 0.25 },
+    medium: { min: 0.1, max: 0.6 },
+  },
+};
+
+export const checkSelfStartSchema = {
+  type: "object" as const,
+  properties: {
+    available_torque_nm: {
+      type: "number" as const,
+      description:
+        "Torque available at standstill, N·m — PM: Kt·I (or pass kt_nm_per_a + current_a " +
+        "instead); induction: locked_rotor_torque_nm from calc_motor mode:'induction'.",
+    },
+    kt_nm_per_a: {
+      type: "number" as const,
+      description: "Alternative to available_torque_nm: torque constant Kt (N·m/A), multiplied by current_a.",
+    },
+    current_a: {
+      type: "number" as const,
+      description: "Alternative to available_torque_nm: standstill phase current (A), multiplied by kt_nm_per_a.",
+    },
+    friction_torque_nm: {
+      type: "number" as const,
+      description:
+        "Direct friction estimate, N·m (single value or a measurement). Overrides `bearings` when given.",
+    },
+    bearings: {
+      type: "object" as const,
+      description:
+        "Bearing-friction estimator (used when friction_torque_nm is omitted). Fields: " +
+        "type ('608-2RS' | '608-ZZ' | '625' | '688'; 625/688 assume shielded non-contact variants), " +
+        "preload ('light' default | 'medium'), count (number of bearings, default 2).",
+    },
+  },
+};
+
+/**
+ * The single most important motor design question — will it spin? — as a pure
+ * fail-closed check: starting torque (given directly, or Kt·I) against a
+ * friction estimate (given directly, or from documented typical bearing-drag
+ * ranges). `starts` is judged against the WORST-CASE (max) friction; a design
+ * that only beats the optimistic end is reported `starts: false` with
+ * `starts_best_case: true` so the margin story is visible.
+ */
+export function checkSelfStart(args: Record<string, unknown>) {
+  const fail = ecadError;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : NaN);
+
+  // Available starting torque: direct, or Kt·I.
+  let available = num(args.available_torque_nm);
+  let availableSource: "direct" | "kt_times_current" = "direct";
+  if (!Number.isFinite(available)) {
+    const kt = num(args.kt_nm_per_a);
+    const i = num(args.current_a);
+    if (!(kt > 0) || !(i > 0)) {
+      return fail(
+        "pass available_torque_nm (> 0), or both kt_nm_per_a and current_a (> 0) to compute Kt·I",
+      );
+    }
+    available = kt * i;
+    availableSource = "kt_times_current";
+  }
+  if (!(available > 0)) return fail("available_torque_nm must be > 0");
+
+  // Friction estimate: direct value, or the bearing catalog.
+  let frictionMinNm: number;
+  let frictionMaxNm: number;
+  let frictionSource: "direct" | "bearing-catalog" = "direct";
+  let bearing:
+    | { type: string; preload: "light" | "medium"; count: number; per_bearing_mnm: { min: number; max: number } }
+    | undefined;
+  const directFriction = num(args.friction_torque_nm);
+  if (Number.isFinite(directFriction)) {
+    if (!(directFriction > 0)) return fail("friction_torque_nm must be > 0");
+    frictionMinNm = directFriction;
+    frictionMaxNm = directFriction;
+  } else {
+    const b = (args.bearings ?? {}) as Record<string, unknown>;
+    const type = typeof b.type === "string" ? b.type : "608-2RS";
+    const table = BEARING_FRICTION_MNM[type];
+    if (!table) {
+      return fail(
+        `unknown bearing type '${type}' — presets: ${Object.keys(BEARING_FRICTION_MNM).join(", ")} ` +
+          "(or pass friction_torque_nm directly)",
+      );
+    }
+    const preload = b.preload === "medium" ? "medium" : b.preload === "light" || b.preload === undefined ? "light" : null;
+    if (preload === null) return fail("bearings.preload must be 'light' or 'medium'");
+    const count = Number.isFinite(num(b.count)) ? num(b.count) : 2;
+    if (!(count >= 1 && Number.isInteger(count))) return fail("bearings.count must be an integer >= 1");
+    const range = table[preload];
+    frictionMinNm = range.min * count * 1e-3;
+    frictionMaxNm = range.max * count * 1e-3;
+    frictionSource = "bearing-catalog";
+    bearing = { type, preload, count, per_bearing_mnm: range };
+  }
+
+  const starts = available > frictionMaxNm;
+  const startsBestCase = available > frictionMinNm;
+  const margin = available / frictionMaxNm;
+
+  const claimInputs: Record<string, number | string> = {
+    available_torque_nm: sig6(available),
+    available_torque_source: availableSource,
+    friction_source: frictionSource,
+    ...(bearing
+      ? {
+          bearing_type: bearing.type,
+          bearing_preload: bearing.preload,
+          bearing_count: bearing.count,
+        }
+      : { friction_torque_nm: sig6(frictionMaxNm) }),
+  };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({
+          success: true,
+          starts,
+          starts_best_case: startsBestCase,
+          margin: sig6(margin),
+          available_torque_nm: sig6(available),
+          available_torque_source: availableSource,
+          friction_torque_mnm: { min: sig6(frictionMinNm * 1e3), max: sig6(frictionMaxNm * 1e3) },
+          friction_source: frictionSource,
+          ...(bearing ? { bearings: bearing } : {}),
+          note:
+            "`starts` is fail-closed: available torque vs the WORST-CASE (max) friction " +
+            "estimate; `margin` = available / worst-case (aim for ≥ 2 to absorb cogging, " +
+            "cold grease, and preload spread). Bearing ranges are documented catalog-" +
+            "typical running drag for greased bearings, not measurements of yours.",
+          claims: [
+            // The friction estimate is only a claim when this tool predicted it
+            // (catalog lookup); a passthrough of the caller's number is not.
+            ...(frictionSource === "bearing-catalog"
+              ? [
+                  emClaim(
+                    "friction_torque",
+                    sig6(frictionMaxNm),
+                    "N·m",
+                    "bearing-friction-catalog",
+                    claimInputs,
+                  ),
+                ]
+              : []),
+            emClaim("start_margin", sig6(margin), "dimensionless", "torque-friction-margin", claimInputs),
+          ],
         }),
       },
     ],

--- a/packages/mcp/src/tools/em-claims.ts
+++ b/packages/mcp/src/tools/em-claims.ts
@@ -2,9 +2,10 @@
  * The electromagnetics (EM) receipt-claim family.
  *
  * Every EM calculator (calc_coil, calc_motor, calc_rf, calc_impedance,
- * size_coil, size_impedance, size_pdn, winding_layout) predicts values for
- * named physical quantities — inductance, torque constant, Z0, winding
- * factor, resonance. A claim records one such prediction in a uniform,
+ * size_coil, size_impedance, size_pdn, winding_layout, check_self_start)
+ * predicts values for named physical quantities — inductance, torque
+ * constant, Z0, winding factor, resonance, locked-rotor torque, starting
+ * margin. A claim records one such prediction in a uniform,
  * plainly serializable shape: what quantity, what value, by what method,
  * from what inputs. That is exactly what a receipt needs to ledger the
  * prediction and what a later measurement or FEA pass needs to grade it.
@@ -34,7 +35,13 @@ export type EmQuantity =
   | "back_emf_constant"
   | "no_load_speed"
   | "stall_torque"
-  | "airgap_flux_density";
+  | "airgap_flux_density"
+  | "torque_per_unit_slip"
+  | "locked_rotor_torque"
+  | "synchronous_speed"
+  | "rotor_copper_loss"
+  | "friction_torque"
+  | "start_margin";
 
 /** Stable identifiers for the closed-form models behind each claim. */
 export type EmMethod =
@@ -47,7 +54,11 @@ export type EmMethod =
   | "rlc-analytic" // series/parallel RLC frequency response
   | "star-of-slots" // polyphase winding factor kw = kp·kd
   | "mec-reluctance" // air-gap B via magnetic equivalent circuit
-  | "first-order-dc-motor"; // Kt/Ke, V = iR + Ke·ω envelope
+  | "first-order-dc-motor" // Kt/Ke, V = iR + Ke·ω envelope
+  | "mec-fringing-derate" // Carter-like w/(w+2g) pole-edge fringing on the MEC B
+  | "thin-sheet-induction" // rotating-MMF B1 + linear eddy slip torque (Russell–Norsworthy end effect)
+  | "bearing-friction-catalog" // documented typical bearing running-drag ranges
+  | "torque-friction-margin"; // starting torque vs worst-case friction, fail-closed
 
 /**
  * One quantitative prediction made by an EM calculator — the unit of the


### PR DESCRIPTION
## Summary

Extends the motor analysis toolkit with two new capabilities: a thin-sheet axial induction machine model (for drag-cup and PCB-cage rotors) and a Carter-like fringing derate for permanent-magnet flux predictions. Adds a new `check_self_start` tool to answer the critical design question: will the motor overcome bearing friction and spin?

## Key Changes

### Induction Motor Mode (`calc_motor mode: "induction"`)
- New `calcMotorInduction()` function implementing the Russell–Norsworthy thin-sheet induction closed form
- Computes fundamental gap field B1 from rotating MMF, torque-per-unit-slip (linear in slip), locked-rotor torque, synchronous speed, and rotor sheet dissipation
- Rust mirror in new `crates/vcad-ecad-sim/src/induction.rs` with full test coverage
- Schema updated to make PM-mode inputs conditional; induction mode requires `phase_current_a`, `electrical_freq_hz`, `effective_gap_mm`, `sheet_conductance_s`
- Optional `end_effect_factor` (default 0.65) models eddy-current return paths outside the active annulus

### PM Mode Fringing Derate
- New `fringing_derate()` function in `crates/vcad-ecad-sim/src/airgap.rs` implements Carter-like pole-edge fringing: `B_derated = B_raw · w/(w+2g)`
- Opt-in via `magnet.pole_width_mm` in `calc_motor`; when provided, both raw MEC prediction and derated flux are reported and claimed
- Kt/Ke and speed–torque curve use the derated flux; raw value available for FEA grading
- Honest for pole width ≳ 2× gap; below that treated as a lower bound

### New `check_self_start` Tool
- Answers "will it spin?" by comparing available standstill torque against bearing friction
- Accepts either direct `available_torque_nm` or computed from `kt_nm_per_a × current_a`
- Friction estimated from bearing catalog (presets: 608-2RS, 608-ZZ, 625, 688 with light/medium preload) or supplied directly
- Returns `starts` (fail-closed: beats worst-case friction), `starts_best_case` (beats optimistic end), and margin in mN·m
- Typical sealed 608-2RS pair: 1–4 mN·m; shielded and miniature variants an order of magnitude freer
- Demonstrates that thin-sheet induction machines (µN·m locked-rotor) require ultra-low-friction bearings to self-start

## Implementation Details

- **Induction model:** First-order only — linear-in-slip torque (no breakdown peak), no stator leakage/magnetizing reactance, no slotting/saturation. Valid for will-it-spin sizing; not an FEA substitute.
- **Fringing derate:** Pure geometry ratio, first-order in gap/width. Mirrors Rust `vcad_ecad_sim::airgap::fringing_derate`.
- **EM claims:** Both induction and fringing derate report their predictions as EM receipt claims (method: "thin-sheet-induction", "mec-fringing-derate") with full input traceability.
- **Schema:** `calcMotorSchema.required` reduced to `["pole_pairs", "turns_per_phase"]`; mode-specific inputs validated at runtime.
- **Tests:** Comprehensive coverage in `ecad.test.ts` including reference machine validation (N=30, kw=0.866, p=3, I=1.5 A, f=100 Hz → B1 ≈ 4.7 mT, locked-rotor ≈ 18 µN·m), scaling laws, and edge cases.

## Files Modified

- `packages/mcp/src/tools/ecad.ts` — `calcMotor()` refactored to dispatch on mode; new `calc

https://claude.ai/code/session_01J1BhGkMGF3m4hEDXVKeTar