### PR TITLE
solid_from_board: PCB to solid CAD part (inverse of board_from_solid)

### DIFF
--- a/changelog/entries/2026-07-07-solid-from-board.json
+++ b/changelog/entries/2026-07-07-solid-from-board.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-07-solid-from-board",
+  "version": "0.9.4",
+  "date": "2026-07-07",
+  "category": "feat",
+  "title": "solid_from_board: PCB to solid CAD part",
+  "summary": "The inverse of board_from_solid: extrudes the board outline with its cutouts intact, adds component keep-out volumes, and carries a homogenized FR4+copper mass so inspect/physics see the real board.",
+  "features": ["ecad", "pcb", "solid", "mass-properties", "round-trip", "mcp"],
+  "mcpTools": ["solid_from_board", "board_from_solid", "check_enclosure_fit", "inspect_cad"]
+}

--- a/packages/mcp/src/__tests__/solid-from-board.test.ts
+++ b/packages/mcp/src/__tests__/solid-from-board.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document, Pcb, Vec2 } from "@vcad/ir";
+import { createDocument } from "@vcad/ir";
+import { addZone, solidFromBoard } from "../tools/ecad.js";
+import { checkEnclosureFit } from "../tools/enclosure.js";
+import { computeInspection } from "../tools/inspect.js";
+import { documents, getSession, openDocument, registerSession } from "../tools/session.js";
+// Proven showcase case geometry (untyped demo module; src/__tests__ is
+// excluded from tsc so the JS import needs no declarations).
+import { f405CaseDocument } from "../../../../examples/f405-enclosure/geometry.mjs";
+
+let engine: Engine;
+
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+beforeEach(() => {
+  documents.clear();
+});
+
+/** Parse the single JSON text block of a tool result. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function out(result: { content: Array<{ type: string; text: string }> }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+/** CCW n-gon approximating a circle. */
+function circleLoop(cx: number, cy: number, r: number, n: number): Vec2[] {
+  const pts: Vec2[] = [];
+  for (let i = 0; i < n; i++) {
+    const t = (2 * Math.PI * i) / n;
+    pts.push({ x: cx + r * Math.cos(t), y: cy + r * Math.sin(t) });
+  }
+  return pts;
+}
+
+/** Absolute shoelace area of a closed loop, mm². */
+function loopArea(loop: Vec2[]): number {
+  let area = 0;
+  for (let i = 0; i < loop.length; i++) {
+    const a = loop[i];
+    const b = loop[(i + 1) % loop.length];
+    area += a.x * b.y - b.x * a.y;
+  }
+  return Math.abs(area / 2);
+}
+
+// The rotor board under test: a 58mm disc with a center bore and four hub
+// holes (a real PCB-motor rotor shape), 2oz copper pours on both faces.
+const BOARD_R = 29;
+const BORE_R = 4;
+const HUB_R = 1.6;
+const HUB_PITCH_R = 16;
+const THICKNESS = 1.6;
+const CU_2OZ_MM = 0.07;
+
+const FR4_DENSITY_KG_M3 = 1850;
+const COPPER_DENSITY_KG_M3 = 8960;
+
+function rotorOutline(): { vertices: Vec2[]; cutouts: Vec2[][] } {
+  return {
+    vertices: circleLoop(0, 0, BOARD_R, 96),
+    cutouts: [
+      circleLoop(0, 0, BORE_R, 48),
+      ...[0, 90, 180, 270].map((deg) => {
+        const t = (deg * Math.PI) / 180;
+        return circleLoop(
+          HUB_PITCH_R * Math.cos(t),
+          HUB_PITCH_R * Math.sin(t),
+          HUB_R,
+          32,
+        );
+      }),
+    ],
+  };
+}
+
+/** Polygonized board area (outline minus bore + hub cutouts), mm². */
+function rotorPolygonArea(): number {
+  const { vertices, cutouts } = rotorOutline();
+  return loopArea(vertices) - cutouts.reduce((s, c) => s + loopArea(c), 0);
+}
+
+/** Register a PCB session holding the rotor board with 2oz pours both sides. */
+function registerRotorBoard(): string {
+  const { vertices, cutouts } = rotorOutline();
+  const pcb = {
+    outline: { vertices, cutouts, thickness: THICKNESS },
+    stackup: {
+      layers: [
+        {
+          layer: "FCu",
+          copperThickness: CU_2OZ_MM,
+          dielectricThickness: 1.46,
+          dielectricEr: 4.5,
+          material: "FR4",
+        },
+        { layer: "BCu", copperThickness: CU_2OZ_MM },
+      ],
+    },
+    nets: [{ id: "GND", name: "GND" }],
+    rules: {
+      defaultRules: {
+        name: "Default",
+        traceWidth: 0.25,
+        clearance: 0.2,
+        viaDiameter: 0.8,
+        viaDrill: 0.4,
+      },
+      classRules: [],
+      netClassAssignments: {},
+      edgeClearance: 0.5,
+      holeToHole: 0.5,
+      minAnnularRing: 0.15,
+      minDrill: 0.2,
+    },
+    footprints: [],
+    traces: [],
+    vias: [],
+    zones: [],
+  } as unknown as Pcb;
+  const doc = createDocument();
+  (doc as Document & { pcb?: Pcb }).pcb = pcb;
+  const id = registerSession(doc);
+  // 2oz pours on both faces; fill_board carries the bore/hub cutouts as voids.
+  expect(out(addZone({ document_id: id, net: "GND", layer: "FCu", fill_board: true })).success).toBe(true);
+  expect(out(addZone({ document_id: id, net: "GND", layer: "BCu", fill_board: true })).success).toBe(true);
+  return id;
+}
+
+describe("solid_from_board (58mm rotor board round trip)", () => {
+  it("extrudes the outline with bore + hub cutouts intact", async () => {
+    const id = registerRotorBoard();
+    const res = out(await solidFromBoard({ document_id: id }));
+
+    expect(res.success).toBe(true);
+    expect(res.created_session).toBe(true);
+    expect(res.source_document_id).toBe(id);
+    expect(res.substrate.cutouts).toBe(5);
+
+    const solidDoc = getSession(res.document_id);
+    expect(solidDoc.roots.length).toBe(1);
+    const insp = computeInspection(solidDoc, engine);
+
+    // Volume ≈ board area × thickness within 2% (the task's round-trip gate).
+    const expectedVolume = rotorPolygonArea() * THICKNESS;
+    expect(Math.abs(insp.volume_mm3 - expectedVolume) / expectedVolume).toBeLessThan(0.02);
+
+    // Cutouts actually removed: a hole-less disc is ~3.2% bigger, well outside
+    // the 2% gate above — but assert the direction explicitly too.
+    const noHoleVolume = loopArea(rotorOutline().vertices) * THICKNESS;
+    const holeVolume = noHoleVolume - expectedVolume;
+    expect(insp.volume_mm3).toBeLessThan(noHoleVolume - 0.5 * holeVolume);
+
+    // Bbox: 58mm disc, board bottom at z = 0, top at thickness.
+    expect(insp.bounding_box.min.x).toBeCloseTo(-BOARD_R, 0);
+    expect(insp.bounding_box.max.x).toBeCloseTo(BOARD_R, 0);
+    expect(insp.bounding_box.min.y).toBeCloseTo(-BOARD_R, 0);
+    expect(insp.bounding_box.max.y).toBeCloseTo(BOARD_R, 0);
+    expect(insp.bounding_box.min.z).toBeCloseTo(0, 3);
+    expect(insp.bounding_box.max.z).toBeCloseTo(THICKNESS, 3);
+  });
+
+  it("mass metadata lands within 5% of hand-computed FR4 + 2oz copper", async () => {
+    const id = registerRotorBoard();
+    const res = out(await solidFromBoard({ document_id: id }));
+
+    // Hand computation from ideal circles (datasheet style).
+    const idealArea = Math.PI * (BOARD_R ** 2 - BORE_R ** 2 - 4 * HUB_R ** 2);
+    const fr4G = (idealArea * THICKNESS * FR4_DENSITY_KG_M3) / 1e6;
+    const copperG = (2 * idealArea * CU_2OZ_MM * COPPER_DENSITY_KG_M3) / 1e6;
+    const totalG = fr4G + copperG;
+
+    expect(Math.abs(res.mass.fr4_g - fr4G) / fr4G).toBeLessThan(0.05);
+    expect(Math.abs(res.mass.copper_g - copperG) / copperG).toBeLessThan(0.05);
+    expect(Math.abs(res.mass.total_g - totalG) / totalG).toBeLessThan(0.05);
+
+    // Both pours were counted, each capped at the board area.
+    expect(res.mass.copper_area_mm2_by_layer.FCu).toBeGreaterThan(0);
+    expect(res.mass.copper_area_mm2_by_layer.BCu).toBeGreaterThan(0);
+
+    // inspect_cad sees the same mass through the homogenized-density material —
+    // this is what makes physics / mass-property queries realistic.
+    const insp = computeInspection(getSession(res.document_id), engine);
+    expect(insp.mass_g).toBeDefined();
+    expect(Math.abs(insp.mass_g! - res.mass.total_g) / res.mass.total_g).toBeLessThan(0.05);
+    const material = getSession(res.document_id).materials[res.mass.material];
+    expect(material?.density).toBeGreaterThan(FR4_DENSITY_KG_M3);
+  });
+
+  it("emits simplified component keep-out volumes above the board", async () => {
+    const id = registerRotorBoard();
+    const pcb = (getSession(id) as Document & { pcb?: Pcb }).pcb!;
+    pcb.footprints.push({
+      ref: "R1",
+      value: "10k",
+      footprintName: "Resistor_SMD:R_0805",
+      position: { x: 22, y: 0 },
+      rotation: 0,
+      front: true,
+      pads: [
+        {
+          number: "1",
+          padType: "SMD",
+          shape: { type: "Rect", width: 1.0, height: 1.3 },
+          position: { x: -0.95, y: 0 },
+          layers: ["FCu"],
+        },
+        {
+          number: "2",
+          padType: "SMD",
+          shape: { type: "Rect", width: 1.0, height: 1.3 },
+          position: { x: 0.95, y: 0 },
+          layers: ["FCu"],
+        },
+      ],
+    } as unknown as Pcb["footprints"][number]);
+
+    const res = out(await solidFromBoard({ document_id: id }));
+    expect(res.components.count).toBe(1);
+    expect(res.components.part_ids.length).toBe(1);
+    const solidDoc = getSession(res.document_id);
+    expect(solidDoc.roots.length).toBe(2); // substrate + R1 keep-out
+
+    // The keep-out sits on the board top with a plausible chip height.
+    const box = res.components.boxes[0];
+    expect(box.ref).toBe("R1");
+    expect(box.min.z).toBeGreaterThanOrEqual(THICKNESS - 0.2);
+    expect(box.max.z).toBeGreaterThan(THICKNESS);
+    expect(box.max.z).toBeLessThan(THICKNESS + 3);
+    expect(box.min.x).toBeGreaterThan(19);
+    expect(box.max.x).toBeLessThan(25);
+
+    // Opt-out leaves just the substrate.
+    const bare = out(await solidFromBoard({ document_id: id, include_components: false }));
+    expect(bare.components.count).toBe(0);
+    expect(getSession(bare.document_id).roots.length).toBe(1);
+  });
+
+  it("injects into an existing CAD session that still works for check_enclosure_fit", async () => {
+    const enc = out(openDocument({ initial: f405CaseDocument() as unknown as Document }));
+    const encDoc = getSession(enc.document_id);
+    const caseRootId = encDoc.roots[0].root;
+    const rootsBefore = encDoc.roots.length;
+
+    const id = registerRotorBoard();
+    const res = out(
+      await solidFromBoard({
+        document_id: id,
+        document_id_target: enc.document_id,
+        part_name: "rotor-board",
+      }),
+    );
+    expect(res.success).toBe(true);
+    expect(res.created_session).toBe(false);
+    expect(res.document_id).toBe(enc.document_id);
+    expect(getSession(enc.document_id).roots.length).toBe(rootsBefore + 1);
+    const partNode = getSession(enc.document_id).nodes[res.part_id];
+    expect(partNode?.name).toBe("rotor-board");
+    expect((partNode?.op as { type?: string }).type).toBe("Extrude");
+
+    // The enclosure session — now also holding the injected board solid —
+    // still serves as check_enclosure_fit's enclosure input. The board solid
+    // is vertex-heavier than the case, so select the case explicitly.
+    const fit = out(
+      await checkEnclosureFit(
+        {
+          document_id: id,
+          enclosure_document_id: enc.document_id,
+          enclosure_part_id: String(caseRootId),
+        },
+        engine,
+      ),
+    );
+    expect(fit.success).toBe(true);
+    expect(fit.cavity).toBeTruthy();
+    expect(fit.checks.some((c: { id: string }) => c.id === "board_fit")).toBe(true);
+  });
+
+  it("errors cleanly without a PCB or with an unknown target session", async () => {
+    const cad = out(openDocument({}));
+    const noPcb = await solidFromBoard({ document_id: cad.document_id });
+    expect(noPcb.isError).toBe(true);
+    expect(noPcb.content[0].text).toMatch(/no PCB/i);
+
+    const id = registerRotorBoard();
+    const badTarget = await solidFromBoard({
+      document_id: id,
+      document_id_target: "doc_nope",
+    });
+    expect(badTarget.isError).toBe(true);
+    expect(badTarget.content[0].text).toMatch(/unknown document_id/i);
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -216,6 +216,8 @@ import {
   windingLayoutSchema,
   boardFromSolid,
   boardFromSolidSchema,
+  solidFromBoard,
+  solidFromBoardSchema,
   addTrace,
   addTraceSchema,
   getPadPositions,
@@ -691,6 +693,7 @@ const TOOL_PACKS: Record<string, readonly string[]> = {
     "add_motor_winding",
     "winding_layout",
     "board_from_solid",
+    "solid_from_board",
     "check_enclosure_fit",
     "import_kicad",
     "import_eagle",
@@ -1502,6 +1505,20 @@ export async function createServer(
           "the XY plane. Bridges solid modeling and PCB layout: feed the " +
           "returned `outline` to place_components.",
         inputSchema: boardFromSolidSchema,
+      },
+      {
+        name: "solid_from_board",
+        description:
+          "Materialize the session PCB as a solid CAD part — the inverse of " +
+          "board_from_solid. Extrudes the board outline to its thickness " +
+          "through the hole-aware sketch path (bore/cutout polygons survive " +
+          "as real holes), adds simplified per-component keep-out volumes " +
+          "(kernel 3D body extents, else courtyard × package-class height), " +
+          "and gives the substrate a homogenized FR4+copper density so " +
+          "inspect_cad / physics see the real board mass. Inject into an " +
+          "existing CAD session with `document_id_target` (enclosure fit, " +
+          "motor stacks, clash checks) or omit it to mint a fresh session.",
+        inputSchema: solidFromBoardSchema,
       },
       {
         name: "check_enclosure_fit",
@@ -2384,6 +2401,43 @@ export async function createServer(
         case "board_from_solid":
           result = boardFromSolid(args, engine);
           break;
+
+        case "solid_from_board": {
+          // Cross-session writer: reads the PCB in `document_id`, writes the
+          // CAD session in `document_id_target` (or mints one). The central
+          // hydrate/snapshot/persist plumbing keys off args.document_id —
+          // here the read-only PCB source — so the target is handled here.
+          const targetId =
+            typeof args.document_id_target === "string" ? args.document_id_target : null;
+          if (targetId) {
+            try {
+              await hydrateSession(sessionStore, targetId);
+            } catch {
+              // Durable load failed — fall back to cache.
+            }
+            if (documents.has(targetId)) recordHistorySnapshot(targetId);
+          }
+          result = await solidFromBoard(args);
+          const writtenId = result.structuredContent?.document_id;
+          if (!result.isError && typeof writtenId === "string" && documents.has(writtenId)) {
+            try {
+              await persistSession(sessionStore, writtenId);
+            } catch {
+              // best-effort durable write
+            }
+            try {
+              await eventStore.append(writtenId, {
+                author: context.user?.sub ?? "agent",
+                kind: "kernel",
+                type: name,
+                payload: buildKernelEventPayload(name, args, result),
+              });
+            } catch {
+              // best-effort event append
+            }
+          }
+          break;
+        }
 
         case "check_enclosure_fit":
           result = await checkEnclosureFit(args, engine);

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -28,6 +28,9 @@ import type {
   Via,
   Zone,
   Vec2,
+  Vec3,
+  CsgOp,
+  SketchSegment2D,
   Receipt,
 } from "@vcad/ir";
 import { createDocument } from "@vcad/ir";
@@ -35,6 +38,7 @@ import { summarize, unifiedFromPcbReceipt } from "../receipt-unified.js";
 import { getNodePcb, getPcbNodeIds, buildEntry, agentView } from "@vcad/core";
 import {
   computeRatsnest,
+  componentMeshes,
   exportFabFiles,
   pcbPreviewMeshes,
   exportKicadPcb,
@@ -10002,6 +10006,485 @@ export function boardFromSolid(args: Record<string, unknown>, engine: Engine) {
         }),
       },
     ],
+  };
+}
+
+// ============================================================================
+// solid_from_board — materialize the session PCB as a solid CAD part
+// (the inverse of board_from_solid)
+// ============================================================================
+
+/** JSON Schema for solid_from_board tool. */
+export const solidFromBoardSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description:
+        "PCB session id (from create_schematic / open_document) holding the " +
+        "board to materialize as a solid.",
+    },
+    document_id_target: {
+      type: "string" as const,
+      description:
+        "Existing CAD session to inject the part into (e.g. the enclosure " +
+        "or motor-stack assembly it must fit). Omit to mint a fresh CAD " +
+        "session; the response then carries the new document_id plus the " +
+        "document IR (usable with open_document elsewhere).",
+    },
+    include_components: {
+      type: "boolean" as const,
+      description:
+        "Also emit simplified component keep-out volumes — one box per " +
+        "placed footprint, body extents from the kernel's 3D component " +
+        "bodies where available, else courtyard × a per-package-class " +
+        "default height. Default true.",
+    },
+    part_name: {
+      type: "string" as const,
+      description:
+        "Name for the substrate part (default 'board'). Component keep-out " +
+        "parts are named '<part_name>:<ref>'.",
+    },
+  },
+  required: ["document_id"],
+} as const;
+
+/** FR4 substrate density, kg/m³ — matches the app's `__pcb_fr4__` preset. */
+const FR4_DENSITY_KG_M3 = 1850;
+/** Copper density, kg/m³ — matches the app's `copper` preset. */
+const COPPER_DENSITY_KG_M3 = 8960;
+/** 1 oz/ft² copper in mm, the fallback when a stackup layer omits thickness. */
+const DEFAULT_COPPER_THICKNESS_MM = 0.035;
+
+/** Absolute (sign-agnostic) shoelace area of a closed loop, mm². */
+const loopArea = (loop: Vec2[]): number => Math.abs(loopSignedArea(loop));
+
+/** Closed polygon → Line segments for a Sketch2D loop (zero-length runs from
+ *  duplicated vertices are dropped). */
+function loopToSegments(loop: Vec2[]): SketchSegment2D[] {
+  const segs: SketchSegment2D[] = [];
+  for (let i = 0; i < loop.length; i++) {
+    const a = loop[i]!;
+    const b = loop[(i + 1) % loop.length]!;
+    if (Math.hypot(b.x - a.x, b.y - a.y) < 1e-9) continue;
+    segs.push({ type: "Line", start: { x: a.x, y: a.y }, end: { x: b.x, y: b.y } });
+  }
+  return segs;
+}
+
+/** Copper area of one pad, mm² (Oval/RoundRect ≈ their bounding rect). */
+function padAreaMm2(pad: Pad): number {
+  const s = pad.shape;
+  switch (s.type) {
+    case "Circle":
+      return (Math.PI / 4) * s.diameter * s.diameter;
+    case "Rect":
+    case "Oval":
+    case "RoundRect":
+      return s.width * s.height;
+    case "Custom":
+      return loopArea(s.vertices);
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Estimated copper coverage per copper layer, mm²: zones (outline minus
+ * holes; hatched pours count half), traces and arcs (length × width), pad
+ * copper, and via annular rings on their span-end layers. Overlaps between
+ * features are not deduplicated — a slight overestimate on dense boards —
+ * and each layer is capped at the board area.
+ */
+function copperAreaByLayer(pcb: Pcb, boardArea: number): Record<string, number> {
+  const area: Record<string, number> = {};
+  const add = (layer: string, a: number) => {
+    if (!/Cu$/.test(layer) || !(a > 0)) return;
+    area[layer] = (area[layer] ?? 0) + a;
+  };
+  for (const z of pcb.zones) {
+    const holes = (z.holes ?? []).reduce((s, h) => s + loopArea(h), 0);
+    const fill = z.fillType === "Hatched" ? 0.5 : 1;
+    add(z.layer, Math.max(0, loopArea(z.outline) - holes) * fill);
+  }
+  for (const t of pcb.traces) {
+    add(t.layer, Math.hypot(t.end.x - t.start.x, t.end.y - t.start.y) * t.width);
+  }
+  for (const a of pcb.traceArcs ?? []) {
+    const sweep = (Math.abs(a.endAngle - a.startAngle) * Math.PI) / 180;
+    add(a.layer, sweep * a.radius * a.width);
+  }
+  for (const fp of pcb.footprints) {
+    for (const pad of fp.pads) {
+      const padArea = padAreaMm2(pad);
+      for (const layer of pad.layers) add(layer, padArea);
+    }
+  }
+  for (const v of pcb.vias) {
+    const ring = (Math.PI / 4) * Math.max(0, v.diameter * v.diameter - v.drill * v.drill);
+    add(v.startLayer, ring);
+    if (v.endLayer !== v.startLayer) add(v.endLayer, ring);
+  }
+  for (const k of Object.keys(area)) area[k] = Math.min(area[k]!, boardArea);
+  return area;
+}
+
+/** Mass estimate for a bare board: FR4 slab + per-layer copper coverage. */
+interface BoardMassEstimate {
+  fr4VolumeMm3: number;
+  copperVolumeMm3: number;
+  copperAreaByLayer: Record<string, number>;
+  fr4G: number;
+  copperG: number;
+  totalG: number;
+  /** total mass / substrate solid volume — the density that makes the
+   *  extruded slab weigh what the real FR4+copper board weighs. */
+  homogenizedDensityKgM3: number;
+}
+
+/** Compute the board's FR4 + copper mass from outline area and stackup. */
+function estimateBoardMass(pcb: Pcb, boardArea: number): BoardMassEstimate {
+  const thickness = pcb.outline.thickness;
+  const fr4VolumeMm3 = boardArea * thickness;
+  const copperArea = copperAreaByLayer(pcb, boardArea);
+  const thicknessByLayer = new Map<string, number | undefined>(
+    pcb.stackup.layers.map((l) => [l.layer as string, l.copperThickness]),
+  );
+  let copperVolumeMm3 = 0;
+  for (const [layer, a] of Object.entries(copperArea)) {
+    copperVolumeMm3 += a * (thicknessByLayer.get(layer) ?? DEFAULT_COPPER_THICKNESS_MM);
+  }
+  // mass (g) = volume (mm³) × density (kg/m³) / 1e6
+  const fr4G = (fr4VolumeMm3 * FR4_DENSITY_KG_M3) / 1e6;
+  const copperG = (copperVolumeMm3 * COPPER_DENSITY_KG_M3) / 1e6;
+  const totalG = fr4G + copperG;
+  return {
+    fr4VolumeMm3,
+    copperVolumeMm3,
+    copperAreaByLayer: copperArea,
+    fr4G,
+    copperG,
+    totalG,
+    homogenizedDensityKgM3:
+      fr4VolumeMm3 > 0 ? (totalG / fr4VolumeMm3) * 1e6 : FR4_DENSITY_KG_M3,
+  };
+}
+
+/** One simplified component keep-out volume, board-local mm (bottom of the
+ *  substrate at z = 0, top at z = thickness). */
+interface ComponentBoxOut {
+  ref: string;
+  footprint: string;
+  /** "mesh" = kernel 3D body extents; "courtyard" = pad/courtyard bbox ×
+   *  per-package-class default height. */
+  source: "mesh" | "courtyard";
+  min: Vec3;
+  max: Vec3;
+}
+
+/** Footprints that are holes in the board, not bodies on it. */
+const MOUNTING_FP_RE = /mount(ing)?[_-]?hole/i;
+
+/** Default body height (mm) by package-class name — mirrors the kernel's
+ *  component-mesh table (vcad-ecad-pcb::component_mesh::package_height). */
+function packageHeightMm(footprintName: string): number {
+  const n = footprintName.toUpperCase();
+  if (n.includes("0402")) return 0.35;
+  if (n.includes("0603")) return 0.45;
+  if (n.includes("0805")) return 0.5;
+  if (n.includes("1206")) return 0.55;
+  if (n.includes("SOIC")) return 1.75;
+  if (n.includes("QFP")) return 1.6;
+  if (n.includes("DIP")) return 4.0;
+  if (/SOT-?223/.test(n)) return 1.6;
+  if (/SOT-?23/.test(n)) return 1.1;
+  if (n.includes("HEADER")) return 8.5;
+  return 1.0;
+}
+
+/**
+ * Simplified keep-out volume per placed footprint. Preferred source is the
+ * kernel's parametric 3D component bodies (exact XY + Z extents in board
+ * coordinates); when the ECAD WASM is unavailable or a footprint has no
+ * body, fall back to its courtyard/pad bbox extruded to a per-package-class
+ * default height on the correct side of the board.
+ */
+async function componentKeepouts(
+  pcb: Pcb,
+): Promise<{ boxes: ComponentBoxOut[]; warnings: string[] }> {
+  const thickness = pcb.outline.thickness;
+  const warnings: string[] = [];
+  const meshBoxes = new Map<string, { min: Vec3; max: Vec3 }>();
+  try {
+    for (const m of await componentMeshes(pcb)) {
+      let minX = Infinity;
+      let minY = Infinity;
+      let minZ = Infinity;
+      let maxX = -Infinity;
+      let maxY = -Infinity;
+      let maxZ = -Infinity;
+      for (let i = 0; i + 2 < m.positions.length; i += 3) {
+        if (m.positions[i] < minX) minX = m.positions[i];
+        if (m.positions[i] > maxX) maxX = m.positions[i];
+        if (m.positions[i + 1] < minY) minY = m.positions[i + 1];
+        if (m.positions[i + 1] > maxY) maxY = m.positions[i + 1];
+        if (m.positions[i + 2] < minZ) minZ = m.positions[i + 2];
+        if (m.positions[i + 2] > maxZ) maxZ = m.positions[i + 2];
+      }
+      if (
+        Number.isFinite(minX) &&
+        maxX - minX > 1e-6 &&
+        maxY - minY > 1e-6 &&
+        maxZ - minZ > 1e-6
+      ) {
+        meshBoxes.set(m.footprint_ref, {
+          min: { x: minX, y: minY, z: minZ },
+          max: { x: maxX, y: maxY, z: maxZ },
+        });
+      }
+    }
+  } catch {
+    // ECAD WASM unavailable — every footprint takes the courtyard fallback.
+  }
+
+  const boxes: ComponentBoxOut[] = [];
+  for (const fp of pcb.footprints) {
+    // Mounting holes / NPTH-only footprints are voids, not bodies.
+    if (MOUNTING_FP_RE.test(fp.footprintName) || MOUNTING_FP_RE.test(fp.ref)) continue;
+    if (fp.pads.length > 0 && fp.pads.every((p) => p.padType === "NPTH")) continue;
+
+    const mesh = meshBoxes.get(fp.ref);
+    if (mesh) {
+      boxes.push({
+        ref: fp.ref,
+        footprint: fp.footprintName,
+        source: "mesh",
+        min: mesh.min,
+        max: mesh.max,
+      });
+      continue;
+    }
+    const local = localCourtyardAabb(fp.pads, fp.graphics ?? []);
+    const board = boardCourtyardAabb(local, fp.position, fp.rotation ?? 0, fp.front ?? true);
+    if (!board) {
+      warnings.push(`${fp.ref}: no 3D body, pads, or courtyard — keep-out skipped`);
+      continue;
+    }
+    const h = packageHeightMm(fp.footprintName);
+    const front = fp.front ?? true;
+    boxes.push({
+      ref: fp.ref,
+      footprint: fp.footprintName,
+      source: "courtyard",
+      min: { x: board.min.x, y: board.min.y, z: front ? thickness : -h },
+      max: { x: board.max.x, y: board.max.y, z: front ? thickness + h : 0 },
+    });
+  }
+  return { boxes, warnings };
+}
+
+/** Cap on the per-component box list echoed in the response. */
+const KEEPOUT_ECHO_CAP = 32;
+/** Cap on the inline `document` IR echoed when a fresh session is minted. */
+const INLINE_DOC_ECHO_CAP = 100_000;
+
+/**
+ * Materialize the session PCB as a solid CAD part — the inverse of
+ * board_from_solid. The substrate is the board outline extruded to the board
+ * thickness through the hole-aware sketch path, so bore/cutout polygons
+ * survive as real holes (no boolean pass). Optional simplified component
+ * keep-out volumes ride along as child parts. The substrate's material
+ * carries a homogenized FR4+copper density so inspect_cad and physics see
+ * the real board mass, not bare-FR4 mass.
+ *
+ * Injects into `document_id_target` when given (board bottom lands at
+ * z = 0 in that session's frame), else mints a fresh CAD session.
+ */
+export async function solidFromBoard(args: Record<string, unknown>) {
+  const documentId = String(args.document_id ?? "");
+  const doc = getSession(documentId);
+  const pcb = getDocPcb(doc);
+  if (!pcb) {
+    return ecadError(
+      "Document has no PCB — run place_components first (or open a document that has a board)",
+    );
+  }
+  const outline = pcb.outline;
+  if (!outline.vertices || outline.vertices.length < 3) {
+    return ecadError("Board outline needs >= 3 vertices — set_board_outline first");
+  }
+  const thickness = outline.thickness;
+  if (!(thickness > 0)) return ecadError("Board thickness must be > 0");
+
+  const partName =
+    typeof args.part_name === "string" && args.part_name.trim()
+      ? args.part_name.trim()
+      : "board";
+  const includeComponents = args.include_components !== false;
+
+  const cutouts = outline.cutouts ?? [];
+  const boardArea = Math.max(
+    0,
+    loopArea(outline.vertices) - cutouts.reduce((s, c) => s + loopArea(c), 0),
+  );
+  if (!(boardArea > 0)) return ecadError("Board outline has no area to extrude");
+  const mass = estimateBoardMass(pcb, boardArea);
+
+  const warnings: string[] = [];
+  let boxes: ComponentBoxOut[] = [];
+  if (includeComponents && pcb.footprints.length > 0) {
+    const keepouts = await componentKeepouts(pcb);
+    boxes = keepouts.boxes;
+    warnings.push(...keepouts.warnings);
+  }
+
+  // Target: inject into an existing CAD session, or mint a fresh document.
+  const targetId =
+    typeof args.document_id_target === "string" && args.document_id_target
+      ? args.document_id_target
+      : undefined;
+  let target: Document;
+  if (targetId) {
+    try {
+      target = getSession(targetId);
+    } catch (e) {
+      return ecadError(e instanceof Error ? e.message : String(e));
+    }
+  } else {
+    target = createDocument();
+  }
+
+  const existingIds = Object.keys(target.nodes)
+    .map(Number)
+    .filter(Number.isFinite);
+  let nextId = (existingIds.length > 0 ? Math.max(...existingIds) : 0) + 1;
+  const alloc = (name: string | null, op: CsgOp): number => {
+    const id = nextId++;
+    target.nodes[String(id)] = { id, name, op };
+    return id;
+  };
+
+  // Substrate: hole-aware sketch + extrude (#396) — cutouts become interior
+  // walls of one multi-loop solid, no Difference pass. Board bottom at z = 0.
+  const sketchId = alloc(`${partName} profile`, {
+    type: "Sketch2D",
+    origin: { x: 0, y: 0, z: 0 },
+    x_dir: { x: 1, y: 0, z: 0 },
+    y_dir: { x: 0, y: 1, z: 0 },
+    segments: loopToSegments(ensureCcw(outline.vertices)),
+    ...(cutouts.length > 0 ? { holes: cutouts.map((c) => loopToSegments(c)) } : {}),
+  });
+  const substrateId = alloc(partName, {
+    type: "Extrude",
+    sketch: sketchId,
+    direction: { x: 0, y: 0, z: thickness },
+  });
+
+  // Homogenized material: the extruded slab weighs what the real FR4+copper
+  // board weighs, so inspect_cad / physics read a realistic mass off it.
+  let materialKey = `pcb:${partName}`;
+  for (let i = 2; target.materials[materialKey]; i++) materialKey = `pcb:${partName}-${i}`;
+  target.materials[materialKey] = {
+    name: materialKey,
+    color: [0.05, 0.35, 0.18], // FR4 soldermask green
+    metallic: 0.1,
+    roughness: 0.7,
+    density: Math.round(mass.homogenizedDensityKgM3 * 100) / 100,
+  };
+  target.roots.push({ root: substrateId, material: materialKey });
+  target.part_materials[partName] = materialKey;
+
+  const componentPartIds: string[] = [];
+  for (const b of boxes) {
+    const size = {
+      x: b.max.x - b.min.x,
+      y: b.max.y - b.min.y,
+      z: b.max.z - b.min.z,
+    };
+    const cubeId = alloc(null, { type: "Cube", size });
+    const moveId = alloc(`${partName}:${b.ref}`, {
+      type: "Translate",
+      child: cubeId,
+      offset: { x: b.min.x, y: b.min.y, z: b.min.z },
+    });
+    target.roots.push({ root: moveId, material: "default" });
+    componentPartIds.push(String(moveId));
+  }
+
+  const created = !targetId;
+  const outId = targetId ?? registerSession(target);
+
+  const roundVec = (v: Vec3) => ({ x: round3(v.x), y: round3(v.y), z: round3(v.z) });
+  const copperAreaRounded = Object.fromEntries(
+    Object.entries(mass.copperAreaByLayer).map(([k, v]) => [k, round3(v)]),
+  );
+  // Echo the minted IR so the part can travel to another server via
+  // open_document — unless the outline is huge, in which case get_document
+  // on the returned document_id serves it instead.
+  const inlineDoc =
+    created && JSON.stringify(target).length <= INLINE_DOC_ECHO_CAP ? target : undefined;
+
+  const payload = {
+    success: true,
+    document_id: outId,
+    created_session: created,
+    source_document_id: documentId,
+    part_id: String(substrateId),
+    part_name: partName,
+    substrate: {
+      outline_vertices: outline.vertices.length,
+      cutouts: cutouts.length,
+      thickness,
+      area_mm2: round3(boardArea),
+      volume_mm3: round3(mass.fr4VolumeMm3),
+    },
+    components: {
+      included: includeComponents,
+      count: boxes.length,
+      part_ids: componentPartIds,
+      ...(boxes.length > 0
+        ? {
+            boxes: boxes.slice(0, KEEPOUT_ECHO_CAP).map((b) => ({
+              ref: b.ref,
+              footprint: b.footprint,
+              source: b.source,
+              min: roundVec(b.min),
+              max: roundVec(b.max),
+            })),
+            ...(boxes.length > KEEPOUT_ECHO_CAP ? { boxes_truncated: true } : {}),
+          }
+        : {}),
+    },
+    mass: {
+      fr4_g: round3(mass.fr4G),
+      copper_g: round3(mass.copperG),
+      total_g: round3(mass.totalG),
+      fr4_volume_mm3: round3(mass.fr4VolumeMm3),
+      copper_volume_mm3: round3(mass.copperVolumeMm3),
+      copper_area_mm2_by_layer: copperAreaRounded,
+      homogenized_density_kg_m3: Math.round(mass.homogenizedDensityKgM3 * 100) / 100,
+      material: materialKey,
+    },
+    ...(inlineDoc ? { document: inlineDoc } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
+    hint: created
+      ? "Fresh CAD session minted — render_view / inspect_cad it, or feed `document` to open_document elsewhere"
+      : "Part injected — render_view / inspect_cad the target session (e.g. run check_enclosure_fit against it)",
+  };
+
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    structuredContent: {
+      solid_from_board: {
+        part_id: String(substrateId),
+        part_name: partName,
+        components: componentPartIds.length,
+        mass_g: round3(mass.totalG),
+      },
+      document_id: outId,
+      source_document_id: documentId,
+    },
   };
 }
 

--- a/packages/mcp/src/tools/next-actions.ts
+++ b/packages/mcp/src/tools/next-actions.ts
@@ -292,6 +292,21 @@ export function happyPathNext(toolName: string, docId?: string): NextAction[] {
           tool: "render_pcb",
         }),
       ];
+    // docId here is the CAD session that received the solid (the result body's
+    // document_id wins over args), not the PCB source — exactly the session
+    // these consumers want.
+    case "solid_from_board":
+      return [
+        withDoc({
+          action: "Render the board solid to visually cross-check it.",
+          tool: "render_view",
+        }),
+        withDoc({
+          action:
+            "Measure the solid — volume, bbox, and the homogenized FR4+copper mass.",
+          tool: "inspect_cad",
+        }),
+      ];
     default:
       return [];
   }


### PR DESCRIPTION
## Summary

Adds `solid_from_board`, the inverse operation of `board_from_solid`. This tool materializes a PCB session as a solid CAD part by extruding the board outline (with cutouts preserved as interior holes) and optionally adding simplified component keep-out volumes. The substrate is assigned a homogenized FR4+copper density so that `inspect_cad` and physics simulations see the real board mass rather than bare FR4.

## Key Changes

- **New tool `solid_from_board`** (`packages/mcp/src/tools/ecad.ts`):
  - Extrudes board outline to thickness via hole-aware sketch path (cutouts become interior walls, no boolean pass needed)
  - Computes FR4 + copper mass from stackup and copper coverage (zones, traces, pads, vias)
  - Generates simplified component keep-out volumes: prefers kernel 3D body extents, falls back to courtyard × per-package-class default height
  - Injects into existing CAD session (`document_id_target`) or mints fresh session
  - Assigns homogenized density material so mass properties are realistic
  - Returns detailed mass breakdown, component part IDs, and optional inline document IR

- **Helper functions**:
  - `loopArea()` — shoelace area of closed polygon
  - `loopToSegments()` — convert polygon to Sketch2D line segments
  - `padAreaMm2()` — copper area per pad shape
  - `copperAreaByLayer()` — per-layer copper coverage (zones, traces, vias, pads)
  - `estimateBoardMass()` — FR4 + copper mass from outline area and stackup
  - `componentKeepouts()` — generate keep-out boxes from 3D meshes or courtyard fallback
  - `packageHeightMm()` — default body height by package class (0402, SOIC, DIP, etc.)

- **Comprehensive test suite** (`packages/mcp/src/__tests__/solid-from-board.test.ts`):
  - 58mm rotor board with bore and hub cutouts as reference geometry
  - Validates outline extrusion with cutouts intact (volume within 2%)
  - Verifies mass metadata against hand-computed FR4 + 2oz copper (within 5%)
  - Tests component keep-out volumes above board with plausible heights
  - Validates injection into existing CAD session (e.g., enclosure) and downstream `check_enclosure_fit` compatibility
  - Error handling for missing PCB and unknown target sessions

- **Server integration** (`packages/mcp/src/server.ts`):
  - Registered as MCP tool with schema and description
  - Cross-session writer: reads PCB from `document_id`, writes CAD to `document_id_target` (or mints new)
  - Handles durable persistence and event logging for target session

- **Next-action hints** (`packages/mcp/src/tools/next-actions.ts`):
  - Suggests `render_view` to visually cross-check the solid
  - Suggests `inspect_cad` to measure volume, bbox, and homogenized mass

## Notable Implementation Details

- **Hole-aware extrusion**: Uses multi-loop sketch (outline + cutouts as holes) so bore/cutout polygons survive as real interior walls without needing a boolean Difference pass.
- **Mass homogenization**: Computes total FR4 + copper mass, then derives a single density for the extruded slab so that `inspect_cad` and physics engines read the correct mass off the material property.
- **Copper coverage estimation**: Sums zone fill (hatched pours count half), trace/arc length × width, pad copper per layer, and via annular rings; each layer capped at board area to avoid double-counting overlaps.
- **Component fallback chain**: Tries kernel 3D body extents first (exact XY + Z), falls back to courtyard/pad bbox extruded to package-class default height, skips mounting holes and NPTH-only footprints.
- **Response truncation**: Component

https://claude.ai/code/session_01GepcQepAbbTJLcEzsK1f8X