### PR TITLE
fix(ci): pin agent model + fail loudly when the agent run produces no PR

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -118,7 +118,26 @@ jobs:
             and post a comment on the issue describing the conflict instead
             of guessing.
           claude_args: |
+            --model claude-opus-4-8
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(cargo:*),Bash(npm:*),Bash(git:*),Bash(gh:*),Bash(rustup:*)"
+
+      # The action exits 0 even when the Claude session dies on its first API
+      # call (result JSON carries is_error:true but the step still "succeeds"),
+      # which leaves the issue stuck at agent:running with no branch, no PR,
+      # and no comment. Fail loudly instead: no PR from the expected head
+      # branch means the run produced nothing, and the failure handler below
+      # flips the label to agent:failed and links this run on the issue.
+      - name: Verify agent produced a PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          n="$(gh pr list --repo ${{ github.repository }} \
+            --head agent/issue-${{ github.event.issue.number }} \
+            --state all --json number --jq 'length')"
+          if [ "$n" = "0" ]; then
+            echo "::error::Agent run finished without opening a PR from agent/issue-${{ github.event.issue.number }} — see the 'Run agent' step output."
+            exit 1
+          fi
 
       - name: Mark failed on error
         if: failure()


### PR DESCRIPTION
## Why

All four `agent:ready` dispatches today (#429, #430, #433, #437 — runs 150–153) silently no-opped. The job logs show the Claude session inside `anthropics/claude-code-action` died on its **first API call** — `{"is_error": true, "num_turns": 1, "total_cost_usd": 0, "duration_ms": 920}` — with the model resolved to the 1M-context beta variant (`claude-opus-4-8[1m]`), which errors for orgs without that beta enabled. The action still exited 0, so the workflow concluded `success`, `Mark failed on error` never fired, and the issues sat stuck at `agent:running` with no branch, no PR, and no comment.

## What

- Pin `--model claude-opus-4-8` (plain GA id, no beta suffix) in `claude_args`.
- Add a **Verify agent produced a PR** step: if no PR exists from the expected `agent/issue-<N>` head branch after the agent step, fail the job — so the existing failure handler flips the issue to `agent:failed` and links the run, instead of stalling silently. (A legitimate ambiguity-stop that only comments on the issue will also flag `agent:failed`; the comment is on the issue either way, which beats a silent stall.)

After this merges, the four stuck issues get `agent:running` → `agent:ready` reset to re-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Jh8P571762nh3812kj76

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5Jh8P571762nh3812kj76)_