### PR TITLE
fix(ci): single-writer kernel-wasm artifacts — end wasm merge conflicts

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -105,7 +105,12 @@ jobs:
             Execute the spec:
             1. Create a branch: `agent/issue-${{ github.event.issue.number }}`.
             2. Implement the changes. Keep the diff minimal — don't refactor
-               surrounding code that wasn't asked for.
+               surrounding code that wasn't asked for. Never commit the
+               generated `packages/kernel-wasm/vcad_kernel_wasm*` artifacts
+               (CI blocks PRs that touch them) — a workflow refreshes them
+               on main after merge. Use `VCAD_WASM_SKIP=1` for workspace
+               builds; if your change needs fresh WASM to test, build it
+               locally but leave the artifacts out of the commit.
             3. Run every command in the spec's "Verification" section. All
                must pass. If a command fails, fix the root cause and re-run
                — never use --no-verify or bypass checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,3 +271,26 @@ jobs:
         # tooling churn too often to block on. See cargo-audit above for
         # how to flip this into a blocking check.
         run: npm audit --audit-level=moderate || true
+
+  # Generated kernel-wasm artifacts have a single writer: wasm-refresh.yml
+  # rebuilds and commits them on main after kernel merges. A feature branch
+  # that commits its own rebuild conflicts with every other branch that did
+  # the same (wasm-pack output is not byte-reproducible), so block them at
+  # the door. PRs lose nothing — the TypeScript job consumes wasm built
+  # from source by the `wasm` job above, never the checked-in copies.
+  wasm-artifact-guard:
+    name: No committed WASM artifacts
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Fail on artifact changes
+        run: |
+          if git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- \
+               'packages/kernel-wasm/vcad_kernel_wasm*' | grep -q .; then
+            echo "::error::This PR commits generated kernel-wasm artifacts. wasm-refresh.yml maintains them on main after merge — drop the change with: git checkout origin/main -- 'packages/kernel-wasm/vcad_kernel_wasm*' && git commit"
+            exit 1
+          fi
+          echo "no generated artifacts committed — ok"

--- a/.github/workflows/wasm-refresh.yml
+++ b/.github/workflows/wasm-refresh.yml
@@ -1,0 +1,84 @@
+name: WASM refresh
+
+# Single writer for the generated kernel-wasm artifacts.
+#
+# wasm-pack output is not byte-reproducible, so two branches that each
+# rebuilt packages/kernel-wasm/vcad_kernel_wasm* conflict on every merge
+# even when their Rust changes don't overlap. Feature branches therefore
+# never commit those files (ci.yml's wasm-artifact-guard enforces it);
+# instead this workflow rebuilds them on main after any kernel-source
+# merge and commits the refresh itself.
+#
+# The refresh commit only touches packages/kernel-wasm/**, which does not
+# match the paths filter below — so it can never re-trigger itself.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      # loon stdlib is include_str! into crates/vcad-loon
+      - "lib/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  # Manual re-fire for the rare push race (a merge landing between this
+  # workflow's checkout and its push makes the push fail cleanly).
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wasm-refresh-main
+  # Only the newest kernel state matters — a superseded rebuild is waste.
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Clone sibling repos
+        run: |
+          git clone --depth 1 https://github.com/ecto/tang.git ../tang
+          git clone --depth 1 https://github.com/ecto/phyz.git ../phyz
+          git clone --depth 1 https://github.com/ecto/loon.git ../loon
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-workspace-crates: true
+      - name: Install wasm-pack
+        # Via cargo so the binary comes through the same trust chain as the
+        # rest of the toolchain (matches ci.yml).
+        run: cargo install wasm-pack --locked --version 0.13.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      # node_modules is needed for the builtin font include_bytes! in
+      # vcad-kernel-text; --ignore-scripts skips native builds we don't use.
+      - run: npm ci --prefer-offline --no-audit --no-fund --ignore-scripts
+      # build.mjs (not raw wasm-pack): it also re-applies the trap-recovery
+      # hook to the wasm-bindgen glue, which the checked-in artifacts carry.
+      - name: Rebuild kernel WASM artifacts
+        run: node packages/kernel-wasm/scripts/build.mjs
+      - name: Commit refreshed artifacts
+        run: |
+          git add packages/kernel-wasm/vcad_kernel_wasm.js \
+                  packages/kernel-wasm/vcad_kernel_wasm.d.ts \
+                  packages/kernel-wasm/vcad_kernel_wasm_bg.wasm \
+                  packages/kernel-wasm/vcad_kernel_wasm_bg.wasm.d.ts
+          if git diff --cached --quiet; then
+            echo "artifacts unchanged — nothing to refresh"
+            exit 0
+          fi
+          git config user.name  "vcad-agent[bot]"
+          git config user.email "vcad-agent@users.noreply.github.com"
+          git commit -m "chore(wasm): refresh kernel artifacts for ${GITHUB_SHA:0:7}"
+          # Cheap insurance against a non-artifact merge racing us; a binary
+          # conflict here means a policy violation upstream and should fail
+          # loudly (re-run via workflow_dispatch after fixing).
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,15 @@ VCAD_WASM_SKIP=1 npm run build --workspaces --if-present
 `VCAD_WASM_SKIP=1` skips the wasm-pack rebuild when `packages/kernel-wasm/vcad_kernel_wasm*`
 artifacts are already checked in; drop it if you need a fresh kernel WASM.
 
+**Never commit the generated `packages/kernel-wasm/vcad_kernel_wasm*` artifacts from a
+feature branch** — wasm-pack output is not byte-reproducible, so two branches that each
+rebuilt them merge-conflict on every merge even when their Rust changes don't overlap.
+They have a single writer: `.github/workflows/wasm-refresh.yml` rebuilds and commits them
+on `main` after any kernel-source merge, and CI (`wasm-artifact-guard`) fails a PR that
+touches them. If you accidentally committed a rebuild, drop it with
+`git checkout origin/main -- 'packages/kernel-wasm/vcad_kernel_wasm*'`. PR CI does not
+depend on the checked-in copies — the TypeScript job consumes WASM built from source.
+
 ## Commands
 
 ```bash


### PR DESCRIPTION
## Why

Every branch that rebuilds `packages/kernel-wasm/vcad_kernel_wasm*` conflicts with every other one: wasm-pack output is not byte-reproducible, so the four generated files hard-conflict (git treats them as binary) even when the underlying Rust changes don't overlap. Verified with `git merge-tree` against today's open PRs (#428, #438): the **only** conflicting paths on both are the four artifact files — `drc.rs`, `lib.rs`, `server.ts`, `ecad.ts` all auto-merge clean. Each time a kernel PR merges (#426, #427 today), every other branch carrying its own rebuild goes conflicted.

## What

**Single writer for generated artifacts:**
- **`.github/workflows/wasm-refresh.yml`** — on any kernel-source merge to main (`crates/**`, `lib/**`, `Cargo.*`), rebuild via `packages/kernel-wasm/scripts/build.mjs` (which also re-applies the trap-recovery glue hook) and commit the refreshed artifacts. The refresh commit touches only `packages/kernel-wasm/**`, so it can't re-trigger itself. `workflow_dispatch` covers the rare push race.
- **`ci.yml` → `wasm-artifact-guard`** — fails any PR whose diff touches the generated artifacts, with the one-line fix in the error message. Safe because the TypeScript job already consumes WASM **built from source** by the `wasm` job — PR CI never depends on the checked-in copies.
- **`agent.yml` prompt + `CLAUDE.md`** — the rule, documented for agents and humans.

## Unblocking the currently-conflicted branches (#428, #438)

No rebase or rebuild needed — on each branch:
```bash
git checkout origin/main -- 'packages/kernel-wasm/vcad_kernel_wasm*'
git commit -m "drop hand-committed wasm artifacts (single-writer policy)"
git push
```
Their CI still validates their new WASM bindings from source, and `wasm-refresh.yml` regenerates the artifacts *with* their changes immediately after each merge.

Note: if `main` ever gets branch protection requiring PRs, flip the refresh workflow's direct push to an auto-PR; today's direct-merge flow works as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Jh8P571762nh3812kj76

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5Jh8P571762nh3812kj76)_