### PR TITLE
fix(test): await async addCoil — un-break main's CI (#428 × #438 collision)

### DIFF
--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -2895,7 +2895,7 @@ describe("add_coil", () => {
   it("run_drc flags a same-net trace over the coil's inner via as SameNetBypass", async () => {
     const id = await circleBoardSession();
     const coil = out(
-      addCoil({
+      await addCoil({
         document_id: id,
         center: { x: 40, y: 40 },
         turns: 10,


### PR DESCRIPTION
## Why

Main's CI is red since #438 merged: `ecad.test.ts > add_coil > run_drc flags a same-net trace over the coil's inner via as SameNetBypass` fails with `TypeError: Cannot read properties of undefined (reading '0')`.

Semantic collision, not a bad PR: #428 wrote the test when `addCoil` was synchronous; #438 made the copper mutators async (drc_delta wrap). Each PR's CI ran before the other landed, so `out(addCoil(...))` receiving a Promise only manifested on main. Every open PR currently inherits this red, including #445.

## What

One word: `out(await addCoil({...}))` at the test's coil setup. Audited the rest of the test file for the same pattern — the other non-awaited async-tool call sites are all legitimate (`await expect(...).rejects` and Promise-returning helpers).

Verification: `npx vitest run` in `packages/mcp` — 41 files, **665 passed, 0 failed** locally on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Jh8P571762nh3812kj76

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5Jh8P571762nh3812kj76)_