### PR TITLE
fix(eval): clear nightly clippy's chunks_exact_to_as_chunks — un-red the nightly leg

### DIFF
--- a/crates/vcad-eval/src/diff.rs
+++ b/crates/vcad-eval/src/diff.rs
@@ -206,7 +206,7 @@ pub struct PartQoiGradient {
 fn mesh_extents(mesh: &EvaluatedMesh) -> [f64; 3] {
     let mut min = [f64::INFINITY; 3];
     let mut max = [f64::NEG_INFINITY; 3];
-    for v in mesh.positions.chunks_exact(3) {
+    for v in mesh.positions.as_chunks::<3>().0 {
         for a in 0..3 {
             let c = v[a] as f64;
             if c < min[a] {


### PR DESCRIPTION
## Why

Every PR and main run since #445 shows a red **Rust (nightly)** check: nightly clippy gained `chunks_exact_to_as_chunks`, which `-D warnings` promotes to an error at `crates/vcad-eval/src/diff.rs:209` (`mesh.positions.chunks_exact(3)` in the bbox-extents helper). The leg is `continue-on-error` so nothing is gated, but a red X on every PR is alarm fatigue — the informational leg only has value when green is its normal state.

## What

One line: `chunks_exact(3)` → `as_chunks::<3>().0` (the lint's own suggestion; `slice::as_chunks` is stable since Rust 1.88, so stable and nightly are both satisfied — the iteration variable just becomes `&[f32; 3]`, same body).

Verification: `cargo clippy -p vcad-eval -- -D warnings` clean on stable, `cargo test -p vcad-eval` all green (40 tests), `rustfmt --check` clean. The nightly leg on this PR's own CI is the end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5Jh8P571762nh3812kj76

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5Jh8P571762nh3812kj76)_