### PR TITLE
add apply_edits MCP tool for atomic batch editing

### DIFF
--- a/changelog/entries/2026-07-08-apply-edits-mcp-tool.json
+++ b/changelog/entries/2026-07-08-apply-edits-mcp-tool.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-apply-edits-mcp-tool",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "feat",
+  "title": "apply_edits MCP tool: atomic batch editing",
+  "summary": "Apply an ordered list of create/update/delete/set_material ops to a session atomically, with one changed diff, one integrity certificate, and a dry_run mode.",
+  "features": ["mcp", "editing"],
+  "mcpTools": ["apply_edits"]
+}

--- a/packages/mcp/src/__tests__/batch-edit.test.ts
+++ b/packages/mcp/src/__tests__/batch-edit.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage of `apply_edits` through the real CallTool pipeline (in-
+ * memory MCP client, anonymous connection). Exercises atomic multi-op batches,
+ * all-or-nothing rollback, single-entry undo, and dry_run — the acceptance
+ * criteria from issue #435.
+ */
+
+async function connect(engine: Engine) {
+  const server = await createServer(engine, { user: null });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "batch-test", version: "0.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function firstText(result: unknown): string {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return content[0].text;
+}
+
+async function openDoc(client: Client): Promise<string> {
+  const open = await client.callTool({ name: "open_document", arguments: {} });
+  return JSON.parse(firstText(open)).document_id as string;
+}
+
+async function getDoc(
+  client: Client,
+  id: string,
+): Promise<{ nodes: Record<string, unknown>; roots: unknown[] }> {
+  const got = await client.callTool({
+    name: "get_document",
+    arguments: { document_id: id },
+  });
+  return JSON.parse(firstText(got));
+}
+
+describe("apply_edits (atomic multi-op batch)", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+  beforeEach(() => {
+    documents.clear();
+  });
+
+  it("applies a multi-op batch with one changed diff and one integrity block", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 10, y: 10, z: 10 } } },
+          { op: "create", type: "cube", params: { size: { x: 4, y: 4, z: 4 } } },
+        ],
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+    const parsed = JSON.parse(firstText(res));
+    expect(parsed.applied).toBe(2);
+    expect(parsed.ops).toHaveLength(2);
+    // One aggregated changed diff covering both ops (two new parts).
+    expect(parsed.changed).toBeDefined();
+    expect(parsed.changed.added).toHaveLength(2);
+    // One integrity certificate over the final document.
+    expect(parsed.integrity).toBeDefined();
+    expect(parsed.integrity.parts).toBe(2);
+
+    // Document state is correct: two root parts.
+    const doc = await getDoc(client, id);
+    expect(doc.roots).toHaveLength(2);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("rolls back the whole batch on a mid-list failure, leaving the doc byte-identical", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    // Seed one valid part so there is prior state to preserve.
+    await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [{ op: "create", type: "cube", params: { size: { x: 5, y: 5, z: 5 } } }],
+      },
+    });
+    const before = JSON.stringify(await getDoc(client, id));
+
+    // Batch: valid create, then a malformed create (size missing z) the planner
+    // rejects → the batch fails at op index 1.
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 2, y: 2, z: 2 } } },
+          { op: "create", type: "cube", params: { size: { x: 2, y: 2 } } },
+        ],
+      },
+    });
+    expect(res.isError).toBe(true);
+    // Error names the failing op index (index 1).
+    expect(firstText(res)).toMatch(/op 1/);
+
+    // Document is byte-identical to its pre-call state.
+    const after = JSON.stringify(await getDoc(client, id));
+    expect(after).toBe(before);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("undo after a batch rewinds the entire batch", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 3, y: 3, z: 3 } } },
+          { op: "create", type: "cube", params: { size: { x: 3, y: 3, z: 3 } } },
+          { op: "create", type: "sphere", params: { radius: 2 } },
+        ],
+      },
+    });
+    expect((await getDoc(client, id)).roots).toHaveLength(3);
+
+    // A single undo rewinds all three creates at once.
+    const u = await client.callTool({
+      name: "undo",
+      arguments: { document_id: id },
+    });
+    expect(JSON.parse(firstText(u)).success).toBe(true);
+    expect((await getDoc(client, id)).roots).toHaveLength(0);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("dry_run reports the per-op plan and mutates nothing", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+    const before = JSON.stringify(await getDoc(client, id));
+
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        dry_run: true,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 1, y: 1, z: 1 } } },
+          { op: "create", type: "sphere", params: { radius: 1 } },
+        ],
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+    const parsed = JSON.parse(firstText(res));
+    expect(parsed.dry_run).toBe(true);
+    expect(parsed.planned).toBe(2);
+    expect(parsed.ops).toHaveLength(2);
+    // Nothing committed: no changed / integrity block, document untouched.
+    expect(parsed.changed).toBeUndefined();
+
+    const after = JSON.stringify(await getDoc(client, id));
+    expect(after).toBe(before);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("rejects an over-cap batch with a clear error", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    const ops = Array.from({ length: 51 }, () => ({
+      op: "create",
+      type: "cube",
+      params: { size: { x: 1, y: 1, z: 1 } },
+    }));
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: { document_id: id, ops },
+    });
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/cap/);
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -924,6 +924,34 @@
     }
   },
   {
+    "name": "apply_edits",
+    "description": "Apply an ordered list of edit ops (create/update/delete/set_material) to a session document atomically — all-or-nothing. One call replaces N single-node round-trips: it returns one aggregated `changed` diff over every op and one integrity certificate, and a subsequent `undo` rewinds the whole batch. Any op failing restores the pre-call document byte-for-byte and reports the failing op index. Pass `dry_run: true` to validate and get the per-op plan without mutating. Each op is `{op, ...args}` (e.g. {op:'create', type:'cube', params:{size:{x,y,z}}}); later ops may reference nodes created earlier in the same batch.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id from open_document. The batch mutates this session's document."
+        },
+        "ops": {
+          "type": "array",
+          "description": "Ordered list of edit ops applied atomically (all-or-nothing). Each op is `{op, ...args}` where op is one of create/update/delete/set_material and the remaining fields are that tool's arguments (minus document_id): create {op, type, params}, update {op, node_id|part_id, ...fields}, delete {op, part_id}, set_material {op, part_id, material}. Later ops may reference nodes created by earlier ops in the same batch. Max 50 per call.",
+          "items": {
+            "type": "object"
+          }
+        },
+        "dry_run": {
+          "type": "boolean",
+          "description": "When true, run planning/validation for every op against a scratch copy and report the per-op plan WITHOUT mutating the session. Use to preflight a batch."
+        }
+      },
+      "required": [
+        "document_id",
+        "ops"
+      ]
+    }
+  },
+  {
     "name": "create_cad_loon",
     "description": "The preferred authoring tool for whole parts and multi-feature models \u2014 one call, full vocabulary. Create a CAD document from loon source code. Loon is a Lisp-like language for parametric CAD \u2014 the FULL modeling vocabulary (patterns, sketches, extrude/revolve/sweep/loft, assemblies) is available here even where no dedicated MCP tool exists. For incremental single-node edits to an open session, use create/update/delete instead.\n\nPrimitives: [cube x y z], [cylinder r h], [sphere r], [cone r-bottom r-top h]\nBooleans (subject-last): [difference tool subject], [union other subject], [intersection other subject]\nTransforms (subject-last): [translate x y z s], [rotate rx ry rz s], [scale sx sy sz s]\nFeatures: [fillet r s], [chamfer d s], [shell t s]\nPatterns (subject-last): [linear-pattern dx dy dz count spacing s], [circular-pattern ox oy oz ax ay az count angle s] \u2014 e.g. a bolt circle is [circular-pattern 0 0 0 0 0 1 6 360 bolt-hole]\nSketches: [sketch ox oy oz xx xy xz yx yy yz #[segments]] with [line x1 y1 x2 y2] and [arc x1 y1 x2 y2 cx cy ccw]\nSketch ops (sketch-last): [extrude dx dy dz sk], [revolve aox aoy aoz adx ady adz angle sk], [sweep-line sx sy sz ex ey ez sk], [sweep-helix radius pitch height turns sk], [loft #[sk1 sk2 \u2026]]\nAssemblies: [assembly #[parts] #[instances] #[joints] ground-id] with [part name solid \"material\"], [instance name part-name x y z], [revolute-joint \u2026], [prismatic-joint \u2026], [fixed-joint \u2026], [ball-joint \u2026]\nPipe: [pipe [cube 50 30 5] [difference [cylinder 3 10]] [fillet 1.0]]\nLet bindings: [let body [cube 50 30 5]]\nScene: [root solid \"material-name\"]",
     "inputSchema": {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -92,6 +92,7 @@ import type { ToolResult } from "./tools/tool-result.js";
 import { buildKernelEventPayload } from "./tools/kernel-event.js";
 
 import { toolDefs as sessionToolDefs } from "./tools/session.js";
+import { toolDefs as batchEditToolDefs } from "./tools/batch-edit.js";
 import { toolDefs as checkpointToolDefs } from "./tools/checkpoint.js";
 import { toolDefs as continueDocToolDefs } from "./tools/continue-doc.js";
 import { toolDefs as orderToolDefs } from "./tools/order.js";
@@ -261,6 +262,7 @@ const WIDGET_CALLABLE_META = {
  */
 const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...sessionToolDefs,
+  ...batchEditToolDefs,
   ...checkpointToolDefs,
   ...continueDocToolDefs,
   ...orderToolDefs,
@@ -331,6 +333,8 @@ const LIST_TOOL_ORDER: readonly string[] = [
   // ── MCP Apps: app-only preview fetch + version poll ────────
   "get_preview_glb",
   "get_preview_version",
+  // ── Atomic multi-op editing ────────────────────────────────
+  "apply_edits",
   // ── Loon DSL one-shot + core see/measure/export ────────────
   "create_cad_loon",
   "export_cad",

--- a/packages/mcp/src/tools/batch-edit.ts
+++ b/packages/mcp/src/tools/batch-edit.ts
@@ -1,0 +1,260 @@
+/**
+ * `apply_edits` — atomic multi-op editing for a session document.
+ *
+ * Each single-node mutation (create/update/delete/set_material) is otherwise a
+ * full round-trip: on the hosted server, hydrate + persist + event-append per
+ * call. An agent editing a multi-feature part pays N calls for what is one
+ * intent. `apply_edits` collapses that to one call: an ordered list of ops
+ * applied all-or-nothing, returning one aggregated `changed` diff and one
+ * integrity certificate.
+ *
+ * Atomicity is a swap, not a patch: ops run against a working COPY of the live
+ * document, and the session is only pointed at the copy once every op has
+ * succeeded. A mid-list failure therefore leaves the live session byte-identical
+ * to its pre-call state — the partially-mutated copy is simply discarded — and
+ * the error names the failing op index plus the underlying error. `dry_run`
+ * runs the same validation against the copy but never commits it, so it reports
+ * the per-op plan while mutating nothing.
+ *
+ * One session-scoped concern is handled by the server pipeline, not here: the
+ * pre-mutation undo snapshot (so a single `undo` rewinds the whole batch) and
+ * the single durable persist + event-spine append both key off this tool's
+ * `writesDoc` behavior flag, exactly once per call.
+ */
+
+import type { Document } from "@vcad/ir";
+import { documents, getSession } from "./session.js";
+import {
+  runMutation,
+  snapshotParts,
+  diffParts,
+  appendChanged,
+} from "./registry-dispatch.js";
+import { computeIntegrity, appendIntegrity } from "./integrity.js";
+import { behavior, type ToolDef } from "./tool-def.js";
+import type { ToolResult } from "./tool-result.js";
+
+/** Ops a single `apply_edits` op may name — the surgical single-node mutators. */
+const ALLOWED_OPS = ["create", "update", "delete", "set_material"] as const;
+type AllowedOp = (typeof ALLOWED_OPS)[number];
+
+/** Max ops per call. Beyond this an agent should split the batch — the cap
+ *  keeps one call from monopolizing an instance and bounds the restore clone. */
+const MAX_BATCH_OPS = 50;
+
+export const applyEditsSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description: "Session id from open_document. The batch mutates this session's document.",
+    },
+    ops: {
+      type: "array" as const,
+      description:
+        "Ordered list of edit ops applied atomically (all-or-nothing). Each op is " +
+        "`{op, ...args}` where op is one of create/update/delete/set_material and the " +
+        "remaining fields are that tool's arguments (minus document_id): " +
+        "create {op, type, params}, update {op, node_id|part_id, ...fields}, " +
+        "delete {op, part_id}, set_material {op, part_id, material}. Later ops may " +
+        `reference nodes created by earlier ops in the same batch. Max ${MAX_BATCH_OPS} per call.`,
+      items: { type: "object" as const },
+    },
+    dry_run: {
+      type: "boolean" as const,
+      description:
+        "When true, run planning/validation for every op against a scratch copy and " +
+        "report the per-op plan WITHOUT mutating the session. Use to preflight a batch.",
+    },
+  },
+  required: ["document_id", "ops"],
+};
+
+/** Thrown when an op in the batch fails; carries the 0-based index. */
+class BatchOpError extends Error {
+  constructor(
+    readonly index: number,
+    readonly opName: string,
+    readonly cause: unknown,
+  ) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(detail);
+    this.name = "BatchOpError";
+  }
+}
+
+/** Deep clone a document via the JSON round-trip openDocument uses, so the live
+ *  session can never be mutated through a retained reference to the copy. */
+function cloneDoc(doc: Document): Document {
+  return JSON.parse(JSON.stringify(doc)) as Document;
+}
+
+/** Normalize one op entry into its tool name + forwarded args. Throws (with the
+ *  index) when the op is malformed or names a disallowed tool. */
+function normalizeOp(
+  op: unknown,
+  index: number,
+): { name: AllowedOp; args: Record<string, unknown> } {
+  if (!op || typeof op !== "object" || Array.isArray(op)) {
+    throw new BatchOpError(index, "?", new Error("op must be an object"));
+  }
+  const { op: opName, ...args } = op as Record<string, unknown>;
+  const name = String(opName ?? "");
+  if (!ALLOWED_OPS.includes(name as AllowedOp)) {
+    throw new BatchOpError(
+      index,
+      name || "?",
+      new Error(
+        `unknown op "${name}" — apply_edits ops must be one of ${ALLOWED_OPS.join(", ")}`,
+      ),
+    );
+  }
+  return { name: name as AllowedOp, args };
+}
+
+/**
+ * Apply every op in order to `doc` (mutated in place), returning a per-op plan
+ * entry for each. Throws `BatchOpError` on the first failure — the caller owns
+ * rollback (it works on a throwaway copy, so a failure just discards it).
+ */
+function applyOps(
+  doc: Document,
+  ops: unknown[],
+  documentId: string,
+): Array<Record<string, unknown>> {
+  const results: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < ops.length; i++) {
+    const { name, args } = normalizeOp(ops[i], i);
+    let result;
+    try {
+      result = runMutation(name, args, doc, documentId);
+    } catch (err) {
+      throw new BatchOpError(i, name, err);
+    }
+    // runMutation returns a single JSON text block — surface its fields as the
+    // op's plan (part_id / node_id / result), tagged with the op index.
+    let parsed: Record<string, unknown> = {};
+    try {
+      parsed = JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+    } catch {
+      // non-JSON result — keep the raw text
+      parsed = { result: result.content[0]?.text };
+    }
+    const { document_id: _docId, ...rest } = parsed;
+    void _docId;
+    results.push({ index: i, op: name, ...rest });
+  }
+  return results;
+}
+
+/** Handle an `apply_edits` call. */
+export function applyEdits(
+  args: Record<string, unknown>,
+  engine?: import("@vcad/engine").Engine,
+): ToolResult {
+  const documentId = String(args.document_id ?? "");
+  const ops = args.ops;
+  const dryRun = args.dry_run === true;
+
+  if (!Array.isArray(ops)) {
+    throw new Error("apply_edits: `ops` must be an array of edit ops");
+  }
+  if (ops.length === 0) {
+    throw new Error("apply_edits: `ops` is empty — pass at least one edit op");
+  }
+  if (ops.length > MAX_BATCH_OPS) {
+    throw new Error(
+      `apply_edits: ${ops.length} ops exceeds the ${MAX_BATCH_OPS}-op cap — split the batch into multiple calls`,
+    );
+  }
+
+  const live = getSession(documentId);
+  // Ops run against a copy; the live session is swapped in only on full success.
+  // So a failed batch (or any dry run) never touches the session — the copy is
+  // discarded and the live document stays byte-identical.
+  const before = snapshotParts(live);
+  const working = cloneDoc(live);
+
+  let opResults: Array<Record<string, unknown>>;
+  try {
+    opResults = applyOps(working, ops, documentId);
+  } catch (err) {
+    if (err instanceof BatchOpError) {
+      throw new Error(
+        `apply_edits: op ${err.index} (${err.opName}) failed — ${err.message}. ` +
+          `No changes were applied; the document is unchanged (${ops.length} ops, all rolled back).`,
+      );
+    }
+    throw err;
+  }
+
+  if (dryRun) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            document_id: documentId,
+            dry_run: true,
+            planned: opResults.length,
+            ops: opResults,
+          }),
+        },
+      ],
+    };
+  }
+
+  // Commit: point the session at the fully-applied copy.
+  documents.set(documentId, working);
+
+  // Narrow content shape (like the registry dispatcher) so appendChanged's
+  // strict `{type:"text"}` block type is satisfied; widens to ToolResult on
+  // return.
+  const result: {
+    content: Array<{ type: "text"; text: string }>;
+    structuredContent?: Record<string, unknown>;
+  } = {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          document_id: documentId,
+          applied: opResults.length,
+          ops: opResults,
+        }),
+      },
+    ],
+  };
+
+  // One aggregated `changed` diff covering every op, and one integrity
+  // certificate over the final document — the same trust layer every single-op
+  // mutation carries, computed once for the whole batch.
+  const changed = diffParts(before, snapshotParts(working));
+  if (changed) {
+    appendChanged(result, changed);
+    if (engine) {
+      const integrity = computeIntegrity(working, engine);
+      if (integrity) appendIntegrity(result, integrity);
+    }
+  }
+  return result;
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "apply_edits",
+    pack: null,
+    description:
+      "Apply an ordered list of edit ops (create/update/delete/set_material) to a " +
+      "session document atomically — all-or-nothing. One call replaces N single-node " +
+      "round-trips: it returns one aggregated `changed` diff over every op and one " +
+      "integrity certificate, and a subsequent `undo` rewinds the whole batch. Any op " +
+      "failing restores the pre-call document byte-for-byte and reports the failing op " +
+      "index. Pass `dry_run: true` to validate and get the per-op plan without mutating. " +
+      "Each op is `{op, ...args}` (e.g. {op:'create', type:'cube', params:{size:{x,y,z}}}); " +
+      "later ops may reference nodes created earlier in the same batch.",
+    inputSchema: applyEditsSchema,
+    handler: (a, c) => applyEdits(a, c.engine),
+    behavior: behavior({ writesDoc: true, geometry: true }),
+  },
+];

--- a/packages/mcp/src/tools/registry-dispatch.ts
+++ b/packages/mcp/src/tools/registry-dispatch.ts
@@ -204,7 +204,7 @@ interface PartDiffEntry {
 }
 
 /** Compact before/after diff of a mutation, reported back to the agent. */
-interface PartsDiff {
+export interface PartsDiff {
   added: PartDiffEntry[];
   removed: PartDiffEntry[];
   modified: PartDiffEntry[];
@@ -216,7 +216,7 @@ interface PartsDiff {
  * pass over reachable nodes — and exact enough to attribute any
  * mutation to the parts it touched.
  */
-function snapshotParts(
+export function snapshotParts(
   doc: import("@vcad/ir").Document,
 ): Map<string, { name?: string; fingerprint: string }> {
   const map = new Map<string, { name?: string; fingerprint: string }>();
@@ -248,7 +248,7 @@ function snapshotParts(
 }
 
 /** Diff two part snapshots. Returns null when nothing changed. */
-function diffParts(
+export function diffParts(
   before: ReturnType<typeof snapshotParts>,
   after: ReturnType<typeof snapshotParts>,
 ): PartsDiff | null {
@@ -278,7 +278,7 @@ function diffParts(
  *  2. the single JSON text block — kept for the agent and for hosts
  *     (Cursor) with known gaps forwarding structuredContent to widgets.
  */
-function appendChanged(
+export function appendChanged(
   result: {
     content: Array<{ type: "text"; text: string }>;
     structuredContent?: Record<string, unknown>;
@@ -353,7 +353,7 @@ export function dispatchRegistryTool(
 }
 
 /** Execute a mutating registry tool against an open session document. */
-function runMutation(
+export function runMutation(
   toolName: string,
   toolArgs: Record<string, unknown>,
   doc: import("@vcad/ir").Document,


### PR DESCRIPTION
## Summary

Introduces `apply_edits`, a new MCP tool that applies an ordered list of edit operations (create/update/delete/set_material) to a session document atomically. This replaces N single-node round-trips with one call, returning a single aggregated `changed` diff and one integrity certificate. Any operation failure rolls back the entire batch, leaving the document byte-identical to its pre-call state.

## Key Changes

- **New tool: `apply_edits`** (`packages/mcp/src/tools/batch-edit.ts`)
  - Accepts an ordered list of ops (create/update/delete/set_material) with a 50-op cap per call
  - Applies all ops atomically against a working copy of the document
  - On success: commits the copy, returns aggregated `changed` diff and integrity certificate
  - On failure: discards the copy, returns error with failing op index; document unchanged
  - Supports `dry_run` mode to validate and report per-op plan without mutating the session
  - Later ops in a batch can reference nodes created by earlier ops

- **Exports from `registry-dispatch.ts`**
  - Made `snapshotParts`, `diffParts`, and `PartsDiff` public to support batch-edit's diff aggregation

- **Server integration** (`packages/mcp/src/server.ts`)
  - Registered `apply_edits` tool via `batchEditToolDefs`

- **Comprehensive test suite** (`packages/mcp/src/__tests__/batch-edit.test.ts`)
  - Multi-op batch with aggregated diff and integrity block
  - All-or-nothing rollback on mid-list failure
  - Single `undo` rewinds entire batch
  - `dry_run` validation without mutation
  - Over-cap batch rejection

- **Tool surface fixture** updated with `apply_edits` schema

- **Changelog entry** documenting the feature

## Implementation Details

- **Atomicity via copy-swap**: Operations run against a JSON-cloned copy of the live document. The session is only pointed at the copy once every op succeeds. Failed batches discard the copy; the live document is never touched.
- **Unified undo**: The server pipeline treats the entire batch as one mutation (via `writesDoc: true`), so a single `undo` rewinds all ops at once and creates one pre-mutation snapshot.
- **Error reporting**: `BatchOpError` carries the 0-based op index and underlying error, allowing agents to identify and fix the failing operation.
- **Dry-run**: Runs the same validation and planning against a scratch copy but never commits, enabling agents to preflight batches before applying them.

https://claude.ai/code/session_01M5Jh8P571762nh3812kj76