### PR TITLE
fix(sheet-metal): watertight tessellation for flanges with holes

### DIFF
--- a/changelog/entries/2026-07-08-sheet-metal-hole-tessellation.json
+++ b/changelog/entries/2026-07-08-sheet-metal-hole-tessellation.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-sheet-metal-hole-tessellation",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "Sheet-metal flanges with holes tessellate watertight",
+  "summary": "Panel meshes now cut hole loops into the caps, wall each bore, and wind outward — inspect_cad/verify_spec volume and watertightness match the solid instead of reporting garbage.",
+  "features": ["sheet-metal", "mesh", "verification"],
+  "mcpTools": ["sheet_metal_create", "inspect_cad", "verify_spec"]
+}

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -1451,13 +1451,20 @@ pub fn triangulate_polygon_2d(
         return None;
     }
     // Normalize the output winding to CCW via the TOTAL signed area of the
-    // triangulation — immune to any individual degenerate triangle.
+    // triangulation — immune to any individual degenerate triangle. A zero
+    // (or non-finite) total means the input was fully degenerate (collinear
+    // points earcut still triangulated into non-empty but zero-area output):
+    // the winding is undefined, so reject rather than return a coin-flip
+    // orientation the caller would pair with mis-wound walls.
     let mut area2 = 0.0;
     for t in tris.chunks(3) {
         let (ax, ay) = (data[2 * t[0]], data[2 * t[0] + 1]);
         let (bx, by) = (data[2 * t[1]], data[2 * t[1] + 1]);
         let (cx, cy) = (data[2 * t[2]], data[2 * t[2] + 1]);
         area2 += (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    }
+    if !area2.is_finite() || area2 == 0.0 {
+        return None;
     }
     let flip = area2 < 0.0;
     Some(
@@ -4792,6 +4799,50 @@ mod tests {
                 "vertex {v} normal not unit: {n:?}"
             );
         }
+    }
+
+    #[test]
+    fn triangulate_polygon_2d_square_is_ccw() {
+        let sq = [(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0)];
+        let tris = triangulate_polygon_2d(&sq, &[]).expect("non-degenerate");
+        // Two triangles, and the summed signed area is positive (CCW) and
+        // equals the square's area.
+        assert_eq!(tris.len(), 2);
+        let mut area2 = 0.0;
+        for t in &tris {
+            let p = |i: u32| sq[i as usize];
+            let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+            area2 += (b.0 - a.0) * (c.1 - a.1) - (b.1 - a.1) * (c.0 - a.0);
+        }
+        assert!((area2 / 2.0 - 4.0).abs() < 1e-9, "area {}", area2 / 2.0);
+    }
+
+    #[test]
+    fn triangulate_polygon_2d_cuts_a_hole() {
+        // 10×10 square with a 2×2 CW hole → area 100 − 4 = 96.
+        let outer = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)];
+        let hole = vec![(4.0, 4.0), (4.0, 6.0), (6.0, 6.0), (6.0, 4.0)];
+        let tris = triangulate_polygon_2d(&outer, &[hole.clone()]).expect("holed");
+        let combined: Vec<(f64, f64)> = outer.iter().copied().chain(hole).collect();
+        let mut area2 = 0.0;
+        for t in &tris {
+            let (a, b, c) = (
+                combined[t[0] as usize],
+                combined[t[1] as usize],
+                combined[t[2] as usize],
+            );
+            area2 += (b.0 - a.0) * (c.1 - a.1) - (b.1 - a.1) * (c.0 - a.0);
+        }
+        assert!((area2 / 2.0 - 96.0).abs() < 1e-6, "area {}", area2 / 2.0);
+    }
+
+    #[test]
+    fn triangulate_polygon_2d_rejects_degenerate() {
+        // Fewer than 3 points, and collinear points (zero total area) both
+        // return None rather than a mis-wound or garbage triangulation.
+        assert!(triangulate_polygon_2d(&[(0.0, 0.0), (1.0, 0.0)], &[]).is_none());
+        let collinear = [(0.0, 0.0), (1.0, 0.0), (2.0, 0.0), (3.0, 0.0)];
+        assert!(triangulate_polygon_2d(&collinear, &[]).is_none());
     }
 
     /// A mesh whose normals buffer is shorter than its vertex buffer (partial)

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -1416,6 +1416,63 @@ fn tessellate_planar_face_with_holes(
 // layers, thousands of vertices) take the fast path.
 const EARCUT_VERTEX_THRESHOLD: usize = 256;
 
+/// Triangulate a planar polygon with interior holes, purely in 2D.
+///
+/// `outer` is the boundary ring and `holes` the interior rings (either
+/// winding — earcut normalizes internally). Returns index triples into the
+/// combined vertex list (outer ring first, then each hole ring in order),
+/// wound CCW in the 2D plane, or `None` when the polygon is degenerate or
+/// earcut fails. No vertices are added or removed, so callers can pair the
+/// resulting cap with lateral walls built from the same rings and stay
+/// watertight.
+pub fn triangulate_polygon_2d(
+    outer: &[(f64, f64)],
+    holes: &[Vec<(f64, f64)>],
+) -> Option<Vec<[u32; 3]>> {
+    if outer.len() < 3 {
+        return None;
+    }
+    let total = outer.len() + holes.iter().map(Vec::len).sum::<usize>();
+    let mut data: Vec<f64> = Vec::with_capacity(2 * total);
+    let mut hole_starts: Vec<usize> = Vec::with_capacity(holes.len());
+    for &(x, y) in outer {
+        data.push(x);
+        data.push(y);
+    }
+    for hole in holes {
+        hole_starts.push(data.len() / 2);
+        for &(x, y) in hole {
+            data.push(x);
+            data.push(y);
+        }
+    }
+    let tris = earcutr::earcut(&data, &hole_starts, 2).ok()?;
+    if tris.is_empty() {
+        return None;
+    }
+    // Normalize the output winding to CCW via the TOTAL signed area of the
+    // triangulation — immune to any individual degenerate triangle.
+    let mut area2 = 0.0;
+    for t in tris.chunks(3) {
+        let (ax, ay) = (data[2 * t[0]], data[2 * t[0] + 1]);
+        let (bx, by) = (data[2 * t[1]], data[2 * t[1] + 1]);
+        let (cx, cy) = (data[2 * t[2]], data[2 * t[2] + 1]);
+        area2 += (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    }
+    let flip = area2 < 0.0;
+    Some(
+        tris.chunks(3)
+            .map(|t| {
+                if flip {
+                    [t[0] as u32, t[2] as u32, t[1] as u32]
+                } else {
+                    [t[0] as u32, t[1] as u32, t[2] as u32]
+                }
+            })
+            .collect(),
+    )
+}
+
 /// Triangulate a projected planar polygon (with optional holes) via earcut.
 ///
 /// `outer_2d`/`inner_2d` are the projected loops; `outer_3d`/`inner_3d` the

--- a/crates/vcad-kernel-wasm/src/sheet_metal.rs
+++ b/crates/vcad-kernel-wasm/src/sheet_metal.rs
@@ -811,114 +811,164 @@ fn tessellate_model(model: &SheetMetalModel) -> MeshDto {
     let mut normals: Vec<f32> = Vec::new();
     let mut indices: Vec<u32> = Vec::new();
     let half_t = model.thickness * 0.5;
+    let signed_area2 = |ring: &[Point2]| -> f64 {
+        let mut a = 0.0;
+        for i in 0..ring.len() {
+            let p = ring[i];
+            let q = ring[(i + 1) % ring.len()];
+            a += p.x * q.y - q.x * p.y;
+        }
+        a
+    };
     for panel in &model.panels {
         let frame = panel.frame_bent;
         let n = frame.normal();
-        let outline = &panel.outline;
-        if outline.len() < 3 {
+        if panel.outline.len() < 3 {
             continue;
         }
-        // Top vertices (outside face, +n side).
-        let base_top = (positions.len() / 3) as u32;
-        for p in outline {
-            let w = frame.to_world(*p);
-            positions.push((w.x + n.x * half_t) as f32);
-            positions.push((w.y + n.y * half_t) as f32);
-            positions.push((w.z + n.z * half_t) as f32);
-            normals.push(n.x as f32);
-            normals.push(n.y as f32);
-            normals.push(n.z as f32);
+        // Normalize ring windings locally: outline CCW, holes CW. That's the
+        // documented convention, but construction doesn't enforce it and the
+        // cap + wall windings below depend on it.
+        let mut outline = panel.outline.clone();
+        if signed_area2(&outline) < 0.0 {
+            outline.reverse();
         }
-        // Bottom vertices.
-        let base_bot = (positions.len() / 3) as u32;
-        for p in outline {
-            let w = frame.to_world(*p);
-            positions.push((w.x - n.x * half_t) as f32);
-            positions.push((w.y - n.y * half_t) as f32);
-            positions.push((w.z - n.z * half_t) as f32);
-            normals.push(-n.x as f32);
-            normals.push(-n.y as f32);
-            normals.push(-n.z as f32);
-        }
-        // Triangulate top with fan from vertex 0.
-        for i in 1..(outline.len() - 1) {
-            indices.push(base_top);
-            indices.push(base_top + i as u32);
-            indices.push(base_top + (i + 1) as u32);
-        }
-        // Triangulate bottom (reverse winding).
-        for i in 1..(outline.len() - 1) {
-            indices.push(base_bot);
-            indices.push(base_bot + (i + 1) as u32);
-            indices.push(base_bot + i as u32);
-        }
-        // Side walls: one quad per outline edge with its own normals.
-        for i in 0..outline.len() {
-            let a = outline[i];
-            let b = outline[(i + 1) % outline.len()];
-            let a_world = frame.to_world(a);
-            let b_world = frame.to_world(b);
-            let edge_x = b_world.x - a_world.x;
-            let edge_y = b_world.y - a_world.y;
-            let edge_z = b_world.z - a_world.z;
-            // Side normal = edge × n, normalised.
-            let mut snx = edge_y * n.z - edge_z * n.y;
-            let mut sny = edge_z * n.x - edge_x * n.z;
-            let mut snz = edge_x * n.y - edge_y * n.x;
-            let m = (snx * snx + sny * sny + snz * snz).sqrt();
-            if m > 1e-12 {
-                snx /= m;
-                sny /= m;
-                snz /= m;
-            } else {
-                snx = 0.0;
-                sny = 0.0;
-                snz = 1.0;
+        let mut holes: Vec<Vec<Point2>> = panel
+            .holes
+            .iter()
+            .filter(|h| h.len() >= 3)
+            .cloned()
+            .collect();
+        for h in &mut holes {
+            if signed_area2(h) > 0.0 {
+                h.reverse();
             }
-            let base = (positions.len() / 3) as u32;
-            // a_top, b_top, b_bot, a_bot.
-            let push = |positions: &mut Vec<f32>, normals: &mut Vec<f32>, x, y, z| {
-                positions.push(x);
-                positions.push(y);
-                positions.push(z);
-                normals.push(snx as f32);
-                normals.push(sny as f32);
-                normals.push(snz as f32);
-            };
-            push(
-                &mut positions,
-                &mut normals,
-                (a_world.x + n.x * half_t) as f32,
-                (a_world.y + n.y * half_t) as f32,
-                (a_world.z + n.z * half_t) as f32,
-            );
-            push(
-                &mut positions,
-                &mut normals,
-                (b_world.x + n.x * half_t) as f32,
-                (b_world.y + n.y * half_t) as f32,
-                (b_world.z + n.z * half_t) as f32,
-            );
-            push(
-                &mut positions,
-                &mut normals,
-                (b_world.x - n.x * half_t) as f32,
-                (b_world.y - n.y * half_t) as f32,
-                (b_world.z - n.z * half_t) as f32,
-            );
-            push(
-                &mut positions,
-                &mut normals,
-                (a_world.x - n.x * half_t) as f32,
-                (a_world.y - n.y * half_t) as f32,
-                (a_world.z - n.z * half_t) as f32,
-            );
-            indices.push(base);
-            indices.push(base + 1);
-            indices.push(base + 2);
-            indices.push(base);
-            indices.push(base + 2);
-            indices.push(base + 3);
+        }
+        let rings: Vec<&[Point2]> = std::iter::once(outline.as_slice())
+            .chain(holes.iter().map(|h| h.as_slice()))
+            .collect();
+
+        // Top (+n) and bottom (−n) cap vertices: every ring, outline first —
+        // the cap triangulation below indexes into this combined order.
+        let base_top = (positions.len() / 3) as u32;
+        for ring in &rings {
+            for p in *ring {
+                let w = frame.to_world(*p);
+                positions.push((w.x + n.x * half_t) as f32);
+                positions.push((w.y + n.y * half_t) as f32);
+                positions.push((w.z + n.z * half_t) as f32);
+                normals.push(n.x as f32);
+                normals.push(n.y as f32);
+                normals.push(n.z as f32);
+            }
+        }
+        let base_bot = (positions.len() / 3) as u32;
+        for ring in &rings {
+            for p in *ring {
+                let w = frame.to_world(*p);
+                positions.push((w.x - n.x * half_t) as f32);
+                positions.push((w.y - n.y * half_t) as f32);
+                positions.push((w.z - n.z * half_t) as f32);
+                normals.push(-n.x as f32);
+                normals.push(-n.y as f32);
+                normals.push(-n.z as f32);
+            }
+        }
+        // Cap triangulation honouring hole loops (earcut; also correct for
+        // concave outlines, unlike a fan). CCW triples in the panel frame
+        // face +n on the top cap; the bottom cap mirrors them.
+        let outer_2d: Vec<(f64, f64)> = outline.iter().map(|p| (p.x, p.y)).collect();
+        let holes_2d: Vec<Vec<(f64, f64)>> = holes
+            .iter()
+            .map(|h| h.iter().map(|p| (p.x, p.y)).collect())
+            .collect();
+        if let Some(tris) = vcad_kernel_tessellate::triangulate_polygon_2d(&outer_2d, &holes_2d) {
+            for t in &tris {
+                indices.push(base_top + t[0]);
+                indices.push(base_top + t[1]);
+                indices.push(base_top + t[2]);
+            }
+            for t in &tris {
+                indices.push(base_bot + t[0]);
+                indices.push(base_bot + t[2]);
+                indices.push(base_bot + t[1]);
+            }
+        }
+        // Lateral walls: outline perimeter + one bore per hole. With the
+        // outline CCW and holes CW, `edge × n` is the outward
+        // (away-from-material) normal for BOTH ring kinds, and one quad
+        // winding faces outward for both.
+        for ring in &rings {
+            for i in 0..ring.len() {
+                let a = ring[i];
+                let b = ring[(i + 1) % ring.len()];
+                let a_world = frame.to_world(a);
+                let b_world = frame.to_world(b);
+                let edge_x = b_world.x - a_world.x;
+                let edge_y = b_world.y - a_world.y;
+                let edge_z = b_world.z - a_world.z;
+                // Side normal = edge × n, normalised.
+                let mut snx = edge_y * n.z - edge_z * n.y;
+                let mut sny = edge_z * n.x - edge_x * n.z;
+                let mut snz = edge_x * n.y - edge_y * n.x;
+                let m = (snx * snx + sny * sny + snz * snz).sqrt();
+                if m > 1e-12 {
+                    snx /= m;
+                    sny /= m;
+                    snz /= m;
+                } else {
+                    snx = 0.0;
+                    sny = 0.0;
+                    snz = 1.0;
+                }
+                let base = (positions.len() / 3) as u32;
+                // a_top, b_top, b_bot, a_bot.
+                let push = |positions: &mut Vec<f32>, normals: &mut Vec<f32>, x, y, z| {
+                    positions.push(x);
+                    positions.push(y);
+                    positions.push(z);
+                    normals.push(snx as f32);
+                    normals.push(sny as f32);
+                    normals.push(snz as f32);
+                };
+                push(
+                    &mut positions,
+                    &mut normals,
+                    (a_world.x + n.x * half_t) as f32,
+                    (a_world.y + n.y * half_t) as f32,
+                    (a_world.z + n.z * half_t) as f32,
+                );
+                push(
+                    &mut positions,
+                    &mut normals,
+                    (b_world.x + n.x * half_t) as f32,
+                    (b_world.y + n.y * half_t) as f32,
+                    (b_world.z + n.z * half_t) as f32,
+                );
+                push(
+                    &mut positions,
+                    &mut normals,
+                    (b_world.x - n.x * half_t) as f32,
+                    (b_world.y - n.y * half_t) as f32,
+                    (b_world.z - n.z * half_t) as f32,
+                );
+                push(
+                    &mut positions,
+                    &mut normals,
+                    (a_world.x - n.x * half_t) as f32,
+                    (a_world.y - n.y * half_t) as f32,
+                    (a_world.z - n.z * half_t) as f32,
+                );
+                // Wound so the face agrees with `edge × n` (outward). The
+                // previous fan-era winding faced inward, which broke the
+                // directed-edge pairing and the signed-volume integral.
+                indices.push(base);
+                indices.push(base + 2);
+                indices.push(base + 1);
+                indices.push(base);
+                indices.push(base + 3);
+                indices.push(base + 2);
+            }
         }
     }
     MeshDto {

--- a/crates/vcad-kernel-wasm/tests/repro_sheet_holes.rs
+++ b/crates/vcad-kernel-wasm/tests/repro_sheet_holes.rs
@@ -1,0 +1,174 @@
+//! Regression tests for sheet-metal panel tessellation: hole loops must be
+//! cut into the top/bottom caps and walled, and every face must wind
+//! outward so the mesh is watertight and its signed-volume integral is
+//! trustworthy. Field repro: a 64-gon D58 disc flange (t = 2.7) with a
+//! 16-gon bore and four 12-gon BCD holes measured ~2374 mm³ (≈⅓ of truth)
+//! with 256 unpaired directed edges — the caps ignored the holes and the
+//! side quads were wound inside-out.
+
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+fn ring(cx: f64, cy: f64, r: f64, n: usize, ccw: bool) -> Vec<[f64; 2]> {
+    let mut pts: Vec<[f64; 2]> = (0..n)
+        .map(|i| {
+            let a = 2.0 * PI * (i as f64) / (n as f64);
+            [cx + r * a.cos(), cy + r * a.sin()]
+        })
+        .collect();
+    if !ccw {
+        pts.reverse();
+    }
+    pts
+}
+
+/// Area of a regular n-gon inscribed in radius r.
+fn ngon_area(r: f64, n: usize) -> f64 {
+    0.5 * (n as f64) * r * r * (2.0 * PI / (n as f64)).sin()
+}
+
+struct MeshCheck {
+    signed_volume_mm3: f64,
+    open_directed_edges: i64,
+}
+
+/// Evaluate a base-flange-polygon chain and integrate its mesh.
+fn evaluate_flange(outline: Vec<[f64; 2]>, holes: Vec<Vec<[f64; 2]>>, thickness: f64) -> MeshCheck {
+    let chain = serde_json::json!([{
+        "type": "BaseFlangePolygon",
+        "outline": outline,
+        "holes": holes,
+        "thickness": thickness,
+        "material": "steel"
+    }]);
+    let out = vcad_kernel_wasm::sheet_metal::evaluate_sheet_metal_chain(&chain.to_string());
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert!(v["error"].is_null(), "kernel error: {}", v["error"]);
+    let positions: Vec<f64> = v["mesh"]["positions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|x| x.as_f64().unwrap())
+        .collect();
+    let indices: Vec<usize> = v["mesh"]["indices"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|x| x.as_u64().unwrap() as usize)
+        .collect();
+
+    let p = |i: usize| [positions[i * 3], positions[i * 3 + 1], positions[i * 3 + 2]];
+    let mut vol = 0.0;
+    for t in indices.chunks(3) {
+        let (a, b, c) = (p(t[0]), p(t[1]), p(t[2]));
+        vol += (a[0] * (b[1] * c[2] - c[1] * b[2]) - b[0] * (a[1] * c[2] - c[1] * a[2])
+            + c[0] * (a[1] * b[2] - b[1] * a[2]))
+            / 6.0;
+    }
+
+    // Unpaired directed edges, vertices matched by quantized position (the
+    // walls duplicate cap vertices) — mirrors the MCP integrity check.
+    let key = |i: usize| {
+        let q = 1e-5;
+        (
+            (positions[i * 3] / q).round() as i64,
+            (positions[i * 3 + 1] / q).round() as i64,
+            (positions[i * 3 + 2] / q).round() as i64,
+        )
+    };
+    let mut net: HashMap<((i64, i64, i64), (i64, i64, i64)), i64> = HashMap::new();
+    for t in indices.chunks(3) {
+        let ks = [key(t[0]), key(t[1]), key(t[2])];
+        for e in 0..3 {
+            let (a, b) = (ks[e], ks[(e + 1) % 3]);
+            if a == b {
+                continue;
+            }
+            if a < b {
+                *net.entry((a, b)).or_default() += 1;
+            } else {
+                *net.entry((b, a)).or_default() -= 1;
+            }
+        }
+    }
+    let open: i64 = net.values().map(|c| c.abs()).sum();
+
+    MeshCheck {
+        signed_volume_mm3: vol,
+        open_directed_edges: open,
+    }
+}
+
+fn assert_solid(check: &MeshCheck, analytic_mm3: f64) {
+    assert_eq!(
+        check.open_directed_edges, 0,
+        "mesh is not watertight ({} unpaired directed edges)",
+        check.open_directed_edges
+    );
+    assert!(
+        check.signed_volume_mm3 > 0.0,
+        "signed volume is not positive: {} mm³ (inverted winding)",
+        check.signed_volume_mm3
+    );
+    let err = (check.signed_volume_mm3 - analytic_mm3).abs();
+    assert!(
+        err <= analytic_mm3 * 0.01,
+        "volume {} mm³ deviates from analytic {} mm³ by more than 1%",
+        check.signed_volume_mm3,
+        analytic_mm3
+    );
+}
+
+/// Field repro: 64-gon circular flange D58, t = 2.7, one 16-gon bore D8.4
+/// and four 12-gon D3.3 holes on a 22 mm BCD.
+#[test]
+fn disc_flange_with_bore_and_bcd_holes_is_watertight() {
+    let outline = ring(0.0, 0.0, 29.0, 64, true);
+    let mut holes = vec![ring(0.0, 0.0, 4.2, 16, false)];
+    for k in 0..4 {
+        let a = 2.0 * PI * (k as f64) / 4.0;
+        holes.push(ring(11.0 * a.cos(), 11.0 * a.sin(), 1.65, 12, false));
+    }
+    let analytic = (ngon_area(29.0, 64) - ngon_area(4.2, 16) - 4.0 * ngon_area(1.65, 12)) * 2.7;
+    let check = evaluate_flange(outline, holes, 2.7);
+    assert_solid(&check, analytic);
+}
+
+/// Minimal case: a rectangular flange with one rectangular hole.
+#[test]
+fn square_flange_with_single_hole_is_watertight() {
+    let outline = vec![[0.0, 0.0], [20.0, 0.0], [20.0, 10.0], [0.0, 10.0]];
+    // CW hole, matching the documented hole-winding convention.
+    let hole = vec![[5.0, 3.0], [5.0, 7.0], [8.0, 7.0], [8.0, 3.0]];
+    let analytic = (20.0 * 10.0 - 3.0 * 4.0) * 1.0;
+    let check = evaluate_flange(outline, vec![hole], 1.0);
+    assert_solid(&check, analytic);
+}
+
+/// Concave outline (L-bracket): the old fan triangulation filled the
+/// notch; earcut must not.
+#[test]
+fn concave_outline_without_holes_is_watertight() {
+    let outline = vec![
+        [0.0, 0.0],
+        [40.0, 0.0],
+        [40.0, 10.0],
+        [10.0, 10.0],
+        [10.0, 40.0],
+        [0.0, 40.0],
+    ];
+    let analytic = (40.0 * 10.0 + 10.0 * 30.0) * 1.0;
+    let check = evaluate_flange(outline, Vec::new(), 1.0);
+    assert_solid(&check, analytic);
+}
+
+/// Mis-wound input (CW outline, CCW hole) must tessellate identically —
+/// the mesher normalizes ring windings rather than trusting the caller.
+#[test]
+fn miswound_rings_are_normalized() {
+    let outline = ring(0.0, 0.0, 29.0, 64, false);
+    let holes = vec![ring(0.0, 0.0, 4.2, 16, true)];
+    let analytic = (ngon_area(29.0, 64) - ngon_area(4.2, 16)) * 2.7;
+    let check = evaluate_flange(outline, holes, 2.7);
+    assert_solid(&check, analytic);
+}

--- a/packages/mcp/src/__tests__/verify-spec.test.ts
+++ b/packages/mcp/src/__tests__/verify-spec.test.ts
@@ -21,6 +21,7 @@ import {
   type SpecMeasurement,
 } from "../receipt-unified.js";
 import { verifySpec } from "../tools/verify-spec.js";
+import { sheetMetalCreate } from "../tools/sheet-metal.js";
 import { documents, registerSession } from "../tools/session.js";
 
 let engine: Engine;
@@ -245,5 +246,113 @@ describe("verifySpec (MCP tool)", () => {
     expect(receipt.claims.some((c) => c.verdict === "unverifiable")).toBe(true);
     expect(receipt.claims.some((c) => c.verdict === "pass")).toBe(false);
     expectValidReceipt(receipt);
+  });
+
+  it("mirrors each claim's spec bound as `expected` in the tool output", () => {
+    // Display alias of the schema's `predicted` — readers of the tool result
+    // looking for "expected" must find the bound, not nothing.
+    const id = registerSession(cubeDoc());
+    const { receipt } = out(
+      verifySpec(
+        { document_id: id, spec: { volume: { min: 5950, max: 6050 }, watertight: true } },
+        engine,
+      ),
+    );
+    for (const c of receipt.claims) {
+      const raw = c as unknown as Record<string, unknown>;
+      expect(raw.expected).toBeDefined();
+      expect(raw.expected).toEqual(c.predicted);
+    }
+    expectValidReceipt(receipt);
+  });
+});
+
+/**
+ * Field-repro regression: a SheetMetalBaseFlangePolygon with hole loops used
+ * to tessellate non-watertight (caps ignored the holes, side quads wound
+ * inside-out) and measure ~2374 mm³ against ~6890 mm³ of truth, so this exact
+ * spec graded `fail` while the STEP export and sheet_metal_cost were sound.
+ */
+describe("verifySpec on sheet-metal flanges with hole loops", () => {
+  function ring(
+    cx: number,
+    cy: number,
+    r: number,
+    n: number,
+    ccw: boolean,
+  ): Array<{ x: number; y: number }> {
+    const pts = Array.from({ length: n }, (_, i) => {
+      const a = (2 * Math.PI * i) / n;
+      return { x: cx + r * Math.cos(a), y: cy + r * Math.sin(a) };
+    });
+    if (!ccw) pts.reverse();
+    return pts;
+  }
+
+  function createFlange(args: Record<string, unknown>): string {
+    const res = sheetMetalCreate(args, engine);
+    const body = JSON.parse(res.content[0].text) as { document_id: string };
+    expect(body.document_id).toBeTruthy();
+    return body.document_id;
+  }
+
+  function grade(
+    id: string,
+    volume: { min: number; max: number },
+  ): ReturnType<typeof summarize> {
+    const res = verifySpec(
+      { document_id: id, spec: { volume, watertight: true, part_count: 1 } },
+      engine,
+    );
+    const parsed = JSON.parse(res.content[0].text) as {
+      receipt: DesignReceipt;
+      summary: ReturnType<typeof summarize>;
+    };
+    expectValidReceipt(parsed.receipt);
+    return parsed.summary;
+  }
+
+  it("64-gon disc flange with a bore and four BCD holes passes volume + watertight", () => {
+    const holes = [ring(0, 0, 4.2, 16, false)];
+    for (let k = 0; k < 4; k++) {
+      const a = (2 * Math.PI * k) / 4;
+      holes.push(ring(11 * Math.cos(a), 11 * Math.sin(a), 1.65, 12, false));
+    }
+    const id = createFlange({
+      outline: ring(0, 0, 29, 64, true),
+      holes,
+      thickness: 2.7,
+      material: "steel-mild",
+    });
+    // Analytic n-gon volume 6888.1 mm³, bounds ±1%.
+    const summary = grade(id, { min: 6820, max: 6960 });
+    expect(summary.overall).toBe("pass");
+    expect(summary.failed).toBe(0);
+  });
+
+  it("square flange with a single rectangular hole passes volume + watertight", () => {
+    const id = createFlange({
+      outline: [
+        { x: 0, y: 0 },
+        { x: 20, y: 0 },
+        { x: 20, y: 10 },
+        { x: 0, y: 10 },
+      ],
+      // CW hole, matching the documented hole-winding convention.
+      holes: [
+        [
+          { x: 5, y: 3 },
+          { x: 5, y: 7 },
+          { x: 8, y: 7 },
+          { x: 8, y: 3 },
+        ],
+      ],
+      thickness: 1,
+      material: "steel-mild",
+    });
+    // Analytic (200 − 12) × 1 = 188 mm³, bounds ±1%.
+    const summary = grade(id, { min: 186.1, max: 189.9 });
+    expect(summary.overall).toBe("pass");
+    expect(summary.failed).toBe(0);
   });
 });

--- a/packages/mcp/src/tools/verify-spec.ts
+++ b/packages/mcp/src/tools/verify-spec.ts
@@ -13,6 +13,7 @@
 
 import { createHash } from "node:crypto";
 import type { Engine } from "@vcad/engine";
+import type { DesignReceipt } from "@vcad/ir";
 import { behavior, type ToolDef } from "./tool-def.js";
 import { computeIntegrity } from "./integrity.js";
 import { getSession } from "./session.js";
@@ -22,6 +23,28 @@ import {
   type DesignSpec,
   type SpecMeasurement,
 } from "../receipt-unified.js";
+
+/**
+ * The unified receipt schema names the spec-bound field `predicted` (Rust
+ * `vcad_receipt::ReceiptClaim` — "a spec bound, a rule limit, a declared
+ * target"). Everyone eyeballing a verify_spec claim looks for "expected"
+ * (the tool description promises measured-vs-expected), so mirror the bound
+ * under that name in the tool output. Display alias only: `predicted` stays
+ * the schema field, and round-tripping the receipt through the Rust
+ * deserializer simply drops the alias.
+ */
+function withExpectedAlias(
+  receipt: DesignReceipt,
+): Omit<DesignReceipt, "claims"> & {
+  claims: Array<DesignReceipt["claims"][number] & { expected?: unknown }>;
+} {
+  return {
+    ...receipt,
+    claims: receipt.claims.map((c) =>
+      c.predicted !== undefined ? { ...c, expected: c.predicted } : c,
+    ),
+  };
+}
 
 const pointSpecSchema = {
   type: "object" as const,
@@ -124,7 +147,11 @@ export function verifySpec(
     content: [
       {
         type: "text",
-        text: JSON.stringify({ receipt, summary }, null, 2),
+        text: JSON.stringify(
+          { receipt: withExpectedAlias(receipt), summary },
+          null,
+          2,
+        ),
       },
     ],
   };


### PR DESCRIPTION
## What

Sheet-metal panel meshes for `SheetMetalBaseFlangePolygon` ignored interior hole loops and wound the lateral walls inward, so `inspect_cad` / `verify_spec` measured garbage geometry even though the underlying solid was correct.

**Field repro:** a 64-gon D58 disc flange (t=2.7) with a 16-gon D8.4 bore + four 12-gon D3.3 holes at BCD 22 measured **2374 mm³ vs ~6890 analytic**, watertight **false** (256 unpaired directed edges). Independent evidence the solid was fine: `sheet_metal_cost` reported the correct mass (0.0541 kg = 6870 mm³ × 7.87 g/cc) and the STEP export was dimensionally sound — both read the solid, not this mesh path.

## Root cause

`tessellate_model` in `crates/vcad-kernel-wasm/src/sheet_metal.rs` is the only mesh path for sheet-metal on the web/MCP surface (STEP uses `folded_sheet_solid`). Two defects:

1. **Caps ignored `panel.holes`** and fan-triangulated the outline only (also wrong for concave outlines like L-brackets).
2. **Side-wall quads were wound inward** — for *every* flange ever meshed, not just ones with holes. It never showed visually because the normal *attribute* was computed separately (`edge × n`, correct) and the material renders double-sided; only the signed-volume integral and the directed-edge watertight check caught it. Decomposing the repro's signed volume by face group made it obvious: top fan +1187, bottom fan +1187, sides **−4748** → −2374 mm³.

## The fix

- New public `triangulate_polygon_2d` in `vcad-kernel-tessellate` (earcut wrapper, output normalized CCW by total signed area).
- `tessellate_model` now cuts hole loops into both caps, emits a wall per hole bore, normalizes ring windings locally (outline→CCW, holes→CW; robust to mis-wound input), and winds all walls outward. Model / unfold / DXF conventions untouched.
- **verify_spec `expected: None`:** the receipt schema names the spec-bound field `predicted`, so anything reading claims for "expected" found nothing. Fixed as a display alias — the tool output mirrors `predicted` into an `expected` field; schema and Rust round-trip unchanged.

Repro now measures **6888.14 mm³ vs analytic 6888.1, watertight true**, and `verify_spec` rolls up to `pass`.

## Tests

- `crates/vcad-kernel-wasm/tests/repro_sheet_holes.rs`: repro disc, single-hole square, concave L-shape, mis-wound rings — each asserting watertight + volume within 1% of analytic.
- `packages/mcp/.../verify-spec.test.ts`: both repro geometries grade `pass` on volume/watertight through the real tool, plus an `expected`-alias assertion.
- Full suites green: MCP 698, engine 96, tessellate/wasm/kernel/eval crates all pass. `cargo clippy --workspace -D warnings` and `cargo fmt --check` clean.

## Reviewer notes

- The checked-in `packages/kernel-wasm/vcad_kernel_wasm*` artifacts are **deliberately not touched** (single-writer `wasm-refresh.yml` on main; CI builds WASM from source). I rebuilt them locally only to run the TS tests.
- The `expected` alias is display-only to avoid a schema bump; `predicted` is consumed by the PCB/mech/EM receipt adapters and stays the canonical field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)