### PR TITLE
fix(mcp): consume child parts on create; @N refs + string ids in apply_edits

### DIFF
--- a/changelog/entries/2026-07-08-mcp-root-consumption-symbolic-refs.json
+++ b/changelog/entries/2026-07-08-mcp-root-consumption-symbolic-refs.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-mcp-root-consumption-symbolic-refs",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "MCP creates consume child parts; @N refs in apply_edits",
+  "summary": "Booleans/transforms via MCP no longer leave consumed intermediates as ghost parts that double-count volume; child refs accept string ids, and apply_edits ops reference earlier ops as \"@N\".",
+  "features": ["mcp", "editing"],
+  "mcpTools": ["apply_edits", "create", "inspect_cad"]
+}

--- a/packages/core/src/commands/document-mutations.ts
+++ b/packages/core/src/commands/document-mutations.ts
@@ -101,13 +101,36 @@ export function applyToolOutcome(
         op: outcome.op as unknown as CsgOp,
       };
       doc.nodes[String(id)] = node;
-      // For now, every add_feature creates a new root part. parent_part_id
-      // would imply wrapping the parent's root in a new node; the Rust
-      // planner doesn't currently emit wrapped outcomes for this path
-      // (modifier features go through their own create flow). When that
-      // changes, extend here.
-      const entry: SceneEntry = { root: id, material: "default" };
-      doc.roots.push(entry);
+      // A feature that references existing ROOT nodes as children consumes
+      // those parts: the referenced roots become interior nodes of the new
+      // part and must stop being independent scene entries — otherwise every
+      // boolean/transform chain leaves its intermediates behind as ghost
+      // parts that double-count volume. Mirrors the app docstore's
+      // applyBoolean/wrap semantics. The first consumed entry is reused in
+      // place so its material/visibility/scene position survive; any other
+      // consumed entries (e.g. a boolean's right operand) are dropped.
+      const children = new Set(opChildren(node.op));
+      const consumedIdxs: number[] = [];
+      doc.roots.forEach((r, i) => {
+        if (children.has(r.root)) consumedIdxs.push(i);
+      });
+      if (consumedIdxs.length > 0) {
+        const first = doc.roots[consumedIdxs[0]!]!;
+        const firstPartId = String(first.root);
+        doc.roots[consumedIdxs[0]!] = { ...first, root: id };
+        if (doc.part_materials[firstPartId] !== undefined) {
+          doc.part_materials[String(id)] = doc.part_materials[firstPartId]!;
+          delete doc.part_materials[firstPartId];
+        }
+        for (let k = consumedIdxs.length - 1; k >= 1; k--) {
+          const idx = consumedIdxs[k]!;
+          delete doc.part_materials[String(doc.roots[idx]!.root)];
+          doc.roots.splice(idx, 1);
+        }
+      } else {
+        const entry: SceneEntry = { root: id, material: "default" };
+        doc.roots.push(entry);
+      }
       return { partId: String(id), nodeId: String(id) };
     }
     case "remove_part": {

--- a/packages/mcp/src/__tests__/batch-edit.test.ts
+++ b/packages/mcp/src/__tests__/batch-edit.test.ts
@@ -185,6 +185,177 @@ describe("apply_edits (atomic multi-op batch)", () => {
     await server.close();
   });
 
+  it("consumes intermediate roots: a boolean chain yields exactly ONE part (symbolic @N refs)", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    // The issue-repro batch: cylinder → translate → cylinder → translate →
+    // difference. Before the consumption fix this left 5 roots (ghost
+    // intermediates double-counting volume); it must yield exactly one part
+    // whose volume is the difference volume.
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cylinder", params: { radius: 10, height: 20 } },
+          { op: "create", type: "translate", params: { child: "@0", offset: { x: 1, y: 2, z: 0 } } },
+          { op: "create", type: "cylinder", params: { radius: 4, height: 20 } },
+          { op: "create", type: "translate", params: { child: "@2", offset: { x: 1, y: 2, z: 0 } } },
+          { op: "create", type: "difference", params: { left: "@1", right: "@3" } },
+        ],
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+    const parsed = JSON.parse(firstText(res));
+    expect(parsed.applied).toBe(5);
+    // The aggregated diff reports ONE new part — not five.
+    expect(parsed.changed.added).toHaveLength(1);
+
+    // read: exactly one part remains.
+    const read = await client.callTool({
+      name: "read",
+      arguments: { document_id: id },
+    });
+    const parts = JSON.parse(firstText(read)).parts as unknown[];
+    expect(parts).toHaveLength(1);
+
+    // inspect_cad: one part, and total volume is the DIFFERENCE volume
+    // (π·(10²−4²)·20), not big+small+difference double-counted.
+    const insp = await client.callTool({
+      name: "inspect_cad",
+      arguments: { document_id: id },
+    });
+    const inspection = JSON.parse(firstText(insp)) as {
+      parts: number;
+      volume_mm3: number;
+    };
+    expect(inspection.parts).toBe(1);
+    const expected = Math.PI * (10 * 10 - 4 * 4) * 20;
+    expect(Math.abs(inspection.volume_mm3 - expected) / expected).toBeLessThan(0.02);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("keeps back-compat: raw numeric node ids still work as child refs", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    // Fresh document: node ids are assigned sequentially from 1.
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cylinder", params: { radius: 10, height: 20 } },
+          { op: "create", type: "translate", params: { child: 1, offset: { x: 1, y: 2, z: 0 } } },
+          { op: "create", type: "cylinder", params: { radius: 4, height: 20 } },
+          { op: "create", type: "translate", params: { child: 3, offset: { x: 1, y: 2, z: 0 } } },
+          { op: "create", type: "difference", params: { left: 2, right: 4 } },
+        ],
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+
+    const read = await client.callTool({
+      name: "read",
+      arguments: { document_id: id },
+    });
+    const parts = JSON.parse(firstText(read)).parts as Array<{ id: string }>;
+    expect(parts).toHaveLength(1);
+    expect(parts[0].id).toBe("5");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("accepts string part ids from prior results in single create calls (and consumes roots there too)", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    // Two independent creates, then a difference referencing the returned
+    // string part ids — the dialect every other MCP tool speaks.
+    const a = await client.callTool({
+      name: "create",
+      arguments: { document_id: id, type: "cube", params: { size: { x: 10, y: 10, z: 10 } } },
+    });
+    const aId = JSON.parse(firstText(a)).part_id as string;
+    const b = await client.callTool({
+      name: "create",
+      arguments: { document_id: id, type: "cube", params: { size: { x: 4, y: 4, z: 4 } } },
+    });
+    const bId = JSON.parse(firstText(b)).part_id as string;
+    expect(typeof aId).toBe("string");
+
+    const diff = await client.callTool({
+      name: "create",
+      arguments: {
+        document_id: id,
+        type: "difference",
+        params: { left: aId, right: bId },
+      },
+    });
+    expect(diff.isError ?? false).toBe(false);
+
+    const doc = await getDoc(client, id);
+    expect(doc.roots).toHaveLength(1);
+
+    await client.close();
+    await server.close();
+  });
+
+  it("consumption preserves the consumed root's material and symbolic refs work in part_id positions", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 5, y: 5, z: 5 } } },
+          { op: "set_material", part_id: "@0", material: "steel" },
+          { op: "create", type: "translate", params: { child: "@0", offset: { x: 3, y: 0, z: 0 } } },
+        ],
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+
+    const doc = await getDoc(client, id);
+    expect(doc.roots).toHaveLength(1);
+    expect((doc.roots[0] as { material: string }).material).toBe("steel");
+
+    await client.close();
+    await server.close();
+  });
+
+  it("rejects forward and dangling @N refs atomically", async () => {
+    const { client, server } = await connect(engine);
+    const id = await openDoc(client);
+
+    const res = await client.callTool({
+      name: "apply_edits",
+      arguments: {
+        document_id: id,
+        ops: [
+          { op: "create", type: "cube", params: { size: { x: 5, y: 5, z: 5 } } },
+          { op: "create", type: "translate", params: { child: "@5", offset: { x: 1, y: 0, z: 0 } } },
+        ],
+      },
+    });
+    expect(res.isError).toBe(true);
+    expect(firstText(res)).toMatch(/op 1/);
+    expect(firstText(res)).toMatch(/@5/);
+
+    // Nothing applied — the valid op 0 rolled back with the batch.
+    const doc = await getDoc(client, id);
+    expect(doc.roots).toHaveLength(0);
+
+    await client.close();
+    await server.close();
+  });
+
   it("rejects an over-cap batch with a clear error", async () => {
     const { client, server } = await connect(engine);
     const id = await openDoc(client);

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1007,7 +1007,7 @@
   },
   {
     "name": "apply_edits",
-    "description": "Apply an ordered list of edit ops (create/update/delete/set_material) to a session document atomically — all-or-nothing. One call replaces N single-node round-trips: it returns one aggregated `changed` diff over every op and one integrity certificate, and a subsequent `undo` rewinds the whole batch. Any op failing restores the pre-call document byte-for-byte and reports the failing op index. Pass `dry_run: true` to validate and get the per-op plan without mutating. Each op is `{op, ...args}` (e.g. {op:'create', type:'cube', params:{size:{x,y,z}}}); later ops may reference nodes created earlier in the same batch.",
+    "description": "Apply an ordered list of edit ops (create/update/delete/set_material) to a session document atomically \u2014 all-or-nothing. One call replaces N single-node round-trips: it returns one aggregated `changed` diff over every op and one integrity certificate, and a subsequent `undo` rewinds the whole batch. Any op failing restores the pre-call document byte-for-byte and reports the failing op index. Pass `dry_run: true` to validate and get the per-op plan without mutating. Each op is `{op, ...args}` (e.g. {op:'create', type:'cube', params:{size:{x,y,z}}}); later ops reference nodes created earlier in the batch as \"@N\" (op index N), so a boolean chain never predicts node ids.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1017,7 +1017,7 @@
         },
         "ops": {
           "type": "array",
-          "description": "Ordered list of edit ops applied atomically (all-or-nothing). Each op is `{op, ...args}` where op is one of create/update/delete/set_material and the remaining fields are that tool's arguments (minus document_id): create {op, type, params}, update {op, node_id|part_id, ...fields}, delete {op, part_id}, set_material {op, part_id, material}. Later ops may reference nodes created by earlier ops in the same batch. Max 50 per call.",
+          "description": "Ordered list of edit ops applied atomically (all-or-nothing). Each op is `{op, ...args}` where op is one of create/update/delete/set_material and the remaining fields are that tool's arguments (minus document_id): create {op, type, params}, update {op, node_id|part_id, ...fields}, delete {op, part_id}, set_material {op, part_id, material}. Later ops may reference nodes created by earlier ops in the same batch symbolically: \"@N\" (in params.child/left/right/sketch or part_id/node_id) resolves to the node created by op index N \u2014 no need to predict node ids. Max 50 per call.",
           "items": {
             "type": "object"
           }

--- a/packages/mcp/src/tools/batch-edit.ts
+++ b/packages/mcp/src/tools/batch-edit.ts
@@ -57,7 +57,9 @@ export const applyEditsSchema = {
         "remaining fields are that tool's arguments (minus document_id): " +
         "create {op, type, params}, update {op, node_id|part_id, ...fields}, " +
         "delete {op, part_id}, set_material {op, part_id, material}. Later ops may " +
-        `reference nodes created by earlier ops in the same batch. Max ${MAX_BATCH_OPS} per call.`,
+        'reference nodes created by earlier ops in the same batch symbolically: "@N" ' +
+        "(in params.child/left/right/sketch or part_id/node_id) resolves to the node " +
+        `created by op index N — no need to predict node ids. Max ${MAX_BATCH_OPS} per call.`,
       items: { type: "object" as const },
     },
     dry_run: {
@@ -112,6 +114,58 @@ function normalizeOp(
   return { name: name as AllowedOp, args };
 }
 
+/** Matches a symbolic reference to an earlier op's created node: "@3". */
+const SYMBOLIC_REF = /^@(\d+)$/;
+
+/**
+ * Resolve "@N" symbolic references in one op's args against the node ids
+ * created by earlier ops in the batch, so callers never hand-predict
+ * sequential node ids. Substitutes in the positions that name nodes: the
+ * top-level `part_id`/`node_id` and the child refs inside `params`
+ * (child/left/right/sketch/sketches). Returns a copy; throws on a forward
+ * reference or a reference to an op that created no node.
+ */
+function resolveSymbolicRefs(
+  args: Record<string, unknown>,
+  createdIds: Array<string | undefined>,
+  index: number,
+): Record<string, unknown> {
+  const resolve = (v: unknown): unknown => {
+    if (typeof v !== "string") return v;
+    const m = SYMBOLIC_REF.exec(v);
+    if (!m) return v;
+    const refIdx = Number(m[1]);
+    if (refIdx >= index) {
+      throw new Error(
+        `"@${refIdx}" is not resolvable from op ${index} — symbolic refs may only point at EARLIER ops in the batch`,
+      );
+    }
+    const id = createdIds[refIdx];
+    if (id === undefined) {
+      throw new Error(
+        `"@${refIdx}" refers to op ${refIdx}, which did not create a node`,
+      );
+    }
+    return id;
+  };
+
+  const out = { ...args };
+  for (const key of ["part_id", "node_id"]) {
+    if (key in out) out[key] = resolve(out[key]);
+  }
+  if (out.params && typeof out.params === "object" && !Array.isArray(out.params)) {
+    const params = { ...(out.params as Record<string, unknown>) };
+    for (const key of ["child", "left", "right", "sketch"]) {
+      if (key in params) params[key] = resolve(params[key]);
+    }
+    if (Array.isArray(params.sketches)) {
+      params.sketches = params.sketches.map(resolve);
+    }
+    out.params = params;
+  }
+  return out;
+}
+
 /**
  * Apply every op in order to `doc` (mutated in place), returning a per-op plan
  * entry for each. Throws `BatchOpError` on the first failure — the caller owns
@@ -123,11 +177,19 @@ function applyOps(
   documentId: string,
 ): Array<Record<string, unknown>> {
   const results: Array<Record<string, unknown>> = [];
+  // Node id created by each op so far (undefined for ops that create none),
+  // the targets "@N" refs resolve against.
+  const createdIds: Array<string | undefined> = [];
   for (let i = 0; i < ops.length; i++) {
     const { name, args } = normalizeOp(ops[i], i);
     let result;
     try {
-      result = runMutation(name, args, doc, documentId);
+      result = runMutation(
+        name,
+        resolveSymbolicRefs(args, createdIds, i),
+        doc,
+        documentId,
+      );
     } catch (err) {
       throw new BatchOpError(i, name, err);
     }
@@ -142,6 +204,11 @@ function applyOps(
     }
     const { document_id: _docId, ...rest } = parsed;
     void _docId;
+    createdIds.push(
+      name === "create" && typeof rest.node_id === "string"
+        ? rest.node_id
+        : undefined,
+    );
     results.push({ index: i, op: name, ...rest });
   }
   return results;
@@ -252,7 +319,8 @@ export const toolDefs: ToolDef[] = [
       "failing restores the pre-call document byte-for-byte and reports the failing op " +
       "index. Pass `dry_run: true` to validate and get the per-op plan without mutating. " +
       "Each op is `{op, ...args}` (e.g. {op:'create', type:'cube', params:{size:{x,y,z}}}); " +
-      "later ops may reference nodes created earlier in the same batch.",
+      'later ops reference nodes created earlier in the batch as "@N" (op index N), ' +
+      "so a boolean chain never predicts node ids.",
     inputSchema: applyEditsSchema,
     handler: (a, c) => applyEdits(a, c.engine),
     behavior: behavior({ writesDoc: true, geometry: true }),

--- a/packages/mcp/src/tools/next-actions.ts
+++ b/packages/mcp/src/tools/next-actions.ts
@@ -161,14 +161,14 @@ export function suggestNextActions(
         tool: toolName,
       });
     }
-    // Booleans take numeric ids of pre-created children, not inline geometry.
+    // Booleans take ids of pre-created children, not inline geometry.
     if (
       (type === "union" || type === "difference" || type === "intersection") &&
       lower.includes("node")
     ) {
       actions.push({
         action:
-          "Create both child nodes first, then reference their numeric ids — inline child definitions aren't supported.",
+          "Create both child nodes first, then reference their ids (numeric or string) — inline child definitions aren't supported.",
       });
     }
     if (actions.length) return actions;

--- a/packages/mcp/src/tools/registry-dispatch.ts
+++ b/packages/mcp/src/tools/registry-dispatch.ts
@@ -109,11 +109,11 @@ export const CREATE_PARAM_HINTS: Record<string, string> = {
   sphere: "{radius, segments? (default 32)}",
   cone: "{radius_bottom, radius_top, height, segments? (default 64)} — axis along Z",
   union:
-    "{left, right} — numeric node ids of existing nodes. Create both children first, then combine; inline child definitions are not supported.",
+    "{left, right} — node ids of existing nodes (numeric or string). Create both children first, then combine; inline child definitions are not supported.",
   difference:
-    "{left, right} — numeric node ids of existing nodes (left minus right). Create both children first; inline child definitions are not supported.",
+    "{left, right} — node ids of existing nodes (left minus right; numeric or string). Create both children first; inline child definitions are not supported.",
   intersection:
-    "{left, right} — numeric node ids of existing nodes. Create both children first; inline child definitions are not supported.",
+    "{left, right} — node ids of existing nodes (numeric or string). Create both children first; inline child definitions are not supported.",
   translate: "{child: nodeId, offset: {x, y, z}}",
   rotate: "{child: nodeId, angles: {x, y, z}} — degrees",
   scale: "{child: nodeId, factor: {x, y, z}}",
@@ -123,6 +123,51 @@ export const CREATE_PARAM_HINTS: Record<string, string> = {
   fillet: "{child: nodeId, radius}",
   chamfer: "{child: nodeId, distance}",
 };
+
+/** Param keys that reference another node by id (CsgOp child refs). */
+const NODE_REF_PARAM_KEYS = ["child", "left", "right", "sketch"] as const;
+
+/** Coerce a single node reference: the Rust planner's serde parse wants
+ *  JSON numbers for CsgOp child refs, but part ids travel as strings
+ *  everywhere else on the MCP surface ("5" from a prior result's part_id).
+ *  Accept both by converting digit-strings to numbers. */
+function coerceNodeRef(v: unknown): unknown {
+  if (typeof v === "string" && /^\d+$/.test(v)) return Number(v);
+  return v;
+}
+
+/**
+ * Unify the two id dialects at the dispatch boundary so agents can pass
+ * either. Top-level `node_id`/`part_id` are strings on the planner side —
+ * accept numbers by stringifying. Child refs inside create/update `params`
+ * (child/left/right/sketch/sketches) are numeric NodeIds on the planner
+ * side — accept digit-strings by numbering. Returns a copy; never mutates.
+ */
+export function normalizeNodeRefs(
+  toolName: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const out = { ...args };
+  for (const key of ["node_id", "part_id"]) {
+    if (typeof out[key] === "number") out[key] = String(out[key]);
+  }
+  if (
+    (toolName === "create" || toolName === "update") &&
+    out.params &&
+    typeof out.params === "object" &&
+    !Array.isArray(out.params)
+  ) {
+    const params = { ...(out.params as Record<string, unknown>) };
+    for (const key of NODE_REF_PARAM_KEYS) {
+      if (key in params) params[key] = coerceNodeRef(params[key]);
+    }
+    if (Array.isArray(params.sketches)) {
+      params.sketches = params.sketches.map(coerceNodeRef);
+    }
+    out.params = params;
+  }
+  return out;
+}
 
 /** Fill defaultable fields into create/update params in place. */
 function applyParamDefaults(args: Record<string, unknown>): Record<string, unknown> {
@@ -378,10 +423,11 @@ export function dispatchRegistryTool(
 /** Execute a mutating registry tool against an open session document. */
 export function runMutation(
   toolName: string,
-  toolArgs: Record<string, unknown>,
+  rawArgs: Record<string, unknown>,
   doc: import("@vcad/ir").Document,
   documentId: string,
 ): { content: Array<{ type: "text"; text: string }> } {
+  const toolArgs = normalizeNodeRefs(toolName, rawArgs);
   // `delete` and `set_material` go directly to applyToolOutcome — the
   // Rust planner expects CRDT stable_ids, but the IR-direct MCP path
   // uses stringified NodeIds for part_id. The args are already


### PR DESCRIPTION
## Problem

The MCP raw-IR create path (`create` and `apply_edits`) left every intermediate node as a live document **root**. Building one boolean part from primitives — `create cylinder` → `create translate{child}` → `create difference{left,right}` — produced 3+ entries in `doc.roots`: the consumed cylinder and translate remained roots. Consequences:

- **`inspect_cad` double-counts volume** — observed a ~66k mm³ assembly reporting **307k mm³ across 68 "parts"**.
- **Renders show ghost solids** — the untranslated/unconsumed primitives sit at the origin.

The app-side command layer (`executors.ts` → `docStore.applyBoolean`) already has consumption semantics; the MCP raw-IR path did not. The two layers also disagreed on reference types: the MCP path required numeric `u64` node ids in params while the app command layer used string part ids.

## Fix

**1. Root consumption** — [`document-mutations.ts`](../blob/claude/relaxed-leavitt-e4a0c6/packages/core/src/commands/document-mutations.ts): `applyToolOutcome`'s `add_feature` now consumes any `doc.roots` entries whose root node is a direct child of the new op. The first consumed entry is reused in place (material / visibility / scene position survive; `part_materials` key migrated to the new id); extra consumed entries (a boolean's right operand) are removed. This covers both single `create` calls and `apply_edits`, since both go through `applyToolOutcome`. A cylinder→translate→cylinder→translate→difference chain now yields **exactly one part**.

**2. Id-dialect unification** — [`registry-dispatch.ts`](../blob/claude/relaxed-leavitt-e4a0c6/packages/mcp/src/tools/registry-dispatch.ts): new `normalizeNodeRefs` (applied in `runMutation`) accepts both dialects — digit-strings → numbers for create/update child refs (`child`/`left`/`right`/`sketch`/`sketches`, which the Rust planner's serde wants as `u64`), and numbers → strings for top-level `node_id`/`part_id`. Raw numeric ids keep working unchanged.

**3. Symbolic refs** — [`batch-edit.ts`](../blob/claude/relaxed-leavitt-e4a0c6/packages/mcp/src/tools/batch-edit.ts): `apply_edits` ops can reference earlier ops' created nodes as `"@N"` (op index N) anywhere a node is named — no more hand-predicting sequential ids. Forward refs and refs to non-creating ops fail the batch atomically with a clear message.

## Repro / regression tests

Added to [`batch-edit.test.ts`](../blob/claude/relaxed-leavitt-e4a0c6/packages/mcp/src/__tests__/batch-edit.test.ts):

- The issue repro: `open_document` → `apply_edits` with the 5-op cylinder/translate/cylinder/translate/difference batch (using `@N` refs) → `read` returns **exactly 1 part**, `inspect_cad` reports `parts: 1` and volume within 2% of the analytic difference volume π(10²−4²)·20 (tessellation tolerance).
- Numeric-id back-compat (result lands as part `"5"`).
- String part ids from prior `create` results on single `create` calls (and consumption there too).
- Material preservation through consumption.
- `@N` forward/dangling ref → atomic batch failure.

## Notes for reviewer

- Pure TypeScript change — no Rust/WASM edits, so no kernel-artifact concerns.
- The tool-surface fixture (`tool-surface.fixture.json`) was regenerated for the two updated `apply_edits` descriptions (only those two lines changed).
- Verification: MCP suite **700 passed** / 46 files, core **127 passed**, full workspace test run green.
- **Known pre-existing gap left alone:** `update` still only accepts `node_id` (the planner rejects `part_id`), though the `apply_edits` doc string implies both work. Can unify in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)