### PR TITLE
fix(ci): unwedge wasm-refresh — stale kernel WASM was shipping pre-#473 DFM

### DIFF
--- a/.github/workflows/wasm-refresh.yml
+++ b/.github/workflows/wasm-refresh.yml
@@ -77,6 +77,19 @@ jobs:
           git config user.name  "vcad-agent[bot]"
           git config user.email "vcad-agent@users.noreply.github.com"
           git commit -m "chore(wasm): refresh kernel artifacts for ${GITHUB_SHA:0:7}"
+          # The build can dirty tracked files this job doesn't own — most
+          # commonly Cargo.lock, when a PR pinned a sibling-repo version from
+          # a stale local checkout and cargo re-resolves against the fresh
+          # clones above. Single-writer policy: this job only ever commits the
+          # kernel-wasm artifacts, so surface the drift as a warning and
+          # discard it — a dirty tree here otherwise wedges `pull --rebase`
+          # and silently freezes the published artifacts (see #469→#473,
+          # where a phyz 0.3.1→0.3.0 lockfile regression did exactly that).
+          if ! git diff --quiet; then
+            echo "::warning::discarding non-artifact build dirt (stale sibling pin in a merged PR?):"
+            git --no-pager diff --stat
+            git checkout -- .
+          fi
           # Cheap insurance against a non-artifact merge racing us; a binary
           # conflict here means a policy violation upstream and should fail
           # loudly (re-run via workflow_dispatch after fixing).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tang",
 ]

--- a/crates/vcad-ecad-pcb/src/dfm.rs
+++ b/crates/vcad-ecad-pcb/src/dfm.rs
@@ -1955,8 +1955,7 @@ mod tests {
         );
         assert!(mc.locations.is_empty());
 
-        let report =
-            check_dfm(&board((TIE.0 - 5.0, TIE.1)), PcbFabProfile::Jlcpcb, None).unwrap();
+        let report = check_dfm(&board((TIE.0 - 5.0, TIE.1)), PcbFabProfile::Jlcpcb, None).unwrap();
         let mc = find(&report, "min_clearance");
         assert!(
             !mc.passed && mc.violations >= 4,

--- a/crates/vcad-ecad-pcb/src/dfm.rs
+++ b/crates/vcad-ecad-pcb/src/dfm.rs
@@ -1916,6 +1916,54 @@ mod tests {
         assert!(nets.contains(&"B".to_string()));
     }
 
+    /// Field repro: the stator-v3 9s/6p wye board (examples/pcb-motor). Its
+    /// star point is one region-scoped tie over {PHA,PHB,PHC,WIND_N} at
+    /// (46.691, 27.715) r=2.95, and dfm_check in the field flagged four
+    /// phase↔neutral contacts inside that region as min_clearance errors
+    /// while the tie-aware DRC was clean. Encode those exact contacts here:
+    /// covered by the tie they must pass; with the tie moved 5mm away every
+    /// junction is a genuine violation again.
+    #[test]
+    fn min_clearance_field_repro_stator_v3_star_point() {
+        const TIE: (f64, f64) = (46.691, 27.715);
+        const CONTACTS: [((f64, f64), &str); 4] = [
+            ((46.8485, 27.197), "PHA"),
+            ((46.503, 27.44325), "PHB"),
+            ((46.2035, 27.7515), "PHC"),
+            ((45.66225, 28.0885), "PHC"),
+        ];
+        let board = |tie_at: (f64, f64)| {
+            let mut pcb = base_pcb();
+            for ((x, y), phase) in CONTACTS {
+                // Phase and neutral stubs meeting at the reported contact.
+                pcb.traces.push(fcu_trace((x, y), (x, y + 0.5), phase));
+                pcb.traces.push(fcu_trace((x, y), (x, y - 0.5), "WIND_N"));
+            }
+            pcb.net_ties.push(NetTie {
+                nets: vec!["PHA".into(), "PHB".into(), "PHC".into(), "WIND_N".into()],
+                position: Some(Vec2::new(tie_at.0, tie_at.1)),
+                radius: Some(2.95),
+            });
+            pcb
+        };
+
+        let report = check_dfm(&board(TIE), PcbFabProfile::Jlcpcb, None).unwrap();
+        let mc = find(&report, "min_clearance");
+        assert!(
+            mc.passed && mc.violations == 0,
+            "contacts inside the tie region must be exempt: {mc:?}"
+        );
+        assert!(mc.locations.is_empty());
+
+        let report =
+            check_dfm(&board((TIE.0 - 5.0, TIE.1)), PcbFabProfile::Jlcpcb, None).unwrap();
+        let mc = find(&report, "min_clearance");
+        assert!(
+            !mc.passed && mc.violations >= 4,
+            "with the tie 5mm away every star contact must violate: {mc:?}"
+        );
+    }
+
     #[test]
     fn override_toml_relaxes_threshold() {
         let mut pcb = base_pcb();


### PR DESCRIPTION
## The field failure

After #473 merged, `dfm_check` still flagged four tie-covered star-point contacts on the stator-v3 wye board as `min_clearance` errors (all inside the region-scoped netTie `{PHA,PHB,PHC,WIND_N}` @ (46.691, 27.715) r 2.95), while the tie-aware `run_drc` was clean.

**The kernel fix from #473 is correct.** Running `check_dfm` against the exact field board (`examples/pcb-motor/stator-v3.vcad`, 4591 traces, 1 netTie) on current `main` source: `min_clearance passed=true, violations=0, measured=0.230mm`.

## The actual bug: the published WASM is frozen at pre-#469

`wasm-refresh` has failed on both kernel merges since #470:

1. #469 committed a `Cargo.lock` built against a stale local phyz sibling checkout, downgrading the phyz pin **0.3.1 → 0.3.0**.
2. `wasm-refresh` clones siblings at their current main (phyz = 0.3.1), so cargo silently re-updates the lockfile during the rebuild.
3. The workflow commits only the four artifacts, then dies at `git pull --rebase` — `error: cannot pull with rebase: You have unstaged changes.` (runs 28972057039 and the #469-triggered run before it).
4. Result: checked-in artifacts stuck at `5dead49f` (for #470) — every consumer runs a kernel **without #469's boolean seam work and without #473's DFM netTie exemption**. The field repro's output format (x/y + `'A'↔'B'` labels) matches the pre-#473 code exactly.

## Fixes

- **Cargo.lock**: revert the phyz pin to 0.3.1 — the exact inverse of #469's one-line regression; matches phyz `origin/main`, which is what CI builds against.
- **wasm-refresh.yml**: after committing the artifacts, surface non-artifact build dirt as a workflow warning and `git checkout -- .` before the rebase. Single-writer policy: this job only ever commits kernel-wasm artifacts, and incidental lockfile drift must not silently freeze the published kernel. Genuine artifact conflicts still fail loudly at the rebase/push.
- **dfm.rs regression test**: `min_clearance_field_repro_stator_v3_star_point` — the four field contact points inside the scoped tie pass; the same board with the tie moved 5mm away fails with ≥4 violations.

## After merge

This PR touches `Cargo.lock`, which matches wasm-refresh's paths filter — the refresh re-fires automatically and publishes artifacts containing both #469 and #473. The hosted MCP then needs its usual redeploy to pick up the fresh kernel.

Verification: `cargo test -p vcad-ecad-pcb dfm` (14 passed, incl. new test), `cargo clippy -p vcad-ecad-pcb --tests -- -D warnings` clean, plus the real-board repro harness described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)