### PR TITLE
fix(engine): FK results were silently dropped — Map result misread as plain object

### DIFF
--- a/changelog/entries/2026-07-08-fk-map-result.json
+++ b/changelog/entries/2026-07-08-fk-map-result.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-08-fk-map-result",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "Forward kinematics results no longer silently dropped",
+  "summary": "The engine wrapper misread the WASM FK solver's Map result as a plain object, so assembly instances were never posed by joints; joint state now applies correctly.",
+  "features": ["assembly", "joints", "kinematics"]
+}

--- a/packages/engine/src/__tests__/kinematics.test.ts
+++ b/packages/engine/src/__tests__/kinematics.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import type { Document } from "@vcad/ir";
+import { createDocument } from "@vcad/ir";
+import { getKernelWasm } from "../wasm-singleton.js";
+import {
+  solveForwardKinematics,
+  applyForwardKinematics,
+} from "../kinematics.js";
+
+beforeAll(async () => {
+  await getKernelWasm();
+});
+
+/**
+ * A minimal assembly: two cube instances, the first grounded, the second
+ * attached by a revolute joint at 90°. Regression doc for the wrapper bug
+ * where serde_wasm_bindgen's JS Map result was fed through
+ * Object.entries() and always came back empty.
+ */
+function twoInstanceRevoluteDoc(): Document {
+  const doc = createDocument();
+  doc.nodes["1"] = {
+    id: 1,
+    name: "link",
+    op: { type: "Cube", size: { x: 10, y: 10, z: 10 } },
+  };
+  doc.partDefs = { link: { id: "link", root: 1 } };
+  doc.instances = [
+    {
+      id: "base",
+      partDefId: "link",
+      transform: {
+        translation: { x: 0, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+    },
+    {
+      id: "arm",
+      partDefId: "link",
+      transform: {
+        translation: { x: 10, y: 0, z: 0 },
+        rotation: { x: 0, y: 0, z: 0 },
+        scale: { x: 1, y: 1, z: 1 },
+      },
+    },
+  ];
+  doc.joints = [
+    {
+      id: "j1",
+      parentInstanceId: "base",
+      childInstanceId: "arm",
+      parentAnchor: { x: 10, y: 0, z: 0 },
+      childAnchor: { x: 0, y: 0, z: 0 },
+      kind: { type: "Revolute", axis: { x: 0, y: 0, z: 1 } },
+      state: 90,
+    },
+  ];
+  doc.groundInstanceId = "base";
+  return doc;
+}
+
+describe("solveForwardKinematics", () => {
+  it("returns a non-empty Map for a 2-instance revolute assembly", () => {
+    const result = solveForwardKinematics(twoInstanceRevoluteDoc());
+    expect(result).toBeInstanceOf(Map);
+    expect(result.size).toBe(2);
+
+    const base = result.get("base");
+    const arm = result.get("arm");
+    expect(base).toBeDefined();
+    expect(arm).toBeDefined();
+    // Values are plain Transform3D objects, not WASM handles.
+    expect(base!.translation).toEqual({ x: 0, y: 0, z: 0 });
+    // The arm rotates 90° about Z around the joint anchor at (10,0,0).
+    expect(arm!.rotation.z).toBeCloseTo(90);
+  });
+
+  it("applyForwardKinematics poses instances in place", () => {
+    const doc = twoInstanceRevoluteDoc();
+    applyForwardKinematics(doc);
+    const arm = doc.instances!.find((i) => i.id === "arm")!;
+    expect(arm.transform!.rotation.z).toBeCloseTo(90);
+  });
+});

--- a/packages/engine/src/kinematics.ts
+++ b/packages/engine/src/kinematics.ts
@@ -2,50 +2,40 @@
  * Forward kinematics solver — backed by Rust WASM.
  *
  * Thin wrapper around the Rust `solve_forward_kinematics` exposed via WASM.
- * The WASM binding returns a Map<string, Transform3D>.
+ * `serde_wasm_bindgen` serializes the Rust HashMap as a JS Map (not a plain
+ * object), so the result is normalized here for both shapes.
  */
 
 import type { Document, Transform3D } from "@vcad/ir";
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let wasmModule: any = null;
-
-async function loadWasm(): Promise<typeof wasmModule | null> {
-  if (wasmModule) return wasmModule;
-  try {
-    wasmModule = await import("@vcad/kernel-wasm");
-    return wasmModule;
-  } catch {
-    return null;
-  }
-}
-
-// Eagerly start loading
-loadWasm();
+import { getKernelWasmSync } from "./wasm-singleton.js";
 
 /**
  * Solve forward kinematics for an assembly document.
  *
  * Returns a Map from instance ID to world Transform3D.
- * Uses the Rust WASM implementation. If WASM is not yet loaded, returns
- * an empty map (callers should ensure WASM is loaded before physics runs).
+ * Uses the Rust WASM implementation via the shared singleton. If the
+ * singleton hasn't finished initializing (`getKernelWasm()` not yet
+ * awaited anywhere), returns an empty map — callers must ensure WASM is
+ * initialized before relying on FK results.
  */
 export function solveForwardKinematics(
   doc: Document,
 ): Map<string, Transform3D> {
-  if (wasmModule?.solveForwardKinematics) {
-    try {
-      const result = wasmModule.solveForwardKinematics(
-        JSON.stringify(doc),
-      ) as Record<string, Transform3D>;
-      // Convert plain object to Map
-      return new Map(Object.entries(result));
-    } catch (e) {
-      console.warn("[ENGINE] WASM solveForwardKinematics failed:", e);
-      return new Map();
+  const wasm = getKernelWasmSync();
+  if (!wasm?.solveForwardKinematics) return new Map();
+  try {
+    const result: unknown = wasm.solveForwardKinematics(JSON.stringify(doc));
+    // serde_wasm_bindgen returns a JS Map; older glue returned a plain object.
+    if (result instanceof Map) {
+      return result as Map<string, Transform3D>;
     }
+    return new Map(
+      Object.entries(result as Record<string, Transform3D>),
+    );
+  } catch (e) {
+    console.warn("[ENGINE] WASM solveForwardKinematics failed:", e);
+    return new Map();
   }
-  return new Map();
 }
 
 /**


### PR DESCRIPTION
## What

`solveForwardKinematics` in `packages/engine/src/kinematics.ts` converted the WASM result with `new Map(Object.entries(result))` — but the wasm-bindgen glue (`serde_wasm_bindgen::to_value` on a Rust `HashMap`) returns a JS **Map**, and `Object.entries` on a Map is `[]`. So the engine wrapper always returned an empty Map even when FK succeeded, silently breaking `applyForwardKinematics` and TS-fallback instance posing. Verified empirically: the raw glue call returns a populated `Map<instance_id, Transform3D>`.

## Changes

- Return the result directly when `result instanceof Map` (values are already plain `Transform3D` objects); keep the `Object.entries` path for plain-object shapes from older glue builds.
- Route through the wasm-singleton (`getKernelWasmSync`) instead of a raw `import("@vcad/kernel-wasm")`, which the singleton's doc comment forbids — pre-init calls now return an empty Map cleanly instead of throwing `__wbindgen_malloc` errors into a swallowed catch.
- Regression test (`kinematics.test.ts`): FK on a 2-instance, 1-revolute-joint (90°) doc returns a populated Map with correct transforms, and `applyForwardKinematics` poses the child instance in place.
- Changelog entry (user-facing fix: joint state never applied to assembly instances via this path).

## Testing

- `npm run build` in `packages/engine` (tsc clean)
- Full engine suite: 98 passed, 2 pre-existing skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)