### PR TITLE
fix(mcp): artifact URLs actually resolve — route /artifacts + durable store

### DIFF
--- a/changelog/entries/2026-07-08-artifact-store-durable.json
+++ b/changelog/entries/2026-07-08-artifact-store-durable.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-artifact-store-durable",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "Artifact URLs actually resolve: /artifacts routed + durable store",
+  "summary": "export_gerber/export_cad artifact handles now work: the /artifacts route is wired into the serverless deployment (it was missing, so every download 403'd at the platform), and artifacts persist to a durable mcp_artifacts table so a handle minted on one instance resolves on any other — quote_manufacturing no longer rejects a fab_artifact_id minted minutes earlier as \"Unknown or expired\".",
+  "features": ["mcp", "fabricate", "artifacts"],
+  "mcpTools": ["export_gerber", "export_cad", "get_document", "quote_manufacturing", "place_order"]
+}

--- a/packages/mcp/src/__tests__/artifact-store.test.ts
+++ b/packages/mcp/src/__tests__/artifact-store.test.ts
@@ -200,3 +200,176 @@ describe("import_step large-result offload", () => {
     expect(out.summary.bodies).toBe(1);
   });
 });
+
+// ── Durable backend (mcp_artifacts) ─────────────────────────────────────────
+//
+// Fakes the PostgREST surface via the injectable sessionFetch seam (the same
+// hook the session-store tests use) and simulates a serverless COLD START by
+// clearing the warm registry between the write and the read — the exact
+// failure that shipped: a handle minted on one instance was unreadable on
+// every other ("Unknown or expired" / a 404 artifact_url).
+
+import {
+  getArtifactAsync,
+  getArtifactFileAsync,
+  resolveArtifactRefAsync,
+  flushArtifacts,
+  artifactStoreInfo,
+} from "../tools/artifact-store.js";
+import { setSessionFetch } from "../session-store.js";
+
+interface FakeRow {
+  artifact_id: string;
+  bytes: number;
+  manifest: unknown;
+  files: unknown;
+  expires_at: string;
+}
+
+function fakeSupabase(rows: Map<string, FakeRow>): {
+  fetch: typeof fetch;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const reply = (status: number, body: unknown = {}) =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+    }) as unknown as Response;
+
+  const fetchImpl = (async (input: unknown, init?: RequestInit) => {
+    const url = new URL(String(input));
+    const method = init?.method ?? "GET";
+    calls.push(`${method} ${url.pathname}${url.search}`);
+    if (!url.pathname.endsWith("/rest/v1/mcp_artifacts")) return reply(404);
+    const idFilter = url.searchParams.get("artifact_id"); // "eq.<id>"
+    const id = idFilter?.startsWith("eq.") ? idFilter.slice(3) : null;
+    if (method === "POST") {
+      const body = JSON.parse(String(init?.body ?? "[]")) as FakeRow[];
+      for (const row of body) rows.set(row.artifact_id, row);
+      return reply(201);
+    }
+    if (method === "GET") {
+      const row = id ? rows.get(id) : undefined;
+      return row ? reply(200, row) : reply(406, {});
+    }
+    if (method === "DELETE") {
+      if (id) rows.delete(id);
+      return reply(204);
+    }
+    return reply(405);
+  }) as typeof fetch;
+
+  return { fetch: fetchImpl, calls };
+}
+
+describe("durable artifact store (mcp_artifacts)", () => {
+  const rows = new Map<string, FakeRow>();
+  let calls: string[] = [];
+
+  beforeEach(() => {
+    rows.clear();
+    process.env.SUPABASE_URL = "https://fake.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-test-key";
+    const fake = fakeSupabase(rows);
+    calls = fake.calls;
+    setSessionFetch(fake.fetch);
+  });
+
+  afterEach(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    setSessionFetch((...args) => fetch(...args));
+  });
+
+  it("reports durability from the shared Supabase env", () => {
+    expect(artifactStoreInfo()).toEqual({ artifact_store: "supabase" });
+    delete process.env.SUPABASE_URL;
+    expect(artifactStoreInfo()).toEqual({ artifact_store: "in-memory" });
+  });
+
+  it("persists on store and hydrates on a cold instance (the shipped bug)", async () => {
+    const handle = storeArtifact([
+      { name: "F_Cu.gbr", content: "G04 fcu*" },
+      { name: "drill.drl", content: "M48" },
+    ]);
+    await flushArtifacts();
+    expect(rows.has(handle.artifact_id)).toBe(true);
+
+    // Cold start: the warm registry is gone; only the durable row survives.
+    clearArtifacts();
+    expect(getArtifact(handle.artifact_id)).toBeNull(); // sync path misses
+
+    const a = await getArtifactAsync(handle.artifact_id);
+    expect(a).not.toBeNull();
+    expect(a!.manifest).toEqual(handle.manifest);
+    const f = await getArtifactFileAsync(handle.artifact_id, "F_Cu.gbr");
+    expect(f!.buf.toString("utf8")).toBe("G04 fcu*");
+    expect(f!.contentType).toBe("application/vnd.gerber");
+
+    // The hydrate warmed the cache — the next read is sync, no extra fetch.
+    const fetches = calls.length;
+    expect(getArtifact(handle.artifact_id)).not.toBeNull();
+    expect(calls.length).toBe(fetches);
+  });
+
+  it("binds a cross-instance handle for quote/order (resolveArtifactRefAsync)", async () => {
+    const handle = storeArtifact([{ name: "board.zip", content: "PK" }]);
+    await flushArtifacts();
+    clearArtifacts();
+
+    const ref = await resolveArtifactRefAsync(handle.artifact_url);
+    expect(ref).not.toBeNull();
+    expect(ref!.artifact_id).toBe(handle.artifact_id);
+    expect(ref!.manifest).toEqual(handle.manifest);
+    expect(await resolveArtifactRefAsync("art_nope")).toBeNull();
+  });
+
+  it("serves a cold-instance read over the /artifacts route", async () => {
+    const handle = storeArtifact([{ name: "Edge_Cuts.gbr", content: "G04 edge*" }]);
+    await flushArtifacts();
+    clearArtifacts();
+
+    const idx = res();
+    expect(
+      await handleArtifactRequest(makeReq("GET", `/artifacts/${handle.artifact_id}`), idx),
+    ).toBe(true);
+    expect(idx.statusCode).toBe(200);
+    expect(JSON.parse(idx.body).files).toHaveLength(1);
+
+    const file = res();
+    expect(
+      await handleArtifactRequest(
+        makeReq("GET", `/artifacts/${handle.artifact_id}/Edge_Cuts.gbr`),
+        file,
+      ),
+    ).toBe(true);
+    expect(file.statusCode).toBe(200);
+    expect(file.bodyBuf?.toString("utf8")).toBe("G04 edge*");
+  });
+
+  it("treats an expired durable row as absent and deletes it", async () => {
+    const handle = storeArtifact([{ name: "x.gbr", content: "hi" }]);
+    await flushArtifacts();
+    clearArtifacts();
+    const row = rows.get(handle.artifact_id)!;
+    row.expires_at = new Date(Date.now() - 1000).toISOString();
+
+    expect(await getArtifactAsync(handle.artifact_id)).toBeNull();
+    // Lazy sweep: the expired row was deleted (fire-and-forget).
+    await new Promise((r) => setTimeout(r, 0));
+    expect(rows.has(handle.artifact_id)).toBe(false);
+  });
+
+  it("degrades to warm-cache-only when the durable write fails", async () => {
+    setSessionFetch((async () =>
+      ({ ok: false, status: 500, json: async () => ({}), text: async () => "boom" })
+    ) as unknown as typeof fetch);
+    const handle = storeArtifact([{ name: "y.gbr", content: "yo" }]);
+    await flushArtifacts();
+    // Same-instance read still works off the warm cache.
+    expect((await getArtifactAsync(handle.artifact_id))?.id).toBe(handle.artifact_id);
+  });
+});

--- a/packages/mcp/src/artifact-route.ts
+++ b/packages/mcp/src/artifact-route.ts
@@ -15,7 +15,11 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { getArtifact, getArtifactFile, artifactFileUrl } from "./tools/artifact-store.js";
+import {
+  getArtifactAsync,
+  getArtifactFileAsync,
+  artifactFileUrl,
+} from "./tools/artifact-store.js";
 
 const text = (res: ServerResponse, status: number, body: string): void => {
   res.writeHead(status, { "Content-Type": "text/plain" });
@@ -55,7 +59,7 @@ export async function handleArtifactRequest(
     return true;
   }
 
-  const artifact = getArtifact(id);
+  const artifact = await getArtifactAsync(id);
   if (!artifact) {
     text(res, 404, "Not Found");
     return true;
@@ -78,7 +82,7 @@ export async function handleArtifactRequest(
     return true;
   }
 
-  const file = getArtifactFile(id, fileName);
+  const file = await getArtifactFileAsync(id, fileName);
   if (!file) {
     text(res, 404, "Not Found");
     return true;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -71,6 +71,7 @@ import { getStaleness } from "./edge-config.js";
 // server (http.ts).
 export { handleLiveRequest } from "./live-route.js";
 export { handleArtifactRequest } from "./artifact-route.js";
+export { flushArtifacts, artifactStoreInfo } from "./tools/artifact-store.js";
 import {
   getViewerHtml,
   VIEWER_RESOURCE_URI,
@@ -82,6 +83,7 @@ import {
 } from "./viewer.js";
 import { fireToolAlert } from "./notify.js";
 import { configureTelemetry, flushTelemetry } from "./telemetry.js";
+import { artifactStoreInfo as artifactStoreInfoLocal } from "./tools/artifact-store.js";
 
 // ── ToolDef registry: one record per tool, contributed by its module ────────
 import {
@@ -795,6 +797,7 @@ export async function createServer(
             text: JSON.stringify({
               ...buildInfo,
               ...sessionStoreInfo(),
+              ...artifactStoreInfoLocal(),
               ...staleness,
               kernel_wasm: kernelWasmLoaded ? "ok" : "unavailable",
               ...(kernelWasmMissing.length > 0

--- a/packages/mcp/src/tools/artifact-store.ts
+++ b/packages/mcp/src/tools/artifact-store.ts
@@ -12,15 +12,24 @@
  * context. quote_manufacturing / place_order accept the same handle, so an
  * order references the bundle without ever re-sending the files.
  *
- * Backing: an in-process, bounded, TTL'd registry served over /artifacts/<id>.
- * It is durable across WARM invocations (the common single-agent case) and on
- * the standalone Fly/local server. It is NOT durable across COLD serverless
- * instances — the same isolation that affects warm session caches (see
- * session.ts). A Supabase Storage backend is the natural follow-up and slots in
- * behind storeArtifact() without changing the handle shape callers see.
+ * Backing: an in-process, bounded, TTL'd registry (a warm-instance CACHE)
+ * in front of a durable Supabase table (`mcp_artifacts`, migration 033) —
+ * the same hydrate-on-miss / persist-after-write model as session-store.ts,
+ * and gated by the same env (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY).
+ * Without that env (stdio/local) the in-memory registry alone reproduces the
+ * old behavior. WHY: the hosted MCP runs as a serverless function, so a
+ * handle minted on one instance was unreadable on every other — the
+ * /artifacts URL 404'd from a cold instance and quote_manufacturing rejected
+ * a fab_artifact_id minted minutes earlier by export_gerber ("Unknown or
+ * expired"). Writes stay SYNC for callers: storeArtifact caches, kicks off a
+ * best-effort durable persist, and the entrypoint awaits flushArtifacts()
+ * before the instance can freeze (the flushTelemetry idiom). Reads that must
+ * work cross-instance go through the async getters, which fall back to the
+ * durable row on a warm-cache miss.
  */
 
 import { createHash, randomBytes } from "node:crypto";
+import { sessionFetch } from "../session-store.js";
 
 /** One file handed to the store (Gerber text, an STL/GLB binary, an IR doc). */
 export interface ArtifactInputFile {
@@ -176,7 +185,9 @@ function newArtifactId(): string {
   return `art_${randomBytes(12).toString("base64url")}`;
 }
 
-/** Store a bundle and return its handle (id, url, manifest). */
+/** Store a bundle and return its handle (id, url, manifest). Sync for
+ *  callers; the durable persist runs in the background and is drained by
+ *  flushArtifacts() before a serverless instance can freeze. */
 export function storeArtifact(files: ArtifactInputFile[]): ArtifactHandle {
   const now = Date.now();
   evict(now);
@@ -193,7 +204,16 @@ export function storeArtifact(files: ArtifactInputFile[]): ArtifactHandle {
   }));
   const bytes = stored.reduce((n, f) => n + f.buf.length, 0);
   const expiresAt = now + ttlMs();
-  registry.set(id, { id, files: stored, manifest, bytes, createdAt: now, expiresAt });
+  const artifact: StoredArtifact = {
+    id,
+    files: stored,
+    manifest,
+    bytes,
+    createdAt: now,
+    expiresAt,
+  };
+  registry.set(id, artifact);
+  trackPersist(persistArtifact(artifact));
   return {
     artifact_id: id,
     artifact_url: artifactUrl(id),
@@ -203,7 +223,9 @@ export function storeArtifact(files: ArtifactInputFile[]): ArtifactHandle {
   };
 }
 
-/** Read a stored artifact by id (expired → treated as absent). */
+/** Read a stored artifact by id from the WARM CACHE only (expired → absent).
+ *  Cross-instance callers want getArtifactAsync, which falls back to the
+ *  durable row on a miss. */
 export function getArtifact(id: string): StoredArtifact | null {
   const a = registry.get(id);
   if (!a) return null;
@@ -214,9 +236,205 @@ export function getArtifact(id: string): StoredArtifact | null {
   return a;
 }
 
-/** Read one file from a stored artifact. */
+/** Read one file from a stored artifact (warm cache only — see getArtifact). */
 export function getArtifactFile(id: string, name: string): StoredFile | null {
   const a = getArtifact(id);
+  if (!a) return null;
+  return a.files.find((f) => f.name === name) ?? null;
+}
+
+// ─── Durable backend (mcp_artifacts, migration 033) ──────────────────────────
+//
+// Same raw-PostgREST/service-role pattern (and the same injectable
+// `sessionFetch` seam) as session-store.ts. Capability-keyed by the
+// unguessable artifact id alone — RLS is on with no anon/authenticated
+// policies, so only the server ever reads or writes rows. Best-effort
+// throughout: a durable outage degrades to warm-cache-only (the old
+// behavior), never a tool failure.
+
+interface ArtifactRow {
+  artifact_id: string;
+  bytes: number;
+  manifest: ManifestEntry[];
+  /** Files with base64 content — jsonb can't hold raw bytes. */
+  files: Array<{ name: string; content_type: string; b64: string }>;
+  created_at?: string;
+  expires_at: string;
+}
+
+function durableEnv(): { url: string; key: string } | null {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return url && key ? { url, key } : null;
+}
+
+/** True when artifact handles survive across serverless instances. Same env
+ *  gate as isSessionStoreDurable — the two stores share the backend. */
+export function isArtifactStoreDurable(): boolean {
+  return durableEnv() !== null;
+}
+
+/** Durability state for server_info / the /health endpoint. */
+export function artifactStoreInfo(): {
+  artifact_store: "supabase" | "in-memory";
+} {
+  return { artifact_store: isArtifactStoreDurable() ? "supabase" : "in-memory" };
+}
+
+function durableHeaders(key: string, extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    apikey: key,
+    Authorization: `Bearer ${key}`,
+    "Content-Type": "application/json",
+    ...extra,
+  };
+}
+
+/** In-flight durable persists, drained by flushArtifacts() — the
+ *  flushTelemetry idiom: a serverless instance freezes the moment the
+ *  response is written, killing any un-awaited fetch. */
+const pendingPersists = new Set<Promise<void>>();
+
+function trackPersist(p: Promise<void>): void {
+  pendingPersists.add(p);
+  void p.finally(() => pendingPersists.delete(p));
+}
+
+/** Await outstanding durable writes (bounded). The HTTP entrypoints call this
+ *  before returning, alongside flushTelemetry. */
+export async function flushArtifacts(timeoutMs = 5000): Promise<void> {
+  if (pendingPersists.size === 0) return;
+  const timeout = new Promise<void>((resolve) => {
+    const t = setTimeout(resolve, timeoutMs);
+    // Don't hold the event loop open just for the flush timer.
+    if (typeof t === "object" && "unref" in t) t.unref();
+  });
+  await Promise.race([Promise.allSettled([...pendingPersists]), timeout]);
+}
+
+/** Write-through to the durable table. Best-effort: logs, never throws. */
+async function persistArtifact(a: StoredArtifact): Promise<void> {
+  const env = durableEnv();
+  if (!env) return;
+  try {
+    const row: ArtifactRow = {
+      artifact_id: a.id,
+      bytes: a.bytes,
+      manifest: a.manifest,
+      files: a.files.map((f) => ({
+        name: f.name,
+        content_type: f.contentType,
+        b64: f.buf.toString("base64"),
+      })),
+      expires_at: new Date(a.expiresAt).toISOString(),
+    };
+    const res = await sessionFetch(
+      `${env.url}/rest/v1/mcp_artifacts?on_conflict=artifact_id`,
+      {
+        method: "POST",
+        headers: durableHeaders(env.key, {
+          Prefer: "resolution=merge-duplicates,return=minimal",
+        }),
+        body: JSON.stringify([row]),
+      },
+    );
+    if (!res.ok) {
+      console.error(
+        "[artifact-store] persist failed:",
+        res.status,
+        await res.text().catch(() => ""),
+      );
+    }
+  } catch (err) {
+    console.error("[artifact-store] persist failed:", err);
+  }
+}
+
+/** Best-effort delete of an expired durable row. */
+async function dropDurable(id: string): Promise<void> {
+  const env = durableEnv();
+  if (!env) return;
+  try {
+    await sessionFetch(
+      `${env.url}/rest/v1/mcp_artifacts?artifact_id=eq.${encodeURIComponent(id)}`,
+      { method: "DELETE", headers: durableHeaders(env.key) },
+    );
+  } catch (err) {
+    console.error("[artifact-store] expired-row delete failed:", err);
+  }
+}
+
+/** Fetch a durable row and rehydrate it into the warm cache. Null on miss,
+ *  expiry (the row is then deleted), malformed content, or any error. */
+async function loadDurable(id: string): Promise<StoredArtifact | null> {
+  const env = durableEnv();
+  if (!env) return null;
+  try {
+    const res = await sessionFetch(
+      `${env.url}/rest/v1/mcp_artifacts` +
+        `?artifact_id=eq.${encodeURIComponent(id)}` +
+        `&select=artifact_id,bytes,manifest,files,created_at,expires_at&limit=1`,
+      {
+        method: "GET",
+        headers: durableHeaders(env.key, {
+          Accept: "application/vnd.pgrst.object+json",
+        }),
+      },
+    );
+    if (!res.ok) return null; // 406 = zero rows → miss
+    const row = (await res.json()) as ArtifactRow;
+    if (!row || row.artifact_id !== id || !Array.isArray(row.files)) return null;
+    const expiresAt = Date.parse(row.expires_at);
+    if (!Number.isFinite(expiresAt)) return null;
+    if (expiresAt <= Date.now()) {
+      void dropDurable(id);
+      return null;
+    }
+    const files: StoredFile[] = row.files.map((f) => ({
+      name: String(f.name),
+      buf: Buffer.from(String(f.b64 ?? ""), "base64"),
+      contentType: String(f.content_type || guessContentType(String(f.name))),
+    }));
+    const artifact: StoredArtifact = {
+      id,
+      files,
+      manifest: Array.isArray(row.manifest)
+        ? row.manifest
+        : files.map((f) => ({
+            file: f.name,
+            bytes: f.buf.length,
+            sha256: createHash("sha256").update(f.buf).digest("hex"),
+          })),
+      bytes:
+        typeof row.bytes === "number"
+          ? row.bytes
+          : files.reduce((n, f) => n + f.buf.length, 0),
+      createdAt: row.created_at ? Date.parse(row.created_at) : Date.now(),
+      expiresAt,
+    };
+    // Rehydrate the warm cache so subsequent same-instance reads are sync.
+    evict(Date.now());
+    registry.set(id, artifact);
+    return artifact;
+  } catch (err) {
+    console.error("[artifact-store] load failed:", err);
+    return null;
+  }
+}
+
+/** Read an artifact by id: warm cache first, then the durable row. The
+ *  cross-instance read path — the /artifacts route and the order tools use
+ *  this, so a handle minted on another instance still resolves. */
+export async function getArtifactAsync(id: string): Promise<StoredArtifact | null> {
+  return getArtifact(id) ?? (await loadDurable(id));
+}
+
+/** Read one file from an artifact (warm cache, then durable). */
+export async function getArtifactFileAsync(
+  id: string,
+  name: string,
+): Promise<StoredFile | null> {
+  const a = await getArtifactAsync(id);
   if (!a) return null;
   return a.files.find((f) => f.name === name) ?? null;
 }
@@ -232,6 +450,14 @@ export function resolveArtifact(handle: string): StoredArtifact | null {
   return id ? getArtifact(id) : null;
 }
 
+/** resolveArtifact with the durable fallback — the cross-instance path. */
+export async function resolveArtifactAsync(
+  handle: string,
+): Promise<StoredArtifact | null> {
+  const id = parseArtifactId(handle);
+  return id ? getArtifactAsync(id) : null;
+}
+
 /** A persistable reference to a stored bundle — metadata only, never bytes. */
 export interface ArtifactRef {
   artifact_id: string;
@@ -244,6 +470,22 @@ export interface ArtifactRef {
  *  (the fab bytes stay in the store; only id/url/manifest travel). */
 export function resolveArtifactRef(handle: string): ArtifactRef | null {
   const a = resolveArtifact(handle);
+  if (!a) return null;
+  return {
+    artifact_id: a.id,
+    artifact_url: artifactUrl(a.id),
+    bytes: a.bytes,
+    manifest: a.manifest,
+  };
+}
+
+/** resolveArtifactRef with the durable fallback — quote_manufacturing /
+ *  place_order use this so a handle minted by export_gerber on ANOTHER
+ *  instance still binds to the order. */
+export async function resolveArtifactRefAsync(
+  handle: string,
+): Promise<ArtifactRef | null> {
+  const a = await resolveArtifactAsync(handle);
   if (!a) return null;
   return {
     artifact_id: a.id,

--- a/packages/mcp/src/tools/order.ts
+++ b/packages/mcp/src/tools/order.ts
@@ -23,7 +23,7 @@ import { toDfmProcess, catalogMaterial } from "../fabricate/process-map.js";
 import { ownerId, type FabricateStore } from "../fabricate/store.js";
 import { buildFabHandoff } from "../fabricate/handoff.js";
 import { captureEvent } from "../telemetry.js";
-import { resolveArtifactRef } from "./artifact-store.js";
+import { resolveArtifactRefAsync } from "./artifact-store.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import {
   PROCESSES,
@@ -129,7 +129,7 @@ export async function quoteManufacturing(
   const fabHandle = typeof args.fab_artifact_id === "string" ? args.fab_artifact_id : "";
   let fabArtifact: FabArtifactRef | null = null;
   if (fabHandle) {
-    const ref = resolveArtifactRef(fabHandle);
+    const ref = await resolveArtifactRefAsync(fabHandle);
     if (!ref) {
       return err(
         `Unknown or expired fab artifact "${fabHandle}". Re-run export_gerber / export_cad and pass the artifact_id it returns.`,

--- a/packages/mcp/src/tools/ordering.ts
+++ b/packages/mcp/src/tools/ordering.ts
@@ -20,7 +20,7 @@
 import { randomUUID } from "node:crypto";
 import type { AuthUser } from "../oauth.js";
 import { ownerId, type FabricateStore } from "../fabricate/store.js";
-import { resolveArtifactRef } from "./artifact-store.js";
+import { resolveArtifactRefAsync } from "./artifact-store.js";
 import type { SessionEventStore } from "../session-store.js";
 import type { FabArtifactRef, SpendAuthorization } from "../fabricate/types.js";
 import { behavior, type ToolDef } from "./tool-def.js";
@@ -219,7 +219,7 @@ export async function placeOrder(
   const fabHandle = typeof args.fab_artifact_id === "string" ? args.fab_artifact_id : "";
   let fabArtifact: FabArtifactRef | null = order.fab_artifact ?? null;
   if (fabHandle) {
-    const ref = resolveArtifactRef(fabHandle);
+    const ref = await resolveArtifactRefAsync(fabHandle);
     if (!ref) {
       return err(
         `Unknown or expired fab artifact "${fabHandle}". Re-run export_gerber / export_cad and pass the artifact_id it returns.`,

--- a/services/mcp/build.sh
+++ b/services/mcp/build.sh
@@ -130,6 +130,11 @@ cat > "$OUT/config.json" << 'EOF'
       "dest": "/mcp"
     },
     {
+      "src": "/artifacts/(.*)",
+      "methods": ["GET", "HEAD", "OPTIONS"],
+      "dest": "/mcp"
+    },
+    {
       "src": "/live/(.*)",
       "methods": ["GET", "POST", "OPTIONS"],
       "dest": "/mcp"

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -19,6 +19,8 @@ import {
   flushTelemetry,
   handleLiveRequest,
   handleArtifactRequest,
+  flushArtifacts,
+  artifactStoreInfo,
 } from "@vcad/mcp/server";
 import {
   getOAuthConfig,
@@ -131,6 +133,7 @@ export default async function handler(
         // prod deploy → open sessions are in-memory only and a redeploy drops
         // them. Verifiable with `curl https://mcp.vcad.io/health`.
         ...sessionStoreInfo(),
+        ...artifactStoreInfo(),
         engine: !!engine,
         timestamp: new Date().toISOString(),
       });
@@ -192,9 +195,11 @@ export default async function handler(
     try {
       await transport.handleRequest(req, res);
     } finally {
-      // Drain PostHog captures before the serverless instance can freeze —
-      // an in-flight fetch is killed the instant the function returns.
-      await flushTelemetry();
+      // Drain PostHog captures AND pending durable artifact writes before
+      // the serverless instance can freeze — an in-flight fetch is killed
+      // the instant the function returns, and an unflushed artifact would
+      // reintroduce the 404-from-another-instance bug.
+      await Promise.all([flushTelemetry(), flushArtifacts()]);
       await transport.close();
       await server.close();
     }

--- a/supabase/migrations/033_mcp_artifacts.sql
+++ b/supabase/migrations/033_mcp_artifacts.sql
@@ -1,0 +1,58 @@
+-- Durable MCP artifact store (capability-keyed) — the backing for the
+-- /artifacts/* channel that keeps large export/fab bundles out of model
+-- context.
+--
+-- WHY: artifacts lived only in a per-instance in-memory registry
+-- (packages/mcp/src/tools/artifact-store.ts), so on the serverless deploy a
+-- handle minted by export_gerber on one instance was unreadable everywhere
+-- else — the artifact_url 404'd from any other instance and
+-- quote_manufacturing rejected a fab_artifact_id minted minutes earlier
+-- ("Unknown or expired"). Same failure class - and same fix - as anonymous
+-- sessions (migration 025): a service-role-only table keyed by the
+-- unguessable id; possession of the id IS the capability.
+
+create table if not exists mcp_artifacts (
+  -- The artifact id ("art_<random>", 96-bit suffix). Possession = access.
+  artifact_id text primary key,
+  -- Total bundle size across all files (pre-base64 bytes).
+  bytes bigint not null,
+  -- [{file, bytes, sha256}] — the verification manifest the tool returned.
+  manifest jsonb not null,
+  -- [{name, content_type, b64}] — file contents, base64-encoded (jsonb can't
+  -- hold raw bytes). Bundles are bounded by the tools that produce them
+  -- (Gerber sets / meshes, ~100 KB–10 MB), well inside row limits.
+  files jsonb not null,
+  created_at timestamptz not null default now(),
+  -- TTL, mirrored from the in-memory registry (MCP_ARTIFACT_TTL_MS, 24 h
+  -- default). Reads treat an expired row as absent and delete it.
+  expires_at timestamptz not null
+);
+
+create index if not exists mcp_artifacts_expires_idx on mcp_artifacts (expires_at);
+
+-- RLS on + no policies = deny all to anon/authenticated; service_role
+-- bypasses RLS, so only the MCP server ever reads or writes rows — clients
+-- cannot enumerate or read artifacts except through the /artifacts route,
+-- which requires the unguessable id.
+alter table mcp_artifacts enable row level security;
+
+grant all on mcp_artifacts to service_role;
+
+-- Artifacts are transient by design — sweep expired rows. Reads already
+-- delete-on-expiry lazily; this catches never-read rows. Callable manually
+-- or from a scheduled job (same follow-up wiring as
+-- cleanup_stale_mcp_sessions, migration 025).
+create or replace function cleanup_expired_mcp_artifacts()
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  swept integer;
+begin
+  delete from mcp_artifacts where expires_at < now();
+  get diagnostics swept = row_count;
+  return swept;
+end;
+$$;


### PR DESCRIPTION
## What

Every artifact handle on the hosted deploy was a dead end, from two stacked bugs:

1. **The `/artifacts` route was never wired into the deployment.** The Build Output API routing table in `services/mcp/build.sh` has explicit routes for `/mcp`, `/health`, `/live/*`, `/oauth/*` — but not `/artifacts/(.*)`. The path never reached the function; Vercel's platform answered **403**. `handleArtifactRequest` was dead code in prod. Added the route (GET/HEAD/OPTIONS → the mcp function).

2. **The store was a per-instance in-memory `Map`** (documented as such in the file header, with this exact fix named as the follow-up). Even with the route, a handle minted by `export_gerber` on one serverless instance was unreadable everywhere else: `quote_manufacturing` rejected a `fab_artifact_id` minted **2 minutes earlier** on the same deployment ("Unknown or expired"), and cold instances 404'd downloads.

The store now mirrors `session-store.ts` exactly: the in-memory registry becomes a warm-instance **cache** in front of a durable, service-role-only **`mcp_artifacts`** table (migration 033), gated by the same `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY` env and using the same injectable `sessionFetch` test seam.

- **Writes stay sync for callers**: `storeArtifact` caches, kicks off a best-effort persist, and `entry.ts` awaits `flushArtifacts()` alongside `flushTelemetry()` so the write survives the instance freeze.
- **Cross-instance reads go async with hydrate-on-miss**: the `/artifacts` route and `quote_manufacturing`/`place_order` use `getArtifactAsync` / `resolveArtifactRefAsync`. Expired durable rows read as absent and are lazily deleted; `cleanup_expired_mcp_artifacts()` sweeps never-read rows (same cron follow-up as migration 025's session sweep).
- **Observable**: `server_info` and `/health` now report `artifact_store: supabase|in-memory` next to `session_store`.
- **Degrades safely**: a durable outage falls back to warm-cache-only (today's behavior) — never a tool failure.

## Field repro

TMP-1 motor-board session on prod `f6d9258`: `export_gerber` returned `art_LWz9vu0YPGcqL5HA` with a 24 h expiry; the URL 403'd from two independent networks, and `quote_manufacturing` couldn't bind the freshly re-minted `art_FeCf9KhrUVklPMAQ` two minutes after creation. The session had to fall back to `export_kicad`'s inline path to deliver fab files at all.

## Tests

- 6 new durable-store cases in `artifact-store.test.ts`: cold-start hydrate (registry cleared between write and read — the shipped failure), route serving from the durable row, cross-instance quote binding, warm-cache rehydration (no double fetch), expiry-as-absent + lazy delete, and degraded-write fallback.
- Full `@vcad/mcp` suite: **721 passed / 47 files**.
- Routing heredoc JSON validated; `@vcad/mcp` build green.

## Deploy notes

- Apply `supabase/migrations/033_mcp_artifacts.sql` before/with the deploy (table is additive; no existing reads change until it exists — persist failures just log).
- No env changes: durability keys off the same Supabase env sessions already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uDJYmC9cSQhB3tPwNUtnD

---
_Generated by [Claude Code](https://claude.ai/code/session_018uDJYmC9cSQhB3tPwNUtnD)_