### PR TITLE
fix(app): render Transform3D rotations with kernel euler order (ZYX)

### DIFF
--- a/changelog/entries/2026-07-08-app-euler-order-zyx.json
+++ b/changelog/entries/2026-07-08-app-euler-order-zyx.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-08-app-euler-order-zyx",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "App renders multi-axis rotations with kernel euler order",
+  "summary": "The viewport now composes instance and board rotations as extrinsic X→Y→Z (ZYX) to match the kernel, so multi-axis rotations render identically in app, tessellation, and raytrace.",
+  "features": ["assembly", "viewport", "pcb"]
+}

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -741,11 +741,13 @@ export const SceneMesh = memo(function SceneMesh({
         transform.translation.y,
         transform.translation.z,
       );
+      // Kernel euler convention is extrinsic X→Y→Z (matrix Rz·Ry·Rx), which
+      // is three.js order "ZYX" — must match engine transformMesh / evaluate.rs.
       const euler = new THREE.Euler(
         transform.rotation.x * DEG2RAD,
         transform.rotation.y * DEG2RAD,
         transform.rotation.z * DEG2RAD,
-        "XYZ",
+        "ZYX",
       );
       m.quaternion.setFromEuler(euler);
       m.scale.set(transform.scale.x, transform.scale.y, transform.scale.z);

--- a/packages/app/src/components/TransformGizmo.tsx
+++ b/packages/app/src/components/TransformGizmo.tsx
@@ -38,8 +38,9 @@ function kernelEulerToDisplayQuat(
   angles: { x: number; y: number; z: number },
   out: THREE.Quaternion,
 ): THREE.Quaternion {
+  // Kernel euler convention is extrinsic X→Y→Z (matrix Rz·Ry·Rx) = three.js "ZYX".
   const kernelQuat = _tempQuat.setFromEuler(
-    _tempEuler.set(angles.x * DEG2RAD, angles.y * DEG2RAD, angles.z * DEG2RAD),
+    _tempEuler.set(angles.x * DEG2RAD, angles.y * DEG2RAD, angles.z * DEG2RAD, "ZYX"),
   );
   return out.copy(COORD_QUAT).multiply(kernelQuat);
 }
@@ -47,7 +48,7 @@ function kernelEulerToDisplayQuat(
 /** Display quaternion → kernel Euler angles (strips coord rotation) */
 function displayQuatToKernelEuler(q: THREE.Quaternion): { x: number; y: number; z: number } {
   _tempQuat.copy(COORD_QUAT_INV).multiply(q);
-  _tempEuler.setFromQuaternion(_tempQuat, "XYZ");
+  _tempEuler.setFromQuaternion(_tempQuat, "ZYX");
   return {
     x: _tempEuler.x * RAD2DEG,
     y: _tempEuler.y * RAD2DEG,

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -1793,6 +1793,8 @@ export function ViewportContent({
               ((boardTransform?.rotationDeg.x ?? 0) * Math.PI) / 180,
               ((boardTransform?.rotationDeg.y ?? 0) * Math.PI) / 180,
               ((boardTransform?.rotationDeg.z ?? 0) * Math.PI) / 180,
+              // Kernel euler = extrinsic X→Y→Z (Rz·Ry·Rx) = three.js "ZYX"
+              "ZYX",
             ]}
             scale={[
               boardTransform?.scale.x ?? 1,

--- a/packages/app/src/hooks/useElectronicsSync.ts
+++ b/packages/app/src/hooks/useElectronicsSync.ts
@@ -129,7 +129,8 @@ export function useElectronicsSync() {
               (xf.rotationDeg.x * Math.PI) / 180,
               (xf.rotationDeg.y * Math.PI) / 180,
               (xf.rotationDeg.z * Math.PI) / 180,
-              "XYZ",
+              // Kernel euler = extrinsic X→Y→Z (Rz·Ry·Rx) = three.js "ZYX"
+              "ZYX",
             ),
           ),
           new THREE.Vector3(xf.scale.x, xf.scale.y, xf.scale.z),

--- a/packages/app/src/hooks/usePcbAutoFit.ts
+++ b/packages/app/src/hooks/usePcbAutoFit.ts
@@ -61,7 +61,8 @@ export function usePcbAutoFit(): void {
             (xf.rotationDeg.x * Math.PI) / 180,
             (xf.rotationDeg.y * Math.PI) / 180,
             (xf.rotationDeg.z * Math.PI) / 180,
-            "XYZ",
+            // Kernel euler = extrinsic X→Y→Z (Rz·Ry·Rx) = three.js "ZYX"
+            "ZYX",
           ),
         ),
         new THREE.Vector3(xf.scale.x, xf.scale.y, xf.scale.z),

--- a/packages/app/src/test/euler-order.test.ts
+++ b/packages/app/src/test/euler-order.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import * as THREE from "three";
+import { transformMesh, type TransformInfo } from "@vcad/engine";
+
+/**
+ * Regression: the app's Transform3D rendering must agree with the kernel's
+ * euler convention — extrinsic X→Y→Z (matrix Rz·Ry·Rx), i.e. three.js Euler
+ * order "ZYX". Authorities: crates/vcad-eval/src/kinematics.rs euler_to_matrix
+ * and packages/engine/src/evaluate.ts transformMesh. The app historically used
+ * three.js's default "XYZ", which diverges for any multi-axis rotation.
+ */
+
+const DEG2RAD = Math.PI / 180;
+
+/** Asymmetric sample points so no axis or order coincidence can hide a bug. */
+const SAMPLE_POINTS: [number, number, number][] = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+  [2, 3, 5],
+  [-1, 4, -2],
+  [7, -6, 1.5],
+];
+
+const TRANSFORM: TransformInfo = {
+  translate: { x: 10, y: -5, z: 3 },
+  rotate: { x: 30, y: 45, z: 60 },
+  scale: { x: 1, y: 2, z: 0.5 },
+};
+
+/** Points through the engine's authoritative transformMesh. */
+function enginePoints(t: TransformInfo): number[] {
+  const mesh = {
+    positions: new Float32Array(SAMPLE_POINTS.flat()),
+    indices: new Uint32Array(),
+  };
+  return Array.from(transformMesh(mesh, t).positions);
+}
+
+/**
+ * Points through the app's render path: SceneMesh sets object position /
+ * quaternion-from-euler / scale, which three.js composes as T·R·S.
+ */
+function appPoints(t: TransformInfo, order: THREE.EulerOrder): number[] {
+  const matrix = new THREE.Matrix4().compose(
+    new THREE.Vector3(t.translate.x, t.translate.y, t.translate.z),
+    new THREE.Quaternion().setFromEuler(
+      new THREE.Euler(
+        t.rotate.x * DEG2RAD,
+        t.rotate.y * DEG2RAD,
+        t.rotate.z * DEG2RAD,
+        order,
+      ),
+    ),
+    new THREE.Vector3(t.scale.x, t.scale.y, t.scale.z),
+  );
+  return SAMPLE_POINTS.flatMap((p) => {
+    const v = new THREE.Vector3(...p).applyMatrix4(matrix);
+    return [v.x, v.y, v.z];
+  });
+}
+
+function maxDeviation(a: number[], b: number[]): number {
+  let max = 0;
+  for (let i = 0; i < a.length; i++) {
+    max = Math.max(max, Math.abs(a[i]! - b[i]!));
+  }
+  return max;
+}
+
+describe("Transform3D euler order (app render path vs kernel)", () => {
+  it('app "ZYX" euler matches engine transformMesh for rotation (30,45,60)', () => {
+    const engine = enginePoints(TRANSFORM);
+    const app = appPoints(TRANSFORM, "ZYX");
+    // Float32Array round-trip in the engine path limits precision to ~1e-6.
+    expect(maxDeviation(engine, app)).toBeLessThan(1e-4);
+  });
+
+  it('three.js default "XYZ" diverges — guards that this test is sensitive', () => {
+    const engine = enginePoints(TRANSFORM);
+    const app = appPoints(TRANSFORM, "XYZ");
+    expect(maxDeviation(engine, app)).toBeGreaterThan(1);
+  });
+
+  it("single-axis rotations agree regardless of order", () => {
+    for (const axis of ["x", "y", "z"] as const) {
+      const t: TransformInfo = {
+        translate: { x: 0, y: 0, z: 0 },
+        rotate: { x: 0, y: 0, z: 0, [axis]: 90 },
+        scale: { x: 1, y: 1, z: 1 },
+      };
+      expect(maxDeviation(enginePoints(t), appPoints(t, "ZYX"))).toBeLessThan(1e-4);
+      expect(maxDeviation(enginePoints(t), appPoints(t, "XYZ"))).toBeLessThan(1e-4);
+    }
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -95,6 +95,10 @@ export { SolidCache, hashCsgOp } from "./solid-cache.js";
 export { MeshCache } from "./mesh-cache.js";
 export { DependencyGraph } from "./dependency-graph.js";
 export type { EvaluateOptions } from "./evaluate.js";
+// The authoritative TS-side Transform3D application (extrinsic X→Y→Z euler,
+// matrix Rz·Ry·Rx) — exported so renderers can regression-test against it.
+export { transformMesh } from "./evaluate.js";
+export type { TransformInfo } from "./transform-walk.js";
 
 // Sheet-metal — thin types that ride on EvaluatedPart.sheetMetal so the
 // UI can render the flat pattern and bend list without re-querying WASM.


### PR DESCRIPTION
## What

The web app composed instance and PCB-board euler angles with three.js's default `"XYZ"` order, disagreeing with the kernel's authoritative **extrinsic X→Y→Z** convention (matrix `Rz·Ry·Rx` = three.js `"ZYX"`). Multi-axis instance rotations therefore rendered differently in the app than in kernel tessellation/raytrace — and than the MCP viewer / GLB exporter, which were already fixed to ZYX on 2026-07-08.

This switches all five Transform3D-derived rotation sites in `packages/app` to `"ZYX"`:

- **SceneMesh.tsx** — assembly instance transforms (the main render path)
- **TransformGizmo.tsx** — both `kernelEulerToDisplayQuat` and `displayQuatToKernelEuler` helpers, so gizmo drags also *write back* angles the kernel interprets identically
- **useElectronicsSync.ts** / **usePcbAutoFit.ts** — PCB board world transforms via `getPcbBoardTransform`
- **ViewportContent.tsx** — PCB edit-focus group (R3F takes the order as the 4th `rotation` tuple element)

## Why the other Euler sites were left alone

- **XRPresence.tsx** — a self-consistent quaternion↔euler roundtrip of a peer's head pose, not Transform3D-derived.
- **PlaneGizmo.tsx** — single-axis plane orientations (order-independent).

## Authorities

Kernel euler = `Rz·Ry·Rx`, per `crates/vcad-eval/src/kinematics.rs` (`euler_to_matrix`), `crates/vcad-eval/src/evaluate.rs`, and `packages/engine/src/evaluate.ts` (`transformMesh`).

## Test

New `packages/app/src/test/euler-order.test.ts` compares the app's compose path against the engine's `transformMesh` for rotation `(30,45,60)` over asymmetric sample points, asserts the old `"XYZ"` order diverges (sensitivity guard), and checks single-axis rotations agree under both orders. To support it, `transformMesh` and `TransformInfo` are now exported from `@vcad/engine`.

## Verification

- New test: 3/3 ✅
- Full app suite: 50/50 ✅ · engine suite: 98 passed ✅ · app `tsc -b` clean ✅
- **In-app, end-to-end:** loaded a document with an instance rotated `(30,45,60)` through the real store and read the instance mesh's matrix from the live R3F scene — matches kernel `Rz·Ry·Rx` to 1e-16, where the old behavior was off by up to 0.83 per matrix element.

Changelog entry included (user-facing `fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)