### PR TITLE
fix(physics): deterministic joint ordering in observation contract

### DIFF
--- a/changelog/entries/2026-07-08-physics-joint-order.json
+++ b/changelog/entries/2026-07-08-physics-joint-order.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-physics-joint-order",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "fix",
+  "title": "Deterministic joint ordering in physics observations",
+  "summary": "Observation vectors now index joints in document order, create_robot_env reports joint_ids, and record_simulation maps poses by joint id — multi-joint replays can no longer permute.",
+  "features": ["physics", "simulation", "assembly"],
+  "mcpTools": ["create_robot_env", "record_simulation", "gym_observe"]
+}

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -7,6 +7,9 @@ use crate::error::PhysicsError;
 use crate::world::PhysicsWorld;
 
 /// Observation from the robot environment.
+///
+/// Joint vectors are indexed by [`RobotEnv::joint_ids`] order, which is the
+/// document's `joints` array order (deterministic).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Observation {
     /// Joint positions (radians for revolute, meters for prismatic).
@@ -178,6 +181,14 @@ impl RobotEnv {
     /// Set the maximum episode length.
     pub fn set_max_steps(&mut self, max_steps: u32) {
         self.max_steps = max_steps;
+    }
+
+    /// Joint ids in observation order (document order).
+    ///
+    /// `Observation::joint_positions[i]` / `joint_velocities[i]` and action
+    /// vectors all index against this list.
+    pub fn joint_ids(&self) -> &[String] {
+        &self.joint_ids
     }
 
     /// Get the number of joints (action dimension for position/velocity control).
@@ -380,6 +391,118 @@ mod tests {
         doc.ground_instance_id = Some("base_inst".to_string());
 
         doc
+    }
+
+    /// Three-link chain whose `joints` array is declared in REVERSE of the
+    /// BFS discovery order (leaf joint first). Each joint carries a distinct
+    /// initial state so a permuted observation ordering is detectable.
+    fn create_three_joint_robot_reversed() -> Document {
+        let mut doc = Document::new();
+
+        for (node_id, name) in [(1, "base"), (2, "link1"), (3, "link2"), (4, "link3")] {
+            doc.nodes.insert(
+                node_id,
+                vcad_ir::Node {
+                    id: node_id,
+                    name: Some(name.to_string()),
+                    op: vcad_ir::CsgOp::Cube {
+                        size: Vec3::new(20.0, 20.0, 100.0),
+                    },
+                },
+            );
+        }
+
+        let mut part_defs = HashMap::new();
+        for (root, name) in [(1, "base"), (2, "link1"), (3, "link2"), (4, "link3")] {
+            part_defs.insert(
+                name.to_string(),
+                PartDef {
+                    id: name.to_string(),
+                    name: None,
+                    root,
+                    default_material: None,
+                    inertial: None,
+                },
+            );
+        }
+        doc.part_defs = Some(part_defs);
+
+        doc.instances = Some(
+            ["base", "link1", "link2", "link3"]
+                .iter()
+                .map(|name| Instance {
+                    id: format!("{name}_inst"),
+                    part_def_id: name.to_string(),
+                    name: None,
+                    tags: Vec::new(),
+                    transform: None,
+                    material: None,
+                })
+                .collect(),
+        );
+
+        let make_joint = |id: &str, parent: &str, child: &str, state: f64| Joint {
+            id: id.to_string(),
+            name: None,
+            parent_instance_id: Some(format!("{parent}_inst")),
+            child_instance_id: format!("{child}_inst"),
+            parent_anchor: Vec3::new(0.0, 0.0, 50.0),
+            child_anchor: Vec3::new(0.0, 0.0, -50.0),
+            kind: JointKind::Revolute {
+                axis: Vec3::new(0.0, 1.0, 0.0),
+                limits: Some((-90.0, 90.0)),
+            },
+            state,
+        };
+
+        // Leaf-most joint first: doc order is the opposite of the order the
+        // world builder's BFS from ground discovers them in.
+        doc.joints = Some(vec![
+            make_joint("joint3", "link2", "link3", 30.0),
+            make_joint("joint2", "link1", "link2", 20.0),
+            make_joint("joint1", "base", "link1", 10.0),
+        ]);
+
+        doc.ground_instance_id = Some("base_inst".to_string());
+        doc
+    }
+
+    #[test]
+    fn joint_observation_order_matches_document_order() {
+        let doc = create_three_joint_robot_reversed();
+        let env = RobotEnv::new(doc, vec!["link3_inst".to_string()], None, None).unwrap();
+
+        // The contract: joint_ids() is doc.joints order, not BFS or HashMap
+        // order. Before joint_order landed this permuted run-to-run.
+        assert_eq!(env.joint_ids(), ["joint3", "joint2", "joint1"]);
+
+        // Each observation slot must carry the state of the joint at the
+        // same index of joint_ids(): 30/20/10 degrees, not any permutation.
+        let obs = env.observe();
+        assert_eq!(obs.joint_positions.len(), 3);
+        assert!(
+            (obs.joint_positions[0] - 30.0).abs() < 1e-6,
+            "slot 0 should be joint3 (30 deg), got {}",
+            obs.joint_positions[0]
+        );
+        assert!(
+            (obs.joint_positions[1] - 20.0).abs() < 1e-6,
+            "slot 1 should be joint2 (20 deg), got {}",
+            obs.joint_positions[1]
+        );
+        assert!(
+            (obs.joint_positions[2] - 10.0).abs() < 1e-6,
+            "slot 2 should be joint1 (10 deg), got {}",
+            obs.joint_positions[2]
+        );
+
+        // reset() rebuilds the world from the initial doc — ordering must
+        // survive the round trip.
+        let mut env = env;
+        let obs = env.reset();
+        assert_eq!(env.joint_ids(), ["joint3", "joint2", "joint1"]);
+        assert!((obs.joint_positions[0] - 30.0).abs() < 1e-6);
+        assert!((obs.joint_positions[2] - 10.0).abs() < 1e-6);
     }
 
     #[test]

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -46,6 +46,11 @@ pub struct PhysicsWorld {
     instance_to_body: HashMap<String, usize>,
     joint_to_index: HashMap<String, usize>,
 
+    // Joint ids in document order — the canonical ordering for observation
+    // vectors and positional q arguments. Never iterate joint_to_index for
+    // ordering: HashMap iteration order permutes run-to-run.
+    joint_order: Vec<String>,
+
     // Original joint definitions for unit conversion
     joint_kinds: HashMap<String, JointKind>,
 
@@ -233,6 +238,15 @@ impl PhysicsWorld {
             }
         }
 
+        // Canonical joint ordering: document order, restricted to joints the
+        // BFS actually realized (a joint whose child is unreachable from
+        // ground, or already claimed by an earlier joint, is skipped above).
+        let joint_order: Vec<String> = joints
+            .iter()
+            .filter(|j| joint_to_index.contains_key(&j.id))
+            .map(|j| j.id.clone())
+            .collect();
+
         // 3. Add remaining instances as free-floating bodies
         for inst in instances {
             if visited.contains(&inst.id) {
@@ -277,6 +291,7 @@ impl PhysicsWorld {
             motors: HashMap::new(),
             instance_to_body,
             joint_to_index,
+            joint_order,
             joint_kinds,
             joint_q_offsets,
             joint_v_offsets,
@@ -603,8 +618,14 @@ impl PhysicsWorld {
     }
 
     /// Get list of all joint IDs.
+    ///
+    /// Order is deterministic: document order (`doc.joints`), restricted to
+    /// joints realized in the physics model. Observation vectors
+    /// ([`crate::Observation`]) and the positional `q` arguments of
+    /// [`Self::forward_kinematics_at`] / [`Self::gravity_torques_at`] all
+    /// index against this order.
     pub fn joint_ids(&self) -> Vec<String> {
-        self.joint_to_index.keys().cloned().collect()
+        self.joint_order.clone()
     }
 
     /// Get list of all instance IDs.

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -3532,6 +3532,15 @@ impl PhysicsSim {
         self.env.num_joints()
     }
 
+    /// Joint ids in observation order (document `joints` order).
+    ///
+    /// `joint_positions[i]` / `joint_velocities[i]` in every observation
+    /// correspond to `jointIds()[i]`, as do action vector entries.
+    #[wasm_bindgen(js_name = jointIds)]
+    pub fn joint_ids(&self) -> Vec<String> {
+        self.env.joint_ids().to_vec()
+    }
+
     /// Get the observation dimension.
     #[wasm_bindgen(js_name = observationDim)]
     pub fn observation_dim(&self) -> usize {

--- a/packages/engine/src/__tests__/physics-joint-order.test.ts
+++ b/packages/engine/src/__tests__/physics-joint-order.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import type { Document } from "@vcad/ir";
+import { createDocument } from "@vcad/ir";
+import { getKernelWasm } from "../wasm-singleton.js";
+import { PhysicsEnv, isPhysicsAvailable } from "../physics.js";
+import { solveForwardKinematics } from "../kinematics.js";
+
+beforeAll(async () => {
+  await getKernelWasm();
+});
+
+/**
+ * Regression doc for the joint-ordering bug: PhysicsWorld::joint_ids() used
+ * to iterate a HashMap, so observation slots could silently permute against
+ * doc.joints for multi-joint assemblies. This chain declares its `joints`
+ * array in REVERSE of the kinematic (BFS-from-ground) order, with a distinct
+ * angle per joint, so any permutation is detectable.
+ */
+function threeJointChainDoc(): Document {
+  const doc = createDocument();
+  const names = ["base", "link1", "link2", "link3"];
+  names.forEach((name, i) => {
+    doc.nodes[String(i + 1)] = {
+      id: i + 1,
+      name,
+      op: { type: "Cube", size: { x: 20, y: 20, z: 100 } },
+    };
+  });
+  doc.partDefs = Object.fromEntries(
+    names.map((name, i) => [name, { id: name, root: i + 1 }]),
+  );
+  doc.instances = names.map((name) => ({
+    id: `${name}_inst`,
+    partDefId: name,
+    transform: {
+      translation: { x: 0, y: 0, z: 0 },
+      rotation: { x: 0, y: 0, z: 0 },
+      scale: { x: 1, y: 1, z: 1 },
+    },
+  }));
+  const revolute = (id: string, parent: string, child: string, state: number) => ({
+    id,
+    parentInstanceId: `${parent}_inst`,
+    childInstanceId: `${child}_inst`,
+    parentAnchor: { x: 0, y: 0, z: 50 },
+    childAnchor: { x: 0, y: 0, z: -50 },
+    kind: { type: "Revolute" as const, axis: { x: 0, y: 1, z: 0 } },
+    state,
+  });
+  // Leaf-most joint first: doc order is the opposite of BFS discovery order.
+  doc.joints = [
+    revolute("joint3", "link2", "link3", 30),
+    revolute("joint2", "link1", "link2", 20),
+    revolute("joint1", "base", "link1", 10),
+  ];
+  doc.groundInstanceId = "base_inst";
+  return doc;
+}
+
+describe("physics joint observation ordering", () => {
+  it("observation slots map onto the right doc joints and instance transforms", async () => {
+    if (!(await isPhysicsAvailable())) return;
+
+    const doc = threeJointChainDoc();
+    const env = await PhysicsEnv.create(doc, {
+      endEffectorIds: ["link3_inst"],
+    });
+    try {
+      // The kernel must expose its joint order, and it must be doc order.
+      expect(env.jointIds).toEqual(["joint3", "joint2", "joint1"]);
+
+      // Each observation slot carries the state of jointIds[i]: 30/20/10,
+      // not any permutation.
+      const obs = env.observe();
+      expect(obs.joint_positions.length).toBe(3);
+      expect(obs.joint_positions[0]).toBeCloseTo(30, 4);
+      expect(obs.joint_positions[1]).toBeCloseTo(20, 4);
+      expect(obs.joint_positions[2]).toBeCloseTo(10, 4);
+
+      // End-to-end: write the observation back into a zeroed clone by id
+      // (the record_simulation / get_sim_replay mapping) and check every
+      // instance lands on the same world transform FK gives the original
+      // doc. A permuted mapping bends the wrong joints and diverges.
+      const clone: Document = JSON.parse(JSON.stringify(doc));
+      for (const j of clone.joints!) j.state = 0;
+      const byId = new Map(clone.joints!.map((j) => [j.id, j]));
+      env.jointIds!.forEach((id, i) => {
+        byId.get(id)!.state = obs.joint_positions[i]!;
+      });
+
+      const expected = solveForwardKinematics(doc);
+      const actual = solveForwardKinematics(clone);
+      expect(actual.size).toBe(expected.size);
+      for (const [instId, want] of expected) {
+        const got = actual.get(instId);
+        expect(got, `instance ${instId} missing from FK result`).toBeDefined();
+        for (const axis of ["x", "y", "z"] as const) {
+          expect(got!.translation[axis]).toBeCloseTo(want.translation[axis], 4);
+          expect(got!.rotation[axis]).toBeCloseTo(want.rotation[axis], 4);
+        }
+      }
+    } finally {
+      env.close();
+    }
+  });
+});

--- a/packages/engine/src/physics.ts
+++ b/packages/engine/src/physics.ts
@@ -8,7 +8,12 @@
 import type { Document } from "@vcad/ir";
 import type { PhysicsSim as WasmPhysicsSim } from "@vcad/kernel-wasm";
 
-/** Observation from the physics simulation */
+/**
+ * Observation from the physics simulation.
+ *
+ * Joint vectors are indexed by {@link PhysicsEnv.jointIds} order — the
+ * document's `joints` array order.
+ */
 export interface PhysicsObservation {
   /** Joint positions (degrees for revolute, mm for prismatic) */
   joint_positions: number[];
@@ -90,12 +95,21 @@ export class PhysicsEnv {
   private _numJoints: number;
   private _actionDim: number;
   private _observationDim: number;
+  private _jointIds: string[] | null;
 
   private constructor(sim: WasmPhysicsSim) {
     this.sim = sim;
     this._numJoints = sim.numJoints();
     this._actionDim = sim.actionDim();
     this._observationDim = sim.observationDim();
+    // jointIds() postdates some shipped kernel builds; feature-detect so a
+    // stale WASM degrades to jointIds === null instead of throwing. The
+    // structural cast (not WasmPhysicsSim) keeps typecheck green against a
+    // checked-in .d.ts that predates the binding.
+    const maybeJointIds = (sim as unknown as { jointIds?: () => string[] })
+      .jointIds;
+    this._jointIds =
+      typeof maybeJointIds === "function" ? maybeJointIds.call(sim) : null;
   }
 
   /**
@@ -134,6 +148,15 @@ export class PhysicsEnv {
   /** Number of joints in the simulation */
   get numJoints(): number {
     return this._numJoints;
+  }
+
+  /**
+   * Joint ids in observation order (document `joints` order), or null when
+   * the loaded kernel WASM predates `jointIds()`. Index `i` of
+   * `joint_positions` / `joint_velocities` corresponds to `jointIds[i]`.
+   */
+  get jointIds(): string[] | null {
+    return this._jointIds;
   }
 
   /** Dimension of the action space */

--- a/packages/mcp/src/__tests__/joint-order.test.ts
+++ b/packages/mcp/src/__tests__/joint-order.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveObservationJoints } from "../tools/joint-order.js";
+
+const joint = (id: string, state = 0) =>
+  ({ id, state }) as unknown as Parameters<
+    typeof resolveObservationJoints
+  >[0][number];
+
+describe("resolveObservationJoints", () => {
+  it("aligns doc joints to the env's joint-id order", () => {
+    const docJoints = [joint("a"), joint("b"), joint("c")];
+    const result = resolveObservationJoints(docJoints, ["c", "a", "b"]);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.joints.map((j) => j.id)).toEqual(["c", "a", "b"]);
+    // Same objects, not copies — writes must land on the doc's joints.
+    expect(result.joints[1]).toBe(docJoints[0]);
+  });
+
+  it("falls back to positional order when the kernel exposes no ids", () => {
+    const docJoints = [joint("a"), joint("b")];
+    const result = resolveObservationJoints(docJoints, null);
+    if ("error" in result) throw new Error(result.error);
+    expect(result.joints).toBe(docJoints);
+  });
+
+  it("names env joints missing from the document", () => {
+    const result = resolveObservationJoints([joint("a")], ["a", "ghost"]);
+    expect(result).toHaveProperty("error");
+    if (!("error" in result)) throw new Error("expected error");
+    expect(result.error).toContain("ghost");
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -2784,7 +2784,7 @@
         },
         "document_id": {
           "type": "string",
-          "description": "Session document id from open_document. Must describe the same assembly the env was created from (same joint order)."
+          "description": "Session document id from open_document. Must describe the same assembly the env was created from (same joint ids)."
         },
         "steps": {
           "type": "number",

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -555,6 +555,11 @@ describe("gym tools", () => {
     } else {
       expect(info.env_id).toBeDefined();
       expect(info.num_joints).toBeGreaterThanOrEqual(0);
+      // Observation-ordering contract: joint_ids is doc.joints order (null
+      // only for kernel WASM builds that predate jointIds()).
+      if (info.joint_ids !== null) {
+        expect(info.joint_ids).toEqual(["joint1"]);
+      }
       expect(info.end_effector_ids).toContain("link1_inst");
       gymClose({ env_id: info.env_id });
     }

--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -182,6 +182,10 @@ export async function createRobotEnv(input: unknown): Promise<GymResult> {
     const info = {
       env_id: envId,
       num_joints: env.numJoints,
+      // Observation/action ordering contract: joint_positions[i],
+      // joint_velocities[i], and action values[i] all refer to joint_ids[i].
+      // Null when the loaded kernel WASM predates jointIds().
+      joint_ids: env.jointIds,
       action_dim: env.actionDim,
       observation_dim: env.observationDim,
       end_effector_ids: args.end_effector_ids,

--- a/packages/mcp/src/tools/joint-order.ts
+++ b/packages/mcp/src/tools/joint-order.ts
@@ -1,0 +1,39 @@
+/**
+ * Observation-to-document joint mapping.
+ *
+ * The physics kernel emits `joint_positions[i]` / `joint_velocities[i]`
+ * indexed by the env's joint order. Kernels that expose `jointIds()` make
+ * that order explicit; we map each observation slot onto the doc joint with
+ * the matching id, immune to any ordering drift between the env and
+ * `doc.joints`. Older kernel builds (no `jointIds`) fall back to positional
+ * mapping — correct for kernels since the joint_order fix pinned the
+ * observation order to document order, and the shipped assumption before it.
+ */
+
+import type { Document } from "@vcad/ir";
+
+type DocJoint = NonNullable<Document["joints"]>[number];
+
+/**
+ * Resolve, once per recording, the doc joint that each observation slot
+ * writes into. Returns the joints array aligned to observation order, or an
+ * error naming the env joints that have no counterpart in the document.
+ */
+export function resolveObservationJoints(
+  joints: DocJoint[],
+  jointIds: string[] | null,
+): { joints: DocJoint[] } | { error: string } {
+  if (!jointIds) {
+    return { joints };
+  }
+  const byId = new Map(joints.map((j) => [j.id, j]));
+  const missing = jointIds.filter((id) => !byId.has(id));
+  if (missing.length > 0) {
+    return {
+      error:
+        `env joints [${missing.join(", ")}] do not exist in the document — ` +
+        "the env must have been created from a different assembly.",
+    };
+  }
+  return { joints: jointIds.map((id) => byId.get(id)!) };
+}

--- a/packages/mcp/src/tools/record.ts
+++ b/packages/mcp/src/tools/record.ts
@@ -18,6 +18,7 @@ import { getKernelWasm, resetKernelWasm } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { getSession } from "./session.js";
 import { getSimulation } from "./gym.js";
+import { resolveObservationJoints } from "./joint-order.js";
 import type { PhysicsActionType } from "@vcad/engine";
 import { behavior, type ToolDef } from "./tool-def.js";
 import type { ToolResult } from "./tool-result.js";
@@ -32,7 +33,7 @@ export const recordSimulationSchema = {
     document_id: {
       type: "string" as const,
       description:
-        "Session document id from open_document. Must describe the same assembly the env was created from (same joint order).",
+        "Session document id from open_document. Must describe the same assembly the env was created from (same joint ids).",
     },
     steps: {
       type: "number" as const,
@@ -271,6 +272,14 @@ export async function recordSimulation(
   // gym_observe afterward to see the final pose.
   const docClone: Document = JSON.parse(JSON.stringify(doc));
 
+  // Align observation slots to doc joints by id (kernels exposing jointIds),
+  // falling back to positional order for older WASM builds. Resolved once,
+  // up front, so an env/document mismatch fails before we burn steps.
+  const obsJoints = resolveObservationJoints(docClone.joints!, env.jointIds);
+  if ("error" in obsJoints) {
+    return errorResult(`record_simulation refused: ${obsJoints.error}`);
+  }
+
   const jointTrajectory: number[][] = [];
   const delayMs = Math.max(1, Math.round(1000 / fps));
 
@@ -284,9 +293,9 @@ export async function recordSimulation(
     const result = env.step(actionType, perStepActions.values[s]!);
     const obs = result.observation;
 
-    for (let j = 0; j < docClone.joints!.length; j++) {
+    for (let j = 0; j < obsJoints.joints.length; j++) {
       const pos = obs.joint_positions[j];
-      if (typeof pos === "number") docClone.joints![j]!.state = pos;
+      if (typeof pos === "number") obsJoints.joints[j]!.state = pos;
     }
     jointTrajectory.push([...obs.joint_positions]);
 


### PR DESCRIPTION
## What

`PhysicsWorld::joint_ids()` returned `joint_to_index.keys()` from a `std::HashMap`, so the order of `joint_positions` / `joint_velocities` in observations was **not guaranteed to match `doc.joints` order**. `record_simulation` (and the yet-to-merge `sim-replay.ts`) write observation slot `j` into `doc.joints[j].state` for FK rendering — so for multi-joint assemblies, poses could silently permute onto the wrong instances. Single-joint docs were unaffected.

## Fix (bottom to top)

- **Kernel** (`world.rs`): `PhysicsWorld` now carries `joint_order: Vec<String>`, built in `doc.joints` order and restricted to joints the BFS-from-ground actually realized. `joint_ids()` returns it instead of HashMap keys. This also makes the positional `q` contracts of `forward_kinematics_at` / `gravity_torques_at` deterministic.
- **Gym** (`gym.rs`): `RobotEnv::joint_ids()` accessor; `Observation` docs the ordering contract.
- **WASM** (`lib.rs`): new `PhysicsSim.jointIds()` binding.
- **Engine** (`physics.ts`): `PhysicsEnv.jointIds` — feature-detected, so it returns `null` (and typechecks) against stale WASM builds that predate the binding.
- **MCP**: `create_robot_env` returns `joint_ids`; `record_simulation` maps observation slots onto doc joints **by id** via a new `resolveObservationJoints` helper (`joint-order.ts`), resolved once before the step loop with an up-front mismatch error, and a positional fallback for old WASM.

## Tests (all passing)

- **Rust** (`gym.rs`): 3-joint chain whose `joints` array is declared in *reverse* BFS order with distinct angles (30/20/10°); asserts `joint_ids()` is doc order and each observation slot carries the right angle, surviving `reset()`.
- **Engine** (`physics-joint-order.test.ts`): end-to-end — writes an observation back into a zeroed doc by id (the record_simulation path) and asserts every instance lands on the same transform `solveForwardKinematics` gives the original doc.
- **MCP** (`joint-order.test.ts`): unit tests for the id-mapping helper; plus a `create_robot_env` `joint_ids` assertion in `tools.test.ts`.

Full runs: `cargo test -p vcad-kernel-physics`, workspace `cargo check --exclude vcad-desktop`, engine vitest (99), MCP vitest (730/49 files).

## Reviewer notes

- **WASM artifacts are intentionally not committed** — `wasm-refresh.yml` owns them on `main` after merge (per CLAUDE.md / `wasm-artifact-guard`). Until that refresh runs, `env.jointIds` is `null` against the checked-in WASM and `record_simulation` uses the positional fallback, which is still correct once the kernel fix lands in the deployed WASM.
- **`sim-replay.ts` is on a separate unmerged branch** and still maps positionally — now benign (kernel emits doc order), and a follow-up applies the same `resolveObservationJoints` helper there.
- Pre-existing: standalone `cargo clippy -p vcad-kernel-wasm` trips 4 dead-code lints in `vcad-render` (feature-unification artifact, fires on a clean tree too — not from this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)