### PR TITLE
fix(mcp): map sim-replay observation slots to joints by id

### DIFF
--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -77,6 +77,12 @@ export interface EnvRecord {
   dt: number;
   /** Physics substeps per step. */
   substeps: number;
+  /** Observation-order joint id list captured from the env at creation, so
+   *  replay FK maps `trajectory[row][i]` onto the doc joint with id
+   *  `jointIds[i]` (via resolveObservationJoints) rather than by position.
+   *  Null when the loaded kernel WASM predates `jointIds()` — replay then
+   *  falls back to positional order, matching the shipped assumption. */
+  jointIds: string[] | null;
 }
 
 /** Replay records keyed by env_id, populated by create_robot_env. */
@@ -242,6 +248,7 @@ export async function createRobotEnv(input: unknown): Promise<GymResult> {
       resetEpoch: 0,
       dt: args.dt ?? 1 / 240,
       substeps: args.substeps ?? 4,
+      jointIds: env.jointIds,
     });
 
     const info = {

--- a/packages/mcp/src/tools/sim-replay.ts
+++ b/packages/mcp/src/tools/sim-replay.ts
@@ -14,6 +14,7 @@
 import type { Document } from "@vcad/ir";
 import { getKernelWasm, resetKernelWasm } from "@vcad/engine";
 import { getEnvRecord } from "./gym.js";
+import { resolveObservationJoints } from "./joint-order.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
 /** MCP tool result for the replay tools. Error paths set `isError: true` so
@@ -157,21 +158,17 @@ export async function getSimReplay(input: unknown): Promise<ReplayResult> {
   }
 
   // Per-step FK: clone the stored assembly ONCE, write each trajectory row
-  // into the clone's joints[j].state, and let the kernel solver reconstruct
-  // world poses (the record_simulation pattern, tools/record.ts). The
-  // per-row serialization happens at the WASM boundary, so the single clone
-  // never aliases across rows.
+  // into the FK clone's joints, and let the kernel solver reconstruct world
+  // poses (the record_simulation pattern, tools/record.ts). The per-row
+  // serialization happens at the WASM boundary, so the single clone never
+  // aliases across rows.
   //
-  // Joint-order contract: trajectory row[j] is written into doc.joints[j] —
-  // the SAME positional assumption record_simulation ships on (record.ts,
-  // its obs.joint_positions[j] → docClone.joints[j].state loop). The order
-  // is the kernel's: RobotEnv captures PhysicsWorld::joint_ids() at
-  // construction and emits observation.joint_positions in that fixed order
-  // (crates/vcad-kernel-physics gym.rs observe()). NOTE joint_ids() today
-  // iterates the joint_to_index HashMap (world.rs), so for multi-joint
-  // documents the emitted order is not guaranteed to equal doc.joints order
-  // — if the kernel ever exposes its joint id list, both this loop and
-  // record.ts should map by id instead of index.
+  // Observation slots map onto doc joints BY ID via resolveObservationJoints
+  // (shared with record_simulation): trajectory row[i] is the kernel's
+  // joint_positions[i], which refers to jointIds[i], so a permuted kernel
+  // joint order can't land a pose on the wrong joint. Older WASM builds
+  // without jointIds() leave record.jointIds null and fall back to positional
+  // order. Resolved once, before the row loop.
   const instanceTransforms: Array<Record<string, SimTrs>> = [];
   const jointCount = record.document.joints?.length ?? 0;
   const instanceCount = record.document.instances?.length ?? 0;
@@ -182,16 +179,25 @@ export async function getSimReplay(input: unknown): Promise<ReplayResult> {
       };
       if (typeof wasm.solveForwardKinematics === "function") {
         const docClone: Document = JSON.parse(JSON.stringify(record.document));
-        for (const row of record.trajectory) {
-          for (let j = 0; j < docClone.joints!.length; j++) {
-            const pos = row[j];
-            if (typeof pos === "number") docClone.joints![j]!.state = pos;
+        const obsJoints = resolveObservationJoints(
+          docClone.joints!,
+          record.jointIds,
+        );
+        // A mismatch means the record's jointIds don't match its own document
+        // — impossible for a live env, so degrade to a transform-less replay
+        // (the viewer falls back to static geometry) rather than mis-posing.
+        if (!("error" in obsJoints)) {
+          for (const row of record.trajectory) {
+            for (let j = 0; j < obsJoints.joints.length; j++) {
+              const pos = row[j];
+              if (typeof pos === "number") obsJoints.joints[j]!.state = pos;
+            }
+            instanceTransforms.push(
+              toTransformRecord(
+                wasm.solveForwardKinematics(JSON.stringify(docClone)),
+              ),
+            );
           }
-          instanceTransforms.push(
-            toTransformRecord(
-              wasm.solveForwardKinematics(JSON.stringify(docClone)),
-            ),
-          );
         }
       }
     } catch (err) {


### PR DESCRIPTION
## What

`get_sim_replay` (the inline viewer's replay path) wrote trajectory `row[j]` into `doc.joints[j].state` **positionally** — the exact assumption [#513](https://github.com/ecto/vcad/pull/513) just removed from `record_simulation`. On a multi-joint assembly where the kernel's joint order permutes against `doc.joints`, FK could pose the wrong joints during playback.

This applies the same id-based mapping to the replay path.

## How

- `getSimReplay` now resolves observation slots to doc joints **by id** via `resolveObservationJoints(...)` (the helper `record_simulation` uses), instead of index.
- Added `jointIds: string[] | null` to `EnvRecord`, populated from `env.jointIds` in `create_robot_env`. Replay reads the **persisted ring-buffer record**, not the live env, so #513's `env.jointIds` alone wasn't enough — the id list has to be captured onto the record at creation.
- Older WASM without `jointIds()` leaves `record.jointIds` null → positional fallback, unchanged behavior.
- Removed the now-stale "Joint-order contract … positional" caveat comment.

### One deliberate difference from `record_simulation`
`record_simulation` hard-errors on a joint/document mismatch. `get_sim_replay` instead **degrades to a transform-less replay** (the viewer falls back to static geometry) — a mismatch is impossible for a live env, and this tool backs a per-tick playback poll that shouldn't error the viewer.

## Changelog

No new entry — `get_sim_replay` is internal to the inline viewer, and the user-facing contract fix already shipped its changelog entry with #513 (`2026-07-08-physics-joint-order.json`). This is the same fix family extended to the replay path.

## Verification

Change is byte-identical to one already run green locally: `tsc --noEmit` on `@vcad/mcp` clean, and the MCP suites pass (66 tests across `joint-order`, `sim-replay`, `gym-errors`, `tools`) — the `sim-replay` test exercises the id path against source-built WASM that has the `jointIds()` binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)