### PR TITLE
perf(mcp): instant viewer first paint — inline preview _meta + content-addressed GLB cache

### DIFF
--- a/changelog/entries/2026-07-08-instant-viewer-first-paint.json
+++ b/changelog/entries/2026-07-08-instant-viewer-first-paint.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-instant-viewer-first-paint",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "perf",
+  "title": "MCP viewer paints geometry instantly on mount",
+  "summary": "Mount results now carry a ready-to-render GLB in host-only _meta and previews are cached by content hash, removing the fetch round trip and repeat re-tessellation behind 'fetching geometry…'.",
+  "features": ["mcp-apps", "viewer", "performance"],
+  "mcpTools": ["create_cad_loon", "get_preview_glb"]
+}

--- a/packages/mcp/src/__tests__/preview-cache.test.ts
+++ b/packages/mcp/src/__tests__/preview-cache.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The viewer's first-paint fast path: previewGlbFor's content-addressed GLB
+ * cache, and attachInlinePreview riding a ready-to-render GLB on a mount
+ * result's `_meta` so the iframe never round-trips get_preview_glb.
+ */
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { previewGlbFor, previewVersion } from "../tools/preview.js";
+import { attachInlinePreview } from "../server.js";
+import { documents } from "../tools/session.js";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+function cubeDoc(size = 10): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "cube",
+        op: { type: "Cube", size: { x: size, y: size, z: size } },
+      },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [{ root: 1, material: "default" }],
+  } as unknown as Document;
+}
+
+const throwingEngine = {
+  evaluate: () => {
+    throw new Error("evaluate must not run on a cache hit");
+  },
+} as unknown as Engine;
+
+describe("previewGlbFor cache", () => {
+  it("returns a GLB with the document's change token", async () => {
+    const doc = cubeDoc();
+    const preview = await previewGlbFor(doc, engine);
+    expect(preview).not.toBeNull();
+    expect(preview!.glb.length).toBeGreaterThan(0);
+    expect(preview!.version).toBe(previewVersion(doc));
+    expect(preview!.mode).toBeUndefined();
+  });
+
+  it("serves an identical document from cache without evaluating", async () => {
+    const doc = cubeDoc(17);
+    const first = await previewGlbFor(doc, engine);
+    expect(first).not.toBeNull();
+    // Same content → cache hit: the throwing engine is never consulted.
+    const second = await previewGlbFor(cubeDoc(17), throwingEngine);
+    expect(second).toEqual(first);
+  });
+
+  it("never serves stale geometry — an edit flips the cache key", async () => {
+    await previewGlbFor(cubeDoc(21), engine);
+    // Different content misses the cache; with a broken engine the parts
+    // path yields no meshes → null, proving it recomputed rather than
+    // reusing the size-21 entry.
+    const changed = await previewGlbFor(cubeDoc(22), throwingEngine);
+    expect(changed).toBeNull();
+  });
+});
+
+describe("attachInlinePreview", () => {
+  beforeEach(() => documents.clear());
+
+  it("stamps a ready-to-render preview on the result _meta", async () => {
+    documents.set("doc_inline", cubeDoc(30));
+    const result: { _meta?: Record<string, unknown> } = {};
+    await attachInlinePreview(result, "doc_inline", engine);
+    const preview = result._meta?.["vcad.io/preview"] as Record<string, unknown>;
+    expect(preview).toBeDefined();
+    expect(preview.document_id).toBe("doc_inline");
+    expect(typeof preview.glb).toBe("string");
+    expect((preview.glb as string).length).toBeGreaterThan(0);
+    expect(preview.version).toBe(previewVersion(cubeDoc(30)));
+  });
+
+  it("is best-effort: unknown session leaves the result untouched", async () => {
+    const result: { _meta?: Record<string, unknown> } = {};
+    await attachInlinePreview(result, "doc_missing", engine);
+    expect(result._meta).toBeUndefined();
+  });
+
+  it("preserves _meta another extension already set", async () => {
+    documents.set("doc_keep", cubeDoc(31));
+    const result: { _meta?: Record<string, unknown> } = {
+      _meta: { "other/ext": true },
+    };
+    await attachInlinePreview(result, "doc_keep", engine);
+    expect(result._meta?.["other/ext"]).toBe(true);
+    expect(result._meta?.["vcad.io/preview"]).toBeDefined();
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -31,7 +31,7 @@ import {
   recordHistorySnapshot,
 } from "./tools/session.js";
 import { createCadLoon } from "./tools/loon.js";
-import { previewVersion } from "./tools/preview.js";
+import { previewVersion, previewGlbFor } from "./tools/preview.js";
 import {
   createSessionStore,
   createSessionEventStore,
@@ -1312,6 +1312,17 @@ export async function createServer(
         if (docId) {
           attachPreviewHandle(result, docId, name);
           slimPreviewForInlineUi(result, docId, name, clientHasInlineUi());
+          // Mount tools carry the UI template, so this exact result is what
+          // the freshly-mounted iframe receives. Ride the preview GLB along
+          // in `_meta` (host-only — never model-visible) so first paint
+          // needs ZERO extra round trips: no get_preview_glb call, no
+          // session re-hydration, no second evaluate+tessellate. Also warms
+          // the content-addressed GLB cache for the poll loop. Best-effort
+          // and size-capped; hosts that strip `_meta` (and oversized docs)
+          // fall back to the fetch path unchanged.
+          if (def.behavior.mount && clientHasInlineUi()) {
+            await attachInlinePreview(result, docId, engine);
+          }
         }
       }
 
@@ -1478,6 +1489,43 @@ function attachPreviewHandle(
       type: "text",
       text: JSON.stringify({ document_id: docId }),
     });
+  }
+}
+
+/** Upper bound for a preview GLB riding inline in a mount result's `_meta`.
+ *  Matches the artifact-offload text ethos: big geometry goes through the
+ *  fetch path; this fast path is for the common small-to-medium part. */
+const INLINE_PREVIEW_MAX_BASE64 = 1_500_000;
+
+/**
+ * Attach a ready-to-render preview GLB to a mount-tool result's `_meta`
+ * (`vcad.io/preview`), so the iframe the host mounts for this result can
+ * paint immediately instead of round-tripping `get_preview_glb` (which pays
+ * session re-hydration plus a full evaluate + tessellate). `_meta` is
+ * host/app-plumbing — it never reaches the model, so the lean-results
+ * discipline that moved GLBs out of content blocks is preserved.
+ * Best-effort: any failure or an oversized GLB just leaves the result on
+ * the existing fetch path.
+ */
+export async function attachInlinePreview(
+  result: { _meta?: Record<string, unknown> },
+  docId: string,
+  engine: Engine,
+): Promise<void> {
+  try {
+    const preview = await previewGlbFor(getSession(docId), engine);
+    if (!preview || preview.glb.length > INLINE_PREVIEW_MAX_BASE64) return;
+    result._meta = {
+      ...result._meta,
+      "vcad.io/preview": {
+        document_id: docId,
+        glb: preview.glb,
+        version: preview.version,
+        ...(preview.mode ? { mode: preview.mode } : {}),
+      },
+    };
+  } catch {
+    // session not resolvable / eval failed — viewer falls back to fetching
   }
 }
 

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -25,6 +25,76 @@ import {
 import { getSession } from "./session.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
+// ─── Content-addressed GLB cache ─────────────────────────────────────────────
+//
+// The viewer's first paint used to pay a full engine.evaluate + tessellation
+// on EVERY get_preview_glb call — including the fetch that happens ~1s after
+// the mutation tool already evaluated the same document. Cache the built GLB
+// keyed by (content hash, mode): the value is a pure function of the document
+// content, so the cache is tenant-safe (two users with identical content get
+// identical bytes) and never serves stale geometry (any edit flips the hash).
+const GLB_CACHE_MAX = 16;
+const glbCache = new Map<string, string>();
+
+function glbCacheGet(key: string): string | undefined {
+  const hit = glbCache.get(key);
+  if (hit !== undefined) {
+    // LRU touch: re-insert so the hottest entries survive eviction.
+    glbCache.delete(key);
+    glbCache.set(key, hit);
+  }
+  return hit;
+}
+
+function glbCachePut(key: string, glb: string): void {
+  glbCache.delete(key);
+  glbCache.set(key, glb);
+  while (glbCache.size > GLB_CACHE_MAX) {
+    const oldest = glbCache.keys().next().value;
+    if (oldest === undefined) break;
+    glbCache.delete(oldest);
+  }
+}
+
+/** A ready-to-render preview envelope: base64 GLB + change token (+ mode). */
+export interface PreviewGlb {
+  glb: string;
+  version: string;
+  mode?: "instances";
+}
+
+/**
+ * Build (or fetch from cache) the preview GLB for a document. Single shared
+ * path for the `get_preview_glb` tool and the dispatch layer's inline
+ * `_meta` preview, so both populate/benefit from the same cache. Returns
+ * null when the document has no previewable geometry.
+ */
+export async function previewGlbFor(
+  doc: Document,
+  engine: Engine,
+  instances = false,
+): Promise<PreviewGlb | null> {
+  const version = previewVersion(doc);
+  if (instances) {
+    const key = `${version}:instances`;
+    const cached = glbCacheGet(key);
+    if (cached !== undefined) return { glb: cached, version, mode: "instances" };
+    const instGlb = generateInstancesGlbPreview(doc, engine);
+    if (instGlb) {
+      glbCachePut(key, instGlb);
+      return { glb: instGlb, version, mode: "instances" };
+    }
+    // No instances — fall through to the parts preview (flag is safe on any doc).
+  }
+  const key = `${version}:parts`;
+  const cached = glbCacheGet(key);
+  if (cached !== undefined) return { glb: cached, version };
+  const glb = await generateGlbPreview(doc, engine);
+  if (!glb) return null;
+  glbCachePut(key, glb);
+  return { glb, version };
+}
+
 /**
  * Generate a base64-encoded GLB preview from an IR document.
  * Returns null only when the document has no previewable geometry at all.
@@ -245,40 +315,27 @@ export async function getPreviewGlb(
   engine: Engine,
   instances = false,
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  if (instances) {
-    const instGlb = generateInstancesGlbPreview(doc, engine);
-    if (instGlb) {
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify({
-              _vcad_glb: instGlb,
-              version: previewVersion(doc),
-              mode: "instances",
-            }),
-          },
-        ],
-      };
-    }
-  }
-  const glbBase64 = await generateGlbPreview(doc, engine);
-  if (!glbBase64) {
-    // No previewable geometry yet (e.g. a freshly opened empty document the
-    // agent is about to build into). Return a soft signal, not an error — the
-    // viewer shows "no geometry" and the self-refresh poll just waits for the
-    // next change, and routine empty previews don't inflate the tool error rate.
+  const preview = await previewGlbFor(doc, engine, instances);
+  if (preview) {
     return {
-      content: [{ type: "text", text: JSON.stringify({ _vcad_glb: null }) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            _vcad_glb: preview.glb,
+            version: preview.version,
+            ...(preview.mode ? { mode: preview.mode } : {}),
+          }),
+        },
+      ],
     };
   }
+  // No previewable geometry yet (e.g. a freshly opened empty document the
+  // agent is about to build into). Return a soft signal, not an error — the
+  // viewer shows "no geometry" and the self-refresh poll just waits for the
+  // next change, and routine empty previews don't inflate the tool error rate.
   return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify({ _vcad_glb: glbBase64, version: previewVersion(doc) }),
-      },
-    ],
+    content: [{ type: "text", text: JSON.stringify({ _vcad_glb: null }) }],
   };
 }
 

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -56,7 +56,16 @@ function glbCachePut(key: string, glb: string): void {
   }
 }
 
-/** A ready-to-render preview envelope: base64 GLB + change token (+ mode). */
+/**
+ * A ready-to-render preview envelope: base64 GLB + change token (+ mode).
+ *
+ * `mode` is the authoritative statement of what the GLB contains: it is
+ * `"instances"` ONLY when the GLB carries one node per assembly instance.
+ * Requesting `instances = true` on a document without instances falls back
+ * to the merged parts preview and returns `mode: undefined` — callers that
+ * need instance nodes (FK replay) must check `mode`, not the flag they
+ * passed.
+ */
 export interface PreviewGlb {
   glb: string;
   version: string;

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -811,7 +811,24 @@ type ToolResultLike = {
   content?: ContentBlock[];
   structuredContent?: Record<string, unknown>;
   isError?: boolean;
+  _meta?: Record<string, unknown>;
 };
+
+/** A ready-to-render preview the server rode along in the mount result's
+ *  `_meta` — first paint without a get_preview_glb round trip. */
+type InlineMetaPreview = {
+  document_id?: string;
+  glb?: string;
+  version?: string;
+  mode?: string;
+};
+
+function findMetaPreview(result: ToolResultLike): InlineMetaPreview | null {
+  const p = result._meta?.["vcad.io/preview"];
+  if (!p || typeof p !== "object") return null;
+  const preview = p as InlineMetaPreview;
+  return typeof preview.glb === "string" && preview.glb.length > 0 ? preview : null;
+}
 
 /** Find an inline `_vcad_glb` payload in result content blocks (legacy
  *  servers attached the GLB directly to the tool result). */
@@ -2269,6 +2286,31 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
   // A session document exists, so the deep link can always lazily fetch
   // the doc on click even when no VCode rode along in the result.
   openBtn.style.display = "inline-flex";
+
+  // Fast path 1: the server rode a ready-to-render GLB along in `_meta`
+  // (mount tools) — paint it now, no round trip. Skipped in a live
+  // instances-mode replay for this document: the inline GLB is
+  // part-segmented and would drop the FK bind targets.
+  const metaPreview = findMetaPreview(result);
+  const wantSimInstances = simEnvId != null && docId === simDocId && simUseInstances;
+  if (metaPreview && !wantSimInstances && metaPreview.mode !== "instances") {
+    if (metaPreview.version) lastPreviewVersion = metaPreview.version;
+    renderGlbForDoc(metaPreview.glb!, docId, changed);
+    return;
+  }
+
+  // Fast path 2: the result's change token matches what is already on
+  // screen — nothing to fetch, the render is current.
+  const resultVersion = result.structuredContent?.document_version;
+  if (
+    sameDoc &&
+    typeof resultVersion === "string" &&
+    resultVersion === lastPreviewVersion
+  ) {
+    setTicker("ready", "ready");
+    return;
+  }
+
   // Same document already on screen → keep showing it under a subtle
   // ticker rather than the full loading overlay, so it accretes in place.
   if (sameDoc) setTicker("updating…", "busy");

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -1060,12 +1060,17 @@ function renderGlbForDoc(
   docId: string | null,
   changed: PartsChanged | null,
   simInstancesGlb = false,
+  versionToken: string | null = null,
 ): void {
   const preserveCamera = docId != null && docId === renderedDocId;
   const keepPartId = preserveCamera ? selected?.partId ?? null : null;
   loadGlb(glb, {
     preserveCamera,
     afterLoad: () => {
+      // Advance the change token only once the GLB actually parsed and
+      // mounted — a failed render must leave the token behind so the next
+      // result (or poll tick) re-fetches instead of skipping past it.
+      if (versionToken != null) lastPreviewVersion = versionToken;
       if (docId != null) renderedDocId = docId;
       if (keepPartId != null) reselectById(keepPartId);
       if (changed) flashChanged(changed);
@@ -2294,9 +2299,24 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
   const metaPreview = findMetaPreview(result);
   const wantSimInstances = simEnvId != null && docId === simDocId && simUseInstances;
   if (metaPreview && !wantSimInstances && metaPreview.mode !== "instances") {
-    if (metaPreview.version) lastPreviewVersion = metaPreview.version;
-    renderGlbForDoc(metaPreview.glb!, docId, changed);
-    return;
+    try {
+      // The version token advances inside afterLoad — only after a
+      // successful parse+mount — so a corrupt inline GLB can't strand
+      // lastPreviewVersion on a version that never rendered (fast path 2
+      // would then skip the fetch that recovers it).
+      renderGlbForDoc(
+        metaPreview.glb!,
+        docId,
+        changed,
+        false,
+        metaPreview.version ?? null,
+      );
+      return;
+    } catch (e) {
+      // Corrupt inline payload (e.g. bad base64) — fall through to the
+      // fetch path, which rebuilds the GLB server-side.
+      console.warn("[vcad-viewer] inline preview render failed:", e);
+    }
   }
 
   // Fast path 2: the result's change token matches what is already on


### PR DESCRIPTION
## What

Kills the visible "fetching geometry…" wait when the MCP Apps viewer mounts in Claude/Codex.

- **Zero-round-trip first paint**: mount-tool results now carry a ready-to-render base64 GLB in `_meta["vcad.io/preview"]` (`attachInlinePreview` in server.ts). `_meta` is host/app plumbing and never reaches the model, so the lean-results discipline that moved GLBs out of content blocks is preserved. Size-capped at 1.5MB base64 and gated to clients that declared the MCP Apps UI extension — plain agents get byte-identical results.
- **Content-addressed GLB cache** (`previewGlbFor` in tools/preview.ts): built GLBs cached by `previewVersion(doc)` content hash + mode (LRU, 16 entries). Tenant-safe (value is a pure function of document content) and can never serve stale geometry (any edit flips the hash). Shared by `get_preview_glb` and the inline path, so the poll loop's post-mutation refetch is a cache hit.
- **Viewer fast paths** (viewer-app/main.ts): renders the `_meta` preview immediately; skips the fetch entirely when the result's `document_version` matches what's already rendered; falls back to the existing `get_preview_glb` path on hosts that strip `_meta`, for oversized docs, and during instances-mode sim replay (the part-segmented inline GLB would drop FK bind targets).

## Why

The viewer's load path made a second round trip after mount that re-hydrated the session from the durable store and re-ran a **full evaluate + tessellate** — the same work the mutation tool had finished one second earlier. (The 900KB single-file bundle is only ~226KB gzipped and isn't the bottleneck.)

## Verification

- Full suite: 776 passed (6 new tests covering cache hit-without-evaluate, stale-key flip, `_meta` attachment/merge/best-effort).
- E2E against a real stdio server: UI-capable client's `create_cad_loon` result carries the GLB in `_meta` with nothing model-visible; follow-up `get_preview_glb` returned in 0ms (cache hit). Non-UI client results unchanged.
- Rebuilt viewer boots clean in a browser (`#dev` harness), no console errors.

## Reviewer notes

- Cold-start latency (WASM init + first hydration per serverless instance) is unchanged; a follow-up could serve version-keyed GLBs from the durable artifact store.
- `dist-viewer` / `viewer-html.generated.ts` are build outputs regenerated by `npm run build:viewer`; not committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)