### PR TITLE
Fabricate: /authorize/<id> approval page + approve/decline RPCs

### DIFF
--- a/changelog/entries/2026-07-08-authorize-approval-page.json
+++ b/changelog/entries/2026-07-08-authorize-approval-page.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-08-authorize-approval-page",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "feat",
+  "title": "Spend authorization approval page",
+  "summary": "vcad.io/authorize/<id> now lets you approve or decline an agent's proposed fabrication spend — the human side of authorize_spend, with cap, fab allowlist, and expiry shown before you decide.",
+  "features": ["fabricate", "orders"],
+  "mcpTools": ["authorize_spend", "place_order"]
+}

--- a/packages/app/src/components/AuthorizePage.tsx
+++ b/packages/app/src/components/AuthorizePage.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useState } from "react";
+import { getSupabase, useAuth, SignInButton } from "@vcad/auth";
+
+/**
+ * Spend-authorization approval page, rendered at /authorize/<id>.
+ *
+ * The MCP agent proposes a spend (`authorize_spend` → a spend_authorizations
+ * row with status pending_human) and deep-links the human here. This page is
+ * the human side of that handshake — the only place an authorization can be
+ * approved or declined. RLS scopes the read to the signed-in user's own rows;
+ * the approve/decline RPCs (migration 035) re-check ownership, status, and
+ * expiry server-side.
+ *
+ * Mounted standalone from main.tsx (like CliAuth) — it never shares the App
+ * render path.
+ */
+
+interface AuthorizePageProps {
+  authorizationId: string;
+}
+
+interface AuthorizationRow {
+  id: string;
+  kind: "one_time" | "standing";
+  max_amount_minor: number;
+  daily_cap_minor: number | null;
+  process_allowlist: string[] | null;
+  fab_allowlist: string[] | null;
+  status: "pending_human" | "authorized" | "consumed" | "revoked" | "expired";
+  expires_at: string;
+  created_at: string;
+}
+
+interface RpcResult {
+  ok: boolean;
+  status?: string;
+  reason?: string;
+}
+
+/** Minor units (USD cents) → "$12.34". */
+function usd(minor: number): string {
+  return `$${(minor / 100).toFixed(2)}`;
+}
+
+/** Remaining time until an ISO timestamp, e.g. "23h 14m" / "3m 12s". */
+function formatRemaining(expiresAt: string, now: number): string | null {
+  const ms = new Date(expiresAt).getTime() - now;
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  const s = Math.floor(ms / 1000);
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s % 60}s`;
+  return `${s}s`;
+}
+
+type PageState =
+  | { phase: "loading" }
+  | { phase: "not-found" }
+  | { phase: "error"; message: string }
+  | { phase: "loaded"; row: AuthorizationRow; acting: "approve" | "decline" | null };
+
+export function AuthorizePage({ authorizationId }: AuthorizePageProps) {
+  const auth = useAuth();
+  const [state, setState] = useState<PageState>({ phase: "loading" });
+  const [now, setNow] = useState(() => Date.now());
+
+  const loadRow = useCallback(async () => {
+    const supabase = getSupabase();
+    if (!supabase) {
+      setState({ phase: "error", message: "Sync is not configured in this build." });
+      return;
+    }
+    const { data, error } = await supabase
+      .from("spend_authorizations")
+      .select(
+        "id, kind, max_amount_minor, daily_cap_minor, process_allowlist, fab_allowlist, status, expires_at, created_at",
+      )
+      .eq("id", authorizationId)
+      .maybeSingle();
+    if (error) {
+      setState({ phase: "error", message: error.message });
+      return;
+    }
+    if (!data) {
+      // RLS returns nothing for rows the caller doesn't own, so someone
+      // else's id looks identical to a missing one.
+      setState({ phase: "not-found" });
+      return;
+    }
+    setState({ phase: "loaded", row: data as AuthorizationRow, acting: null });
+  }, [authorizationId]);
+
+  // Load once the user has a permanent identity. Anonymous sessions have an
+  // auth.uid(), but authorizations are minted for the signed-in MCP account —
+  // an anon read would always come back empty and mislabel the row not-found.
+  useEffect(() => {
+    if (!auth.initialized || !auth.isAuthenticated) return;
+    void loadRow();
+  }, [auth.initialized, auth.isAuthenticated, loadRow]);
+
+  // Tick the expiry countdown while a pending authorization is on screen.
+  const pending =
+    state.phase === "loaded" && state.row.status === "pending_human";
+  useEffect(() => {
+    if (!pending) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [pending]);
+
+  const act = useCallback(
+    async (action: "approve" | "decline") => {
+      if (state.phase !== "loaded" || state.acting) return;
+      const supabase = getSupabase();
+      if (!supabase) return;
+      setState({ ...state, acting: action });
+      const fn =
+        action === "approve"
+          ? "approve_spend_authorization"
+          : "decline_spend_authorization";
+      const { data, error } = await supabase.rpc(fn, {
+        p_authorization_id: authorizationId,
+      });
+      if (error) {
+        setState({ phase: "error", message: error.message });
+        return;
+      }
+      const result = (data ?? {}) as RpcResult;
+      if (!result.ok && result.reason === "not_found") {
+        setState({ phase: "not-found" });
+        return;
+      }
+      // Success, not_pending, and expired all resolve the same way: re-read
+      // the row — the DB is the truth about where the lifecycle landed.
+      await loadRow();
+    },
+    [state, authorizationId, loadRow],
+  );
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg p-6 font-mono">
+      <div className="w-full max-w-md border border-border bg-surface p-6">
+        <div className="mb-4 flex items-center gap-2">
+          <span className="text-sm font-bold tracking-tighter text-text">
+            vcad<span className="text-brand">.</span>
+          </span>
+          <span className="text-xs text-text-muted">Spend authorization</span>
+        </div>
+
+        {renderBody()}
+      </div>
+    </div>
+  );
+
+  function renderBody() {
+    if (!auth.initialized || auth.loading) {
+      return <p className="text-xs text-text-muted">Loading…</p>;
+    }
+
+    if (!auth.isAuthenticated) {
+      return (
+        <>
+          <p className="mb-3 text-xs text-text">
+            An agent is asking to spend from your vcad wallet. Sign in with the
+            account your agent is connected to, then review and approve or
+            decline the request.
+          </p>
+          <SignInButton className="h-8 w-full border border-border bg-bg px-3 text-xs text-text hover:bg-hover" />
+        </>
+      );
+    }
+
+    switch (state.phase) {
+      case "loading":
+        return <p className="text-xs text-text-muted">Loading authorization…</p>;
+
+      case "not-found":
+        return (
+          <p className="text-xs text-text-muted">
+            Authorization not found. It may belong to a different account —
+            make sure you are signed in as the same user your agent uses.
+          </p>
+        );
+
+      case "error":
+        return (
+          <p className="text-xs text-brand">Error: {state.message}</p>
+        );
+
+      case "loaded":
+        return renderLoaded(state.row, state.acting);
+    }
+  }
+
+  function renderLoaded(
+    row: AuthorizationRow,
+    acting: "approve" | "decline" | null,
+  ) {
+    const remaining = formatRemaining(row.expires_at, now);
+    const expired = row.status === "expired" || (row.status === "pending_human" && !remaining);
+
+    const details = (
+      <dl className="mb-4 space-y-2 text-xs">
+        <div className="flex justify-between gap-4">
+          <dt className="text-text-muted">Spending cap</dt>
+          <dd className="text-text font-bold">{usd(row.max_amount_minor)}</dd>
+        </div>
+        {row.daily_cap_minor != null && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-text-muted">Daily cap</dt>
+            <dd className="text-text">{usd(row.daily_cap_minor)}</dd>
+          </div>
+        )}
+        <div className="flex justify-between gap-4">
+          <dt className="text-text-muted">Kind</dt>
+          <dd className="text-text">
+            {row.kind === "one_time" ? "One order" : "Standing budget"}
+          </dd>
+        </div>
+        {row.fab_allowlist && row.fab_allowlist.length > 0 && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-text-muted">Manufacturers</dt>
+            <dd className="text-text text-right">{row.fab_allowlist.join(", ")}</dd>
+          </div>
+        )}
+        {row.process_allowlist && row.process_allowlist.length > 0 && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-text-muted">Processes</dt>
+            <dd className="text-text text-right">{row.process_allowlist.join(", ")}</dd>
+          </div>
+        )}
+        {row.status === "pending_human" && remaining && (
+          <div className="flex justify-between gap-4">
+            <dt className="text-text-muted">Expires in</dt>
+            <dd className="text-text">{remaining}</dd>
+          </div>
+        )}
+      </dl>
+    );
+
+    if (row.status === "pending_human" && !expired) {
+      return (
+        <>
+          <p className="mb-3 text-xs text-text">
+            An agent wants to place a fabrication order on your behalf. It can
+            spend at most the cap below, and only after you approve.
+          </p>
+          {details}
+          <div className="flex gap-2">
+            <button
+              onClick={() => void act("approve")}
+              disabled={acting !== null}
+              className="h-8 flex-1 border border-brand bg-brand px-3 text-xs font-bold text-white hover:bg-brand-hover disabled:opacity-50"
+            >
+              {acting === "approve" ? "Approving…" : `Approve ${usd(row.max_amount_minor)}`}
+            </button>
+            <button
+              onClick={() => void act("decline")}
+              disabled={acting !== null}
+              className="h-8 flex-1 border border-border bg-bg px-3 text-xs text-text hover:bg-hover disabled:opacity-50"
+            >
+              {acting === "decline" ? "Declining…" : "Decline"}
+            </button>
+          </div>
+          <p className="mt-3 text-[10px] text-text-muted">
+            Funds only move when the order is placed, and never more than the
+            cap. You can revoke an approved authorization before it is used.
+          </p>
+        </>
+      );
+    }
+
+    if (expired) {
+      return (
+        <>
+          {details}
+          <p className="text-xs text-text">
+            This authorization expired before it was approved. Nothing was
+            charged. Ask the agent to propose the spend again if you still
+            want the order.
+          </p>
+        </>
+      );
+    }
+
+    switch (row.status) {
+      case "authorized":
+        return (
+          <>
+            {details}
+            <p className="text-xs text-text">
+              Approved. The agent can now place the order — up to the cap
+              above, nothing more. You can close this tab.
+            </p>
+          </>
+        );
+      case "consumed":
+        return (
+          <>
+            {details}
+            <p className="text-xs text-text">
+              This authorization has already been used — the order was placed.
+              You can close this tab.
+            </p>
+          </>
+        );
+      case "revoked":
+        return (
+          <>
+            {details}
+            <p className="text-xs text-text">
+              Declined. The authorization was revoked and the agent cannot
+              charge against it. You can close this tab.
+            </p>
+          </>
+        );
+      default:
+        return <p className="text-xs text-text-muted">Status: {row.status}</p>;
+    }
+  }
+}

--- a/packages/app/src/lib/authorize-route.ts
+++ b/packages/app/src/lib/authorize-route.ts
@@ -1,0 +1,27 @@
+/**
+ * /authorize/<authorization_id> — spend-authorization approval deep link.
+ *
+ * The MCP `authorize_spend` tool proposes a spend (status pending_human) and
+ * points the human at `https://vcad.io/authorize/<id>`. Like `/cli-auth`,
+ * this page is mounted from `main.tsx` by pathname match — it never shares
+ * the App render path, so it can't break the normal editor load.
+ */
+
+const AUTHORIZE_ROUTE_RE =
+  /^\/authorize\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\/?$/;
+
+/**
+ * Parse an /authorize/<uuid> pathname into the authorization id.
+ * Returns null for anything else (including malformed ids — the page only
+ * ever queries by uuid, so non-uuid paths fall through to the editor).
+ */
+export function parseAuthorizeRoute(pathname: string): string | null {
+  const match = pathname.match(AUTHORIZE_ROUTE_RE);
+  return match?.[1] ?? null;
+}
+
+/** Authorization id from the current URL, or null when not on /authorize/. */
+export function getAuthorizeRouteId(): string | null {
+  if (typeof window === "undefined") return null;
+  return parseAuthorizeRoute(window.location.pathname);
+}

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -24,6 +24,8 @@ import {
 } from "@vcad/auth";
 import { App } from "./App";
 import { CliAuth } from "./components/CliAuth";
+import { AuthorizePage } from "./components/AuthorizePage";
+import { getAuthorizeRouteId } from "./lib/authorize-route";
 import "./index.css";
 import {
   getAllDocuments,
@@ -124,10 +126,21 @@ function onSignInGated(): void {
 // normal load path since App never runs in this branch.
 const isCliAuth = window.location.pathname === "/cli-auth";
 
+// Route: `/authorize/<id>` is the spend-authorization approval page the MCP
+// `authorize_spend` elicitation deep-links to. Same standalone pattern as
+// /cli-auth — App never runs in this branch.
+const authorizeId = getAuthorizeRouteId();
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AuthProvider onSignIn={onSignInGated}>
-      {isCliAuth ? <CliAuth /> : <App />}
+      {isCliAuth ? (
+        <CliAuth />
+      ) : authorizeId ? (
+        <AuthorizePage authorizationId={authorizeId} />
+      ) : (
+        <App />
+      )}
     </AuthProvider>
   </StrictMode>,
 );

--- a/packages/app/src/test/authorize-route.test.ts
+++ b/packages/app/src/test/authorize-route.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { parseAuthorizeRoute } from "../lib/authorize-route";
+
+const ID = "6f9619ff-8b86-d011-b42d-00c04fc964ff";
+
+describe("parseAuthorizeRoute", () => {
+  it("extracts the authorization id from /authorize/<uuid>", () => {
+    expect(parseAuthorizeRoute(`/authorize/${ID}`)).toBe(ID);
+  });
+
+  it("tolerates a trailing slash", () => {
+    expect(parseAuthorizeRoute(`/authorize/${ID}/`)).toBe(ID);
+  });
+
+  it("accepts uppercase hex (uuids are case-insensitive)", () => {
+    expect(parseAuthorizeRoute(`/authorize/${ID.toUpperCase()}`)).toBe(
+      ID.toUpperCase(),
+    );
+  });
+
+  it("rejects non-uuid ids so they fall through to the editor", () => {
+    expect(parseAuthorizeRoute("/authorize/not-a-uuid")).toBeNull();
+    expect(parseAuthorizeRoute("/authorize/")).toBeNull();
+    expect(parseAuthorizeRoute("/authorize")).toBeNull();
+    // sql-ish / traversal-ish junk never reaches the page
+    expect(parseAuthorizeRoute(`/authorize/${ID}%20or%201=1`)).toBeNull();
+    expect(parseAuthorizeRoute(`/authorize/../${ID}`)).toBeNull();
+  });
+
+  it("ignores unrelated routes", () => {
+    expect(parseAuthorizeRoute("/")).toBeNull();
+    expect(parseAuthorizeRoute("/cli-auth")).toBeNull();
+    expect(parseAuthorizeRoute(`/view/${ID}`)).toBeNull();
+    expect(parseAuthorizeRoute(`/authorized/${ID}`)).toBeNull();
+    expect(parseAuthorizeRoute(`/x/authorize/${ID}`)).toBeNull();
+  });
+});

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -8,6 +8,7 @@
     { "source": "/~(.*)", "destination": "/" },
     { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },
+    { "source": "/authorize/(.*)", "destination": "/" },
     { "source": "/@:path*", "destination": "/" },
     { "source": "/(privacy|terms|security)", "destination": "/" }
   ],

--- a/supabase/migrations/035_approve_spend_authorization.sql
+++ b/supabase/migrations/035_approve_spend_authorization.sql
@@ -1,0 +1,123 @@
+-- vcad Fabricate — human approval write-path for spend authorizations.
+--
+-- Migration 027 minted the authorization lifecycle (pending_human → authorized
+-- → consumed/revoked/expired) but left users READ-ONLY on their own rows: RLS
+-- grants SELECT, and every write ran through service-role-only RPCs. The agent
+-- can PROPOSE a spend (authorize_spend → status pending_human) and deep-link
+-- the human to vcad.io/authorize/<id>, but there was no way for the human to
+-- actually flip the row. These two functions are that missing write-path.
+--
+-- Guardrails:
+--   1. These are the HUMAN's own actions, so unlike the money RPCs they are
+--      granted to `authenticated` — but only under RLS-equivalent guards
+--      enforced INSIDE the function: auth.uid() must be non-null and equal to
+--      the row's user_id, and the only legal transition is FROM pending_human.
+--      A caller can never approve someone else's authorization, re-approve a
+--      consumed one, or resurrect a revoked/expired one.
+--   2. Not-owner is deliberately indistinguishable from not-found — the
+--      response never confirms that a foreign authorization id exists.
+--   3. No wallet/ledger touches. Money still moves ONLY through debit_wallet()
+--      (service-role, migration 027), which independently re-checks status,
+--      expiry, ownership, caps, and allowlists at consume time. Approving here
+--      unlocks at most ONE bounded, already-proposed spend.
+--   4. The row is locked (FOR UPDATE) before the status check, so a concurrent
+--      approve/decline race resolves to exactly one winner; the loser gets
+--      {ok:false, reason:'not_pending'}.
+--
+-- Returns jsonb, never raises for guarded failures:
+--   { ok:true,  status }            on success
+--   { ok:false, reason, status? }   reasons: not_found | not_pending | expired
+
+-- ─── approve_spend_authorization() — pending_human → authorized ──────────────
+create or replace function approve_spend_authorization(p_authorization_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_authz spend_authorizations%rowtype;
+begin
+  -- Unauthenticated (no JWT uid) folds into not_found: the caller learns
+  -- nothing about whether the id exists.
+  if v_uid is null then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+
+  -- Ownership is part of the lookup, so a foreign id is indistinguishable
+  -- from a missing one. Lock the row to serialize concurrent decisions.
+  select * into v_authz
+    from spend_authorizations
+    where id = p_authorization_id and user_id = v_uid
+    for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+
+  if v_authz.status <> 'pending_human' then
+    return jsonb_build_object('ok', false, 'reason', 'not_pending',
+                              'status', v_authz.status);
+  end if;
+
+  if v_authz.expires_at <= now() then
+    return jsonb_build_object('ok', false, 'reason', 'expired');
+  end if;
+
+  update spend_authorizations
+    set status = 'authorized', approved_by = v_uid, approved_at = now()
+    where id = v_authz.id;
+
+  return jsonb_build_object('ok', true, 'status', 'authorized');
+end;
+$$;
+
+-- ─── decline_spend_authorization() — pending_human → revoked ─────────────────
+create or replace function decline_spend_authorization(p_authorization_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid := auth.uid();
+  v_authz spend_authorizations%rowtype;
+begin
+  if v_uid is null then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+
+  select * into v_authz
+    from spend_authorizations
+    where id = p_authorization_id and user_id = v_uid
+    for update;
+  if not found then
+    return jsonb_build_object('ok', false, 'reason', 'not_found');
+  end if;
+
+  if v_authz.status <> 'pending_human' then
+    return jsonb_build_object('ok', false, 'reason', 'not_pending',
+                              'status', v_authz.status);
+  end if;
+
+  if v_authz.expires_at <= now() then
+    return jsonb_build_object('ok', false, 'reason', 'expired');
+  end if;
+
+  update spend_authorizations
+    set status = 'revoked', revoked_at = now()
+    where id = v_authz.id;
+
+  return jsonb_build_object('ok', true, 'status', 'revoked');
+end;
+$$;
+
+-- ─── grants — the human's own action, under the in-function guards ───────────
+-- authenticated only: anon (pre-session) callers have no uid to own a row, and
+-- the service role already has its own authorization write-paths. This does
+-- NOT weaken the migration-027 money plane — debit_wallet remains service-role
+-- only and re-verifies everything at consume time.
+revoke all on function approve_spend_authorization(uuid) from public;
+revoke all on function decline_spend_authorization(uuid) from public;
+grant execute on function approve_spend_authorization(uuid) to authenticated;
+grant execute on function decline_spend_authorization(uuid) to authenticated;

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,7 @@
     { "source": "/~(.*)", "destination": "/" },
     { "source": "/d/(.*)", "destination": "/" },
     { "source": "/view/(.*)", "destination": "/" },
+    { "source": "/authorize/(.*)", "destination": "/" },
     { "source": "/@:path*", "destination": "/" },
     { "source": "/(privacy|terms|security)", "destination": "/" }
   ],


### PR DESCRIPTION
## What

The landing page for the L2 elicitation lane — and the first real approval write-path for Fabricate spend.

PR #511's `authorize_spend` flow deep-links the human to `https://vcad.io/authorize/<authorization_id>`, but that URL 404'd and nothing anywhere could flip a `spend_authorizations` row: migration 027 deliberately left users read-only, with every write behind service-role-only RPCs. The agent could propose a spend; the human had no way to answer.

### Migration `035_approve_spend_authorization.sql`

- `approve_spend_authorization(p_authorization_id uuid) returns jsonb` — pending_human + unexpired + owned by `auth.uid()` → `authorized`, stamps `approved_by`/`approved_at`
- `decline_spend_authorization(p_authorization_id uuid) returns jsonb` — same guards → `revoked`, stamps `revoked_at`
- Returns `{ok:true, status}` or `{ok:false, reason}` with reasons `not_found` (not-owner and unauthenticated fold in — foreign ids are indistinguishable from missing), `not_pending` (with current status), `expired`
- `GRANT EXECUTE ... TO authenticated` only — this is the human's own action under RLS-equivalent guards inside the function (ownership check + pending-only transition + `FOR UPDATE` row lock so a concurrent approve/decline race has exactly one winner)
- No wallet/ledger touches. `debit_wallet` (027) remains service-role only and independently re-verifies status, expiry, ownership, caps, and allowlists at consume time — approving here unlocks at most one bounded, already-proposed spend

Verified behaviorally on an ephemeral Postgres (stubbed `auth` schema + settable uid, 027 applied first): happy paths, unauth, foreign-owner, re-approve, re-decline, expired (row untouched), consumed, unknown-id, and grant checks (`authenticated` yes, `anon` no) all pass. CI's "Verify migrations" job re-applies the chain against a real Supabase stack.

### App `/authorize/:id`

- `AuthorizePage` mounted standalone from `main.tsx` by pathname match — the same zero-risk pattern as `/cli-auth`, so the editor load path is untouched
- Requires a permanent identity (Supabase anon sessions have an `auth.uid()` but would RLS-read nothing and mislabel the row as not-found); signed-out visitors get the app's standard sign-in flow, and the OAuth popup returns them to the same URL
- Loads the row through the user's own Supabase client (RLS read), shows the spending cap (from `max_amount_minor`), fab/process allowlists, kind, and a live expiry countdown
- Approve / Decline call the new RPCs, then re-read the row — the DB is the truth about where the lifecycle landed, never the RPC echo. Already-actioned states (authorized / consumed / revoked / expired) and not-found each get explicit copy
- Root-caused the 404: neither `vercel.json` had a rewrite for `/authorize/*` — added to both deploy configs
- UUID-strict route parser (`lib/authorize-route.ts`) with vitest coverage; junk ids fall through to the editor

### Verification

- Ephemeral-Postgres behavioral suite for 035 (above)
- `VCAD_WASM_SKIP=1 npm run build --workspaces --if-present` clean; `npm run build -w @vcad/app` clean
- App tests green: 8 files, 55 tests (5 new)
- Rendered end-to-end in headless Chrome against the dev server: `/authorize/<uuid>` shows the approval card (sign-in gate when signed out), non-uuid paths fall through to the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)