### PR TITLE
fix(mcp): inline _meta preview on stateless HTTP (hosted deployment)

### DIFF
--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -105,7 +105,10 @@ async function handleMcpRequest(
 ): Promise<void> {
   const eng = await getEngine();
   const user = verifyAccessToken(req);
-  const server = await createServer(eng, { user });
+  // assumeUiClient: this stateless path builds a fresh Server per request,
+  // so the UI-extension capability from `initialize` is never visible here —
+  // attach the inline `_meta` preview unconditionally (see ServerContext).
+  const server = await createServer(eng, { user, assumeUiClient: true });
 
   const transport = new StreamableHTTPServerTransport({
     // Stateless: no session tracking

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -51,6 +51,16 @@ import type { AuthUser } from "./oauth.js";
  *  otherwise null (stdio, anonymous HTTP, or OAuth disabled). */
 export interface ServerContext {
   user: AuthUser | null;
+  /** Stateless HTTP handles each request on a fresh Server, so the client
+   *  capabilities declared at `initialize` (including the MCP Apps UI
+   *  extension) are gone by the time `tools/call` arrives — the caps-based
+   *  gate can never fire. Set this to have mount results carry the inline
+   *  `_meta` preview anyway: `_meta` is host plumbing, never model-visible,
+   *  and clients without a viewer ignore it per spec, so over-attaching
+   *  costs only wire bytes while under-attaching costs the viewer its
+   *  zero-round-trip first paint. Leave unset for stateful transports
+   *  (stdio), where the real capability check works. */
+  assumeUiClient?: boolean;
 }
 import {
   registryToolDescriptors,
@@ -1320,7 +1330,10 @@ export async function createServer(
           // the content-addressed GLB cache for the poll loop. Best-effort
           // and size-capped; hosts that strip `_meta` (and oversized docs)
           // fall back to the fetch path unchanged.
-          if (def.behavior.mount && clientHasInlineUi()) {
+          if (
+            def.behavior.mount &&
+            (clientHasInlineUi() || context.assumeUiClient === true)
+          ) {
             await attachInlinePreview(result, docId, engine);
           }
         }

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -184,7 +184,10 @@ export default async function handler(
   // MCP endpoint — parse body for POST, then delegate to transport
   try {
     const engine = await getEngine();
-    const server = await createServer(engine, { user });
+    // assumeUiClient: stateless per-request Server — the UI-extension
+    // capability from `initialize` never reaches tools/call, so attach the
+    // inline `_meta` preview unconditionally (see ServerContext in @vcad/mcp).
+    const server = await createServer(engine, { user, assumeUiClient: true });
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
       enableJsonResponse: true, // return JSON instead of SSE — Vercel buffers responses and adds Content-Length which breaks SSE streaming


### PR DESCRIPTION
## What

Follow-up to #515. The hosted deployment (mcp.vcad.io) is stateless — a fresh `Server` per request — so the MCP Apps UI capability from `initialize` is never visible at `tools/call` time and `clientHasInlineUi()` always returned false there. The zero-round-trip first paint only worked over stdio.

Adds `ServerContext.assumeUiClient`, set by both stateless HTTP entrypoints (`packages/mcp/src/http.ts` and `services/mcp/entry.ts`), gating only the `_meta` preview attach — the model-visible slimming gate is untouched.

## Why it's safe to over-attach

`_meta` is host/app plumbing: never model-visible, and clients without a viewer ignore unknown `_meta` per spec. Cost is wire bytes on mount-tool results only (size-capped at 1.5MB base64); benefit is the viewer paints instantly on the deployment users actually hit.

## Verification

- Verified prod today: `create_cad_loon` on mcp.vcad.io (build 550ad57) returned no inline preview — confirming the gap.
- Local stateless HTTP server (same code path): inline preview attaches (`hasInlinePreview: true`), nothing model-visible, cached `get_preview_glb` ~2ms.
- `tsc --noEmit` clean, all 776 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)