### PR TITLE
Inline render assets in MCP tool results

### DIFF
--- a/changelog/entries/2026-07-08-render-assets-inline.json
+++ b/changelog/entries/2026-07-08-render-assets-inline.json
@@ -4,7 +4,7 @@
   "date": "2026-07-08",
   "category": "feat",
   "title": "Render tools return transcript-ready image artifacts",
-  "summary": "PNG render tools now keep their visible MCP image blocks and also store each render in the artifact channel, returning asset metadata plus suggested Markdown so clients and agents can inline molecule, CAD, and PCB renders in final responses instead of burying them in tool traces.",
+  "summary": "PNG render tools now keep their MCP image blocks, store renders as artifacts, and return asset metadata plus suggested Markdown for inline final-answer galleries.",
   "features": ["mcp", "artifacts", "rendering", "atoms", "ecad"],
   "mcpTools": [
     "render_view",

--- a/changelog/entries/2026-07-08-render-assets-inline.json
+++ b/changelog/entries/2026-07-08-render-assets-inline.json
@@ -1,0 +1,16 @@
+{
+  "id": "2026-07-08-render-assets-inline",
+  "version": "0.9.4",
+  "date": "2026-07-08",
+  "category": "feat",
+  "title": "Render tools return transcript-ready image artifacts",
+  "summary": "PNG render tools now keep their visible MCP image blocks and also store each render in the artifact channel, returning asset metadata plus suggested Markdown so clients and agents can inline molecule, CAD, and PCB renders in final responses instead of burying them in tool traces.",
+  "features": ["mcp", "artifacts", "rendering", "atoms", "ecad"],
+  "mcpTools": [
+    "render_view",
+    "render_molecule",
+    "render_pcb",
+    "render_ratsnest",
+    "render_stackup"
+  ]
+}

--- a/packages/mcp/src/__tests__/atoms-render.test.ts
+++ b/packages/mcp/src/__tests__/atoms-render.test.ts
@@ -47,7 +47,19 @@ describe("render_molecule", () => {
         type: "text";
         text: string;
       };
-      expect(JSON.parse(meta.text).format).toBe("png");
+      const parsedMeta = JSON.parse(meta.text);
+      expect(parsedMeta.format).toBe("png");
+      expect(parsedMeta.asset.url).toMatch(/\/artifacts\/art_[^/]+\/.+\.png$/);
+      expect(parsedMeta.suggested_final_markdown).toBe(parsedMeta.asset.markdown);
+      const asset = out.structuredContent?.assets as
+        | Array<{ url?: string; mimeType?: string; markdown?: string; height?: number }>
+        | undefined;
+      expect(asset?.[0]?.url).toMatch(/\/artifacts\/art_[^/]+\/.+\.png$/);
+      expect(asset?.[0]?.mimeType).toBe("image/png");
+      expect(asset?.[0]?.height).toBe(320);
+      expect(out.structuredContent?.suggestedFinalMarkdown).toEqual([
+        asset![0]!.markdown,
+      ]);
     } else {
       // Fallback path: raw SVG text with an honest note about why.
       const meta = out.content[0] as { type: "text"; text: string };

--- a/packages/mcp/src/__tests__/render-verify.test.ts
+++ b/packages/mcp/src/__tests__/render-verify.test.ts
@@ -100,7 +100,20 @@ describe("render_view", () => {
       | { type: "text"; text: string }
       | undefined;
     expect(meta).toBeDefined();
-    expect(JSON.parse(meta!.text).view).toBe("isometric");
+    const parsedMeta = JSON.parse(meta!.text);
+    expect(parsedMeta.view).toBe("isometric");
+    expect(parsedMeta.asset.url).toMatch(/\/artifacts\/art_[^/]+\/.+\.png$/);
+    expect(parsedMeta.suggested_final_markdown).toBe(parsedMeta.asset.markdown);
+
+    const asset = out.structuredContent?.assets as
+      | Array<{ url?: string; mimeType?: string; markdown?: string; promoteToTranscript?: boolean }>
+      | undefined;
+    expect(asset?.[0]?.url).toMatch(/\/artifacts\/art_[^/]+\/.+\.png$/);
+    expect(asset?.[0]?.mimeType).toBe("image/png");
+    expect(asset?.[0]?.promoteToTranscript).toBe(true);
+    expect(out.structuredContent?.suggestedFinalMarkdown).toEqual([
+      asset![0]!.markdown,
+    ]);
   });
 
   it("renders an inline document with no resident session", async () => {

--- a/packages/mcp/src/tools/artifact-store.ts
+++ b/packages/mcp/src/tools/artifact-store.ts
@@ -157,6 +157,12 @@ function guessContentType(name: string): string {
       return "text/plain";
     case "zip":
       return "application/zip";
+    case "png":
+      return "image/png";
+    case "svg":
+      return "image/svg+xml";
+    case "gif":
+      return "image/gif";
     default:
       return "application/octet-stream";
   }

--- a/packages/mcp/src/tools/atoms.ts
+++ b/packages/mcp/src/tools/atoms.ts
@@ -20,6 +20,11 @@ import {
   type MdConfig,
 } from "@vcad/engine";
 import { rasterize } from "./render.js";
+import {
+  makePngRenderAsset,
+  renderAssetSummary,
+  withRenderAssets,
+} from "./render-assets.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import { okPretty as ok, toolResult, type ToolResult } from "./tool-result.js";
 
@@ -31,6 +36,7 @@ type ImageToolResult = {
     | { type: "image"; data: string; mimeType: string }
   >;
   isError?: boolean;
+  structuredContent?: Record<string, unknown>;
 };
 
 function fail(e: unknown): ToolResult {
@@ -497,20 +503,30 @@ export async function renderMolecule(input: unknown): Promise<ImageToolResult> {
     // render_view); degrade to raw SVG text when @resvg/resvg-js is absent.
     const raster = await rasterize(svg, W, "#0d1117");
     if (raster.png) {
-      return {
+      const representation = spaceFilling ? "space_filling" : "ball_and_stick";
+      const asset = makePngRenderAsset(raster.png, {
+        tool: "render_molecule",
+        filename: `molecule-${representation}-${mol.positions.length}-atoms-${W}.png`,
+        width: W,
+        height: W,
+        alt: `${representation.replace(/_/g, " ")} molecule render with ${mol.positions.length} atoms`,
+      });
+      return withRenderAssets({
         content: [
           { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
           {
             type: "text",
             text: JSON.stringify({
               width_px: W,
-              representation: spaceFilling ? "space_filling" : "ball_and_stick",
+              representation,
               atoms: mol.positions.length,
               format: "png",
+              asset: renderAssetSummary(asset),
+              suggested_final_markdown: asset.markdown,
             }),
           },
         ],
-      };
+      }, [asset]);
     }
     const note =
       raster.reason === "module-missing"

--- a/packages/mcp/src/tools/atoms.ts
+++ b/packages/mcp/src/tools/atoms.ts
@@ -511,7 +511,7 @@ export async function renderMolecule(input: unknown): Promise<ImageToolResult> {
         height: W,
         alt: `${representation.replace(/_/g, " ")} molecule render with ${mol.positions.length} atoms`,
       });
-      return withRenderAssets({
+      return withRenderAssets<ImageToolResult>({
         content: [
           { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
           {

--- a/packages/mcp/src/tools/render-assets.ts
+++ b/packages/mcp/src/tools/render-assets.ts
@@ -63,10 +63,14 @@ export function makePngRenderAsset(
   };
 }
 
-export function withRenderAssets<T extends { structuredContent?: Record<string, unknown> }>(
-  result: T,
+type RenderAssetCarrier<T extends object> = T & {
+  structuredContent?: Record<string, unknown>;
+};
+
+export function withRenderAssets<T extends object>(
+  result: RenderAssetCarrier<T>,
   assets: RenderAsset[],
-): T {
+): RenderAssetCarrier<T> {
   if (assets.length === 0) return result;
   const existing = result.structuredContent ?? {};
   const prevAssets = Array.isArray(existing.assets) ? existing.assets : [];

--- a/packages/mcp/src/tools/render-assets.ts
+++ b/packages/mcp/src/tools/render-assets.ts
@@ -1,0 +1,118 @@
+import { artifactFileUrl, storeArtifact, type ArtifactHandle } from "./artifact-store.js";
+
+export interface RenderAsset {
+  id: string;
+  artifact_id: string;
+  artifact_url: string;
+  url: string;
+  uri: string;
+  name: string;
+  mimeType: string;
+  bytes: number;
+  width: number;
+  height?: number;
+  alt: string;
+  role: string;
+  display: "inline";
+  promoteToTranscript: boolean;
+  markdown: string;
+  manifest: ArtifactHandle["manifest"];
+}
+
+export interface RenderAssetOptions {
+  tool: string;
+  filename: string;
+  width: number;
+  height?: number;
+  alt: string;
+  role?: string;
+}
+
+export function makePngRenderAsset(
+  png: Buffer,
+  opts: RenderAssetOptions,
+): RenderAsset {
+  const name = sanitizeFilename(opts.filename);
+  const handle = storeArtifact([
+    {
+      name,
+      content: png,
+      contentType: "image/png",
+    },
+  ]);
+  const url = artifactFileUrl(handle.artifact_id, name);
+  const id = `${opts.tool}:${handle.artifact_id}:${name}`;
+  const markdown = `![${escapeMarkdownAlt(opts.alt)}](${url})`;
+  return {
+    id,
+    artifact_id: handle.artifact_id,
+    artifact_url: handle.artifact_url,
+    url,
+    uri: `mcp://vcad/artifacts/${handle.artifact_id}/${encodeURIComponent(name)}`,
+    name,
+    mimeType: "image/png",
+    bytes: png.length,
+    width: opts.width,
+    ...(opts.height ? { height: opts.height } : {}),
+    alt: opts.alt,
+    role: opts.role ?? "primary_output",
+    display: "inline",
+    promoteToTranscript: true,
+    markdown,
+    manifest: handle.manifest,
+  };
+}
+
+export function withRenderAssets<T extends { structuredContent?: Record<string, unknown> }>(
+  result: T,
+  assets: RenderAsset[],
+): T {
+  if (assets.length === 0) return result;
+  const existing = result.structuredContent ?? {};
+  const prevAssets = Array.isArray(existing.assets) ? existing.assets : [];
+  const prevMarkdown = Array.isArray(existing.suggestedFinalMarkdown)
+    ? existing.suggestedFinalMarkdown
+    : [];
+  result.structuredContent = {
+    ...existing,
+    assets: [...prevAssets, ...assets],
+    suggestedFinalMarkdown: [
+      ...prevMarkdown,
+      ...assets.map((a) => a.markdown),
+    ],
+  };
+  return result;
+}
+
+export function renderAssetSummary(asset: RenderAsset): Record<string, unknown> {
+  return {
+    id: asset.id,
+    artifact_id: asset.artifact_id,
+    artifact_url: asset.artifact_url,
+    url: asset.url,
+    uri: asset.uri,
+    name: asset.name,
+    mimeType: asset.mimeType,
+    bytes: asset.bytes,
+    width: asset.width,
+    ...(asset.height ? { height: asset.height } : {}),
+    alt: asset.alt,
+    role: asset.role,
+    display: asset.display,
+    promoteToTranscript: asset.promoteToTranscript,
+    markdown: asset.markdown,
+  };
+}
+
+function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .trim()
+    .replace(/[/\\]/g, "-")
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned || "render.png";
+}
+
+function escapeMarkdownAlt(text: string): string {
+  return text.replace(/[\[\]]/g, "");
+}

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -20,6 +20,11 @@ import { getSession, resolveDocInput } from "./session.js";
 import { validatePcb, pcbValidationError } from "./pcb-validate.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import type { ToolResult } from "./tool-result.js";
+import {
+  makePngRenderAsset,
+  renderAssetSummary,
+  withRenderAssets,
+} from "./render-assets.js";
 
 export const renderViewSchema = {
   type: "object" as const,
@@ -55,6 +60,7 @@ type ContentBlock =
 interface RenderViewResult {
   content: ContentBlock[];
   isError?: boolean;
+  structuredContent?: Record<string, unknown>;
 }
 
 /** px-per-mm passed to the kernel renderer; the raster step handles
@@ -239,7 +245,13 @@ export async function renderView(
 
   const raster = await rasterize(svg, widthPx);
   if (raster.png) {
-    return {
+    const asset = makePngRenderAsset(raster.png, {
+      tool: "render_view",
+      filename: `${documentId || "inline"}-${viewLabel}-${widthPx}.png`,
+      width: widthPx,
+      alt: `vcad ${viewLabel} render`,
+    });
+    return withRenderAssets({
       content: [
         {
           type: "image",
@@ -253,10 +265,12 @@ export async function renderView(
             view: viewLabel,
             width_px: widthPx,
             format: "png",
+            asset: renderAssetSummary(asset),
+            suggested_final_markdown: asset.markdown,
           }),
         },
       ],
-    };
+    }, [asset]);
   }
 
   // Rasterizer unavailable or failed — degrade to raw SVG text (size
@@ -454,7 +468,13 @@ export async function renderPcb(
 
   const raster = await rasterize(svg, widthPx, theme === "light" ? "white" : "#0E1014");
   if (raster.png) {
-    return {
+    const asset = makePngRenderAsset(raster.png, {
+      tool: "render_pcb",
+      filename: `${documentId || "board"}-${layers.join("-")}-${widthPx}.png`,
+      width: widthPx,
+      alt: `PCB render of ${layers.join(", ")}`,
+    });
+    return withRenderAssets({
       content: [
         { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
         {
@@ -465,10 +485,12 @@ export async function renderPcb(
             width_px: widthPx,
             theme,
             format: "png",
+            asset: renderAssetSummary(asset),
+            suggested_final_markdown: asset.markdown,
           }),
         },
       ],
-    };
+    }, [asset]);
   }
 
   const note =
@@ -677,12 +699,26 @@ export async function renderRatsnest(
 
   const raster = await rasterize(svg, widthPx);
   if (raster.png) {
-    return {
+    const asset = makePngRenderAsset(raster.png, {
+      tool: "render_ratsnest",
+      filename: `${documentId || "board"}-ratsnest-${widthPx}.png`,
+      width: widthPx,
+      alt: `PCB ratsnest render with ${lines.length} airwires`,
+    });
+    return withRenderAssets({
       content: [
         { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
-        { type: "text", text: JSON.stringify({ ...meta, format: "png" }) },
+        {
+          type: "text",
+          text: JSON.stringify({
+            ...meta,
+            format: "png",
+            asset: renderAssetSummary(asset),
+            suggested_final_markdown: asset.markdown,
+          }),
+        },
       ],
-    };
+    }, [asset]);
   }
   const note =
     raster.reason === "module-missing"
@@ -798,6 +834,7 @@ export async function renderStackup(
   const pcbJson = JSON.stringify(pcb);
   const content: ContentBlock[] = [];
   const index: Array<{ layer: string; image_index: number }> = [];
+  const assets: ReturnType<typeof makePngRenderAsset>[] = [];
   let resvgMissing = false;
   for (const layer of copper) {
     let svg: string;
@@ -817,6 +854,15 @@ export async function renderStackup(
         data: raster.png.toString("base64"),
         mimeType: "image/png",
       });
+      assets.push(
+        makePngRenderAsset(raster.png, {
+          tool: "render_stackup",
+          filename: `${documentId || "board"}-${layer}-${widthPx}.png`,
+          width: widthPx,
+          alt: `PCB ${layer} layer render`,
+          role: "layer_render",
+        }),
+      );
     } else if (raster.reason === "module-missing") {
       resvgMissing = true;
       break;
@@ -849,9 +895,11 @@ export async function renderStackup(
       width_px: widthPx,
       format: "png",
       layers: index,
+      assets: assets.map(renderAssetSummary),
+      suggested_final_markdown: assets.map((a) => a.markdown),
     }),
   });
-  return { content };
+  return withRenderAssets({ content }, assets);
 }
 
 export const toolDefs: ToolDef[] = [

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -251,7 +251,7 @@ export async function renderView(
       width: widthPx,
       alt: `vcad ${viewLabel} render`,
     });
-    return withRenderAssets({
+    return withRenderAssets<RenderViewResult>({
       content: [
         {
           type: "image",
@@ -474,7 +474,7 @@ export async function renderPcb(
       width: widthPx,
       alt: `PCB render of ${layers.join(", ")}`,
     });
-    return withRenderAssets({
+    return withRenderAssets<RenderViewResult>({
       content: [
         { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
         {
@@ -705,7 +705,7 @@ export async function renderRatsnest(
       width: widthPx,
       alt: `PCB ratsnest render with ${lines.length} airwires`,
     });
-    return withRenderAssets({
+    return withRenderAssets<RenderViewResult>({
       content: [
         { type: "image", data: raster.png.toString("base64"), mimeType: "image/png" },
         {
@@ -899,7 +899,7 @@ export async function renderStackup(
       suggested_final_markdown: assets.map((a) => a.markdown),
     }),
   });
-  return withRenderAssets({ content }, assets);
+  return withRenderAssets<RenderViewResult>({ content }, assets);
 }
 
 export const toolDefs: ToolDef[] = [


### PR DESCRIPTION
## Summary
- Add render asset creation for PNG outputs from `render_view`, `render_molecule`, `render_pcb`, `render_ratsnest`, and `render_stackup`.
- Preserve the existing visible image blocks while also returning artifact metadata and suggested Markdown via structured content.
- Extend artifact MIME type detection for `png`, `svg`, and `gif`.
- Add coverage for the new asset metadata and transcript-ready Markdown fields.

## Testing
- Added/updated unit tests for render tool outputs to validate artifact URLs, MIME types, promotion flags, and suggested Markdown.
- Not run (not requested)