### PR TITLE
fix(shell): cavity wound outward — hollow parts reported outer + cavity volume

### DIFF
--- a/changelog/entries/2026-07-09-shell-cavity-volume.json
+++ b/changelog/entries/2026-07-09-shell-cavity-volume.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-09-shell-cavity-volume",
+  "version": "0.9.4",
+  "date": "2026-07-09",
+  "category": "fix",
+  "title": "Shelled solids no longer report cavity as solid volume",
+  "summary": "shell() wound the inner cavity outward, so volume/mass of hollow parts reported outer + cavity — a thinner wall showed a heavier part. Volume, mass properties, and downstream booleans are now correct.",
+  "features": ["kernel", "shell", "inspect"]
+}

--- a/crates/vcad-kernel-shell/src/lib.rs
+++ b/crates/vcad-kernel-shell/src/lib.rs
@@ -208,12 +208,12 @@ pub fn shell_brep_analytical(
         };
 
         let old_verts = topo.loop_vertices(face.outer_loop);
-        // Reverse vertex order for inner face (face inward)
-        let new_verts: Vec<VertexId> = old_verts
-            .iter()
-            .rev()
-            .map(|v| inner_vertex_map[v])
-            .collect();
+        // Keep the loop wound consistent with the offset surface's stored
+        // normal (which matches the outer face's): the tessellator reverses
+        // winding for `Orientation::Reversed` faces itself, so pre-reversing
+        // the loop here would cancel that flip and leave the cavity wound
+        // outward (counting as solid volume instead of void).
+        let new_verts: Vec<VertexId> = old_verts.iter().map(|v| inner_vertex_map[v]).collect();
 
         let mut hes = Vec::new();
         for (j, &nv) in new_verts.iter().enumerate() {
@@ -689,6 +689,28 @@ mod tests {
             12,
             "should have 12 surfaces"
         );
+    }
+
+    #[test]
+    fn test_shell_cube_analytical_volume() {
+        // The tessellated analytical shell must enclose outer − inner volume:
+        // the cavity subtracts. A winding bug here makes the cavity *add*
+        // (volume > the solid cube), which inverts thickness→mass scaling.
+        for &t in &[0.8, 1.0, 2.0, 3.5] {
+            let cube = vcad_kernel_primitives::make_cube(10.0, 10.0, 10.0);
+            let shelled = shell_brep_analytical(&cube, t, &[]).unwrap();
+            let mesh = vcad_kernel_tessellate::tessellate_brep(&shelled, 32);
+            let vol = compute_volume(&mesh);
+            let expected = 1000.0 - (10.0 - 2.0 * t).powi(3);
+            // Relative tolerance: tessellated vertices are f32.
+            assert!(
+                (vol - expected).abs() < expected * 1e-5,
+                "shell thickness {}: volume {} != expected {}",
+                t,
+                vol,
+                expected
+            );
+        }
     }
 
     #[test]

--- a/crates/vcad-kernel/tests/shell_difference_volume.rs
+++ b/crates/vcad-kernel/tests/shell_difference_volume.rs
@@ -1,0 +1,56 @@
+//! Regression: hollow-box volume must track wall thickness, including through
+//! a boolean cut (the vcad.io /prove demo path: cube → shell → difference).
+//!
+//! The analytical shell used to pre-reverse the inner loop *and* mark the
+//! inner faces `Orientation::Reversed`; the tessellator reverses winding for
+//! `Reversed` faces itself, so the two flips cancelled and the cavity was
+//! wound outward — `volume()` reported outer + cavity, so a *thinner* wall
+//! reported a *larger* volume.
+
+use vcad_kernel::Solid;
+
+fn analytic_shell_volume(w: f64) -> f64 {
+    100.0 * 80.0 * 60.0 - (100.0 - 2.0 * w) * (80.0 - 2.0 * w) * (60.0 - 2.0 * w)
+}
+
+#[test]
+fn shelled_box_volume_matches_wall_thickness() {
+    for &w in &[0.8, 1.2, 2.0, 3.5, 5.0] {
+        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w);
+        let vol = hollow.volume();
+        let expected = analytic_shell_volume(w);
+        assert!(
+            (vol - expected).abs() < expected * 1e-5,
+            "w={w}: shelled volume {vol} != expected {expected}"
+        );
+    }
+}
+
+#[test]
+fn shell_then_difference_volume_decreases_with_thinner_wall() {
+    // Corner cutter from the /prove demo: overlaps the box at
+    // x 55..100, y 45..80, z 5..60.
+    let part_volume = |w: f64| -> f64 {
+        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w);
+        let cutter = Solid::cube(60.0, 50.0, 70.0).translate(55.0, 45.0, 5.0);
+        hollow.difference(&cutter).volume()
+    };
+
+    let mut prev = 0.0;
+    for &w in &[0.8, 1.2, 2.0, 3.5] {
+        let vol = part_volume(w);
+        // Wall material removed by the cutter = cutter∩outer − cutter∩cavity.
+        let ov_outer = 45.0 * 35.0 * 55.0;
+        let ov_cavity = (45.0 - w) * (35.0 - w) * (55.0 - w);
+        let expected = analytic_shell_volume(w) - (ov_outer - ov_cavity);
+        assert!(
+            (vol - expected).abs() < expected * 1e-5,
+            "w={w}: cut part volume {vol} != expected {expected}"
+        );
+        assert!(
+            vol > prev,
+            "w={w}: volume {vol} should exceed thinner-walled {prev}"
+        );
+        prev = vol;
+    }
+}


### PR DESCRIPTION
## What

`shell()` on a closed solid reported volume/mass as **outer + cavity** instead of outer − cavity, so a hollow part got *heavier* as its wall got thinner. The vcad.io /prove demo surfaced it: `cube(100,80,60).shell(w).difference(corner)` gave 1666 g at w=0.8 and 1506 g at w=3.5 (2.7 g/cm³) — both heavier than the fully **solid** block (1296 g). True values are 66.9 g and 272.4 g.

## Why

`shell_brep_analytical` built inner faces with the loop vertex order reversed **and** `Orientation::Reversed`. The tessellator's contract (`tessellate_planar_face_core`) is that producers wind loops consistent with the stored surface normal and the orientation flag alone flips winding — the tessellator reverses the fan itself for `Reversed` faces. Since `Plane::offset` preserves `normal_dir`, the two flips cancelled: cavity triangles wound outward, and the divergence-theorem `compute_volume` **added** the cavity. The pre-reversed loops also broke twin pairing against side-wall quads in the open-face path (`pair_twin_half_edges` matches (a→b)/(b→a)).

Fix: keep the inner loop in original order; `Orientation::Reversed` alone expresses the inward face normal. `shell_brep_analytical` is only reachable in production through `shell_brep` (no open faces), so the blast radius is exactly this path.

## Verification

- New `test_shell_cube_analytical_volume` in the shell crate — the existing analytical-shell tests only counted faces, never asserted volume, which is how this survived.
- New integration test `crates/vcad-kernel/tests/shell_difference_volume.rs` mirrors the /prove path (cube → shell → difference) and asserts exact closed-form volumes plus monotonicity in wall thickness.
- Shelled volumes now match analytic values to ~1e-6 relative (f32 tessellation); volume assertions use relative tolerance for that reason.
- `cargo test --workspace` green, `clippy --workspace --exclude vcad-desktop -- -D warnings` clean, `fmt --check` clean.

## Reviewer notes

- No WASM artifacts committed (per policy — `wasm-refresh.yml` regenerates on main). The /prove demo imports the checked-in artifacts, so it picks up the fix after merge + refresh.
- Changelog entry included: hollow-part volume/mass affects `inspect_cad`, the app property panel, and any mass-based receipt — not just the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)