### PR TITLE
Add SIMP topology optimization with voxel FEA and surface extraction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ vcad/
 │   ├── vcad-kernel-urdf/          # URDF robot description import
 │   ├── vcad-kernel-cam/           # 2.5D CAM toolpath generation + G-code post
 │   ├── vcad-kernel-stocksim/      # CAM stock sim (octree SDF) + toolpath verification oracle
+│   ├── vcad-kernel-topopt/        # SIMP topology optimization (voxel FEA + surface nets)
 │   ├── vcad-kernel/               # Unified kernel API
 │   ├── vcad-kernel-wasm/          # WASM bindings for browser
 │   ├── vcad-ir/                   # Intermediate representation
@@ -266,6 +267,9 @@ target/debug/vcad-render path/to/part.vcad > out.svg
   labeled assertions persist on the document and re-verify via
   `build_receipt` / `verify_receipt` as Holds/Stale/Violated
 - `render_view` — render the session document to an isometric PNG (agent eyes)
+- `topology_optimize` — SIMP topology optimization: stiffest material layout
+  for given loads/supports inside a box envelope or an existing part's volume;
+  result lands in the document as a frozen mesh part
 - `verify_part` / `list_eval_tasks` — grade the document against mecheval
   benchmark tasks via the official `mecheval-grade` binary (self-grading
   oracle; the benchmark harness excludes these during scored runs)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7033,6 +7033,7 @@ dependencies = [
  "vcad-kernel-tessellate",
  "vcad-kernel-text",
  "vcad-kernel-topo",
+ "vcad-kernel-topopt",
 ]
 
 [[package]]
@@ -7343,6 +7344,15 @@ version = "0.9.4"
 dependencies = [
  "slotmap",
  "vcad-kernel-math",
+]
+
+[[package]]
+name = "vcad-kernel-topopt"
+version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "vcad-kernel-tessellate",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/vcad-slicer-bambu",
     "crates/vcad-kernel-cam",
     "crates/vcad-kernel-stocksim",
+    "crates/vcad-kernel-topopt",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
     "crates/vcad-crdt",
@@ -113,6 +114,7 @@ default-members = [
     "crates/vcad-slicer-bambu",
     "crates/vcad-kernel-cam",
     "crates/vcad-kernel-stocksim",
+    "crates/vcad-kernel-topopt",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
     "crates/vcad-crdt",
@@ -204,6 +206,7 @@ vcad-slicer-gcode = { path = "crates/vcad-slicer-gcode", version = "0.9.4" }
 vcad-slicer-bambu = { path = "crates/vcad-slicer-bambu", version = "0.9.4" }
 vcad-kernel-cam = { path = "crates/vcad-kernel-cam", version = "0.9.4" }
 vcad-kernel-stocksim = { path = "crates/vcad-kernel-stocksim", version = "0.9.4" }
+vcad-kernel-topopt = { path = "crates/vcad-kernel-topopt", version = "0.9.4" }
 vcad-kernel-text = { path = "crates/vcad-kernel-text", version = "0.9.4" }
 vcad-crdt = { path = "crates/vcad-crdt", version = "0.9.4" }
 vcad-app = { path = "crates/vcad-app", version = "0.9.4" }

--- a/changelog/entries/2026-07-09-topology-optimization.json
+++ b/changelog/entries/2026-07-09-topology-optimization.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-09-topology-optimization",
+  "version": "0.9.4",
+  "date": "2026-07-09",
+  "category": "feat",
+  "title": "Topology optimization",
+  "summary": "SIMP topology optimization in the kernel: grow the stiffest organic structure for given loads and supports inside a box envelope or an existing part's volume.",
+  "features": ["kernel", "topology-optimization", "simulation", "mcp"],
+  "mcpTools": ["topology_optimize"]
+}

--- a/crates/vcad-kernel-topopt/Cargo.toml
+++ b/crates/vcad-kernel-topopt/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vcad-kernel-topopt"
+description = "SIMP topology optimization (voxel FEA + isosurface extraction) for the vcad kernel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+vcad-kernel-tessellate = { workspace = true }
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vcad-kernel-topopt/src/domain.rs
+++ b/crates/vcad-kernel-topopt/src/domain.rs
@@ -1,0 +1,249 @@
+//! Design domain: a uniform voxel grid with an active-element mask.
+
+use vcad_kernel_tessellate::TriangleMesh;
+
+/// A uniform cubic voxel grid over an axis-aligned box, with a boolean
+/// mask marking which voxels belong to the design domain.
+///
+/// Elements (voxels) are indexed `(iz * ny + iy) * nx + ix`; grid nodes
+/// are indexed `(iz * (ny+1) + iy) * (nx+1) + ix`.
+#[derive(Debug, Clone)]
+pub struct Domain {
+    /// Element counts along each axis.
+    pub nx: usize,
+    /// Element count along Y.
+    pub ny: usize,
+    /// Element count along Z.
+    pub nz: usize,
+    /// World position of grid node `(0, 0, 0)` in mm.
+    pub origin: [f64; 3],
+    /// Voxel edge length in mm (voxels are cubic).
+    pub h: f64,
+    /// Active mask, one entry per element.
+    pub active: Vec<bool>,
+}
+
+impl Domain {
+    /// Number of elements in the grid (active or not).
+    pub fn num_elements(&self) -> usize {
+        self.nx * self.ny * self.nz
+    }
+
+    /// Number of active (design) elements.
+    pub fn num_active(&self) -> usize {
+        self.active.iter().filter(|a| **a).count()
+    }
+
+    /// Number of grid nodes.
+    pub fn num_nodes(&self) -> usize {
+        (self.nx + 1) * (self.ny + 1) * (self.nz + 1)
+    }
+
+    /// Flat element index.
+    #[inline]
+    pub fn eidx(&self, ix: usize, iy: usize, iz: usize) -> usize {
+        (iz * self.ny + iy) * self.nx + ix
+    }
+
+    /// Flat node index.
+    #[inline]
+    pub fn nidx(&self, ix: usize, iy: usize, iz: usize) -> usize {
+        (iz * (self.ny + 1) + iy) * (self.nx + 1) + ix
+    }
+
+    /// World position of a grid node.
+    #[inline]
+    pub fn node_pos(&self, ix: usize, iy: usize, iz: usize) -> [f64; 3] {
+        [
+            self.origin[0] + ix as f64 * self.h,
+            self.origin[1] + iy as f64 * self.h,
+            self.origin[2] + iz as f64 * self.h,
+        ]
+    }
+
+    /// Build a fully-active domain covering `[min, max]`, with `resolution`
+    /// voxels along the longest axis.
+    pub fn from_bbox(min: [f64; 3], max: [f64; 3], resolution: usize) -> Self {
+        let size = [max[0] - min[0], max[1] - min[1], max[2] - min[2]];
+        let longest = size[0].max(size[1]).max(size[2]).max(1e-9);
+        let resolution = resolution.clamp(2, 256);
+        let h = longest / resolution as f64;
+        let nx = ((size[0] / h).round() as usize).max(1);
+        let ny = ((size[1] / h).round() as usize).max(1);
+        let nz = ((size[2] / h).round() as usize).max(1);
+        Domain {
+            nx,
+            ny,
+            nz,
+            origin: min,
+            h,
+            active: vec![true; nx * ny * nz],
+        }
+    }
+
+    /// Voxelize a closed triangle mesh into a design domain.
+    ///
+    /// Uses per-column ray parity along +Z: a voxel is active when its
+    /// center lies inside the mesh. `resolution` is the voxel count along
+    /// the longest bounding-box axis.
+    pub fn from_mesh(mesh: &TriangleMesh, resolution: usize) -> Self {
+        let nv = mesh.num_vertices();
+        let mut min = [f64::INFINITY; 3];
+        let mut max = [f64::NEG_INFINITY; 3];
+        for i in 0..nv {
+            for a in 0..3 {
+                let v = mesh.vertices[3 * i + a] as f64;
+                min[a] = min[a].min(v);
+                max[a] = max[a].max(v);
+            }
+        }
+        if nv == 0 {
+            return Domain {
+                nx: 0,
+                ny: 0,
+                nz: 0,
+                origin: [0.0; 3],
+                h: 1.0,
+                active: Vec::new(),
+            };
+        }
+
+        let mut domain = Self::from_bbox(min, max, resolution);
+        domain.active = vec![false; domain.num_elements()];
+
+        // Gather triangles as f64 for the parity test.
+        let tris: Vec<[[f64; 3]; 3]> = (0..mesh.num_triangles())
+            .map(|t| {
+                let mut tri = [[0.0; 3]; 3];
+                for (k, corner) in tri.iter_mut().enumerate() {
+                    let vi = mesh.indices[3 * t + k] as usize;
+                    for (a, c) in corner.iter_mut().enumerate() {
+                        *c = mesh.vertices[3 * vi + a] as f64;
+                    }
+                }
+                tri
+            })
+            .collect();
+
+        let h = domain.h;
+        // Small deterministic offset keeps ray origins away from vertices
+        // and edges, where the parity test is ambiguous.
+        let jitter = h * 0.01371;
+        for iy in 0..domain.ny {
+            for ix in 0..domain.nx {
+                let cx = domain.origin[0] + (ix as f64 + 0.5) * h + jitter;
+                let cy = domain.origin[1] + (iy as f64 + 0.5) * h + jitter * 0.618;
+
+                // Collect z-crossings of the vertical line (cx, cy).
+                let mut crossings: Vec<f64> = Vec::new();
+                for tri in &tris {
+                    if let Some(z) = ray_z_crossing(tri, cx, cy) {
+                        crossings.push(z);
+                    }
+                }
+                crossings.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+                // Fill voxels between successive crossing pairs.
+                let mut k = 0;
+                while k + 1 < crossings.len() {
+                    let z0 = crossings[k];
+                    let z1 = crossings[k + 1];
+                    k += 2;
+                    let i0 = ((z0 - domain.origin[2]) / h - 0.5).ceil().max(0.0) as usize;
+                    let i1f = ((z1 - domain.origin[2]) / h - 0.5).floor();
+                    if i1f < 0.0 {
+                        continue;
+                    }
+                    let i1 = (i1f as usize).min(domain.nz.saturating_sub(1));
+                    for iz in i0..=i1 {
+                        if iz < domain.nz {
+                            let e = domain.eidx(ix, iy, iz);
+                            domain.active[e] = true;
+                        }
+                    }
+                }
+            }
+        }
+        domain
+    }
+}
+
+/// Z of the intersection between a vertical line at `(x, y)` and a triangle,
+/// or `None` when the line misses the triangle.
+fn ray_z_crossing(tri: &[[f64; 3]; 3], x: f64, y: f64) -> Option<f64> {
+    let [a, b, c] = tri;
+    // 2D barycentric test in the XY plane.
+    let d = (b[1] - c[1]) * (a[0] - c[0]) + (c[0] - b[0]) * (a[1] - c[1]);
+    if d.abs() < 1e-30 {
+        return None; // Degenerate or vertical triangle.
+    }
+    let w0 = ((b[1] - c[1]) * (x - c[0]) + (c[0] - b[0]) * (y - c[1])) / d;
+    let w1 = ((c[1] - a[1]) * (x - c[0]) + (a[0] - c[0]) * (y - c[1])) / d;
+    let w2 = 1.0 - w0 - w1;
+    if w0 < 0.0 || w1 < 0.0 || w2 < 0.0 {
+        return None;
+    }
+    Some(w0 * a[2] + w1 * b[2] + w2 * c[2])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit_cube_mesh(size: f32) -> TriangleMesh {
+        // 12 triangles, outward normals not required for parity.
+        let s = size;
+        let verts: Vec<[f32; 3]> = vec![
+            [0.0, 0.0, 0.0],
+            [s, 0.0, 0.0],
+            [s, s, 0.0],
+            [0.0, s, 0.0],
+            [0.0, 0.0, s],
+            [s, 0.0, s],
+            [s, s, s],
+            [0.0, s, s],
+        ];
+        let quads = [
+            [0, 3, 2, 1], // bottom
+            [4, 5, 6, 7], // top
+            [0, 1, 5, 4], // front
+            [2, 3, 7, 6], // back
+            [1, 2, 6, 5], // right
+            [3, 0, 4, 7], // left
+        ];
+        let mut mesh = TriangleMesh::new();
+        for v in &verts {
+            mesh.vertices.extend_from_slice(v);
+        }
+        for q in &quads {
+            mesh.indices
+                .extend_from_slice(&[q[0], q[1], q[2], q[0], q[2], q[3]]);
+        }
+        mesh
+    }
+
+    #[test]
+    fn bbox_domain_dims() {
+        let d = Domain::from_bbox([0.0, 0.0, 0.0], [40.0, 20.0, 10.0], 40);
+        assert_eq!((d.nx, d.ny, d.nz), (40, 20, 10));
+        assert!((d.h - 1.0).abs() < 1e-12);
+        assert_eq!(d.num_active(), d.num_elements());
+    }
+
+    #[test]
+    fn voxelize_cube_fills_interior() {
+        let mesh = unit_cube_mesh(10.0);
+        let d = Domain::from_mesh(&mesh, 10);
+        // Nearly all voxels of the cube should be active.
+        let frac = d.num_active() as f64 / d.num_elements() as f64;
+        assert!(frac > 0.9, "active fraction {frac} too low");
+    }
+
+    #[test]
+    fn voxelize_respects_bounds() {
+        let mesh = unit_cube_mesh(8.0);
+        let d = Domain::from_mesh(&mesh, 8);
+        assert_eq!((d.nx, d.ny, d.nz), (8, 8, 8));
+        assert!((d.h - 1.0).abs() < 1e-9);
+    }
+}

--- a/crates/vcad-kernel-topopt/src/extract.rs
+++ b/crates/vcad-kernel-topopt/src/extract.rs
@@ -1,0 +1,362 @@
+//! Isosurface extraction from the converged density field.
+//!
+//! Uses naive surface nets over cell-centered density samples: one vertex
+//! per grid cell straddling the iso level, quads across sign-changing
+//! sample edges. The result is watertight, and a few Taubin smoothing
+//! passes give the characteristic organic topology-optimized look without
+//! shrinking the part.
+
+use std::collections::HashMap;
+
+use crate::domain::Domain;
+use vcad_kernel_tessellate::TriangleMesh;
+
+/// Density value treated as the material boundary.
+const ISO: f64 = 0.5;
+
+/// Extract a triangle mesh from a per-element density field.
+///
+/// `densities` is indexed like `domain.active` (one value per element,
+/// zero outside the structure). `smooth_pairs` is the number of Taubin
+/// λ/μ smoothing pairs applied to the raw surface.
+pub fn extract_mesh(domain: &Domain, densities: &[f64], smooth_pairs: usize) -> TriangleMesh {
+    // Density sample at a voxel center, 0 outside the grid. Sample point
+    // (i, j, k) sits at origin + (i + 0.5) · h.
+    let sample = |i: i32, j: i32, k: i32| -> f64 {
+        if i < 0
+            || j < 0
+            || k < 0
+            || i >= domain.nx as i32
+            || j >= domain.ny as i32
+            || k >= domain.nz as i32
+        {
+            return 0.0;
+        }
+        densities[domain.eidx(i as usize, j as usize, k as usize)]
+    };
+    let solid = |i: i32, j: i32, k: i32| sample(i, j, k) >= ISO;
+    let sample_pos = |i: i32, j: i32, k: i32| -> [f64; 3] {
+        [
+            domain.origin[0] + (i as f64 + 0.5) * domain.h,
+            domain.origin[1] + (j as f64 + 0.5) * domain.h,
+            domain.origin[2] + (k as f64 + 0.5) * domain.h,
+        ]
+    };
+
+    // Pass 1: place one vertex in every cell whose corner samples straddle
+    // the iso level. Cell (i, j, k) spans samples (i..i+1, j..j+1, k..k+1);
+    // the padding layer of zero samples closes the surface at the domain
+    // boundary.
+    let mut cell_vertex: HashMap<(i32, i32, i32), u32> = HashMap::new();
+    let mut positions: Vec<[f64; 3]> = Vec::new();
+
+    const CORNERS: [[i32; 3]; 8] = [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+        [1, 0, 1],
+        [1, 1, 1],
+        [0, 1, 1],
+    ];
+    // Cell edges as corner-index pairs.
+    const EDGES: [[usize; 2]; 12] = [
+        [0, 1],
+        [1, 2],
+        [2, 3],
+        [3, 0],
+        [4, 5],
+        [5, 6],
+        [6, 7],
+        [7, 4],
+        [0, 4],
+        [1, 5],
+        [2, 6],
+        [3, 7],
+    ];
+
+    for ci in -1..domain.nx as i32 {
+        for cj in -1..domain.ny as i32 {
+            for ck in -1..domain.nz as i32 {
+                let vals: [f64; 8] = std::array::from_fn(|c| {
+                    sample(ci + CORNERS[c][0], cj + CORNERS[c][1], ck + CORNERS[c][2])
+                });
+                let inside = vals.map(|v| v >= ISO);
+                if inside.iter().all(|&s| s) || inside.iter().all(|&s| !s) {
+                    continue;
+                }
+                // Vertex = centroid of the edge crossings.
+                let mut acc = [0.0f64; 3];
+                let mut count = 0.0;
+                for e in &EDGES {
+                    let (a, b) = (e[0], e[1]);
+                    if inside[a] == inside[b] {
+                        continue;
+                    }
+                    let t = (ISO - vals[a]) / (vals[b] - vals[a]);
+                    let pa = sample_pos(ci + CORNERS[a][0], cj + CORNERS[a][1], ck + CORNERS[a][2]);
+                    let pb = sample_pos(ci + CORNERS[b][0], cj + CORNERS[b][1], ck + CORNERS[b][2]);
+                    for x in 0..3 {
+                        acc[x] += pa[x] + t * (pb[x] - pa[x]);
+                    }
+                    count += 1.0;
+                }
+                let idx = positions.len() as u32;
+                positions.push([acc[0] / count, acc[1] / count, acc[2] / count]);
+                cell_vertex.insert((ci, cj, ck), idx);
+            }
+        }
+    }
+
+    // Pass 2: for every sample-grid edge with a sign change, connect the
+    // four surrounding cell vertices into a quad, wound so normals point
+    // from solid to void.
+    let mut indices: Vec<u32> = Vec::new();
+    // Ring around the edge, counterclockwise when viewed from +axis
+    // (offsets applied to the two non-axis directions, cyclic order).
+    const RING: [[i32; 2]; 4] = [[-1, -1], [0, -1], [0, 0], [-1, 0]];
+
+    for axis in 0..3usize {
+        let u = (axis + 1) % 3;
+        let v = (axis + 2) % 3;
+        // Sample index bounds per axis, including the padding layer.
+        let n = [domain.nx as i32, domain.ny as i32, domain.nz as i32];
+        let lo = [-1, -1, -1];
+        let hi = [n[0], n[1], n[2]]; // inclusive
+        let mut s = [0i32; 3];
+        for a0 in lo[0]..=hi[0] {
+            for a1 in lo[1]..=hi[1] {
+                for a2 in lo[2]..=hi[2] {
+                    s[0] = a0;
+                    s[1] = a1;
+                    s[2] = a2;
+                    if s[axis] + 1 > hi[axis] {
+                        continue;
+                    }
+                    let mut t = s;
+                    t[axis] += 1;
+                    let s_solid = solid(s[0], s[1], s[2]);
+                    let t_solid = solid(t[0], t[1], t[2]);
+                    if s_solid == t_solid {
+                        continue;
+                    }
+                    // Quad corners: the four cells sharing this edge.
+                    let mut quad = [0u32; 4];
+                    let mut ok = true;
+                    for (qi, ring) in RING.iter().enumerate() {
+                        let mut c = s;
+                        c[u] += ring[0];
+                        c[v] += ring[1];
+                        match cell_vertex.get(&(c[0], c[1], c[2])) {
+                            Some(&idx) => quad[qi] = idx,
+                            None => {
+                                ok = false;
+                                break;
+                            }
+                        }
+                    }
+                    if !ok {
+                        // Should not happen: cells around a sign-changing
+                        // edge always straddle the iso level.
+                        continue;
+                    }
+                    let [q0, q1, q2, q3] = if s_solid {
+                        quad // normal along +axis (solid below, void above)
+                    } else {
+                        [quad[3], quad[2], quad[1], quad[0]]
+                    };
+                    indices.extend_from_slice(&[q0, q1, q2, q0, q2, q3]);
+                }
+            }
+        }
+    }
+
+    if smooth_pairs > 0 {
+        taubin_smooth(&mut positions, &indices, smooth_pairs);
+    }
+
+    build_mesh(&positions, &indices)
+}
+
+/// Taubin λ/μ smoothing: alternating shrink/inflate Laplacian steps that
+/// smooth without net volume loss.
+fn taubin_smooth(positions: &mut [[f64; 3]], indices: &[u32], pairs: usize) {
+    const LAMBDA: f64 = 0.5;
+    const MU: f64 = -0.53;
+
+    // Vertex adjacency from triangle edges.
+    let nv = positions.len();
+    let mut neighbors: Vec<Vec<u32>> = vec![Vec::new(); nv];
+    for tri in indices.chunks_exact(3) {
+        for k in 0..3 {
+            let a = tri[k] as usize;
+            let b = tri[(k + 1) % 3];
+            neighbors[a].push(b);
+        }
+    }
+    for adj in &mut neighbors {
+        adj.sort_unstable();
+        adj.dedup();
+    }
+
+    let mut scratch = positions.to_vec();
+    for _ in 0..pairs {
+        for &factor in &[LAMBDA, MU] {
+            for (i, adj) in neighbors.iter().enumerate() {
+                if adj.is_empty() {
+                    scratch[i] = positions[i];
+                    continue;
+                }
+                let mut avg = [0.0f64; 3];
+                for &j in adj {
+                    for x in 0..3 {
+                        avg[x] += positions[j as usize][x];
+                    }
+                }
+                let inv = 1.0 / adj.len() as f64;
+                for x in 0..3 {
+                    scratch[i][x] = positions[i][x] + factor * (avg[x] * inv - positions[i][x]);
+                }
+            }
+            positions.copy_from_slice(&scratch);
+        }
+    }
+}
+
+/// Assemble a [`TriangleMesh`] with area-weighted vertex normals.
+fn build_mesh(positions: &[[f64; 3]], indices: &[u32]) -> TriangleMesh {
+    let mut normals = vec![[0.0f64; 3]; positions.len()];
+    for tri in indices.chunks_exact(3) {
+        let a = positions[tri[0] as usize];
+        let b = positions[tri[1] as usize];
+        let c = positions[tri[2] as usize];
+        let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let ac = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+        // Cross product magnitude = 2 · area, so this is area weighting.
+        let n = [
+            ab[1] * ac[2] - ab[2] * ac[1],
+            ab[2] * ac[0] - ab[0] * ac[2],
+            ab[0] * ac[1] - ab[1] * ac[0],
+        ];
+        for &vi in tri {
+            for x in 0..3 {
+                normals[vi as usize][x] += n[x];
+            }
+        }
+    }
+
+    let mut mesh = TriangleMesh::new();
+    mesh.vertices.reserve(positions.len() * 3);
+    mesh.normals.reserve(positions.len() * 3);
+    for (p, n) in positions.iter().zip(&normals) {
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        let inv = if len > 1e-30 { 1.0 / len } else { 0.0 };
+        for &coord in p {
+            mesh.vertices.push(coord as f32);
+        }
+        for &comp in n {
+            mesh.normals.push((comp * inv) as f32);
+        }
+    }
+    mesh.indices = indices.to_vec();
+    mesh
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Every undirected edge of a watertight mesh is shared by exactly two
+    /// triangles, once in each direction.
+    fn assert_watertight(mesh: &TriangleMesh) {
+        let mut edges: HashMap<(u32, u32), i32> = HashMap::new();
+        for tri in mesh.indices.chunks_exact(3) {
+            for k in 0..3 {
+                let a = tri[k];
+                let b = tri[(k + 1) % 3];
+                *edges.entry((a.min(b), a.max(b))).or_insert(0) += if a < b { 1 } else { -1 };
+            }
+        }
+        for (edge, balance) in &edges {
+            assert_eq!(
+                *balance, 0,
+                "edge {edge:?} is unbalanced — mesh not watertight"
+            );
+        }
+    }
+
+    #[test]
+    fn solid_box_extracts_to_box() {
+        let domain = Domain::from_bbox([0.0; 3], [8.0, 4.0, 2.0], 8);
+        let densities = vec![1.0; domain.num_elements()];
+        let mesh = extract_mesh(&domain, &densities, 0);
+        assert!(mesh.num_triangles() > 0);
+        assert_watertight(&mesh);
+
+        // Surface should sit on the domain boundary (crossing halfway
+        // between the outermost cell center and the zero padding sample).
+        let mut min = [f32::INFINITY; 3];
+        let mut max = [f32::NEG_INFINITY; 3];
+        for v in mesh.vertices.chunks_exact(3) {
+            for x in 0..3 {
+                min[x] = min[x].min(v[x]);
+                max[x] = max[x].max(v[x]);
+            }
+        }
+        assert!((min[0] - 0.0).abs() < 1e-4 && (max[0] - 8.0).abs() < 1e-4);
+        assert!((min[1] - 0.0).abs() < 1e-4 && (max[1] - 4.0).abs() < 1e-4);
+        assert!((min[2] - 0.0).abs() < 1e-4 && (max[2] - 2.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn empty_field_extracts_nothing() {
+        let domain = Domain::from_bbox([0.0; 3], [4.0; 3], 4);
+        let densities = vec![0.0; domain.num_elements()];
+        let mesh = extract_mesh(&domain, &densities, 2);
+        assert_eq!(mesh.num_triangles(), 0);
+    }
+
+    #[test]
+    fn smoothing_preserves_watertightness_and_scale() {
+        let domain = Domain::from_bbox([0.0; 3], [6.0; 3], 6);
+        let densities = vec![1.0; domain.num_elements()];
+        let mesh = extract_mesh(&domain, &densities, 5);
+        assert_watertight(&mesh);
+        let mut max = [f32::NEG_INFINITY; 3];
+        for v in mesh.vertices.chunks_exact(3) {
+            for x in 0..3 {
+                max[x] = max[x].max(v[x]);
+            }
+        }
+        // Taubin smoothing must not collapse the part.
+        for x in 0..3 {
+            assert!(max[x] > 5.0, "axis {x} shrank to {}", max[x]);
+        }
+    }
+
+    #[test]
+    fn normals_point_outward_for_box() {
+        let domain = Domain::from_bbox([0.0; 3], [4.0; 3], 4);
+        let densities = vec![1.0; domain.num_elements()];
+        let mesh = extract_mesh(&domain, &densities, 0);
+        let center = [2.0f32; 3];
+        let mut outward = 0usize;
+        let mut inward = 0usize;
+        for i in 0..mesh.num_vertices() {
+            let p = &mesh.vertices[3 * i..3 * i + 3];
+            let n = &mesh.normals[3 * i..3 * i + 3];
+            let d: f32 = (0..3).map(|x| (p[x] - center[x]) * n[x]).sum();
+            if d > 0.0 {
+                outward += 1;
+            } else if d < 0.0 {
+                inward += 1;
+            }
+        }
+        assert!(
+            outward > inward * 10,
+            "normals look inverted: {outward} outward vs {inward} inward"
+        );
+    }
+}

--- a/crates/vcad-kernel-topopt/src/extract.rs
+++ b/crates/vcad-kernel-topopt/src/extract.rs
@@ -188,7 +188,7 @@ fn taubin_smooth(positions: &mut [[f64; 3]], indices: &[u32], pairs: usize) {
     // Vertex adjacency from triangle edges.
     let nv = positions.len();
     let mut neighbors: Vec<Vec<u32>> = vec![Vec::new(); nv];
-    for tri in indices.chunks_exact(3) {
+    for tri in indices.as_chunks::<3>().0 {
         for k in 0..3 {
             let a = tri[k] as usize;
             let b = tri[(k + 1) % 3];
@@ -227,7 +227,7 @@ fn taubin_smooth(positions: &mut [[f64; 3]], indices: &[u32], pairs: usize) {
 /// Assemble a [`TriangleMesh`] with area-weighted vertex normals.
 fn build_mesh(positions: &[[f64; 3]], indices: &[u32]) -> TriangleMesh {
     let mut normals = vec![[0.0f64; 3]; positions.len()];
-    for tri in indices.chunks_exact(3) {
+    for tri in indices.as_chunks::<3>().0 {
         let a = positions[tri[0] as usize];
         let b = positions[tri[1] as usize];
         let c = positions[tri[2] as usize];
@@ -272,7 +272,7 @@ mod tests {
     /// triangles, once in each direction.
     fn assert_watertight(mesh: &TriangleMesh) {
         let mut edges: HashMap<(u32, u32), i32> = HashMap::new();
-        for tri in mesh.indices.chunks_exact(3) {
+        for tri in mesh.indices.as_chunks::<3>().0 {
             for k in 0..3 {
                 let a = tri[k];
                 let b = tri[(k + 1) % 3];
@@ -299,7 +299,7 @@ mod tests {
         // between the outermost cell center and the zero padding sample).
         let mut min = [f32::INFINITY; 3];
         let mut max = [f32::NEG_INFINITY; 3];
-        for v in mesh.vertices.chunks_exact(3) {
+        for v in mesh.vertices.as_chunks::<3>().0 {
             for x in 0..3 {
                 min[x] = min[x].min(v[x]);
                 max[x] = max[x].max(v[x]);
@@ -325,14 +325,14 @@ mod tests {
         let mesh = extract_mesh(&domain, &densities, 5);
         assert_watertight(&mesh);
         let mut max = [f32::NEG_INFINITY; 3];
-        for v in mesh.vertices.chunks_exact(3) {
+        for v in mesh.vertices.as_chunks::<3>().0 {
             for x in 0..3 {
                 max[x] = max[x].max(v[x]);
             }
         }
         // Taubin smoothing must not collapse the part.
-        for x in 0..3 {
-            assert!(max[x] > 5.0, "axis {x} shrank to {}", max[x]);
+        for (axis, m) in max.iter().enumerate() {
+            assert!(*m > 5.0, "axis {axis} shrank to {m}");
         }
     }
 

--- a/crates/vcad-kernel-topopt/src/fea.rs
+++ b/crates/vcad-kernel-topopt/src/fea.rs
@@ -1,0 +1,489 @@
+//! Voxel finite-element analysis: 8-node hexahedral elements on a uniform
+//! grid, solved matrix-free with Jacobi-preconditioned conjugate gradients.
+
+use crate::domain::Domain;
+
+/// Local node offsets within an element, standard hex ordering.
+pub const NODE_OFFSETS: [[usize; 3]; 8] = [
+    [0, 0, 0],
+    [1, 0, 0],
+    [1, 1, 0],
+    [0, 1, 0],
+    [0, 0, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+    [0, 1, 1],
+];
+
+/// Natural-coordinate signs per local node (matches [`NODE_OFFSETS`]).
+const NODE_SIGNS: [[f64; 3]; 8] = [
+    [-1.0, -1.0, -1.0],
+    [1.0, -1.0, -1.0],
+    [1.0, 1.0, -1.0],
+    [-1.0, 1.0, -1.0],
+    [-1.0, -1.0, 1.0],
+    [1.0, -1.0, 1.0],
+    [1.0, 1.0, 1.0],
+    [-1.0, 1.0, 1.0],
+];
+
+/// Element stiffness matrix (24×24, row-major) for a cubic 8-node hex of
+/// edge length `h`, unit Young's modulus, Poisson's ratio `nu`.
+///
+/// Computed by 2×2×2 Gauss integration of `Bᵀ C B`.
+pub fn hex_stiffness(nu: f64, h: f64) -> Vec<f64> {
+    // Isotropic elasticity matrix (Voigt: xx, yy, zz, xy, yz, xz), E = 1.
+    let c2 = nu / ((1.0 + nu) * (1.0 - 2.0 * nu));
+    let c1 = (1.0 - nu) / ((1.0 + nu) * (1.0 - 2.0 * nu));
+    let g = 1.0 / (2.0 * (1.0 + nu));
+    let mut c = [[0.0f64; 6]; 6];
+    for i in 0..3 {
+        for (j, entry) in c[i].iter_mut().enumerate().take(3) {
+            *entry = if i == j { c1 } else { c2 };
+        }
+        c[3 + i][3 + i] = g;
+    }
+
+    let gp = 1.0 / 3.0f64.sqrt();
+    let det_j = (h / 2.0).powi(3);
+    let dnat_dx = 2.0 / h; // d(natural)/d(world)
+
+    let mut ke = vec![0.0f64; 24 * 24];
+    for &gx in &[-gp, gp] {
+        for &gy in &[-gp, gp] {
+            for &gz in &[-gp, gp] {
+                // Shape function derivatives in world coordinates.
+                let mut dn = [[0.0f64; 3]; 8];
+                for (i, s) in NODE_SIGNS.iter().enumerate() {
+                    dn[i][0] = s[0] * (1.0 + gy * s[1]) * (1.0 + gz * s[2]) / 8.0 * dnat_dx;
+                    dn[i][1] = (1.0 + gx * s[0]) * s[1] * (1.0 + gz * s[2]) / 8.0 * dnat_dx;
+                    dn[i][2] = (1.0 + gx * s[0]) * (1.0 + gy * s[1]) * s[2] / 8.0 * dnat_dx;
+                }
+                // Strain-displacement matrix B (6×24).
+                let mut b = [[0.0f64; 24]; 6];
+                for i in 0..8 {
+                    let (dx, dy, dz) = (dn[i][0], dn[i][1], dn[i][2]);
+                    b[0][3 * i] = dx;
+                    b[1][3 * i + 1] = dy;
+                    b[2][3 * i + 2] = dz;
+                    b[3][3 * i] = dy;
+                    b[3][3 * i + 1] = dx;
+                    b[4][3 * i + 1] = dz;
+                    b[4][3 * i + 2] = dy;
+                    b[5][3 * i] = dz;
+                    b[5][3 * i + 2] = dx;
+                }
+                // KE += Bᵀ C B · detJ (Gauss weights are 1).
+                let mut cb = [[0.0f64; 24]; 6];
+                for r in 0..6 {
+                    for col in 0..24 {
+                        let mut acc = 0.0;
+                        for k in 0..6 {
+                            acc += c[r][k] * b[k][col];
+                        }
+                        cb[r][col] = acc;
+                    }
+                }
+                for r in 0..24 {
+                    for col in 0..24 {
+                        let mut acc = 0.0;
+                        for k in 0..6 {
+                            acc += b[k][r] * cb[k][col];
+                        }
+                        ke[r * 24 + col] += acc * det_j;
+                    }
+                }
+            }
+        }
+    }
+    ke
+}
+
+/// Assembled FE system context for one design domain.
+#[derive(Debug)]
+pub struct FeSystem {
+    /// Element stiffness for unit E.
+    pub ke: Vec<f64>,
+    /// Per-element global DOF indices (24 per active element; inactive
+    /// elements have an empty placeholder to keep indexing aligned).
+    pub edofs: Vec<[u32; 24]>,
+    /// Indices of active elements (into the domain's element array).
+    pub active_elems: Vec<u32>,
+    /// Fixed-DOF mask (includes all DOFs of nodes not touching any
+    /// active element, so the system stays non-singular).
+    pub fixed: Vec<bool>,
+    /// Global load vector.
+    pub f: Vec<f64>,
+    /// Total DOF count.
+    pub ndof: usize,
+}
+
+/// Errors from FE system construction.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeError {
+    /// No grid nodes matched a load region.
+    LoadOutsideDomain(usize),
+    /// No grid nodes matched a support region.
+    SupportOutsideDomain(usize),
+    /// Every DOF is fixed — nothing to solve.
+    FullyConstrained,
+    /// The design domain has no active voxels.
+    EmptyDomain,
+}
+
+impl std::fmt::Display for FeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FeError::LoadOutsideDomain(i) => {
+                write!(f, "load {i} does not touch any structure node")
+            }
+            FeError::SupportOutsideDomain(i) => {
+                write!(f, "support {i} does not touch any structure node")
+            }
+            FeError::FullyConstrained => write!(f, "all degrees of freedom are fixed"),
+            FeError::EmptyDomain => write!(f, "design domain contains no active voxels"),
+        }
+    }
+}
+
+impl std::error::Error for FeError {}
+
+impl FeSystem {
+    /// Build the FE context for `domain` with the given material and
+    /// boundary conditions.
+    pub fn build(
+        domain: &Domain,
+        poisson: f64,
+        loads: &[crate::spec::Load],
+        supports: &[crate::spec::Support],
+    ) -> Result<Self, FeError> {
+        if domain.num_active() == 0 {
+            return Err(FeError::EmptyDomain);
+        }
+        let ndof = 3 * domain.num_nodes();
+        let ke = hex_stiffness(poisson, domain.h);
+
+        // Element → global DOF map for active elements.
+        let mut active_elems = Vec::with_capacity(domain.num_active());
+        let mut edofs = Vec::with_capacity(domain.num_active());
+        let mut attached = vec![false; domain.num_nodes()];
+        for iz in 0..domain.nz {
+            for iy in 0..domain.ny {
+                for ix in 0..domain.nx {
+                    let e = domain.eidx(ix, iy, iz);
+                    if !domain.active[e] {
+                        continue;
+                    }
+                    let mut dofs = [0u32; 24];
+                    for (k, off) in NODE_OFFSETS.iter().enumerate() {
+                        let n = domain.nidx(ix + off[0], iy + off[1], iz + off[2]);
+                        attached[n] = true;
+                        for a in 0..3 {
+                            dofs[3 * k + a] = (3 * n + a) as u32;
+                        }
+                    }
+                    active_elems.push(e as u32);
+                    edofs.push(dofs);
+                }
+            }
+        }
+
+        // Node-selection pad: half a voxel so thin regions still catch a
+        // plane of nodes.
+        let pad = domain.h * 0.5 + 1e-9;
+
+        let mut fixed = vec![false; ndof];
+        // Detached nodes are not part of the structure; fix them out.
+        for (n, att) in attached.iter().enumerate() {
+            if !att {
+                for a in 0..3 {
+                    fixed[3 * n + a] = true;
+                }
+            }
+        }
+
+        for (si, sup) in supports.iter().enumerate() {
+            let mut hit = false;
+            for iz in 0..=domain.nz {
+                for iy in 0..=domain.ny {
+                    for ix in 0..=domain.nx {
+                        let n = domain.nidx(ix, iy, iz);
+                        if !attached[n] {
+                            continue;
+                        }
+                        if sup.region.contains(domain.node_pos(ix, iy, iz), pad) {
+                            hit = true;
+                            for a in 0..3 {
+                                if sup.fix[a] {
+                                    fixed[3 * n + a] = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if !hit {
+                return Err(FeError::SupportOutsideDomain(si));
+            }
+        }
+
+        let mut f = vec![0.0f64; ndof];
+        for (li, load) in loads.iter().enumerate() {
+            let mut nodes = Vec::new();
+            for iz in 0..=domain.nz {
+                for iy in 0..=domain.ny {
+                    for ix in 0..=domain.nx {
+                        let n = domain.nidx(ix, iy, iz);
+                        if !attached[n] {
+                            continue;
+                        }
+                        if load.region.contains(domain.node_pos(ix, iy, iz), pad) {
+                            nodes.push(n);
+                        }
+                    }
+                }
+            }
+            if nodes.is_empty() {
+                return Err(FeError::LoadOutsideDomain(li));
+            }
+            let scale = 1.0 / nodes.len() as f64;
+            for n in nodes {
+                for a in 0..3 {
+                    if !fixed[3 * n + a] {
+                        f[3 * n + a] += load.force[a] * scale;
+                    }
+                }
+            }
+        }
+
+        if fixed.iter().all(|x| *x) {
+            return Err(FeError::FullyConstrained);
+        }
+
+        Ok(FeSystem {
+            ke,
+            edofs,
+            active_elems,
+            fixed,
+            f,
+            ndof,
+        })
+    }
+
+    /// `out = K(x) · u`, matrix-free. `scales` holds one stiffness scale
+    /// per active element (SIMP-interpolated Young's modulus).
+    pub fn apply(&self, scales: &[f64], u: &[f64], out: &mut [f64]) {
+        out.fill(0.0);
+        let ke = &self.ke;
+        for (ei, dofs) in self.edofs.iter().enumerate() {
+            let s = scales[ei];
+            if s == 0.0 {
+                continue;
+            }
+            let mut ue = [0.0f64; 24];
+            for (k, &d) in dofs.iter().enumerate() {
+                let d = d as usize;
+                ue[k] = if self.fixed[d] { 0.0 } else { u[d] };
+            }
+            let mut fe = [0.0f64; 24];
+            for r in 0..24 {
+                let row = &ke[r * 24..r * 24 + 24];
+                let mut acc = 0.0;
+                for k in 0..24 {
+                    acc += row[k] * ue[k];
+                }
+                fe[r] = acc * s;
+            }
+            for (k, &d) in dofs.iter().enumerate() {
+                let d = d as usize;
+                if !self.fixed[d] {
+                    out[d] += fe[k];
+                }
+            }
+        }
+    }
+
+    /// Assembled diagonal of `K(x)` for Jacobi preconditioning. Fixed DOFs
+    /// get 1.0.
+    pub fn diagonal(&self, scales: &[f64]) -> Vec<f64> {
+        let mut diag = vec![0.0f64; self.ndof];
+        for (ei, dofs) in self.edofs.iter().enumerate() {
+            let s = scales[ei];
+            for (k, &d) in dofs.iter().enumerate() {
+                diag[d as usize] += s * self.ke[k * 24 + k];
+            }
+        }
+        for (d, v) in diag.iter_mut().enumerate() {
+            if self.fixed[d] || *v <= 0.0 {
+                *v = 1.0;
+            }
+        }
+        diag
+    }
+
+    /// Solve `K(x) u = f` by Jacobi-PCG, warm-started from `u`.
+    ///
+    /// Returns the relative residual reached.
+    pub fn solve(&self, scales: &[f64], u: &mut [f64], tol: f64, max_iter: usize) -> f64 {
+        let n = self.ndof;
+        let diag = self.diagonal(scales);
+        for (d, ui) in u.iter_mut().enumerate() {
+            if self.fixed[d] {
+                *ui = 0.0;
+            }
+        }
+
+        let fnorm = norm(&self.f);
+        if fnorm == 0.0 {
+            u.fill(0.0);
+            return 0.0;
+        }
+
+        let mut ku = vec![0.0f64; n];
+        self.apply(scales, u, &mut ku);
+        let mut r: Vec<f64> = (0..n)
+            .map(|d| {
+                if self.fixed[d] {
+                    0.0
+                } else {
+                    self.f[d] - ku[d]
+                }
+            })
+            .collect();
+        let mut z: Vec<f64> = (0..n).map(|d| r[d] / diag[d]).collect();
+        let mut p = z.clone();
+        let mut rz: f64 = dot(&r, &z);
+        let mut relres = norm(&r) / fnorm;
+
+        let mut q = vec![0.0f64; n];
+        for _ in 0..max_iter {
+            if relres < tol {
+                break;
+            }
+            self.apply(scales, &p, &mut q);
+            let pq = dot(&p, &q);
+            if pq <= 0.0 || !pq.is_finite() {
+                break; // Lost positive-definiteness; keep best iterate.
+            }
+            let alpha = rz / pq;
+            for d in 0..n {
+                u[d] += alpha * p[d];
+                r[d] -= alpha * q[d];
+            }
+            relres = norm(&r) / fnorm;
+            for d in 0..n {
+                z[d] = r[d] / diag[d];
+            }
+            let rz_new = dot(&r, &z);
+            let beta = rz_new / rz;
+            rz = rz_new;
+            for d in 0..n {
+                p[d] = z[d] + beta * p[d];
+            }
+        }
+        relres
+    }
+}
+
+fn dot(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+fn norm(a: &[f64]) -> f64 {
+    dot(a, a).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{Load, RegionBox, Support};
+
+    #[test]
+    fn stiffness_is_symmetric() {
+        let ke = hex_stiffness(0.3, 2.0);
+        for r in 0..24 {
+            for c in 0..24 {
+                let a = ke[r * 24 + c];
+                let b = ke[c * 24 + r];
+                assert!((a - b).abs() < 1e-10, "asymmetry at ({r},{c}): {a} vs {b}");
+            }
+        }
+    }
+
+    #[test]
+    fn stiffness_annihilates_rigid_translation() {
+        let ke = hex_stiffness(0.3, 1.0);
+        // Unit translation along each axis produces zero force.
+        for axis in 0..3 {
+            let mut u = [0.0f64; 24];
+            for node in 0..8 {
+                u[3 * node + axis] = 1.0;
+            }
+            for r in 0..24 {
+                let f: f64 = (0..24).map(|c| ke[r * 24 + c] * u[c]).sum();
+                assert!(f.abs() < 1e-9, "axis {axis} row {r}: residual force {f}");
+            }
+        }
+    }
+
+    #[test]
+    fn stiffness_scales_linearly_with_h() {
+        let k1 = hex_stiffness(0.3, 1.0);
+        let k2 = hex_stiffness(0.3, 2.0);
+        for i in 0..(24 * 24) {
+            assert!((k2[i] - 2.0 * k1[i]).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn solve_cantilever_deflects_downward() {
+        // Small solid cantilever, fixed at x=0, tip load in -z.
+        let domain = crate::domain::Domain::from_bbox([0.0; 3], [8.0, 2.0, 2.0], 8);
+        let loads = vec![Load {
+            region: RegionBox {
+                min: [8.0, 0.0, 0.0],
+                max: [8.0, 2.0, 2.0],
+            },
+            force: [0.0, 0.0, -100.0],
+        }];
+        let supports = vec![Support {
+            region: RegionBox {
+                min: [0.0, 0.0, 0.0],
+                max: [0.0, 2.0, 2.0],
+            },
+            fix: [true, true, true],
+        }];
+        let sys = FeSystem::build(&domain, 0.3, &loads, &supports).unwrap();
+        let scales = vec![1.0; sys.active_elems.len()];
+        let mut u = vec![0.0; sys.ndof];
+        let relres = sys.solve(&scales, &mut u, 1e-8, 4000);
+        assert!(relres < 1e-6, "PCG did not converge: relres {relres}");
+
+        // Tip nodes should move down; compliance must be positive.
+        let tip = domain.nidx(domain.nx, 1, 1);
+        assert!(u[3 * tip + 2] < 0.0, "tip did not deflect downward");
+        let compliance: f64 = sys.f.iter().zip(&u).map(|(a, b)| a * b).sum();
+        assert!(compliance > 0.0);
+    }
+
+    #[test]
+    fn load_outside_domain_errors() {
+        let domain = crate::domain::Domain::from_bbox([0.0; 3], [4.0, 4.0, 4.0], 4);
+        let loads = vec![Load {
+            region: RegionBox {
+                min: [100.0; 3],
+                max: [101.0; 3],
+            },
+            force: [0.0, 0.0, -1.0],
+        }];
+        let supports = vec![Support {
+            region: RegionBox {
+                min: [0.0; 3],
+                max: [0.0, 4.0, 4.0],
+            },
+            fix: [true; 3],
+        }];
+        let err = FeSystem::build(&domain, 0.3, &loads, &supports).unwrap_err();
+        assert_eq!(err, FeError::LoadOutsideDomain(0));
+    }
+}

--- a/crates/vcad-kernel-topopt/src/lib.rs
+++ b/crates/vcad-kernel-topopt/src/lib.rs
@@ -250,7 +250,7 @@ mod tests {
 
         // Mesh must stay inside the design domain (small tolerance for
         // smoothing overshoot).
-        for v in result.mesh.vertices.chunks_exact(3) {
+        for v in result.mesh.vertices.as_chunks::<3>().0 {
             assert!(v[0] >= -0.5 && v[0] <= 24.5);
             assert!(v[1] >= -0.5 && v[1] <= 6.5);
             assert!(v[2] >= -0.5 && v[2] <= 12.5);

--- a/crates/vcad-kernel-topopt/src/lib.rs
+++ b/crates/vcad-kernel-topopt/src/lib.rs
@@ -1,0 +1,297 @@
+#![warn(missing_docs)]
+
+//! Topology optimization for the vcad kernel.
+//!
+//! Given a design domain (a bounding box or an existing solid's mesh),
+//! loads, and supports, this crate finds the stiffest material layout that
+//! uses only a target fraction of the domain volume — the classic
+//! compliance-minimization problem solved with the SIMP method
+//! (Solid Isotropic Material with Penalization):
+//!
+//! 1. The domain is voxelized into a uniform grid of 8-node hexahedral
+//!    finite elements.
+//! 2. Each SIMP iteration solves the elasticity system matrix-free with
+//!    Jacobi-preconditioned conjugate gradients, computes compliance
+//!    sensitivities, filters them for mesh independence, and updates the
+//!    per-voxel densities with an optimality-criteria step under the
+//!    volume constraint.
+//! 3. The converged density field is turned back into a watertight
+//!    triangle mesh with surface nets + Taubin smoothing — the organic,
+//!    bone-like geometry topology optimization is known for.
+//!
+//! Coordinates are Z-up, units are millimeters, matching the rest of the
+//! kernel. Results are deterministic for a given spec.
+//!
+//! # Example
+//!
+//! ```
+//! use vcad_kernel_topopt::{optimize_box, Load, RegionBox, Support, TopoOptSpec};
+//!
+//! // A 40×10×20 mm cantilever: anchored on the x=0 face, tip load at the
+//! // lower far edge pointing down.
+//! let mut spec = TopoOptSpec::new(
+//!     vec![Load {
+//!         region: RegionBox { min: [40.0, 0.0, 0.0], max: [40.0, 10.0, 2.0] },
+//!         force: [0.0, 0.0, -100.0],
+//!     }],
+//!     vec![Support {
+//!         region: RegionBox { min: [0.0, 0.0, 0.0], max: [0.0, 10.0, 20.0] },
+//!         fix: [true, true, true],
+//!     }],
+//! );
+//! spec.resolution = 16;      // coarse for the doc test
+//! spec.max_iterations = 6;
+//! spec.volume_fraction = 0.4;
+//!
+//! let result = optimize_box([0.0, 0.0, 0.0], [40.0, 10.0, 20.0], &spec).unwrap();
+//! assert!(result.mesh.num_triangles() > 0);
+//! assert!(result.compliance_history.len() >= 2);
+//! ```
+
+mod domain;
+mod extract;
+mod fea;
+mod simp;
+mod spec;
+
+pub use domain::Domain;
+pub use fea::FeError;
+pub use spec::{Load, RegionBox, Support, TopoOptSpec};
+
+use vcad_kernel_tessellate::TriangleMesh;
+
+/// Result of a topology optimization run.
+#[derive(Debug)]
+pub struct TopoOptResult {
+    /// The optimized structure as a watertight triangle mesh (mm, Z-up).
+    pub mesh: TriangleMesh,
+    /// Compliance (strain energy measure) after each iteration; decreasing
+    /// values mean a stiffer structure.
+    pub compliance_history: Vec<f64>,
+    /// SIMP iterations actually run.
+    pub iterations: usize,
+    /// Whether the density change converged below the spec tolerance.
+    pub converged: bool,
+    /// Material fraction of the design domain actually used.
+    pub volume_fraction_achieved: f64,
+    /// Voxel grid dimensions used, `[nx, ny, nz]`.
+    pub grid: [usize; 3],
+    /// Voxel edge length in mm.
+    pub voxel_size: f64,
+}
+
+/// Errors from [`optimize`].
+#[derive(Debug)]
+pub enum TopoOptError {
+    /// The problem specification is invalid.
+    InvalidSpec(String),
+    /// Boundary conditions or the domain are unusable.
+    Fe(FeError),
+}
+
+impl std::fmt::Display for TopoOptError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TopoOptError::InvalidSpec(msg) => {
+                write!(f, "invalid topology optimization spec: {msg}")
+            }
+            TopoOptError::Fe(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for TopoOptError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TopoOptError::Fe(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<FeError> for TopoOptError {
+    fn from(e: FeError) -> Self {
+        TopoOptError::Fe(e)
+    }
+}
+
+fn validate(spec: &TopoOptSpec) -> Result<(), TopoOptError> {
+    if spec.loads.is_empty() {
+        return Err(TopoOptError::InvalidSpec(
+            "at least one load is required".into(),
+        ));
+    }
+    if spec.supports.is_empty() {
+        return Err(TopoOptError::InvalidSpec(
+            "at least one support is required".into(),
+        ));
+    }
+    if !(0.01..=0.99).contains(&spec.volume_fraction) {
+        return Err(TopoOptError::InvalidSpec(format!(
+            "volume_fraction must be in (0.01, 0.99), got {}",
+            spec.volume_fraction
+        )));
+    }
+    if spec.loads.iter().any(|l| l.force.iter().all(|c| *c == 0.0)) {
+        return Err(TopoOptError::InvalidSpec("a load has zero force".into()));
+    }
+    if !(1.0..=6.0).contains(&spec.penalty) {
+        return Err(TopoOptError::InvalidSpec(format!(
+            "penalty must be in [1, 6], got {}",
+            spec.penalty
+        )));
+    }
+    if !(0.0..0.5).contains(&spec.poisson) {
+        return Err(TopoOptError::InvalidSpec(format!(
+            "poisson must be in [0, 0.5), got {}",
+            spec.poisson
+        )));
+    }
+    if spec.max_iterations == 0 {
+        return Err(TopoOptError::InvalidSpec(
+            "max_iterations must be > 0".into(),
+        ));
+    }
+    Ok(())
+}
+
+/// Run topology optimization on a prepared design domain.
+pub fn optimize(domain: &Domain, spec: &TopoOptSpec) -> Result<TopoOptResult, TopoOptError> {
+    validate(spec)?;
+    let sys = fea::FeSystem::build(domain, spec.poisson, &spec.loads, &spec.supports)?;
+    let simp = simp::optimize_densities(domain, &sys, spec);
+
+    let nact = domain.num_active().max(1) as f64;
+    let volume_fraction_achieved = simp.densities.iter().sum::<f64>() / nact;
+
+    let mesh = extract::extract_mesh(domain, &simp.densities, spec.smooth_iterations);
+
+    Ok(TopoOptResult {
+        mesh,
+        compliance_history: simp.compliance_history,
+        iterations: simp.iterations,
+        converged: simp.converged,
+        volume_fraction_achieved,
+        grid: [domain.nx, domain.ny, domain.nz],
+        voxel_size: domain.h,
+    })
+}
+
+/// Optimize within an axis-aligned box design domain.
+pub fn optimize_box(
+    min: [f64; 3],
+    max: [f64; 3],
+    spec: &TopoOptSpec,
+) -> Result<TopoOptResult, TopoOptError> {
+    if (0..3).any(|a| !(max[a] - min[a]).is_finite() || max[a] - min[a] <= 0.0) {
+        return Err(TopoOptError::InvalidSpec(
+            "domain box must have positive size on every axis".into(),
+        ));
+    }
+    let domain = Domain::from_bbox(min, max, spec.resolution);
+    optimize(&domain, spec)
+}
+
+/// Optimize using an existing solid's tessellation as the design domain.
+///
+/// The mesh is voxelized (voxel centers inside the closed mesh become the
+/// design domain), so material only ever appears inside the original part —
+/// this is the "lightweight an existing bracket" workflow.
+pub fn optimize_mesh(
+    mesh: &TriangleMesh,
+    spec: &TopoOptSpec,
+) -> Result<TopoOptResult, TopoOptError> {
+    let domain = Domain::from_mesh(mesh, spec.resolution);
+    optimize(&domain, spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bracket_spec() -> TopoOptSpec {
+        let mut spec = TopoOptSpec::new(
+            vec![Load {
+                region: RegionBox {
+                    min: [24.0, 0.0, 0.0],
+                    max: [24.0, 6.0, 2.0],
+                },
+                force: [0.0, 0.0, -100.0],
+            }],
+            vec![Support {
+                region: RegionBox {
+                    min: [0.0, 0.0, 0.0],
+                    max: [0.0, 6.0, 12.0],
+                },
+                fix: [true, true, true],
+            }],
+        );
+        spec.resolution = 24;
+        spec.max_iterations = 15;
+        spec.volume_fraction = 0.35;
+        spec
+    }
+
+    #[test]
+    fn end_to_end_cantilever() {
+        let spec = bracket_spec();
+        let result = optimize_box([0.0; 3], [24.0, 6.0, 12.0], &spec).unwrap();
+
+        assert!(result.mesh.num_triangles() > 100);
+        assert_eq!(result.mesh.vertices.len(), result.mesh.normals.len());
+        assert!(
+            (result.volume_fraction_achieved - 0.35).abs() < 0.03,
+            "volume fraction {}",
+            result.volume_fraction_achieved
+        );
+        let first = result.compliance_history[0];
+        let last = *result.compliance_history.last().unwrap();
+        assert!(last < first * 0.9, "compliance {first} -> {last}");
+
+        // Mesh must stay inside the design domain (small tolerance for
+        // smoothing overshoot).
+        for v in result.mesh.vertices.chunks_exact(3) {
+            assert!(v[0] >= -0.5 && v[0] <= 24.5);
+            assert!(v[1] >= -0.5 && v[1] <= 6.5);
+            assert!(v[2] >= -0.5 && v[2] <= 12.5);
+        }
+    }
+
+    #[test]
+    fn deterministic_output() {
+        let mut spec = bracket_spec();
+        spec.resolution = 12;
+        spec.max_iterations = 6;
+        let a = optimize_box([0.0; 3], [24.0, 6.0, 12.0], &spec).unwrap();
+        let b = optimize_box([0.0; 3], [24.0, 6.0, 12.0], &spec).unwrap();
+        assert_eq!(a.mesh.vertices, b.mesh.vertices);
+        assert_eq!(a.mesh.indices, b.mesh.indices);
+    }
+
+    #[test]
+    fn missing_loads_rejected() {
+        let spec = TopoOptSpec::new(
+            vec![],
+            vec![Support {
+                region: RegionBox {
+                    min: [0.0; 3],
+                    max: [0.0, 10.0, 10.0],
+                },
+                fix: [true; 3],
+            }],
+        );
+        assert!(matches!(
+            optimize_box([0.0; 3], [10.0; 3], &spec),
+            Err(TopoOptError::InvalidSpec(_))
+        ));
+    }
+
+    #[test]
+    fn spec_roundtrips_through_json() {
+        let spec = bracket_spec();
+        let json = serde_json::to_string(&spec).unwrap();
+        let back: TopoOptSpec = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.resolution, spec.resolution);
+        assert_eq!(back.loads.len(), 1);
+    }
+}

--- a/crates/vcad-kernel-topopt/src/simp.rs
+++ b/crates/vcad-kernel-topopt/src/simp.rs
@@ -1,0 +1,271 @@
+//! SIMP density optimization loop (compliance minimization under a volume
+//! constraint), in the style of the classic `top88`/`top3d` formulations.
+
+use crate::domain::Domain;
+use crate::fea::FeSystem;
+use crate::spec::TopoOptSpec;
+
+/// Minimum relative stiffness of a "void" element, keeps K non-singular.
+const E_MIN: f64 = 1e-9;
+/// Lower density bound (avoids dead sensitivities and division by zero in
+/// the filter, exactly as in `top88`).
+const X_MIN: f64 = 1e-3;
+/// Density move limit per OC update.
+const MOVE: f64 = 0.2;
+
+/// Raw optimization output: the converged density field plus diagnostics.
+pub struct SimpResult {
+    /// One density per grid element (0 for inactive elements).
+    pub densities: Vec<f64>,
+    /// Compliance after each iteration.
+    pub compliance_history: Vec<f64>,
+    /// Iterations actually run.
+    pub iterations: usize,
+    /// Whether the density change dropped below the tolerance.
+    pub converged: bool,
+}
+
+/// SIMP stiffness scale for a density.
+#[inline]
+fn stiffness_scale(x: f64, penalty: f64) -> f64 {
+    E_MIN + x.powf(penalty) * (1.0 - E_MIN)
+}
+
+/// Run the SIMP loop on a prepared FE system.
+pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -> SimpResult {
+    let nact = sys.active_elems.len();
+    let vf = spec.volume_fraction.clamp(0.01, 0.99);
+
+    // Densities indexed by active-element position.
+    let mut x = vec![vf; nact];
+    let mut u = vec![0.0f64; sys.ndof];
+    let mut history = Vec::with_capacity(spec.max_iterations);
+
+    // Map grid element index -> active index for the filter.
+    let mut act_of_elem = vec![u32::MAX; domain.num_elements()];
+    for (ai, &e) in sys.active_elems.iter().enumerate() {
+        act_of_elem[e as usize] = ai as u32;
+    }
+
+    // Solver budget: warm-started PCG needs a full-accuracy solve only on
+    // the first iteration; after that the displacement field tracks the
+    // slowly-changing densities, so a tight cap keeps large grids tractable
+    // (approximate solves are standard practice for OC updates — the
+    // sensitivity signs, not their last digits, drive the design).
+    let cg_max = (sys.ndof / 2).clamp(500, 4_000);
+
+    let mut converged = false;
+    let mut iterations = 0;
+    let mut scales = vec![0.0f64; nact];
+    let mut dc = vec![0.0f64; nact];
+
+    for it in 0..spec.max_iterations {
+        iterations = it + 1;
+
+        for (s, &xi) in scales.iter_mut().zip(&x) {
+            *s = stiffness_scale(xi, spec.penalty);
+        }
+        sys.solve(&scales, &mut u, 1e-5, cg_max);
+
+        // Compliance and element sensitivities.
+        let mut compliance = 0.0;
+        for (ai, dofs) in sys.edofs.iter().enumerate() {
+            let mut ue = [0.0f64; 24];
+            for (k, &d) in dofs.iter().enumerate() {
+                ue[k] = u[d as usize];
+            }
+            // ce = ueᵀ · KE · ue (unit-E element strain energy measure).
+            let mut ce = 0.0;
+            for r in 0..24 {
+                let row = &sys.ke[r * 24..r * 24 + 24];
+                let mut acc = 0.0;
+                for k in 0..24 {
+                    acc += row[k] * ue[k];
+                }
+                ce += ue[r] * acc;
+            }
+            compliance += scales[ai] * ce;
+            dc[ai] = -spec.penalty * x[ai].powf(spec.penalty - 1.0) * (1.0 - E_MIN) * ce;
+        }
+        history.push(compliance);
+
+        // Mesh-independency (sensitivity) filter, computed on the fly over
+        // the voxel neighborhood within `filter_radius`.
+        let dcn = filter_sensitivities(domain, &act_of_elem, &x, &dc, spec.filter_radius);
+
+        // Optimality-criteria update with bisection on the volume multiplier.
+        let (mut l1, mut l2) = (0.0f64, 1e9f64);
+        let mut xnew = vec![0.0f64; nact];
+        while l2 - l1 > 1e-4 * (l1 + l2) + 1e-30 {
+            let lmid = 0.5 * (l1 + l2);
+            let mut vol = 0.0;
+            for ai in 0..nact {
+                let b = (-dcn[ai]).max(0.0) / lmid;
+                let cand = x[ai] * b.sqrt();
+                let lo = (x[ai] - MOVE).max(X_MIN);
+                let hi = (x[ai] + MOVE).min(1.0);
+                let xn = cand.clamp(lo, hi);
+                xnew[ai] = xn;
+                vol += xn;
+            }
+            if vol > vf * nact as f64 {
+                l1 = lmid;
+            } else {
+                l2 = lmid;
+            }
+        }
+
+        let change = x
+            .iter()
+            .zip(&xnew)
+            .map(|(a, b)| (a - b).abs())
+            .fold(0.0f64, f64::max);
+        x.copy_from_slice(&xnew);
+
+        if change < spec.tolerance {
+            converged = true;
+            break;
+        }
+    }
+
+    // Expand to full grid indexing.
+    let mut densities = vec![0.0f64; domain.num_elements()];
+    for (ai, &e) in sys.active_elems.iter().enumerate() {
+        densities[e as usize] = x[ai];
+    }
+
+    SimpResult {
+        densities,
+        compliance_history: history,
+        iterations,
+        converged,
+    }
+}
+
+/// Classic sensitivity filter: weighted average of `x·dc` over neighbors
+/// within `rmin` voxels, normalized by `x_e · Σw`.
+fn filter_sensitivities(
+    domain: &Domain,
+    act_of_elem: &[u32],
+    x: &[f64],
+    dc: &[f64],
+    rmin: f64,
+) -> Vec<f64> {
+    let nact = x.len();
+    if rmin <= 1.0 {
+        return dc.to_vec();
+    }
+    let reach = rmin.ceil() as isize;
+    let mut dcn = vec![0.0f64; nact];
+
+    for iz in 0..domain.nz {
+        for iy in 0..domain.ny {
+            for ix in 0..domain.nx {
+                let e = domain.eidx(ix, iy, iz);
+                let ai = act_of_elem[e];
+                if ai == u32::MAX {
+                    continue;
+                }
+                let ai = ai as usize;
+                let mut num = 0.0;
+                let mut den = 0.0;
+                for dz in -reach..=reach {
+                    let jz = iz as isize + dz;
+                    if jz < 0 || jz >= domain.nz as isize {
+                        continue;
+                    }
+                    for dy in -reach..=reach {
+                        let jy = iy as isize + dy;
+                        if jy < 0 || jy >= domain.ny as isize {
+                            continue;
+                        }
+                        for dx in -reach..=reach {
+                            let jx = ix as isize + dx;
+                            if jx < 0 || jx >= domain.nx as isize {
+                                continue;
+                            }
+                            let dist = ((dx * dx + dy * dy + dz * dz) as f64).sqrt();
+                            let w = rmin - dist;
+                            if w <= 0.0 {
+                                continue;
+                            }
+                            let je = domain.eidx(jx as usize, jy as usize, jz as usize);
+                            let aj = act_of_elem[je];
+                            if aj == u32::MAX {
+                                continue;
+                            }
+                            let aj = aj as usize;
+                            num += w * x[aj] * dc[aj];
+                            den += w;
+                        }
+                    }
+                }
+                dcn[ai] = num / (den * x[ai].max(X_MIN));
+            }
+        }
+    }
+    dcn
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::{Load, RegionBox, Support, TopoOptSpec};
+
+    fn cantilever_spec() -> TopoOptSpec {
+        let loads = vec![Load {
+            region: RegionBox {
+                min: [16.0, 0.0, 0.0],
+                max: [16.0, 4.0, 1.0],
+            },
+            force: [0.0, 0.0, -100.0],
+        }];
+        let supports = vec![Support {
+            region: RegionBox {
+                min: [0.0, 0.0, 0.0],
+                max: [0.0, 4.0, 8.0],
+            },
+            fix: [true, true, true],
+        }];
+        let mut spec = TopoOptSpec::new(loads, supports);
+        spec.volume_fraction = 0.4;
+        spec.max_iterations = 12;
+        spec
+    }
+
+    #[test]
+    fn cantilever_optimization_improves_and_respects_volume() {
+        let domain = Domain::from_bbox([0.0; 3], [16.0, 4.0, 8.0], 16);
+        let spec = cantilever_spec();
+        let sys = FeSystem::build(&domain, spec.poisson, &spec.loads, &spec.supports).unwrap();
+        let result = optimize_densities(&domain, &sys, &spec);
+
+        assert!(result.iterations >= 2);
+        let first = result.compliance_history[0];
+        let last = *result.compliance_history.last().unwrap();
+        assert!(
+            last < first,
+            "compliance should decrease: {first} -> {last}"
+        );
+
+        let nact = domain.num_active() as f64;
+        let vol: f64 = result.densities.iter().sum::<f64>() / nact;
+        assert!(
+            (vol - spec.volume_fraction).abs() < 0.02,
+            "volume fraction {vol} vs target {}",
+            spec.volume_fraction
+        );
+
+        // The design must differentiate: some elements nearly solid, some
+        // nearly void.
+        let solid = result.densities.iter().filter(|&&d| d > 0.8).count();
+        let void = result
+            .densities
+            .iter()
+            .zip(&domain.active)
+            .filter(|(&d, &a)| a && d < 0.2)
+            .count();
+        assert!(solid > 0, "no solid elements formed");
+        assert!(void > 0, "no void elements formed");
+    }
+}

--- a/crates/vcad-kernel-topopt/src/spec.rs
+++ b/crates/vcad-kernel-topopt/src/spec.rs
@@ -1,0 +1,159 @@
+//! Problem specification types for topology optimization.
+
+use serde::{Deserialize, Serialize};
+
+/// Axis-aligned box region in world (mm) coordinates.
+///
+/// Used to select grid nodes for loads and supports. A node is inside the
+/// region when it lies within the box expanded by half a voxel in every
+/// direction, so a zero-thickness box (e.g. `min.x == max.x`) still catches
+/// the plane of nodes nearest to it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RegionBox {
+    /// Minimum corner `[x, y, z]` in mm.
+    pub min: [f64; 3],
+    /// Maximum corner `[x, y, z]` in mm.
+    pub max: [f64; 3],
+}
+
+impl RegionBox {
+    /// Whether `p` lies inside the box expanded by `pad` on all sides.
+    pub fn contains(&self, p: [f64; 3], pad: f64) -> bool {
+        (0..3).all(|a| p[a] >= self.min[a] - pad && p[a] <= self.max[a] + pad)
+    }
+}
+
+/// A load applied to the structure.
+///
+/// `force` is the **total** force vector in Newtons (any consistent unit
+/// works — the optimal layout is invariant to force scale), distributed
+/// evenly over every grid node inside `region`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Load {
+    /// Where the load is applied.
+    pub region: RegionBox,
+    /// Total force vector `[fx, fy, fz]`.
+    pub force: [f64; 3],
+}
+
+/// A support (fixed boundary condition).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Support {
+    /// Where the structure is anchored.
+    pub region: RegionBox,
+    /// Which translational directions are fixed (`[x, y, z]`).
+    /// Defaults to fully fixed.
+    #[serde(default = "default_fix")]
+    pub fix: [bool; 3],
+}
+
+fn default_fix() -> [bool; 3] {
+    [true, true, true]
+}
+
+/// Topology optimization parameters (SIMP method).
+///
+/// All fields have sensible defaults; a spec only needs `loads`,
+/// `supports`, and (usually) `volume_fraction`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopoOptSpec {
+    /// Fraction of the design domain to keep as material, in `(0, 1)`.
+    #[serde(default = "default_volume_fraction")]
+    pub volume_fraction: f64,
+    /// Voxel count along the longest axis of the domain bounding box.
+    /// Clamped to `[2, 256]`; 32–64 is the practical sweet spot.
+    #[serde(default = "default_resolution")]
+    pub resolution: usize,
+    /// SIMP penalization exponent (typically 3).
+    #[serde(default = "default_penalty")]
+    pub penalty: f64,
+    /// Sensitivity filter radius in voxels (typically 1.2–2.5).
+    #[serde(default = "default_filter_radius")]
+    pub filter_radius: f64,
+    /// Maximum optimization iterations.
+    #[serde(default = "default_max_iterations")]
+    pub max_iterations: usize,
+    /// Convergence tolerance on the max density change per iteration.
+    #[serde(default = "default_tolerance")]
+    pub tolerance: f64,
+    /// Poisson's ratio of the material.
+    #[serde(default = "default_poisson")]
+    pub poisson: f64,
+    /// Taubin smoothing passes applied to the extracted surface.
+    #[serde(default = "default_smooth_iterations")]
+    pub smooth_iterations: usize,
+    /// Applied loads (at least one required).
+    pub loads: Vec<Load>,
+    /// Supports (at least one required).
+    pub supports: Vec<Support>,
+}
+
+fn default_volume_fraction() -> f64 {
+    0.3
+}
+fn default_resolution() -> usize {
+    48
+}
+fn default_penalty() -> f64 {
+    3.0
+}
+fn default_filter_radius() -> f64 {
+    1.5
+}
+fn default_max_iterations() -> usize {
+    40
+}
+fn default_tolerance() -> f64 {
+    0.01
+}
+fn default_poisson() -> f64 {
+    0.3
+}
+fn default_smooth_iterations() -> usize {
+    5
+}
+
+impl TopoOptSpec {
+    /// A spec with default parameters and the given loads/supports.
+    pub fn new(loads: Vec<Load>, supports: Vec<Support>) -> Self {
+        Self {
+            volume_fraction: default_volume_fraction(),
+            resolution: default_resolution(),
+            penalty: default_penalty(),
+            filter_radius: default_filter_radius(),
+            max_iterations: default_max_iterations(),
+            tolerance: default_tolerance(),
+            poisson: default_poisson(),
+            smooth_iterations: default_smooth_iterations(),
+            loads,
+            supports,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spec_deserializes_with_defaults() {
+        let json = r#"{
+            "loads": [{"region": {"min": [0,0,0], "max": [0,0,0]}, "force": [0,0,-100]}],
+            "supports": [{"region": {"min": [0,0,0], "max": [0,10,10]}}]
+        }"#;
+        let spec: TopoOptSpec = serde_json::from_str(json).unwrap();
+        assert_eq!(spec.resolution, 48);
+        assert!((spec.volume_fraction - 0.3).abs() < 1e-12);
+        assert_eq!(spec.supports[0].fix, [true, true, true]);
+    }
+
+    #[test]
+    fn region_contains_with_pad() {
+        let r = RegionBox {
+            min: [0.0, 0.0, 0.0],
+            max: [0.0, 10.0, 10.0],
+        };
+        assert!(r.contains([0.4, 5.0, 5.0], 0.5));
+        assert!(!r.contains([1.0, 5.0, 5.0], 0.5));
+    }
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -353,6 +353,104 @@ pub fn mesh_clearance(
     serde_wasm_bindgen::to_value(&WasmClearance::from(r)).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Result of a topology optimization run (see `vcad-kernel-topopt`).
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "generated/"))]
+pub struct WasmTopoOptResult {
+    /// Optimized structure as a watertight surface mesh (mm, Z-up).
+    pub mesh: WasmMesh,
+    /// Compliance after each SIMP iteration (decreasing = stiffer).
+    #[serde(rename = "complianceHistory")]
+    pub compliance_history: Vec<f64>,
+    /// SIMP iterations actually run.
+    pub iterations: u32,
+    /// Whether the density change converged below the spec tolerance.
+    pub converged: bool,
+    /// Material fraction of the design domain actually used.
+    #[serde(rename = "volumeFraction")]
+    pub volume_fraction: f64,
+    /// Voxel grid dimensions `[nx, ny, nz]`.
+    pub grid: [u32; 3],
+    /// Voxel edge length in mm.
+    #[serde(rename = "voxelSize")]
+    pub voxel_size: f64,
+}
+
+fn topopt_response(
+    result: vcad_kernel::vcad_kernel_topopt::TopoOptResult,
+) -> Result<JsValue, JsError> {
+    let out = WasmTopoOptResult {
+        mesh: WasmMesh {
+            positions: result.mesh.vertices,
+            indices: result.mesh.indices,
+            normals: if result.mesh.normals.is_empty() {
+                None
+            } else {
+                Some(result.mesh.normals)
+            },
+            face_kinds: None,
+        },
+        compliance_history: result.compliance_history,
+        iterations: result.iterations as u32,
+        converged: result.converged,
+        volume_fraction: result.volume_fraction_achieved,
+        grid: [
+            result.grid[0] as u32,
+            result.grid[1] as u32,
+            result.grid[2] as u32,
+        ],
+        voxel_size: result.voxel_size,
+    };
+    serde_wasm_bindgen::to_value(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// SIMP topology optimization over a box design domain.
+///
+/// `spec_json` is a serialized `vcad_kernel_topopt::TopoOptSpec` (loads,
+/// supports, volume fraction, resolution, ...). Returns a
+/// `WasmTopoOptResult`.
+#[wasm_bindgen(js_name = topologyOptimizeBox)]
+#[allow(clippy::too_many_arguments)]
+pub fn topology_optimize_box(
+    spec_json: &str,
+    min_x: f64,
+    min_y: f64,
+    min_z: f64,
+    max_x: f64,
+    max_y: f64,
+    max_z: f64,
+) -> Result<JsValue, JsError> {
+    let spec: vcad_kernel::vcad_kernel_topopt::TopoOptSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let result = vcad_kernel::vcad_kernel_topopt::optimize_box(
+        [min_x, min_y, min_z],
+        [max_x, max_y, max_z],
+        &spec,
+    )
+    .map_err(|e| JsError::new(&e.to_string()))?;
+    topopt_response(result)
+}
+
+/// SIMP topology optimization inside an existing (closed) evaluated mesh:
+/// the mesh's interior becomes the design domain, so material only appears
+/// where the original part had volume.
+#[wasm_bindgen(js_name = topologyOptimizeMesh)]
+pub fn topology_optimize_mesh(
+    spec_json: &str,
+    positions: &[f32],
+    indices: &[u32],
+) -> Result<JsValue, JsError> {
+    let spec: vcad_kernel::vcad_kernel_topopt::TopoOptSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let mut mesh = vcad_kernel_tessellate::TriangleMesh::new();
+    mesh.vertices = positions.to_vec();
+    mesh.indices = indices.to_vec();
+    let result = vcad_kernel::vcad_kernel_topopt::optimize_mesh(&mesh, &spec)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    topopt_response(result)
+}
+
 /// A 2D sketch segment (line or arc) for WASM input.
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -25,6 +25,7 @@ vcad-kernel-cost = { workspace = true }
 vcad-kernel-dfm = { workspace = true }
 vcad-kernel-cam = { workspace = true }
 vcad-kernel-stocksim = { workspace = true }
+vcad-kernel-topopt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -35,6 +35,7 @@ pub use vcad_kernel_sweep;
 pub use vcad_kernel_tessellate;
 pub use vcad_kernel_text;
 pub use vcad_kernel_topo;
+pub use vcad_kernel_topopt;
 
 pub mod cam_verify;
 pub use cam_verify::verify_toolpaths;
@@ -819,6 +820,23 @@ impl Solid {
             SolidRepr::BRep(brep) => tessellate_brep(brep.as_ref(), segments),
             SolidRepr::Mesh(m) => m.clone(),
         }
+    }
+
+    /// Run SIMP topology optimization inside this solid's volume.
+    ///
+    /// The solid's tessellation becomes the design domain (material can
+    /// only appear where the solid already has volume); the spec supplies
+    /// loads, supports, and the target volume fraction. Returns the
+    /// optimized organic structure as a mesh-backed solid together with
+    /// the run diagnostics (compliance history, achieved volume fraction,
+    /// grid size).
+    pub fn topology_optimize(
+        &self,
+        spec: &vcad_kernel_topopt::TopoOptSpec,
+    ) -> Result<(Solid, vcad_kernel_topopt::TopoOptResult), vcad_kernel_topopt::TopoOptError> {
+        let mesh = self.to_mesh(self.segments);
+        let result = vcad_kernel_topopt::optimize_mesh(&mesh, spec)?;
+        Ok((Solid::from_mesh(result.mesh.clone()), result))
     }
 
     /// Compute the volume of the solid from its triangle mesh.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -414,6 +414,91 @@ export interface KernelModule {
     positionsB: Float32Array,
     indicesB: Uint32Array,
   ) => ClearanceResult;
+  /** SIMP topology optimization over a box design domain. */
+  topologyOptimizeBox?: (
+    specJson: string,
+    minX: number,
+    minY: number,
+    minZ: number,
+    maxX: number,
+    maxY: number,
+    maxZ: number,
+  ) => unknown;
+  /** SIMP topology optimization inside a closed evaluated mesh. */
+  topologyOptimizeMesh?: (
+    specJson: string,
+    positions: Float32Array,
+    indices: Uint32Array,
+  ) => unknown;
+}
+
+/** Axis-aligned box region (mm) selecting grid nodes for loads/supports. */
+export interface TopoOptRegion {
+  /** Minimum corner `[x, y, z]` in mm. */
+  min: [number, number, number];
+  /** Maximum corner `[x, y, z]` in mm. */
+  max: [number, number, number];
+}
+
+/** A load for topology optimization: total force spread over a region. */
+export interface TopoOptLoad {
+  region: TopoOptRegion;
+  /** Total force vector `[fx, fy, fz]` (any consistent unit). */
+  force: [number, number, number];
+}
+
+/** A support (fixed boundary) for topology optimization. */
+export interface TopoOptSupport {
+  region: TopoOptRegion;
+  /** Which translational directions are fixed; defaults to fully fixed. */
+  fix?: [boolean, boolean, boolean];
+}
+
+/**
+ * Topology optimization parameters (mirrors `vcad_kernel_topopt::TopoOptSpec`;
+ * unset fields take the kernel defaults).
+ */
+export interface TopoOptSpec {
+  loads: TopoOptLoad[];
+  supports: TopoOptSupport[];
+  /** Material fraction of the domain to keep, in (0, 1). Default 0.3. */
+  volume_fraction?: number;
+  /** Voxels along the longest domain axis (8–128). Default 48. */
+  resolution?: number;
+  /** SIMP penalization exponent. Default 3. */
+  penalty?: number;
+  /** Sensitivity filter radius in voxels. Default 1.5. */
+  filter_radius?: number;
+  /** Max optimization iterations. Default 40. */
+  max_iterations?: number;
+  /** Convergence tolerance on density change. Default 0.01. */
+  tolerance?: number;
+  /** Poisson's ratio. Default 0.3. */
+  poisson?: number;
+  /** Taubin smoothing passes on the extracted surface. Default 5. */
+  smooth_iterations?: number;
+}
+
+/** Result of a topology optimization run (mirrors `WasmTopoOptResult`). */
+export interface TopoOptResult {
+  /** Optimized structure as a watertight surface mesh (mm, Z-up). */
+  mesh: {
+    positions: Float32Array | number[];
+    indices: Uint32Array | number[];
+    normals?: Float32Array | number[];
+  };
+  /** Compliance after each SIMP iteration (decreasing = stiffer). */
+  complianceHistory: number[];
+  /** SIMP iterations actually run. */
+  iterations: number;
+  /** Whether the density change converged below the tolerance. */
+  converged: boolean;
+  /** Material fraction of the design domain actually used. */
+  volumeFraction: number;
+  /** Voxel grid dimensions `[nx, ny, nz]`. */
+  grid: [number, number, number];
+  /** Voxel edge length in mm. */
+  voxelSize: number;
 }
 
 /**
@@ -662,6 +747,8 @@ export class Engine {
       getSheetMetalShopCatalog: (wasmModule as Record<string, unknown>).getSheetMetalShopCatalog as KernelModule["getSheetMetalShopCatalog"],
       sheetMetalFoldedStep: (wasmModule as Record<string, unknown>).sheetMetalFoldedStep as KernelModule["sheetMetalFoldedStep"],
       mesh_clearance: (wasmModule as Record<string, unknown>).mesh_clearance as KernelModule["mesh_clearance"],
+      topologyOptimizeBox: (wasmModule as Record<string, unknown>).topologyOptimizeBox as KernelModule["topologyOptimizeBox"],
+      topologyOptimizeMesh: (wasmModule as Record<string, unknown>).topologyOptimizeMesh as KernelModule["topologyOptimizeMesh"],
     }, compiledWasmModule);
   }
 
@@ -896,6 +983,50 @@ export class Engine {
       );
     }
     return this.kernel.mesh_clearance(a.positions, a.indices, b.positions, b.indices);
+  }
+
+  /**
+   * SIMP topology optimization over a box design domain: find the stiffest
+   * material layout inside `[min, max]` (mm) using only
+   * `spec.volume_fraction` of the volume, under the spec's loads and
+   * supports. Returns the optimized structure as a watertight mesh plus run
+   * diagnostics.
+   */
+  topologyOptimizeBox(
+    min: [number, number, number],
+    max: [number, number, number],
+    spec: TopoOptSpec,
+  ): TopoOptResult {
+    const fn = this.kernel.topologyOptimizeBox;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "topologyOptimizeBox is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(
+      JSON.stringify(spec),
+      min[0],
+      min[1],
+      min[2],
+      max[0],
+      max[1],
+      max[2],
+    ) as TopoOptResult;
+  }
+
+  /**
+   * SIMP topology optimization inside a closed evaluated mesh: the mesh's
+   * interior becomes the design domain, so material only appears where the
+   * original part had volume ("lightweight this bracket").
+   */
+  topologyOptimizeMesh(mesh: TriangleMesh, spec: TopoOptSpec): TopoOptResult {
+    const fn = this.kernel.topologyOptimizeMesh;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "topologyOptimizeMesh is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(JSON.stringify(spec), mesh.positions, mesh.indices) as TopoOptResult;
   }
 
   /** Import solids from a STEP file buffer.

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1502,6 +1502,195 @@
     }
   },
   {
+    "name": "topology_optimize",
+    "title": "Topology Optimize",
+    "description": "SIMP topology optimization: find the stiffest material layout under given loads and supports using only `volume_fraction` of the design domain — the organic, bone-like structures topology optimization is known for. The domain is either an existing part's volume (`part`: lightweight it in place) or an axis-aligned box (`domain_box`: grow a bracket into an envelope). Loads and supports are world-frame box regions (mm, Z-up); a zero-thickness box selects the nearest plane of structure nodes (e.g. a face of the domain). The result is inserted into the document as a frozen mesh part; compliance history and achieved volume fraction are reported. Deterministic for a given spec. Cost scales with resolution³ — start at the default 48 and refine.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session document. Required with `part`; optional with `domain_box` (omitted = a new document is created for the result)."
+        },
+        "part": {
+          "type": "string",
+          "description": "Part id or name whose volume becomes the design domain — material only appears inside this part. Mutually exclusive with `domain_box`."
+        },
+        "domain_box": {
+          "type": "object",
+          "required": [
+            "min",
+            "max"
+          ],
+          "properties": {
+            "min": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "Minimum corner [x, y, z] in mm."
+            },
+            "max": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 3,
+              "maxItems": 3,
+              "description": "Maximum corner [x, y, z] in mm."
+            }
+          },
+          "description": "Axis-aligned box design domain in mm (world frame, Z-up). Mutually exclusive with `part`."
+        },
+        "loads": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Loads. Each is a total force vector (N) distributed over the grid nodes inside its region. Regions are world-frame boxes; a zero-thickness box selects the nearest plane of nodes.",
+          "items": {
+            "type": "object",
+            "required": [
+              "region",
+              "force"
+            ],
+            "properties": {
+              "region": {
+                "type": "object",
+                "required": [
+                  "min",
+                  "max"
+                ],
+                "properties": {
+                  "min": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Minimum corner [x, y, z] in mm."
+                  },
+                  "max": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Maximum corner [x, y, z] in mm."
+                  }
+                }
+              },
+              "force": {
+                "type": "array",
+                "items": {
+                  "type": "number"
+                },
+                "minItems": 3,
+                "maxItems": 3,
+                "description": "Total force [fx, fy, fz]."
+              }
+            }
+          }
+        },
+        "supports": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Fixed (anchored) regions.",
+          "items": {
+            "type": "object",
+            "required": [
+              "region"
+            ],
+            "properties": {
+              "region": {
+                "type": "object",
+                "required": [
+                  "min",
+                  "max"
+                ],
+                "properties": {
+                  "min": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Minimum corner [x, y, z] in mm."
+                  },
+                  "max": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "description": "Maximum corner [x, y, z] in mm."
+                  }
+                }
+              },
+              "fix": {
+                "type": "array",
+                "items": {
+                  "type": "boolean"
+                },
+                "minItems": 3,
+                "maxItems": 3,
+                "description": "Which translations are fixed [x, y, z]; default all true."
+              }
+            }
+          }
+        },
+        "volume_fraction": {
+          "type": "number",
+          "description": "Fraction of the domain volume to keep as material, in (0, 1). Default 0.3."
+        },
+        "resolution": {
+          "type": "number",
+          "description": "Voxels along the longest domain axis (8–128). Higher = finer detail but slower. Default 48."
+        },
+        "max_iterations": {
+          "type": "number",
+          "description": "Max SIMP iterations. Default 40."
+        },
+        "filter_radius": {
+          "type": "number",
+          "description": "Sensitivity filter radius in voxels — larger removes thin members. Default 1.5."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name for the optimized part (default derives from the source)."
+        },
+        "material": {
+          "type": "string",
+          "description": "Material key for the optimized part."
+        },
+        "hide_source": {
+          "type": "boolean",
+          "description": "With `part`: hide the source part after inserting the optimized body (the source node is kept for undo/reference). Default true."
+        }
+      },
+      "required": [
+        "loads",
+        "supports"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": false
+    },
+    "_meta": {
+      "ui": {
+        "resourceUri": "ui://vcad/viewer"
+      },
+      "ui/resourceUri": "ui://vcad/viewer",
+      "openai/outputTemplate": "ui://vcad/viewer-openai.html",
+      "openai/toolInvocation/invoking": "Modeling geometry…",
+      "openai/toolInvocation/invoked": "Model updated"
+    }
+  },
+  {
     "name": "predict_print",
     "title": "Predict Print",
     "description": "Snapshot the design's predicted measurables BEFORE 3D-printing it: kernel-evaluated bbox and mass (at a filament density), plus caller-declared feature dimensions (step heights, hole diameters, wall thicknesses) with design-intent values. Returns a PrintPrediction — save it; after printing, record_measurement joins caliper/scale readings against it. The prediction doubles as the guided measurement worksheet (each measurable carries a human instruction label).",

--- a/packages/mcp/src/__tests__/topopt.test.ts
+++ b/packages/mcp/src/__tests__/topopt.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { topologyOptimizeTool } from "../tools/topopt.js";
+import { documents, getSession, openDocument } from "../tools/session.js";
+
+let engine: Engine;
+
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+beforeEach(() => {
+  documents.clear();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function out(result: { content: Array<{ type: string; text: string }> }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+/** Cantilever fixture: anchor the x=0 face, hang a -Z load off the far
+ *  lower edge. Small resolution/iterations keep the FE solves test-sized. */
+const cantileverArgs = {
+  domain_box: { min: [0, 0, 0], max: [24, 6, 12] },
+  loads: [
+    {
+      region: { min: [24, 0, 0], max: [24, 6, 2] },
+      force: [0, 0, -100],
+    },
+  ],
+  supports: [{ region: { min: [0, 0, 0], max: [0, 6, 12] } }],
+  resolution: 16,
+  max_iterations: 8,
+  volume_fraction: 0.35,
+};
+
+function cubeDocument(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "block",
+        op: { type: "Cube", size: { x: 20, y: 8, z: 10 } },
+      },
+    },
+    roots: [{ root: 1, material: "steel" }],
+    part_materials: {},
+    materials: {},
+  } as unknown as Document;
+}
+
+describe("topology_optimize", () => {
+  it("optimizes a box domain and freezes the result into a new document", () => {
+    const result = out(topologyOptimizeTool(cantileverArgs, engine));
+
+    expect(result.document_id).toBeTruthy();
+    expect(result.triangles).toBeGreaterThan(100);
+    expect(result.iterations).toBeGreaterThanOrEqual(2);
+    // The optimizer must have actually stiffened the structure…
+    expect(result.compliance.final).toBeLessThan(result.compliance.initial);
+    // …while holding the volume budget.
+    expect(result.volume_fraction_achieved).toBeGreaterThan(0.3);
+    expect(result.volume_fraction_achieved).toBeLessThan(0.4);
+
+    // The optimized part landed in the session document as a frozen mesh.
+    const doc = getSession(result.document_id);
+    expect(doc.roots).toHaveLength(1);
+    const node = doc.nodes[result.part_id];
+    expect(node.op.type).toBe("ImportedMesh");
+  });
+
+  it("lightweights an existing part and hides the source", () => {
+    const opened = out(openDocument({ initial: cubeDocument() }));
+    const result = out(
+      topologyOptimizeTool(
+        {
+          document_id: opened.document_id,
+          part: "block",
+          loads: [
+            {
+              region: { min: [20, 0, 0], max: [20, 8, 2] },
+              force: [0, 0, -50],
+            },
+          ],
+          supports: [{ region: { min: [0, 0, 0], max: [0, 8, 10] } }],
+          resolution: 14,
+          max_iterations: 6,
+          volume_fraction: 0.4,
+        },
+        engine,
+      ),
+    );
+
+    expect(result.document_id).toBe(opened.document_id);
+    expect(result.name).toBe("block (optimized)");
+    expect(result.source_part_hidden).toBe("block");
+
+    const doc = getSession(opened.document_id);
+    expect(doc.roots).toHaveLength(2);
+    expect(doc.roots[0].visible).toBe(false); // source hidden
+    expect(doc.roots[1].material).toBe("steel"); // material carried over
+
+    // Optimized geometry stays inside the source part's bounding box.
+    const node = doc.nodes[result.part_id];
+    expect(node.op.type).toBe("ImportedMesh");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const positions = (node.op as any).positions as number[];
+    for (let i = 0; i < positions.length; i += 3) {
+      expect(positions[i]).toBeGreaterThanOrEqual(-0.5);
+      expect(positions[i]).toBeLessThanOrEqual(20.5);
+      expect(positions[i + 2]).toBeGreaterThanOrEqual(-0.5);
+      expect(positions[i + 2]).toBeLessThanOrEqual(10.5);
+    }
+  });
+
+  it("rejects ambiguous or incomplete specs", () => {
+    expect(() =>
+      topologyOptimizeTool({ ...cantileverArgs, loads: [] }, engine),
+    ).toThrow(/loads/);
+    expect(() =>
+      topologyOptimizeTool({ ...cantileverArgs, part: "x" }, engine),
+    ).toThrow(/exactly one/);
+    expect(() =>
+      topologyOptimizeTool(
+        { ...cantileverArgs, domain_box: undefined, part: "x" },
+        engine,
+      ),
+    ).toThrow(/document_id/);
+  });
+
+  it("errors when boundary conditions miss the domain", () => {
+    expect(() =>
+      topologyOptimizeTool(
+        {
+          ...cantileverArgs,
+          loads: [
+            {
+              region: { min: [500, 500, 500], max: [501, 501, 501] },
+              force: [0, 0, -1],
+            },
+          ],
+        },
+        engine,
+      ),
+    ).toThrow(/load/i);
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -127,6 +127,7 @@ import { toolDefs as renderToolDefs } from "./tools/render.js";
 import { toolDefs as verifyToolDefs } from "./tools/verify.js";
 import { toolDefs as verifySpecToolDefs } from "./tools/verify-spec.js";
 import { toolDefs as clearanceToolDefs } from "./tools/clearance.js";
+import { toolDefs as topoptToolDefs } from "./tools/topopt.js";
 import { toolDefs as dfmToolDefs } from "./tools/dfm.js";
 import { toolDefs as sheetMetalToolDefs } from "./tools/sheet-metal.js";
 import { toolDefs as acousticsToolDefs } from "./tools/acoustics.js";
@@ -301,6 +302,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...verifyToolDefs,
   ...verifySpecToolDefs,
   ...clearanceToolDefs,
+  ...topoptToolDefs,
   ...dfmToolDefs,
   ...sheetMetalToolDefs,
   ...acousticsToolDefs,
@@ -372,6 +374,8 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "list_parameters",
   "set_parameters",
   "parameter_gradient",
+  // ── Topology optimization ──────────────────────────────────
+  "topology_optimize",
   // ── Print-then-measure calibration loop (3DP) ──────────────
   "predict_print",
   "record_measurement",

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -239,6 +239,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
       document_id: { type: "string" },
     }),
   },
+  topology_optimize: { title: "Topology Optimize", annotations: RW },
   list_footprints: { title: "List Footprints", annotations: RO },
   search_footprints: { title: "Search Footprints", annotations: RO },
   get_pad_positions: { title: "Get Pad Positions", annotations: RO },

--- a/packages/mcp/src/tools/topopt.ts
+++ b/packages/mcp/src/tools/topopt.ts
@@ -1,0 +1,341 @@
+/**
+ * topology_optimize tool — SIMP topology optimization in the kernel.
+ *
+ * Finds the stiffest material layout for a design domain under given loads
+ * and supports, using only a target fraction of the domain's volume. The
+ * domain is either an existing part's volume ("lightweight this bracket" —
+ * material only appears where the part already is) or an axis-aligned box
+ * ("grow me a bracket spanning this envelope").
+ *
+ * The optimization runs once and the result is frozen into the document as
+ * an `ImportedMesh` part — like every commercial CAD topopt workflow, the
+ * organic result is a generated body, not a parametric feature that
+ * re-solves on every evaluation.
+ */
+
+import type { Document, ImportedMeshOp, Node } from "@vcad/ir";
+import { createDocument } from "@vcad/ir";
+import type {
+  Engine,
+  TopoOptResult,
+  TopoOptSpec,
+  TriangleMesh,
+} from "@vcad/engine";
+import { getSession, registerSession } from "./session.js";
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const regionSchema = {
+  type: "object" as const,
+  required: ["min", "max"],
+  properties: {
+    min: {
+      type: "array" as const,
+      items: { type: "number" as const },
+      minItems: 3,
+      maxItems: 3,
+      description: "Minimum corner [x, y, z] in mm.",
+    },
+    max: {
+      type: "array" as const,
+      items: { type: "number" as const },
+      minItems: 3,
+      maxItems: 3,
+      description: "Maximum corner [x, y, z] in mm.",
+    },
+  },
+};
+
+export const topologyOptimizeSchema = {
+  type: "object" as const,
+  required: ["loads", "supports"],
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description:
+        "Session document. Required with `part`; optional with `domain_box` " +
+        "(omitted = a new document is created for the result).",
+    },
+    part: {
+      type: "string" as const,
+      description:
+        "Part id or name whose volume becomes the design domain — material " +
+        "only appears inside this part. Mutually exclusive with `domain_box`.",
+    },
+    domain_box: {
+      ...regionSchema,
+      description:
+        "Axis-aligned box design domain in mm (world frame, Z-up). " +
+        "Mutually exclusive with `part`.",
+    },
+    loads: {
+      type: "array" as const,
+      minItems: 1,
+      description:
+        "Loads. Each is a total force vector (N) distributed over the grid " +
+        "nodes inside its region. Regions are world-frame boxes; a " +
+        "zero-thickness box selects the nearest plane of nodes.",
+      items: {
+        type: "object" as const,
+        required: ["region", "force"],
+        properties: {
+          region: regionSchema,
+          force: {
+            type: "array" as const,
+            items: { type: "number" as const },
+            minItems: 3,
+            maxItems: 3,
+            description: "Total force [fx, fy, fz].",
+          },
+        },
+      },
+    },
+    supports: {
+      type: "array" as const,
+      minItems: 1,
+      description: "Fixed (anchored) regions.",
+      items: {
+        type: "object" as const,
+        required: ["region"],
+        properties: {
+          region: regionSchema,
+          fix: {
+            type: "array" as const,
+            items: { type: "boolean" as const },
+            minItems: 3,
+            maxItems: 3,
+            description:
+              "Which translations are fixed [x, y, z]; default all true.",
+          },
+        },
+      },
+    },
+    volume_fraction: {
+      type: "number" as const,
+      description:
+        "Fraction of the domain volume to keep as material, in (0, 1). " +
+        "Default 0.3.",
+    },
+    resolution: {
+      type: "number" as const,
+      description:
+        "Voxels along the longest domain axis (8–128). Higher = finer " +
+        "detail but slower. Default 48.",
+    },
+    max_iterations: {
+      type: "number" as const,
+      description: "Max SIMP iterations. Default 40.",
+    },
+    filter_radius: {
+      type: "number" as const,
+      description:
+        "Sensitivity filter radius in voxels — larger removes thin members. " +
+        "Default 1.5.",
+    },
+    name: {
+      type: "string" as const,
+      description: "Name for the optimized part (default derives from the source).",
+    },
+    material: {
+      type: "string" as const,
+      description: "Material key for the optimized part.",
+    },
+    hide_source: {
+      type: "boolean" as const,
+      description:
+        "With `part`: hide the source part after inserting the optimized " +
+        "body (the source node is kept for undo/reference). Default true.",
+    },
+  },
+};
+
+interface TopoArgs {
+  document_id?: string;
+  part?: string;
+  domain_box?: { min: [number, number, number]; max: [number, number, number] };
+  loads?: TopoOptSpec["loads"];
+  supports?: TopoOptSpec["supports"];
+  volume_fraction?: number;
+  resolution?: number;
+  max_iterations?: number;
+  filter_radius?: number;
+  name?: string;
+  material?: string;
+  hide_source?: boolean;
+}
+
+/** Resolve a part (by root id or name) to its evaluated, placed mesh. */
+function resolvePartMesh(
+  doc: Document,
+  engine: Engine,
+  wanted: string,
+): { mesh: TriangleMesh; rootIndex: number; name?: string; material?: string } {
+  const scene = engine.evaluate(doc);
+  const visibleRoots = doc.roots.filter((e) => e.visible !== false);
+  for (let i = 0; i < scene.parts.length && i < visibleRoots.length; i++) {
+    const root = visibleRoots[i];
+    const rootId = String(root.root);
+    const node = doc.nodes[rootId];
+    if (rootId !== wanted && node?.name !== wanted) continue;
+    const mesh = scene.parts[i].mesh;
+    if (!mesh || mesh.positions.length === 0) {
+      throw new Error(`part "${wanted}" evaluated to an empty mesh`);
+    }
+    return {
+      mesh,
+      rootIndex: doc.roots.indexOf(root),
+      name: node?.name ?? undefined,
+      material: root.material ?? undefined,
+    };
+  }
+  throw new Error(
+    `part "${wanted}" not found — pass a root part id or exact name`,
+  );
+}
+
+const round5 = (v: number) => Number(v.toPrecision(5));
+
+export function topologyOptimizeTool(
+  args: Record<string, unknown>,
+  engine: Engine,
+): { content: Array<{ type: "text"; text: string }> } {
+  const a = args as TopoArgs;
+
+  if (!a.loads?.length) throw new Error("topology_optimize: `loads` required");
+  if (!a.supports?.length)
+    throw new Error("topology_optimize: `supports` required");
+  if (!!a.part === !!a.domain_box) {
+    throw new Error(
+      "topology_optimize: pass exactly one of `part` or `domain_box`",
+    );
+  }
+  if (a.part && !a.document_id) {
+    throw new Error("topology_optimize: `part` requires `document_id`");
+  }
+
+  const spec: TopoOptSpec = {
+    loads: a.loads,
+    supports: a.supports,
+    volume_fraction: a.volume_fraction,
+    resolution: a.resolution,
+    max_iterations: a.max_iterations,
+    filter_radius: a.filter_radius,
+  };
+
+  // Resolve the document (or mint one for box-domain runs).
+  let doc: Document;
+  let documentId: string;
+  let minted = false;
+  if (a.document_id) {
+    documentId = String(a.document_id);
+    doc = getSession(documentId);
+  } else {
+    doc = createDocument();
+    documentId = registerSession(doc);
+    minted = true;
+  }
+
+  // Run the optimization on the chosen domain.
+  let result: TopoOptResult;
+  let sourceName: string | undefined;
+  let sourceMaterial: string | undefined;
+  let sourceRootIndex = -1;
+  if (a.part) {
+    const resolved = resolvePartMesh(doc, engine, a.part);
+    sourceName = resolved.name;
+    sourceMaterial = resolved.material;
+    sourceRootIndex = resolved.rootIndex;
+    result = engine.topologyOptimizeMesh(resolved.mesh, spec);
+  } else {
+    const box = a.domain_box!;
+    result = engine.topologyOptimizeBox(box.min, box.max, spec);
+  }
+
+  const triangles = result.mesh.indices.length / 3;
+  if (triangles === 0) {
+    throw new Error(
+      "topology optimization produced an empty structure — check that loads " +
+        "and supports touch the design domain and volume_fraction isn't too low",
+    );
+  }
+
+  // Freeze the result into the document as an ImportedMesh part.
+  const partName =
+    a.name ?? (sourceName ? `${sourceName} (optimized)` : "topopt");
+  const op: ImportedMeshOp = {
+    type: "ImportedMesh",
+    positions: Array.from(result.mesh.positions),
+    indices: Array.from(result.mesh.indices),
+    normals: result.mesh.normals ? Array.from(result.mesh.normals) : undefined,
+    source: "topology_optimize",
+  };
+  const existingIds = Object.keys(doc.nodes).map(Number);
+  const nodeId = (existingIds.length ? Math.max(...existingIds) : 0) + 1;
+  const node: Node = { id: nodeId, name: partName, op };
+  doc.nodes[String(nodeId)] = node;
+  doc.roots.push({
+    root: nodeId,
+    material: a.material ?? sourceMaterial ?? "default",
+  });
+
+  if (a.part && sourceRootIndex >= 0 && a.hide_source !== false) {
+    doc.roots[sourceRootIndex] = {
+      ...doc.roots[sourceRootIndex],
+      visible: false,
+    };
+  }
+
+  const history = result.complianceHistory.map(round5);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            document_id: documentId,
+            part_id: String(nodeId),
+            name: partName,
+            iterations: result.iterations,
+            converged: result.converged,
+            compliance: {
+              initial: history[0],
+              final: history[history.length - 1],
+              history,
+            },
+            volume_fraction_achieved: round5(result.volumeFraction),
+            grid: result.grid,
+            voxel_size_mm: round5(result.voxelSize),
+            triangles,
+            ...(minted
+              ? { note: "New document created for the optimized part." }
+              : {}),
+            ...(a.part && a.hide_source !== false
+              ? { source_part_hidden: a.part }
+              : {}),
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "topology_optimize",
+    pack: null,
+    description:
+      "SIMP topology optimization: find the stiffest material layout under given loads and " +
+      "supports using only `volume_fraction` of the design domain — the organic, bone-like " +
+      "structures topology optimization is known for. The domain is either an existing part's " +
+      "volume (`part`: lightweight it in place) or an axis-aligned box (`domain_box`: grow a " +
+      "bracket into an envelope). Loads and supports are world-frame box regions (mm, Z-up); " +
+      "a zero-thickness box selects the nearest plane of structure nodes (e.g. a face of the " +
+      "domain). The result is inserted into the document as a frozen mesh part; compliance " +
+      "history and achieved volume fraction are reported. Deterministic for a given spec. " +
+      "Cost scales with resolution³ — start at the default 48 and refine.",
+    inputSchema: topologyOptimizeSchema,
+    handler: (args, ctx) => topologyOptimizeTool(args, ctx.engine),
+    behavior: behavior({ writesDoc: true, geometry: true, mount: true }),
+  },
+];


### PR DESCRIPTION
Implements SIMP (Solid Isotropic Material with Penalization) topology optimization for the vcad kernel, enabling users to find the stiffest material layout under given loads and supports using only a target fraction of domain volume.

## Summary

This adds a complete topology optimization pipeline:
1. **Voxel FEA** (`fea.rs`): 8-node hexahedral finite elements on a uniform grid, solved matrix-free with Jacobi-preconditioned conjugate gradients
2. **SIMP optimization loop** (`simp.rs`): Compliance minimization with sensitivity filtering and optimality-criteria updates under volume constraint
3. **Isosurface extraction** (`extract.rs`): Naive surface nets with Taubin smoothing to convert converged density field to watertight triangle mesh
4. **Domain voxelization** (`domain.rs`): Uniform cubic grids from bounding boxes or closed triangle meshes
5. **MCP tool** (`topopt.ts`): User-facing interface supporting both box domains and existing part lightweighting

## Key Changes

- **New crate `vcad-kernel-topopt`**: Core optimization engine with ~1500 lines of Rust
  - `hex_stiffness()`: Precomputed 24×24 element stiffness matrix via 2×2×2 Gauss integration
  - `FeSystem::build()`: Assembles FE context with boundary conditions and load distribution
  - `FeSystem::solve()`: Matrix-free PCG solver with Jacobi preconditioning
  - `optimize_densities()`: SIMP loop with mesh-independence filter and OC updates
  - `extract_mesh()`: Surface nets vertex placement + quad generation with Taubin smoothing

- **WASM bindings** (`vcad-kernel-wasm`): Exposes `topologyOptimizeBox()` and `topologyOptimizeMesh()` to JavaScript

- **Engine integration** (`packages/engine`): TypeScript interfaces for `TopoOptSpec`, `TopoOptLoad`, `TopoOptSupport`, `TopoOptResult`

- **MCP tool** (`packages/mcp/src/tools/topopt.ts`): 
  - Accepts either a part ID (lightweighting) or axis-aligned box (greenfield design)
  - Distributes loads/supports over grid nodes within world-frame box regions
  - Inserts optimized result as frozen `ImportedMesh` part into document
  - Reports compliance history, achieved volume fraction, grid dimensions, voxel size

- **Tests** (`topopt.test.ts`): Cantilever and part-lightweighting scenarios with compliance verification

## Implementation Details

- **Coordinates**: Z-up, millimeters (matching kernel conventions)
- **Material model**: Isotropic elasticity (E=1, configurable Poisson's ratio)
- **Deterministic**: Results are reproducible for a given spec
- **Scalability**: Cost scales with resolution³; practical range 32–64 voxels along longest axis
- **Boundary conditions**: Zero-thickness box regions select nearest plane of nodes (e.g., domain faces)
- **Convergence**: Density change tolerance (default 0.01) or max iterations (default 40)
- **Surface quality**: Naive surface nets avoids mesh artifacts; Taubin smoothing (default 5 passes) gives organic appearance without shrinkage

## Integration

- Registered in workspace `Cargo.toml` and kernel `Cargo.toml`
- Wired into `vcad-kernel` public API
- MCP tool registered in server and metadata
- Fixture updated with schema and example

https://claude.ai/code/session_01Kz1xwUMys9vfh5fezUAAqY