### PR TITLE
fix: assemblies visible through render_view, GLB preview, and inspect_cad

### DIFF
--- a/changelog/entries/2026-07-12-assembly-see-measure.json
+++ b/changelog/entries/2026-07-12-assembly-see-measure.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-12-assembly-see-measure",
+  "version": "0.9.4",
+  "date": "2026-07-12",
+  "category": "fix",
+  "title": "Assemblies render, preview, and inspect",
+  "summary": "Assembly-only documents (partDefs + instances) now work across render_view, the inline 3D preview, and inspect_cad instead of reporting no geometry.",
+  "features": ["assembly", "render", "mcp"],
+  "mcpTools": ["render_view", "inspect_cad", "create_cad_loon"]
+}

--- a/crates/vcad-loon/tests/assembly_lets.rs
+++ b/crates/vcad-loon/tests/assembly_lets.rs
@@ -1,0 +1,26 @@
+//! Assembly built from let-bound solids must produce part defs + instances.
+
+const SRC: &str = r#"
+[let base [cube 120 70 3]]
+[let cell [rotate 0 90 0 [cylinder 9.25 65]]]
+[let tec [cube 40 40 3.8]]
+[assembly
+  #[[part "base" base "aluminum"]
+    [part "cell" cell "chrome"]
+    [part "tec" tec "ceramic"]]
+  #[[instance "base1" "base" 0 0 0]
+    [instance "cell1" "cell" 4.5 26 17]
+    [instance "tec1" "tec" 70 15 6]]
+  #[]
+  "base1"]
+"#;
+
+#[test]
+fn assembly_with_let_bindings_produces_parts() {
+    let doc = vcad_loon::eval_vcad(SRC, None).expect("eval failed");
+    let parts = doc.part_defs.as_ref().map(|p| p.len()).unwrap_or(0);
+    let insts = doc.instances.as_ref().map(|i| i.len()).unwrap_or(0);
+    assert_eq!(parts, 3, "expected 3 part defs, doc: roots={}", doc.roots.len());
+    assert_eq!(insts, 3);
+    assert_eq!(doc.ground_instance_id.as_deref(), Some("base1"));
+}

--- a/crates/vcad-loon/tests/assembly_lets.rs
+++ b/crates/vcad-loon/tests/assembly_lets.rs
@@ -20,7 +20,12 @@ fn assembly_with_let_bindings_produces_parts() {
     let doc = vcad_loon::eval_vcad(SRC, None).expect("eval failed");
     let parts = doc.part_defs.as_ref().map(|p| p.len()).unwrap_or(0);
     let insts = doc.instances.as_ref().map(|i| i.len()).unwrap_or(0);
-    assert_eq!(parts, 3, "expected 3 part defs, doc: roots={}", doc.roots.len());
+    assert_eq!(
+        parts,
+        3,
+        "expected 3 part defs, doc: roots={}",
+        doc.roots.len()
+    );
     assert_eq!(insts, 3);
     assert_eq!(doc.ground_instance_id.as_deref(), Some("base1"));
 }

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -45,6 +45,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use vcad_eval::{evaluate_document, EvalOptions};
 use vcad_ir::file_io::parse_vcad_file;
+use vcad_kernel::vcad_kernel_math::Transform;
 use vcad_kernel::Solid;
 
 // ─── tunable knobs ────────────────────────────────────────────────────────
@@ -247,7 +248,7 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<TintedSolid>, String> {
     .map_err(|e| format!("eval: {}", e))?;
 
     let materials = &parsed.document.materials;
-    let solids: Vec<TintedSolid> = scene
+    let mut solids: Vec<TintedSolid> = scene
         .parts
         .iter()
         .filter_map(|p| {
@@ -257,7 +258,82 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<TintedSolid>, String> {
             })
         })
         .collect();
+
+    // Assembly instances: `evaluate_document` only carries meshes for
+    // instances, not BRep solids, so re-evaluate each referenced part
+    // definition once and place a transformed copy per instance. Without
+    // this, an assembly-only document (no scene roots) rendered as
+    // "no solids produced" despite being perfectly valid.
+    solids.extend(evaluate_assembly_instances(&parsed.document)?);
     Ok(solids)
+}
+
+/// Evaluate the document's assembly instances (if any) into world-placed
+/// tinted solids. Part-definition solids are evaluated once and shared;
+/// per-instance world poses come from forward kinematics, falling back to
+/// the instance's static transform.
+fn evaluate_assembly_instances(doc: &vcad_ir::Document) -> Result<Vec<TintedSolid>, String> {
+    let (Some(part_defs), Some(instances)) = (&doc.part_defs, &doc.instances) else {
+        return Ok(Vec::new());
+    };
+    if part_defs.is_empty() || instances.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let world = catch_unwind(AssertUnwindSafe(|| {
+        vcad_eval::solve_forward_kinematics(doc)
+    }))
+    .map_err(|_| "fk panicked".to_string())?;
+
+    let mut cache: HashMap<vcad_ir::NodeId, Option<Solid>> = HashMap::new();
+    let mut def_solids: HashMap<&str, Option<Solid>> = HashMap::new();
+    let mut out = Vec::new();
+
+    for inst in instances {
+        let Some(def) = part_defs.get(&inst.part_def_id) else {
+            continue;
+        };
+        let solid = def_solids
+            .entry(inst.part_def_id.as_str())
+            .or_insert_with(|| {
+                catch_unwind(AssertUnwindSafe(|| {
+                    vcad_eval::evaluate_node(def.root, &doc.nodes, &mut cache)
+                        .ok()
+                        .flatten()
+                }))
+                .unwrap_or(None)
+            })
+            .clone();
+        let Some(solid) = solid else { continue };
+
+        let placed = match world.get(&inst.id).cloned().or(inst.transform) {
+            Some(t) => solid.apply_transform(&transform3d_to_kernel(&t)),
+            None => solid,
+        };
+
+        let material = inst
+            .material
+            .clone()
+            .or_else(|| def.default_material.clone())
+            .unwrap_or_else(|| "default".to_string());
+        let color = doc.materials.get(&material).map(|m| m.color);
+        out.push((placed, color));
+    }
+    Ok(out)
+}
+
+/// IR `Transform3D` → kernel `Transform`, matching the evaluator's
+/// convention: scale, then Rx·Ry·Rz (applied x-first), then translation.
+fn transform3d_to_kernel(t: &vcad_ir::Transform3D) -> Transform {
+    Transform::scale(t.scale.x, t.scale.y, t.scale.z)
+        .then(&Transform::rotation_x(t.rotation.x.to_radians()))
+        .then(&Transform::rotation_y(t.rotation.y.to_radians()))
+        .then(&Transform::rotation_z(t.rotation.z.to_radians()))
+        .then(&Transform::translation(
+            t.translation.x,
+            t.translation.y,
+            t.translation.z,
+        ))
 }
 
 // ─── canonicalized per-solid mesh ─────────────────────────────────────────
@@ -1789,6 +1865,37 @@ mod tests {
   "roots": [{{ "root": 1, "material": "aluminum" }}]
 }}"#
         )
+    }
+
+    /// Regression: an assembly-only document (partDefs + instances, no
+    /// scene roots) must render its placed instances rather than failing
+    /// with "no solids produced".
+    #[test]
+    fn assembly_instances_render() {
+        let vcad = r#"{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "base", "op": { "type": "Cube", "size": { "x": 40.0, "y": 40.0, "z": 5.0 } } },
+    "2": { "id": 2, "name": "post", "op": { "type": "Cylinder", "radius": 5.0, "height": 30.0, "segments": 0 } }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [],
+  "partDefs": {
+    "base": { "id": "base", "name": "base", "root": 1 },
+    "post": { "id": "post", "name": "post", "root": 2 }
+  },
+  "instances": [
+    { "id": "base1", "partDefId": "base", "transform": { "translation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } } },
+    { "id": "post1", "partDefId": "post", "transform": { "translation": { "x": 20.0, "y": 20.0, "z": 5.0 }, "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 }, "scale": { "x": 1.0, "y": 1.0, "z": 1.0 } } }
+  ],
+  "groundInstanceId": "base1"
+}"#;
+        let svg = render_svg_str(vcad, 2.0).expect("assembly should render");
+        assert!(
+            svg.matches("<polygon").count() > 6,
+            "expected filled polygons for both instances"
+        );
     }
 
     /// Regression: the cone's lateral facets wind inward, so winding-only

--- a/packages/mcp/src/__tests__/assembly-visibility.test.ts
+++ b/packages/mcp/src/__tests__/assembly-visibility.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Assembly documents (partDefs + instances, no scene roots) must be visible
+ * through the see/measure surface: GLB preview and inspect_cad. Regression
+ * for the "no geometry to preview" / "no parts to inspect" family — the
+ * evaluator returns assembly geometry as `scene.instances`, which these
+ * paths previously ignored.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { previewGlbFor } from "../tools/preview.js";
+import { computeInspection } from "../tools/inspect.js";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+const ASSEMBLY_LOON = `
+[let base [cube 40 40 5]]
+[let post [cylinder 5 30]]
+[assembly
+  #[[part "base" base "aluminum"]
+    [part "post" post "steel"]]
+  #[[instance "base1" "base" 0 0 0]
+    [instance "post1" "post" 20 20 5]]
+  #[]
+  "base1"]
+`;
+
+function assemblyDoc(): Document {
+  const doc = engine.evalVcadSource(ASSEMBLY_LOON);
+  if (!doc) throw new Error("loon eval failed");
+  return doc;
+}
+
+describe("assembly visibility", () => {
+  it("previewGlbFor renders instances of an assembly-only document", async () => {
+    const doc = assemblyDoc();
+    expect(doc.roots?.length ?? 0).toBe(0);
+    expect(doc.instances?.length).toBe(2);
+    const preview = await previewGlbFor(doc, engine);
+    expect(preview).not.toBeNull();
+    expect(preview!.glb.length).toBeGreaterThan(0);
+  });
+
+  it("computeInspection aggregates instance geometry", () => {
+    const doc = assemblyDoc();
+    const result = computeInspection(doc, engine);
+    expect(result.parts).toBe(2);
+    // base 40*40*5 + post ~ pi*25*30 (world-placed, tessellated)
+    expect(result.volume_mm3).toBeGreaterThan(8000);
+    // The post instance is translated to z=5..35 — world bbox must include it.
+    expect(result.bounding_box.max.z).toBeGreaterThan(30);
+    expect(result.bounding_box.max.x).toBeGreaterThanOrEqual(25);
+  });
+});

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -8,7 +8,7 @@
  * all three reuse the tessellation-bound mesh math exported from here.
  */
 
-import type { Engine, TriangleMesh } from "@vcad/engine";
+import { transformMesh, type Engine, type TriangleMesh } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { isoperimetricViolation } from "./integrity.js";
 import { resolveDocInput } from "./session.js";
@@ -223,7 +223,22 @@ export function computeInspection(ir: Document, engine: Engine): InspectResult {
   // Evaluate the document
   const scene = engine.evaluate(ir);
 
-  if (scene.parts.length === 0) {
+  // Assembly instances carry part-local meshes plus a world transform;
+  // fold them in as world-placed units so assembly-only documents (no
+  // scene roots) inspect instead of erroring.
+  const instanceUnits = (scene.instances ?? []).map((inst) => ({
+    mesh: inst.transform
+      ? transformMesh(inst.mesh, {
+          translate: inst.transform.translation,
+          rotate: inst.transform.rotation,
+          scale: inst.transform.scale,
+        })
+      : inst.mesh,
+    material: inst.material,
+    name: inst.name ?? inst.instanceId,
+  }));
+
+  if (scene.parts.length === 0 && instanceUnits.length === 0) {
     throw new Error("Document has no parts to inspect");
   }
 
@@ -254,8 +269,22 @@ export function computeInspection(ir: Document, engine: Engine): InspectResult {
     }
   }
 
-  for (let i = 0; i < scene.parts.length; i++) {
-    const part = scene.parts[i];
+  const units = [
+    ...scene.parts.map((part, i) => {
+      const rootEntry = ir.roots[i];
+      return {
+        mesh: part.mesh,
+        material: part.material ?? "default",
+        name: rootEntry
+          ? rootNameMap.get(rootEntry.root) ?? `part_${i + 1}`
+          : `part_${i + 1}`,
+      };
+    }),
+    ...instanceUnits,
+  ];
+
+  for (let i = 0; i < units.length; i++) {
+    const part = units[i];
     const props = computeMeshProperties(part.mesh);
 
     totalVolume += props.volume;
@@ -276,13 +305,11 @@ export function computeInspection(ir: Document, engine: Engine): InspectResult {
     bbox.max.z = Math.max(bbox.max.z, props.bbox.max.z);
 
     // Compute mass if material has density
-    const materialKey = part.material ?? "default";
+    const materialKey = part.material;
     const material = ir.materials?.[materialKey];
     const density = material?.density;
 
-    // Get part name from root or use index
-    const rootEntry = ir.roots[i];
-    const partName = rootEntry ? rootNameMap.get(rootEntry.root) ?? `part_${i + 1}` : `part_${i + 1}`;
+    const partName = part.name;
 
     // Isoperimetric impossibility: A³ ≥ 36πV² for any real solid, so a
     // violating (volume, area) pair means the volume integral is corrupt
@@ -349,7 +376,7 @@ export function computeInspection(ir: Document, engine: Engine): InspectResult {
       z: Math.round(com.z * 1000) / 1000,
     },
     triangles: totalTriangles,
-    parts: scene.parts.length,
+    parts: units.length,
   };
 
   // Add mass data if any materials have density

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -234,7 +234,7 @@ export function computeInspection(ir: Document, engine: Engine): InspectResult {
           scale: inst.transform.scale,
         })
       : inst.mesh,
-    material: inst.material,
+    material: inst.material ?? "default",
     name: inst.name ?? inst.instanceId,
   }));
 

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Document } from "@vcad/ir";
-import { pcbPreviewMeshes, type Engine } from "@vcad/engine";
+import { pcbPreviewMeshes, transformMesh, type Engine } from "@vcad/engine";
 import { getNodePcb } from "@vcad/core";
 import {
   buildGlb,
@@ -172,6 +172,28 @@ export async function generateGlbPreview(
         positions: part.mesh.positions,
         indices: part.mesh.indices,
         normals: part.mesh.normals,
+        color: DEFAULT_MATERIAL.color,
+        metallic: DEFAULT_MATERIAL.metallic,
+        roughness: DEFAULT_MATERIAL.roughness,
+      });
+    }
+
+    // Assembly instances (part-local mesh + world transform). Bake the
+    // transform into the vertices so an assembly-only document previews
+    // instead of showing an empty grid.
+    for (const inst of scene?.instances ?? []) {
+      const mesh = inst.transform
+        ? transformMesh(inst.mesh, {
+            translate: inst.transform.translation,
+            rotate: inst.transform.rotation,
+            scale: inst.transform.scale,
+          })
+        : inst.mesh;
+      meshes.push({
+        name: `${inst.instanceId}:${inst.name ?? ""}`,
+        positions: mesh.positions,
+        indices: mesh.indices,
+        normals: mesh.normals,
         color: DEFAULT_MATERIAL.color,
         metallic: DEFAULT_MATERIAL.metallic,
         roughness: DEFAULT_MATERIAL.roughness,


### PR DESCRIPTION
## Problem

An assembly-only document (`partDefs` + `instances`, no scene roots) — e.g. anything authored with loon's `[assembly …]` form — was invisible to the entire see/measure surface:

- `render_view` → `no solids produced`
- inline 3D viewer → `no geometry to preview`
- `inspect_cad` → `Document has no parts to inspect`

The evaluator returns assembly geometry as `scene.instances` (part-local meshes + world transforms), and all three consumers only read `scene.parts`.

## Fix

- **vcad-render**: evaluate each referenced part definition once to a BRep solid and place a transformed copy per instance (FK world pose, falling back to the static instance transform). New `transform3d_to_kernel` mirrors the evaluator's scale → Rx·Ry·Rz → translate convention.
- **MCP GLB preview** (`generateGlbPreview`): bake instance transforms into vertices and append instance meshes, so the inline viewer paints assemblies.
- **`inspect_cad`** (`computeInspection`): fold world-placed instance meshes into the aggregate (volume/area/bbox/COM/mass), so assembly docs inspect.

## Tests

- `crates/vcad-loon/tests/assembly_lets.rs` — assembly built from let-bound solids yields part defs + instances (guards the authoring path).
- `vcad-render::tests::assembly_instances_render` — assembly-only JSON doc renders polygons.
- `packages/mcp/src/__tests__/assembly-visibility.test.ts` — `previewGlbFor` + `computeInspection` on a loon-authored assembly.

`cargo test -p vcad-render -p vcad-loon`, clippy `-D warnings`, fmt clean; MCP suite 813 passed. WASM artifacts untouched per policy (verified locally against a fresh wasm build: `render_svg` on an assembly returns 134 polygons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)