### PR TITLE
fix: make PCB DRC and zone fill scale to large imported boards

### DIFF
--- a/changelog/entries/2026-07-15-drc-large-board-scaling.json
+++ b/changelog/entries/2026-07-15-drc-large-board-scaling.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-15-drc-large-board-scaling",
+  "version": "0.9.4",
+  "date": "2026-07-15",
+  "category": "fix",
+  "title": "DRC and describe_pcb scale to large imported boards",
+  "summary": "run_drc/describe_pcb on dense imported KiCad boards (10 layers, 100+ zones) now finish in seconds instead of crashing the MCP server after ~17 minutes.",
+  "features": ["pcb", "drc", "import"],
+  "mcpTools": ["run_drc", "describe_pcb", "import_kicad", "export_gerber"]
+}

--- a/crates/vcad-ecad-pcb/src/copper_pour.rs
+++ b/crates/vcad-ecad-pcb/src/copper_pour.rs
@@ -105,12 +105,38 @@ fn collect_clearance_regions(pcb: &Pcb, zone: &Zone) -> Vec<Poly> {
     let clearance = zone.clearance;
     let mut clips: Vec<Poly> = Vec::new();
 
+    // A clip whose bounding box is disjoint from the zone outline's bbox can't
+    // change the difference — skip it up front so a partial pour on a dense
+    // board doesn't pay for every far-away element's capsule in the boolean.
+    let mut zmin = Vec2::new(f64::MAX, f64::MAX);
+    let mut zmax = Vec2::new(f64::MIN, f64::MIN);
+    for v in &zone.outline {
+        zmin.x = zmin.x.min(v.x);
+        zmin.y = zmin.y.min(v.y);
+        zmax.x = zmax.x.max(v.x);
+        zmax.y = zmax.y.max(v.y);
+    }
+    let hits_zone = |min: Vec2, max: Vec2| -> bool {
+        max.x >= zmin.x && min.x <= zmax.x && max.y >= zmin.y && min.y <= zmax.y
+    };
+
     // Other-net traces on this layer: capsule (thick segment) clearance.
     for trace in &pcb.traces {
         if trace.net == zone.net || trace.layer != zone.layer {
             continue;
         }
         let r = trace.width / 2.0 + clearance;
+        let min = Vec2::new(
+            trace.start.x.min(trace.end.x) - r,
+            trace.start.y.min(trace.end.y) - r,
+        );
+        let max = Vec2::new(
+            trace.start.x.max(trace.end.x) + r,
+            trace.start.y.max(trace.end.y) + r,
+        );
+        if !hits_zone(min, max) {
+            continue;
+        }
         clips.push(capsule_poly(trace.start, trace.end, r));
     }
 
@@ -119,7 +145,13 @@ fn collect_clearance_regions(pcb: &Pcb, zone: &Zone) -> Vec<Poly> {
         if via.net == zone.net {
             continue;
         }
-        clips.push(circle_poly(via.position, via.diameter / 2.0 + clearance));
+        let r = via.diameter / 2.0 + clearance;
+        let min = Vec2::new(via.position.x - r, via.position.y - r);
+        let max = Vec2::new(via.position.x + r, via.position.y + r);
+        if !hits_zone(min, max) {
+            continue;
+        }
+        clips.push(circle_poly(via.position, r));
     }
 
     // Pads: other-net pads get a full clearance void; same-net pads get
@@ -136,6 +168,15 @@ fn collect_clearance_regions(pcb: &Pcb, zone: &Zone) -> Vec<Poly> {
             let ang = fr + pad.rotation.to_radians();
             let (hw, hh) = pad_half_extents(pad);
             let same_net = pad.net.as_deref() == Some(zone.net.as_str());
+            // Covers the worst case: thermal-relief spokes reach
+            // (max_half_extent + gap) * 2 from the pad center.
+            let reach = (hw.max(hh) + clearance.max(gap)) * 2.0;
+            if !hits_zone(
+                Vec2::new(world.x - reach, world.y - reach),
+                Vec2::new(world.x + reach, world.y + reach),
+            ) {
+                continue;
+            }
 
             if !same_net {
                 clips.push(oriented_rect_poly(

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -1180,7 +1180,74 @@ enum NodeGeom {
     /// is in the pour by the even-odd rule over the rings, so the plane connects
     /// to same-net copper it floods over and not to the cleared other-net copper
     /// sitting in its voids.
-    Pour(Vec<Vec<Vec2>>),
+    Pour(PourRings),
+}
+
+/// A pour's filled rings with cached per-ring bounding boxes, so the even-odd
+/// and distance narrowphases can skip the thousands of small void rings a
+/// dense plane carries instead of scanning every vertex per query.
+struct PourRings {
+    rings: Vec<Vec<Vec2>>,
+    /// Per-ring axis-aligned bbox `(min, max)`.
+    bboxes: Vec<(Vec2, Vec2)>,
+}
+
+impl PourRings {
+    fn new(rings: Vec<Vec<Vec2>>) -> Self {
+        let bboxes = rings
+            .iter()
+            .map(|r| {
+                let mut min = Vec2::new(f64::MAX, f64::MAX);
+                let mut max = Vec2::new(f64::MIN, f64::MIN);
+                for p in r {
+                    min.x = min.x.min(p.x);
+                    min.y = min.y.min(p.y);
+                    max.x = max.x.max(p.x);
+                    max.y = max.y.max(p.y);
+                }
+                (min, max)
+            })
+            .collect();
+        Self { rings, bboxes }
+    }
+
+    /// Distance from a point to a ring's bbox (0 inside).
+    fn bbox_dist_point(bb: &(Vec2, Vec2), p: Vec2) -> f64 {
+        let dx = (bb.0.x - p.x).max(0.0).max(p.x - bb.1.x);
+        let dy = (bb.0.y - p.y).max(0.0).max(p.y - bb.1.y);
+        (dx * dx + dy * dy).sqrt()
+    }
+
+    /// Distance from a segment's bbox to a ring's bbox (0 on overlap).
+    fn bbox_dist_segment(bb: &(Vec2, Vec2), a: Vec2, b: Vec2) -> f64 {
+        let dx = (bb.0.x - a.x.max(b.x)).max(0.0).max(a.x.min(b.x) - bb.1.x);
+        let dy = (bb.0.y - a.y.max(b.y)).max(0.0).max(a.y.min(b.y) - bb.1.y);
+        (dx * dx + dy * dy).sqrt()
+    }
+}
+
+/// Axis-aligned bounding box of a connectivity node's geometry (mm).
+fn node_bounds(geom: &NodeGeom) -> ([f64; 2], [f64; 2]) {
+    match geom {
+        NodeGeom::Copper(g) => g.bounds(),
+        NodeGeom::Pour(pour) => {
+            let mut min = [f64::MAX, f64::MAX];
+            let mut max = [f64::MIN, f64::MIN];
+            for ring in &pour.rings {
+                for p in ring {
+                    min[0] = min[0].min(p.x);
+                    min[1] = min[1].min(p.y);
+                    max[0] = max[0].max(p.x);
+                    max[1] = max[1].max(p.y);
+                }
+            }
+            if min[0] > max[0] {
+                (min, min)
+            } else {
+                (min, max)
+            }
+        }
+    }
 }
 
 /// A piece of copper participating in connectivity analysis.
@@ -1235,17 +1302,37 @@ fn node_geoms_touch(a: &NodeGeom, b: &NodeGeom) -> bool {
     }
 }
 
-/// Even-odd point-in-pour test over the filled rings.
-fn point_in_pour(rings: &[Vec<Vec2>], p: Vec2) -> bool {
-    rings.iter().filter(|r| point_in_polygon(p, r)).count() % 2 == 1
+/// Even-odd point-in-pour test over the filled rings. Rings whose bbox
+/// excludes the point contribute an even (zero) crossing count, so they are
+/// skipped outright.
+fn point_in_pour(pour: &PourRings, p: Vec2) -> bool {
+    pour.rings
+        .iter()
+        .zip(&pour.bboxes)
+        .filter(|(r, bb)| {
+            p.x >= bb.0.x
+                && p.x <= bb.1.x
+                && p.y >= bb.0.y
+                && p.y <= bb.1.y
+                && point_in_polygon(p, r)
+        })
+        .count()
+        % 2
+        == 1
 }
 
-/// Minimum distance from a point to the nearest edge of any ring.
-fn min_dist_point_to_pour(p: Vec2, rings: &[Vec<Vec2>]) -> f64 {
-    rings
-        .iter()
-        .map(|r| min_distance_to_polygon(&p, r))
-        .fold(f64::MAX, f64::min)
+/// Minimum distance from a point to the nearest ring edge, ignoring rings
+/// whose bbox is already farther than `cutoff` (the caller's touch
+/// threshold) — the result is only ever compared against `cutoff`.
+fn min_dist_point_to_pour(p: Vec2, pour: &PourRings, cutoff: f64) -> f64 {
+    let mut best = f64::MAX;
+    for (r, bb) in pour.rings.iter().zip(&pour.bboxes) {
+        if PourRings::bbox_dist_point(bb, p) > cutoff.min(best) {
+            continue;
+        }
+        best = best.min(min_distance_to_polygon(&p, r));
+    }
+    best
 }
 
 /// True if a copper geom touches/overlaps a filled pour (even-odd over rings).
@@ -1254,34 +1341,39 @@ fn min_dist_point_to_pour(p: Vec2, rings: &[Vec<Vec2>]) -> f64 {
 /// sitting in a clearance void reads as outside (its hole adds an even count),
 /// and is also a full `clearance` from the nearest void edge, so the proximity
 /// check never false-connects it.
-fn copper_touches_pour(g: &CopperGeom, rings: &[Vec<Vec2>]) -> bool {
+fn copper_touches_pour(g: &CopperGeom, pour: &PourRings) -> bool {
     match g {
         CopperGeom::Disc { center, r } => {
-            point_in_pour(rings, *center)
-                || min_dist_point_to_pour(*center, rings) <= *r + TOUCH_EPS
+            point_in_pour(pour, *center)
+                || min_dist_point_to_pour(*center, pour, *r + TOUCH_EPS) <= *r + TOUCH_EPS
         }
         CopperGeom::Segment { a, b, half_w } => {
             let mid = Vec2::new((a.x + b.x) / 2.0, (a.y + b.y) / 2.0);
-            if point_in_pour(rings, *a) || point_in_pour(rings, *b) || point_in_pour(rings, mid) {
+            if point_in_pour(pour, *a) || point_in_pour(pour, *b) || point_in_pour(pour, mid) {
                 return true;
             }
-            min_dist_segment_to_pour(*a, *b, rings) <= *half_w + TOUCH_EPS
+            min_dist_segment_to_pour(*a, *b, pour, *half_w + TOUCH_EPS) <= *half_w + TOUCH_EPS
         }
         CopperGeom::Rect { center, .. } => {
-            if point_in_pour(rings, *center) {
+            if point_in_pour(pour, *center) {
                 return true;
             }
-            rect_corners(g).iter().any(|c| point_in_pour(rings, *c))
+            rect_corners(g).iter().any(|c| point_in_pour(pour, *c))
         }
     }
 }
 
-/// Minimum distance from a segment to the nearest edge of any ring.
-fn min_dist_segment_to_pour(a: Vec2, b: Vec2, rings: &[Vec<Vec2>]) -> f64 {
-    rings
-        .iter()
-        .map(|r| min_dist_segment_to_polygon_edges(a, b, r))
-        .fold(f64::MAX, f64::min)
+/// Minimum distance from a segment to the nearest ring edge, ignoring rings
+/// whose bbox is already farther than `cutoff`.
+fn min_dist_segment_to_pour(a: Vec2, b: Vec2, pour: &PourRings, cutoff: f64) -> f64 {
+    let mut best = f64::MAX;
+    for (r, bb) in pour.rings.iter().zip(&pour.bboxes) {
+        if PourRings::bbox_dist_segment(bb, a, b) > cutoff.min(best) {
+            continue;
+        }
+        best = best.min(min_dist_segment_to_polygon_edges(a, b, r));
+    }
+    best
 }
 
 /// Corners of a [`CopperGeom::Rect`] (empty otherwise).
@@ -1333,17 +1425,20 @@ fn min_dist_segment_to_polygon_edges(a: Vec2, b: Vec2, poly: &[Vec2]) -> f64 {
 }
 
 /// True if two filled pours touch/overlap (even-odd over each ring set).
-fn pours_touch(a: &[Vec<Vec2>], b: &[Vec<Vec2>]) -> bool {
-    if a.iter().flatten().any(|p| point_in_pour(b, *p))
-        || b.iter().flatten().any(|p| point_in_pour(a, *p))
+fn pours_touch(a: &PourRings, b: &PourRings) -> bool {
+    if a.rings.iter().flatten().any(|p| point_in_pour(b, *p))
+        || b.rings.iter().flatten().any(|p| point_in_pour(a, *p))
     {
         return true;
     }
-    // Any ring edge of one crossing a ring of the other.
-    for ra in a {
+    // Any ring edge of one crossing a ring of the other (bbox-pruned).
+    for ra in &a.rings {
         for i in 0..ra.len() {
             let (s, e) = (ra[i], ra[(i + 1) % ra.len()]);
-            if b.iter().any(|rb| segment_polygon_intersects(s, e, rb)) {
+            if b.rings.iter().zip(&b.bboxes).any(|(rb, bb)| {
+                PourRings::bbox_dist_segment(bb, s, e) <= 0.0
+                    && segment_polygon_intersects(s, e, rb)
+            }) {
                 return true;
             }
         }
@@ -1454,7 +1549,7 @@ fn build_conn_nodes(pcb: &Pcb) -> Vec<ConnNode> {
                 .map(|outer| polygon_centroid(outer))
                 .unwrap_or_else(|| polygon_centroid(&zone.outline));
             nodes.push(ConnNode {
-                geom: NodeGeom::Pour(island),
+                geom: NodeGeom::Pour(PourRings::new(island)),
                 layers: layer,
                 net: zone.net.clone(),
                 pad: None,
@@ -2235,15 +2330,80 @@ fn build_connectivity_with_contacts(pcb: &Pcb) -> (Vec<ConnNode>, Dsu, Vec<NodeC
     let nodes = build_conn_nodes(pcb);
     let mut dsu = Dsu::new(nodes.len());
     let mut contacts = Vec::new();
-    for i in 0..nodes.len() {
-        for j in (i + 1)..nodes.len() {
-            if nodes[i].touches(&nodes[j]) {
-                dsu.union(i, j);
-                contacts.push(NodeContact {
-                    i,
-                    j,
-                    at: contact_point(&nodes[i].geom, &nodes[j].geom),
-                });
+
+    // Broadphase: two nodes whose (slightly inflated) bounding boxes are
+    // disjoint can't touch, so bucket nodes into a uniform grid and only run
+    // the narrowphase on pairs sharing a cell. On a dense imported board
+    // (~12k copper nodes, pours with 10k-vertex rings) the old all-pairs loop
+    // was ~80M narrowphase calls — most against pour polygons.
+    let bboxes: Vec<([f64; 2], [f64; 2])> = nodes
+        .iter()
+        .map(|n| {
+            let (mut min, mut max) = node_bounds(&n.geom);
+            min[0] -= TOUCH_EPS;
+            min[1] -= TOUCH_EPS;
+            max[0] += TOUCH_EPS;
+            max[1] += TOUCH_EPS;
+            (min, max)
+        })
+        .collect();
+    let mut gmin = [f64::MAX, f64::MAX];
+    let mut gmax = [f64::MIN, f64::MIN];
+    for (min, max) in &bboxes {
+        gmin[0] = gmin[0].min(min[0]);
+        gmin[1] = gmin[1].min(min[1]);
+        gmax[0] = gmax[0].max(max[0]);
+        gmax[1] = gmax[1].max(max[1]);
+    }
+    if nodes.is_empty() {
+        return (nodes, dsu, contacts);
+    }
+    const GRID_RES: f64 = 128.0;
+    let cell = ((gmax[0] - gmin[0]).max(gmax[1] - gmin[1]) / GRID_RES).max(1e-3);
+    let cols = (((gmax[0] - gmin[0]) / cell) as usize).max(1) + 1;
+    let rows = (((gmax[1] - gmin[1]) / cell) as usize).max(1) + 1;
+    let cell_of = |x: f64, y: f64| -> (usize, usize) {
+        (
+            (((x - gmin[0]) / cell) as usize).min(cols - 1),
+            (((y - gmin[1]) / cell) as usize).min(rows - 1),
+        )
+    };
+    let mut buckets: Vec<Vec<u32>> = vec![Vec::new(); cols * rows];
+    for (i, (min, max)) in bboxes.iter().enumerate() {
+        let (c0, r0) = cell_of(min[0], min[1]);
+        let (c1, r1) = cell_of(max[0], max[1]);
+        for r in r0..=r1 {
+            for c in c0..=c1 {
+                buckets[r * cols + c].push(i as u32);
+            }
+        }
+    }
+    let mut seen = vec![u32::MAX; nodes.len()];
+    for (i, (min, max)) in bboxes.iter().enumerate() {
+        let (c0, r0) = cell_of(min[0], min[1]);
+        let (c1, r1) = cell_of(max[0], max[1]);
+        for r in r0..=r1 {
+            for c in c0..=c1 {
+                for &j32 in &buckets[r * cols + c] {
+                    let j = j32 as usize;
+                    if j <= i || seen[j] == i as u32 {
+                        continue;
+                    }
+                    seen[j] = i as u32;
+                    let (jmin, jmax) = &bboxes[j];
+                    if min[0] > jmax[0] || jmin[0] > max[0] || min[1] > jmax[1] || jmin[1] > max[1]
+                    {
+                        continue;
+                    }
+                    if nodes[i].touches(&nodes[j]) {
+                        dsu.union(i, j);
+                        contacts.push(NodeContact {
+                            i,
+                            j,
+                            at: contact_point(&nodes[i].geom, &nodes[j].geom),
+                        });
+                    }
+                }
             }
         }
     }
@@ -2327,10 +2487,12 @@ fn contact_point(a: &NodeGeom, b: &NodeGeom) -> Vec2 {
         }
         (NodeGeom::Pour(ra), NodeGeom::Pour(rb)) => {
             let p = ra
+                .rings
                 .first()
                 .map(|r| polygon_centroid(r))
                 .unwrap_or(Vec2::new(0.0, 0.0));
             let q = rb
+                .rings
                 .first()
                 .map(|r| polygon_centroid(r))
                 .unwrap_or(Vec2::new(0.0, 0.0));

--- a/crates/vcad-kernel-sheet/src/poly2d.rs
+++ b/crates/vcad-kernel-sheet/src/poly2d.rs
@@ -175,6 +175,20 @@ fn snap_ring(ring: &[Point2]) -> Option<Vec<IPt>> {
 /// predicate can apply the outer-minus-holes rule per polygon.
 struct SnappedPoly {
     rings: Vec<Vec<IPt>>, // rings[0] = outer, rest = holes
+    /// Per-ring bounding box (min, max), for cheap point-probe rejection.
+    bboxes: Vec<(IPt, IPt)>,
+}
+
+fn ring_bbox(ring: &[IPt]) -> (IPt, IPt) {
+    let mut min = (i64::MAX, i64::MAX);
+    let mut max = (i64::MIN, i64::MIN);
+    for &(x, y) in ring {
+        min.0 = min.0.min(x);
+        min.1 = min.1.min(y);
+        max.0 = max.0.max(x);
+        max.1 = max.1.max(y);
+    }
+    (min, max)
 }
 
 fn snap_poly(p: &Poly) -> Option<SnappedPoly> {
@@ -185,7 +199,8 @@ fn snap_poly(p: &Poly) -> Option<SnappedPoly> {
             rings.push(r);
         }
     }
-    Some(SnappedPoly { rings })
+    let bboxes = rings.iter().map(|r| ring_bbox(r)).collect();
+    Some(SnappedPoly { rings, bboxes })
 }
 
 /// Even-odd point-in-ring test in grid space (f64 probe vs integer ring).
@@ -207,13 +222,22 @@ fn point_in_ring(ring: &[IPt], px: f64, py: f64) -> bool {
     inside
 }
 
+/// Probe point strictly outside a ring's bbox (with 1-cell slack for the
+/// f64 probe offset) can't be inside the ring.
+fn probe_outside_bbox(bbox: &(IPt, IPt), px: f64, py: f64) -> bool {
+    px < (bbox.0 .0 - 1) as f64
+        || px > (bbox.1 .0 + 1) as f64
+        || py < (bbox.0 .1 - 1) as f64
+        || py > (bbox.1 .1 + 1) as f64
+}
+
 /// Point inside polygon = inside outer and not inside any hole.
 fn point_in_poly(p: &SnappedPoly, px: f64, py: f64) -> bool {
-    if !point_in_ring(&p.rings[0], px, py) {
+    if probe_outside_bbox(&p.bboxes[0], px, py) || !point_in_ring(&p.rings[0], px, py) {
         return false;
     }
-    for h in &p.rings[1..] {
-        if point_in_ring(h, px, py) {
+    for (h, bb) in p.rings[1..].iter().zip(&p.bboxes[1..]) {
+        if !probe_outside_bbox(bb, px, py) && point_in_ring(h, px, py) {
             return false;
         }
     }
@@ -307,6 +331,103 @@ fn dedup_sorted_along(a: IPt, b: IPt, pts: &mut Vec<IPt>) {
     pts.dedup();
 }
 
+/// Uniform-grid broadphase over segment bounding boxes: `candidates(a, b)`
+/// returns every segment index whose bbox shares a cell with `[a, b]`'s bbox.
+/// A superset of all segments that can interact with `[a, b]` (any split
+/// point lies on both segments, hence inside both bboxes).
+struct SegGrid {
+    cell: i64,
+    min: IPt,
+    cols: i64,
+    rows: i64,
+    /// cell index → segment indices whose bbox covers that cell.
+    buckets: Vec<Vec<u32>>,
+    /// Scratch stamp per segment to dedupe candidates across cells.
+    stamp: std::cell::RefCell<(u64, Vec<u64>)>,
+}
+
+impl SegGrid {
+    /// Target grid resolution per axis. 128×128 keeps bucket fan-out small
+    /// while a board-length segment still only touches 128 cells.
+    const RES: i64 = 128;
+
+    fn new(segs: &[(IPt, IPt)]) -> Self {
+        let mut min = (i64::MAX, i64::MAX);
+        let mut max = (i64::MIN, i64::MIN);
+        for &(a, b) in segs {
+            min.0 = min.0.min(a.0).min(b.0);
+            min.1 = min.1.min(a.1).min(b.1);
+            max.0 = max.0.max(a.0).max(b.0);
+            max.1 = max.1.max(a.1).max(b.1);
+        }
+        if segs.is_empty() {
+            min = (0, 0);
+            max = (0, 0);
+        }
+        let extent = (max.0 - min.0).max(max.1 - min.1).max(1);
+        let cell = (extent / Self::RES).max(1);
+        let cols = (max.0 - min.0) / cell + 1;
+        let rows = (max.1 - min.1) / cell + 1;
+        let mut buckets = vec![Vec::new(); (cols * rows) as usize];
+        for (idx, &(a, b)) in segs.iter().enumerate() {
+            let (c0, c1, r0, r1) = Self::cell_range(min, cell, cols, rows, a, b);
+            for r in r0..=r1 {
+                for c in c0..=c1 {
+                    buckets[(r * cols + c) as usize].push(idx as u32);
+                }
+            }
+        }
+        Self {
+            cell,
+            min,
+            cols,
+            rows,
+            buckets,
+            stamp: std::cell::RefCell::new((0, vec![0; segs.len()])),
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn cell_range(
+        min: IPt,
+        cell: i64,
+        cols: i64,
+        rows: i64,
+        a: IPt,
+        b: IPt,
+    ) -> (i64, i64, i64, i64) {
+        let clamp = |v: i64, hi: i64| v.clamp(0, hi - 1);
+        (
+            clamp((a.0.min(b.0) - min.0) / cell, cols),
+            clamp((a.0.max(b.0) - min.0) / cell, cols),
+            clamp((a.1.min(b.1) - min.1) / cell, rows),
+            clamp((a.1.max(b.1) - min.1) / cell, rows),
+        )
+    }
+
+    /// Collect (deduplicated) indices of segments whose grid cells overlap
+    /// the query segment's bbox cells.
+    fn candidates(&self, a: IPt, b: IPt, out: &mut Vec<usize>) {
+        out.clear();
+        let mut guard = self.stamp.borrow_mut();
+        let (ref mut tick, ref mut seen) = *guard;
+        *tick += 1;
+        let t = *tick;
+        let (c0, c1, r0, r1) = Self::cell_range(self.min, self.cell, self.cols, self.rows, a, b);
+        for r in r0..=r1 {
+            for c in c0..=c1 {
+                for &j in &self.buckets[(r * self.cols + c) as usize] {
+                    let j = j as usize;
+                    if seen[j] != t {
+                        seen[j] = t;
+                        out.push(j);
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn boolean(subject: &[Poly], clip: &[Poly], op: BoolOp) -> Vec<Poly> {
     let subj: Vec<SnappedPoly> = subject.iter().filter_map(snap_poly).collect();
     let clp: Vec<SnappedPoly> = clip.iter().filter_map(snap_poly).collect();
@@ -330,11 +451,30 @@ fn boolean(subject: &[Poly], clip: &[Poly], op: BoolOp) -> Vec<Poly> {
     }
 
     // Split every segment at every interaction with every other segment.
+    //
+    // Broadphase: a split point always lies on both segments, so a pair whose
+    // bounding boxes are disjoint contributes nothing — bucket segments into a
+    // uniform grid and only test pairs sharing a cell. Exact same splits as
+    // the all-pairs loop, without the O(S²) pair sweep that made dense PCB
+    // pours (thousands of clearance capsules) take minutes.
+    let seg_grid = SegGrid::new(&segs);
+    let mut candidates: Vec<usize> = Vec::new();
     let mut sub_edges: std::collections::BTreeSet<(IPt, IPt)> = std::collections::BTreeSet::new();
     for (i, &(a, b)) in segs.iter().enumerate() {
         let mut cuts: Vec<IPt> = vec![a, b];
-        for (j, &(c, d)) in segs.iter().enumerate() {
+        seg_grid.candidates(a, b, &mut candidates);
+        for &j in &candidates {
             if i == j {
+                continue;
+            }
+            let (c, d) = segs[j];
+            // Cheap exact bbox rejection (candidates from shared cells can
+            // still be disjoint within the cell).
+            if a.0.max(b.0) < c.0.min(d.0)
+                || c.0.max(d.0) < a.0.min(b.0)
+                || a.1.max(b.1) < c.1.min(d.1)
+                || c.1.max(d.1) < a.1.min(b.1)
+            {
                 continue;
             }
             splits_from(a, b, c, d, &mut cuts);
@@ -370,12 +510,15 @@ fn boolean(subject: &[Poly], clip: &[Poly], op: BoolOp) -> Vec<Poly> {
         directed.push((p, q));
         directed.push((q, p));
     }
-    let mut twin: std::collections::BTreeMap<(IPt, IPt), usize> = std::collections::BTreeMap::new();
+    // Lookup-only (never iterated): HashMap, not BTreeMap — the arrangement's
+    // determinism comes from `sub_edges`/`boundary` ordering, not these maps.
+    let mut twin: std::collections::HashMap<(IPt, IPt), usize> =
+        std::collections::HashMap::with_capacity(directed.len());
     for (idx, &(u, v)) in directed.iter().enumerate() {
         twin.insert((u, v), idx);
     }
-    let mut out_edges: std::collections::BTreeMap<IPt, Vec<usize>> =
-        std::collections::BTreeMap::new();
+    let mut out_edges: std::collections::HashMap<IPt, Vec<usize>> =
+        std::collections::HashMap::with_capacity(directed.len());
     for (idx, &(u, _)) in directed.iter().enumerate() {
         out_edges.entry(u).or_default().push(idx);
     }
@@ -491,7 +634,8 @@ fn boolean(subject: &[Poly], clip: &[Poly], op: BoolOp) -> Vec<Poly> {
     // ── Walk boundary loops ──────────────────────────────────────────────
     // The boundary of a union of faces is vertex-balanced, so loops always
     // close under the same next-edge rule.
-    let mut bout: std::collections::BTreeMap<IPt, Vec<usize>> = std::collections::BTreeMap::new();
+    let mut bout: std::collections::HashMap<IPt, Vec<usize>> =
+        std::collections::HashMap::with_capacity(boundary.len());
     for (idx, &(u, _)) in boundary.iter().enumerate() {
         bout.entry(u).or_default().push(idx);
     }

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -3824,6 +3824,30 @@ export async function drcPcb(
   // Kernel DRC: copper clearance (trace↔copper and pad↔pad shorts), trace
   // width, drill, annular ring, edge clearance, hole-to-hole. Falls back to
   // basic scalar checks when the kernel WASM is unavailable.
+  //
+  // Size guard: a board past this budget risks exhausting the shared WASM
+  // instance's linear memory, and a wasm OOM can take down the whole server
+  // (killing every session) rather than just this call. Fail closed with a
+  // structured error the agent can branch on. The CM5 reverse-engineering
+  // board (10 layers, ~6.5k traces, ~3k vias, ~3k pads, 107 zones ≈ 13k
+  // elements) checks in seconds, so the default cap leaves ample headroom.
+  const elementCount =
+    pcb.traces.length +
+    pcb.vias.length +
+    pcb.zones.length +
+    pcb.footprints.reduce((n, fp) => n + fp.pads.length, 0);
+  const maxElements = Number(process.env.VCAD_DRC_MAX_ELEMENTS ?? 200_000);
+  if (elementCount > maxElements) {
+    return {
+      success: false,
+      status: "errored",
+      reason:
+        `Board too large for DRC: ${elementCount} copper elements ` +
+        `(traces + vias + pads + zones) exceeds the ${maxElements} budget. ` +
+        `Run DRC on a region (verify-on-write covers edits), or raise ` +
+        `VCAD_DRC_MAX_ELEMENTS if this host has the memory for it.`,
+    };
+  }
   let violations: DrcViol[];
   if (await isEcadAvailable()) {
     // The kernel can refuse a board it can't deserialize (e.g. a malformed


### PR DESCRIPTION
## Problem

`describe_pcb` / `run_drc` on a large imported KiCad board (CM5RevEng: 11MB, 10 copper layers, ~6.5k traces, ~2.9k vias, ~3k pads, 107 zones) ground for ~1000–1050s and then the node process died silently — the MCP client saw `MCP error -32000: Connection closed`, taking down every session on the server.

## Root causes (all superlinear)

1. **`poly2d::boolean`** (vcad-kernel-sheet) split every segment against every other segment — O(S²). A zone fill's difference carries thousands of clearance-capsule clips, and it runs once per zone.
2. **`copper_pour::collect_clearance_regions`** built a clip polygon for every element on the layer, even ones nowhere near the zone.
3. **DRC connectivity** unioned all ~12.5k copper nodes pairwise, and the pour narrowphase scanned every vertex of 10k-vertex plane rings per query.

## Fixes

- Uniform-grid broadphase over segment bboxes in `poly2d::boolean` — identical splits (a split point lies on both segments, so bbox-disjoint pairs contribute nothing), near-linear pair count. Lookup-only BTreeMaps → HashMaps; per-ring bbox rejection for point probes.
- Zone-bbox prefilter for clearance clips (covers thermal-spoke reach).
- Grid broadphase for connectivity node pairing + cached per-ring bboxes (`PourRings`) with cutoff-aware distance queries.
- **Fail-closed size guard** in `drcPcb` (MCP): boards past `VCAD_DRC_MAX_ELEMENTS` (default 200k copper elements) return a structured `errored` outcome instead of risking a WASM OOM that kills the server. Kernel traps were already recovered at the server chokepoint (`resetKernelWasm`).

## Results (CM5RevEng board)

| Path | Before | After |
|---|---|---|
| `check_drc` native | >17 min (never finished) | 2.2s, 120MB RSS |
| `run_drc` via WASM/MCP | ~1050s → process death | 3.1s |
| `describe_pcb` via MCP | ~1050s → process death | ~30s |
| `generate_gerbers` native | (same blowup) | 17s |

Violation count is byte-identical before/after the broadphase (47,345 on this board, both at the 20s intermediate stage and final).

## Verification

- `cargo test -p vcad-ecad-pcb -p vcad-kernel-sheet -p vcad-ecad-export -p vcad-ecad-verify` — 357 passed
- `npm test -w @vcad/engine -w @vcad/mcp` — 919 passed
- clippy + fmt clean
- No wasm artifacts committed (wasm-refresh handles main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)