### PR TITLE
feat(vcad-render): clap CLI with -o output and batch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7464,6 +7464,7 @@ dependencies = [
 name = "vcad-render"
 version = "0.9.3"
 dependencies = [
+ "clap",
  "image",
  "serde_json",
  "vcad-ecad-pcb",

--- a/changelog/entries/2026-07-15-vcad-render-cli-batch.json
+++ b/changelog/entries/2026-07-15-vcad-render-cli-batch.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-15-vcad-render-cli-batch",
+  "version": "0.9.4",
+  "date": "2026-07-15",
+  "category": "feat",
+  "title": "vcad-render CLI: -o output, batch mode, --help",
+  "summary": "The vcad-render CLI gains -o with extension-driven format, batch rendering of multiple files or a directory with --out-dir/--format, and proper --help.",
+  "features": ["render", "cli"]
+}

--- a/crates/vcad-render/Cargo.toml
+++ b/crates/vcad-render/Cargo.toml
@@ -6,9 +6,11 @@ publish = false
 description = "Project a .vcad document to static line art: isometric/orthographic SVG or raster JPEG."
 
 [features]
-default = ["raster"]
+default = ["raster", "cli"]
 # Raster (JPEG) output. Off for the WASM build, which only needs SVG.
 raster = ["dep:image"]
+# The vcad-render binary. Off for the WASM build, which only needs the lib.
+cli = ["dep:clap"]
 
 [dependencies]
 vcad-eval = { workspace = true }
@@ -16,6 +18,7 @@ vcad-ir = { workspace = true }
 vcad-kernel = { workspace = true }
 vcad-ecad-pcb = { workspace = true }
 serde_json = { workspace = true }
+clap = { version = "4", features = ["derive"], optional = true }
 image = { version = "0.25", default-features = false, features = ["jpeg"], optional = true }
 
 [lib]
@@ -25,6 +28,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "vcad-render"
 path = "src/main.rs"
+required-features = ["cli"]
 
 [dev-dependencies]
 vcad-loon = { workspace = true }

--- a/crates/vcad-render/README.md
+++ b/crates/vcad-render/README.md
@@ -33,16 +33,32 @@ mecheval leaderboard defaults to `target/debug/vcad-render`.
 ## Usage
 
 ```bash
-vcad-render path/to/part.vcad > out.svg
+vcad-render path/to/part.vcad > out.svg          # SVG on stdout
 vcad-render part.vcad --scale 4.0 > big.svg
+vcad-render part.vcad -o out.jpg                 # format from extension
+vcad-render parts/ --out-dir renders/ --format jpeg   # batch a directory
 ```
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `--scale <N>` | `2.0` | Pixels per millimetre. Bigger = larger SVG. |
+| `--view <V>` | `iso` | Camera: `iso`/`front`/`side`/`top`/`hero`. |
+| `--scale <N>` | `2.0` | Pixels per millimetre (SVG). Bigger = larger SVG. |
+| `--transparent` | off | Transparent SVG background. |
+| `-o, --output <PATH>` | stdout | Output path; format inferred from `.svg`/`.jpg`/`.jpeg`. `-o -` = SVG on stdout. Single input only. |
+| `--jpeg <PATH>` | — | Legacy alias for `-o <path.jpg>`. |
+| `--out-dir <DIR>` | sibling | Directory for batch outputs. |
+| `--format <F>` | `svg` | Batch output format: `svg` or `jpeg`. |
+| `--size <N>` | `1024` | Raster canvas size in pixels (JPEG). |
+| `--fill <F>` | `0.6` | Fraction of canvas the part's long axis fills (JPEG). |
+| `--quality <Q>` | `92` | JPEG quality, 1–100. |
+
+Multiple inputs (or a directory, which expands to its `*.vcad` files)
+render in batch, each to `<stem>.<ext>` next to the input or in
+`--out-dir`. A per-file failure is reported on stderr but doesn't abort
+the batch.
 
 Exit codes: `0` on success, `2` on parse/eval/render failure (with a
-human-readable message on stderr).
+human-readable message on stderr). A batch exits `2` if any file failed.
 
 ## Tunable constants
 

--- a/crates/vcad-render/src/main.rs
+++ b/crates/vcad-render/src/main.rs
@@ -1,126 +1,228 @@
-//! `vcad-render` CLI — project a `.vcad` to static line art.
+//! `vcad-render` CLI — project `.vcad` documents to static line art.
 //!
 //! Usage:
 //!   vcad-render <path.vcad> [--view iso|front|side|top|hero] [--scale <px-per-mm>] [--transparent]
-//!   vcad-render <path.vcad> --jpeg <out.jpg> [--view ...] [--size <px>] [--fill <frac>] [--quality <1-100>]
+//!   vcad-render <path.vcad> -o out.jpg [--view ...] [--size <px>] [--fill <frac>] [--quality <1-100>]
+//!   vcad-render <dir-or-paths...> [--out-dir <dir>] [--format svg|jpeg]
 //!
-//! Without `--jpeg`: a single self-contained `<svg>` on stdout.
-//! With `--jpeg`: a z-buffered raster render written to the given path.
-//! All rendering logic lives in the `vcad-render` library (see `lib.rs`);
-//! this binary only handles argument parsing and file IO.
+//! With a single input and no output flag, a self-contained `<svg>` goes to
+//! stdout. `-o <path>` picks the format from the extension (`.svg`, `.jpg`,
+//! `.jpeg`); `-o -` writes SVG to stdout. `--jpeg <path>` is the legacy
+//! spelling of `-o <path.jpg>`. Multiple inputs (or a directory, which
+//! expands to its `*.vcad` files) render in batch, each to a sibling output
+//! file or into `--out-dir`; a per-file failure is reported but does not
+//! abort the batch. All rendering logic lives in the `vcad-render` library
+//! (see `lib.rs`); this binary only handles argument parsing and file IO.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::str::FromStr;
 
+use clap::{Parser, ValueEnum};
 use vcad_render::{render_svg_str_view_opts, View, DEFAULT_SCALE};
 
-struct Args {
-    path: PathBuf,
-    scale: f64,
-    view: View,
-    jpeg: Option<PathBuf>,
-    size: u32,
-    fill: f64,
-    quality: u8,
-    transparent: bool,
+/// Raster/vector format for batch outputs (single-file `-o` infers the
+/// format from the extension instead).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum Format {
+    /// Drafting-style vector SVG.
+    Svg,
+    /// Z-buffered raster JPEG.
+    Jpeg,
 }
 
-fn parse_args() -> Result<Args, String> {
-    let mut args = std::env::args().skip(1);
-    let path = args.next().ok_or(
-        "usage: vcad-render <path.vcad> [--view iso|front|side|top|hero] [--scale N] [--transparent] \
-         [--jpeg out.jpg [--size N] [--fill F] [--quality Q]]",
-    )?;
-    let mut out = Args {
-        path: PathBuf::from(path),
-        scale: DEFAULT_SCALE,
-        view: View::Isometric,
-        jpeg: None,
-        size: 1024,
-        fill: 0.6,
-        quality: 92,
-        transparent: false,
-    };
-    while let Some(flag) = args.next() {
-        let mut value = |name: &str| args.next().ok_or(format!("{name} needs a value"));
-        match flag.as_str() {
-            "--scale" => {
-                out.scale = value("--scale")?
-                    .parse()
-                    .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+impl Format {
+    fn extension(self) -> &'static str {
+        match self {
+            Format::Svg => "svg",
+            Format::Jpeg => "jpg",
+        }
+    }
+
+    fn from_extension(path: &Path) -> Result<Self, String> {
+        match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(str::to_ascii_lowercase)
+            .as_deref()
+        {
+            Some("svg") => Ok(Format::Svg),
+            Some("jpg") | Some("jpeg") => Ok(Format::Jpeg),
+            _ => Err(format!(
+                "cannot infer format from '{}' (expected .svg, .jpg, or .jpeg)",
+                path.display()
+            )),
+        }
+    }
+}
+
+/// Project `.vcad` documents to static line art: isometric/orthographic
+/// SVG or raster JPEG.
+#[derive(Parser)]
+#[command(name = "vcad-render", version)]
+struct Cli {
+    /// Input `.vcad` file(s); a directory expands to its `*.vcad` files.
+    #[arg(required = true)]
+    inputs: Vec<PathBuf>,
+
+    /// Camera view: iso|front|side|top|hero.
+    #[arg(long, default_value = "iso", value_parser = View::from_str)]
+    view: View,
+
+    /// Pixels per millimetre (SVG only).
+    #[arg(long, default_value_t = DEFAULT_SCALE)]
+    scale: f64,
+
+    /// Transparent SVG background.
+    #[arg(long)]
+    transparent: bool,
+
+    /// Output path; format inferred from extension (.svg/.jpg/.jpeg).
+    /// Use `-o -` for SVG on stdout. Single input only.
+    #[arg(short, long, conflicts_with = "jpeg")]
+    output: Option<PathBuf>,
+
+    /// Legacy alias for `-o <path.jpg>`: write a JPEG to this path.
+    #[arg(long)]
+    jpeg: Option<PathBuf>,
+
+    /// Directory for batch outputs (default: next to each input).
+    #[arg(long, conflicts_with_all = ["output", "jpeg"])]
+    out_dir: Option<PathBuf>,
+
+    /// Output format in batch mode (single-file `-o` infers from extension).
+    #[arg(long, value_enum, default_value_t = Format::Svg)]
+    format: Format,
+
+    /// Raster canvas size in pixels (JPEG only).
+    #[arg(long, default_value_t = 1024)]
+    size: u32,
+
+    /// Fraction of the canvas the part's long axis fills (JPEG only).
+    #[arg(long, default_value_t = 0.6)]
+    fill: f64,
+
+    /// JPEG quality, 1-100.
+    #[arg(long, default_value_t = 92)]
+    quality: u8,
+}
+
+/// Expand directory inputs to their `*.vcad` files (sorted); pass files
+/// through untouched.
+fn expand_inputs(inputs: &[PathBuf]) -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    for input in inputs {
+        if input.is_dir() {
+            let mut found: Vec<PathBuf> = std::fs::read_dir(input)
+                .map_err(|e| format!("read dir {}: {}", input.display(), e))?
+                .filter_map(|entry| entry.ok().map(|e| e.path()))
+                .filter(|p| {
+                    p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("vcad")
+                })
+                .collect();
+            if found.is_empty() {
+                return Err(format!("no .vcad files in {}", input.display()));
             }
-            "--view" => {
-                out.view = View::from_str(&value("--view")?)?;
-            }
-            "--jpeg" => {
-                out.jpeg = Some(PathBuf::from(value("--jpeg")?));
-            }
-            "--size" => {
-                out.size = value("--size")?
-                    .parse()
-                    .map_err(|e: std::num::ParseIntError| e.to_string())?;
-            }
-            "--fill" => {
-                out.fill = value("--fill")?
-                    .parse()
-                    .map_err(|e: std::num::ParseFloatError| e.to_string())?;
-            }
-            "--quality" => {
-                out.quality = value("--quality")?
-                    .parse()
-                    .map_err(|e: std::num::ParseIntError| e.to_string())?;
-            }
-            "--transparent" => {
-                out.transparent = true;
-            }
-            other => return Err(format!("unknown flag: {}", other)),
+            found.sort();
+            out.extend(found);
+        } else {
+            out.push(input.clone());
         }
     }
     Ok(out)
 }
 
 #[cfg(feature = "raster")]
-fn run_jpeg(raw: &str, args: &Args, out_path: &std::path::Path) -> Result<(), String> {
+fn render_jpeg(raw: &str, cli: &Cli) -> Result<Vec<u8>, String> {
     let opts = vcad_render::RasterOptions {
-        view: args.view,
-        size_px: args.size,
-        fill_frac: args.fill,
-        quality: args.quality,
+        view: cli.view,
+        size_px: cli.size,
+        fill_frac: cli.fill,
+        quality: cli.quality,
     };
-    let bytes = vcad_render::render_jpeg_str(raw, &opts)?;
-    std::fs::write(out_path, bytes).map_err(|e| format!("write {}: {}", out_path.display(), e))
+    vcad_render::render_jpeg_str(raw, &opts)
 }
 
 #[cfg(not(feature = "raster"))]
-fn run_jpeg(_raw: &str, _args: &Args, _out_path: &std::path::Path) -> Result<(), String> {
+fn render_jpeg(_raw: &str, _cli: &Cli) -> Result<Vec<u8>, String> {
     Err("this build of vcad-render lacks the `raster` feature".to_string())
 }
 
+/// Render one input to `dest` (`None` = SVG on stdout) in `format`.
+fn render_one(input: &Path, dest: Option<&Path>, format: Format, cli: &Cli) -> Result<(), String> {
+    let raw = std::fs::read_to_string(input)
+        .map_err(|e| format!("read {}: {}", input.display(), e))?;
+    let bytes = match format {
+        Format::Svg => {
+            let svg = render_svg_str_view_opts(&raw, cli.scale, cli.view, cli.transparent)?;
+            match dest {
+                None => {
+                    println!("{}", svg);
+                    return Ok(());
+                }
+                Some(_) => svg.into_bytes(),
+            }
+        }
+        Format::Jpeg => render_jpeg(&raw, cli)?,
+    };
+    let dest = dest.expect("raster output always has a destination path");
+    std::fs::write(dest, bytes).map_err(|e| format!("write {}: {}", dest.display(), e))
+}
+
+/// Batch destination for `input`: `<stem>.<ext>` in `out_dir` or next to
+/// the input.
+fn batch_dest(input: &Path, out_dir: Option<&Path>, format: Format) -> PathBuf {
+    let name = input.with_extension(format.extension());
+    match out_dir {
+        Some(dir) => dir.join(name.file_name().expect("input paths have file names")),
+        None => name,
+    }
+}
+
+fn run(cli: &Cli) -> Result<(), String> {
+    let inputs = expand_inputs(&cli.inputs)?;
+    let batch = inputs.len() > 1 || cli.out_dir.is_some();
+
+    if batch {
+        if cli.output.is_some() || cli.jpeg.is_some() {
+            return Err("-o/--jpeg take a single output path; use --out-dir with multiple inputs".into());
+        }
+        if let Some(dir) = &cli.out_dir {
+            std::fs::create_dir_all(dir)
+                .map_err(|e| format!("create {}: {}", dir.display(), e))?;
+        }
+        let mut failures = 0usize;
+        for input in &inputs {
+            let dest = batch_dest(input, cli.out_dir.as_deref(), cli.format);
+            match render_one(input, Some(&dest), cli.format, cli) {
+                Ok(()) => eprintln!("{} -> {}", input.display(), dest.display()),
+                Err(e) => {
+                    failures += 1;
+                    eprintln!("{}: {}", input.display(), e);
+                }
+            }
+        }
+        if failures > 0 {
+            return Err(format!("{failures} of {} renders failed", inputs.len()));
+        }
+        return Ok(());
+    }
+
+    let input = &inputs[0];
+    // Legacy --jpeg <path> spelling.
+    if let Some(path) = &cli.jpeg {
+        return render_one(input, Some(path), Format::Jpeg, cli);
+    }
+    match &cli.output {
+        None => render_one(input, None, Format::Svg, cli),
+        Some(path) if path.as_os_str() == "-" => render_one(input, None, Format::Svg, cli),
+        Some(path) => render_one(input, Some(path), Format::from_extension(path)?, cli),
+    }
+}
+
 fn main() -> ExitCode {
-    let args = match parse_args() {
-        Ok(a) => a,
-        Err(e) => {
-            eprintln!("{}", e);
-            return ExitCode::from(2);
-        }
-    };
-
-    let raw = match std::fs::read_to_string(&args.path) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("read error: {}", e);
-            return ExitCode::from(2);
-        }
-    };
-
-    let result = match &args.jpeg {
-        Some(out_path) => run_jpeg(&raw, &args, out_path),
-        None => render_svg_str_view_opts(&raw, args.scale, args.view, args.transparent)
-            .map(|svg| println!("{}", svg)),
-    };
-
-    match result {
+    let cli = Cli::parse();
+    match run(&cli) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("{}", e);

--- a/crates/vcad-render/src/main.rs
+++ b/crates/vcad-render/src/main.rs
@@ -116,9 +116,7 @@ fn expand_inputs(inputs: &[PathBuf]) -> Result<Vec<PathBuf>, String> {
             let mut found: Vec<PathBuf> = std::fs::read_dir(input)
                 .map_err(|e| format!("read dir {}: {}", input.display(), e))?
                 .filter_map(|entry| entry.ok().map(|e| e.path()))
-                .filter(|p| {
-                    p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("vcad")
-                })
+                .filter(|p| p.is_file() && p.extension().and_then(|e| e.to_str()) == Some("vcad"))
                 .collect();
             if found.is_empty() {
                 return Err(format!("no .vcad files in {}", input.display()));
@@ -150,8 +148,8 @@ fn render_jpeg(_raw: &str, _cli: &Cli) -> Result<Vec<u8>, String> {
 
 /// Render one input to `dest` (`None` = SVG on stdout) in `format`.
 fn render_one(input: &Path, dest: Option<&Path>, format: Format, cli: &Cli) -> Result<(), String> {
-    let raw = std::fs::read_to_string(input)
-        .map_err(|e| format!("read {}: {}", input.display(), e))?;
+    let raw =
+        std::fs::read_to_string(input).map_err(|e| format!("read {}: {}", input.display(), e))?;
     let bytes = match format {
         Format::Svg => {
             let svg = render_svg_str_view_opts(&raw, cli.scale, cli.view, cli.transparent)?;
@@ -170,12 +168,17 @@ fn render_one(input: &Path, dest: Option<&Path>, format: Format, cli: &Cli) -> R
 }
 
 /// Batch destination for `input`: `<stem>.<ext>` in `out_dir` or next to
-/// the input.
-fn batch_dest(input: &Path, out_dir: Option<&Path>, format: Format) -> PathBuf {
+/// the input. Fails on a path with no file name (e.g. one ending in `..`).
+fn batch_dest(input: &Path, out_dir: Option<&Path>, format: Format) -> Result<PathBuf, String> {
     let name = input.with_extension(format.extension());
     match out_dir {
-        Some(dir) => dir.join(name.file_name().expect("input paths have file names")),
-        None => name,
+        Some(dir) => {
+            let file = name
+                .file_name()
+                .ok_or_else(|| format!("input {} has no file name", input.display()))?;
+            Ok(dir.join(file))
+        }
+        None => Ok(name),
     }
 }
 
@@ -185,17 +188,19 @@ fn run(cli: &Cli) -> Result<(), String> {
 
     if batch {
         if cli.output.is_some() || cli.jpeg.is_some() {
-            return Err("-o/--jpeg take a single output path; use --out-dir with multiple inputs".into());
+            return Err(
+                "-o/--jpeg take a single output path; use --out-dir with multiple inputs".into(),
+            );
         }
         if let Some(dir) = &cli.out_dir {
-            std::fs::create_dir_all(dir)
-                .map_err(|e| format!("create {}: {}", dir.display(), e))?;
+            std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {}", dir.display(), e))?;
         }
         let mut failures = 0usize;
         for input in &inputs {
-            let dest = batch_dest(input, cli.out_dir.as_deref(), cli.format);
-            match render_one(input, Some(&dest), cli.format, cli) {
-                Ok(()) => eprintln!("{} -> {}", input.display(), dest.display()),
+            let result = batch_dest(input, cli.out_dir.as_deref(), cli.format)
+                .and_then(|dest| render_one(input, Some(&dest), cli.format, cli).map(|()| dest));
+            match result {
+                Ok(dest) => eprintln!("{} -> {}", input.display(), dest.display()),
                 Err(e) => {
                     failures += 1;
                     eprintln!("{}: {}", input.display(), e);


### PR DESCRIPTION
## What

Modernizes the `vcad-render` CLI ([crates/vcad-render/src/main.rs](../blob/claude/vcad-render-improvements-c61478/crates/vcad-render/src/main.rs)), replacing the hand-rolled argument parser with **clap derive**.

- **`-o/--output <path>`** — format inferred from the extension (`.svg`/`.jpg`/`.jpeg`); `-o -` writes SVG to stdout.
- **Batch mode** — multiple input paths or a directory (expands to sorted `*.vcad`), each rendered to `<stem>.<ext>` next to the input or in `--out-dir`, with `--format svg|jpeg`. A per-file failure is reported on stderr without aborting; the batch exits `2` if any file failed.
- **`--help` / `--version`** now work properly.

## Backward compatibility

Every existing flag (`--view`, `--scale`, `--transparent`, `--jpeg`, `--size`, `--fill`, `--quality`) and the positional input path are preserved. `--jpeg <path>` remains as a legacy alias for `-o <path.jpg>`. The exact mecheval invocation shape (`<file> --view front --jpeg out --size --fill --quality`) is unchanged, so `mecheval/scripts/render-task-assets.mjs` needed no edits.

## WASM build

`clap` is optional behind a new **default-on `cli` feature** (with `required-features = ["cli"]` on the binary), so the WASM build (`vcad-kernel-wasm` depends on vcad-render with `default-features = false`) does not pull clap in. Verified `cargo check -p vcad-render --no-default-features` still compiles.

## Verification

- `cargo test -p vcad-render` — passes
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean
- Smoke-tested with a real fixture: stdout SVG, `-o out.jpg`/`.svg`/`-o -`, legacy `--jpeg`, bad-extension rejection, and a 3-file batch with one corrupt file (2 rendered, exit 2).

## Reviewer note

This is the smallest of a fan-out of 9 vcad-render improvement branches, and it restructures the CLI surface the others will add flags to (PNG output, camera, annotations, sections, sheet mode, etc.). **Landing this first** avoids each of those conflicting on the old hand-rolled parser. The extension→format map has a `TODO`-shaped seam where `.png` slots in once the PNG-output branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)