### PR TITLE
fix(raytrace): full sphere renders in GPU ray-traced viewport

### DIFF
--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -667,6 +667,23 @@ fn winding_number_polygon(uv: vec2<f32>, start: u32, count: u32) -> i32 {
     return winding;
 }
 
+// Twice the signed shoelace area of a polygon in UV space.
+// Used to detect degenerate (near-zero-area) trim loops.
+fn polygon_signed_area(start: u32, count: u32) -> f32 {
+    if count < 3u {
+        return 0.0;
+    }
+
+    var area: f32 = 0.0;
+    for (var i = 0u; i < count; i++) {
+        let p1 = trim_verts[start + i];
+        let p2 = trim_verts[start + ((i + 1u) % count)];
+        area += p1.x * p2.y - p2.x * p1.y;
+    }
+
+    return area;
+}
+
 // Simple AABB check for outer loop (for debugging)
 fn uv_in_trim_bounds(uv: vec2<f32>, start: u32, count: u32) -> bool {
     if count == 0u {
@@ -709,15 +726,22 @@ fn point_in_face(uv: vec2<f32>, face_idx: u32) -> bool {
         return false;
     }
 
-    // Quick AABB rejection before expensive winding number test
-    if !uv_in_trim_bounds(uv, face.trim_start, face.trim_count) {
-        return false;
-    }
+    // A primitive sphere (or full torus) face is bounded only by its seam,
+    // which projects to a zero-area UV polygon. Treat such a degenerate outer
+    // loop as untrimmed so every ray hit isn't spuriously rejected — inner
+    // loops (holes) are still honored below.
+    let outer_area = polygon_signed_area(face.trim_start, face.trim_count);
+    if abs(outer_area) >= 1e-9 {
+        // Quick AABB rejection before expensive winding number test
+        if !uv_in_trim_bounds(uv, face.trim_start, face.trim_count) {
+            return false;
+        }
 
-    // Winding number test for proper polygon boundary
-    let outer_winding = winding_number_polygon(uv, face.trim_start, face.trim_count);
-    if outer_winding == 0 {
-        return false; // Outside outer boundary
+        // Winding number test for proper polygon boundary
+        let outer_winding = winding_number_polygon(uv, face.trim_start, face.trim_count);
+        if outer_winding == 0 {
+            return false; // Outside outer boundary
+        }
     }
 
     // Check inner loops (holes) - point must be outside all holes

--- a/crates/vcad-kernel-raytrace/tests/gpu_smoke.rs
+++ b/crates/vcad-kernel-raytrace/tests/gpu_smoke.rs
@@ -17,7 +17,7 @@
 #![cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
 
 use vcad_kernel_gpu::{GpuContext, GpuError};
-use vcad_kernel_primitives::make_cube;
+use vcad_kernel_primitives::{make_cube, make_sphere};
 use vcad_kernel_raytrace::gpu::{GpuCamera, GpuScene, RayTracePipeline};
 
 /// Skip with a clear message when no adapter is available (e.g. macOS
@@ -97,5 +97,60 @@ fn render_cube_produces_non_zero_pixels() {
          error (bad shader, oversized bind group, etc.) puts the device in \
          an error state and dispatch_workgroups no-ops. Check the \
          `on_uncaptured_error` log for the actual cause.",
+    );
+}
+
+/// A primitive sphere face is bounded only by its seam, which projects to a
+/// zero-area UV polygon. Before the degenerate-outer-loop fix, the WGSL
+/// `point_in_face` winding-number test rejected every ray hit, so a full
+/// sphere traced as nothing. This asserts the sphere now produces pixels.
+#[test]
+#[ignore = "requires GPU"]
+fn render_sphere_produces_non_zero_pixels() {
+    let Some(ctx) = ctx_or_skip("render_sphere_produces_non_zero_pixels") else {
+        return;
+    };
+    let pipeline = RayTracePipeline::new(ctx).expect("pipeline creation");
+
+    // Sphere centered at the origin with radius 5.
+    let sphere = make_sphere(5.0, 32);
+    let scene = GpuScene::from_brep(&sphere).expect("scene upload");
+
+    let w = 64u32;
+    let h = 64u32;
+    let camera = GpuCamera::new(
+        [20.0, 20.0, 20.0], // position — look at the sphere from the +XYZ corner
+        [0.0, 0.0, 0.0],    // target — sphere center
+        [0.0, 0.0, 1.0],    // up (Z-up, the kernel convention)
+        45.0_f32.to_radians(),
+        w,
+        h,
+    );
+
+    let pixels = pollster::block_on(pipeline.render(ctx, &scene, &camera, w, h)).expect("render");
+    assert_eq!(pixels.len() as u32, w * h * 4, "pixel buffer wrong size");
+
+    // The camera targets the sphere center, so the middle pixel must land on
+    // the sphere. A `non_zero > 0` check is useless here — the shader renders a
+    // sky + ground background, so the buffer is never all-zero even when the
+    // sphere is missing. Instead compare the center pixel (sphere) against a
+    // corner pixel (background): if the degenerate seam-only outer loop rejects
+    // every hit, the center falls through to the background and the two match.
+    let px = |x: u32, y: u32| {
+        let i = ((y * w + x) * 4) as usize;
+        [pixels[i], pixels[i + 1], pixels[i + 2]]
+    };
+    let center = px(w / 2, h / 2);
+    let corner = px(1, 1);
+    let diff: i32 = (0..3)
+        .map(|c| (center[c] as i32 - corner[c] as i32).abs())
+        .sum();
+    assert!(
+        diff > 30,
+        "sphere center pixel {center:?} matches the background corner {corner:?} \
+         (diff {diff}) — the full sphere traced as nothing. Its outer trim loop is \
+         the seam, which projects to a zero-area UV polygon, so the winding-number \
+         test rejects every ray hit unless the degenerate loop is treated as \
+         untrimmed.",
     );
 }


### PR DESCRIPTION
## What

Ports the CPU trim-test degenerate-outer-loop fix to the WebGPU ray-tracing path.

A primitive `make_sphere` (and full torus) face is bounded only by its **seam**, which projects to a **zero-area UV polygon**. In the WGSL `point_in_face` trim test, that degenerate outer loop made the AABB + winding-number check reject *every* ray hit — so a full sphere rendered as **nothing** in the app's ray-traced viewport. This is the GPU counterpart of the already-fixed CPU `src/trim.rs` bug.

## Fix

In [`raytrace.wgsl`](../blob/claude/stoic-northcutt-c149dc/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl):
- Add a `polygon_signed_area()` (shoelace) helper.
- In `point_in_face`, when `abs(outer_area) < 1e-9`, skip the outer AABB/winding test (treat the face as untrimmed) while **still honoring inner loops** (holes).

## Verification

Confirmed empirically that the bug was real and the fix is load-bearing:
- `make_sphere(5.0, 32)` yields one face whose outer loop is 4 collinear seam points (`u=0`), shoelace area `= 0`.
- Sphere-center pixel with fix **off**: `(139,134,127)` = background. With fix **on**: `(234,236,240)` = lit sphere surface.

Adds a `render_sphere_produces_non_zero_pixels` GPU smoke test. Note the existing `non_zero > 0` pattern is useless for this class of bug — the shader always paints a sky + ground background — so the new test compares the sphere-center pixel against a background corner. Verified it **fails without the fix** (`diff 3`) and **passes with it**.

Run locally (GPU required; single-threaded because the `GpuContext` singleton races across parallel test inits):

```
cargo test -p vcad-kernel-raytrace --features gpu --test gpu_smoke -- --ignored --test-threads=1
```

All 3 smoke tests pass; `cargo fmt` clean.

## Reviewer note

The task described the CPU `src/trim.rs` `point_in_face` as already fixed, but on this branch it is **not** — the CPU `point_in_face` still lacks the degenerate-area check and has the same full-sphere bug. Scope here was kept to the GPU port as requested; the matching CPU fix is a likely follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)