### PR TITLE
perf(mcp): stream export_video frames to ffmpeg instead of buffering

### DIFF
--- a/packages/mcp/src/__tests__/animate.test.ts
+++ b/packages/mcp/src/__tests__/animate.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Engine } from "@vcad/engine";
 import type { Document, Timeline } from "@vcad/ir";
+import { spawn } from "node:child_process";
 import {
   animate,
   renderSequence,
@@ -15,6 +16,7 @@ import {
   verifySequenceClearance,
   injectHud,
   compileRolloutTimeline,
+  startMp4Encoder,
 } from "../tools/animate.js";
 import { documents, openDocument } from "../tools/session.js";
 import { sampleSequence } from "@vcad/engine";
@@ -286,6 +288,79 @@ describe("export_video", () => {
       expect(text.artifact).toBeTruthy();
     }
   });
+});
+
+/** Probe once whether ffmpeg is spawnable, to gate the mp4 tests. */
+async function ffmpegPresent(): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const p = spawn("ffmpeg", ["-version"], { stdio: "ignore" });
+      p.on("error", () => resolve(false));
+      p.on("exit", (code) => resolve(code === 0));
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+const hasFfmpeg = await ffmpegPresent();
+
+describe("export_video mp4 (streaming ffmpeg pipe)", () => {
+  it.skipIf(!hasFfmpeg)(
+    "streams frames to ffmpeg and produces a playable mp4",
+    async () => {
+      const docId = openArm();
+      await animate({ document_id: docId, timeline: spinTimeline });
+      const res = await exportVideo(
+        { document_id: docId, format: "mp4", width_px: 160 },
+        { engine } as never,
+      );
+      if (res.isError)
+        throw new Error(`export_video failed: ${res.content[0]!.text}`);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const blocks = res.content as Array<any>;
+      const text = JSON.parse(blocks.find((b) => b.type === "text")!.text);
+      expect(text.format).toBe("mp4");
+      expect(text.frames).toBe(13);
+      expect(text.bytes).toBeGreaterThan(0);
+      // mp4 always offloads to an artifact.
+      expect(text.artifact).toBeTruthy();
+    },
+    60_000,
+  );
+
+  it.skipIf(!hasFfmpeg)(
+    "startMp4Encoder handles backpressure across many frames",
+    async () => {
+      const w = 320;
+      const h = 240;
+      const enc = startMp4Encoder(w, h, 24);
+      const frame = new Uint8Array(w * h * 4).fill(200);
+      for (let i = 0; i < 120; i++) await enc.writeFrame(frame);
+      const bytes = await enc.finish();
+      expect(bytes.byteLength).toBeGreaterThan(0);
+      // ftyp box near the start of a fragmented mp4.
+      expect(bytes.subarray(4, 8).toString("ascii")).toBe("ftyp");
+    },
+    30_000,
+  );
+
+  it.skipIf(!hasFfmpeg)(
+    "surfaces ffmpeg early-exit as a write/finish error",
+    async () => {
+      // Invalid frame geometry makes ffmpeg reject its args and exit
+      // immediately; the failure must surface instead of hanging.
+      const enc = startMp4Encoder(0, 0, 24);
+      await expect(
+        (async () => {
+          const frame = new Uint8Array(64 * 64 * 4);
+          for (let i = 0; i < 100; i++) await enc.writeFrame(frame);
+          return enc.finish();
+        })(),
+      ).rejects.toThrow(/ffmpeg/);
+    },
+    30_000,
+  );
 });
 
 describe("compileRolloutTimeline", () => {

--- a/packages/mcp/src/tools/animate.ts
+++ b/packages/mcp/src/tools/animate.ts
@@ -776,12 +776,16 @@ export function startMp4Encoder(
         if (p.stdin.write(rgba)) return resolve();
         // Backpressure: wait for drain, but bail if ffmpeg exits first
         // (drain would never fire and the loop would hang).
-        const onClose = () => reject(failure ?? exitError(p.exitCode));
-        p.once("close", onClose);
-        p.stdin.once("drain", () => {
+        const onDrain = () => {
           p.removeListener("close", onClose);
           resolve();
-        });
+        };
+        const onClose = () => {
+          p.stdin.removeListener("drain", onDrain);
+          reject(failure ?? exitError(p.exitCode));
+        };
+        p.once("close", onClose);
+        p.stdin.once("drain", onDrain);
       });
     },
     finish(): Promise<Buffer> {
@@ -1021,7 +1025,7 @@ export async function exportVideo(
     try {
       bytes = await mp4!.finish();
     } catch (e) {
-      return err(
+      return bail(
         `mp4 encode failed: ${e instanceof Error ? e.message : String(e)}`,
       );
     }

--- a/packages/mcp/src/tools/animate.ts
+++ b/packages/mcp/src/tools/animate.ts
@@ -705,13 +705,26 @@ async function hasFfmpeg(): Promise<boolean> {
   return ffmpegAvailable;
 }
 
-/** Encode raw RGBA frames to MP4 via ffmpeg stdin pipe. */
-async function encodeMp4(
-  framesRgba: Uint8Array[],
+/**
+ * Streaming MP4 encoder: spawns ffmpeg once and pipes frames to its stdin
+ * as they rasterize, so a full sequence never sits in memory (600 frames
+ * at 1280px is ~4GB of raw RGBA). Exported for tests.
+ */
+export interface Mp4Encoder {
+  /** Write one raw RGBA frame; resolves after backpressure drains. */
+  writeFrame(rgba: Uint8Array): Promise<void>;
+  /** End stdin and resolve with the encoded MP4. */
+  finish(): Promise<Buffer>;
+  /** Kill ffmpeg when the render loop bails early. */
+  abort(): void;
+}
+
+/** Spawn ffmpeg for a rawvideo→mp4 pipe at the given frame geometry. */
+export function startMp4Encoder(
   width: number,
   height: number,
   fps: number,
-): Promise<Buffer> {
+): Mp4Encoder {
   const args = [
     "-y",
     "-f", "rawvideo",
@@ -725,25 +738,60 @@ async function encodeMp4(
     "-f", "mp4",
     "-",
   ];
-  return new Promise<Buffer>((resolve, reject) => {
-    const p = spawn("ffmpeg", args, { stdio: ["pipe", "pipe", "pipe"] });
-    const out: Buffer[] = [];
-    const errChunks: Buffer[] = [];
-    p.stdout.on("data", (c: Buffer) => out.push(c));
-    p.stderr.on("data", (c: Buffer) => errChunks.push(c));
-    p.on("error", reject);
+  const p = spawn("ffmpeg", args, { stdio: ["pipe", "pipe", "pipe"] });
+  const out: Buffer[] = [];
+  const errChunks: Buffer[] = [];
+  let failure: Error | null = null;
+  p.stdout.on("data", (c: Buffer) => out.push(c));
+  p.stderr.on("data", (c: Buffer) => errChunks.push(c));
+  // ffmpeg dying mid-stream EPIPEs stdin; the exit error surfaces instead.
+  p.stdin.on("error", () => {});
+  const exitError = (code: number | null) =>
+    new Error(
+      `ffmpeg exited ${code}: ${Buffer.concat(errChunks).toString().slice(-400)}`,
+    );
+  const done = new Promise<Buffer>((resolve, reject) => {
+    p.on("error", (e) => {
+      failure = e;
+      reject(e);
+    });
     p.on("close", (code) => {
       if (code === 0) resolve(Buffer.concat(out));
-      else
-        reject(
-          new Error(
-            `ffmpeg exited ${code}: ${Buffer.concat(errChunks).toString().slice(-400)}`,
-          ),
-        );
+      else {
+        failure ??= exitError(code);
+        reject(failure);
+      }
     });
-    for (const f of framesRgba) p.stdin.write(f);
-    p.stdin.end();
   });
+  // Callers may abort before awaiting finish(); don't leak a rejection.
+  done.catch(() => {});
+
+  return {
+    writeFrame(rgba: Uint8Array): Promise<void> {
+      return new Promise((resolve, reject) => {
+        if (failure) return reject(failure);
+        if (p.exitCode !== null || p.stdin.destroyed) {
+          return reject(failure ?? exitError(p.exitCode));
+        }
+        if (p.stdin.write(rgba)) return resolve();
+        // Backpressure: wait for drain, but bail if ffmpeg exits first
+        // (drain would never fire and the loop would hang).
+        const onClose = () => reject(failure ?? exitError(p.exitCode));
+        p.once("close", onClose);
+        p.stdin.once("drain", () => {
+          p.removeListener("close", onClose);
+          resolve();
+        });
+      });
+    },
+    finish(): Promise<Buffer> {
+      p.stdin.end();
+      return done;
+    },
+    abort(): void {
+      p.kill("SIGKILL");
+    },
+  };
 }
 
 /** Center-pad/crop an RGBA frame to the target dimensions (white fill). */
@@ -895,9 +943,13 @@ export async function exportVideo(
   const gifMod = "mod" in gifLoad ? gifLoad.mod : null;
   if (format === "gif" && gifMod) encoder = gifMod.GIFEncoder();
 
-  const rawFrames: Uint8Array[] = [];
+  let mp4: Mp4Encoder | null = null;
   let size: { width: number; height: number } | null = null;
   const delayMs = Math.max(1, Math.round(1000 / fps));
+  const bail = (message: string): ToolResult => {
+    mp4?.abort();
+    return err(message);
+  };
 
   for (let i = 0; i < frames.length; i++) {
     const frame = frames[i]!;
@@ -911,9 +963,9 @@ export async function exportVideo(
     } catch (e) {
       if (e instanceof WebAssembly.RuntimeError) {
         resetKernelWasm(`render_svg trapped during export_video: ${e.message}`);
-        return err(`kernel trap at frame ${i + 1}/${frames.length}: ${e.message}`);
+        return bail(`kernel trap at frame ${i + 1}/${frames.length}: ${e.message}`);
       }
-      return err(
+      return bail(
         `render failed at frame ${i + 1}/${frames.length}: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
@@ -922,7 +974,7 @@ export async function exportVideo(
     }
     const raster = await rasterize(svg, widthPx);
     if (!raster.rgba) {
-      return err(
+      return bail(
         `rasterization failed at frame ${i + 1}: ${"reason" in raster ? raster.reason : "unknown"}`,
       );
     }
@@ -942,7 +994,17 @@ export async function exportVideo(
         delay: delayMs,
       });
     } else {
-      rawFrames.push(rgba.slice());
+      // Stream each frame straight into ffmpeg — no buffering of the
+      // full sequence in memory. Spawned lazily off the first frame's
+      // dimensions; writeFrame awaits stdin drain (backpressure).
+      mp4 ??= startMp4Encoder(size.width, size.height, fps);
+      try {
+        await mp4.writeFrame(rgba);
+      } catch (e) {
+        return bail(
+          `mp4 encode failed at frame ${i + 1}/${frames.length}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+      }
     }
   }
   if (!size) return err("no frames rendered.");
@@ -956,7 +1018,13 @@ export async function exportVideo(
     mime = "image/gif";
     filename = "sequence.gif";
   } else {
-    bytes = await encodeMp4(rawFrames, size.width, size.height, fps);
+    try {
+      bytes = await mp4!.finish();
+    } catch (e) {
+      return err(
+        `mp4 encode failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
     mime = "video/mp4";
     filename = "sequence.mp4";
   }


### PR DESCRIPTION
## What

`export_video` (the animation MP4/GIF exporter) buffered every rendered RGBA frame in a `rawFrames` array and only piped them to ffmpeg **after** the render loop finished. At 600 frames × 1280px that's ~4GB of raw RGBA resident before encoding even starts.

This refactors the MP4 path to spawn ffmpeg **once** before the loop and stream each frame to its stdin as it rasterizes. Peak memory drops to a single frame plus ffmpeg's pipe buffer.

## Changes

- **New `startMp4Encoder(width, height, fps)`** (exported) replaces the buffered `encodeMp4(frames[])`. Returns `{ writeFrame, finish, abort }`:
  - ffmpeg is spawned with the same arg list as before, `-s` derived from the first frame's dimensions.
  - `writeFrame` resolves immediately when `stdin.write` returns `true`, otherwise **awaits `drain`** for backpressure — with a `close` listener racing it so the loop can't hang if ffmpeg dies mid-stream.
  - ffmpeg early-exit / nonzero exit surfaces as a `writeFrame`/`finish` rejection carrying the stderr tail; an EPIPE-absorbing `stdin.on("error")` keeps it from throwing unhandled.
- **`bail()` helper** in the render loop: every error return (kernel trap, rasterization failure, encode failure) now SIGKILLs the ffmpeg child so it never leaks.
- The encoder is spawned lazily off the first frame inside the loop; **the GIF path is unchanged**.

## Tests

Extended `animate.test.ts` with an ffmpeg-gated (`it.skipIf`) describe block:
- End-to-end MP4 export through `exportVideo` (asserts format/frames/bytes + artifact offload).
- 120-frame `startMp4Encoder` backpressure run, asserting a valid `ftyp` box.
- Early-exit case (invalid geometry) asserting the failure surfaces rather than hanging.

`npm run build -w @vcad/mcp && npx vitest run --root packages/mcp` — full suite green (66 files, 842 passed / 2 skipped). ffmpeg present locally, so all three new tests ran live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)