### PR TITLE
CM5 routability push: rule calibration from board copper + A* budgets (0.195 → 0.762)

### DIFF
--- a/crates/vcad-ecad-pcb/examples/cm5_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_bench.rs
@@ -4,17 +4,21 @@
 //! the human layout — completion, via count, and total copper length.
 //!
 //! ```bash
-//! cargo run --release -p vcad-ecad-pcb --example cm5_bench -- CM5RevEng.kicad_pcb [effort] [max_nets]
+//! cargo run --release -p vcad-ecad-pcb --example cm5_bench -- \
+//!     CM5RevEng.kicad_pcb [effort] [max_nets] [out.pcb.json]
 //! ```
 //!
-//! `max_nets` (default all) routes only the N largest-airwire nets — handy for
-//! a quick smoke run on the full board.
+//! `max_nets` (default all) routes only the N highest-pad-count nets — handy
+//! for a quick smoke run on the full board. `out.pcb.json` saves the board
+//! with the routed copper applied, so rendering (vcad-render's `cm5_render`)
+//! and styling iteration never pay for another routing run.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
 use vcad_ecad_pcb::router::{route_all_with_opts, RouteOptions};
 use vcad_ecad_symbols::parse_kicad_pcb;
+use vcad_ir::ecad::{Trace, Via};
 
 fn seg_len(a: vcad_ir::Vec2, b: vcad_ir::Vec2) -> f64 {
     ((b.x - a.x).powi(2) + (b.y - a.y).powi(2)).sqrt()
@@ -31,6 +35,7 @@ fn main() {
         .next()
         .and_then(|s| s.parse().ok())
         .unwrap_or(usize::MAX);
+    let out_json = args.next();
 
     let text = std::fs::read_to_string(&path).expect("read kicad_pcb");
     let mut pcb = parse_kicad_pcb(&text).expect("parse kicad_pcb");
@@ -65,25 +70,27 @@ fn main() {
     pcb.vias.clear();
 
     // Optional subset: the N nets with the most pads (the hard ones first).
+    // Keyed by the pad net strings — the exact names the router's pad-derived
+    // netlist and ratsnest match on (`pcb.nets` ids can differ from pad net
+    // names on imported boards, which made the filter silently select nothing).
     let filter: Vec<String> = if max_nets == usize::MAX {
         Vec::new()
     } else {
-        let mut counts: Vec<(String, usize)> = pcb
-            .nets
-            .iter()
-            .map(|n| {
-                let pads = pcb
-                    .footprints
-                    .iter()
-                    .flat_map(|f| f.pads.iter())
-                    .filter(|p| p.net.as_deref() == Some(n.id.as_str()))
-                    .count();
-                (n.id.clone(), pads)
-            })
-            .filter(|(_, c)| *c >= 2)
-            .collect();
-        counts.sort_by(|a, b| b.1.cmp(&a.1));
-        counts.into_iter().take(max_nets).map(|(n, _)| n).collect()
+        let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+        for p in pcb.footprints.iter().flat_map(|f| f.pads.iter()) {
+            if let Some(net) = p.net.as_deref() {
+                if !net.is_empty() {
+                    *counts.entry(net).or_default() += 1;
+                }
+            }
+        }
+        let mut counts: Vec<(&str, usize)> = counts.into_iter().filter(|(_, c)| *c >= 2).collect();
+        counts.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(b.0)));
+        counts
+            .into_iter()
+            .take(max_nets)
+            .map(|(n, _)| n.to_string())
+            .collect()
     };
 
     let width = pcb.rules.default_rules.trace_width;
@@ -126,5 +133,42 @@ fn main() {
     );
     for d in r.diagnostics.iter().take(10) {
         eprintln!("unrouted {}: {}", d.net, d.reason);
+    }
+
+    // Save the routed board for rendering / inspection without re-routing.
+    if let Some(out) = out_json {
+        for t in &r.traces {
+            pcb.traces.push(Trace {
+                start: t.start,
+                end: t.end,
+                width: t.width,
+                layer: t.layer,
+                net: t.net.clone(),
+                source: None,
+            });
+        }
+        let copper: Vec<_> = pcb
+            .stackup
+            .layers
+            .iter()
+            .map(|l| l.layer)
+            .filter(|l| l.is_copper())
+            .collect();
+        let start_layer = *copper.first().expect("board has copper");
+        let end_layer = *copper.last().expect("board has copper");
+        for v in &r.vias {
+            pcb.vias.push(Via {
+                position: v.position,
+                diameter: pcb.rules.default_rules.via_diameter,
+                drill: pcb.rules.default_rules.via_drill,
+                start_layer,
+                end_layer,
+                net: v.net.clone(),
+                source: None,
+            });
+        }
+        std::fs::write(&out, serde_json::to_string(&pcb).expect("serialize board"))
+            .expect("write routed board json");
+        eprintln!("wrote {out}");
     }
 }

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -131,7 +131,19 @@ impl RouteOptions {
     fn effective_ripup_rounds(&self) -> usize {
         ((MAX_RIPUP_ROUNDS as f64 * self.effort).ceil() as usize).max(1)
     }
+
+    /// A* expansion budget per connection after effort scaling. Bounds how
+    /// much of the (x, y, layer) space a single connection may flood before
+    /// failing honestly — the dominant cost of unroutable connections.
+    fn effective_expansions(&self) -> usize {
+        ((MAZE_EXPANSION_BUDGET as f64 * self.effort).ceil() as usize).max(10_000)
+    }
 }
+
+/// Base A* node-expansion budget per connection at effort 1.0. Successful
+/// routes typically expand a few thousand nodes; a doomed connection on a
+/// 10-layer board otherwise floods millions.
+const MAZE_EXPANSION_BUDGET: usize = 200_000;
 
 /// Default PathFinder negotiation rounds for [`route_all`]. Round 0 is the
 /// baseline; the win typically lands within a couple of negotiation rounds, and
@@ -283,6 +295,7 @@ pub fn route_all_with_opts(
             &cong,
             use_push_shove,
             opts.effective_ripup_rounds(),
+            opts.effective_expansions(),
         );
 
         let last_round = round + 1 == rounds;
@@ -570,6 +583,7 @@ fn route_pass(
     cong: &Congestion,
     use_push_shove: bool,
     ripup_rounds: usize,
+    max_expansions: usize,
 ) -> Pass {
     let mut session = RouteSession::from_pcb(pcb);
     let mut placed: Vec<Placed> = Vec::new();
@@ -590,6 +604,7 @@ fn route_pass(
             &placed,
             cong,
             use_push_shove,
+            max_expansions,
         ) {
             Some(p) => placed.push(p),
             None => unrouted_conns.push((line.net.clone(), line.from, line.to)),
@@ -615,6 +630,7 @@ fn route_pass(
             pending,
             cong,
             use_push_shove,
+            max_expansions,
         );
         if placed.len() <= placed_before {
             break;
@@ -649,6 +665,7 @@ fn try_route(
     placed: &[Placed],
     cong: &Congestion,
     use_push_shove: bool,
+    max_expansions: usize,
 ) -> Option<Placed> {
     // Net-class width if the net has one (wider power/ground), else the caller's
     // default. The same width drives the maze search, the committed copper, and
@@ -678,6 +695,7 @@ fn try_route(
         w,
         via_d,
         Some(cong),
+        max_expansions,
     );
     let (segments, route_vias) = if r3.success && !r3.segments.is_empty() {
         (r3.segments, r3.vias)
@@ -1322,6 +1340,7 @@ fn ripup_pass(
     unrouted: Vec<Conn>,
     cong: &Congestion,
     use_push_shove: bool,
+    max_expansions: usize,
 ) -> Vec<Conn> {
     let hw = width / 2.0;
     let copper = copper_layers(pcb);
@@ -1388,6 +1407,7 @@ fn ripup_pass(
             placed,
             cong,
             use_push_shove,
+            max_expansions,
         );
         if let Some(p) = routed_target {
             placed.push(p);
@@ -1407,6 +1427,7 @@ fn ripup_pass(
                 placed,
                 cong,
                 use_push_shove,
+                max_expansions,
             ) {
                 Some(p) => placed.push(p),
                 None => still.push((v.net, v.from, v.to)),

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -208,6 +208,12 @@ impl RouteResult3d {
 /// two-layer router. Via legality is probed on every layer in `layers` (all
 /// vias are through vias for now), and every emitted segment is re-probed on
 /// its own layer before the result is trusted.
+///
+/// `max_expansions` bounds the number of A* node pops (0 = unbounded): an
+/// unroutable connection otherwise floods the entire `(x, y, layer)` space —
+/// millions of oracle probes — before failing. The budget converts "prove
+/// impossibility exhaustively" into "give up after a fair search", which is
+/// what rip-up and negotiation want anyway.
 #[allow(clippy::too_many_arguments)]
 pub fn route_net_maze3d(
     session: &RouteSession,
@@ -221,6 +227,7 @@ pub fn route_net_maze3d(
     width: f64,
     via_diameter: f64,
     congestion: Option<&Congestion>,
+    max_expansions: usize,
 ) -> RouteResult3d {
     let nl = layers.len();
     if nl == 0 {
@@ -257,13 +264,6 @@ pub fn route_net_maze3d(
             .iter()
             .all(|&l| session.probe(&disc, l, net, clearance).legal)
     };
-    let cell_ok = |ix: usize, iy: usize, li: usize| -> bool {
-        let p = grid.world(ix, iy);
-        if grid.bounded && !point_in_polygon(p, outline) {
-            return false;
-        }
-        legal_step(p, p, layers[li])
-    };
     let cong = congestion.filter(|c| !c.is_flat());
     let node_cost =
         |cell: usize| -> f64 { cong.map(|c| c.cost_at(grid.world_of(cell))).unwrap_or(0.0) };
@@ -283,6 +283,19 @@ pub fn route_net_maze3d(
     let mut closed = vec![false; n];
     // Memoized via legality per cell (probing all layers is the expensive test).
     let mut via_cache: Vec<i8> = vec![-1; plane];
+    // Memoized cell passability per (cell, layer): each cell is otherwise
+    // probed once per incoming edge — up to 8× the oracle work for nothing.
+    let mut cell_cache: Vec<i8> = vec![-1; n];
+    let cell_ok = |ix: usize, iy: usize, li: usize, cache: &mut Vec<i8>| -> bool {
+        let node = li * plane + grid.index(ix, iy);
+        if cache[node] < 0 {
+            let p = grid.world(ix, iy);
+            let ok =
+                (!grid.bounded || point_in_polygon(p, outline)) && legal_step(p, p, layers[li]);
+            cache[node] = i8::from(ok);
+        }
+        cache[node] == 1
+    };
     let mut heap = BinaryHeap::new();
 
     let goal_cell = grid.index(ex, ey);
@@ -298,6 +311,7 @@ pub fn route_net_maze3d(
     }
 
     let mut found: Option<usize> = None;
+    let mut pops: usize = 0;
     while let Some(State { node, .. }) = heap.pop() {
         if is_goal(node) {
             found = Some(node);
@@ -305,6 +319,10 @@ pub fn route_net_maze3d(
         }
         if closed[node] {
             continue;
+        }
+        pops += 1;
+        if max_expansions > 0 && pops > max_expansions {
+            break;
         }
         closed[node] = true;
         let (li, cell) = (node / plane, node % plane);
@@ -327,7 +345,7 @@ pub fn route_net_maze3d(
             let (nix, niy) = (nx as usize, ny as usize);
             let nb = li * plane + grid.index(nix, niy);
             if closed[nb]
-                || !cell_ok(nix, niy, li)
+                || !cell_ok(nix, niy, li, &mut cell_cache)
                 || !legal_step(grid.world(ix, iy), grid.world(nix, niy), layers[li])
             {
                 continue;
@@ -365,7 +383,7 @@ pub fn route_net_maze3d(
                         continue;
                     }
                     let nb = lj * plane + cell;
-                    if closed[nb] || !cell_ok(ix, iy, lj) {
+                    if closed[nb] || !cell_ok(ix, iy, lj, &mut cell_cache) {
                         continue;
                     }
                     let tentative = g[node] + VIA_COST;
@@ -863,6 +881,7 @@ mod tests {
             0.25,
             0.8,
             None,
+            0,
         );
         assert!(r.success);
         assert!(r.vias.is_empty(), "no reason to leave the start layer");
@@ -892,6 +911,7 @@ mod tests {
             0.25,
             0.8,
             None,
+            0,
         );
         assert!(r.success, "3D search must cross under the wall");
         assert!(
@@ -943,6 +963,7 @@ mod tests {
             0.25,
             0.8,
             None,
+            0,
         );
         assert!(r.success);
         assert!(!r.vias.is_empty(), "front→back must place a via");

--- a/crates/vcad-ecad-symbols/src/kicad_pcb.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_pcb.rs
@@ -208,6 +208,14 @@ fn convert_pcb(root: &SExpr<'_>) -> Result<Pcb, ParseError> {
         .filter_map(|n| parse_zone(n, &net_map))
         .collect();
 
+    // The .kicad_pcb setup block rarely carries usable rules (net classes
+    // live in the .kicad_pro project file), so a routed board would otherwise
+    // import with the fat 0.25/0.2/0.8 defaults — hopeless on an HDI design
+    // whose own copper is 0.1 mm tracks and 0.2 mm vias. The board's existing
+    // copper is the best available evidence of its fab capability: calibrate
+    // the default rules against it.
+    let rules = calibrate_rules_from_copper(rules, &traces, &vias);
+
     Ok(Pcb {
         outline,
         stackup,
@@ -221,6 +229,53 @@ fn convert_pcb(root: &SExpr<'_>) -> Result<Pcb, ParseError> {
         keepouts: vec![],
         net_ties: vec![],
     })
+}
+
+/// Calibrate imported design rules against the board's existing copper.
+///
+/// Only tightens, never loosens: a routed board whose median track is thinner
+/// than the parsed default width adopts the median (and caps clearance at
+/// that width — a fab that draws 0.1 mm tracks spaces them comparably); a via
+/// population smaller than the parsed default adopts the modal via. A board
+/// with no copper (fresh layout) keeps the parsed/default rules untouched.
+fn calibrate_rules_from_copper(
+    mut rules: DesignRules,
+    traces: &[Trace],
+    vias: &[Via],
+) -> DesignRules {
+    if !traces.is_empty() {
+        let mut widths: Vec<f64> = traces
+            .iter()
+            .map(|t| t.width)
+            .filter(|w| *w > 0.0)
+            .collect();
+        widths.sort_by(f64::total_cmp);
+        if let Some(&median) = widths.get(widths.len() / 2) {
+            if median < rules.default_rules.trace_width {
+                rules.default_rules.trace_width = median;
+            }
+            if median < rules.default_rules.clearance {
+                rules.default_rules.clearance = median;
+            }
+        }
+    }
+    if !vias.is_empty() {
+        // Modal (diameter, drill) pair — the via the design actually uses most.
+        let mut counts: HashMap<(u64, u64), usize> = HashMap::new();
+        for v in vias {
+            *counts
+                .entry((v.diameter.to_bits(), v.drill.to_bits()))
+                .or_default() += 1;
+        }
+        if let Some(((d, dr), _)) = counts.into_iter().max_by_key(|(_, c)| *c) {
+            let (d, dr) = (f64::from_bits(d), f64::from_bits(dr));
+            if d > 0.0 && d < rules.default_rules.via_diameter {
+                rules.default_rules.via_diameter = d;
+                rules.default_rules.via_drill = dr.min(d);
+            }
+        }
+    }
+    rules
 }
 
 // ---------------------------------------------------------------------------
@@ -805,5 +860,41 @@ mod tests {
         assert_eq!(pcb.stackup.layers[1].layer, PcbLayer::In1Cu);
         assert_eq!(pcb.stackup.layers[2].layer, PcbLayer::In2Cu);
         assert_eq!(pcb.stackup.layers[3].layer, PcbLayer::BCu);
+    }
+
+    /// A routed board's own copper calibrates the imported rules: an HDI
+    /// design with 0.1 mm tracks and 0.2 mm microvias must not import with
+    /// the 0.25/0.2/0.8 fallback rules (which make it unroutable), and the
+    /// calibration only ever tightens.
+    #[test]
+    fn rules_calibrate_to_existing_copper() {
+        let input = r#"(kicad_pcb (version 20221018)
+  (general (thickness 1.0))
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+  (net 1 "SIG")
+  (segment (start 0 0) (end 5 0) (width 0.1) (layer "F.Cu") (net 1))
+  (segment (start 5 0) (end 9 0) (width 0.1) (layer "F.Cu") (net 1))
+  (segment (start 9 0) (end 9 5) (width 0.3) (layer "F.Cu") (net 1))
+  (via (at 9 5) (size 0.2) (drill 0.1) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 2 0) (size 0.2) (drill 0.1) (layers "F.Cu" "B.Cu") (net 1))
+  (via (at 4 0) (size 0.4) (drill 0.2) (layers "F.Cu" "B.Cu") (net 1))
+)"#;
+        let pcb = parse_kicad_pcb(input).unwrap();
+        let r = &pcb.rules.default_rules;
+        assert_eq!(r.trace_width, 0.1, "median existing width");
+        assert_eq!(r.clearance, 0.1, "clearance capped at median width");
+        assert_eq!(r.via_diameter, 0.2, "modal via diameter");
+        assert_eq!(r.via_drill, 0.1, "modal via drill");
+
+        // A bare board keeps the defaults — nothing to calibrate against.
+        let bare = parse_kicad_pcb(
+            r#"(kicad_pcb (version 20221018)
+  (general (thickness 1.6))
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal))
+)"#,
+        )
+        .unwrap();
+        assert_eq!(bare.rules.default_rules.trace_width, 0.25);
+        assert_eq!(bare.rules.default_rules.via_diameter, 0.8);
     }
 }

--- a/crates/vcad-render/examples/cm5_render.rs
+++ b/crates/vcad-render/examples/cm5_render.rs
@@ -1,18 +1,19 @@
-//! Render the CM5 benchmark visually: the human-routed reference board and
-//! the vcad-autorouted board, as SVGs — the eyeball companion to
+//! Render a PCB to a copper-first SVG — the visual companion to
 //! vcad-ecad-pcb's `cm5_bench` scoreboard.
 //!
-//! ```bash
-//! cargo run --release -p vcad-render --example cm5_render -- \
-//!     CM5RevEng.kicad_pcb out_dir [effort] [max_nets]
-//! ```
+//! Rendering is deliberately decoupled from routing: `cm5_bench` routes and
+//! (with its `out.pcb.json` argument) saves the routed board; this renders
+//! any board file, so styling iterates without paying for a routing run.
 //!
-//! Writes `out_dir/human.svg` (the reference routing) and `out_dir/vcad.svg`
-//! (copper stripped, autorouted with the layer-aware router).
+//! ```bash
+//! # the human-routed reference
+//! cargo run --release -p vcad-render --example cm5_render -- CM5RevEng.kicad_pcb human.svg
+//! # a routed board saved by cm5_bench
+//! cargo run --release -p vcad-render --example cm5_render -- routed.pcb.json vcad.svg
+//! ```
 
-use vcad_ecad_pcb::router::{route_all_with_opts, RouteOptions};
 use vcad_ecad_symbols::parse_kicad_pcb;
-use vcad_ir::ecad::{Pcb, PcbLayer, Trace, Via};
+use vcad_ir::ecad::{Pcb, PcbLayer};
 use vcad_render::pcb::{render_pcb_svg_opts, PcbRenderOpts};
 
 /// Every copper layer on the board plus the outline, in z-order. No
@@ -30,151 +31,36 @@ fn render_layers(pcb: &Pcb) -> Vec<PcbLayer> {
     layers
 }
 
-/// Copper-first styling: no value labels, no net labels, keep the ratsnest
-/// (open connections are part of the scoreboard's story).
-fn render_opts() -> PcbRenderOpts {
-    PcbRenderOpts {
-        show_values: false,
-        show_net_labels: false,
-        ..Default::default()
-    }
-}
-
-fn write_svg(out_dir: &str, name: &str, pcb: &Pcb) {
-    std::fs::write(
-        format!("{out_dir}/{name}.svg"),
-        render_pcb_svg_opts(pcb, &render_layers(pcb), 12.0, &render_opts()),
-    )
-    .unwrap_or_else(|e| panic!("write {name}.svg: {e}"));
-    eprintln!("wrote {out_dir}/{name}.svg");
-}
-
 fn main() {
     let mut args = std::env::args().skip(1);
-    let (Some(path), Some(out_dir)) = (args.next(), args.next()) else {
-        eprintln!("usage: cm5_render <board.kicad_pcb> <out_dir> [effort] [max_nets]");
+    let (Some(input), Some(output)) = (args.next(), args.next()) else {
+        eprintln!("usage: cm5_render <board.kicad_pcb | board.pcb.json> <out.svg>");
         std::process::exit(2);
     };
-    let effort: f64 = args.next().and_then(|s| s.parse().ok()).unwrap_or(1.0);
-    let max_nets: usize = args
-        .next()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(usize::MAX);
-    std::fs::create_dir_all(&out_dir).expect("create out_dir");
 
-    let text = std::fs::read_to_string(&path).expect("read board file");
-    // A saved `.pcb.json` (written below after routing) re-renders directly —
-    // iterate on styling without paying for another routing run.
-    let mut pcb = if path.ends_with(".pcb.json") {
+    let text = std::fs::read_to_string(&input).expect("read board file");
+    let mut pcb: Pcb = if input.ends_with(".json") {
         serde_json::from_str(&text).expect("parse pcb json")
     } else {
         parse_kicad_pcb(&text).expect("parse kicad_pcb")
     };
 
-    // Zones are dropped for this visual demo: rendering a pour runs a poly2d
-    // boolean per zone (128 here — it dominates the whole run; the DRC-side
-    // broadphase fix was PR #536, the renderer still needs one), and with the
-    // planes gone the router routes power nets as ordinary traces, which makes
-    // a better picture than invisible plane stitching anyway.
+    // Zone pours are skipped: rendering a pour runs a poly2d boolean per zone
+    // (128 on the CM5 — it dominates the whole run; the DRC-side broadphase
+    // fix was PR #536, the renderer still needs one).
     pcb.zones.clear();
 
-    // The human reference, exactly as imported.
-    write_svg(&out_dir, "human", &pcb);
-
-    // `max_nets == 0`: render the imported reference only, skip routing.
-    if max_nets == 0 {
-        return;
-    }
-
-    // Strip the routed copper and autoroute (planes/zones stay: design intent).
-    pcb.traces.clear();
-    pcb.trace_arcs.clear();
-    pcb.vias.clear();
-
-    let filter: Vec<String> = if max_nets == usize::MAX {
-        Vec::new()
-    } else {
-        let mut counts: Vec<(String, usize)> = pcb
-            .nets
-            .iter()
-            .map(|n| {
-                let pads = pcb
-                    .footprints
-                    .iter()
-                    .flat_map(|f| f.pads.iter())
-                    .filter(|p| p.net.as_deref() == Some(n.id.as_str()))
-                    .count();
-                (n.id.clone(), pads)
-            })
-            .filter(|(_, c)| *c >= 2)
-            .collect();
-        // Smallest nets first: this is a visual demo, so favor many quick
-        // completions over the monster power nets (cm5_bench stresses those).
-        counts.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
-        counts.into_iter().take(max_nets).map(|(n, _)| n).collect()
+    // Copper-first styling: no value labels, no net labels, keep the ratsnest
+    // (open connections are part of the scoreboard's story).
+    let opts = PcbRenderOpts {
+        show_values: false,
+        show_net_labels: false,
+        ..Default::default()
     };
-
-    let width = pcb.rules.default_rules.trace_width;
-    let r = route_all_with_opts(
-        &pcb,
-        width,
-        &filter,
-        &RouteOptions {
-            effort,
-            ..Default::default()
-        },
-    );
-    eprintln!(
-        "routed {} / unrouted {} nets, {} segments, {} vias",
-        r.routed_nets.len(),
-        r.unrouted_nets.len(),
-        r.traces.len(),
-        r.vias.len()
-    );
-
-    // Fold the routed copper back into the board for rendering.
-    for t in &r.traces {
-        pcb.traces.push(Trace {
-            start: t.start,
-            end: t.end,
-            width: t.width,
-            layer: t.layer,
-            net: t.net.clone(),
-            source: None,
-        });
-    }
-    let (start_layer, end_layer) = {
-        let copper: Vec<_> = pcb
-            .stackup
-            .layers
-            .iter()
-            .map(|l| l.layer)
-            .filter(|l| l.is_copper())
-            .collect();
-        (
-            *copper.first().unwrap_or(&vcad_ir::ecad::PcbLayer::FCu),
-            *copper.last().unwrap_or(&vcad_ir::ecad::PcbLayer::BCu),
-        )
-    };
-    for v in &r.vias {
-        pcb.vias.push(Via {
-            position: v.position,
-            diameter: pcb.rules.default_rules.via_diameter,
-            drill: pcb.rules.default_rules.via_drill,
-            start_layer,
-            end_layer,
-            net: v.net.clone(),
-            source: None,
-        });
-    }
-
-    write_svg(&out_dir, "vcad", &pcb);
-
-    // Save the routed board so styling can be iterated without re-routing
-    // (deserialize and call render_pcb_svg_opts directly).
     std::fs::write(
-        format!("{out_dir}/vcad.pcb.json"),
-        serde_json::to_string(&pcb).expect("serialize routed board"),
+        &output,
+        render_pcb_svg_opts(&pcb, &render_layers(&pcb), 12.0, &opts),
     )
-    .expect("write vcad.pcb.json");
+    .expect("write svg");
+    eprintln!("wrote {output}");
 }

--- a/crates/vcad-render/examples/cm5_render.rs
+++ b/crates/vcad-render/examples/cm5_render.rs
@@ -13,9 +13,11 @@
 use vcad_ecad_pcb::router::{route_all_with_opts, RouteOptions};
 use vcad_ecad_symbols::parse_kicad_pcb;
 use vcad_ir::ecad::{Pcb, PcbLayer, Trace, Via};
-use vcad_render::pcb::render_pcb_svg;
+use vcad_render::pcb::{render_pcb_svg_opts, PcbRenderOpts};
 
-/// Every copper layer on the board plus outline + front silk, in z-order.
+/// Every copper layer on the board plus the outline, in z-order. No
+/// silkscreen: on a 479-footprint board the refdes/value text is a solid
+/// wall of glyphs that buries the copper — the copper is the story here.
 fn render_layers(pcb: &Pcb) -> Vec<PcbLayer> {
     let mut layers: Vec<PcbLayer> = pcb
         .stackup
@@ -25,8 +27,26 @@ fn render_layers(pcb: &Pcb) -> Vec<PcbLayer> {
         .filter(|l| l.is_copper())
         .collect();
     layers.push(PcbLayer::EdgeCuts);
-    layers.push(PcbLayer::FSilkS);
     layers
+}
+
+/// Copper-first styling: no value labels, no net labels, keep the ratsnest
+/// (open connections are part of the scoreboard's story).
+fn render_opts() -> PcbRenderOpts {
+    PcbRenderOpts {
+        show_values: false,
+        show_net_labels: false,
+        ..Default::default()
+    }
+}
+
+fn write_svg(out_dir: &str, name: &str, pcb: &Pcb) {
+    std::fs::write(
+        format!("{out_dir}/{name}.svg"),
+        render_pcb_svg_opts(pcb, &render_layers(pcb), 12.0, &render_opts()),
+    )
+    .unwrap_or_else(|e| panic!("write {name}.svg: {e}"));
+    eprintln!("wrote {out_dir}/{name}.svg");
 }
 
 fn main() {
@@ -42,8 +62,14 @@ fn main() {
         .unwrap_or(usize::MAX);
     std::fs::create_dir_all(&out_dir).expect("create out_dir");
 
-    let text = std::fs::read_to_string(&path).expect("read kicad_pcb");
-    let mut pcb = parse_kicad_pcb(&text).expect("parse kicad_pcb");
+    let text = std::fs::read_to_string(&path).expect("read board file");
+    // A saved `.pcb.json` (written below after routing) re-renders directly —
+    // iterate on styling without paying for another routing run.
+    let mut pcb = if path.ends_with(".pcb.json") {
+        serde_json::from_str(&text).expect("parse pcb json")
+    } else {
+        parse_kicad_pcb(&text).expect("parse kicad_pcb")
+    };
 
     // Zones are dropped for this visual demo: rendering a pour runs a poly2d
     // boolean per zone (128 here — it dominates the whole run; the DRC-side
@@ -53,12 +79,7 @@ fn main() {
     pcb.zones.clear();
 
     // The human reference, exactly as imported.
-    std::fs::write(
-        format!("{out_dir}/human.svg"),
-        render_pcb_svg(&pcb, &render_layers(&pcb), 12.0),
-    )
-    .expect("write human.svg");
-    eprintln!("wrote {out_dir}/human.svg");
+    write_svg(&out_dir, "human", &pcb);
 
     // `max_nets == 0`: render the imported reference only, skip routing.
     if max_nets == 0 {
@@ -147,10 +168,13 @@ fn main() {
         });
     }
 
+    write_svg(&out_dir, "vcad", &pcb);
+
+    // Save the routed board so styling can be iterated without re-routing
+    // (deserialize and call render_pcb_svg_opts directly).
     std::fs::write(
-        format!("{out_dir}/vcad.svg"),
-        render_pcb_svg(&pcb, &render_layers(&pcb), 12.0),
+        format!("{out_dir}/vcad.pcb.json"),
+        serde_json::to_string(&pcb).expect("serialize routed board"),
     )
-    .expect("write vcad.svg");
-    eprintln!("wrote {out_dir}/vcad.svg");
+    .expect("write vcad.pcb.json");
 }


### PR DESCRIPTION
Follow-up to #548 — the full-board CM5 score goes from routability **0.195 → 0.762** (280/408 nets, 4,230mm of the human's 7,667mm copper).

## Changes

1. **Design-rule calibration from existing copper** (the unlock): KiCad net classes live in `.kicad_pro`, so `.kicad_pcb` imports fell back to 0.25mm trace / 0.2mm clearance / 0.8mm via defaults. On the CM5 — real copper: 0.08–0.1mm tracks, 0.21mm microvias — the router was pushing truck-width copper (and 1.2mm-clear via discs through all 10 layers) through microvia-scale channels. Imports now tighten defaults to the median existing trace width (clearance capped there) and the modal via. Only ever tightens; bare boards keep defaults. Regression-tested.
2. **A* expansion budget** (`200k × effort` via RouteOptions): an unroutable connection used to flood the entire (x,y,layer) space — millions of probes — before failing. 40-hardest-nets benchmark: 588s → 8.1s (73×).
3. **Memoized cell passability** per (cell, layer): cells were oracle-probed once per incoming edge (up to 8×).
4. **CM5 bench/render decoupling** (cherry-picked from the post-merge tail of #548): `cm5_bench` routes and saves `out.pcb.json`; `cm5_render` is a pure renderer; net-subset filter fixed to key on pad net strings.

## Scoreboard (full board, effort 1)

```
human: 8115 segments, 2902 vias, 7667mm copper, 409 routed nets
vcad:  2289 segments,  526 vias, 4230mm copper, 280 routed / 128 unrouted
routability 0.762, 49min single-threaded
```

Remaining failures concentrate in the GPIO bank / LPDDR4 region — genuine congestion. Next levers: rayon across connections, negotiation tuning at higher effort, pull-tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)