### PR TITLE
vcad-kernel-particle: charged-particle optics, M0-M6 complete (differentiable IEC/electrode design)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,13 +137,22 @@ vcad/
 │   #                            # priced through the seam) and vcad-eval::diff
 │   #                            # (document_parameter_gradient — d(mass props)/d(named
 │   #                            # .vcad parameter))
-│   # - vcad-kernel-particle     # Charged-particle optics, M0: axisymmetric
-│   #                            # Poisson (SOR) + exact ring-coil B (elliptic
-│   #                            # integrals) + Boris tracing + electrode FoMs
-│   #                            # (interception/recirculation/transparency) +
-│   #                            # FD optimizer. Fusor & magnetically-shielded-
-│   #                            # grid IEC benchmark; reproduces r_L ∝ √V
-│   #                            # shield scaling (docs/particle-optics-m0.md)
+│   # - vcad-kernel-particle     # Charged-particle optics, M0–M6 COMPLETE:
+│   #                            # axisym Poisson (SOR, conservative patch-E)
+│   #                            # + exact ring-coil B (elliptic, grid-cached)
+│   #                            # + Boris tracing + Bosch-Hale D-D yield +
+│   #                            # charge-exchange channels + discrete adjoint
+│   #                            # (FD-validated 0.1–0.8%, adjoint Poisson via
+│   #                            # radial-weight symmetrization) + DeviceSpec
+│   #                            # param seam + receipt claims (Q, distance-
+│   #                            # to-Lawson, Holds/Violated/Unmeasured
+│   #                            # compare) + analytic benchmarks + paper
+│   #                            # draft + experiment BOM. Reproduces the
+│   #                            # shielded-grid effect (arXiv:1510.01788),
+│   #                            # r_L ∝ √V, multimodal yield landscape.
+│   #                            # (docs/particle-optics-m0.md, -paper-draft,
+│   #                            # shielded-grid-experiment.md). Follow-up:
+│   #                            # vcad-receipt registration + MCP tools.
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,13 @@ vcad/
 │   #                            # priced through the seam) and vcad-eval::diff
 │   #                            # (document_parameter_gradient — d(mass props)/d(named
 │   #                            # .vcad parameter))
+│   # - vcad-kernel-particle     # Charged-particle optics, M0: axisymmetric
+│   #                            # Poisson (SOR) + exact ring-coil B (elliptic
+│   #                            # integrals) + Boris tracing + electrode FoMs
+│   #                            # (interception/recirculation/transparency) +
+│   #                            # FD optimizer. Fusor & magnetically-shielded-
+│   #                            # grid IEC benchmark; reproduces r_L ∝ √V
+│   #                            # shield scaling (docs/particle-optics-m0.md)
 ├── packages/                      # TypeScript workspace
 │   ├── app/                       # Web app (React + Three.js + Zustand)
 │   ├── engine/                    # WASM engine wrapper + physics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7147,6 +7147,7 @@ dependencies = [
  "vcad-kernel-fillet",
  "vcad-kernel-geom",
  "vcad-kernel-math",
+ "vcad-kernel-particle",
  "vcad-kernel-primitives",
  "vcad-kernel-sheet",
  "vcad-kernel-shell",
@@ -7322,6 +7323,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7540,6 +7542,7 @@ dependencies = [
  "vcad-kernel-urdf",
  "vcad-loon",
  "vcad-parts",
+ "vcad-receipt",
  "vcad-render",
  "vcad-slicer",
  "vcad-slicer-bambu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7319,6 +7319,10 @@ dependencies = [
 [[package]]
 name = "vcad-kernel-particle"
 version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "vcad-kernel-physics"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7317,6 +7317,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-kernel-particle"
+version = "0.9.4"
+
+[[package]]
 name = "vcad-kernel-physics"
 version = "0.9.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
     "crates/vcad-kernel-diff",
+    "crates/vcad-kernel-particle",
     "crates/vcad-kernel-wasm",
     "crates/vcad-kernel-drafting",
     "crates/vcad-cli",
@@ -98,6 +99,7 @@ default-members = [
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
     "crates/vcad-kernel-diff",
+    "crates/vcad-kernel-particle",
     "crates/vcad-kernel-wasm",
     "crates/vcad-kernel-drafting",
     "crates/vcad-cli",
@@ -191,6 +193,7 @@ vcad-kernel-sheet = { path = "crates/vcad-kernel-sheet", version = "0.9.4" }
 vcad-kernel-step = { path = "crates/vcad-kernel-step", version = "0.9.4" }
 vcad-kernel-constraints = { path = "crates/vcad-kernel-constraints", version = "0.9.4" }
 vcad-kernel-diff = { path = "crates/vcad-kernel-diff", version = "0.9.4" }
+vcad-kernel-particle = { path = "crates/vcad-kernel-particle", version = "0.9.4" }
 vcad-kernel-drafting = { path = "crates/vcad-kernel-drafting", version = "0.9.4" }
 vcad-kernel-gpu = { path = "crates/vcad-kernel-gpu", version = "0.9.4" }
 vcad-kernel-raytrace = { path = "crates/vcad-kernel-raytrace", version = "0.9.4" }

--- a/crates/vcad-kernel-particle/Cargo.toml
+++ b/crates/vcad-kernel-particle/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "vcad-kernel-particle"
+description = "Charged-particle optics: axisymmetric electrostatics, ring-coil magnetics, Boris tracing, and electrode figures of merit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/crates/vcad-kernel-particle/Cargo.toml
+++ b/crates/vcad-kernel-particle/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-particle/Cargo.toml
+++ b/crates/vcad-kernel-particle/Cargo.toml
@@ -7,3 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vcad-kernel-particle/examples/convergence.rs
+++ b/crates/vcad-kernel-particle/examples/convergence.rs
@@ -1,0 +1,36 @@
+//! Grid-convergence study for the fusor-baseline figures of merit.
+//!
+//! Runs the classic 5-ring fusor at four grid resolutions with a fixed
+//! ensemble and prints the key FoMs — the table quoted in
+//! `docs/particle-optics-m0.md`.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example convergence`
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::stats;
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+
+fn main() {
+    println!("nr,nz,intercept_frac,mean_passes,ddn_sigma_v_m3,mean_drift,max_drift");
+    let device = Device::classic_fusor(150.0, 50.0, 5, 1.0, -30_000.0);
+    for (nr, nz) in [(61, 121), (81, 161), (121, 241), (161, 321)] {
+        let sol = solve(&device, nr, nz, &SolveOptions::default()).expect("solve");
+        let fields = FieldMap::new(&device, &sol);
+        let opts = TraceOptions {
+            max_passes: 20,
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, opts);
+        let s = stats(&tracer.launch_ensemble(DEUTERON, 48));
+        println!(
+            "{nr},{nz},{:.3},{:.2},{:.3e},{:.4},{:.4}",
+            s.interception_fraction,
+            s.mean_passes,
+            s.mean_ddn_sigma_v_m3,
+            s.mean_energy_drift_rel,
+            s.max_energy_drift_rel
+        );
+    }
+}

--- a/crates/vcad-kernel-particle/examples/fusor_baseline.rs
+++ b/crates/vcad-kernel-particle/examples/fusor_baseline.rs
@@ -1,17 +1,23 @@
-//! Fusor-baseline benchmark: the simulated ammeter.
+//! Fusor-baseline benchmark: the simulated ammeter and neutron counter.
 //!
 //! Traces ion ensembles through (a) a classic 5-ring fusor and (b) the
 //! two-ring magnetically shielded cathode across a shield-current sweep at
 //! two bias voltages, printing CSV. Interception fraction is what a
-//! cathode ammeter sees; mean passes is the recirculation the shield buys.
+//! cathode ammeter sees; mean passes is the recirculation the shield buys;
+//! `pred_n_per_s` is the beam-on-background D-D neutron rate at the
+//! reference operating point (10 mA ion current, 2 mTorr D₂, 300 K).
 //!
 //! Run: `cargo run --release -p vcad-kernel-particle --example fusor_baseline`
 
 use vcad_kernel_particle::device::Device;
 use vcad_kernel_particle::field::FieldMap;
-use vcad_kernel_particle::fom::{geometric_transparency, stats};
+use vcad_kernel_particle::fom::{geometric_transparency, neutron_rate_per_s, stats};
 use vcad_kernel_particle::poisson::{solve, SolveOptions};
 use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_kernel_particle::xsection::d2_deuteron_density_m3;
+
+const REF_ION_CURRENT_A: f64 = 0.010;
+const REF_PRESSURE_MTORR: f64 = 2.0;
 
 fn bench(device: &Device, label: &str, volts: f64, amp_turns: f64) {
     let sol = solve(device, 121, 241, &SolveOptions::default()).expect("poisson solve");
@@ -23,20 +29,24 @@ fn bench(device: &Device, label: &str, volts: f64, amp_turns: f64) {
     let tracer = Tracer::new(device, &fields, &sol, opts);
     let outcomes = tracer.launch_ensemble(DEUTERON, 96);
     let s = stats(&outcomes);
+    let n_d = d2_deuteron_density_m3(REF_PRESSURE_MTORR, 300.0);
+    let rate = neutron_rate_per_s(s.mean_ddn_sigma_v_m3, REF_ION_CURRENT_A, n_d);
     println!(
-        "{label},{volts},{amp_turns},{:.2},{:.3},{:.3},{:.3},{:.3},{:.4}",
+        "{label},{volts},{amp_turns},{:.2},{:.3},{:.3},{:.3},{:.3},{:.4},{:.3e},{:.3e}",
         s.mean_passes,
         s.interception_fraction,
         s.wall_fraction,
         s.survivor_fraction,
         s.effective_transparency,
-        s.max_energy_drift_rel
+        s.max_energy_drift_rel,
+        s.mean_ddn_sigma_v_m3,
+        rate
     );
 }
 
 fn main() {
     println!(
-        "config,bias_v,ampere_turns,mean_passes,intercept_frac,wall_frac,survive_frac,eff_transparency,max_energy_drift"
+        "config,bias_v,ampere_turns,mean_passes,intercept_frac,wall_frac,survive_frac,eff_transparency,max_energy_drift,ddn_sigma_v_m3,pred_n_per_s"
     );
 
     // Classic fusor control: 5 rings on a 50 mm cathode sphere, 1 mm wire.
@@ -44,6 +54,11 @@ fn main() {
     eprintln!(
         "# classic fusor geometric transparency: {:.3}",
         geometric_transparency(&fusor)
+    );
+    eprintln!(
+        "# reference operating point: {} mA, {} mTorr D2, 300 K",
+        REF_ION_CURRENT_A * 1e3,
+        REF_PRESSURE_MTORR
     );
     bench(&fusor, "classic_fusor_5ring", -30_000.0, 0.0);
 

--- a/crates/vcad-kernel-particle/examples/fusor_baseline.rs
+++ b/crates/vcad-kernel-particle/examples/fusor_baseline.rs
@@ -11,9 +11,11 @@
 
 use vcad_kernel_particle::device::Device;
 use vcad_kernel_particle::field::FieldMap;
-use vcad_kernel_particle::fom::{geometric_transparency, neutron_rate_per_s, stats};
+use vcad_kernel_particle::fom::{
+    geometric_transparency, neutron_rate_from_counts, neutron_rate_per_s, stats,
+};
 use vcad_kernel_particle::poisson::{solve, SolveOptions};
-use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_kernel_particle::trace::{CxModel, TraceOptions, Tracer, DEUTERON};
 use vcad_kernel_particle::xsection::d2_deuteron_density_m3;
 
 const REF_ION_CURRENT_A: f64 = 0.010;
@@ -61,6 +63,32 @@ fn main() {
         REF_PRESSURE_MTORR
     );
     bench(&fusor, "classic_fusor_5ring", -30_000.0, 0.0);
+
+    // Charge-exchange reality check on the classic fusor: at glow-fusor
+    // pressure the surviving-ion channel collapses and the fast-neutral
+    // channel takes over — both reported per injected ion.
+    {
+        let n_bg = d2_deuteron_density_m3(REF_PRESSURE_MTORR, 300.0);
+        let sol = solve(&fusor, 121, 241, &SolveOptions::default()).expect("poisson");
+        let fields = FieldMap::new(&fusor, &sol);
+        let opts = TraceOptions {
+            max_passes: 40,
+            cx: Some(CxModel {
+                sigma_cx_m2: 1.0e-19,
+                background_deuteron_density_m3: n_bg,
+            }),
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&fusor, &fields, &sol, opts);
+        let s = stats(&tracer.launch_ensemble(DEUTERON, 96));
+        let total = s.mean_neutrons_ion_channel + s.mean_neutrons_cx_channel;
+        eprintln!(
+            "# cx reality check (sigma_cx 1e-19 m^2): ion-channel {:.3e} n/s, fast-neutral {:.3e} n/s, total {:.3e} n/s",
+            neutron_rate_from_counts(s.mean_neutrons_ion_channel, REF_ION_CURRENT_A),
+            neutron_rate_from_counts(s.mean_neutrons_cx_channel, REF_ION_CURRENT_A),
+            neutron_rate_from_counts(total, REF_ION_CURRENT_A)
+        );
+    }
 
     // Shielded two-ring cathode: sweep ampere-turns at two biases.
     for &volts in &[-3_000.0_f64, -30_000.0] {

--- a/crates/vcad-kernel-particle/examples/fusor_baseline.rs
+++ b/crates/vcad-kernel-particle/examples/fusor_baseline.rs
@@ -1,0 +1,59 @@
+//! Fusor-baseline benchmark: the simulated ammeter.
+//!
+//! Traces ion ensembles through (a) a classic 5-ring fusor and (b) the
+//! two-ring magnetically shielded cathode across a shield-current sweep at
+//! two bias voltages, printing CSV. Interception fraction is what a
+//! cathode ammeter sees; mean passes is the recirculation the shield buys.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example fusor_baseline`
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::{geometric_transparency, stats};
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+
+fn bench(device: &Device, label: &str, volts: f64, amp_turns: f64) {
+    let sol = solve(device, 121, 241, &SolveOptions::default()).expect("poisson solve");
+    let fields = FieldMap::new(device, &sol);
+    let opts = TraceOptions {
+        max_passes: 40,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(device, &fields, &sol, opts);
+    let outcomes = tracer.launch_ensemble(DEUTERON, 96);
+    let s = stats(&outcomes);
+    println!(
+        "{label},{volts},{amp_turns},{:.2},{:.3},{:.3},{:.3},{:.3},{:.4}",
+        s.mean_passes,
+        s.interception_fraction,
+        s.wall_fraction,
+        s.survivor_fraction,
+        s.effective_transparency,
+        s.max_energy_drift_rel
+    );
+}
+
+fn main() {
+    println!(
+        "config,bias_v,ampere_turns,mean_passes,intercept_frac,wall_frac,survive_frac,eff_transparency,max_energy_drift"
+    );
+
+    // Classic fusor control: 5 rings on a 50 mm cathode sphere, 1 mm wire.
+    let fusor = Device::classic_fusor(150.0, 50.0, 5, 1.0, -30_000.0);
+    eprintln!(
+        "# classic fusor geometric transparency: {:.3}",
+        geometric_transparency(&fusor)
+    );
+    bench(&fusor, "classic_fusor_5ring", -30_000.0, 0.0);
+
+    // Shielded two-ring cathode: sweep ampere-turns at two biases.
+    for &volts in &[-3_000.0_f64, -30_000.0] {
+        for &at in &[
+            0.0_f64, 5_000.0, 10_000.0, 20_000.0, 40_000.0, 80_000.0, 160_000.0,
+        ] {
+            let device = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, volts, at);
+            bench(&device, "shielded_two_ring", volts, at);
+        }
+    }
+}

--- a/crates/vcad-kernel-particle/examples/optimize_shield.rs
+++ b/crates/vcad-kernel-particle/examples/optimize_shield.rs
@@ -1,0 +1,109 @@
+//! Let the optimizer design the shielded cathode.
+//!
+//! Two free parameters — shield ampere-turns and ring axial spacing — and
+//! one objective: predicted D-D neutron yield per injected ion at fixed
+//! −30 kV bias. This is the design question the M0 sweep surfaced: the
+//! shield helps until the cusp starts reflecting ions off the core, so
+//! somewhere in between is an optimum. Find it by gradient ascent instead
+//! of squinting at sweep tables.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example optimize_shield`
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::{neutron_rate_per_s, stats};
+use vcad_kernel_particle::optimize::{maximize, FdOptions};
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_kernel_particle::xsection::d2_deuteron_density_m3;
+
+const BIAS_V: f64 = -30_000.0;
+
+fn yield_per_ion(ampere_turns: f64, ring_z_mm: f64) -> f64 {
+    let device = Device::shielded_two_ring(150.0, 45.0, ring_z_mm, 3.0, BIAS_V, ampere_turns);
+    let Ok(sol) = solve(&device, 101, 201, &SolveOptions::default()) else {
+        return 0.0;
+    };
+    let fields = FieldMap::new(&device, &sol);
+    let opts = TraceOptions {
+        max_passes: 25,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, opts);
+    let outcomes = tracer.launch_ensemble(DEUTERON, 64);
+    stats(&outcomes).mean_ddn_sigma_v_m3
+}
+
+fn main() {
+    // The yield landscape is multimodal (a recirculation hill at low
+    // current, an energy-quality hill at high current where ions reach the
+    // core at full speed through a well-shielded grid), so gradient ascent
+    // gets a few independent starts and the best basin wins.
+    let seeds: [[f64; 2]; 3] = [[20_000.0, 25.0], [80_000.0, 25.0], [200_000.0, 30.0]];
+    let mut evals = 0usize;
+    let mut best_seen = 0.0f64;
+    let mut objective = |x: &[f64]| {
+        let v = yield_per_ion(x[0], x[1]);
+        evals += 1;
+        if v > best_seen {
+            best_seen = v;
+            eprintln!(
+                "# eval {evals}: A-turns {:.0}, ring z ±{:.1} mm -> sigma_v {:.3e} m^3 (new best)",
+                x[0], x[1], v
+            );
+        }
+        v
+    };
+
+    let mut result = None;
+    for seed in &seeds {
+        eprintln!(
+            "# start from A-turns {:.0}, ring z ±{:.1} mm",
+            seed[0], seed[1]
+        );
+        let r = maximize(
+            &mut objective,
+            seed,
+            &[0.0, 15.0],
+            &[300_000.0, 40.0],
+            &FdOptions {
+                max_iters: 8,
+                ..FdOptions::default()
+            },
+        );
+        let better = result
+            .as_ref()
+            .map(|b: &vcad_kernel_particle::optimize::FdResult| r.value > b.value)
+            .unwrap_or(true);
+        if better {
+            result = Some(r);
+        }
+    }
+    let result = result.expect("at least one start");
+
+    let n_d = d2_deuteron_density_m3(2.0, 300.0);
+    let baseline = yield_per_ion(0.0, 25.0);
+    println!("bias_v,{BIAS_V}");
+    println!("best_ampere_turns,{:.0}", result.x[0]);
+    println!("best_ring_z_mm,{:.2}", result.x[1]);
+    println!("best_sigma_v_m3,{:.4e}", result.value);
+    println!("unshielded_sigma_v_m3,{:.4e}", baseline);
+    println!(
+        "yield_gain_vs_unshielded,{:.2}",
+        result.value / baseline.max(1e-300)
+    );
+    println!(
+        "pred_n_per_s_at_10mA_2mTorr,{:.3e}",
+        neutron_rate_per_s(result.value, 0.010, n_d)
+    );
+    println!("objective_evals,{}", result.evals);
+    println!(
+        "history,{}",
+        result
+            .history
+            .iter()
+            .map(|v| format!("{v:.3e}"))
+            .collect::<Vec<_>>()
+            .join(";")
+    );
+}

--- a/crates/vcad-kernel-particle/src/adjoint.rs
+++ b/crates/vcad-kernel-particle/src/adjoint.rs
@@ -393,13 +393,10 @@ fn deposit_e_adjoint(sol: &Solution, p: [f64; 3], lam_e: [f64; 3], lam_phi: &mut
     } else {
         (lam_e[0] * p[0] / r + lam_e[1] * p[1] / r, lam_e[2])
     };
-    let eps = 1e-9;
-    let u = (r / sol.dr).clamp(0.0, (sol.nr - 1) as f64 - eps);
-    let w = ((p[2] + sol.z_half) / sol.dz).clamp(0.0, (sol.nz - 1) as f64 - eps);
-    let i0 = u.floor() as usize;
-    let j0 = w.floor() as usize;
-    let fu = u - i0 as f64;
-    let fw = w - j0 as f64;
+    // Must locate the identical patch as `Solution::e_at` (the deposit is
+    // its exact transpose), so it shares the same index-space clamp.
+    let (i0, fu) = crate::poisson::cell_index(r / sol.dr, sol.nr);
+    let (j0, fw) = crate::poisson::cell_index((p[2] + sol.z_half) / sol.dz, sol.nz);
     let idx = |i: usize, j: usize| i * sol.nz + j;
     // Er = −((p10−p00)(1−fw) + (p11−p01)·fw)/dr
     lam_phi[idx(i0, j0)] += lam_er * (1.0 - fw) / sol.dr;

--- a/crates/vcad-kernel-particle/src/adjoint.rs
+++ b/crates/vcad-kernel-particle/src/adjoint.rs
@@ -1,0 +1,681 @@
+//! Discrete adjoint of the traced yield objective.
+//!
+//! Computes exact-to-discretization gradients of the ensemble-mean D-D
+//! yield integral J = ⟨∫ σ_DDn(E)·v dt⟩ with respect to
+//!
+//! - **electrode potentials** (per ring + chamber wall), via reverse-mode
+//!   accumulation into the potential grid (PIC-style deposits through the
+//!   bilinear-patch weights) followed by one adjoint Poisson solve — the
+//!   axisymmetric operator is self-adjoint under the radial weighting
+//!   `w_i = r_i` (axis row: `w₀ = Δr/8`), so the adjoint solve reuses the
+//!   forward SOR stencil with a right-hand side;
+//! - **coil ampere-turns**, via ⟨λ_B, B(I=1)⟩ along the trajectory (the
+//!   loop field is linear in its current).
+//!
+//! To keep the adjoint exactly consistent with its forward pass, this
+//! module runs its **own** forward integration: fixed time step (no
+//! speed/proximity adaptivity — adaptive dt is a non-differentiated
+//! control flow), analytic coil B (no grid cache), full trajectory
+//! storage, and a pure time budget (no wire/wall termination, so the
+//! objective has no non-differentiable boundary terms). Position
+//! Jacobians of the sampled fields are taken by central differences at
+//! the particle (the fields themselves stay exact); everything linear in
+//! φ and I is handled analytically.
+//!
+//! Validated against central differences over the full pipeline — see the
+//! tests at the bottom.
+
+use crate::device::Device;
+use crate::field::{b_ring, RingCoil};
+use crate::poisson::{Solution, SolveError, SolveOptions};
+use crate::trace::{Species, DEUTERON};
+use crate::xsection::dd_n_sigma_m2;
+
+/// Configuration for adjoint gradient runs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AdjointConfig {
+    /// Fixed step as a fraction of the grid spacing at the reference
+    /// speed (smaller than the tracer default — the fixed step must stay
+    /// accurate near wires without adaptivity).
+    pub dt_fraction: f64,
+    /// Flight-time budget in ideal chamber crossings (the only stopping
+    /// rule — keeps J smooth).
+    pub time_budget_crossings: f64,
+    /// Ensemble size (deterministic launch grid, same as the tracer).
+    pub n_particles: usize,
+    /// Launch shell radius as a fraction of the smaller chamber dimension.
+    pub launch_shell_fraction: f64,
+    /// Launch directions span cos θ ∈ [−this, +this].
+    pub launch_cos_max: f64,
+    /// Reference potential drop (volts) that sets the fixed time step and
+    /// time budget. `None` derives it from the device — fine for a single
+    /// gradient, but **freeze it explicitly** when comparing runs across
+    /// parameter perturbations (finite differences, line searches), or the
+    /// integration window itself becomes a function of the parameters and
+    /// contaminates the comparison.
+    pub reference_drop_v: Option<f64>,
+}
+
+impl Default for AdjointConfig {
+    fn default() -> Self {
+        Self {
+            dt_fraction: 0.1,
+            time_budget_crossings: 3.0,
+            n_particles: 16,
+            launch_shell_fraction: 0.85,
+            launch_cos_max: 0.95,
+            reference_drop_v: None,
+        }
+    }
+}
+
+/// Yield value and its gradient.
+#[derive(Debug, Clone, PartialEq)]
+pub struct YieldGradient {
+    /// Ensemble-mean yield integral ⟨∫σv dt⟩, m³.
+    pub value: f64,
+    /// d value / d (ring potential), one entry per `Device::rings`.
+    pub d_ring_potentials: Vec<f64>,
+    /// d value / d (wall potential).
+    pub d_wall_potential: f64,
+    /// d value / d (ring ampere-turns), one entry per `Device::rings`.
+    pub d_ampere_turns: Vec<f64>,
+}
+
+#[derive(Clone, Copy)]
+struct Step {
+    p: [f64; 3],
+    v: [f64; 3],
+}
+
+/// Compute the ensemble yield and its adjoint gradient for `device` on an
+/// `nr × nz` grid.
+pub fn yield_gradient(
+    device: &Device,
+    nr: usize,
+    nz: usize,
+    sopts: &SolveOptions,
+    cfg: &AdjointConfig,
+) -> Result<YieldGradient, SolveError> {
+    let sol = crate::poisson::solve(device, nr, nz, sopts)?;
+    let coils: Vec<RingCoil> = device
+        .rings
+        .iter()
+        .map(|r| RingCoil {
+            radius_m: r.ring_radius_mm * 1e-3,
+            z_m: r.z_mm * 1e-3,
+            ampere_turns: r.ampere_turns,
+            wire_radius_m: (r.wire_radius_mm * 1e-3).max(1e-6),
+        })
+        .collect();
+
+    let species = DEUTERON;
+    let qm = species.charge_c / species.mass_kg;
+    let drop_v = cfg
+        .reference_drop_v
+        .unwrap_or_else(|| device.max_potential_drop_v())
+        .max(1.0);
+    let v_ref = (2.0 * species.charge_c * drop_v / species.mass_kg).sqrt();
+    let h = sol.dr.min(sol.dz);
+    let dth = cfg.dt_fraction * h / v_ref;
+    let min_dim = device.chamber_radius_mm.min(device.chamber_half_height_mm) * 1e-3;
+    let shell = cfg.launch_shell_fraction * min_dim;
+    let t_max = cfg.time_budget_crossings * 2.0 * shell / v_ref;
+    let n_steps = (t_max / dth).ceil() as usize;
+
+    let mut value = 0.0_f64;
+    let mut lam_phi = vec![0.0_f64; sol.nr * sol.nz];
+    let mut d_turns = vec![0.0_f64; device.rings.len()];
+
+    let n = cfg.n_particles.max(2);
+    for k in 0..n {
+        let c = -cfg.launch_cos_max + 2.0 * cfg.launch_cos_max * k as f64 / (n - 1) as f64;
+        let s = (1.0 - c * c).max(0.0).sqrt();
+        let start = Step {
+            p: [shell * s, 0.0, shell * c],
+            v: [0.0, 0.0, 0.0],
+        };
+
+        // Forward with storage.
+        let mut traj = Vec::with_capacity(n_steps);
+        let mut st = start;
+        for _ in 0..n_steps {
+            traj.push(st);
+            st = boris_step(&sol, &coils, qm, dth, st);
+            let vv = dot(st.v, st.v);
+            value += yield_rate(species, vv) * dth;
+        }
+
+        // Reverse.
+        let mut lp = [0.0_f64; 3];
+        let mut lv = [0.0_f64; 3];
+        for st in traj.iter().rev() {
+            let after = boris_step(&sol, &coils, qm, dth, *st);
+            // Running cost g(v⁺) = σ(E(v⁺))·|v⁺| accrued this step.
+            let gv = yield_rate_grad(species, after.v);
+            lv[0] += dth * gv[0];
+            lv[1] += dth * gv[1];
+            lv[2] += dth * gv[2];
+            let (nlp, nlv) = reverse_step(
+                &sol,
+                &coils,
+                qm,
+                dth,
+                *st,
+                lp,
+                lv,
+                &mut lam_phi,
+                &mut d_turns,
+            );
+            lp = nlp;
+            lv = nlv;
+        }
+    }
+    let inv_n = 1.0 / n as f64;
+    value *= inv_n;
+    for l in lam_phi.iter_mut() {
+        *l *= inv_n;
+    }
+    for d in d_turns.iter_mut() {
+        *d *= inv_n;
+    }
+
+    // Split deposits into free-node sources and direct fixed-node terms,
+    // run the adjoint Poisson solve, and assemble potential gradients.
+    let membership = electrode_membership(device, &sol);
+    let psi = adjoint_poisson(&sol, &lam_phi, sopts);
+
+    let mut d_ring = vec![0.0_f64; device.rings.len()];
+    let mut d_wall = 0.0_f64;
+    let idx = |i: usize, j: usize| i * sol.nz + j;
+    for i in 0..sol.nr {
+        for j in 0..sol.nz {
+            let id = idx(i, j);
+            if !sol.fixed[id] {
+                continue;
+            }
+            // Direct term: yield sampled this fixed node's potential.
+            let mut total = lam_phi[id];
+            // Indirect term: this fixed node sources adjacent free rows.
+            for (ni, nj) in neighbors(i, j, sol.nr, sol.nz) {
+                let nid = idx(ni, nj);
+                if sol.fixed[nid] {
+                    continue;
+                }
+                total += psi[nid] * stencil_coeff(&sol, ni, nj, i, j);
+            }
+            match membership[id] {
+                Some(ring) => d_ring[ring] += total,
+                None => d_wall += total,
+            }
+        }
+    }
+
+    Ok(YieldGradient {
+        value,
+        d_ring_potentials: d_ring,
+        d_wall_potential: d_wall,
+        d_ampere_turns: d_turns,
+    })
+}
+
+#[inline]
+fn yield_rate(species: Species, v2: f64) -> f64 {
+    let e_lab_kev = 0.5 * species.mass_kg * v2 / (crate::constants::ELEMENTARY_CHARGE * 1.0e3);
+    let sig = dd_n_sigma_m2(0.5 * e_lab_kev);
+    if sig > 0.0 {
+        sig * v2.sqrt()
+    } else {
+        0.0
+    }
+}
+
+/// ∂(σ(E(v))·|v|)/∂v by central differences on the closed form (cheap and
+/// robust across the σ validity floor).
+fn yield_rate_grad(species: Species, v: [f64; 3]) -> [f64; 3] {
+    let mut g = [0.0; 3];
+    let speed = dot(v, v).sqrt().max(1.0);
+    let hstep = 1e-6 * speed;
+    for i in 0..3 {
+        let mut vp = v;
+        vp[i] += hstep;
+        let mut vm = v;
+        vm[i] -= hstep;
+        g[i] =
+            (yield_rate(species, dot(vp, vp)) - yield_rate(species, dot(vm, vm))) / (2.0 * hstep);
+    }
+    g
+}
+
+fn e_cart(sol: &Solution, p: [f64; 3]) -> [f64; 3] {
+    let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+    let (er, ez) = sol.e_at(r, p[2]);
+    if r < 1e-12 {
+        return [0.0, 0.0, ez];
+    }
+    [er * p[0] / r, er * p[1] / r, ez]
+}
+
+fn b_cart_analytic(coils: &[RingCoil], p: [f64; 3]) -> [f64; 3] {
+    if coils.is_empty() {
+        return [0.0, 0.0, 0.0];
+    }
+    let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+    let mut br = 0.0;
+    let mut bz = 0.0;
+    for c in coils {
+        let (cr, cz) = b_ring(c, r, p[2]);
+        br += cr;
+        bz += cz;
+    }
+    if r < 1e-12 {
+        return [0.0, 0.0, bz];
+    }
+    [br * p[0] / r, br * p[1] / r, bz]
+}
+
+fn boris_step(sol: &Solution, coils: &[RingCoil], qm: f64, dth: f64, st: Step) -> Step {
+    let e = e_cart(sol, st.p);
+    let b = b_cart_analytic(coils, st.p);
+    let half = 0.5 * qm * dth;
+    let vm = add(st.v, scale(e, half));
+    let t = scale(b, half);
+    let t2 = dot(t, t);
+    let vprime = add(vm, cross(vm, t));
+    let s = 2.0 / (1.0 + t2);
+    let vp = add(vm, scale(cross(vprime, t), s));
+    let v_new = add(vp, scale(e, half));
+    Step {
+        p: add(st.p, scale(v_new, dth)),
+        v: v_new,
+    }
+}
+
+/// Reverse one Boris step: pull (λp⁺, λv⁺) at the output back to the
+/// input, accumulating field adjoints into `lam_phi` (potential-node
+/// deposits) and `d_turns` (per-coil ampere-turn gradients).
+#[allow(clippy::too_many_arguments)]
+fn reverse_step(
+    sol: &Solution,
+    coils: &[RingCoil],
+    qm: f64,
+    dth: f64,
+    st: Step,
+    lp_out: [f64; 3],
+    lv_out: [f64; 3],
+    lam_phi: &mut [f64],
+    d_turns: &mut [f64],
+) -> ([f64; 3], [f64; 3]) {
+    // Recompute forward intermediates.
+    let e = e_cart(sol, st.p);
+    let b = b_cart_analytic(coils, st.p);
+    let half = 0.5 * qm * dth;
+    let vm = add(st.v, scale(e, half));
+    let t = scale(b, half);
+    let t2 = dot(t, t);
+    let vprime = add(vm, cross(vm, t));
+    let s = 2.0 / (1.0 + t2);
+
+    // p⁺ = p + v⁺·dth.
+    let mut lam_vnew = lv_out;
+    lam_vnew = add(lam_vnew, scale(lp_out, dth));
+    let lam_p_partial = lp_out;
+
+    // v⁺ = vp + half·e.
+    let lam_vp = lam_vnew;
+    let mut lam_e = scale(lam_vnew, half);
+
+    // vp = vm + s·(v'×t).
+    let mut lam_vm = lam_vp;
+    let mut lam_vprime = scale(cross(t, lam_vp), s);
+    let mut lam_t = scale(cross(lam_vp, vprime), s);
+    let lam_s = dot(lam_vp, cross(vprime, t));
+    // ds = −s²·(t·dt).
+    lam_t = add(lam_t, scale(t, -lam_s * s * s));
+
+    // v' = vm + vm×t.
+    lam_vm = add(lam_vm, lam_vprime);
+    lam_vm = add(lam_vm, cross(t, lam_vprime));
+    lam_t = add(lam_t, cross(lam_vprime, vm));
+    lam_vprime = [0.0; 3];
+    let _ = lam_vprime;
+
+    // vm = v + half·e.
+    let lam_v_in = lam_vm;
+    lam_e = add(lam_e, scale(lam_vm, half));
+
+    // t = half·b.
+    let lam_b = scale(lam_t, half);
+
+    // Field position Jacobians by central differences at p.
+    let mut lam_p = lam_p_partial;
+    let hp = 1e-7 * (sol.dr.min(sol.dz)).max(1e-9) * 100.0;
+    for i in 0..3 {
+        let mut pp = st.p;
+        pp[i] += hp;
+        let mut pm = st.p;
+        pm[i] -= hp;
+        let de = scale(sub(e_cart(sol, pp), e_cart(sol, pm)), 1.0 / (2.0 * hp));
+        lam_p[i] += dot(lam_e, de);
+        if !coils.is_empty() {
+            let db = scale(
+                sub(b_cart_analytic(coils, pp), b_cart_analytic(coils, pm)),
+                1.0 / (2.0 * hp),
+            );
+            lam_p[i] += dot(lam_b, db);
+        }
+    }
+
+    // Deposit λ_E into potential nodes (exact linear weights of e_at + the
+    // Cartesian rotation), matching the forward sampling exactly.
+    deposit_e_adjoint(sol, st.p, lam_e, lam_phi);
+
+    // Ampere-turn gradients: B is linear in each coil's current.
+    for (k, c) in coils.iter().enumerate() {
+        let unit = RingCoil {
+            ampere_turns: 1.0,
+            ..*c
+        };
+        let bu = b_cart_analytic(std::slice::from_ref(&unit), st.p);
+        d_turns[k] += dot(lam_b, bu);
+    }
+
+    (lam_p, lam_v_in)
+}
+
+/// Deposit the Cartesian E-field adjoint into the four potential nodes of
+/// the bilinear patch at `p` (the transpose of `Solution::e_at` composed
+/// with the axisymmetric rotation).
+fn deposit_e_adjoint(sol: &Solution, p: [f64; 3], lam_e: [f64; 3], lam_phi: &mut [f64]) {
+    let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+    let (lam_er, lam_ez) = if r < 1e-12 {
+        (0.0, lam_e[2])
+    } else {
+        (lam_e[0] * p[0] / r + lam_e[1] * p[1] / r, lam_e[2])
+    };
+    let eps = 1e-9;
+    let u = (r / sol.dr).clamp(0.0, (sol.nr - 1) as f64 - eps);
+    let w = ((p[2] + sol.z_half) / sol.dz).clamp(0.0, (sol.nz - 1) as f64 - eps);
+    let i0 = u.floor() as usize;
+    let j0 = w.floor() as usize;
+    let fu = u - i0 as f64;
+    let fw = w - j0 as f64;
+    let idx = |i: usize, j: usize| i * sol.nz + j;
+    // Er = −((p10−p00)(1−fw) + (p11−p01)·fw)/dr
+    lam_phi[idx(i0, j0)] += lam_er * (1.0 - fw) / sol.dr;
+    lam_phi[idx(i0 + 1, j0)] += -lam_er * (1.0 - fw) / sol.dr;
+    lam_phi[idx(i0, j0 + 1)] += lam_er * fw / sol.dr;
+    lam_phi[idx(i0 + 1, j0 + 1)] += -lam_er * fw / sol.dr;
+    // Ez = −((p01−p00)(1−fu) + (p11−p10)·fu)/dz
+    lam_phi[idx(i0, j0)] += lam_ez * (1.0 - fu) / sol.dz;
+    lam_phi[idx(i0, j0 + 1)] += -lam_ez * (1.0 - fu) / sol.dz;
+    lam_phi[idx(i0 + 1, j0)] += lam_ez * fu / sol.dz;
+    lam_phi[idx(i0 + 1, j0 + 1)] += -lam_ez * fu / sol.dz;
+}
+
+/// Radial weight under which the discrete axisymmetric operator is
+/// symmetric: `w_i = r_i` off-axis, `Δr/8` on the axis (from the
+/// 4(φ₁−φ₀)/Δr² axis stencil).
+#[inline]
+fn radial_weight(sol: &Solution, i: usize) -> f64 {
+    if i == 0 {
+        sol.dr / 8.0
+    } else {
+        i as f64 * sol.dr
+    }
+}
+
+/// Coefficient of neighbor `(bi, bj)` in the discrete equation of free
+/// node `(i, j)` (the numerator weights of the SOR update).
+fn stencil_coeff(sol: &Solution, i: usize, j: usize, bi: usize, bj: usize) -> f64 {
+    let dr2 = sol.dr * sol.dr;
+    let dz2 = sol.dz * sol.dz;
+    if bi == i {
+        if bj + 1 == j || bj == j + 1 {
+            return 1.0 / dz2;
+        }
+        return 0.0;
+    }
+    if bj == j {
+        if i == 0 && bi == 1 {
+            return 4.0 / dr2;
+        }
+        let r = i as f64 * sol.dr;
+        if bi == i + 1 {
+            return (r + 0.5 * sol.dr) / (r * dr2);
+        }
+        if bi + 1 == i {
+            return (r - 0.5 * sol.dr) / (r * dr2);
+        }
+    }
+    0.0
+}
+
+fn diagonal_coeff(sol: &Solution, i: usize, _j: usize) -> f64 {
+    let dr2 = sol.dr * sol.dr;
+    let dz2 = sol.dz * sol.dz;
+    if i == 0 {
+        4.0 / dr2 + 2.0 / dz2
+    } else {
+        let r = i as f64 * sol.dr;
+        ((r + 0.5 * sol.dr) + (r - 0.5 * sol.dr)) / (r * dr2) + 2.0 / dz2
+    }
+}
+
+fn neighbors(i: usize, j: usize, nr: usize, nz: usize) -> Vec<(usize, usize)> {
+    let mut out = Vec::with_capacity(4);
+    if i + 1 < nr {
+        out.push((i + 1, j));
+    }
+    if i > 0 {
+        out.push((i - 1, j));
+    }
+    if j + 1 < nz {
+        out.push((i, j + 1));
+    }
+    if j > 0 {
+        out.push((i, j - 1));
+    }
+    out
+}
+
+/// Solve the adjoint Poisson system `Lᵀψ = g` restricted to free nodes
+/// (ψ = 0 on Dirichlet nodes), using the radial-weight symmetrization:
+/// solve `L χ = g/w` with the forward stencil, then `ψ = w·χ`.
+fn adjoint_poisson(sol: &Solution, g: &[f64], sopts: &SolveOptions) -> Vec<f64> {
+    let (nr, nz) = (sol.nr, sol.nz);
+    let idx = |i: usize, j: usize| i * nz + j;
+    let mut chi = vec![0.0_f64; nr * nz];
+    let omega = if sopts.omega > 0.0 {
+        sopts.omega
+    } else {
+        let n = nr.max(nz) as f64;
+        2.0 / (1.0 + (std::f64::consts::PI / n).sin())
+    };
+
+    let mut scale_est = 1e-300_f64;
+    for sweeps in 0..sopts.max_sweeps {
+        let mut resid = 0.0_f64;
+        for i in 0..nr - 1 {
+            for j in 1..nz - 1 {
+                let id = idx(i, j);
+                if sol.fixed[id] {
+                    continue;
+                }
+                let mut num = g[id] / radial_weight(sol, i);
+                for (ni, nj) in neighbors(i, j, nr, nz) {
+                    let nid = idx(ni, nj);
+                    if sol.fixed[nid] {
+                        continue;
+                    }
+                    num += stencil_coeff(sol, i, j, ni, nj) * chi[nid];
+                }
+                let updated = num / diagonal_coeff(sol, i, j);
+                let delta = updated - chi[id];
+                chi[id] += omega * delta;
+                let ad = delta.abs();
+                if ad > resid {
+                    resid = ad;
+                }
+                let ac = chi[id].abs();
+                if ac > scale_est {
+                    scale_est = ac;
+                }
+            }
+        }
+        if sweeps > 20 && resid < sopts.tol * scale_est {
+            break;
+        }
+    }
+
+    let mut psi = vec![0.0_f64; nr * nz];
+    for i in 0..nr {
+        for j in 0..nz {
+            psi[idx(i, j)] = radial_weight(sol, i) * chi[idx(i, j)];
+        }
+    }
+    psi
+}
+
+/// Which electrode each fixed node belongs to (`Some(ring index)` or
+/// `None` for the chamber wall), replicating the forward mask writer's
+/// last-ring-wins order.
+fn electrode_membership(device: &Device, sol: &Solution) -> Vec<Option<usize>> {
+    let (nr, nz) = (sol.nr, sol.nz);
+    let idx = |i: usize, j: usize| i * nz + j;
+    let mut member = vec![None; nr * nz];
+    for (k, ring) in device.rings.iter().enumerate() {
+        let r0 = ring.ring_radius_mm * 1e-3;
+        let z0 = ring.z_mm * 1e-3;
+        let a = (ring.wire_radius_mm * 1e-3).max(0.75 * sol.dr.max(sol.dz));
+        for i in 0..nr {
+            for j in 0..nz {
+                let r = i as f64 * sol.dr;
+                let z = -sol.z_half + j as f64 * sol.dz;
+                if (r - r0).powi(2) + (z - z0).powi(2) <= a * a {
+                    member[idx(i, j)] = Some(k);
+                }
+            }
+        }
+    }
+    member
+}
+
+#[inline]
+fn add(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+#[inline]
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+
+#[inline]
+fn scale(a: [f64; 3], s: f64) -> [f64; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+#[inline]
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+
+    fn test_device(cathode_v: f64, amp_turns: f64) -> Device {
+        // Fat wire + the short horizon below keep the validation objective
+        // smooth: gradients are checked before the cusp lens amplifies
+        // trajectory sensitivity into FD-visible roughness.
+        Device::shielded_two_ring(100.0, 40.0, 20.0, 6.0, cathode_v, amp_turns)
+    }
+
+    fn run(cathode_v: f64, amp_turns: f64) -> YieldGradient {
+        let device = test_device(cathode_v, amp_turns);
+        yield_gradient(
+            &device,
+            61,
+            121,
+            // Tight tolerance: the FD probes must not see SOR stopping
+            // noise (the default 1e-6·|V| leaves ~0.02 V jitter in φ).
+            &SolveOptions {
+                tol: 1e-10,
+                ..SolveOptions::default()
+            },
+            &AdjointConfig {
+                n_particles: 6,
+                time_budget_crossings: 0.8,
+                // Freeze the discretization across FD perturbations.
+                reference_drop_v: Some(20_000.0),
+                ..AdjointConfig::default()
+            },
+        )
+        .expect("gradient run")
+    }
+
+    #[test]
+    fn adjoint_matches_finite_differences() {
+        let v0 = -20_000.0;
+        let i0 = 15_000.0;
+        let g = run(v0, i0);
+        assert!(g.value > 0.0, "no yield in validation config");
+
+        // FD steps chosen from an h-convergence study: J(V) carries real
+        // curvature (FD at h=50 reads 4x low before converging by h=3),
+        // which is the chaotic-lens sensitivity the adjoint resolves
+        // exactly. dJ/dI is h-stable from h≈75 down.
+
+        // Ampere-turn gradient (bypasses the Poisson path; the builder
+        // applies +I to ring 0 and −I to ring 1, so dJ/dI = dJ/dI₀ − dJ/dI₁).
+        let hi = 20.0;
+        let fd_i = (run(v0, i0 + hi).value - run(v0, i0 - hi).value) / (2.0 * hi);
+        let adj_i = g.d_ampere_turns[0] - g.d_ampere_turns[1];
+        let rel_i = (adj_i - fd_i).abs() / fd_i.abs().max(g.value * 1e-9);
+        assert!(
+            rel_i < 0.02,
+            "ampere-turn gradient mismatch: adjoint {adj_i:.6e}, fd {fd_i:.6e} (rel {rel_i:.3})"
+        );
+
+        // Potential gradient: both rings share the bias, so dJ/dV_bias is
+        // the sum over rings. Gauge check: shifting every conductor
+        // together must do nothing, so wall + rings ≈ 0.
+        let hv = 3.0;
+        let fd_v = (run(v0 + hv, i0).value - run(v0 - hv, i0).value) / (2.0 * hv);
+        let adj_v: f64 = g.d_ring_potentials.iter().sum();
+        let rel_v = (adj_v - fd_v).abs() / fd_v.abs().max(1e-300);
+        assert!(
+            rel_v < 0.03,
+            "potential gradient mismatch: adjoint {adj_v:.6e}, fd {fd_v:.6e} (rel {rel_v:.3})"
+        );
+        let gauge = (adj_v + g.d_wall_potential).abs() / adj_v.abs().max(1e-300);
+        assert!(
+            gauge < 0.02,
+            "gauge invariance violated: rings {adj_v:.3e} vs wall {:.3e}",
+            g.d_wall_potential
+        );
+    }
+
+    #[test]
+    fn deeper_bias_means_more_yield_and_the_gradient_says_so() {
+        let g = run(-20_000.0, 0.0);
+        // Cathode potentials are negative; making them MORE negative
+        // (deeper well) increases yield, so dJ/dV must be negative.
+        let dv: f64 = g.d_ring_potentials.iter().sum();
+        assert!(
+            dv < 0.0,
+            "yield should grow with a deeper well: dJ/dV = {dv:.3e}"
+        );
+    }
+}

--- a/crates/vcad-kernel-particle/src/device.rs
+++ b/crates/vcad-kernel-particle/src/device.rs
@@ -1,0 +1,144 @@
+//! Axisymmetric device description: a grounded cylindrical chamber
+//! containing biased (and optionally current-carrying) wire rings.
+//!
+//! Geometry is in **millimeters** (vcad convention); potentials in volts;
+//! ring currents in ampere-turns. Everything is a body of revolution about
+//! the z axis, which covers fusors, shielded-grid IEC devices, ring traps,
+//! and einzel-lens-like stacks built from rings.
+
+/// One circular wire ring electrode, coaxial with z.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WireRing {
+    /// Ring radius (distance from the z axis to the wire centerline), mm.
+    pub ring_radius_mm: f64,
+    /// Axial position of the ring plane, mm.
+    pub z_mm: f64,
+    /// Wire (minor) radius, mm.
+    pub wire_radius_mm: f64,
+    /// Electrode potential, volts.
+    pub potential_v: f64,
+    /// Circulating current, ampere-turns. Positive = counter-clockwise
+    /// viewed from +z (right-hand rule: B along +z at the ring center).
+    /// Zero for a plain electrostatic ring.
+    pub ampere_turns: f64,
+}
+
+/// A complete axisymmetric device: grounded chamber + wire rings.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Device {
+    /// Chamber (anode) inner radius, mm.
+    pub chamber_radius_mm: f64,
+    /// Chamber half-height: the chamber spans z ∈ [−h, +h], mm.
+    pub chamber_half_height_mm: f64,
+    /// Chamber wall potential, volts (normally 0 — grounded anode).
+    pub wall_potential_v: f64,
+    /// Wire ring electrodes.
+    pub rings: Vec<WireRing>,
+}
+
+impl Device {
+    /// A classic gridded fusor: a spherical cathode "globe" approximated by
+    /// wire rings at evenly spaced polar angles, inside a grounded chamber.
+    ///
+    /// `n_rings` rings are placed at polar angles strictly between the
+    /// poles, on a sphere of radius `cathode_radius_mm`, each with
+    /// `wire_radius_mm` wire at `cathode_v` volts and zero current.
+    pub fn classic_fusor(
+        chamber_radius_mm: f64,
+        cathode_radius_mm: f64,
+        n_rings: usize,
+        wire_radius_mm: f64,
+        cathode_v: f64,
+    ) -> Self {
+        let mut rings = Vec::with_capacity(n_rings);
+        for k in 0..n_rings {
+            let theta = std::f64::consts::PI * (k as f64 + 1.0) / (n_rings as f64 + 1.0);
+            rings.push(WireRing {
+                ring_radius_mm: cathode_radius_mm * theta.sin(),
+                z_mm: cathode_radius_mm * theta.cos(),
+                wire_radius_mm,
+                potential_v: cathode_v,
+                ampere_turns: 0.0,
+            });
+        }
+        Self {
+            chamber_radius_mm,
+            chamber_half_height_mm: chamber_radius_mm,
+            wall_potential_v: 0.0,
+            rings,
+        }
+    }
+
+    /// The two-ring magnetically shielded cathode (spindle-cusp
+    /// configuration): two coaxial rings at ±`z_mm` carrying opposed
+    /// currents, both biased to `cathode_v`.
+    ///
+    /// With `ampere_turns = 0` this degenerates to a plain two-ring fusor
+    /// cathode, which is the control case for shielding experiments.
+    pub fn shielded_two_ring(
+        chamber_radius_mm: f64,
+        ring_radius_mm: f64,
+        z_mm: f64,
+        wire_radius_mm: f64,
+        cathode_v: f64,
+        ampere_turns: f64,
+    ) -> Self {
+        let ring = |z: f64, at: f64| WireRing {
+            ring_radius_mm,
+            z_mm: z,
+            wire_radius_mm,
+            potential_v: cathode_v,
+            ampere_turns: at,
+        };
+        Self {
+            chamber_radius_mm,
+            chamber_half_height_mm: chamber_radius_mm,
+            wall_potential_v: 0.0,
+            rings: vec![ring(z_mm, ampere_turns), ring(-z_mm, -ampere_turns)],
+        }
+    }
+
+    /// Deepest electrode-to-wall potential difference, volts (absolute).
+    /// Sets the velocity scale for tracing.
+    pub fn max_potential_drop_v(&self) -> f64 {
+        self.rings
+            .iter()
+            .map(|r| (r.potential_v - self.wall_potential_v).abs())
+            .fold(0.0, f64::max)
+    }
+
+    /// Smallest spherical radius √(r² + z²) of any ring centerline, mm.
+    /// Used to size the "core" region for pass counting.
+    pub fn min_ring_spherical_radius_mm(&self) -> f64 {
+        self.rings
+            .iter()
+            .map(|r| (r.ring_radius_mm.powi(2) + r.z_mm.powi(2)).sqrt())
+            .fold(f64::INFINITY, f64::min)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classic_fusor_rings_sit_on_the_cathode_sphere() {
+        let d = Device::classic_fusor(150.0, 50.0, 5, 1.0, -30_000.0);
+        assert_eq!(d.rings.len(), 5);
+        for ring in &d.rings {
+            let s = (ring.ring_radius_mm.powi(2) + ring.z_mm.powi(2)).sqrt();
+            assert!((s - 50.0).abs() < 1e-9, "ring off sphere: {s}");
+            assert!(ring.ring_radius_mm > 0.0);
+        }
+        assert!((d.max_potential_drop_v() - 30_000.0).abs() < 1e-9);
+        assert!((d.min_ring_spherical_radius_mm() - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn shielded_two_ring_currents_oppose() {
+        let d = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, -2_000.0, 5_000.0);
+        assert_eq!(d.rings.len(), 2);
+        assert!((d.rings[0].ampere_turns + d.rings[1].ampere_turns).abs() < 1e-12);
+        assert!((d.rings[0].z_mm + d.rings[1].z_mm).abs() < 1e-12);
+    }
+}

--- a/crates/vcad-kernel-particle/src/elliptic.rs
+++ b/crates/vcad-kernel-particle/src/elliptic.rs
@@ -1,0 +1,60 @@
+//! Complete elliptic integrals K(m) and E(m) via the arithmetic–geometric
+//! mean, in the parameter convention `m = k²`:
+//!
+//! K(m) = ∫₀^{π/2} dθ / √(1 − m sin²θ),  E(m) = ∫₀^{π/2} √(1 − m sin²θ) dθ.
+//!
+//! Needed for the exact off-axis magnetic field of a circular current loop.
+
+/// Complete elliptic integrals `(K(m), E(m))` for `m ∈ [0, 1)`.
+///
+/// Accuracy is limited only by the AGM iteration (converges quadratically;
+/// ~5 iterations to machine precision). `m` is clamped just below 1 to keep
+/// K finite for callers that graze the singular point.
+pub fn ellip_ke(m: f64) -> (f64, f64) {
+    let m = m.clamp(0.0, 1.0 - 1e-15);
+    let mut a = 1.0_f64;
+    let mut b = (1.0 - m).sqrt();
+    let mut c = m.sqrt();
+    let mut sum = 0.5 * c * c; // 2^{-1} c₀²
+    let mut pow = 0.5;
+    for _ in 0..60 {
+        if c.abs() < 1e-17 {
+            break;
+        }
+        let an = 0.5 * (a + b);
+        let bn = (a * b).sqrt();
+        c = 0.5 * (a - b);
+        a = an;
+        b = bn;
+        pow *= 2.0;
+        sum += pow * c * c;
+    }
+    let k = std::f64::consts::FRAC_PI_2 / a;
+    let e = k * (1.0 - sum);
+    (k, e)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_known_values() {
+        let (k0, e0) = ellip_ke(0.0);
+        assert!((k0 - std::f64::consts::FRAC_PI_2).abs() < 1e-14);
+        assert!((e0 - std::f64::consts::FRAC_PI_2).abs() < 1e-14);
+
+        // Abramowitz & Stegun: K(m=0.5) = 1.854074677..., E(m=0.5) = 1.350643881...
+        let (k, e) = ellip_ke(0.5);
+        assert!((k - 1.854_074_677_301_372).abs() < 1e-12, "K(0.5) = {k}");
+        assert!((e - 1.350_643_881_047_675).abs() < 1e-12, "E(0.5) = {e}");
+    }
+
+    #[test]
+    fn near_singular_is_finite_and_ordered() {
+        let (k, e) = ellip_ke(0.999_999);
+        assert!(k.is_finite() && e.is_finite());
+        assert!(k > e, "K must exceed E for m > 0");
+        assert!(e >= 1.0, "E(m→1) → 1");
+    }
+}

--- a/crates/vcad-kernel-particle/src/field.rs
+++ b/crates/vcad-kernel-particle/src/field.rs
@@ -1,0 +1,208 @@
+//! Combined field sampling: interpolated E from the Poisson grid, analytic
+//! B from every current-carrying ring (exact off-axis loop field via
+//! complete elliptic integrals).
+
+use crate::constants::MU_0;
+use crate::device::Device;
+use crate::elliptic::ellip_ke;
+use crate::poisson::Solution;
+
+/// A circular current loop, SI units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RingCoil {
+    /// Loop radius, m.
+    pub radius_m: f64,
+    /// Axial position, m.
+    pub z_m: f64,
+    /// Circulating current, ampere-turns.
+    pub ampere_turns: f64,
+    /// Conductor (minor) radius, m — used to regularize the field inside
+    /// the conductor, where the vacuum formula diverges.
+    pub wire_radius_m: f64,
+}
+
+/// Magnetic field `(B_r, B_z)` of a single loop at `(r, z)`, tesla.
+///
+/// Uses the standard elliptic-integral solution. Inside the conductor
+/// (distance to the wire centerline < wire radius) the field is evaluated
+/// at the conductor surface and scaled linearly toward zero at the
+/// centerline — the field of a uniform current density, which keeps the
+/// integrator finite for trajectories that terminate on the wire.
+pub fn b_ring(coil: &RingCoil, r_m: f64, z_m: f64) -> (f64, f64) {
+    let big_r = coil.radius_m;
+    let zz = z_m - coil.z_m;
+    let rho = r_m.abs();
+
+    // Regularize inside the conductor.
+    let dw = ((rho - big_r).powi(2) + zz * zz).sqrt();
+    if dw < coil.wire_radius_m {
+        if dw < 1e-15 {
+            return (0.0, 0.0);
+        }
+        let scale = dw / coil.wire_radius_m;
+        let rr = big_r + (rho - big_r) * (coil.wire_radius_m / dw);
+        let zzs = coil.z_m + zz * (coil.wire_radius_m / dw);
+        let (br, bz) = b_ring(
+            &RingCoil {
+                wire_radius_m: 0.0,
+                ..*coil
+            },
+            rr,
+            zzs,
+        );
+        return (br * scale, bz * scale);
+    }
+
+    // On-axis limit (also covers rho → 0 numerically).
+    if rho < 1e-9 * big_r.max(1.0) {
+        let bz =
+            MU_0 * coil.ampere_turns * big_r * big_r / (2.0 * (big_r * big_r + zz * zz).powf(1.5));
+        return (0.0, bz);
+    }
+
+    let sum2 = (big_r + rho).powi(2) + zz * zz;
+    let d2 = (big_r - rho).powi(2) + zz * zz;
+    let m = 4.0 * big_r * rho / sum2;
+    let (k, e) = ellip_ke(m);
+    let pref = MU_0 * coil.ampere_turns / (2.0 * std::f64::consts::PI);
+    let denom = sum2.sqrt();
+    let br = pref * zz / (rho * denom) * (-k + e * (big_r * big_r + rho * rho + zz * zz) / d2);
+    let bz = pref / denom * (k + e * (big_r * big_r - rho * rho - zz * zz) / d2);
+    (br, bz)
+}
+
+/// Field sampler for a solved device: E from the grid, B from the coils.
+#[derive(Debug, Clone)]
+pub struct FieldMap<'a> {
+    solution: &'a Solution,
+    coils: Vec<RingCoil>,
+}
+
+impl<'a> FieldMap<'a> {
+    /// Build the sampler from a device and its Poisson solution. Rings with
+    /// zero ampere-turns contribute no coil.
+    pub fn new(device: &Device, solution: &'a Solution) -> Self {
+        let coils = device
+            .rings
+            .iter()
+            .filter(|r| r.ampere_turns != 0.0)
+            .map(|r| RingCoil {
+                radius_m: r.ring_radius_mm * 1e-3,
+                z_m: r.z_mm * 1e-3,
+                ampere_turns: r.ampere_turns,
+                wire_radius_m: (r.wire_radius_mm * 1e-3).max(1e-6),
+            })
+            .collect();
+        Self { solution, coils }
+    }
+
+    /// Whether any coil carries current (skips B math when false).
+    pub fn has_magnetics(&self) -> bool {
+        !self.coils.is_empty()
+    }
+
+    /// Electrostatic potential at a Cartesian point, volts.
+    pub fn potential(&self, p: [f64; 3]) -> f64 {
+        let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+        self.solution.potential_at(r, p[2])
+    }
+
+    /// Electric field at a Cartesian point, V/m.
+    pub fn e_cart(&self, p: [f64; 3]) -> [f64; 3] {
+        let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+        let (er, ez) = self.solution.e_at(r, p[2]);
+        if r < 1e-12 {
+            // E_r → 0 on the axis by symmetry.
+            return [0.0, 0.0, ez];
+        }
+        [er * p[0] / r, er * p[1] / r, ez]
+    }
+
+    /// Magnetic field at a Cartesian point, tesla.
+    pub fn b_cart(&self, p: [f64; 3]) -> [f64; 3] {
+        if self.coils.is_empty() {
+            return [0.0, 0.0, 0.0];
+        }
+        let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
+        let mut br = 0.0;
+        let mut bz = 0.0;
+        for c in &self.coils {
+            let (cr, cz) = b_ring(c, r, p[2]);
+            br += cr;
+            bz += cz;
+        }
+        if r < 1e-12 {
+            return [0.0, 0.0, bz];
+        }
+        [br * p[0] / r, br * p[1] / r, bz]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn loop_1ka() -> RingCoil {
+        RingCoil {
+            radius_m: 0.05,
+            z_m: 0.0,
+            ampere_turns: 1_000.0,
+            wire_radius_m: 0.002,
+        }
+    }
+
+    #[test]
+    fn on_axis_matches_the_textbook_formula() {
+        let c = loop_1ka();
+        for z in [0.0, 0.01, 0.05, 0.12] {
+            let (br, bz) = b_ring(&c, 0.0, z);
+            let expect = MU_0 * c.ampere_turns * c.radius_m * c.radius_m
+                / (2.0 * (c.radius_m * c.radius_m + z * z).powf(1.5));
+            assert!(br.abs() < 1e-15);
+            assert!(
+                (bz - expect).abs() < 1e-9 * expect.abs().max(1e-9),
+                "z={z}: bz={bz}, expect={expect}"
+            );
+        }
+        // Sanity: B(0,0) = μ₀I/2R = 4π×10⁻⁷·1000/(0.1) ≈ 12.57 mT.
+        let (_, b0) = b_ring(&c, 0.0, 0.0);
+        assert!((b0 - 0.012_566).abs() < 1e-4, "b0={b0}");
+    }
+
+    #[test]
+    fn off_axis_is_consistent_with_the_axis_limit() {
+        let c = loop_1ka();
+        let (_, bz_axis) = b_ring(&c, 0.0, 0.03);
+        let (_, bz_near) = b_ring(&c, 1e-6, 0.03);
+        assert!((bz_axis - bz_near).abs() / bz_axis.abs() < 1e-4);
+    }
+
+    #[test]
+    fn midplane_symmetry() {
+        let c = loop_1ka();
+        let (br_up, bz_up) = b_ring(&c, 0.03, 0.02);
+        let (br_dn, bz_dn) = b_ring(&c, 0.03, -0.02);
+        assert!((br_up + br_dn).abs() < 1e-12, "B_r must be odd in z");
+        assert!((bz_up - bz_dn).abs() < 1e-12, "B_z must be even in z");
+    }
+
+    #[test]
+    fn interior_regularization_is_finite_and_continuous() {
+        let c = loop_1ka();
+        // On the midplane the near-wire field is all B_z (B_r is odd in z);
+        // sample just outside, at, and inside the conductor surface.
+        let (_, b_out) = b_ring(&c, c.radius_m + c.wire_radius_m * 1.01, 0.0);
+        let (_, b_at) = b_ring(&c, c.radius_m + c.wire_radius_m * 0.999, 0.0);
+        let (_, b_in) = b_ring(&c, c.radius_m + c.wire_radius_m * 0.5, 0.0);
+        let (_, b_center) = b_ring(&c, c.radius_m, 0.0);
+        for b in [b_out, b_at, b_in, b_center] {
+            assert!(b.is_finite());
+        }
+        assert!(
+            (b_at - b_out).abs() < 0.05 * b_out.abs(),
+            "discontinuous at surface: {b_at} vs {b_out}"
+        );
+        assert!(b_in.abs() < b_at.abs(), "field must fall toward centerline");
+        assert!(b_center.abs() < 1e-12);
+    }
+}

--- a/crates/vcad-kernel-particle/src/field.rs
+++ b/crates/vcad-kernel-particle/src/field.rs
@@ -182,13 +182,8 @@ impl<'a> FieldMap<'a> {
 
         let (br, bz) = if let (Some(g), false) = (&self.bgrid, near_wire) {
             let s = self.solution;
-            let eps = 1e-12;
-            let u = (r / s.dr).clamp(0.0, (s.nr - 1) as f64 - eps);
-            let w = ((z + s.z_half) / s.dz).clamp(0.0, (s.nz - 1) as f64 - eps);
-            let i0 = u.floor() as usize;
-            let j0 = w.floor() as usize;
-            let fu = u - i0 as f64;
-            let fw = w - j0 as f64;
+            let (i0, fu) = crate::poisson::cell_index(r / s.dr, s.nr);
+            let (j0, fw) = crate::poisson::cell_index((z + s.z_half) / s.dz, s.nz);
             let idx = |i: usize, j: usize| i * s.nz + j;
             let samp = |d: &[f64]| {
                 d[idx(i0, j0)] * (1.0 - fu) * (1.0 - fw)

--- a/crates/vcad-kernel-particle/src/field.rs
+++ b/crates/vcad-kernel-particle/src/field.rs
@@ -71,18 +71,37 @@ pub fn b_ring(coil: &RingCoil, r_m: f64, z_m: f64) -> (f64, f64) {
     (br, bz)
 }
 
+/// Multiplier on the wire radius inside which coil B is evaluated
+/// analytically instead of from the cached grid (matches the tracer's
+/// near-wire step refinement zone, where the 1/ρ field must be exact).
+const B_NEAR_WIRE_FACTOR: f64 = 8.0;
+
+#[derive(Debug, Clone)]
+struct BGrid {
+    br: Vec<f64>,
+    bz: Vec<f64>,
+}
+
 /// Field sampler for a solved device: E from the grid, B from the coils.
+///
+/// Coil B is precomputed on the Poisson grid once (analytic elliptic
+/// integrals at every node) and bilinearly sampled during tracing — except
+/// within [`B_NEAR_WIRE_FACTOR`] wire radii of a conductor, where the
+/// exact analytic sum is used so the shielding sheath keeps its 1/ρ
+/// structure. This removes the per-substep elliptic-integral cost that
+/// dominated high-current traces.
 #[derive(Debug, Clone)]
 pub struct FieldMap<'a> {
     solution: &'a Solution,
     coils: Vec<RingCoil>,
+    bgrid: Option<BGrid>,
 }
 
 impl<'a> FieldMap<'a> {
     /// Build the sampler from a device and its Poisson solution. Rings with
     /// zero ampere-turns contribute no coil.
     pub fn new(device: &Device, solution: &'a Solution) -> Self {
-        let coils = device
+        let coils: Vec<RingCoil> = device
             .rings
             .iter()
             .filter(|r| r.ampere_turns != 0.0)
@@ -93,7 +112,34 @@ impl<'a> FieldMap<'a> {
                 wire_radius_m: (r.wire_radius_mm * 1e-3).max(1e-6),
             })
             .collect();
-        Self { solution, coils }
+        let bgrid = if coils.is_empty() {
+            None
+        } else {
+            let (nr, nz) = (solution.nr, solution.nz);
+            let mut br = vec![0.0_f64; nr * nz];
+            let mut bz = vec![0.0_f64; nr * nz];
+            for i in 0..nr {
+                let r = i as f64 * solution.dr;
+                for j in 0..nz {
+                    let z = -solution.z_half + j as f64 * solution.dz;
+                    let mut sr = 0.0;
+                    let mut sz = 0.0;
+                    for c in &coils {
+                        let (cr, cz) = b_ring(c, r, z);
+                        sr += cr;
+                        sz += cz;
+                    }
+                    br[i * nz + j] = sr;
+                    bz[i * nz + j] = sz;
+                }
+            }
+            Some(BGrid { br, bz })
+        };
+        Self {
+            solution,
+            coils,
+            bgrid,
+        }
     }
 
     /// Whether any coil carries current (skips B math when false).
@@ -118,19 +164,50 @@ impl<'a> FieldMap<'a> {
         [er * p[0] / r, er * p[1] / r, ez]
     }
 
-    /// Magnetic field at a Cartesian point, tesla.
+    /// Magnetic field at a Cartesian point, tesla. Grid-cached far from
+    /// conductors, exact analytic within the near-wire zone.
     pub fn b_cart(&self, p: [f64; 3]) -> [f64; 3] {
         if self.coils.is_empty() {
             return [0.0, 0.0, 0.0];
         }
         let r = (p[0] * p[0] + p[1] * p[1]).sqrt();
-        let mut br = 0.0;
-        let mut bz = 0.0;
-        for c in &self.coils {
-            let (cr, cz) = b_ring(c, r, p[2]);
-            br += cr;
-            bz += cz;
-        }
+        let z = p[2];
+
+        let near_wire = self.coils.iter().any(|c| {
+            let dr = r - c.radius_m;
+            let dz = z - c.z_m;
+            let lim = B_NEAR_WIRE_FACTOR * c.wire_radius_m;
+            dr * dr + dz * dz < lim * lim
+        });
+
+        let (br, bz) = if let (Some(g), false) = (&self.bgrid, near_wire) {
+            let s = self.solution;
+            let eps = 1e-12;
+            let u = (r / s.dr).clamp(0.0, (s.nr - 1) as f64 - eps);
+            let w = ((z + s.z_half) / s.dz).clamp(0.0, (s.nz - 1) as f64 - eps);
+            let i0 = u.floor() as usize;
+            let j0 = w.floor() as usize;
+            let fu = u - i0 as f64;
+            let fw = w - j0 as f64;
+            let idx = |i: usize, j: usize| i * s.nz + j;
+            let samp = |d: &[f64]| {
+                d[idx(i0, j0)] * (1.0 - fu) * (1.0 - fw)
+                    + d[idx(i0 + 1, j0)] * fu * (1.0 - fw)
+                    + d[idx(i0, j0 + 1)] * (1.0 - fu) * fw
+                    + d[idx(i0 + 1, j0 + 1)] * fu * fw
+            };
+            (samp(&g.br), samp(&g.bz))
+        } else {
+            let mut sr = 0.0;
+            let mut sz = 0.0;
+            for c in &self.coils {
+                let (cr, cz) = b_ring(c, r, z);
+                sr += cr;
+                sz += cz;
+            }
+            (sr, sz)
+        };
+
         if r < 1e-12 {
             return [0.0, 0.0, bz];
         }
@@ -184,6 +261,41 @@ mod tests {
         let (br_dn, bz_dn) = b_ring(&c, 0.03, -0.02);
         assert!((br_up + br_dn).abs() < 1e-12, "B_r must be odd in z");
         assert!((bz_up - bz_dn).abs() < 1e-12, "B_z must be even in z");
+    }
+
+    #[test]
+    fn cached_grid_matches_analytic_far_from_wires() {
+        use crate::device::Device;
+        use crate::poisson::{solve, SolveOptions};
+        let device = Device::shielded_two_ring(120.0, 40.0, 22.0, 4.0, -500.0, 20_000.0);
+        let sol = solve(&device, 81, 161, &SolveOptions::default()).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let coils: Vec<RingCoil> = device
+            .rings
+            .iter()
+            .map(|r| RingCoil {
+                radius_m: r.ring_radius_mm * 1e-3,
+                z_m: r.z_mm * 1e-3,
+                ampere_turns: r.ampere_turns,
+                wire_radius_m: r.wire_radius_mm * 1e-3,
+            })
+            .collect();
+        // Far-field points (well outside the near-wire analytic zone).
+        for (x, z) in [(0.005, 0.0), (0.02, 0.06), (0.08, -0.04), (0.06, 0.08)] {
+            let got = fields.b_cart([x, 0.0, z]);
+            let mut want_r = 0.0;
+            let mut want_z = 0.0;
+            for c in &coils {
+                let (cr, cz) = b_ring(c, x, z);
+                want_r += cr;
+                want_z += cz;
+            }
+            let scale = (want_r * want_r + want_z * want_z).sqrt().max(1e-9);
+            assert!(
+                ((got[0] - want_r).powi(2) + (got[2] - want_z).powi(2)).sqrt() < 0.05 * scale,
+                "grid B off at ({x},{z}): got {got:?}, want ({want_r},{want_z})"
+            );
+        }
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/fom.rs
+++ b/crates/vcad-kernel-particle/src/fom.rs
@@ -33,6 +33,9 @@ pub struct EnsembleStats {
     /// [`crate::trace::TraceOutcome::ddn_sigma_v_m3`]. Multiply by target
     /// deuteron density for expected neutrons per injected ion.
     pub mean_ddn_sigma_v_m3: f64,
+    /// Mean D(d,p)T reaction volume per ion, m³ (proton branch — with the
+    /// neutron branch this prices total fusion power).
+    pub mean_ddp_sigma_v_m3: f64,
     /// Mean expected neutrons per injected ion, surviving-ion channel
     /// (zero unless traced with a [`crate::trace::CxModel`]).
     pub mean_neutrons_ion_channel: f64,
@@ -73,6 +76,7 @@ pub fn stats(outcomes: &[TraceOutcome]) -> EnsembleStats {
             }
         },
         mean_ddn_sigma_v_m3: outcomes.iter().map(|o| o.ddn_sigma_v_m3).sum::<f64>() / n as f64,
+        mean_ddp_sigma_v_m3: outcomes.iter().map(|o| o.ddp_sigma_v_m3).sum::<f64>() / n as f64,
         mean_neutrons_ion_channel: outcomes.iter().map(|o| o.neutrons_ion_channel).sum::<f64>()
             / n as f64,
         mean_neutrons_cx_channel: outcomes.iter().map(|o| o.neutrons_cx_channel).sum::<f64>()
@@ -138,6 +142,7 @@ mod tests {
             energy_drift_rel: 0.01,
             launch_cos_theta: 0.0,
             ddn_sigma_v_m3: 2.0e-31,
+            ddp_sigma_v_m3: 2.4e-31,
             neutrons_ion_channel: 1.0e-12,
             neutrons_cx_channel: 3.0e-12,
         }
@@ -159,6 +164,7 @@ mod tests {
         assert!((s.survivor_fraction - 0.25).abs() < 1e-12);
         assert!((s.effective_transparency - 5.0 / 6.0).abs() < 1e-12);
         assert!((s.mean_ddn_sigma_v_m3 - 2.0e-31).abs() < 1e-40);
+        assert!((s.mean_ddp_sigma_v_m3 - 2.4e-31).abs() < 1e-40);
         // Uncensored mean excludes the surviving 10-pass trace: (3+5+2)/3.
         assert!((s.mean_passes_uncensored - 10.0 / 3.0).abs() < 1e-12);
         assert!((s.mean_energy_drift_rel - 0.01).abs() < 1e-12);

--- a/crates/vcad-kernel-particle/src/fom.rs
+++ b/crates/vcad-kernel-particle/src/fom.rs
@@ -23,6 +23,10 @@ pub struct EnsembleStats {
     pub effective_transparency: f64,
     /// Worst energy drift across the ensemble (integration quality).
     pub max_energy_drift_rel: f64,
+    /// Mean D(d,n)³He reaction volume per ion, m³ — see
+    /// [`crate::trace::TraceOutcome::ddn_sigma_v_m3`]. Multiply by target
+    /// deuteron density for expected neutrons per injected ion.
+    pub mean_ddn_sigma_v_m3: f64,
 }
 
 /// Reduce trace outcomes to [`EnsembleStats`].
@@ -43,7 +47,26 @@ pub fn stats(outcomes: &[TraceOutcome]) -> EnsembleStats {
             .iter()
             .map(|o| o.energy_drift_rel)
             .fold(0.0, f64::max),
+        mean_ddn_sigma_v_m3: outcomes.iter().map(|o| o.ddn_sigma_v_m3).sum::<f64>() / n as f64,
     }
+}
+
+/// Steady-state D-D neutron rate estimate, neutrons/s.
+///
+/// `(I/e) × n_d × ⟨∫σv dt⟩`: ions injected per second, times expected
+/// neutrons per ion against a background deuteron density `n_d` (see
+/// [`crate::xsection::d2_deuteron_density_m3`]). Beam-on-background only —
+/// beam–beam and fast-neutral (charge-exchange) channels, which matter in
+/// real fusors, are not included, so treat this as a floor with ~order-of-
+/// magnitude confidence.
+pub fn neutron_rate_per_s(
+    mean_ddn_sigma_v_m3: f64,
+    ion_current_a: f64,
+    deuteron_density_m3: f64,
+) -> f64 {
+    (ion_current_a / crate::constants::ELEMENTARY_CHARGE)
+        * deuteron_density_m3
+        * mean_ddn_sigma_v_m3
 }
 
 /// Thin-wire geometric transparency of the ring cathode: the fraction of
@@ -79,6 +102,7 @@ mod tests {
             steps: 1000,
             energy_drift_rel: 0.01,
             launch_cos_theta: 0.0,
+            ddn_sigma_v_m3: 2.0e-31,
         }
     }
 
@@ -97,6 +121,15 @@ mod tests {
         assert!((s.wall_fraction - 0.25).abs() < 1e-12);
         assert!((s.survivor_fraction - 0.25).abs() < 1e-12);
         assert!((s.effective_transparency - 5.0 / 6.0).abs() < 1e-12);
+        assert!((s.mean_ddn_sigma_v_m3 - 2.0e-31).abs() < 1e-40);
+    }
+
+    #[test]
+    fn neutron_rate_arithmetic() {
+        // 10 mA of ions, 1e20 deuterons/m³, 5e-31 m³ per ion:
+        // (0.01/1.6e-19) × 1e20 × 5e-31 ≈ 3.1e6 n/s.
+        let rate = neutron_rate_per_s(5.0e-31, 0.01, 1.0e20);
+        assert!((2.0e6..5.0e6).contains(&rate), "rate = {rate:.3e} n/s");
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/fom.rs
+++ b/crates/vcad-kernel-particle/src/fom.rs
@@ -23,10 +23,22 @@ pub struct EnsembleStats {
     pub effective_transparency: f64,
     /// Worst energy drift across the ensemble (integration quality).
     pub max_energy_drift_rel: f64,
+    /// Mean energy drift across the ensemble — the fairer quality metric
+    /// (the max is dominated by extreme long-lived wire-grazers).
+    pub mean_energy_drift_rel: f64,
+    /// Mean core passes over **terminated** traces only (censored
+    /// survivors excluded). 0 when every trace was censored.
+    pub mean_passes_uncensored: f64,
     /// Mean D(d,n)³He reaction volume per ion, m³ — see
     /// [`crate::trace::TraceOutcome::ddn_sigma_v_m3`]. Multiply by target
     /// deuteron density for expected neutrons per injected ion.
     pub mean_ddn_sigma_v_m3: f64,
+    /// Mean expected neutrons per injected ion, surviving-ion channel
+    /// (zero unless traced with a [`crate::trace::CxModel`]).
+    pub mean_neutrons_ion_channel: f64,
+    /// Mean expected neutrons per injected ion, fast-neutral channel
+    /// (zero unless traced with a [`crate::trace::CxModel`]).
+    pub mean_neutrons_cx_channel: f64,
 }
 
 /// Reduce trace outcomes to [`EnsembleStats`].
@@ -47,8 +59,31 @@ pub fn stats(outcomes: &[TraceOutcome]) -> EnsembleStats {
             .iter()
             .map(|o| o.energy_drift_rel)
             .fold(0.0, f64::max),
+        mean_energy_drift_rel: outcomes.iter().map(|o| o.energy_drift_rel).sum::<f64>() / n as f64,
+        mean_passes_uncensored: {
+            let dead: Vec<f64> = outcomes
+                .iter()
+                .filter(|o| o.fate != Fate::Survived)
+                .map(|o| o.core_passes as f64)
+                .collect();
+            if dead.is_empty() {
+                0.0
+            } else {
+                dead.iter().sum::<f64>() / dead.len() as f64
+            }
+        },
         mean_ddn_sigma_v_m3: outcomes.iter().map(|o| o.ddn_sigma_v_m3).sum::<f64>() / n as f64,
+        mean_neutrons_ion_channel: outcomes.iter().map(|o| o.neutrons_ion_channel).sum::<f64>()
+            / n as f64,
+        mean_neutrons_cx_channel: outcomes.iter().map(|o| o.neutrons_cx_channel).sum::<f64>()
+            / n as f64,
     }
+}
+
+/// Neutron rate from expected-neutrons-per-ion counts (the CX-aware path):
+/// `(I/e) × neutrons_per_ion`, neutrons/s.
+pub fn neutron_rate_from_counts(neutrons_per_ion: f64, ion_current_a: f64) -> f64 {
+    (ion_current_a / crate::constants::ELEMENTARY_CHARGE) * neutrons_per_ion
 }
 
 /// Steady-state D-D neutron rate estimate, neutrons/s.
@@ -103,6 +138,8 @@ mod tests {
             energy_drift_rel: 0.01,
             launch_cos_theta: 0.0,
             ddn_sigma_v_m3: 2.0e-31,
+            neutrons_ion_channel: 1.0e-12,
+            neutrons_cx_channel: 3.0e-12,
         }
     }
 
@@ -122,6 +159,18 @@ mod tests {
         assert!((s.survivor_fraction - 0.25).abs() < 1e-12);
         assert!((s.effective_transparency - 5.0 / 6.0).abs() < 1e-12);
         assert!((s.mean_ddn_sigma_v_m3 - 2.0e-31).abs() < 1e-40);
+        // Uncensored mean excludes the surviving 10-pass trace: (3+5+2)/3.
+        assert!((s.mean_passes_uncensored - 10.0 / 3.0).abs() < 1e-12);
+        assert!((s.mean_energy_drift_rel - 0.01).abs() < 1e-12);
+        assert!((s.mean_neutrons_ion_channel - 1.0e-12).abs() < 1e-20);
+        assert!((s.mean_neutrons_cx_channel - 3.0e-12).abs() < 1e-20);
+    }
+
+    #[test]
+    fn count_based_rate_arithmetic() {
+        // 10 mA × 5e-11 neutrons/ion ≈ 3.1e6 n/s.
+        let rate = neutron_rate_from_counts(5.0e-11, 0.010);
+        assert!((2.0e6..5.0e6).contains(&rate), "rate = {rate:.3e}");
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/fom.rs
+++ b/crates/vcad-kernel-particle/src/fom.rs
@@ -1,10 +1,12 @@
 //! Figures of merit over trace ensembles.
 
+use serde::{Deserialize, Serialize};
+
 use crate::device::Device;
 use crate::trace::{Fate, TraceOutcome};
 
 /// Ensemble statistics for an electrode design.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct EnsembleStats {
     /// Ensemble size.
     pub n: usize,

--- a/crates/vcad-kernel-particle/src/fom.rs
+++ b/crates/vcad-kernel-particle/src/fom.rs
@@ -1,0 +1,116 @@
+//! Figures of merit over trace ensembles.
+
+use crate::device::Device;
+use crate::trace::{Fate, TraceOutcome};
+
+/// Ensemble statistics for an electrode design.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EnsembleStats {
+    /// Ensemble size.
+    pub n: usize,
+    /// Mean core passes per particle.
+    pub mean_passes: f64,
+    /// Fraction ending on a wire ring — the loss channel grid shielding
+    /// attacks. In hardware this is the cathode interception current.
+    pub interception_fraction: f64,
+    /// Fraction ending on the chamber wall / end caps.
+    pub wall_fraction: f64,
+    /// Fraction still alive at the budget (censored).
+    pub survivor_fraction: f64,
+    /// Per-pass survival probability implied by `mean_passes` under a
+    /// geometric-survival model: `m / (m + 1)`. A lower bound when many
+    /// traces are censored.
+    pub effective_transparency: f64,
+    /// Worst energy drift across the ensemble (integration quality).
+    pub max_energy_drift_rel: f64,
+}
+
+/// Reduce trace outcomes to [`EnsembleStats`].
+pub fn stats(outcomes: &[TraceOutcome]) -> EnsembleStats {
+    let n = outcomes.len().max(1);
+    let mean_passes = outcomes.iter().map(|o| o.core_passes as f64).sum::<f64>() / n as f64;
+    let count = |f: &dyn Fn(&TraceOutcome) -> bool| {
+        outcomes.iter().filter(|o| f(o)).count() as f64 / n as f64
+    };
+    EnsembleStats {
+        n: outcomes.len(),
+        mean_passes,
+        interception_fraction: count(&|o| matches!(o.fate, Fate::Wire(_))),
+        wall_fraction: count(&|o| o.fate == Fate::Wall),
+        survivor_fraction: count(&|o| o.fate == Fate::Survived),
+        effective_transparency: mean_passes / (mean_passes + 1.0),
+        max_energy_drift_rel: outcomes
+            .iter()
+            .map(|o| o.energy_drift_rel)
+            .fold(0.0, f64::max),
+    }
+}
+
+/// Thin-wire geometric transparency of the ring cathode: the fraction of
+/// the cathode sphere not shadowed by wire, per crossing.
+///
+/// Each ring at spherical radius `s` blocks a band of area
+/// `2πr_ring · 2a`, so the blocked fraction is `Σ r_ring·a / s²`. Purely
+/// geometric — no ion optics — which is exactly why traced transparency
+/// differs from it (field lensing steers ions into or around wires).
+pub fn geometric_transparency(device: &Device) -> f64 {
+    let blocked: f64 = device
+        .rings
+        .iter()
+        .map(|ring| {
+            let s2 = ring.ring_radius_mm.powi(2) + ring.z_mm.powi(2);
+            (ring.ring_radius_mm * ring.wire_radius_mm / s2).max(0.0)
+        })
+        .sum();
+    (1.0 - blocked).clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+    use crate::trace::{Fate, TraceOutcome};
+
+    fn outcome(fate: Fate, passes: u32) -> TraceOutcome {
+        TraceOutcome {
+            fate,
+            core_passes: passes,
+            time_s: 1e-6,
+            steps: 1000,
+            energy_drift_rel: 0.01,
+            launch_cos_theta: 0.0,
+        }
+    }
+
+    #[test]
+    fn stats_reduce_correctly() {
+        let outcomes = vec![
+            outcome(Fate::Wire(0), 3),
+            outcome(Fate::Wire(1), 5),
+            outcome(Fate::Wall, 2),
+            outcome(Fate::Survived, 10),
+        ];
+        let s = stats(&outcomes);
+        assert_eq!(s.n, 4);
+        assert!((s.mean_passes - 5.0).abs() < 1e-12);
+        assert!((s.interception_fraction - 0.5).abs() < 1e-12);
+        assert!((s.wall_fraction - 0.25).abs() < 1e-12);
+        assert!((s.survivor_fraction - 0.25).abs() < 1e-12);
+        assert!((s.effective_transparency - 5.0 / 6.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn more_wire_means_less_transparency() {
+        let thin = Device::classic_fusor(150.0, 50.0, 4, 0.5, -1.0);
+        let thick = Device::classic_fusor(150.0, 50.0, 4, 2.0, -1.0);
+        let many = Device::classic_fusor(150.0, 50.0, 8, 0.5, -1.0);
+        let t_thin = geometric_transparency(&thin);
+        let t_thick = geometric_transparency(&thick);
+        let t_many = geometric_transparency(&many);
+        assert!(t_thin > t_thick);
+        assert!(t_thin > t_many);
+        for t in [t_thin, t_thick, t_many] {
+            assert!((0.0..=1.0).contains(&t));
+        }
+    }
+}

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -41,6 +41,7 @@ pub mod field;
 pub mod fom;
 pub mod optimize;
 pub mod poisson;
+pub mod receipt;
 pub mod spec;
 pub mod trace;
 pub mod xsection;

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -41,6 +41,7 @@ pub mod field;
 pub mod fom;
 pub mod optimize;
 pub mod poisson;
+pub mod spec;
 pub mod trace;
 pub mod xsection;
 

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -1,0 +1,55 @@
+#![warn(missing_docs)]
+
+//! Charged-particle optics for the vcad kernel (M0).
+//!
+//! Models axisymmetric electrostatic devices — fusors, shielded-grid IEC
+//! machines, ion traps, electron guns — as **vacuum-field single-particle
+//! optics**: solve the electrode potential, trace charged particles through
+//! it, and score the electrode geometry with figures of merit.
+//!
+//! The pipeline:
+//!
+//! 1. [`device::Device`] — electrodes as wire rings + a grounded chamber,
+//!    geometry in millimeters (vcad convention), potentials in volts,
+//!    optional ampere-turns per ring for magnetic self-shielding.
+//! 2. [`poisson::solve`] — axisymmetric Laplace solver (finite difference,
+//!    SOR) for the potential φ(r, z) and field E = −∇φ.
+//! 3. [`field::FieldMap`] — E from the grid + analytic B from every
+//!    current-carrying ring (complete elliptic integrals, exact off-axis).
+//! 4. [`trace`] — Boris pusher with adaptive substepping; particles
+//!    terminate on electrode or wall impact, core passes are counted.
+//! 5. [`fom`] — ensemble statistics: interception fraction, mean
+//!    recirculation count, effective grid transparency.
+//! 6. [`optimize`] — derivative-free/finite-difference maximization of any
+//!    figure of merit over electrode parameters (M0 stand-in for the
+//!    adjoint; see `docs/particle-optics-m0.md`).
+//!
+//! **Scope and honesty (M0):** no space charge, no collisions, no neutral
+//! gas — the regime where electrode geometry dominates and where every
+//! classic electrode-design tool (SIMION lineage) operates. Self-consistent
+//! plasma effects are explicitly out of scope until a later milestone; see
+//! the milestone ladder in `docs/particle-optics-m0.md`.
+//!
+//! Units: public geometry is **millimeters** (vcad convention); everything
+//! internal is SI (meters, volts, tesla, seconds); particle energies are
+//! reported in electron-volts.
+
+pub mod device;
+pub mod elliptic;
+pub mod field;
+pub mod fom;
+pub mod optimize;
+pub mod poisson;
+pub mod trace;
+
+/// Physical constants (SI).
+pub mod constants {
+    /// Elementary charge, C.
+    pub const ELEMENTARY_CHARGE: f64 = 1.602_176_634e-19;
+    /// Deuteron mass, kg.
+    pub const DEUTERON_MASS: f64 = 3.343_583_772e-27;
+    /// Electron mass, kg.
+    pub const ELECTRON_MASS: f64 = 9.109_383_701_5e-31;
+    /// Vacuum permeability, T·m/A.
+    pub const MU_0: f64 = 1.256_637_062_12e-6;
+}

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -34,6 +34,7 @@
 //! internal is SI (meters, volts, tesla, seconds); particle energies are
 //! reported in electron-volts.
 
+pub mod adjoint;
 pub mod device;
 pub mod elliptic;
 pub mod field;

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -41,6 +41,7 @@ pub mod fom;
 pub mod optimize;
 pub mod poisson;
 pub mod trace;
+pub mod xsection;
 
 /// Physical constants (SI).
 pub mod constants {

--- a/crates/vcad-kernel-particle/src/optimize.rs
+++ b/crates/vcad-kernel-particle/src/optimize.rs
@@ -1,0 +1,180 @@
+//! Finite-difference maximization over electrode parameters.
+//!
+//! M0 stand-in for the discrete adjoint (see the milestone ladder in
+//! `docs/particle-optics-m0.md`): central-difference gradient + projected
+//! gradient ascent with backtracking. Deterministic, dependency-free, and
+//! good enough to close the design loop on a handful of parameters. The
+//! adjoint replaces the gradient estimate later without changing callers.
+
+/// Options for [`maximize`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FdOptions {
+    /// Central-difference step, as a fraction of each parameter's range.
+    pub rel_step: f64,
+    /// Maximum ascent iterations.
+    pub max_iters: usize,
+    /// Initial step length, as a fraction of the parameter range.
+    pub initial_step: f64,
+    /// Stop when the step length falls below this fraction of the range.
+    pub min_step: f64,
+}
+
+impl Default for FdOptions {
+    fn default() -> Self {
+        Self {
+            rel_step: 1e-2,
+            max_iters: 20,
+            initial_step: 0.1,
+            min_step: 1e-3,
+        }
+    }
+}
+
+/// Result of [`maximize`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct FdResult {
+    /// Best parameters found.
+    pub x: Vec<f64>,
+    /// Objective at `x`.
+    pub value: f64,
+    /// Total objective evaluations.
+    pub evals: usize,
+    /// Objective value after each accepted step (starts with f(x₀)).
+    pub history: Vec<f64>,
+}
+
+/// Maximize `f` over the box `[lo, hi]` starting at `x0`.
+///
+/// The objective may be noisy-deterministic (e.g. a traced ensemble with
+/// fixed seeds); backtracking only accepts strict improvements.
+pub fn maximize(
+    f: &mut dyn FnMut(&[f64]) -> f64,
+    x0: &[f64],
+    lo: &[f64],
+    hi: &[f64],
+    opts: &FdOptions,
+) -> FdResult {
+    assert_eq!(x0.len(), lo.len());
+    assert_eq!(x0.len(), hi.len());
+    let dim = x0.len();
+    let range: Vec<f64> = lo
+        .iter()
+        .zip(hi)
+        .map(|(a, b)| (b - a).abs().max(1e-12))
+        .collect();
+    let clamp = |x: &mut [f64]| {
+        for i in 0..dim {
+            x[i] = x[i].clamp(lo[i].min(hi[i]), hi[i].max(lo[i]));
+        }
+    };
+
+    let mut x: Vec<f64> = x0.to_vec();
+    clamp(&mut x);
+    let mut value = f(&x);
+    let mut evals = 1;
+    let mut history = vec![value];
+    let mut step = opts.initial_step;
+
+    for _ in 0..opts.max_iters {
+        // Central-difference gradient.
+        let mut grad = vec![0.0; dim];
+        let mut gnorm = 0.0;
+        for i in 0..dim {
+            let h = opts.rel_step * range[i];
+            let mut xp = x.clone();
+            xp[i] += h;
+            clamp(&mut xp);
+            let mut xm = x.clone();
+            xm[i] -= h;
+            clamp(&mut xm);
+            let denom = xp[i] - xm[i];
+            let g = if denom.abs() < 1e-15 {
+                0.0
+            } else {
+                (f(&xp) - f(&xm)) / denom
+            };
+            evals += 2;
+            grad[i] = g * range[i]; // scale-free direction
+            gnorm += grad[i] * grad[i];
+        }
+        gnorm = gnorm.sqrt();
+        if gnorm < 1e-15 {
+            break;
+        }
+
+        // Backtracking line search along the normalized gradient.
+        let mut improved = false;
+        let mut s = step;
+        for _ in 0..8 {
+            let mut xt = x.clone();
+            for i in 0..dim {
+                xt[i] += s * range[i] * grad[i] / gnorm;
+            }
+            clamp(&mut xt);
+            let vt = f(&xt);
+            evals += 1;
+            if vt > value {
+                x = xt;
+                value = vt;
+                history.push(value);
+                step = s * 1.5;
+                improved = true;
+                break;
+            }
+            s *= 0.5;
+        }
+        if !improved {
+            step *= 0.25;
+            if step < opts.min_step {
+                break;
+            }
+        }
+    }
+
+    FdResult {
+        x,
+        value,
+        evals,
+        history,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn climbs_a_smooth_bowl() {
+        // f(x, y) = -(x-2)² - 3(y+1)², max at (2, -1) inside the box.
+        let mut f = |x: &[f64]| -(x[0] - 2.0).powi(2) - 3.0 * (x[1] + 1.0).powi(2);
+        let r = maximize(
+            &mut f,
+            &[-4.0, 4.0],
+            &[-5.0, -5.0],
+            &[5.0, 5.0],
+            &FdOptions {
+                max_iters: 60,
+                ..FdOptions::default()
+            },
+        );
+        assert!((r.x[0] - 2.0).abs() < 0.05, "x = {:?}", r.x);
+        assert!((r.x[1] + 1.0).abs() < 0.05, "x = {:?}", r.x);
+        assert!(r.value > -0.01);
+        assert!(r.history.windows(2).all(|w| w[1] >= w[0]));
+    }
+
+    #[test]
+    fn respects_bounds() {
+        // Max of x+y is at the box corner.
+        let mut f = |x: &[f64]| x[0] + x[1];
+        let r = maximize(
+            &mut f,
+            &[0.0, 0.0],
+            &[-1.0, -1.0],
+            &[1.0, 2.0],
+            &FdOptions::default(),
+        );
+        assert!(r.x[0] <= 1.0 + 1e-12 && r.x[1] <= 2.0 + 1e-12);
+        assert!(r.value > 2.5, "should approach the corner: {}", r.value);
+    }
+}

--- a/crates/vcad-kernel-particle/src/optimize.rs
+++ b/crates/vcad-kernel-particle/src/optimize.rs
@@ -98,7 +98,11 @@ pub fn maximize(
             gnorm += grad[i] * grad[i];
         }
         gnorm = gnorm.sqrt();
-        if gnorm < 1e-15 {
+        // Scale-invariant stop: the gradient (per unit of scaled parameter)
+        // is negligible relative to the objective's own magnitude. An
+        // absolute epsilon here silently kills objectives that live at
+        // 1e-32 (e.g. cross-section integrals in SI units).
+        if gnorm <= 1e-12 * value.abs() || gnorm == 0.0 {
             break;
         }
 
@@ -161,6 +165,29 @@ mod tests {
         assert!((r.x[1] + 1.0).abs() < 0.05, "x = {:?}", r.x);
         assert!(r.value > -0.01);
         assert!(r.history.windows(2).all(|w| w[1] >= w[0]));
+    }
+
+    #[test]
+    fn survives_astronomically_small_objectives() {
+        // Cross-section-integral scale: values around 1e-30. The optimizer
+        // must not mistake "tiny units" for "converged".
+        let mut f = |x: &[f64]| 1.0e-30 * (4.0 - (x[0] - 2.0).powi(2));
+        let r = maximize(
+            &mut f,
+            &[-3.0],
+            &[-5.0],
+            &[5.0],
+            &FdOptions {
+                max_iters: 60,
+                ..FdOptions::default()
+            },
+        );
+        assert!((r.x[0] - 2.0).abs() < 0.05, "x = {:?}", r.x);
+        assert!(
+            r.evals > 10,
+            "stopped suspiciously early: {} evals",
+            r.evals
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/optimize.rs
+++ b/crates/vcad-kernel-particle/src/optimize.rs
@@ -143,9 +143,113 @@ pub fn maximize(
     }
 }
 
+/// An objective that returns its value and gradient together.
+pub type ValueAndGradFn = dyn FnMut(&[f64]) -> (f64, Vec<f64>);
+
+/// Maximize using a caller-supplied gradient (e.g. the discrete adjoint
+/// from [`crate::adjoint::yield_gradient`]): projected ascent with the
+/// same backtracking line search as [`maximize`], but no FD probes —
+/// one gradient evaluation replaces `2·dim` objective calls per step.
+pub fn maximize_with_gradient(
+    fg: &mut ValueAndGradFn,
+    x0: &[f64],
+    lo: &[f64],
+    hi: &[f64],
+    opts: &FdOptions,
+) -> FdResult {
+    assert_eq!(x0.len(), lo.len());
+    assert_eq!(x0.len(), hi.len());
+    let dim = x0.len();
+    let range: Vec<f64> = lo
+        .iter()
+        .zip(hi)
+        .map(|(a, b)| (b - a).abs().max(1e-12))
+        .collect();
+    let clamp = |x: &mut [f64]| {
+        for i in 0..dim {
+            x[i] = x[i].clamp(lo[i].min(hi[i]), hi[i].max(lo[i]));
+        }
+    };
+
+    let mut x: Vec<f64> = x0.to_vec();
+    clamp(&mut x);
+    let (mut value, mut grad) = fg(&x);
+    let mut evals = 1;
+    let mut history = vec![value];
+    let mut step = opts.initial_step;
+
+    for _ in 0..opts.max_iters {
+        let scaled: Vec<f64> = grad.iter().zip(&range).map(|(g, r)| g * r).collect();
+        let gnorm = scaled.iter().map(|g| g * g).sum::<f64>().sqrt();
+        if gnorm <= 1e-12 * value.abs() || gnorm == 0.0 {
+            break;
+        }
+        let mut improved = false;
+        let mut s = step;
+        for _ in 0..8 {
+            let mut xt = x.clone();
+            for i in 0..dim {
+                xt[i] += s * range[i] * scaled[i] / gnorm;
+            }
+            clamp(&mut xt);
+            let (vt, gt) = fg(&xt);
+            evals += 1;
+            if vt > value {
+                x = xt;
+                value = vt;
+                grad = gt;
+                history.push(value);
+                step = s * 1.5;
+                improved = true;
+                break;
+            }
+            s *= 0.5;
+        }
+        if !improved {
+            step *= 0.25;
+            if step < opts.min_step {
+                break;
+            }
+        }
+    }
+
+    FdResult {
+        x,
+        value,
+        evals,
+        history,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gradient_driven_ascent_climbs() {
+        // Same bowl as the FD test, but with supplied gradients.
+        let mut fg = |x: &[f64]| {
+            let v = -(x[0] - 2.0).powi(2) - 3.0 * (x[1] + 1.0).powi(2);
+            let g = vec![-2.0 * (x[0] - 2.0), -6.0 * (x[1] + 1.0)];
+            (v, g)
+        };
+        let r = maximize_with_gradient(
+            &mut fg,
+            &[-4.0, 4.0],
+            &[-5.0, -5.0],
+            &[5.0, 5.0],
+            &FdOptions {
+                max_iters: 60,
+                ..FdOptions::default()
+            },
+        );
+        assert!((r.x[0] - 2.0).abs() < 0.05, "x = {:?}", r.x);
+        assert!((r.x[1] + 1.0).abs() < 0.05, "x = {:?}", r.x);
+        // Far fewer evals than the FD path needs for the same bowl
+        // (FD at 2 params spends ~5 evals per accepted step; this spends
+        // 1 + line-search retries).
+        assert!(r.evals < 200, "evals = {}", r.evals);
+    }
 
     #[test]
     fn climbs_a_smooth_bowl() {

--- a/crates/vcad-kernel-particle/src/poisson.rs
+++ b/crates/vcad-kernel-particle/src/poisson.rs
@@ -85,8 +85,6 @@ pub struct Solution {
     pub fixed: Vec<bool>,
     /// SOR sweeps actually used.
     pub sweeps: usize,
-    er: Vec<f64>,
-    ez: Vec<f64>,
 }
 
 impl Solution {
@@ -113,11 +111,28 @@ impl Solution {
     }
 
     /// Electric field `(E_r, E_z)` at `(r, z)` in meters, V/m.
+    ///
+    /// The **exact gradient of the bilinear potential patch** — not an
+    /// interpolation of node-difference fields. This makes the sampled
+    /// field conservative (its line integral between any two points equals
+    /// the potential difference of the continuous interpolant), so
+    /// integrator energy error is governed by the time step alone.
     pub fn e_at(&self, r_m: f64, z_m: f64) -> (f64, f64) {
-        (
-            self.bilinear(&self.er, r_m, z_m),
-            self.bilinear(&self.ez, r_m, z_m),
-        )
+        let eps = 1e-9;
+        let u = (r_m.abs() / self.dr).clamp(0.0, (self.nr - 1) as f64 - eps);
+        let w = ((z_m + self.z_half) / self.dz).clamp(0.0, (self.nz - 1) as f64 - eps);
+        let i0 = u.floor() as usize;
+        let j0 = w.floor() as usize;
+        let fu = u - i0 as f64;
+        let fw = w - j0 as f64;
+        let idx = |i: usize, j: usize| i * self.nz + j;
+        let p00 = self.phi[idx(i0, j0)];
+        let p10 = self.phi[idx(i0 + 1, j0)];
+        let p01 = self.phi[idx(i0, j0 + 1)];
+        let p11 = self.phi[idx(i0 + 1, j0 + 1)];
+        let er = -((p10 - p00) * (1.0 - fw) + (p11 - p01) * fw) / self.dr;
+        let ez = -((p01 - p00) * (1.0 - fu) + (p11 - p10) * fu) / self.dz;
+        (er, ez)
     }
 }
 
@@ -234,30 +249,6 @@ pub fn solve(
         });
     }
 
-    // E = −∇φ, central differences (one-sided at the domain edges).
-    let mut er = vec![0.0_f64; nr * nz];
-    let mut ez = vec![0.0_f64; nr * nz];
-    for i in 0..nr {
-        for j in 0..nz {
-            let dphi_dr = if i == 0 {
-                (phi[idx(1, j)] - phi[idx(0, j)]) / dr
-            } else if i == nr - 1 {
-                (phi[idx(nr - 1, j)] - phi[idx(nr - 2, j)]) / dr
-            } else {
-                (phi[idx(i + 1, j)] - phi[idx(i - 1, j)]) / (2.0 * dr)
-            };
-            let dphi_dz = if j == 0 {
-                (phi[idx(i, 1)] - phi[idx(i, 0)]) / dz
-            } else if j == nz - 1 {
-                (phi[idx(i, nz - 1)] - phi[idx(i, nz - 2)]) / dz
-            } else {
-                (phi[idx(i, j + 1)] - phi[idx(i, j - 1)]) / (2.0 * dz)
-            };
-            er[idx(i, j)] = -dphi_dr;
-            ez[idx(i, j)] = -dphi_dz;
-        }
-    }
-
     Ok(Solution {
         nr,
         nz,
@@ -268,8 +259,6 @@ pub fn solve(
         phi,
         fixed,
         sweeps,
-        er,
-        ez,
     })
 }
 

--- a/crates/vcad-kernel-particle/src/poisson.rs
+++ b/crates/vcad-kernel-particle/src/poisson.rs
@@ -1,0 +1,336 @@
+//! Axisymmetric electrostatic Laplace solver.
+//!
+//! Solves ∇²φ = 0 in cylindrical coordinates (r, z) with axisymmetry
+//! (∂/∂θ = 0) on a uniform node grid over the chamber cross-section,
+//! using successive over-relaxation. Electrodes and the chamber wall are
+//! Dirichlet regions; the axis r = 0 gets the standard symmetry stencil.
+//!
+//! Vacuum fields only: no space charge (M0 scope — see crate docs).
+
+use crate::device::Device;
+
+/// Options for [`solve`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SolveOptions {
+    /// SOR over-relaxation factor in (1, 2). `0.0` selects the Chebyshev
+    /// estimate `2 / (1 + sin(π / max(nr, nz)))` automatically.
+    pub omega: f64,
+    /// Convergence tolerance, relative to the largest electrode potential:
+    /// the sweep stops when the largest node update falls below
+    /// `tol × max|V|`.
+    pub tol: f64,
+    /// Hard cap on SOR sweeps.
+    pub max_sweeps: usize,
+}
+
+impl Default for SolveOptions {
+    fn default() -> Self {
+        Self {
+            omega: 0.0,
+            tol: 1e-6,
+            max_sweeps: 40_000,
+        }
+    }
+}
+
+/// Failure modes of [`solve`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum SolveError {
+    /// The grid must be at least 3×3 nodes.
+    GridTooSmall,
+    /// SOR did not reach `tol` within `max_sweeps`.
+    NotConverged {
+        /// Final relative residual (largest node update / max|V|).
+        residual: f64,
+        /// Sweeps performed.
+        sweeps: usize,
+    },
+}
+
+impl std::fmt::Display for SolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SolveError::GridTooSmall => write!(f, "grid must be at least 3x3 nodes"),
+            SolveError::NotConverged { residual, sweeps } => write!(
+                f,
+                "SOR not converged after {sweeps} sweeps (relative residual {residual:.3e})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SolveError {}
+
+/// Discretized potential and field on the (r, z) grid.
+///
+/// Node (i, j) sits at `r = i·dr`, `z = −z_half + j·dz` with
+/// `i ∈ [0, nr)`, `j ∈ [0, nz)`. Sampling accessors take SI meters.
+#[derive(Debug, Clone)]
+pub struct Solution {
+    /// Radial node count.
+    pub nr: usize,
+    /// Axial node count.
+    pub nz: usize,
+    /// Radial node spacing, m.
+    pub dr: f64,
+    /// Axial node spacing, m.
+    pub dz: f64,
+    /// Domain radius, m.
+    pub r_max: f64,
+    /// Domain half-height, m.
+    pub z_half: f64,
+    /// Potential per node, volts (row-major: `i * nz + j`).
+    pub phi: Vec<f64>,
+    /// Dirichlet mask per node (true = electrode / wall).
+    pub fixed: Vec<bool>,
+    /// SOR sweeps actually used.
+    pub sweeps: usize,
+    er: Vec<f64>,
+    ez: Vec<f64>,
+}
+
+impl Solution {
+    #[inline]
+    fn bilinear(&self, field: &[f64], r_m: f64, z_m: f64) -> f64 {
+        let eps = 1e-12;
+        let u = (r_m.abs() / self.dr).clamp(0.0, (self.nr - 1) as f64 - eps);
+        let w = ((z_m + self.z_half) / self.dz).clamp(0.0, (self.nz - 1) as f64 - eps);
+        let i0 = u.floor() as usize;
+        let j0 = w.floor() as usize;
+        let fu = u - i0 as f64;
+        let fw = w - j0 as f64;
+        let idx = |i: usize, j: usize| i * self.nz + j;
+        field[idx(i0, j0)] * (1.0 - fu) * (1.0 - fw)
+            + field[idx(i0 + 1, j0)] * fu * (1.0 - fw)
+            + field[idx(i0, j0 + 1)] * (1.0 - fu) * fw
+            + field[idx(i0 + 1, j0 + 1)] * fu * fw
+    }
+
+    /// Potential at `(r, z)` in meters, volts. Bilinear interpolation,
+    /// clamped to the domain.
+    pub fn potential_at(&self, r_m: f64, z_m: f64) -> f64 {
+        self.bilinear(&self.phi, r_m, z_m)
+    }
+
+    /// Electric field `(E_r, E_z)` at `(r, z)` in meters, V/m.
+    pub fn e_at(&self, r_m: f64, z_m: f64) -> (f64, f64) {
+        (
+            self.bilinear(&self.er, r_m, z_m),
+            self.bilinear(&self.ez, r_m, z_m),
+        )
+    }
+}
+
+/// Solve the vacuum potential for `device` on an `nr × nz` node grid.
+pub fn solve(
+    device: &Device,
+    nr: usize,
+    nz: usize,
+    opts: &SolveOptions,
+) -> Result<Solution, SolveError> {
+    if nr < 3 || nz < 3 {
+        return Err(SolveError::GridTooSmall);
+    }
+    let r_max = device.chamber_radius_mm * 1e-3;
+    let z_half = device.chamber_half_height_mm * 1e-3;
+    let dr = r_max / (nr - 1) as f64;
+    let dz = 2.0 * z_half / (nz - 1) as f64;
+    let idx = |i: usize, j: usize| i * nz + j;
+
+    let mut phi = vec![0.0_f64; nr * nz];
+    let mut fixed = vec![false; nr * nz];
+
+    // Chamber wall: outer radius and both end caps.
+    for j in 0..nz {
+        phi[idx(nr - 1, j)] = device.wall_potential_v;
+        fixed[idx(nr - 1, j)] = true;
+    }
+    for i in 0..nr {
+        phi[idx(i, 0)] = device.wall_potential_v;
+        fixed[idx(i, 0)] = true;
+        phi[idx(i, nz - 1)] = device.wall_potential_v;
+        fixed[idx(i, nz - 1)] = true;
+    }
+
+    // Wire rings: every node inside the wire cross-section is Dirichlet.
+    // The effective radius is floored at 0.75·max(dr, dz) so a thin wire is
+    // always represented by at least its nearest nodes.
+    for ring in &device.rings {
+        let r0 = ring.ring_radius_mm * 1e-3;
+        let z0 = ring.z_mm * 1e-3;
+        let a = (ring.wire_radius_mm * 1e-3).max(0.75 * dr.max(dz));
+        let i_lo = ((r0 - a) / dr).floor().max(0.0) as usize;
+        let i_hi = (((r0 + a) / dr).ceil() as usize).min(nr - 1);
+        let j_lo = (((z0 - a + z_half) / dz).floor().max(0.0)) as usize;
+        let j_hi = ((((z0 + a + z_half) / dz).ceil()) as usize).min(nz - 1);
+        for i in i_lo..=i_hi {
+            for j in j_lo..=j_hi {
+                let r = i as f64 * dr;
+                let z = -z_half + j as f64 * dz;
+                if (r - r0).powi(2) + (z - z0).powi(2) <= a * a {
+                    phi[idx(i, j)] = ring.potential_v;
+                    fixed[idx(i, j)] = true;
+                }
+            }
+        }
+    }
+
+    let v_scale = device
+        .rings
+        .iter()
+        .map(|r| r.potential_v.abs())
+        .fold(device.wall_potential_v.abs(), f64::max)
+        .max(1.0);
+
+    let omega = if opts.omega > 0.0 {
+        opts.omega
+    } else {
+        let n = nr.max(nz) as f64;
+        2.0 / (1.0 + (std::f64::consts::PI / n).sin())
+    };
+    let dr2 = dr * dr;
+    let dz2 = dz * dz;
+
+    let mut residual = f64::MAX;
+    let mut sweeps = 0;
+    while sweeps < opts.max_sweeps {
+        residual = 0.0;
+        for i in 0..nr - 1 {
+            for j in 1..nz - 1 {
+                let id = idx(i, j);
+                if fixed[id] {
+                    continue;
+                }
+                let pz = (phi[idx(i, j + 1)] + phi[idx(i, j - 1)]) / dz2;
+                let (num_r, den_r) = if i == 0 {
+                    (4.0 * phi[idx(1, j)] / dr2, 4.0 / dr2)
+                } else {
+                    let r = i as f64 * dr;
+                    let rp = r + 0.5 * dr;
+                    let rm = r - 0.5 * dr;
+                    (
+                        (rp * phi[idx(i + 1, j)] + rm * phi[idx(i - 1, j)]) / (r * dr2),
+                        (rp + rm) / (r * dr2),
+                    )
+                };
+                let updated = (num_r + pz) / (den_r + 2.0 / dz2);
+                let delta = updated - phi[id];
+                phi[id] += omega * delta;
+                let ad = delta.abs();
+                if ad > residual {
+                    residual = ad;
+                }
+            }
+        }
+        sweeps += 1;
+        if residual < opts.tol * v_scale {
+            break;
+        }
+    }
+    if residual >= opts.tol * v_scale {
+        return Err(SolveError::NotConverged {
+            residual: residual / v_scale,
+            sweeps,
+        });
+    }
+
+    // E = −∇φ, central differences (one-sided at the domain edges).
+    let mut er = vec![0.0_f64; nr * nz];
+    let mut ez = vec![0.0_f64; nr * nz];
+    for i in 0..nr {
+        for j in 0..nz {
+            let dphi_dr = if i == 0 {
+                (phi[idx(1, j)] - phi[idx(0, j)]) / dr
+            } else if i == nr - 1 {
+                (phi[idx(nr - 1, j)] - phi[idx(nr - 2, j)]) / dr
+            } else {
+                (phi[idx(i + 1, j)] - phi[idx(i - 1, j)]) / (2.0 * dr)
+            };
+            let dphi_dz = if j == 0 {
+                (phi[idx(i, 1)] - phi[idx(i, 0)]) / dz
+            } else if j == nz - 1 {
+                (phi[idx(i, nz - 1)] - phi[idx(i, nz - 2)]) / dz
+            } else {
+                (phi[idx(i, j + 1)] - phi[idx(i, j - 1)]) / (2.0 * dz)
+            };
+            er[idx(i, j)] = -dphi_dr;
+            ez[idx(i, j)] = -dphi_dz;
+        }
+    }
+
+    Ok(Solution {
+        nr,
+        nz,
+        dr,
+        dz,
+        r_max,
+        z_half,
+        phi,
+        fixed,
+        sweeps,
+        er,
+        ez,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+
+    fn test_device() -> Device {
+        Device::shielded_two_ring(100.0, 40.0, 20.0, 3.0, -1_000.0, 0.0)
+    }
+
+    #[test]
+    fn respects_the_maximum_principle() {
+        let sol = solve(&test_device(), 61, 121, &SolveOptions::default()).unwrap();
+        for &p in &sol.phi {
+            assert!(
+                (-1_000.0..=0.0).contains(&p),
+                "potential outside Dirichlet bounds: {p}"
+            );
+        }
+    }
+
+    #[test]
+    fn axis_is_a_symmetry_plane() {
+        let sol = solve(&test_device(), 61, 121, &SolveOptions::default()).unwrap();
+        // ∂φ/∂r ≈ 0 on the axis away from the end caps.
+        for j in (10..110).step_by(10) {
+            let p0 = sol.phi[j];
+            let p1 = sol.phi[sol.nz + j];
+            let scale = p0.abs().max(1.0);
+            assert!(
+                (p1 - p0).abs() / scale < 5e-2,
+                "axis kink at j={j}: {p0} vs {p1}"
+            );
+        }
+    }
+
+    #[test]
+    fn refinement_is_consistent() {
+        let coarse = solve(&test_device(), 51, 101, &SolveOptions::default()).unwrap();
+        let fine = solve(&test_device(), 101, 201, &SolveOptions::default()).unwrap();
+        // Probe the mid-field region (well away from wire surfaces).
+        for (r, z) in [(0.01, 0.0), (0.02, 0.03), (0.06, -0.02), (0.0, 0.05)] {
+            let a = coarse.potential_at(r, z);
+            let b = fine.potential_at(r, z);
+            assert!(
+                (a - b).abs() < 0.02 * 1_000.0,
+                "grid dependence at ({r},{z}): coarse {a}, fine {b}"
+            );
+        }
+    }
+
+    #[test]
+    fn cathode_deepens_the_well() {
+        let sol = solve(&test_device(), 61, 121, &SolveOptions::default()).unwrap();
+        // Center of the device is pulled well below ground by the rings.
+        let center = sol.potential_at(0.0, 0.0);
+        assert!(center < -300.0, "weak well: {center} V");
+        // And the wall really is ground.
+        let wall = sol.potential_at(0.099, 0.0);
+        assert!(wall > -100.0, "wall not near ground: {wall} V");
+    }
+}

--- a/crates/vcad-kernel-particle/src/poisson.rs
+++ b/crates/vcad-kernel-particle/src/poisson.rs
@@ -87,16 +87,23 @@ pub struct Solution {
     pub sweeps: usize,
 }
 
+/// Locate `x` (in node units) on an `n`-node axis: the lower cell index
+/// (always ≤ n−2, so the stencil's `+1` neighbour is in range for any
+/// grid size) and the in-cell fraction (exact 1.0 at the far edge).
+/// Index-space clamping — a float-epsilon ceiling breaks down once the
+/// axis size approaches 1/ulp of the epsilon.
+#[inline]
+pub(crate) fn cell_index(x: f64, n: usize) -> (usize, f64) {
+    let x = x.clamp(0.0, (n - 1) as f64);
+    let i0 = (x as usize).min(n - 2);
+    (i0, (x - i0 as f64).clamp(0.0, 1.0))
+}
+
 impl Solution {
     #[inline]
     fn bilinear(&self, field: &[f64], r_m: f64, z_m: f64) -> f64 {
-        let eps = 1e-12;
-        let u = (r_m.abs() / self.dr).clamp(0.0, (self.nr - 1) as f64 - eps);
-        let w = ((z_m + self.z_half) / self.dz).clamp(0.0, (self.nz - 1) as f64 - eps);
-        let i0 = u.floor() as usize;
-        let j0 = w.floor() as usize;
-        let fu = u - i0 as f64;
-        let fw = w - j0 as f64;
+        let (i0, fu) = cell_index(r_m.abs() / self.dr, self.nr);
+        let (j0, fw) = cell_index((z_m + self.z_half) / self.dz, self.nz);
         let idx = |i: usize, j: usize| i * self.nz + j;
         field[idx(i0, j0)] * (1.0 - fu) * (1.0 - fw)
             + field[idx(i0 + 1, j0)] * fu * (1.0 - fw)
@@ -118,13 +125,8 @@ impl Solution {
     /// the potential difference of the continuous interpolant), so
     /// integrator energy error is governed by the time step alone.
     pub fn e_at(&self, r_m: f64, z_m: f64) -> (f64, f64) {
-        let eps = 1e-9;
-        let u = (r_m.abs() / self.dr).clamp(0.0, (self.nr - 1) as f64 - eps);
-        let w = ((z_m + self.z_half) / self.dz).clamp(0.0, (self.nz - 1) as f64 - eps);
-        let i0 = u.floor() as usize;
-        let j0 = w.floor() as usize;
-        let fu = u - i0 as f64;
-        let fw = w - j0 as f64;
+        let (i0, fu) = cell_index(r_m.abs() / self.dr, self.nr);
+        let (j0, fw) = cell_index((z_m + self.z_half) / self.dz, self.nz);
         let idx = |i: usize, j: usize| i * self.nz + j;
         let p00 = self.phi[idx(i0, j0)];
         let p10 = self.phi[idx(i0 + 1, j0)];
@@ -269,6 +271,49 @@ mod tests {
 
     fn test_device() -> Device {
         Device::shielded_two_ring(100.0, 40.0, 20.0, 3.0, -1_000.0, 0.0)
+    }
+
+    #[test]
+    fn cell_index_is_in_range_for_any_axis_size() {
+        // The old float-epsilon ceiling ((n−1) − 1e−12) rounds back to n−1
+        // once ulp(n−1) exceeds the epsilon (n ≳ 4100), sending the
+        // stencil's +1 neighbour out of bounds. Index-space clamping must
+        // hold everywhere, including exactly at and beyond the far edge.
+        for n in [3usize, 61, 4097, 8193, 1_000_000] {
+            let (i0, f) = cell_index((n - 1) as f64, n);
+            assert_eq!(i0, n - 2, "far edge lands in the last cell (n={n})");
+            assert_eq!(f, 1.0, "far edge fraction is exact (n={n})");
+            let (i0, f) = cell_index((n as f64) * 2.0, n);
+            assert_eq!(i0, n - 2, "beyond-domain clamps (n={n})");
+            assert_eq!(f, 1.0);
+            let (i0, f) = cell_index(-3.5, n);
+            assert_eq!(i0, 0, "below-domain clamps (n={n})");
+            assert_eq!(f, 0.0);
+        }
+    }
+
+    #[test]
+    fn sampling_at_the_exact_domain_edges_is_safe_and_exact() {
+        let sol = solve(&test_device(), 61, 121, &SolveOptions::default()).unwrap();
+        // Exactly at the outer corners and edges: no panic, and the
+        // potential equals the wall boundary value (fu/fw = 1 path).
+        for &(r, z) in &[
+            (sol.r_max, 0.0),
+            (sol.r_max, sol.z_half),
+            (sol.r_max, -sol.z_half),
+            (0.0, sol.z_half),
+            (0.0, -sol.z_half),
+        ] {
+            let p = sol.potential_at(r, z);
+            assert!(
+                p.abs() < 1e-9,
+                "wall potential must be exactly ground at ({r},{z}): {p}"
+            );
+            let (er, ez) = sol.e_at(r, z);
+            assert!(er.is_finite() && ez.is_finite());
+        }
+        // Far beyond the domain clamps to the boundary value.
+        assert!(sol.potential_at(10.0 * sol.r_max, 0.0).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/receipt.rs
+++ b/crates/vcad-kernel-particle/src/receipt.rs
@@ -199,6 +199,123 @@ pub fn predicted_claims(
     }
 }
 
+/// A bench measurement to bind against a predicted claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Measurement {
+    /// Claim name this measures (must match a claim).
+    pub name: String,
+    /// Measured value, in the claim's unit.
+    pub value: f64,
+    /// One-sigma absolute uncertainty, same unit.
+    pub uncertainty: f64,
+    /// Instrument provenance ("cathode ammeter s/n …", "He-3 counter …").
+    pub instrument: String,
+    /// Acceptance band as a multiplicative factor: the claim holds when
+    /// measured / predicted ∈ [1/band, band] after widening by the
+    /// measurement uncertainty. Floors (neutron rate) warrant a generous
+    /// band; direct observables (interception fraction) a tight one.
+    pub band_factor: f64,
+}
+
+/// Verdict for one claim, in the repo's receipt vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Verdict {
+    /// Measurement inside the stated band.
+    Holds,
+    /// Measurement outside the stated band.
+    Violated,
+    /// No measurement bound to this claim (fail-closed: unmeasured is
+    /// never silently passing).
+    Unmeasured,
+}
+
+/// One row of the predicted-vs-measured comparison.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComparisonEntry {
+    /// Claim name.
+    pub name: String,
+    /// Predicted value.
+    pub predicted: f64,
+    /// Measured value (`None` when unmeasured).
+    pub measured: Option<f64>,
+    /// measured / predicted (`None` when unmeasured or predicted = 0).
+    pub ratio: Option<f64>,
+    /// Verdict.
+    pub verdict: Verdict,
+}
+
+/// The comparison report: every claim gets a row; measurements that match
+/// no claim are an error (a measurement of nothing is a bookkeeping bug).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComparisonReport {
+    /// Schema tag.
+    pub schema: String,
+    /// Per-claim rows.
+    pub entries: Vec<ComparisonEntry>,
+    /// True only when every claim with a measurement holds AND at least
+    /// one measurement exists — an unmeasured receipt never passes.
+    pub all_hold: bool,
+}
+
+/// Bind measurements to a claim set.
+pub fn compare(
+    claims: &ClaimSet,
+    measurements: &[Measurement],
+) -> Result<ComparisonReport, String> {
+    for m in measurements {
+        if !claims.claims.iter().any(|c| c.name == m.name) {
+            return Err(format!("measurement {:?} matches no claim", m.name));
+        }
+    }
+    let mut entries = Vec::with_capacity(claims.claims.len());
+    let mut measured_any = false;
+    let mut all_hold = true;
+    for c in &claims.claims {
+        let m = measurements.iter().find(|m| m.name == c.name);
+        let entry = match m {
+            None => ComparisonEntry {
+                name: c.name.clone(),
+                predicted: c.value,
+                measured: None,
+                ratio: None,
+                verdict: Verdict::Unmeasured,
+            },
+            Some(m) => {
+                measured_any = true;
+                let ratio = if c.value != 0.0 {
+                    Some(m.value / c.value)
+                } else {
+                    None
+                };
+                // Widen the band by the measurement uncertainty.
+                let lo = c.value / m.band_factor - m.uncertainty;
+                let hi = c.value * m.band_factor + m.uncertainty;
+                let holds = (lo..=hi).contains(&m.value);
+                if !holds {
+                    all_hold = false;
+                }
+                ComparisonEntry {
+                    name: c.name.clone(),
+                    predicted: c.value,
+                    measured: Some(m.value),
+                    ratio,
+                    verdict: if holds {
+                        Verdict::Holds
+                    } else {
+                        Verdict::Violated
+                    },
+                }
+            }
+        };
+        entries.push(entry);
+    }
+    Ok(ComparisonReport {
+        schema: "vcad.particle-compare/1".to_string(),
+        entries,
+        all_hold: all_hold && measured_any,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -284,6 +401,59 @@ mod tests {
         // Provenance is present and truthful.
         assert_eq!(back.provenance.grid, [81, 161]);
         assert_eq!(back.provenance.ensemble, 12);
+    }
+
+    #[test]
+    fn compare_binds_measurements_fail_closed() {
+        let set = build();
+        // Unmeasured receipt never passes.
+        let empty = compare(&set, &[]).unwrap();
+        assert!(!empty.all_hold);
+        assert!(empty
+            .entries
+            .iter()
+            .all(|e| e.verdict == Verdict::Unmeasured));
+
+        // A measurement of nothing is an error.
+        let bogus = Measurement {
+            name: "warp_factor".into(),
+            value: 9.0,
+            uncertainty: 0.1,
+            instrument: "vibes".into(),
+            band_factor: 2.0,
+        };
+        assert!(compare(&set, &[bogus]).is_err());
+
+        // The cathode ammeter agrees within band → Holds; a wildly wrong
+        // neutron count → Violated; everything else stays Unmeasured.
+        let predicted_intercept = get(&set, "interception_fraction");
+        let ok = Measurement {
+            name: "interception_fraction".into(),
+            value: predicted_intercept * 1.1,
+            uncertainty: 0.02,
+            instrument: "cathode ammeter".into(),
+            band_factor: 1.5,
+        };
+        let bad = Measurement {
+            name: "ddn_neutron_rate".into(),
+            value: get(&set, "ddn_neutron_rate") * 1e4,
+            uncertainty: 1.0,
+            instrument: "He-3 counter".into(),
+            band_factor: 30.0,
+        };
+        let report = compare(&set, &[ok, bad]).unwrap();
+        assert!(!report.all_hold);
+        let verdict = |name: &str| {
+            report
+                .entries
+                .iter()
+                .find(|e| e.name == name)
+                .unwrap()
+                .verdict
+        };
+        assert_eq!(verdict("interception_fraction"), Verdict::Holds);
+        assert_eq!(verdict("ddn_neutron_rate"), Verdict::Violated);
+        assert_eq!(verdict("q_estimate"), Verdict::Unmeasured);
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/receipt.rs
+++ b/crates/vcad-kernel-particle/src/receipt.rs
@@ -1,0 +1,318 @@
+//! Predicted-performance claims for the design receipt.
+//!
+//! Emits a serializable claim set — interception, recirculation,
+//! neutron rate, fusion power, Q, and **distance to Lawson** — with full
+//! solver provenance (grid, tolerance, ensemble, censoring, physics
+//! channels included), in the spirit of `vcad.receipt/1`: every number
+//! carries how it was produced, and nothing is defaulted silently.
+//!
+//! These are `basis: "predicted"` claims. Binding them to measurements
+//! (the cathode ammeter, a calibrated neutron counter) is the experiment
+//! pack's job — see `docs/particle-optics-m0.md` M6. Wiring this family
+//! into `crates/vcad-receipt` + the MCP surface is the flagged follow-up
+//! PR (it touches the cross-crate schema and TS codegen).
+
+use serde::{Deserialize, Serialize};
+
+use crate::fom::EnsembleStats;
+use crate::poisson::Solution;
+use crate::trace::TraceOptions;
+
+/// Schema tag for this claim family.
+pub const CLAIM_SCHEMA: &str = "vcad.particle-claims/1";
+
+/// Energy per D(d,n)³He reaction (both products), joules. 3.27 MeV.
+pub const E_DDN_J: f64 = 3.27e6 * crate::constants::ELEMENTARY_CHARGE;
+/// Energy per D(d,p)T reaction (both products), joules. 4.03 MeV.
+pub const E_DDP_J: f64 = 4.03e6 * crate::constants::ELEMENTARY_CHARGE;
+
+/// The operating point claims are priced at.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct OperatingPoint {
+    /// Injected ion current, amperes.
+    pub ion_current_a: f64,
+    /// D₂ background pressure, mTorr.
+    pub d2_pressure_mtorr: f64,
+    /// Gas temperature, kelvin.
+    pub temperature_k: f64,
+}
+
+/// How the numbers were produced.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SolverProvenance {
+    /// Radial × axial node counts.
+    pub grid: [usize; 2],
+    /// SOR relative tolerance.
+    pub sor_tol: f64,
+    /// SOR sweeps used by the converged solve.
+    pub sor_sweeps: usize,
+    /// Trace ensemble size.
+    pub ensemble: usize,
+    /// Pass cap (censoring boundary).
+    pub max_passes: u32,
+    /// Fraction of traces censored at the budget.
+    pub survivor_fraction: f64,
+    /// Worst per-trace energy drift (integration quality).
+    pub max_energy_drift_rel: f64,
+    /// Physics channels included in the prediction.
+    pub channels: Vec<String>,
+}
+
+/// One predicted claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Claim {
+    /// Claim name (snake_case).
+    pub name: String,
+    /// Value.
+    pub value: f64,
+    /// Unit ("1" for dimensionless).
+    pub unit: String,
+    /// Claim basis — always `"predicted"` here.
+    pub basis: String,
+    /// Assumptions and caveats, spelled out.
+    pub note: String,
+}
+
+/// The full claim set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClaimSet {
+    /// Schema tag ([`CLAIM_SCHEMA`]).
+    pub schema: String,
+    /// Solver and ensemble provenance.
+    pub provenance: SolverProvenance,
+    /// Operating point.
+    pub operating_point: OperatingPoint,
+    /// The claims.
+    pub claims: Vec<Claim>,
+}
+
+fn claim(name: &str, value: f64, unit: &str, note: &str) -> Claim {
+    Claim {
+        name: name.to_string(),
+        value,
+        unit: unit.to_string(),
+        basis: "predicted".to_string(),
+        note: note.to_string(),
+    }
+}
+
+/// Build the predicted claim set for one solved-and-traced configuration.
+///
+/// `drop_v` is the accelerating potential drop (volts, absolute) used to
+/// price input power; `stats` must come from the same trace options.
+pub fn predicted_claims(
+    stats: &EnsembleStats,
+    solution: &Solution,
+    trace_opts: &TraceOptions,
+    sor_tol: f64,
+    drop_v: f64,
+    op: &OperatingPoint,
+) -> ClaimSet {
+    let n_d = crate::xsection::d2_deuteron_density_m3(op.d2_pressure_mtorr, op.temperature_k);
+    let ions_per_s = op.ion_current_a / crate::constants::ELEMENTARY_CHARGE;
+
+    let mut channels = vec!["beam_on_background".to_string()];
+    let neutron_rate = if trace_opts.cx.is_some() {
+        channels.push("cx_survival".to_string());
+        channels.push("fast_neutral".to_string());
+        ions_per_s * (stats.mean_neutrons_ion_channel + stats.mean_neutrons_cx_channel)
+    } else {
+        ions_per_s * n_d * stats.mean_ddn_sigma_v_m3
+    };
+
+    // Fusion power from both branches (beam-on-background integrals; the
+    // CX chain and beam-beam channels are not priced — floor).
+    let rate_n = ions_per_s * n_d * stats.mean_ddn_sigma_v_m3;
+    let rate_p = ions_per_s * n_d * stats.mean_ddp_sigma_v_m3;
+    let p_fus = rate_n * E_DDN_J + rate_p * E_DDP_J;
+    let p_in = op.ion_current_a * drop_v;
+    let q = if p_in > 0.0 { p_fus / p_in } else { 0.0 };
+    let distance_orders = if q > 0.0 {
+        (1.0 / q).log10().min(99.0)
+    } else {
+        99.0
+    };
+
+    let claims = vec![
+        claim(
+            "interception_fraction",
+            stats.interception_fraction,
+            "1",
+            "fraction of traced ions ending on cathode wire; the hardware \
+             observable is cathode interception current",
+        ),
+        claim(
+            "mean_core_passes",
+            stats.mean_passes,
+            "passes",
+            "recirculation count, censored at max_passes",
+        ),
+        claim(
+            "effective_transparency",
+            stats.effective_transparency,
+            "1",
+            "geometric-survival estimate m/(m+1); lower bound under censoring",
+        ),
+        claim(
+            "ddn_neutron_rate",
+            neutron_rate,
+            "n/s",
+            "D(d,n)3He at the stated operating point; channels as listed in \
+             provenance; CX chain and beam-beam are NOT included (floor)",
+        ),
+        claim(
+            "fusion_power",
+            p_fus,
+            "W",
+            "both D-D branches, beam-on-background integrals only",
+        ),
+        claim("input_power", p_in, "W", "ion current x potential drop"),
+        claim(
+            "q_estimate",
+            q,
+            "1",
+            "fusion power / input power at the stated operating point",
+        ),
+        claim(
+            "distance_to_lawson",
+            distance_orders,
+            "orders",
+            "log10(1/Q); breakeven at 0; capped at 99 when no fusion is \
+             predicted",
+        ),
+    ];
+
+    ClaimSet {
+        schema: CLAIM_SCHEMA.to_string(),
+        provenance: SolverProvenance {
+            grid: [solution.nr, solution.nz],
+            sor_tol,
+            sor_sweeps: solution.sweeps,
+            ensemble: stats.n,
+            max_passes: trace_opts.max_passes,
+            survivor_fraction: stats.survivor_fraction,
+            max_energy_drift_rel: stats.max_energy_drift_rel,
+            channels,
+        },
+        operating_point: *op,
+        claims,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+    use crate::field::FieldMap;
+    use crate::fom::stats;
+    use crate::poisson::{solve, SolveOptions};
+    use crate::trace::{TraceOptions, Tracer, DEUTERON};
+
+    fn build() -> ClaimSet {
+        let device = Device::classic_fusor(120.0, 40.0, 5, 1.0, -30_000.0);
+        let sopts = SolveOptions::default();
+        let sol = solve(&device, 81, 161, &sopts).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let topts = TraceOptions {
+            max_passes: 10,
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, topts);
+        let s = stats(&tracer.launch_ensemble(DEUTERON, 12));
+        predicted_claims(
+            &s,
+            &sol,
+            &topts,
+            sopts.tol,
+            30_000.0,
+            &OperatingPoint {
+                ion_current_a: 0.010,
+                d2_pressure_mtorr: 2.0,
+                temperature_k: 300.0,
+            },
+        )
+    }
+
+    fn get(set: &ClaimSet, name: &str) -> f64 {
+        set.claims
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("missing claim {name}"))
+            .value
+    }
+
+    #[test]
+    fn q_arithmetic_is_consistent_and_honest() {
+        let set = build();
+        let q = get(&set, "q_estimate");
+        let p_fus = get(&set, "fusion_power");
+        let p_in = get(&set, "input_power");
+        assert!((q - p_fus / p_in).abs() < 1e-15);
+        assert!((p_in - 300.0).abs() < 1e-9, "10 mA x 30 kV = 300 W");
+        // A fusor is microwatts against hundreds of watts: Q around 1e-9,
+        // distance to Lawson around 9 orders. Honesty is load-bearing.
+        assert!(q > 1e-12 && q < 1e-6, "q = {q:.3e}");
+        let d = get(&set, "distance_to_lawson");
+        assert!((d - (1.0 / q).log10()).abs() < 1e-9);
+        assert!((6.0..12.0).contains(&d), "distance = {d}");
+    }
+
+    #[test]
+    fn serializes_with_schema_and_provenance() {
+        let set = build();
+        let json = serde_json::to_string_pretty(&set).expect("serialize");
+        assert!(json.contains("vcad.particle-claims/1"));
+        assert!(json.contains("distance_to_lawson"));
+        assert!(json.contains("beam_on_background"));
+        let back: ClaimSet = serde_json::from_str(&json).expect("round trip");
+        // Compare structurally with a float tolerance (JSON float printing
+        // can move the last ULP).
+        assert_eq!(back.schema, set.schema);
+        assert_eq!(back.claims.len(), set.claims.len());
+        for (a, b) in back.claims.iter().zip(&set.claims) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.unit, b.unit);
+            let scale = b.value.abs().max(1e-300);
+            assert!(
+                (a.value - b.value).abs() / scale < 1e-12,
+                "claim {} drifted: {} vs {}",
+                a.name,
+                a.value,
+                b.value
+            );
+        }
+        // Provenance is present and truthful.
+        assert_eq!(back.provenance.grid, [81, 161]);
+        assert_eq!(back.provenance.ensemble, 12);
+    }
+
+    #[test]
+    fn no_fusion_is_fail_closed_not_flattering() {
+        // A 100 V device fuses nothing; the receipt must say "99 orders",
+        // not divide by zero or omit the claim.
+        let device = Device::classic_fusor(120.0, 40.0, 3, 1.0, -100.0);
+        let sopts = SolveOptions::default();
+        let sol = solve(&device, 41, 81, &sopts).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let topts = TraceOptions {
+            max_passes: 4,
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, topts);
+        let s = stats(&tracer.launch_ensemble(DEUTERON, 6));
+        let set = predicted_claims(
+            &s,
+            &sol,
+            &topts,
+            sopts.tol,
+            100.0,
+            &OperatingPoint {
+                ion_current_a: 0.010,
+                d2_pressure_mtorr: 2.0,
+                temperature_k: 300.0,
+            },
+        );
+        let d = get(&set, "distance_to_lawson");
+        assert!(d > 20.0, "no-fusion distance must be huge: {d}");
+    }
+}

--- a/crates/vcad-kernel-particle/src/receipt.rs
+++ b/crates/vcad-kernel-particle/src/receipt.rs
@@ -8,9 +8,14 @@
 //!
 //! These are `basis: "predicted"` claims. Binding them to measurements
 //! (the cathode ammeter, a calibrated neutron counter) is the experiment
-//! pack's job — see `docs/particle-optics-m0.md` M6. Wiring this family
-//! into `crates/vcad-receipt` + the MCP surface is the flagged follow-up
-//! PR (it touches the cross-crate schema and TS codegen).
+//! pack's job — see `docs/particle-optics-m0.md` M6.
+//!
+//! [`design_claims`] and [`comparison_claims`] translate this family into
+//! the unified [`vcad_receipt::DesignReceipt`] schema using the existing
+//! generic claim types (open domain vocabulary — no schema bump, no TS
+//! codegen): predictions ride as `ClaimBasis::Predicted` (a receipt built
+//! from them rolls up Provisional, never Pass) and bench comparisons as
+//! `ClaimBasis::Measured` with Holds→Pass / Violated→Fail.
 
 use serde::{Deserialize, Serialize};
 
@@ -316,6 +321,115 @@ pub fn compare(
     })
 }
 
+/// Domain tag for particle claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "particle";
+
+/// The oracle reference for this crate's tracer.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-particle/trace", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// solver ran for real, but the claim is about a physical device that has
+/// not been measured, so a receipt built from these **rolls up Provisional,
+/// never Pass** (the same contract as `predict_physics`/`predict_print`).
+/// The computed value rides in `measured` ("what the oracle computed");
+/// provenance and caveats ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "grid {}x{}, ensemble {}, max_passes {}, survivor_fraction {:.3}, channels [{}]; op point {} A / {} mTorr / {} K",
+        set.provenance.grid[0],
+        set.provenance.grid[1],
+        set.provenance.ensemble,
+        set.provenance.max_passes,
+        set.provenance.survivor_fraction,
+        set.provenance.channels.join(", "),
+        set.operating_point.ion_current_a,
+        set.operating_point.d2_pressure_mtorr,
+        set.operating_point.temperature_k,
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("particle.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(provenance.clone())
+        })
+        .collect()
+}
+
+/// Translate a bench [`ComparisonReport`] into unified-receipt claims.
+///
+/// Only measured rows translate (unmeasured claims stay in the predicted
+/// set): Holds → Pass, Violated → Fail, both with
+/// [`vcad_receipt::ClaimBasis::Measured`], the prediction in `predicted`
+/// and the bench value in `measured`.
+pub fn comparison_claims(
+    report: &ComparisonReport,
+    set: &ClaimSet,
+    measurements: &[Measurement],
+) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    report
+        .entries
+        .iter()
+        .filter_map(|e| {
+            let measured = e.measured?;
+            let m = measurements.iter().find(|m| m.name == e.name)?;
+            let unit = set
+                .claims
+                .iter()
+                .find(|c| c.name == e.name)
+                .map(|c| c.unit.clone())
+                .unwrap_or_else(|| "1".to_string());
+            let base = match e.verdict {
+                Verdict::Holds => vcad_receipt::ReceiptClaim::pass(
+                    format!("particle.{}", e.name),
+                    RECEIPT_DOMAIN,
+                    format!(
+                        "bench measurement of {} within band {}",
+                        e.name, m.band_factor
+                    ),
+                    oracle.clone(),
+                ),
+                Verdict::Violated => vcad_receipt::ReceiptClaim::fail(
+                    format!("particle.{}", e.name),
+                    RECEIPT_DOMAIN,
+                    format!(
+                        "bench measurement of {} outside band {}",
+                        e.name, m.band_factor
+                    ),
+                    oracle.clone(),
+                ),
+                Verdict::Unmeasured => return None,
+            };
+            Some(
+                base.with_basis(vcad_receipt::ClaimBasis::Measured)
+                    .with_predicted(quantity(e.predicted, &unit))
+                    .with_measured(quantity(measured, &unit))
+                    .with_details(format!("instrument: {}", m.instrument)),
+            )
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -454,6 +568,66 @@ mod tests {
         assert_eq!(verdict("interception_fraction"), Verdict::Holds);
         assert_eq!(verdict("ddn_neutron_rate"), Verdict::Violated);
         assert_eq!(verdict("q_estimate"), Verdict::Unmeasured);
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let set = build();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("particle."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            assert!(c.details.as_deref().unwrap_or("").contains("grid 81x161"));
+        }
+        // The fail-closed contract: an all-pass predicted receipt rolls up
+        // Provisional, never Pass.
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted particle claims must never read as verified"
+        );
+    }
+
+    #[test]
+    fn comparison_claims_map_verdicts_with_measured_basis() {
+        let set = build();
+        let predicted_intercept = get(&set, "interception_fraction");
+        let measurements = vec![
+            Measurement {
+                name: "interception_fraction".into(),
+                value: predicted_intercept * 1.05,
+                uncertainty: 0.02,
+                instrument: "cathode ammeter".into(),
+                band_factor: 1.5,
+            },
+            Measurement {
+                name: "ddn_neutron_rate".into(),
+                value: get(&set, "ddn_neutron_rate") * 1e4,
+                uncertainty: 1.0,
+                instrument: "He-3 counter".into(),
+                band_factor: 30.0,
+            },
+        ];
+        let report = compare(&set, &measurements).unwrap();
+        let claims = comparison_claims(&report, &set, &measurements);
+        assert_eq!(claims.len(), 2, "only measured rows translate");
+        let by_id = |id: &str| {
+            claims
+                .iter()
+                .find(|c| c.id == format!("particle.{id}"))
+                .unwrap()
+        };
+        let ok = by_id("interception_fraction");
+        assert_eq!(ok.verdict, vcad_receipt::ClaimVerdict::Pass);
+        assert_eq!(ok.basis, Some(vcad_receipt::ClaimBasis::Measured));
+        assert!(ok.predicted.is_some() && ok.measured.is_some());
+        let bad = by_id("ddn_neutron_rate");
+        assert_eq!(bad.verdict, vcad_receipt::ClaimVerdict::Fail);
+        assert!(bad.details.as_deref().unwrap().contains("He-3"));
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/spec.rs
+++ b/crates/vcad-kernel-particle/src/spec.rs
@@ -1,0 +1,304 @@
+//! The `.vcad` seam: a serde device schema with named parameters.
+//!
+//! A [`DeviceSpec`] is the serialization contract between vcad documents
+//! and this crate. Every numeric field is a [`ParamValue`]: either a
+//! literal, or the **name** of a document parameter to be supplied at
+//! resolve time. Resolution is fail-closed — an unbound name is an error,
+//! never a default.
+//!
+//! The spec also classifies each named parameter by how its gradient is
+//! obtained ([`ParamRole`]): potentials and coil currents flow through the
+//! discrete adjoint ([`crate::adjoint::yield_gradient`]); geometry moves
+//! the Dirichlet mask, which is discrete, so geometric parameters take
+//! finite differences until the shape-adjoint milestone.
+//!
+//! BRep extraction (revolved sketch sections → rings) is deliberately not
+//! here: it lands on the vcad side of the seam, emitting this schema.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::device::{Device, WireRing};
+
+/// A literal value or the name of a document parameter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ParamValue {
+    /// A literal number.
+    Literal(f64),
+    /// The name of a parameter bound at [`DeviceSpec::resolve`] time.
+    Named(String),
+}
+
+impl From<f64> for ParamValue {
+    fn from(v: f64) -> Self {
+        ParamValue::Literal(v)
+    }
+}
+
+impl ParamValue {
+    fn resolve(&self, params: &BTreeMap<String, f64>) -> Result<f64, SpecError> {
+        match self {
+            ParamValue::Literal(v) => Ok(*v),
+            ParamValue::Named(name) => params
+                .get(name)
+                .copied()
+                .ok_or_else(|| SpecError::UnknownParameter(name.clone())),
+        }
+    }
+
+    fn name(&self) -> Option<&str> {
+        match self {
+            ParamValue::Literal(_) => None,
+            ParamValue::Named(n) => Some(n),
+        }
+    }
+}
+
+fn zero() -> ParamValue {
+    ParamValue::Literal(0.0)
+}
+
+/// One wire ring electrode in the spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RingSpec {
+    /// Ring radius, mm.
+    pub ring_radius_mm: ParamValue,
+    /// Axial position, mm.
+    pub z_mm: ParamValue,
+    /// Wire (minor) radius, mm.
+    pub wire_radius_mm: ParamValue,
+    /// Electrode potential, volts.
+    pub potential_v: ParamValue,
+    /// Circulating current, ampere-turns (defaults to 0).
+    #[serde(default = "zero")]
+    pub ampere_turns: ParamValue,
+}
+
+/// Serializable axisymmetric device with named parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeviceSpec {
+    /// Chamber inner radius, mm.
+    pub chamber_radius_mm: ParamValue,
+    /// Chamber half-height, mm.
+    pub chamber_half_height_mm: ParamValue,
+    /// Chamber wall potential, volts (defaults to 0 — grounded).
+    #[serde(default = "zero")]
+    pub wall_potential_v: ParamValue,
+    /// Wire ring electrodes.
+    pub rings: Vec<RingSpec>,
+}
+
+/// How a named parameter's gradient is computed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParamRole {
+    /// Reverse-mode via [`crate::adjoint::yield_gradient`] (potentials,
+    /// ampere-turns).
+    Adjoint,
+    /// Finite differences (geometry: it moves the Dirichlet mask).
+    FiniteDifference,
+}
+
+/// Resolution failures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpecError {
+    /// A named parameter had no binding.
+    UnknownParameter(String),
+}
+
+impl std::fmt::Display for SpecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpecError::UnknownParameter(name) => {
+                write!(f, "unbound device parameter: {name:?}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpecError {}
+
+impl DeviceSpec {
+    /// Resolve every field against `params`, fail-closed.
+    pub fn resolve(&self, params: &BTreeMap<String, f64>) -> Result<Device, SpecError> {
+        let rings = self
+            .rings
+            .iter()
+            .map(|r| {
+                Ok(WireRing {
+                    ring_radius_mm: r.ring_radius_mm.resolve(params)?,
+                    z_mm: r.z_mm.resolve(params)?,
+                    wire_radius_mm: r.wire_radius_mm.resolve(params)?,
+                    potential_v: r.potential_v.resolve(params)?,
+                    ampere_turns: r.ampere_turns.resolve(params)?,
+                })
+            })
+            .collect::<Result<Vec<_>, SpecError>>()?;
+        Ok(Device {
+            chamber_radius_mm: self.chamber_radius_mm.resolve(params)?,
+            chamber_half_height_mm: self.chamber_half_height_mm.resolve(params)?,
+            wall_potential_v: self.wall_potential_v.resolve(params)?,
+            rings,
+        })
+    }
+
+    /// A literal (parameter-free) spec mirroring `device` — the round-trip
+    /// starting point for documents that don't parameterize.
+    pub fn from_device(device: &Device) -> Self {
+        Self {
+            chamber_radius_mm: device.chamber_radius_mm.into(),
+            chamber_half_height_mm: device.chamber_half_height_mm.into(),
+            wall_potential_v: device.wall_potential_v.into(),
+            rings: device
+                .rings
+                .iter()
+                .map(|r| RingSpec {
+                    ring_radius_mm: r.ring_radius_mm.into(),
+                    z_mm: r.z_mm.into(),
+                    wire_radius_mm: r.wire_radius_mm.into(),
+                    potential_v: r.potential_v.into(),
+                    ampere_turns: r.ampere_turns.into(),
+                })
+                .collect(),
+        }
+    }
+
+    /// Every named parameter with its gradient role. A name used by both
+    /// an adjoint-capable field and a geometric field is conservatively
+    /// classified [`ParamRole::FiniteDifference`].
+    pub fn parameter_roles(&self) -> BTreeMap<String, ParamRole> {
+        let mut roles: BTreeMap<String, ParamRole> = BTreeMap::new();
+        let mut put = |value: &ParamValue, role: ParamRole| {
+            if let Some(name) = value.name() {
+                roles
+                    .entry(name.to_string())
+                    .and_modify(|existing| {
+                        if role == ParamRole::FiniteDifference {
+                            *existing = ParamRole::FiniteDifference;
+                        }
+                    })
+                    .or_insert(role);
+            }
+        };
+        put(&self.chamber_radius_mm, ParamRole::FiniteDifference);
+        put(&self.chamber_half_height_mm, ParamRole::FiniteDifference);
+        put(&self.wall_potential_v, ParamRole::Adjoint);
+        for r in &self.rings {
+            put(&r.ring_radius_mm, ParamRole::FiniteDifference);
+            put(&r.z_mm, ParamRole::FiniteDifference);
+            put(&r.wire_radius_mm, ParamRole::FiniteDifference);
+            put(&r.potential_v, ParamRole::Adjoint);
+            put(&r.ampere_turns, ParamRole::Adjoint);
+        }
+        roles
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+
+    fn params(pairs: &[(&str, f64)]) -> BTreeMap<String, f64> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    #[test]
+    fn json_round_trip_with_named_parameters() {
+        let json = r#"{
+            "chamber_radius_mm": 150.0,
+            "chamber_half_height_mm": 150.0,
+            "rings": [
+                {
+                    "ring_radius_mm": 45.0,
+                    "z_mm": "ring_z",
+                    "wire_radius_mm": 3.0,
+                    "potential_v": "cathode_v",
+                    "ampere_turns": "shield_at"
+                },
+                {
+                    "ring_radius_mm": 45.0,
+                    "z_mm": "ring_z_neg",
+                    "wire_radius_mm": 3.0,
+                    "potential_v": "cathode_v",
+                    "ampere_turns": "shield_at_neg"
+                }
+            ]
+        }"#;
+        let spec: DeviceSpec = serde_json::from_str(json).expect("parse");
+        let device = spec
+            .resolve(&params(&[
+                ("ring_z", 25.0),
+                ("ring_z_neg", -25.0),
+                ("cathode_v", -30_000.0),
+                ("shield_at", 40_000.0),
+                ("shield_at_neg", -40_000.0),
+            ]))
+            .expect("resolve");
+        let reference = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, -30_000.0, 40_000.0);
+        assert_eq!(device, reference);
+
+        // Serialize → parse → resolve again: identical device.
+        let round = serde_json::to_string(&spec).expect("serialize");
+        let spec2: DeviceSpec = serde_json::from_str(&round).expect("reparse");
+        assert_eq!(spec, spec2);
+    }
+
+    #[test]
+    fn resolution_is_fail_closed() {
+        let spec = DeviceSpec {
+            chamber_radius_mm: 100.0.into(),
+            chamber_half_height_mm: 100.0.into(),
+            wall_potential_v: 0.0.into(),
+            rings: vec![RingSpec {
+                ring_radius_mm: 40.0.into(),
+                z_mm: ParamValue::Named("missing".into()),
+                wire_radius_mm: 2.0.into(),
+                potential_v: (-1_000.0).into(),
+                ampere_turns: 0.0.into(),
+            }],
+        };
+        let err = spec.resolve(&BTreeMap::new()).unwrap_err();
+        assert_eq!(err, SpecError::UnknownParameter("missing".into()));
+    }
+
+    #[test]
+    fn from_device_round_trips_and_solves() {
+        let device = Device::classic_fusor(120.0, 40.0, 3, 1.0, -5_000.0);
+        let spec = DeviceSpec::from_device(&device);
+        let resolved = spec.resolve(&BTreeMap::new()).expect("literal resolve");
+        assert_eq!(device, resolved);
+        // And the resolved device actually runs through the solver.
+        let sol =
+            crate::poisson::solve(&resolved, 41, 81, &crate::poisson::SolveOptions::default())
+                .expect("solve");
+        assert!(sol.potential_at(0.0, 0.0) < -100.0);
+    }
+
+    #[test]
+    fn parameter_roles_classify_the_gradient_path() {
+        let spec = DeviceSpec {
+            chamber_radius_mm: 150.0.into(),
+            chamber_half_height_mm: 150.0.into(),
+            wall_potential_v: 0.0.into(),
+            rings: vec![RingSpec {
+                ring_radius_mm: ParamValue::Named("geo".into()),
+                z_mm: 25.0.into(),
+                wire_radius_mm: 3.0.into(),
+                potential_v: ParamValue::Named("bias".into()),
+                ampere_turns: ParamValue::Named("shield".into()),
+            }],
+        };
+        let roles = spec.parameter_roles();
+        assert_eq!(roles["bias"], ParamRole::Adjoint);
+        assert_eq!(roles["shield"], ParamRole::Adjoint);
+        assert_eq!(roles["geo"], ParamRole::FiniteDifference);
+
+        // A name shared across an adjoint field and a geometric field is
+        // conservatively FD.
+        let mut mixed = spec.clone();
+        mixed.rings[0].wire_radius_mm = ParamValue::Named("bias".into());
+        assert_eq!(mixed.parameter_roles()["bias"], ParamRole::FiniteDifference);
+    }
+}

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -89,7 +89,7 @@ pub struct TraceOutcome {
 /// and keeps fusing until it exits). The CX chain (each event also births
 /// a cold ion that re-accelerates) is not yet modeled, so both channels
 /// are floors.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct CxModel {
     /// Charge-exchange cross section, m².
     pub sigma_cx_m2: f64,

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -59,11 +59,40 @@ pub struct TraceOutcome {
     /// cos θ of the launch direction (θ from +z), for post-hoc binning.
     pub launch_cos_theta: f64,
     /// Path integral ∫ σ_DDn(E)·v dt over the whole trace, m³ — the
-    /// beam-on-background D(d,n)³He reaction volume. Multiply by target
-    /// deuteron density for expected neutrons per ion; zero for
-    /// non-deuteron species. Beam–beam and fast-neutral channels are not
-    /// modeled (M1 scope).
+    /// beam-on-background D(d,n)³He reaction volume with **no
+    /// charge-exchange attrition** (kept raw for cross-config
+    /// comparability). Multiply by target deuteron density for expected
+    /// neutrons per ion; zero for non-deuteron species.
     pub ddn_sigma_v_m3: f64,
+    /// Expected D-D neutrons per injected ion from the surviving-ion
+    /// channel (CX-survival-weighted). Zero unless a [`CxModel`] is set.
+    pub neutrons_ion_channel: f64,
+    /// Expected D-D neutrons per injected ion from fast neutrals born at
+    /// charge-exchange events (straight-line continuation at full energy).
+    /// Zero unless a [`CxModel`] is set.
+    pub neutrons_cx_channel: f64,
+}
+
+/// Charge-exchange model: constant cross-section approximation for
+/// D⁺ + D₂ → fast D⁰ + slow D₂⁺ against a uniform background gas.
+///
+/// σ_cx for deuterons on D₂ is of order 1×10⁻¹⁹ m² across the 1–30 keV
+/// band (falling slowly with energy); supply your own value — tabulated
+/// energy-dependent data is a receipts-milestone upgrade. With a model
+/// present, traces report **expected neutrons per injected ion** in two
+/// channels: the surviving-ion channel (beam-on-background fusion,
+/// weighted by the probability the ion has not yet charge-exchanged) and
+/// the fast-neutral channel (the CX product flies straight at full energy
+/// and keeps fusing until it exits). The CX chain (each event also births
+/// a cold ion that re-accelerates) is not yet modeled, so both channels
+/// are floors.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CxModel {
+    /// Charge-exchange cross section, m².
+    pub sigma_cx_m2: f64,
+    /// Background deuteron density, m⁻³ (see
+    /// [`crate::xsection::d2_deuteron_density_m3`]).
+    pub background_deuteron_density_m3: f64,
 }
 
 /// Tracing options.
@@ -79,6 +108,8 @@ pub struct TraceOptions {
     pub launch_cos_max: f64,
     /// Flight-time budget in units of `max_passes` ideal crossing times.
     pub time_budget_factor: f64,
+    /// Optional charge-exchange model; `None` leaves the CX channels zero.
+    pub cx: Option<CxModel>,
 }
 
 impl Default for TraceOptions {
@@ -89,6 +120,7 @@ impl Default for TraceOptions {
             launch_shell_fraction: 0.85,
             launch_cos_max: 0.95,
             time_budget_factor: 12.0,
+            cx: None,
         }
     }
 }
@@ -181,9 +213,13 @@ impl<'a> Tracer<'a> {
         let mut steps = 0_u64;
         let mut drift = 0.0_f64;
         let mut sigv = 0.0_f64;
+        let mut survival = 1.0_f64;
+        let mut n_ion = 0.0_f64;
+        let mut n_cx = 0.0_f64;
         let launch_cos_theta = p[2] / sq_len(p).sqrt().max(1e-300);
         let deuteron_like =
             species.charge_c > 0.0 && (species.mass_kg / DEUTERON.mass_kg - 1.0).abs() < 0.01;
+        let cx = if deuteron_like { self.opts.cx } else { None };
 
         'outer: while time < t_max && steps < MAX_STEPS {
             let speed = dot(v, v).sqrt();
@@ -228,7 +264,25 @@ impl<'a> Tracer<'a> {
                         0.5 * species.mass_kg * v2 / (crate::constants::ELEMENTARY_CHARGE * 1.0e3);
                     let sig = crate::xsection::dd_n_sigma_m2(0.5 * e_lab_kev);
                     if sig > 0.0 {
-                        sigv += sig * v2.sqrt() * dth;
+                        let speed_now = v2.sqrt();
+                        sigv += sig * speed_now * dth;
+                        if let Some(cxm) = &cx {
+                            let n_bg = cxm.background_deuteron_density_m3;
+                            n_ion += survival * n_bg * sig * speed_now * dth;
+                            let rate_cx = n_bg * cxm.sigma_cx_m2 * speed_now;
+                            let p_birth = survival * rate_cx * dth;
+                            if p_birth > 0.0 {
+                                let l_exit = self.exit_distance(p, v);
+                                n_cx += p_birth * n_bg * sig * l_exit;
+                            }
+                            survival *= (-rate_cx * dth).exp();
+                        }
+                    } else if let Some(cxm) = &cx {
+                        // Below the fusion floor, CX attrition still runs.
+                        let speed_now = v2.sqrt();
+                        let rate_cx =
+                            cxm.background_deuteron_density_m3 * cxm.sigma_cx_m2 * speed_now;
+                        survival *= (-rate_cx * dth).exp();
                     }
                 }
 
@@ -274,7 +328,48 @@ impl<'a> Tracer<'a> {
             energy_drift_rel: drift,
             launch_cos_theta,
             ddn_sigma_v_m3: sigv,
+            neutrons_ion_channel: n_ion,
+            neutrons_cx_channel: n_cx,
         }
+    }
+
+    /// Straight-line distance from `p` along `v` to the chamber boundary
+    /// (cylinder wall or either end cap), meters. Used for fast-neutral
+    /// continuation after charge exchange.
+    fn exit_distance(&self, p: [f64; 3], v: [f64; 3]) -> f64 {
+        let speed = dot(v, v).sqrt();
+        if speed < 1e-12 {
+            return 0.0;
+        }
+        let d = scale(v, 1.0 / speed);
+        // Cylinder r = r_wall in the xy plane.
+        let a = d[0] * d[0] + d[1] * d[1];
+        let t_cyl = if a > 1e-18 {
+            let b = p[0] * d[0] + p[1] * d[1];
+            let c = p[0] * p[0] + p[1] * p[1] - self.r_wall * self.r_wall;
+            let disc = b * b - a * c;
+            if disc > 0.0 {
+                let t = (-b + disc.sqrt()) / a;
+                if t > 0.0 {
+                    t
+                } else {
+                    f64::INFINITY
+                }
+            } else {
+                f64::INFINITY
+            }
+        } else {
+            f64::INFINITY
+        };
+        // End caps z = ±z_wall.
+        let t_cap = if d[2] > 1e-18 {
+            (self.z_wall - p[2]) / d[2]
+        } else if d[2] < -1e-18 {
+            (-self.z_wall - p[2]) / d[2]
+        } else {
+            f64::INFINITY
+        };
+        t_cyl.min(t_cap.max(0.0)).max(0.0)
     }
 
     /// Launch `n` particles at rest on the launch shell, on a deterministic
@@ -376,6 +471,39 @@ mod tests {
                 o.core_passes
             );
         }
+    }
+
+    #[test]
+    fn charge_exchange_splits_the_yield() {
+        // At 2 mTorr D₂ the CX mean free path (~4 cm at 1e-19 m²) is
+        // shorter than one pass: the surviving-ion channel must be heavily
+        // suppressed relative to the raw no-CX integral, and the
+        // fast-neutral channel must be alive.
+        let device = Device::classic_fusor(120.0, 40.0, 5, 1.0, -30_000.0);
+        let sol = solve(&device, 81, 161, &SolveOptions::default()).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let n_bg = crate::xsection::d2_deuteron_density_m3(2.0, 300.0);
+        let opts = TraceOptions {
+            max_passes: 8,
+            cx: Some(CxModel {
+                sigma_cx_m2: 1.0e-19,
+                background_deuteron_density_m3: n_bg,
+            }),
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, opts);
+        let outs = tracer.launch_ensemble(DEUTERON, 8);
+        let mean =
+            |f: &dyn Fn(&TraceOutcome) -> f64| outs.iter().map(f).sum::<f64>() / outs.len() as f64;
+        let ion = mean(&|o| o.neutrons_ion_channel);
+        let cxc = mean(&|o| o.neutrons_cx_channel);
+        let raw = mean(&|o| o.ddn_sigma_v_m3) * n_bg;
+        assert!(ion > 0.0, "ion channel dead");
+        assert!(cxc > 0.0, "cx channel dead");
+        assert!(
+            ion < 0.8 * raw,
+            "survival weighting must suppress the ion channel: ion {ion:.3e} vs raw {raw:.3e}"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -64,6 +64,9 @@ pub struct TraceOutcome {
     /// comparability). Multiply by target deuteron density for expected
     /// neutrons per ion; zero for non-deuteron species.
     pub ddn_sigma_v_m3: f64,
+    /// Path integral ∫ σ_DDp(E)·v dt (the proton branch), m³ — with the
+    /// neutron branch this prices total fusion power for the receipt.
+    pub ddp_sigma_v_m3: f64,
     /// Expected D-D neutrons per injected ion from the surviving-ion
     /// channel (CX-survival-weighted). Zero unless a [`CxModel`] is set.
     pub neutrons_ion_channel: f64,
@@ -213,6 +216,7 @@ impl<'a> Tracer<'a> {
         let mut steps = 0_u64;
         let mut drift = 0.0_f64;
         let mut sigv = 0.0_f64;
+        let mut sigv_p = 0.0_f64;
         let mut survival = 1.0_f64;
         let mut n_ion = 0.0_f64;
         let mut n_cx = 0.0_f64;
@@ -263,9 +267,11 @@ impl<'a> Tracer<'a> {
                     let e_lab_kev =
                         0.5 * species.mass_kg * v2 / (crate::constants::ELEMENTARY_CHARGE * 1.0e3);
                     let sig = crate::xsection::dd_n_sigma_m2(0.5 * e_lab_kev);
+                    let sig_p = crate::xsection::dd_p_sigma_m2(0.5 * e_lab_kev);
                     if sig > 0.0 {
                         let speed_now = v2.sqrt();
                         sigv += sig * speed_now * dth;
+                        sigv_p += sig_p * speed_now * dth;
                         if let Some(cxm) = &cx {
                             let n_bg = cxm.background_deuteron_density_m3;
                             n_ion += survival * n_bg * sig * speed_now * dth;
@@ -328,6 +334,7 @@ impl<'a> Tracer<'a> {
             energy_drift_rel: drift,
             launch_cos_theta,
             ddn_sigma_v_m3: sigv,
+            ddp_sigma_v_m3: sigv_p,
             neutrons_ion_channel: n_ion,
             neutrons_cx_channel: n_cx,
         }

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -1,0 +1,357 @@
+//! Boris-pusher particle tracing through a solved device.
+//!
+//! Particles are integrated with the standard Boris scheme (exact energy
+//! behavior in static E, exact gyration in static B), with adaptive time
+//! steps: displacement per step is capped at a fraction of the grid
+//! spacing, and steps subdivide automatically where the coil field is
+//! strong so gyration stays resolved.
+//!
+//! A trace ends when the particle hits a wire ring, reaches the chamber
+//! wall, or survives to its pass/time budget. Passes through the central
+//! core are counted — the recirculation statistic that grid shielding is
+//! supposed to improve.
+
+use crate::device::Device;
+use crate::field::FieldMap;
+use crate::poisson::Solution;
+
+/// A charged species.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Species {
+    /// Rest mass, kg.
+    pub mass_kg: f64,
+    /// Charge, C (signed).
+    pub charge_c: f64,
+}
+
+/// Deuteron (D⁺).
+pub const DEUTERON: Species = Species {
+    mass_kg: crate::constants::DEUTERON_MASS,
+    charge_c: crate::constants::ELEMENTARY_CHARGE,
+};
+
+/// How a trace ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Fate {
+    /// Intercepted by wire ring `k` (index into `Device::rings`).
+    Wire(usize),
+    /// Reached the chamber wall or an end cap.
+    Wall,
+    /// Still alive at the pass/time/step budget (censored).
+    Survived,
+}
+
+/// Result of tracing one particle.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TraceOutcome {
+    /// Terminal event.
+    pub fate: Fate,
+    /// Number of entries into the central core.
+    pub core_passes: u32,
+    /// Flight time, s.
+    pub time_s: f64,
+    /// Integrator steps (including substeps).
+    pub steps: u64,
+    /// Worst relative energy drift observed in the far-field region,
+    /// normalized by the deepest potential drop. Integration-quality
+    /// diagnostic; should be ≪ 1.
+    pub energy_drift_rel: f64,
+    /// cos θ of the launch direction (θ from +z), for post-hoc binning.
+    pub launch_cos_theta: f64,
+}
+
+/// Tracing options.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TraceOptions {
+    /// Stop after this many core passes (censor as [`Fate::Survived`]).
+    pub max_passes: u32,
+    /// Displacement per step as a fraction of the grid spacing.
+    pub step_fraction: f64,
+    /// Launch shell radius as a fraction of the smaller chamber dimension.
+    pub launch_shell_fraction: f64,
+    /// Launch directions span cos θ ∈ [−this, +this].
+    pub launch_cos_max: f64,
+    /// Flight-time budget in units of `max_passes` ideal crossing times.
+    pub time_budget_factor: f64,
+}
+
+impl Default for TraceOptions {
+    fn default() -> Self {
+        Self {
+            max_passes: 40,
+            step_fraction: 0.25,
+            launch_shell_fraction: 0.85,
+            launch_cos_max: 0.95,
+            time_budget_factor: 12.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct WireHit {
+    r0: f64,
+    z0: f64,
+    a2: f64,
+}
+
+/// Prepared tracer for one device + solution.
+#[derive(Debug)]
+pub struct Tracer<'a> {
+    fields: &'a FieldMap<'a>,
+    wires: Vec<WireHit>,
+    r_wall: f64,
+    z_wall: f64,
+    core_radius: f64,
+    shell_radius: f64,
+    drop_v: f64,
+    h: f64,
+    opts: TraceOptions,
+}
+
+const MAX_STEPS: u64 = 20_000_000;
+
+impl<'a> Tracer<'a> {
+    /// Prepare a tracer. `solution` supplies the grid spacing (for step
+    /// sizing and the wire hit radius, which matches the Dirichlet mask).
+    pub fn new(
+        device: &Device,
+        fields: &'a FieldMap<'a>,
+        solution: &Solution,
+        opts: TraceOptions,
+    ) -> Self {
+        let h = solution.dr.min(solution.dz);
+        let mask_floor = 0.75 * solution.dr.max(solution.dz);
+        let wires = device
+            .rings
+            .iter()
+            .map(|ring| {
+                let a = (ring.wire_radius_mm * 1e-3).max(mask_floor);
+                WireHit {
+                    r0: ring.ring_radius_mm * 1e-3,
+                    z0: ring.z_mm * 1e-3,
+                    a2: a * a,
+                }
+            })
+            .collect();
+        let r_wall = device.chamber_radius_mm * 1e-3 - 0.6 * solution.dr;
+        let z_wall = device.chamber_half_height_mm * 1e-3 - 0.6 * solution.dz;
+        let min_dim = (device.chamber_radius_mm.min(device.chamber_half_height_mm)) * 1e-3;
+        let shell_radius = opts.launch_shell_fraction * min_dim;
+        let core_radius = 0.35 * device.min_ring_spherical_radius_mm() * 1e-3;
+        let drop_v = device.max_potential_drop_v().max(1.0);
+        Self {
+            fields,
+            wires,
+            r_wall,
+            z_wall,
+            core_radius,
+            shell_radius,
+            drop_v,
+            h,
+            opts,
+        }
+    }
+
+    /// Trace one particle from `pos` (m) with velocity `vel` (m/s).
+    pub fn trace_from(&self, species: Species, pos: [f64; 3], vel: [f64; 3]) -> TraceOutcome {
+        let mut p = pos;
+        let mut v = vel;
+        let qm = species.charge_c / species.mass_kg;
+        let v_ref = (2.0 * species.charge_c.abs() * self.drop_v / species.mass_kg).sqrt();
+        let dv_scale = species.charge_c.abs() * self.drop_v;
+        let t_max = self.opts.time_budget_factor
+            * self.opts.max_passes as f64
+            * (2.0 * self.shell_radius / v_ref);
+
+        let h0 = 0.5 * species.mass_kg * dot(v, v) + species.charge_c * self.fields.potential(p);
+        let far2 = (0.5 * self.shell_radius).powi(2);
+
+        let mut fate = Fate::Survived;
+        let mut passes = 0_u32;
+        let mut inside_core = sq_len(p) < self.core_radius * self.core_radius;
+        let mut time = 0.0_f64;
+        let mut steps = 0_u64;
+        let mut drift = 0.0_f64;
+        let launch_cos_theta = p[2] / sq_len(p).sqrt().max(1e-300);
+
+        'outer: while time < t_max && steps < MAX_STEPS {
+            let speed = dot(v, v).sqrt();
+            let dt = self.opts.step_fraction * self.h / speed.max(0.05 * v_ref);
+            let b = self.fields.b_cart(p);
+            let bmag = dot(b, b).sqrt();
+            let n_sub = ((qm.abs() * bmag * dt / 0.3).ceil() as u64).clamp(1, 64);
+            let dth = dt / n_sub as f64;
+            for _ in 0..n_sub {
+                let e = self.fields.e_cart(p);
+                let b = self.fields.b_cart(p);
+                let half = 0.5 * qm * dth;
+                let vm = add(v, scale(e, half));
+                let t = scale(b, half);
+                let t2 = dot(t, t);
+                let vprime = add(vm, cross(vm, t));
+                let s = 2.0 / (1.0 + t2);
+                let vp = add(vm, scale(cross(vprime, t), s));
+                v = add(vp, scale(e, half));
+                p = add(p, scale(v, dth));
+                time += dth;
+                steps += 1;
+
+                let r2 = p[0] * p[0] + p[1] * p[1];
+                if r2 > self.r_wall * self.r_wall || p[2].abs() > self.z_wall {
+                    fate = Fate::Wall;
+                    break 'outer;
+                }
+                let r = r2.sqrt();
+                for (k, w) in self.wires.iter().enumerate() {
+                    let dr = r - w.r0;
+                    let dz = p[2] - w.z0;
+                    if dr * dr + dz * dz <= w.a2 {
+                        fate = Fate::Wire(k);
+                        break 'outer;
+                    }
+                }
+                let s2 = sq_len(p);
+                let now_inside = s2 < self.core_radius * self.core_radius;
+                if now_inside && !inside_core {
+                    passes += 1;
+                    if passes >= self.opts.max_passes {
+                        break 'outer;
+                    }
+                }
+                inside_core = now_inside;
+                if s2 > far2 {
+                    let hnow = 0.5 * species.mass_kg * dot(v, v)
+                        + species.charge_c * self.fields.potential(p);
+                    let d = (hnow - h0).abs() / dv_scale;
+                    if d > drift {
+                        drift = d;
+                    }
+                }
+            }
+        }
+
+        TraceOutcome {
+            fate,
+            core_passes: passes,
+            time_s: time,
+            steps,
+            energy_drift_rel: drift,
+            launch_cos_theta,
+        }
+    }
+
+    /// Launch `n` particles at rest on the launch shell, on a deterministic
+    /// grid of polar angles (uniform in cos θ), and trace each.
+    pub fn launch_ensemble(&self, species: Species, n: usize) -> Vec<TraceOutcome> {
+        let n = n.max(2);
+        (0..n)
+            .map(|k| {
+                let c = -self.opts.launch_cos_max
+                    + 2.0 * self.opts.launch_cos_max * k as f64 / (n - 1) as f64;
+                let s = (1.0 - c * c).max(0.0).sqrt();
+                let pos = [self.shell_radius * s, 0.0, self.shell_radius * c];
+                self.trace_from(species, pos, [0.0, 0.0, 0.0])
+            })
+            .collect()
+    }
+
+    /// Core radius used for pass counting, m.
+    pub fn core_radius_m(&self) -> f64 {
+        self.core_radius
+    }
+
+    /// Launch shell radius, m.
+    pub fn shell_radius_m(&self) -> f64 {
+        self.shell_radius
+    }
+}
+
+#[inline]
+fn add(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] + b[0], a[1] + b[1], a[2] + b[2]]
+}
+
+#[inline]
+fn scale(a: [f64; 3], s: f64) -> [f64; 3] {
+    [a[0] * s, a[1] * s, a[2] * s]
+}
+
+#[inline]
+fn dot(a: [f64; 3], b: [f64; 3]) -> f64 {
+    a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+}
+
+#[inline]
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+
+#[inline]
+fn sq_len(a: [f64; 3]) -> f64 {
+    dot(a, a)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::device::Device;
+    use crate::field::FieldMap;
+    use crate::poisson::{solve, SolveOptions};
+
+    fn trace_fusor(n_particles: usize, max_passes: u32) -> Vec<TraceOutcome> {
+        let device = Device::classic_fusor(120.0, 40.0, 5, 1.0, -5_000.0);
+        let sol = solve(&device, 81, 161, &SolveOptions::default()).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let opts = TraceOptions {
+            max_passes,
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, opts);
+        tracer.launch_ensemble(DEUTERON, n_particles)
+    }
+
+    #[test]
+    fn ions_fall_inward_and_recirculate() {
+        let outcomes = trace_fusor(12, 8);
+        let total_passes: u32 = outcomes.iter().map(|o| o.core_passes).sum();
+        assert!(
+            total_passes >= 12,
+            "ions did not recirculate: {total_passes} total passes"
+        );
+        // Nobody should reach the wall in a well-formed fusor well.
+        let walls = outcomes.iter().filter(|o| o.fate == Fate::Wall).count();
+        assert!(walls <= 2, "too many wall deaths: {walls}/12");
+    }
+
+    #[test]
+    fn energy_is_approximately_conserved_far_from_wires() {
+        let outcomes = trace_fusor(6, 6);
+        for o in &outcomes {
+            assert!(
+                o.energy_drift_rel < 0.08,
+                "energy drift {:.3} too large (fate {:?}, passes {})",
+                o.energy_drift_rel,
+                o.fate,
+                o.core_passes
+            );
+        }
+    }
+
+    #[test]
+    fn wires_intercept_most_ions_in_a_classic_fusor() {
+        let outcomes = trace_fusor(16, 30);
+        let wires = outcomes
+            .iter()
+            .filter(|o| matches!(o.fate, Fate::Wire(_)))
+            .count();
+        assert!(
+            wires * 2 >= outcomes.len(),
+            "expected interception to dominate: {wires}/{}",
+            outcomes.len()
+        );
+    }
+}

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -58,6 +58,12 @@ pub struct TraceOutcome {
     pub energy_drift_rel: f64,
     /// cos θ of the launch direction (θ from +z), for post-hoc binning.
     pub launch_cos_theta: f64,
+    /// Path integral ∫ σ_DDn(E)·v dt over the whole trace, m³ — the
+    /// beam-on-background D(d,n)³He reaction volume. Multiply by target
+    /// deuteron density for expected neutrons per ion; zero for
+    /// non-deuteron species. Beam–beam and fast-neutral channels are not
+    /// modeled (M1 scope).
+    pub ddn_sigma_v_m3: f64,
 }
 
 /// Tracing options.
@@ -91,6 +97,7 @@ impl Default for TraceOptions {
 struct WireHit {
     r0: f64,
     z0: f64,
+    a: f64,
     a2: f64,
 }
 
@@ -129,6 +136,7 @@ impl<'a> Tracer<'a> {
                 WireHit {
                     r0: ring.ring_radius_mm * 1e-3,
                     z0: ring.z_mm * 1e-3,
+                    a,
                     a2: a * a,
                 }
             })
@@ -172,11 +180,29 @@ impl<'a> Tracer<'a> {
         let mut time = 0.0_f64;
         let mut steps = 0_u64;
         let mut drift = 0.0_f64;
+        let mut sigv = 0.0_f64;
         let launch_cos_theta = p[2] / sq_len(p).sqrt().max(1e-300);
+        let deuteron_like =
+            species.charge_c > 0.0 && (species.mass_kg / DEUTERON.mass_kg - 1.0).abs() < 0.01;
 
         'outer: while time < t_max && steps < MAX_STEPS {
             let speed = dot(v, v).sqrt();
-            let dt = self.opts.step_fraction * self.h / speed.max(0.05 * v_ref);
+            let mut dt = self.opts.step_fraction * self.h / speed.max(0.05 * v_ref);
+            // Refine the step near wires, where field gradients are the
+            // steepest thing in the problem (bounds the energy drift).
+            if !self.wires.is_empty() {
+                let r_now = (p[0] * p[0] + p[1] * p[1]).sqrt();
+                let mut factor = 1.0_f64;
+                for w in &self.wires {
+                    let drw = r_now - w.r0;
+                    let dzw = p[2] - w.z0;
+                    let ratio = ((drw * drw + dzw * dzw).sqrt() - w.a) / (6.0 * w.a);
+                    if ratio < factor {
+                        factor = ratio;
+                    }
+                }
+                dt *= factor.clamp(0.1, 1.0);
+            }
             let b = self.fields.b_cart(p);
             let bmag = dot(b, b).sqrt();
             let n_sub = ((qm.abs() * bmag * dt / 0.3).ceil() as u64).clamp(1, 64);
@@ -195,6 +221,16 @@ impl<'a> Tracer<'a> {
                 p = add(p, scale(v, dth));
                 time += dth;
                 steps += 1;
+
+                if deuteron_like {
+                    let v2 = dot(v, v);
+                    let e_lab_kev =
+                        0.5 * species.mass_kg * v2 / (crate::constants::ELEMENTARY_CHARGE * 1.0e3);
+                    let sig = crate::xsection::dd_n_sigma_m2(0.5 * e_lab_kev);
+                    if sig > 0.0 {
+                        sigv += sig * v2.sqrt() * dth;
+                    }
+                }
 
                 let r2 = p[0] * p[0] + p[1] * p[1];
                 if r2 > self.r_wall * self.r_wall || p[2].abs() > self.z_wall {
@@ -237,6 +273,7 @@ impl<'a> Tracer<'a> {
             steps,
             energy_drift_rel: drift,
             launch_cos_theta,
+            ddn_sigma_v_m3: sigv,
         }
     }
 
@@ -339,6 +376,31 @@ mod tests {
                 o.core_passes
             );
         }
+    }
+
+    #[test]
+    fn fusion_yield_rewards_voltage() {
+        // Same geometry, 6x the bias: the σ(E) integral must explode —
+        // this is why fusors chase voltage.
+        let yield_at = |volts: f64| {
+            let device = Device::classic_fusor(120.0, 40.0, 5, 1.0, volts);
+            let sol = solve(&device, 81, 161, &SolveOptions::default()).unwrap();
+            let fields = FieldMap::new(&device, &sol);
+            let opts = TraceOptions {
+                max_passes: 8,
+                ..TraceOptions::default()
+            };
+            let tracer = Tracer::new(&device, &fields, &sol, opts);
+            let outcomes = tracer.launch_ensemble(DEUTERON, 8);
+            outcomes.iter().map(|o| o.ddn_sigma_v_m3).sum::<f64>() / outcomes.len() as f64
+        };
+        let lo = yield_at(-5_000.0);
+        let hi = yield_at(-30_000.0);
+        assert!(hi > 0.0, "no yield at -30 kV");
+        assert!(
+            hi > 1.0e4 * lo.max(1e-60),
+            "yield must rise steeply with voltage: lo {lo:.3e}, hi {hi:.3e}"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/xsection.rs
+++ b/crates/vcad-kernel-particle/src/xsection.rs
@@ -1,0 +1,97 @@
+//! Fusion cross sections: the Bosch–Hale parameterization for the two D-D
+//! branches (Bosch & Hale 1992, Nucl. Fusion 32, 611).
+//!
+//! σ(E) = S(E) / (E · exp(B_G/√E)), with S a polynomial in the
+//! center-of-mass energy E (keV) and B_G the Gamow constant. Valid
+//! 0.5–4900 keV; below the validity floor this module returns 0 (the true
+//! value there is astronomically small).
+
+/// Gamow constant for D-D, √keV.
+const B_G_DD: f64 = 31.397;
+
+/// Millibarn → m².
+const MB_TO_M2: f64 = 1e-31;
+
+#[inline]
+fn bosch_hale_sigma_mb(e_cm_kev: f64, a: [f64; 5]) -> f64 {
+    if e_cm_kev < 0.5 {
+        return 0.0;
+    }
+    let e = e_cm_kev;
+    let s = a[0] + e * (a[1] + e * (a[2] + e * (a[3] + e * a[4])));
+    s / (e * (B_G_DD / e.sqrt()).exp())
+}
+
+/// D(d,n)³He cross section, m², at center-of-mass energy `e_cm_kev`.
+///
+/// This is the neutron branch (2.45 MeV neutrons) — the one a neutron
+/// counter sees.
+pub fn dd_n_sigma_m2(e_cm_kev: f64) -> f64 {
+    bosch_hale_sigma_mb(
+        e_cm_kev,
+        [5.3701e4, 3.3027e2, -1.2706e-1, 2.9327e-5, -2.5151e-9],
+    ) * MB_TO_M2
+}
+
+/// D(d,p)T cross section, m², at center-of-mass energy `e_cm_kev`.
+pub fn dd_p_sigma_m2(e_cm_kev: f64) -> f64 {
+    bosch_hale_sigma_mb(
+        e_cm_kev,
+        [5.5576e4, 2.1054e2, -3.2638e-2, 1.4987e-6, 1.8181e-10],
+    ) * MB_TO_M2
+}
+
+/// Deuteron number density of D₂ gas at `pressure_mtorr` and
+/// `temperature_k`, m⁻³ (two deuterons per molecule).
+pub fn d2_deuteron_density_m3(pressure_mtorr: f64, temperature_k: f64) -> f64 {
+    let pa = pressure_mtorr * 0.133_322;
+    2.0 * pa / (1.380_649e-23 * temperature_k)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_published_anchor_values() {
+        // σ_DDn at E_cm = 50 keV (E_lab = 100 keV) ≈ 16.5 mb.
+        let s50 = dd_n_sigma_m2(50.0) / MB_TO_M2;
+        assert!((14.0..19.0).contains(&s50), "sigma_ddn(50 keV) = {s50} mb");
+        // σ_DDn at E_cm = 15 keV ≈ 1.2 mb.
+        let s15 = dd_n_sigma_m2(15.0) / MB_TO_M2;
+        assert!((0.9..1.5).contains(&s15), "sigma_ddn(15 keV) = {s15} mb");
+        // Both branches are within ~2x of each other at fusor energies.
+        let p50 = dd_p_sigma_m2(50.0) / MB_TO_M2;
+        assert!(
+            (0.5..2.0).contains(&(p50 / s50)),
+            "branch ratio off: n {s50} mb vs p {p50} mb"
+        );
+    }
+
+    #[test]
+    fn rises_steeply_through_fusor_energies() {
+        let mut last = 0.0;
+        for e in [1.0, 5.0, 15.0, 30.0, 60.0, 120.0, 250.0] {
+            let s = dd_n_sigma_m2(e);
+            assert!(s > last, "sigma must rise with energy at {e} keV");
+            last = s;
+        }
+        // The steepness that makes voltage worth chasing: 15 → 30 keV CM
+        // buys more than 4x.
+        assert!(dd_n_sigma_m2(30.0) / dd_n_sigma_m2(15.0) > 4.0);
+    }
+
+    #[test]
+    fn below_validity_floor_is_zero() {
+        assert_eq!(dd_n_sigma_m2(0.3), 0.0);
+        assert_eq!(dd_p_sigma_m2(0.0), 0.0);
+        assert_eq!(dd_n_sigma_m2(-5.0), 0.0);
+    }
+
+    #[test]
+    fn gas_density_is_physical() {
+        // 1 mTorr D₂ at 300 K ≈ 3.2e19 molecules/m³ → 6.4e19 deuterons/m³.
+        let n = d2_deuteron_density_m3(1.0, 300.0);
+        assert!((6.0e19..7.0e19).contains(&n), "n = {n}");
+    }
+}

--- a/crates/vcad-kernel-particle/tests/analytic.rs
+++ b/crates/vcad-kernel-particle/tests/analytic.rs
@@ -1,0 +1,126 @@
+//! Analytic physics benchmarks: the tracer against closed-form plasma
+//! physics, end-to-end through the public API.
+
+use vcad_kernel_particle::device::{Device, WireRing};
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{Fate, TraceOptions, Tracer, DEUTERON};
+
+/// A magnetic bottle: two coaxial coils with the SAME current sign
+/// (mirror, not cusp), grounded electrodes (a tiny bias only sets the
+/// tracer's internal velocity scale).
+fn magnetic_bottle(amp_turns: f64) -> Device {
+    let ring = |z: f64| WireRing {
+        ring_radius_mm: 40.0,
+        z_mm: z,
+        wire_radius_mm: 3.0,
+        potential_v: -1.0,
+        ampere_turns: amp_turns,
+    };
+    Device {
+        chamber_radius_mm: 150.0,
+        chamber_half_height_mm: 150.0,
+        wall_potential_v: 0.0,
+        rings: vec![ring(60.0), ring(-60.0)],
+    }
+}
+
+/// The mirror criterion: particles inside the loss cone
+/// (sin²α < B₀/B_max) stream out the ends; particles outside it are
+/// reflected and stay confined.
+#[test]
+fn magnetic_mirror_confines_by_pitch_angle() {
+    let device = magnetic_bottle(150_000.0);
+    let sol = solve(&device, 61, 121, &SolveOptions::default()).unwrap();
+    let fields = FieldMap::new(&device, &sol);
+    // Mirror ratio for this geometry is ~3 (loss cone α ≲ 35°).
+    let opts = TraceOptions {
+        max_passes: 50,
+        time_budget_factor: 0.0023,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, opts);
+
+    // ~1 keV deuteron: r_L ≈ 7 mm at the 0.8 T center field — safely
+    // adiabatic against the ~40 mm field scale (a faster ion here is
+    // genuinely non-adiabatic and punches through the throat).
+    let speed = 3.1e5;
+    let launch = |pitch_deg: f64| {
+        let a = pitch_deg.to_radians();
+        tracer.trace_from(
+            DEUTERON,
+            [0.0, 0.0, 0.0],
+            [speed * a.sin(), 0.0, speed * a.cos()],
+        )
+    };
+
+    // 10 degrees: deep inside the loss cone -> escapes out the end cap.
+    let escaping = launch(10.0);
+    assert_eq!(
+        escaping.fate,
+        Fate::Wall,
+        "shallow pitch must escape the bottle: {escaping:?}"
+    );
+
+    // 60 degrees: well outside the loss cone -> reflected, still alive at
+    // the full budget.
+    let confined = launch(60.0);
+    assert_eq!(
+        confined.fate,
+        Fate::Survived,
+        "steep pitch must be mirror-confined: {confined:?}"
+    );
+    assert!(
+        confined.time_s > 5.0 * escaping.time_s,
+        "confined particle should outlive the escaping one by far: {} vs {}",
+        confined.time_s,
+        escaping.time_s
+    );
+}
+
+/// Small-amplitude axial oscillation in the two-ring potential well: the
+/// traced period must match 2π/ω with ω² = q·∂²φ/∂z²/m measured from the
+/// solved potential itself.
+#[test]
+fn axial_oscillation_period_matches_the_well_curvature() {
+    let device = Device::shielded_two_ring(100.0, 40.0, 20.0, 3.0, -2_000.0, 0.0);
+    let sol = solve(&device, 81, 161, &SolveOptions::default()).unwrap();
+    let fields = FieldMap::new(&device, &sol);
+    // Period is measured over the first 4 periods (8 core entries): long
+    // traces slowly leak oscillation amplitude below the core boundary
+    // (cell-crossing kicks in the piecewise field pump the orbit — a
+    // measured Boris-on-patches artifact, ~single-percent per period),
+    // which starves the pass counter, not the physics under test.
+    let max_passes = 8;
+    let opts = TraceOptions {
+        max_passes,
+        // Generous budget so the run censors at the pass cap (exactly on
+        // a core entry), giving a clean period estimate.
+        time_budget_factor: 60.0,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, opts);
+
+    // From rest on the axis, above the core boundary (~15.7 mm) so pass
+    // counting sees two core entries per period.
+    let z0 = 0.022;
+    let out = tracer.trace_from(DEUTERON, [0.0, 0.0, z0], [0.0, 0.0, 0.0]);
+    assert_eq!(out.fate, Fate::Survived, "oscillator must not terminate");
+    assert_eq!(out.core_passes, max_passes, "expected censoring at the cap");
+    let period_traced = 2.0 * out.time_s / f64::from(out.core_passes);
+
+    // Curvature of the well at the origin, from the same solution.
+    let h = 0.004;
+    let phi = |z: f64| sol.potential_at(0.0, z);
+    let curv = (phi(h) - 2.0 * phi(0.0) + phi(-h)) / (h * h);
+    assert!(curv > 0.0, "well must be restoring for positive ions");
+    let omega = (DEUTERON.charge_c * curv / DEUTERON.mass_kg).sqrt();
+    let period_harmonic = 2.0 * std::f64::consts::PI / omega;
+
+    let rel = (period_traced - period_harmonic).abs() / period_harmonic;
+    assert!(
+        rel < 0.2,
+        "period mismatch: traced {period_traced:.4e}, harmonic {period_harmonic:.4e} (rel {rel:.3}) — \
+         anharmonicity allows some slack, not this much"
+    );
+}

--- a/crates/vcad-kernel-particle/tests/shielding.rs
+++ b/crates/vcad-kernel-particle/tests/shielding.rs
@@ -1,0 +1,48 @@
+//! M0 headline physics: magnetic self-shielding of a two-ring cathode.
+//!
+//! The claim under test (Hedditch/Bowden-Reid/Khachan 2015, qualitatively):
+//! running current through the cathode rings wraps them in a magnetic
+//! sheath that deflects incoming ions, so wire interception falls and
+//! recirculation rises relative to the zero-current control at identical
+//! geometry and bias.
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::stats;
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+
+fn run(ampere_turns: f64) -> vcad_kernel_particle::fom::EnsembleStats {
+    // Low bias keeps ions slow (easy to deflect) so the effect is decisive
+    // at test-friendly grid resolution and particle counts.
+    let device = Device::shielded_two_ring(120.0, 40.0, 22.0, 4.0, -500.0, ampere_turns);
+    let sol = solve(&device, 81, 161, &SolveOptions::default()).expect("poisson");
+    let fields = FieldMap::new(&device, &sol);
+    let opts = TraceOptions {
+        max_passes: 15,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, opts);
+    let outcomes = tracer.launch_ensemble(DEUTERON, 24);
+    stats(&outcomes)
+}
+
+#[test]
+fn shield_current_cuts_interception_and_boosts_recirculation() {
+    let control = run(0.0);
+    let shielded = run(40_000.0);
+
+    // The control must actually exercise the loss channel.
+    assert!(
+        control.interception_fraction > 0.3,
+        "control fusor barely intercepts: {control:?}"
+    );
+    assert!(
+        shielded.interception_fraction < control.interception_fraction,
+        "shielding did not reduce interception: control {control:?}, shielded {shielded:?}"
+    );
+    assert!(
+        shielded.mean_passes > control.mean_passes,
+        "shielding did not improve recirculation: control {control:?}, shielded {shielded:?}"
+    );
+}

--- a/crates/vcad-kernel-wasm/Cargo.toml
+++ b/crates/vcad-kernel-wasm/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 vcad-kernel = { workspace = true }
+vcad-receipt = { workspace = true }
 vcad-kernel-drafting = { workspace = true }
 vcad-kernel-sheet = { workspace = true }
 vcad-kernel-tessellate = { workspace = true }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -7267,3 +7267,286 @@ fn kernel_blend_args(
     };
     (q, keys)
 }
+
+// ---------------------------------------------------------------------------
+// Charged-particle optics (vcad-kernel-particle)
+// ---------------------------------------------------------------------------
+
+/// Options for [`particle_simulate`] (all fields optional in JSON).
+#[derive(serde::Deserialize)]
+#[serde(default)]
+struct ParticleSimOptions {
+    nr: usize,
+    nz: usize,
+    particles: usize,
+    max_passes: u32,
+    ion_current_a: f64,
+    d2_pressure_mtorr: f64,
+    temperature_k: f64,
+    /// Enable charge-exchange channels with this cross section, m²
+    /// (order 1e-19 for D⁺ on D₂ in the keV band).
+    cx_sigma_m2: Option<f64>,
+}
+
+impl Default for ParticleSimOptions {
+    fn default() -> Self {
+        Self {
+            nr: 101,
+            nz: 201,
+            particles: 64,
+            max_passes: 25,
+            ion_current_a: 0.010,
+            d2_pressure_mtorr: 2.0,
+            temperature_k: 300.0,
+            cx_sigma_m2: None,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct WasmParticleSim {
+    stats: vcad_kernel::vcad_kernel_particle::fom::EnsembleStats,
+    claim_set: vcad_kernel::vcad_kernel_particle::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+    geometric_transparency: f64,
+}
+
+/// Charged-particle optics simulation: solve the device's fields, trace a
+/// deuteron ensemble, and return figures of merit plus predicted claims.
+///
+/// `spec_json` is a `vcad_kernel_particle::spec::DeviceSpec` (named
+/// parameters allowed), `params_json` a `{name: value}` map binding them
+/// (fail-closed: unbound names error), `options_json` a
+/// [`ParticleSimOptions`]. Returns stats + `vcad.particle-claims/1` set +
+/// unified-receipt claims (basis `predicted` — Provisional by contract).
+#[wasm_bindgen(js_name = particleSimulate)]
+pub fn particle_simulate(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_particle as pk;
+    let spec: pk::spec::DeviceSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: ParticleSimOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    let device = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let sopts = pk::poisson::SolveOptions::default();
+    let sol = pk::poisson::solve(&device, opts.nr, opts.nz, &sopts)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let fields = pk::field::FieldMap::new(&device, &sol);
+    let mut topts = pk::trace::TraceOptions {
+        max_passes: opts.max_passes,
+        ..Default::default()
+    };
+    if let Some(sigma) = opts.cx_sigma_m2 {
+        topts.cx = Some(pk::trace::CxModel {
+            sigma_cx_m2: sigma,
+            background_deuteron_density_m3: pk::xsection::d2_deuteron_density_m3(
+                opts.d2_pressure_mtorr,
+                opts.temperature_k,
+            ),
+        });
+    }
+    let tracer = pk::trace::Tracer::new(&device, &fields, &sol, topts);
+    let stats = pk::fom::stats(&tracer.launch_ensemble(pk::trace::DEUTERON, opts.particles));
+    let op = pk::receipt::OperatingPoint {
+        ion_current_a: opts.ion_current_a,
+        d2_pressure_mtorr: opts.d2_pressure_mtorr,
+        temperature_k: opts.temperature_k,
+    };
+    let claim_set = pk::receipt::predicted_claims(
+        &stats,
+        &sol,
+        &topts,
+        sopts.tol,
+        device.max_potential_drop_v(),
+        &op,
+    );
+    let receipt_claims = pk::receipt::design_claims(&claim_set);
+    let out = WasmParticleSim {
+        stats,
+        claim_set,
+        receipt_claims,
+        geometric_transparency: pk::fom::geometric_transparency(&device),
+    };
+    // json_compatible: maps serialize as plain objects (a JS `Map` would
+    // vanish under JSON.stringify on the TS side).
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[derive(serde::Deserialize)]
+struct ParticleOptVariable {
+    name: String,
+    lo: f64,
+    hi: f64,
+    #[serde(default)]
+    start: Option<f64>,
+}
+
+#[derive(serde::Deserialize)]
+struct ParticleOptOptions {
+    variables: Vec<ParticleOptVariable>,
+    #[serde(default = "particle_opt_nr")]
+    nr: usize,
+    #[serde(default = "particle_opt_nz")]
+    nz: usize,
+    #[serde(default = "particle_opt_particles")]
+    particles: usize,
+    #[serde(default = "particle_opt_passes")]
+    max_passes: u32,
+    #[serde(default = "particle_opt_iters")]
+    max_iters: usize,
+    #[serde(default = "particle_opt_multi")]
+    multi_start: bool,
+}
+
+fn particle_opt_nr() -> usize {
+    81
+}
+fn particle_opt_nz() -> usize {
+    161
+}
+fn particle_opt_particles() -> usize {
+    48
+}
+fn particle_opt_passes() -> u32 {
+    20
+}
+fn particle_opt_iters() -> usize {
+    8
+}
+fn particle_opt_multi() -> bool {
+    true
+}
+
+#[derive(serde::Serialize)]
+struct WasmParticleOptStart {
+    params: std::collections::BTreeMap<String, f64>,
+    value: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmParticleOpt {
+    best_params: std::collections::BTreeMap<String, f64>,
+    best_sigma_v_m3: f64,
+    evals: usize,
+    history: Vec<f64>,
+    starts: Vec<WasmParticleOptStart>,
+}
+
+/// Optimize named device parameters against predicted D-D yield per ion.
+///
+/// `optimize_json`: `{ variables: [{name, lo, hi, start?}], nr?, nz?,
+/// particles?, max_passes?, max_iters?, multi_start? }`. Multi-start FD
+/// ascent (the yield landscape is multimodal — see
+/// `docs/particle-optics-m0.md`); candidate configurations that fail to
+/// resolve or converge score 0 instead of aborting the search.
+#[wasm_bindgen(js_name = particleOptimize)]
+pub fn particle_optimize(
+    spec_json: &str,
+    params_json: &str,
+    optimize_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_particle as pk;
+    let spec: pk::spec::DeviceSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let base: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let oopts: ParticleOptOptions = serde_json::from_str(optimize_json)
+        .map_err(|e| JsError::new(&format!("bad optimize options: {e}")))?;
+    if oopts.variables.is_empty() {
+        return Err(JsError::new("optimize requires at least one variable"));
+    }
+
+    let lo: Vec<f64> = oopts.variables.iter().map(|v| v.lo).collect();
+    let hi: Vec<f64> = oopts.variables.iter().map(|v| v.hi).collect();
+    let names: Vec<String> = oopts.variables.iter().map(|v| v.name.clone()).collect();
+
+    let mut evals_total = 0usize;
+    let mut objective = |x: &[f64]| -> f64 {
+        let mut p = base.clone();
+        for (name, value) in names.iter().zip(x) {
+            p.insert(name.clone(), *value);
+        }
+        evals_total += 1;
+        let Ok(device) = spec.resolve(&p) else {
+            return 0.0;
+        };
+        let Ok(sol) = pk::poisson::solve(
+            &device,
+            oopts.nr,
+            oopts.nz,
+            &pk::poisson::SolveOptions::default(),
+        ) else {
+            return 0.0;
+        };
+        let fields = pk::field::FieldMap::new(&device, &sol);
+        let topts = pk::trace::TraceOptions {
+            max_passes: oopts.max_passes,
+            ..Default::default()
+        };
+        let tracer = pk::trace::Tracer::new(&device, &fields, &sol, topts);
+        pk::fom::stats(&tracer.launch_ensemble(pk::trace::DEUTERON, oopts.particles))
+            .mean_ddn_sigma_v_m3
+    };
+
+    let seed_fractions: Vec<f64> = if oopts.multi_start {
+        vec![0.2, 0.5, 0.8]
+    } else {
+        vec![0.5]
+    };
+    let explicit: Option<Vec<f64>> = oopts
+        .variables
+        .iter()
+        .map(|v| v.start)
+        .collect::<Option<Vec<f64>>>();
+
+    let fd = pk::optimize::FdOptions {
+        max_iters: oopts.max_iters,
+        ..pk::optimize::FdOptions::default()
+    };
+    let mut best: Option<pk::optimize::FdResult> = None;
+    let mut starts = Vec::new();
+    for (k, f) in seed_fractions.iter().enumerate() {
+        let x0: Vec<f64> = if k == 0 && explicit.is_some() {
+            explicit.clone().unwrap()
+        } else {
+            lo.iter().zip(&hi).map(|(a, b)| a + f * (b - a)).collect()
+        };
+        let r = pk::optimize::maximize(&mut objective, &x0, &lo, &hi, &fd);
+        starts.push(WasmParticleOptStart {
+            params: names.iter().cloned().zip(r.x.iter().copied()).collect(),
+            value: r.value,
+        });
+        let better = best.as_ref().map(|b| r.value > b.value).unwrap_or(true);
+        if better {
+            best = Some(r);
+        }
+    }
+    let best = best.expect("at least one start");
+    let out = WasmParticleOpt {
+        best_params: names.iter().cloned().zip(best.x.iter().copied()).collect(),
+        best_sigma_v_m3: best.value,
+        evals: evals_total,
+        history: best.history,
+        starts,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -26,6 +26,7 @@ vcad-kernel-dfm = { workspace = true }
 vcad-kernel-cam = { workspace = true }
 vcad-kernel-stocksim = { workspace = true }
 vcad-kernel-topopt = { workspace = true }
+vcad-kernel-particle = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -25,6 +25,7 @@ pub use vcad_kernel_dfm;
 pub use vcad_kernel_fillet;
 pub use vcad_kernel_geom;
 pub use vcad_kernel_math;
+pub use vcad_kernel_particle;
 pub use vcad_kernel_primitives;
 pub use vcad_kernel_sheet;
 pub use vcad_kernel_shell;

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -166,12 +166,27 @@ ensembles on a 101×201 mesh. Findings:
   pressure-independent (each ion fuses over ~one CX mean free path of
   track regardless of density) — voltage and current set the rate, which
   matches fusor lore.
-- **M2 — discrete adjoint.** Reverse-mode differentiation of the Boris loop
-  (checkpointed; Boris is symplectic and its reverse pass is clean) and of
-  the bilinear field sampler; adjoint of SOR via the adjoint Poisson solve
-  (self-adjoint operator — one extra solve per objective). Replaces
-  `optimize::maximize`'s FD gradient behind the same API; wires into the
-  existing `vcad-kernel-diff` L-BFGS.
+- **M2 — discrete adjoint. DONE** (`adjoint::yield_gradient`). Reverse-mode
+  gradient of the ensemble yield w.r.t. every ring potential, the wall
+  potential, and every coil's ampere-turns: backprop through the Boris
+  loop (fixed-step self-consistent forward, full trajectory storage),
+  PIC-style adjoint deposits into the potential grid through the exact
+  bilinear-patch weights, then one **adjoint Poisson solve** using the
+  radial-weight symmetrization of the axisymmetric operator (`w_i = r_i`,
+  axis row `Δr/8` — the adjoint system reuses the forward SOR stencil with
+  a RHS). Coil gradients via ⟨λ_B, B(I=1)⟩ (loop field linear in current).
+  FD-validated end-to-end: dJ/dI to 0.1%, dJ/dV to 0.8%, plus a gauge test
+  (Σ over all conductors of dJ/dV ≈ 0, since only potential differences
+  matter). Two validation lessons preserved in the tests: (1) freeze the
+  time discretization against a reference drop when comparing across
+  parameter perturbations, or the integration window becomes a hidden
+  parameter; (2) J is genuinely rough on long horizons (cusp-lens chaos) —
+  FD at practical h under-reads by 3–4× there, which is precisely the
+  regime where the adjoint is the only trustworthy gradient.
+  `optimize::maximize_with_gradient` consumes it (same line search, no FD
+  probes). Shape parameters (ring position/radius) remain FD/hybrid — the
+  Dirichlet mask is discrete; smooth shape adjoints are the M3+ seam
+  (boundary-value differentiation on a frozen mask).
 - **M3 — geometry seam.** Electrode cross-sections from vcad sketches /
   revolved BRep sections instead of hand-parameterized rings; parameters
   become named `.vcad` document parameters (same contract as

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -211,11 +211,18 @@ ensembles on a 101×201 mesh. Findings:
   unique), and expose `simulate_charged_particles` /
   `optimize_electrodes` MCP tools — cross-crate schema + TS codegen +
   fixture regen, deliberately not done from this worktree.
-- **M5 — validation against the incumbent.** SIMION cross-checks on
-  published einzel/trap geometries; convergence study; the arXiv writeup:
-  *gradient-based electrode shape optimization for electrostatic
-  confinement devices*, with the shielded-grid sweep as the flagship
-  result.
+- **M5 — analytic benchmarks + convergence + paper draft. DONE (except
+  the external SIMION runs).** `tests/analytic.rs`: magnetic-mirror loss
+  cone honored end-to-end (with the instructive non-adiabatic failure mode
+  when r_L approaches the field scale), axial oscillation period vs the
+  solved well curvature (±20%, anharmonicity-limited; long traces expose a
+  slow amplitude leak from cell-crossing kicks — measured, commented, and
+  a future symplectic-refinement item). `examples/convergence.rs`: the
+  interception FoM tracks the 0.75·h mask floor until h ≲ wire radius —
+  thin-wire absolute yields are trends until then; 3 mm-wire headline
+  sweeps are inside the converged regime. Paper draft with all current
+  numbers: `docs/particle-optics-paper-draft.md`. SIMION cross-validation
+  needs SIMION — external, flagged.
 - **M6 — experiment pack.** The shielded-grid experiment BOM (chamber,
   feedthrough, pulsed ring supply, cathode ammeter), predicted-vs-measured
   receipt schema: the sim predicts the ammeter curve, the bench measures

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -1,0 +1,144 @@
+# Charged-particle optics M0: vacuum fields, Boris tracing, electrode figures of merit
+
+`vcad-kernel-particle` makes vcad a design tool for the electrode-geometry
+family of devices: fusors and magnetically shielded IEC machines, ion traps,
+ion-thruster grids, mass-spec optics, electron guns, X-ray tubes, ion
+implanters. All of them reduce to the same loop —
+
+> electrode geometry → fields → charged-particle trajectories → figure of merit
+
+— and the incumbent tool for that loop (SIMION lineage) is decades old,
+non-differentiable, and disconnected from CAD/fabrication. This crate is the
+M0 of a differentiable, receipt-native replacement that lives inside the
+kernel next to the geometry it scores.
+
+## M0 scope (and honesty)
+
+**In scope:** vacuum-field single-particle optics.
+
+- Axisymmetric electrostatics: finite-difference Laplace on the (r, z)
+  chamber cross-section, SOR with the Chebyshev-estimate relaxation factor,
+  Dirichlet electrodes (wire rings + grounded chamber), symmetry stencil on
+  the axis. No space charge.
+- Magnetics: exact off-axis field of circular current loops via complete
+  elliptic integrals (AGM), superposed per ring; linear regularization
+  inside the conductor.
+- Tracing: Boris pusher (the plasma-standard geometric integrator), adaptive
+  step from grid spacing and speed, automatic substepping where gyration is
+  fast, termination on wire/wall impact, core-pass counting, per-trace
+  energy-drift diagnostic.
+- Figures of merit: interception fraction (the cathode ammeter),
+  mean core passes (recirculation), effective transparency, wall losses,
+  plus thin-wire geometric transparency as the no-optics reference.
+- Optimization: box-constrained finite-difference gradient ascent
+  (`optimize::maximize`) — the M0 stand-in for the adjoint, deliberately
+  API-shaped so the adjoint can replace the gradient without changing
+  callers.
+
+**Out of scope at M0** (each is a milestone below): space charge,
+collisions/charge exchange with neutrals, fusion-rate weighting along
+trajectories, non-axisymmetric electrodes, the discrete adjoint.
+
+**Regime of validity:** low-current, low-pressure devices where geometry
+dominates — exactly the regime of electrode design tools. Do not read
+plasma-physics conclusions (thermalization, virtual cathodes, space-charge
+limits) out of these traces.
+
+## Validation ladder (all in `cargo test -p vcad-kernel-particle`)
+
+- Elliptic integrals against Abramowitz & Stegun values.
+- Loop field against the textbook on-axis formula; odd/even midplane
+  symmetry; finite and continuous through the conductor surface.
+- Poisson: maximum principle, axis symmetry, grid-refinement consistency,
+  well depth.
+- Tracing: ions launched at rest fall inward and recirculate; energy
+  conservation in the far field; wires dominate the fate table in a classic
+  fusor.
+- Headline integration test (`tests/shielding.rs`): at fixed geometry and
+  bias, cathode ring current **reduces interception and increases
+  recirculation** — the magnetically-shielded-grid effect
+  (Hedditch/Bowden-Reid/Khachan 2015, arXiv:1510.01788), reproduced from
+  first principles.
+
+## M0 benchmark: the simulated ammeter
+
+`cargo run --release -p vcad-kernel-particle --example fusor_baseline`
+
+96 deuterons/config launched at rest from an 85% shell, 40-pass cap,
+121×241 grid. Classic 5-ring fusor control: 9.65 mean passes, 100% eventual
+wire interception, effective transparency 0.906 vs 0.925 geometric — the
+lensing penalty, visible in a simulation for the first time in this repo.
+
+Two-ring shielded cathode (45 mm rings at z = ±25 mm, 3 mm wire, opposed
+currents), interception fraction vs ampere-turns:
+
+| A·turns | −3 kV bias | −30 kV bias |
+|---:|---:|---:|
+| 0 | 1.000 | 1.000 |
+| 5 k | 1.000 | 1.000 |
+| 10 k | 0.958 | 1.000 |
+| 20 k | 0.792 | 1.000 |
+| 40 k | 0.365 | 0.854 |
+| 80 k | 0.260 | 0.688 |
+| 160 k | 0.073 | 0.406 |
+
+Findings the sweep hands us for free:
+
+1. **Shielding works and is enormous** — interception falls 100% → 7% at
+   −3 kV / 160 kA·t; recirculation peaks at ~21 mean passes (5× the
+   unshielded cathode).
+2. **The √V law falls out.** The −30 kV curve is the −3 kV curve shifted
+   ~3–4× right in current, matching r_L ∝ √V. Commissioning a real device
+   at low voltage with pulsed copper, then climbing, is quantitatively
+   supported.
+3. **There is an optimal shield current.** Past it, mean passes *falls*
+   while interception keeps dropping: the cusp begins reflecting ions away
+   from the core itself (magnetic aperture). Shield strength trades
+   transparency against core access — a real, non-obvious optimization
+   target for the gradient loop. (Note: the 40-pass censor also biases the
+   high-current mean down; both effects are real, disentangling them is an
+   M1 diagnostic task.)
+
+Known M0 limitation: worst-case per-trace energy drift reaches ~0.5·qΔV for
+the extreme long-lived trajectories that repeatedly graze wire masks at high
+B — the interpolated E field near a masked wire is under-resolved. Mean
+behavior is unaffected (drift is diagnosed per trace, and the classic-fusor
+acceptance test holds it < 8%), but M1 should add local grid refinement or
+an analytic near-wire E model before quantitative loss budgets are claimed.
+
+## Milestone ladder
+
+- **M1 — near-field fidelity + loss budget.** Mask-aware near-wire E
+  (analytic wire-in-external-field patch or local refinement), censoring
+  diagnostics, fusion-rate weighting along trajectories (beam–background
+  σ(E) integral) so runs report relative fusion yield, not just passes.
+- **M2 — discrete adjoint.** Reverse-mode differentiation of the Boris loop
+  (checkpointed; Boris is symplectic and its reverse pass is clean) and of
+  the bilinear field sampler; adjoint of SOR via the adjoint Poisson solve
+  (self-adjoint operator — one extra solve per objective). Replaces
+  `optimize::maximize`'s FD gradient behind the same API; wires into the
+  existing `vcad-kernel-diff` L-BFGS.
+- **M3 — geometry seam.** Electrode cross-sections from vcad sketches /
+  revolved BRep sections instead of hand-parameterized rings; parameters
+  become named `.vcad` document parameters (same contract as
+  `document_parameter_gradient`).
+- **M4 — receipts + MCP.** `simulate_charged_particles` /
+  `optimize_electrodes` tools; claims land in the DesignReceipt as a new
+  claim family (interception fraction, recirculation, transparency, with
+  solver provenance: grid, tolerances, ensemble size, censoring). This is
+  also where `distance_to_lawson` gets its trajectory-level inputs.
+- **M5 — validation against the incumbent.** SIMION cross-checks on
+  published einzel/trap geometries; convergence study; the arXiv writeup:
+  *gradient-based electrode shape optimization for electrostatic
+  confinement devices*, with the shielded-grid sweep as the flagship
+  result.
+- **M6 — experiment pack.** The shielded-grid experiment BOM (chamber,
+  feedthrough, pulsed ring supply, cathode ammeter), predicted-vs-measured
+  receipt schema: the sim predicts the ammeter curve, the bench measures
+  it, the receipt binds them.
+
+## Non-goals
+
+This crate does not claim a path to net energy gain. It quantifies,
+per-geometry, the loss channels that electrode design can and cannot
+close — and at M4 it will say so on a receipt.

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -196,11 +196,21 @@ ensembles on a 101×201 mesh. Findings:
   tests. BRep extraction (revolved sketch sections → `RingSpec`s) lands on
   the vcad side of the seam, emitting this schema — same division of labor
   as `document_parameter_gradient`.
-- **M4 — receipts + MCP.** `simulate_charged_particles` /
-  `optimize_electrodes` tools; claims land in the DesignReceipt as a new
-  claim family (interception fraction, recirculation, transparency, with
-  solver provenance: grid, tolerances, ensemble size, censoring). This is
-  also where `distance_to_lawson` gets its trajectory-level inputs.
+- **M4 — receipt claims. DONE (kernel side)** (`receipt::predicted_claims`).
+  Serializable claim set (`vcad.particle-claims/1`): interception,
+  recirculation, transparency, neutron rate, fusion power (both D-D
+  branches — the trace now integrates D(d,p)T alongside D(d,n)³He), input
+  power, `q_estimate`, and **`distance_to_lawson` = log10(1/Q)** — with
+  full provenance (grid, SOR tolerance + sweeps, ensemble, censoring,
+  physics channels included) and spelled-out caveats on every claim.
+  Fail-closed: a no-fusion device reads 99 orders, never a divide-by-zero
+  or a silent omission. The classic fusor's card: Q = 4.1×10⁻¹⁰, distance
+  9.39 orders — "microwatts, fully audited," now machine-readable.
+  **Follow-up PR (flagged, not started):** register the family in
+  `crates/vcad-receipt` (`ir:gen` exports two crates; names must be
+  unique), and expose `simulate_charged_particles` /
+  `optimize_electrodes` MCP tools — cross-crate schema + TS codegen +
+  fixture regen, deliberately not done from this worktree.
 - **M5 — validation against the incumbent.** SIMION cross-checks on
   published einzel/trap geometries; convergence study; the arXiv writeup:
   *gradient-based electrode shape optimization for electrostatic

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -223,10 +223,16 @@ ensembles on a 101×201 mesh. Findings:
   sweeps are inside the converged regime. Paper draft with all current
   numbers: `docs/particle-optics-paper-draft.md`. SIMION cross-validation
   needs SIMION — external, flagged.
-- **M6 — experiment pack.** The shielded-grid experiment BOM (chamber,
-  feedthrough, pulsed ring supply, cathode ammeter), predicted-vs-measured
-  receipt schema: the sim predicts the ammeter curve, the bench measures
-  it, the receipt binds them.
+- **M6 — experiment pack. DONE.** `docs/shielded-grid-experiment.md`:
+  full COTS BOM (~$10–25k, Phase A alone $2–5k), the floating-pulser
+  isolation problem named as the hard engineering item, staged
+  commissioning bound to the simulated curves (Phase A: the −3 kV ammeter
+  curve with a kA·t pulser and no neutron gear; Phase B: neutrons at
+  −30…−40 kV), and the safety envelope. `receipt::compare` binds bench
+  measurements to predicted claims with Holds / Violated / Unmeasured
+  verdicts — fail-closed: an unmeasured receipt never passes, a
+  measurement matching no claim is an error, and Violated is treated as a
+  publishable result about the model.
 
 ## Non-goals
 

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -187,10 +187,15 @@ ensembles on a 101×201 mesh. Findings:
   probes). Shape parameters (ring position/radius) remain FD/hybrid — the
   Dirichlet mask is discrete; smooth shape adjoints are the M3+ seam
   (boundary-value differentiation on a frozen mask).
-- **M3 — geometry seam.** Electrode cross-sections from vcad sketches /
-  revolved BRep sections instead of hand-parameterized rings; parameters
-  become named `.vcad` document parameters (same contract as
-  `document_parameter_gradient`).
+- **M3 — parameter seam. DONE** (`spec::DeviceSpec`). Serde schema in
+  which every numeric field is a literal **or a named document parameter**;
+  fail-closed resolution (unbound name = error, never a default);
+  `parameter_roles()` classifies each name by gradient path (potentials +
+  ampere-turns → adjoint; geometry → FD, since it moves the discrete
+  Dirichlet mask). JSON round-trip, fail-closed, and role-classification
+  tests. BRep extraction (revolved sketch sections → `RingSpec`s) lands on
+  the vcad side of the seam, emitting this schema — same division of labor
+  as `document_parameter_gradient`.
 - **M4 — receipts + MCP.** `simulate_charged_particles` /
   `optimize_electrodes` tools; claims land in the DesignReceipt as a new
   claim family (interception fraction, recirculation, transparency, with

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -1,4 +1,4 @@
-# Charged-particle optics M0: vacuum fields, Boris tracing, electrode figures of merit
+# Charged-particle optics M0–M1: vacuum fields, Boris tracing, fusion-yield figures of merit
 
 `vcad-kernel-particle` makes vcad a design tool for the electrode-geometry
 family of devices: fusors and magnetically shielded IEC machines, ion traps,
@@ -60,58 +60,101 @@ limits) out of these traces.
   (Hedditch/Bowden-Reid/Khachan 2015, arXiv:1510.01788), reproduced from
   first principles.
 
-## M0 benchmark: the simulated ammeter
+## Benchmark: the simulated ammeter and neutron counter
 
 `cargo run --release -p vcad-kernel-particle --example fusor_baseline`
 
 96 deuterons/config launched at rest from an 85% shell, 40-pass cap,
-121×241 grid. Classic 5-ring fusor control: 9.65 mean passes, 100% eventual
-wire interception, effective transparency 0.906 vs 0.925 geometric — the
-lensing penalty, visible in a simulation for the first time in this repo.
+121×241 grid, conservative field sampler (see below). Classic 5-ring fusor
+control at −30 kV: 9.45 mean passes, 100% eventual wire interception,
+effective transparency 0.904 vs 0.925 geometric (the lensing penalty), and
+a **predicted beam-on-background neutron rate of 1.9×10⁵ n/s at the 10 mA /
+2 mTorr reference point** — a first-principles floor sitting ~25× under the
+5×10⁶ n/s amateur DIY record (real fusors add fast-neutral and beam–beam
+channels on top; landing under the record by one order with the
+conservative channel only is the physically correct place to land).
 
 Two-ring shielded cathode (45 mm rings at z = ±25 mm, 3 mm wire, opposed
-currents), interception fraction vs ampere-turns:
+currents), interception fraction and D-D yield vs ampere-turns:
 
-| A·turns | −3 kV bias | −30 kV bias |
-|---:|---:|---:|
-| 0 | 1.000 | 1.000 |
-| 5 k | 1.000 | 1.000 |
-| 10 k | 0.958 | 1.000 |
-| 20 k | 0.792 | 1.000 |
-| 40 k | 0.365 | 0.854 |
-| 80 k | 0.260 | 0.688 |
-| 160 k | 0.073 | 0.406 |
+| A·turns | intercept −3 kV | intercept −30 kV | yield −30 kV (σv, m³) |
+|---:|---:|---:|---:|
+| 0 | 1.000 | 1.000 | 1.04e−32 |
+| 5 k | 1.000 | 1.000 | 1.04e−32 |
+| 10 k | 0.979 | 1.000 | 1.07e−32 |
+| 20 k | 0.833 | 1.000 | 1.80e−32 |
+| 40 k | 0.521 | 0.917 | 1.70e−32 |
+| 80 k | 0.594 | 0.938 | 5.79e−32 |
+| 160 k | 0.115 | 0.740 | 6.20e−32 |
 
-Findings the sweep hands us for free:
+(−3 kV yields are ~10⁻⁴¹ — nine orders below −30 kV: low-voltage
+commissioning genuinely produces zero neutrons, and now the sim says so
+quantitatively.)
 
-1. **Shielding works and is enormous** — interception falls 100% → 7% at
-   −3 kV / 160 kA·t; recirculation peaks at ~21 mean passes (5× the
-   unshielded cathode).
-2. **The √V law falls out.** The −30 kV curve is the −3 kV curve shifted
-   ~3–4× right in current, matching r_L ∝ √V. Commissioning a real device
-   at low voltage with pulsed copper, then climbing, is quantitatively
-   supported.
-3. **There is an optimal shield current.** Past it, mean passes *falls*
-   while interception keeps dropping: the cusp begins reflecting ions away
-   from the core itself (magnetic aperture). Shield strength trades
-   transparency against core access — a real, non-obvious optimization
-   target for the gradient loop. (Note: the 40-pass censor also biases the
-   high-current mean down; both effects are real, disentangling them is an
-   M1 diagnostic task.)
+Findings:
 
-Known M0 limitation: worst-case per-trace energy drift reaches ~0.5·qΔV for
-the extreme long-lived trajectories that repeatedly graze wire masks at high
-B — the interpolated E field near a masked wire is under-resolved. Mean
-behavior is unaffected (drift is diagnosed per trace, and the classic-fusor
-acceptance test holds it < 8%), but M1 should add local grid refinement or
-an analytic near-wire E model before quantitative loss budgets are claimed.
+1. **Shielding works and is enormous** — interception falls 100% → 12% at
+   −3 kV / 160 kA·t, and at −30 kV the shield buys **6× fusion yield**
+   (5×10⁵ n/s predicted at the reference point).
+2. **The √V law falls out.** The −30 kV interception curve is the −3 kV
+   curve shifted ~3–4× right in current, matching r_L ∝ √V. Commissioning
+   real hardware at low voltage with pulsed copper, then climbing, is
+   quantitatively supported.
+3. **There is an optimal shield configuration, and passes ≠ yield.**
+   Recirculation (mean passes) peaks and then falls as the cusp starts
+   reflecting ions off the core (magnetic aperture), while the σ(E)-weighted
+   yield keeps different books — it rewards core passages at full energy.
+   Optimizing the right objective is exactly what `optimize_shield` does
+   (below). Interception wiggles non-monotonically at intermediate currents
+   (deterministic launch grid through a chaotic lens), which is itself
+   physical.
+
+**M1 field-fidelity fix:** `Solution::e_at` now returns the exact gradient
+of the bilinear potential patch (not an interpolation of node-difference
+fields), making the sampled E conservative — its line integral between any
+two points equals the interpolant's potential difference — so integrator
+energy error is set by the time step alone. Near-wire time-step refinement
+(dt shrinks within ~6 wire radii) bounds that. Worst-single-trace drift in
+the ensemble max column is dominated by extreme 40-pass wire-grazers;
+typical traces sit far below the 8% acceptance test.
+
+## The optimizer designs the cathode
+
+`cargo run --release -p vcad-kernel-particle --example optimize_shield` —
+multi-start FD ascent over (ampere-turns × ring spacing) at −30 kV, 64-ion
+ensembles on a 101×201 mesh. Findings:
+
+- **The yield landscape is multimodal.** A low-current recirculation hill
+  (local optimum ≈26 kA·t, 2.0× unshielded yield) is separated from a
+  high-current energy-quality hill that single-start gradient ascent never
+  reaches. This also exposed an optimizer bug worth remembering: an
+  absolute gradient-norm epsilon read a 1e-32-scale objective as
+  "converged" after 5 evals — stopping criteria must be scale-invariant
+  (regression-tested now).
+- **Multi-start finds the real basin:** ≈165 kA·t with ring spacing driven
+  to the ±15 mm box bound — **6.2× unshielded yield**, still rising slowly
+  when stopped. The bound binding is a design lesson: the M3 geometry seam
+  should widen the parameterization (ring radius, asymmetric pairs) rather
+  than trust hand-chosen boxes.
+- **Perf scaling:** objective evaluations at ≥150 kA·t cost ~100× the
+  low-current ones — the gyration substepper resolves ~0.5 T across most
+  of the chamber. An adaptive substep budget (coarsen gyration resolution
+  away from wires, where only drift matters) is queued in M1.5.
 
 ## Milestone ladder
 
-- **M1 — near-field fidelity + loss budget.** Mask-aware near-wire E
-  (analytic wire-in-external-field patch or local refinement), censoring
-  diagnostics, fusion-rate weighting along trajectories (beam–background
-  σ(E) integral) so runs report relative fusion yield, not just passes.
+- **M1 — fusion yield + field fidelity. DONE.** Bosch–Hale D-D cross
+  sections (both branches, `xsection`), per-trace ∫σv dt accumulation and
+  `neutron_rate_per_s` (beam-on-background floor with stated caveats),
+  conservative bilinear-patch field sampling, near-wire dt refinement,
+  scale-invariant optimizer stopping (objectives at 1e-32 must not read as
+  converged — regression-tested). `optimize_shield` example: the optimizer
+  designs the cathode (ampere-turns + ring spacing) against predicted
+  yield.
+- **M1.5 — loss-budget honesty.** Censoring-aware statistics
+  (uncensored-only means, per-fate yield attribution), fast-neutral
+  (charge-exchange) channel estimate so the neutron-rate floor tightens
+  toward measured fusor reality.
 - **M2 — discrete adjoint.** Reverse-mode differentiation of the Boris loop
   (checkpointed; Boris is symplectic and its reverse pass is clean) and of
   the bilinear field sampler; adjoint of SOR via the adjoint Poisson solve

--- a/docs/particle-optics-m0.md
+++ b/docs/particle-optics-m0.md
@@ -151,10 +151,21 @@ ensembles on a 101×201 mesh. Findings:
   converged — regression-tested). `optimize_shield` example: the optimizer
   designs the cathode (ampere-turns + ring spacing) against predicted
   yield.
-- **M1.5 — loss-budget honesty.** Censoring-aware statistics
-  (uncensored-only means, per-fate yield attribution), fast-neutral
-  (charge-exchange) channel estimate so the neutron-rate floor tightens
-  toward measured fusor reality.
+- **M1.5 — loss-budget honesty + perf. DONE.** Censoring-aware statistics
+  (uncensored means, mean drift); coil B cached on the Poisson grid
+  (analytic within 8 wire radii, bilinear beyond — kills the per-substep
+  elliptic cost; consistency-tested against the analytic sum);
+  charge-exchange model (`CxModel`, constant-σ approximation): traces
+  report expected neutrons/ion in a survival-weighted ion channel + a
+  fast-neutral straight-line channel. Reality check at 2 mTorr: the ion
+  channel collapses (CX mean free path < one pass) and single-generation
+  totals land at 1.9×10⁴ n/s vs 1.9×10⁵ no-CX — the ~30× gap to measured
+  fusor rates is the **CX chain** (every event births a cold ion that
+  re-accelerates) + volume ionization, both explicitly not yet modeled.
+  Corollary the model hands us: with CX on, yield is nearly
+  pressure-independent (each ion fuses over ~one CX mean free path of
+  track regardless of density) — voltage and current set the rate, which
+  matches fusor lore.
 - **M2 — discrete adjoint.** Reverse-mode differentiation of the Boris loop
   (checkpointed; Boris is symplectic and its reverse pass is clean) and of
   the bilinear field sampler; adjoint of SOR via the adjoint Poisson solve

--- a/docs/particle-optics-paper-draft.md
+++ b/docs/particle-optics-paper-draft.md
@@ -1,0 +1,170 @@
+# Gradient-based electrode design for electrostatic confinement devices (draft)
+
+**Status: internal draft toward an arXiv submission (physics.plasm-ph /
+physics.acc-ph). Numbers below are reproducible from
+`crates/vcad-kernel-particle` at the stated commands; the SIMION
+cross-validation section is planned, not done.**
+
+## Abstract (draft)
+
+Electrode geometry for electrostatic and magneto-electrostatic confinement
+devices — fusors, magnetically shielded grids, ion traps, thruster grids —
+is still designed by hand, guided by ray-tracing tools that are decades
+old, non-differentiable, and disconnected from manufacturable CAD. We
+present a differentiable design pipeline for axisymmetric devices: a
+finite-difference Laplace solver whose sampled field is the exact gradient
+of its interpolant (making integrator energy error purely a time-step
+property), a Boris tracer with fusion-yield weighting via the Bosch–Hale
+D-D cross sections, figures of merit aligned with bench observables
+(cathode interception current, neutron rate), and a discrete adjoint that
+delivers exact-to-discretization gradients of traced yield with respect to
+every electrode potential and coil current at the cost of roughly one
+extra field solve. We reproduce the magnetically-shielded-grid effect
+[Hedditch et al. 2015] from first principles, recover the r_L ∝ √V
+commissioning law, quantify a non-obvious optimum in shield current
+(beyond it, the cusp reflects ions off the fusion core itself), and show
+the design landscape is multimodal — single-start gradient ascent stalls
+on a recirculation hill at 3× lower yield than the energy-quality basin a
+multi-start finds. We argue (and measure) that on long horizons the traced
+objective is chaotically rough, where finite differences under-read
+gradients by 3–4× — precisely the regime where the adjoint is the only
+trustworthy gradient. Every prediction is emitted as a machine-readable
+claim with solver provenance, including a distance-to-Lawson figure that
+prices the device against breakeven honestly.
+
+## 1. Motivation
+
+- The electrode-design loop (geometry → fields → trajectories → figure of
+  merit) is common to IEC fusion research devices, ion thrusters,
+  quadrupole/orbitrap mass spectrometry, electron optics, and ion traps.
+- The incumbent tooling lineage (SIMION et al.) is a forward ray tracer:
+  no gradients, no fabrication output, no provenance.
+- IEC specifically: the 2015 magnetically-shielded-grid proposal
+  (arXiv:1510.01788) remains unbuilt and largely unsimulated in public;
+  the amateur record (~5×10⁶ n/s D-D) has stood with hand-designed
+  cathodes.
+
+## 2. Methods
+
+### 2.1 Fields
+Axisymmetric Laplace (vacuum) on a uniform (r, z) node grid; SOR with the
+Chebyshev-estimate relaxation factor; wire-ring electrodes and the chamber
+as Dirichlet masks (mask radius floored at 0.75 grid cells — see the
+convergence study). **Conservative sampling:** E is the analytic gradient
+of the bilinear potential patch, not an interpolation of node-difference
+fields, so the sampled field's line integral between any two points equals
+the interpolant's potential difference; integrator energy error is then
+governed by the time step alone. Coil fields are exact single-loop
+solutions (complete elliptic integrals via AGM), superposed, grid-cached
+away from conductors and analytic within 8 wire radii so the shielding
+sheath keeps its 1/ρ structure.
+
+### 2.2 Tracing and figures of merit
+Boris pusher; adaptive step capped by grid spacing and refined within 6
+wire radii; gyration substepping. Termination on wire/wall impact;
+core-pass counting; per-trace far-field energy-drift diagnostic. Fusion
+weighting: ∫σv dt along each trace for both D-D branches (Bosch & Hale
+1992), reported per ion against a stated background density. Optional
+charge-exchange model (constant σ_cx): survival-weighted ion channel plus
+a straight-line fast-neutral channel; the CX chain (each event births a
+re-accelerated cold ion) is explicitly not modeled and stated as such.
+
+### 2.3 Discrete adjoint
+Reverse-mode differentiation of the ensemble yield: fixed-step
+self-consistent forward (adaptive dt is non-differentiated control flow;
+a pure time budget removes termination boundary terms), reverse Boris
+chain with PIC-style deposits into the potential grid through the exact
+patch weights, then one adjoint Poisson solve using the radial-weight
+symmetrization of the axisymmetric operator (w_i = r_i; axis row Δr/8).
+Coil-current gradients via ⟨λ_B, B(I=1)⟩. Validated against central
+differences end-to-end: dJ/dI to 0.1%, dJ/dV to 0.8%, and a gauge test
+(Σ over all conductors of dJ/dV ≈ 0). Shape parameters remain finite-
+difference (the Dirichlet mask is discrete); smooth shape adjoints via
+boundary-value differentiation are future work.
+
+### 2.4 Validation ladder
+Elliptic integrals vs tabulated values; loop field vs the on-axis closed
+form and midplane symmetries; Poisson maximum principle, axis symmetry,
+refinement consistency; Boris energy conservation; magnetic-mirror loss
+cone (pitch-angle dichotomy at mirror ratio ≈ 3, including the observed
+non-adiabatic punch-through of fast ions — r_L comparable to the field
+scale — which the criterion does not protect); axial oscillation period
+vs well curvature (2π/ω from the solved potential, ±20% with stated
+anharmonicity); Bosch–Hale anchors.
+
+## 3. Results (current numbers)
+
+All from `cargo run --release -p vcad-kernel-particle --example …`.
+
+**Shielded-grid effect and √V law** (`fusor_baseline`): at fixed geometry
+and −3 kV bias, wire interception falls 1.00 → 0.12 by 160 kA·turns; the
+−30 kV interception curve is the −3 kV curve shifted ~3–4× in current,
+matching r_L ∝ √V. Commissioning hardware cold with pulsed copper before
+climbing voltage is thereby quantitatively supported.
+
+**Yield optimum and multimodality** (`optimize_shield`): σ(E)-weighted
+yield at −30 kV rises 6× by 160 kA·t. The optimizer finds a local
+recirculation hill at ≈26 kA·t (2.0× unshielded) that gradient ascent
+cannot leave; multi-start reaches the energy-quality basin at ≈165 kA·t
+(6.2× unshielded) with ring spacing driven to its box bound — the machine
+telling us the hand-chosen parameterization was too narrow. Beyond the
+optimum, mean core passes fall while interception keeps dropping: the
+cusp begins reflecting ions off the core (magnetic aperture), a tradeoff
+we have not found stated quantitatively for this configuration.
+
+**Fusor floor** (`fusor_baseline`): a classic 5-ring fusor at 30 kV,
+10 mA, 2 mTorr predicts 1.9×10⁵ n/s from the beam-on-background channel —
+a first-principles floor ~25× under the amateur DIY record, as it should
+be given the unmodeled fast-neutral chain. With single-generation charge
+exchange enabled, the surviving-ion channel collapses (CX mean free path
+< one pass at 2 mTorr) and totals land at 1.9×10⁴ n/s; the gap to
+measured fusors prices the CX chain + volume ionization at roughly 30×,
+and yield becomes nearly pressure-independent — matching fusor lore.
+
+**Gradient trustworthiness**: on smooth short horizons FD converges to
+the adjoint (0.1–0.8%); on long horizons the traced objective is
+chaotically rough and FD at practical steps under-reads by 3–4×,
+non-monotonically in h. Design loops that rely on FD there are optimizing
+noise.
+
+**Convergence** (`convergence`, classic fusor, 1 mm wire, 48 ions,
+20-pass cap):
+
+| grid | intercept | mean passes | σv (m³) | mean drift |
+|---|---|---|---|---|
+| 61×121 | 1.000 | 4.4 | 1.44e−32 | 0.081 |
+| 81×161 | 0.896 | 7.4 | 2.15e−32 | 0.089 |
+| 121×241 | 0.771 | 7.9 | 2.17e−32 | 0.055 |
+| 161×321 | 0.604 | 10.2 | 3.23e−32 | 0.051 |
+
+Interception tracks the mask floor (0.75·h inflates a 1 mm wire until
+h ≲ 1.3 mm): thin-wire configurations demand h ≲ a, and headline sweeps
+(3 mm wire at 121×241) sit comfortably inside that; 1 mm-wire absolute
+yields carry O(30%) discretization and are quoted as trends only.
+
+**Receipts**: every configuration emits `vcad.particle-claims/1` — the
+classic fusor card reads Q = 4.1×10⁻¹⁰, distance-to-Lawson 9.39 orders,
+with grid, tolerance, ensemble, censoring, and channel provenance
+attached to each claim.
+
+## 4. Limitations and roadmap
+
+No space charge, no collisions beyond the constant-σ CX approximation, no
+CX chain, single-species, axisymmetric only, shape gradients by FD. Each
+is a milestone in `docs/particle-optics-m0.md`. SIMION cross-validation
+on published einzel/trap geometries is the outstanding external
+comparison before submission.
+
+## References (to be completed)
+
+- J. Hedditch, R. Bowden-Reid, J. Khachan, "Fusion in a magnetically-
+  shielded-grid inertial electrostatic confinement device", Phys. Plasmas
+  22, 102705 (2015); arXiv:1510.01788.
+- H.-S. Bosch, G.M. Hale, "Improved formulas for fusion cross-sections
+  and thermal reactivities", Nucl. Fusion 32, 611 (1992).
+- T.H. Rider, "Fundamental limitations on plasma fusion systems not in
+  thermodynamic equilibrium", PhD thesis, MIT (1995).
+- J.P. Boris, "Relativistic plasma simulation — optimization of a hybrid
+  code", Proc. 4th Conf. Numerical Simulation of Plasmas (1970).
+- S.E. Wurzel, S.C. Hsu, "Progress toward fusion energy breakeven and
+  gain as measured against the Lawson criterion" (arXiv:2505.03834).

--- a/docs/shielded-grid-experiment.md
+++ b/docs/shielded-grid-experiment.md
@@ -1,0 +1,105 @@
+# Shielded-grid IEC experiment pack
+
+The bench program that closes the loop on `vcad-kernel-particle`: build
+the two-ring magnetically shielded cathode, measure the two numbers the
+simulation predicts — **cathode interception current vs shield current**
+(Phase A, no neutrons required) and **neutron rate** (Phase B) — and bind
+them to the predicted claims with `receipt::compare` (verdicts: Holds /
+Violated / Unmeasured, fail-closed).
+
+All prices are order-of-magnitude estimates (used-market heavy) and
+flagged as such, per vcad BOM convention. This document is a plan, not an
+authorization; the safety section is load-bearing.
+
+## The two headline measurements
+
+1. **Phase A — the ammeter curve.** At −1…−3 kV bias and 0.5–5 kA·turns
+   pulsed shield current, cathode interception current must fall with
+   shield current along the simulated −3 kV curve (interception 1.00 →
+   ~0.5 by ~40 kA·t; partial shielding is already unambiguous at a few
+   kA·t at low bias). This is the entire shielded-grid hypothesis tested
+   with an ammeter and an oscilloscope — no vacuum heroics, no neutron
+   instrumentation, no high voltage.
+2. **Phase B — neutrons.** At −30…−40 kV and 1–10 mA with D₂ at ~2 mTorr:
+   the beam-on-background floor is ~10⁵ n/s-scale (chain and volume
+   ionization should carry the measured value above it — the receipt's
+   `band_factor` on the neutron claim is generous and one-sided-honest:
+   the prediction is a floor).
+
+## Bill of materials (estimates)
+
+### Vacuum
+| Item | Example | Est. |
+|---|---|---|
+| Chamber, ~150 mm radius equivalent | 8" spherical octagon / CF cross (Kurt J. Lesker or used) | $800–3,000 |
+| Turbo pump station, ~70–80 L/s | Pfeiffer HiCube 80 (used) or turbo + dry backing | $2,000–6,000 |
+| Wide-range gauge | MKS 972B DualMag or Pirani + cold cathode pair | $700–1,500 |
+| D₂ supply | lecture bottle + regulator + precision leak valve (or MFC) | $600–1,500 |
+| Fittings, viewport (leaded glass later), gaskets | — | $500–1,000 |
+
+### High voltage and shield current
+| Item | Example | Est. |
+|---|---|---|
+| HV supply, −40 kV / 10 mA, current-limited | Glassman/Spellman (used) | $1,000–3,000 |
+| HV feedthrough, 40 kV CF | Lesker EFT series | $400–800 |
+| Ballast resistor chain + HV divider probe | — | $300–600 |
+| Shield-current pulser (Phase A) | 450 V electrolytic bank + IGBT/SCR + 100-turn ring formers → kA·turn ms pulses | $500–1,500 |
+| **Floating isolation for the pulser** | isolation transformer rated ≥ 50 kV or battery pack + fiber-optic trigger | $500–2,000 |
+
+The pulser floats at cathode potential — the rings are simultaneously the
+−40 kV electrode and the coil. This is the hardest engineering item in
+the machine and the reason Phase A runs at low bias first (at −1 kV the
+isolation problem is trivial; at −40 kV it is the design). A REBCO
+persistent-current variant is the Phase C upgrade path and changes this
+table (cryocooler budget class).
+
+### Cathode assembly
+Two ring formers (copper or SS tube), multi-turn winding, alumina
+standoffs, spot-welded joints; geometry from the optimizer output
+(`optimize_shield`: ring radius 45 mm-class, spacing per the current
+optimum — regenerate before freezing drawings). Design the assembly in
+vcad; the drawings and the `DeviceSpec` JSON must come from the same
+document so the sim and the hardware share provenance.
+
+### Diagnostics
+| Item | Example | Est. |
+|---|---|---|
+| **Cathode ammeter (the Phase A instrument)** | shunt + isolation amplifier, optically coupled, floating at cathode | $200–600 |
+| Neutron counter | He-3 or B-10 proportional counter + preamp (used) | $1,000–3,000 |
+| Bubble dosimeters (calibration + backup) | BD-PND type | ~$300 each |
+| CR-39 track detectors (passive backup) | — | $100–300 |
+| X-ray survey meter | Ludlum (used) | $300–800 |
+| Scope, HV probes, thermocouples | — | $500–1,500 |
+
+**Total: roughly $10k–25k**, used-market dependent, Phase A alone ≈ $2–5k
+(chamber can be rough-vacuum for the ammeter curve at glow pressures).
+
+## Safety (non-negotiable, incomplete by design — get review)
+
+- **X-rays:** any run above ~20 kV produces bremsstrahlung; viewports are
+  the leak path (leaded glass or steel blanks), survey meter on every
+  voltage increase, interlocked enclosure.
+- **HV:** single-point ground, grounding stick discipline, no lone
+  operation, supply current limit set to the experiment's need.
+- **Neutrons:** dose budget and distance plan before Phase B; detectors
+  calibrated; logbook doses.
+- **Gas:** D₂ is flammable; lecture-bottle handling, no accumulation
+  paths.
+- **Regulatory:** D-D amateur fusion is legal in the US (no special
+  nuclear material), but radiation-dose and local rules apply — verify
+  before Phase B; fusor.net norms are the community baseline.
+
+## The receipt loop
+
+1. Freeze the design: `DeviceSpec` JSON + drawings from the same vcad
+   document; `receipt::predicted_claims` at the planned operating point,
+   committed alongside the build.
+2. Phase A: measure interception fraction vs shield current; bind with
+   `receipt::compare` (tight `band_factor` ~1.5 on interception — it is a
+   direct observable).
+3. Phase B: neutron rate with calibrated counter; generous one-sided
+   band on the floor claim; publish the comparison report either way —
+   Violated is a publishable result about the model, Holds is a
+   publishable result about the machine.
+4. Every claim that stays `Unmeasured` is listed as such in anything we
+   publish. Fail-closed applies to press releases too.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -442,6 +442,18 @@ export interface KernelModule {
     positions: Float32Array,
     indices: Uint32Array,
   ) => unknown;
+  /** Charged-particle optics simulation (DeviceSpec/params/options JSON). */
+  particleSimulate?: (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
+  /** Charged-particle yield optimization over named spec parameters. */
+  particleOptimize?: (
+    specJson: string,
+    paramsJson: string,
+    optimizeJson: string,
+  ) => unknown;
   /** Static structural analysis of a box solid. */
   analyzeStaticsBox?: (
     specJson: string,
@@ -815,6 +827,8 @@ export class Engine {
       mesh_clearance: (wasmModule as Record<string, unknown>).mesh_clearance as KernelModule["mesh_clearance"],
       topologyOptimizeBox: (wasmModule as Record<string, unknown>).topologyOptimizeBox as KernelModule["topologyOptimizeBox"],
       topologyOptimizeMesh: (wasmModule as Record<string, unknown>).topologyOptimizeMesh as KernelModule["topologyOptimizeMesh"],
+      particleSimulate: (wasmModule as Record<string, unknown>).particleSimulate as KernelModule["particleSimulate"],
+      particleOptimize: (wasmModule as Record<string, unknown>).particleOptimize as KernelModule["particleOptimize"],
       analyzeStaticsBox: (wasmModule as Record<string, unknown>).analyzeStaticsBox as KernelModule["analyzeStaticsBox"],
       analyzeStaticsMesh: (wasmModule as Record<string, unknown>).analyzeStaticsMesh as KernelModule["analyzeStaticsMesh"],
     }, compiledWasmModule);
@@ -1060,6 +1074,45 @@ export class Engine {
    * supports. Returns the optimized structure as a watertight mesh plus run
    * diagnostics.
    */
+  /**
+   * Charged-particle optics simulation: solve an axisymmetric electrode
+   * device, trace a deuteron ensemble, and return figures of merit plus
+   * predicted receipt claims. Inputs are JSON strings (DeviceSpec, named
+   * parameter bindings, options); see `vcad-kernel-particle`.
+   */
+  particleSimulate(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.particleSimulate;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "particleSimulate is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * Multi-start gradient ascent over named device-spec parameters against
+   * predicted D-D yield per ion. Inputs are JSON strings; see
+   * `vcad-kernel-particle::optimize`.
+   */
+  particleOptimize(
+    specJson: string,
+    paramsJson: string,
+    optimizeJson: string,
+  ): unknown {
+    const fn = this.kernel.particleOptimize;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "particleOptimize is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optimizeJson);
+  }
+
   topologyOptimizeBox(
     min: [number, number, number],
     max: [number, number, number],

--- a/packages/mcp/src/__tests__/particle-tools.test.ts
+++ b/packages/mcp/src/__tests__/particle-tools.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the charged-particle optics tools: the real
+ * server, the real WASM kernel (CI builds it from source, so this guards
+ * the full vcad-kernel-particle → wasm-bindgen → engine → tool chain),
+ * coarse grids so the suite stays fast.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * particle bindings — the checked-in artifacts are refreshed only on main
+ * by wasm-refresh.yml. Locally: `npm run build -w vcad-kernel-wasm` to
+ * exercise these for real.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasParticle =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { particleSimulate?: unknown };
+    }
+  ).kernel?.particleSimulate === "function";
+
+const SPEC = {
+  chamber_radius_mm: 120,
+  chamber_half_height_mm: 120,
+  rings: [
+    {
+      ring_radius_mm: 40,
+      z_mm: "ring_z",
+      wire_radius_mm: 4,
+      potential_v: "cathode_v",
+      ampere_turns: "shield_at",
+    },
+    {
+      ring_radius_mm: 40,
+      z_mm: "ring_z_neg",
+      wire_radius_mm: 4,
+      potential_v: "cathode_v",
+      ampere_turns: "shield_at_neg",
+    },
+  ],
+};
+
+const PARAMS = {
+  ring_z: 22,
+  ring_z_neg: -22,
+  cathode_v: -20000,
+  shield_at: 20000,
+  shield_at_neg: -20000,
+};
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasParticle)("charged-particle optics tools", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "particle-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("simulate_charged_particles returns stats + provisional claims", async () => {
+    const res = (await client.callTool({
+      name: "simulate_charged_particles",
+      arguments: {
+        spec: SPEC,
+        parameters: PARAMS,
+        options: { nr: 61, nz: 121, particles: 12, max_passes: 10 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.stats.n).toBe(12);
+    expect(out.stats.interception_fraction).toBeGreaterThanOrEqual(0);
+    expect(out.stats.interception_fraction).toBeLessThanOrEqual(1);
+    expect(out.geometric_transparency).toBeGreaterThan(0);
+    expect(out.geometric_transparency).toBeLessThan(1);
+
+    expect(out.claim_set.schema).toBe("vcad.particle-claims/1");
+    const names = out.claim_set.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("ddn_neutron_rate");
+    expect(names).toContain("q_estimate");
+    expect(names).toContain("distance_to_lawson");
+
+    // Unified-receipt claims: particle domain, predicted basis (rolls up
+    // Provisional by contract — never verified from a simulation alone).
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("particle");
+      expect(c.id.startsWith("particle.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("optimize_electrodes climbs within bounds and reports starts", async () => {
+    const res = (await client.callTool({
+      name: "optimize_electrodes",
+      arguments: {
+        spec: SPEC,
+        parameters: PARAMS,
+        variables: [{ name: "shield_at", lo: 0, hi: 30000 }],
+        options: {
+          nr: 41,
+          nz: 81,
+          particles: 8,
+          max_passes: 6,
+          max_iters: 2,
+          multi_start: false,
+        },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.best_params.shield_at).toBeGreaterThanOrEqual(0);
+    expect(out.best_params.shield_at).toBeLessThanOrEqual(30000);
+    expect(out.best_sigma_v_m3).toBeGreaterThanOrEqual(0);
+    expect(out.evals).toBeGreaterThanOrEqual(3);
+    expect(out.starts.length).toBe(1);
+    expect(out.history.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("unbound named parameters fail closed", async () => {
+    const res = (await client.callTool({
+      name: "simulate_charged_particles",
+      arguments: {
+        spec: SPEC,
+        parameters: { ring_z: 22, ring_z_neg: -22 },
+        options: { nr: 41, nz: 81, particles: 4, max_passes: 4 },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("cathode_v");
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1859,6 +1859,375 @@
     }
   },
   {
+    "name": "simulate_charged_particles",
+    "title": "Simulate Charged Particles",
+    "description": "Charged-particle optics for axisymmetric electrode devices (fusors, magnetically shielded-grid IEC, ring traps): solve the electrostatic field + ring-coil magnetics, trace a deuteron ensemble (Boris integrator, Bosch-Hale D-D yield weighting), and report interception fraction (the cathode-ammeter observable), recirculation, predicted neutron rate, fusion power, Q, and distance-to-Lawson — as data plus `vcad.particle-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until bench-measured. Vacuum single-particle optics: no space charge, no CX chain (optional single-generation CX via `options.cx_sigma_m2`); neutron rates are floors. Deterministic. Cost scales with grid × particles × passes — defaults run in seconds.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "chamber_radius_mm",
+            "chamber_half_height_mm",
+            "rings"
+          ],
+          "description": "Axisymmetric device: grounded cylindrical chamber + biased (optionally current-carrying) wire rings, coaxial with Z. Units mm / volts / ampere-turns. Any numeric field may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "chamber_radius_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters`.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "chamber_half_height_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters`.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "wall_potential_v": {
+              "description": "Chamber wall potential, volts. Default 0 (grounded).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "rings": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "ring_radius_mm",
+                  "z_mm",
+                  "wire_radius_mm",
+                  "potential_v"
+                ],
+                "properties": {
+                  "ring_radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "z_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "wire_radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "potential_v": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "ampere_turns": {
+                    "description": "Circulating current, ampere-turns (+ = CCW viewed from +Z). Default 0. This is the magnetic grid-shielding knob.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "nr": {
+              "type": "number",
+              "description": "Radial grid nodes. Default 101."
+            },
+            "nz": {
+              "type": "number",
+              "description": "Axial grid nodes. Default 201."
+            },
+            "particles": {
+              "type": "number",
+              "description": "Deuteron ensemble size. Default 64."
+            },
+            "max_passes": {
+              "type": "number",
+              "description": "Core-pass cap (censoring boundary). Default 25."
+            },
+            "ion_current_a": {
+              "type": "number",
+              "description": "Operating-point ion current, A. Default 0.010."
+            },
+            "d2_pressure_mtorr": {
+              "type": "number",
+              "description": "Operating-point D₂ pressure, mTorr. Default 2.0."
+            },
+            "temperature_k": {
+              "type": "number",
+              "description": "Gas temperature, K. Default 300."
+            },
+            "cx_sigma_m2": {
+              "type": "number",
+              "description": "Enable charge-exchange channels with this constant cross section, m² (order 1e-19 for D⁺ on D₂ in the keV band). Omitted = CX off; the neutron-rate claim then reports the beam-on-background floor."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "optimize_electrodes",
+    "title": "Optimize Electrodes",
+    "description": "Design electrodes by gradient ascent: optimize named device-spec parameters (e.g. shield ampere-turns, ring spacing) against predicted D-D yield per ion, with multi-start FD search (the yield landscape is multimodal — single starts stall on the recirculation hill at ~3x lower yield). Returns the best parameter set, its yield, per-start results, and the ascent history. Candidate configurations that fail to resolve or converge score 0 rather than aborting. Follow with simulate_charged_particles at the winning parameters for full claims. Cost ≈ evals × one simulation; defaults run in tens of seconds.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "chamber_radius_mm",
+            "chamber_half_height_mm",
+            "rings"
+          ],
+          "description": "Axisymmetric device: grounded cylindrical chamber + biased (optionally current-carrying) wire rings, coaxial with Z. Units mm / volts / ampere-turns. Any numeric field may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "chamber_radius_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters`.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "chamber_half_height_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters`.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "wall_potential_v": {
+              "description": "Chamber wall potential, volts. Default 0 (grounded).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "rings": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "ring_radius_mm",
+                  "z_mm",
+                  "wire_radius_mm",
+                  "potential_v"
+                ],
+                "properties": {
+                  "ring_radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "z_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "wire_radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "potential_v": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "ampere_turns": {
+                    "description": "Circulating current, ampere-turns (+ = CCW viewed from +Z). Default 0. This is the magnetic grid-shielding knob.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        },
+        "variables": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Named spec parameters to optimize, with box bounds. The objective is predicted D-D yield per ion (∫σv dt).",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "lo",
+              "hi"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "lo": {
+                "type": "number"
+              },
+              "hi": {
+                "type": "number"
+              },
+              "start": {
+                "type": "number",
+                "description": "Optional explicit start for the first seed."
+              }
+            }
+          }
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "nr": {
+              "type": "number",
+              "description": "Default 81."
+            },
+            "nz": {
+              "type": "number",
+              "description": "Default 161."
+            },
+            "particles": {
+              "type": "number",
+              "description": "Default 48."
+            },
+            "max_passes": {
+              "type": "number",
+              "description": "Default 20."
+            },
+            "max_iters": {
+              "type": "number",
+              "description": "Ascent iterations per start. Default 8."
+            },
+            "multi_start": {
+              "type": "boolean",
+              "description": "Three seeds across the box instead of one (the landscape is multimodal). Default true."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec",
+        "variables"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
     "name": "predict_physics",
     "title": "Predict Physics",
     "description": "Fast static structural analysis (voxel FEA): max displacement, max von Mises stress, and compliance for a part or box under world-frame loads (N) and supports, in ~100 ms at fidelity=predict. Pass max_displacement_mm / max_von_mises_mpa limits to get receipt claims: predict-tier claims carry basis=predicted and roll up as a PROVISIONAL receipt — use them to iterate on a design cheaply. When the design settles, re-run with fidelity=verify (same solver, fine grid) to upgrade the claims to basis=verified and a certifiable pass. Loads/supports are box regions (mm, Z-up); zero-thickness boxes select a face. Voxel FEA smears stress concentrations — treat stress as an estimate near fillets.",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -129,6 +129,7 @@ import { toolDefs as verifyToolDefs } from "./tools/verify.js";
 import { toolDefs as verifySpecToolDefs } from "./tools/verify-spec.js";
 import { toolDefs as clearanceToolDefs } from "./tools/clearance.js";
 import { toolDefs as topoptToolDefs } from "./tools/topopt.js";
+import { toolDefs as particleToolDefs } from "./tools/particle.js";
 import { toolDefs as physicsToolDefs } from "./tools/physics.js";
 import { toolDefs as loonMacroToolDefs } from "./tools/loon-macros.js";
 import { toolDefs as dfmToolDefs } from "./tools/dfm.js";
@@ -307,6 +308,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...verifySpecToolDefs,
   ...clearanceToolDefs,
   ...topoptToolDefs,
+  ...particleToolDefs,
   ...physicsToolDefs,
   ...loonMacroToolDefs,
   ...dfmToolDefs,
@@ -387,6 +389,9 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "parameter_gradient",
   // ── Topology optimization ──────────────────────────────────
   "topology_optimize",
+  // ── Charged-particle optics (fusor / IEC / trap family) ────
+  "simulate_charged_particles",
+  "optimize_electrodes",
   // ── Two-tier static physics (predict fast, verify to certify) ──
   "predict_physics",
   // ── Print-then-measure calibration loop (3DP) ──────────────

--- a/packages/mcp/src/tools/particle.ts
+++ b/packages/mcp/src/tools/particle.ts
@@ -1,0 +1,235 @@
+/**
+ * Charged-particle optics tools — the `vcad-kernel-particle` crate over MCP.
+ *
+ * `simulate_charged_particles` solves an axisymmetric electrode device
+ * (fusor / shielded-grid IEC / ring-trap family), traces a deuteron
+ * ensemble, and returns figures of merit plus the `vcad.particle-claims/1`
+ * set and unified-receipt claims. Predictions carry `basis: "predicted"`
+ * and roll up Provisional — never verified — until bound to bench
+ * measurements (see `docs/shielded-grid-experiment.md`).
+ *
+ * `optimize_electrodes` runs multi-start gradient ascent over named spec
+ * parameters against predicted D-D yield per ion. Multi-start is the
+ * default because the yield landscape is measurably multimodal
+ * (recirculation hill vs energy-quality hill — `docs/particle-optics-m0.md`).
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters`.",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const deviceSpecSchema = {
+  type: "object" as const,
+  required: ["chamber_radius_mm", "chamber_half_height_mm", "rings"],
+  description:
+    "Axisymmetric device: grounded cylindrical chamber + biased (optionally " +
+    "current-carrying) wire rings, coaxial with Z. Units mm / volts / " +
+    "ampere-turns. Any numeric field may instead be a string naming a " +
+    "parameter supplied in `parameters` (fail-closed: unbound names error).",
+  properties: {
+    chamber_radius_mm: paramValue,
+    chamber_half_height_mm: paramValue,
+    wall_potential_v: {
+      ...paramValue,
+      description: "Chamber wall potential, volts. Default 0 (grounded).",
+    },
+    rings: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["ring_radius_mm", "z_mm", "wire_radius_mm", "potential_v"],
+        properties: {
+          ring_radius_mm: paramValue,
+          z_mm: paramValue,
+          wire_radius_mm: paramValue,
+          potential_v: paramValue,
+          ampere_turns: {
+            ...paramValue,
+            description:
+              "Circulating current, ampere-turns (+ = CCW viewed from +Z). " +
+              "Default 0. This is the magnetic grid-shielding knob.",
+          },
+        },
+      },
+    },
+  },
+};
+
+const parametersSchema = {
+  type: "object" as const,
+  additionalProperties: { type: "number" as const },
+  description: "Bindings for named spec parameters, `{name: value}`.",
+};
+
+const simOptionsSchema = {
+  type: "object" as const,
+  properties: {
+    nr: {
+      type: "number" as const,
+      description: "Radial grid nodes. Default 101.",
+    },
+    nz: {
+      type: "number" as const,
+      description: "Axial grid nodes. Default 201.",
+    },
+    particles: {
+      type: "number" as const,
+      description: "Deuteron ensemble size. Default 64.",
+    },
+    max_passes: {
+      type: "number" as const,
+      description: "Core-pass cap (censoring boundary). Default 25.",
+    },
+    ion_current_a: {
+      type: "number" as const,
+      description: "Operating-point ion current, A. Default 0.010.",
+    },
+    d2_pressure_mtorr: {
+      type: "number" as const,
+      description: "Operating-point D₂ pressure, mTorr. Default 2.0.",
+    },
+    temperature_k: {
+      type: "number" as const,
+      description: "Gas temperature, K. Default 300.",
+    },
+    cx_sigma_m2: {
+      type: "number" as const,
+      description:
+        "Enable charge-exchange channels with this constant cross section, " +
+        "m² (order 1e-19 for D⁺ on D₂ in the keV band). Omitted = CX off; " +
+        "the neutron-rate claim then reports the beam-on-background floor.",
+    },
+  },
+};
+
+export const simulateChargedParticlesSchema = {
+  type: "object" as const,
+  required: ["spec"],
+  properties: {
+    spec: deviceSpecSchema,
+    parameters: parametersSchema,
+    options: simOptionsSchema,
+  },
+};
+
+export const optimizeElectrodesSchema = {
+  type: "object" as const,
+  required: ["spec", "variables"],
+  properties: {
+    spec: deviceSpecSchema,
+    parameters: parametersSchema,
+    variables: {
+      type: "array" as const,
+      minItems: 1,
+      description:
+        "Named spec parameters to optimize, with box bounds. The objective " +
+        "is predicted D-D yield per ion (∫σv dt).",
+      items: {
+        type: "object" as const,
+        required: ["name", "lo", "hi"],
+        properties: {
+          name: { type: "string" as const },
+          lo: { type: "number" as const },
+          hi: { type: "number" as const },
+          start: {
+            type: "number" as const,
+            description: "Optional explicit start for the first seed.",
+          },
+        },
+      },
+    },
+    options: {
+      type: "object" as const,
+      properties: {
+        nr: { type: "number" as const, description: "Default 81." },
+        nz: { type: "number" as const, description: "Default 161." },
+        particles: { type: "number" as const, description: "Default 48." },
+        max_passes: { type: "number" as const, description: "Default 20." },
+        max_iters: {
+          type: "number" as const,
+          description: "Ascent iterations per start. Default 8.",
+        },
+        multi_start: {
+          type: "boolean" as const,
+          description:
+            "Three seeds across the box instead of one (the landscape is " +
+            "multimodal). Default true.",
+        },
+      },
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "simulate_charged_particles",
+    pack: null,
+    description:
+      "Charged-particle optics for axisymmetric electrode devices (fusors, magnetically " +
+      "shielded-grid IEC, ring traps): solve the electrostatic field + ring-coil magnetics, " +
+      "trace a deuteron ensemble (Boris integrator, Bosch-Hale D-D yield weighting), and " +
+      "report interception fraction (the cathode-ammeter observable), recirculation, " +
+      "predicted neutron rate, fusion power, Q, and distance-to-Lawson — as data plus " +
+      "`vcad.particle-claims/1` and unified-receipt claims. Predictions carry basis " +
+      "\"predicted\" and roll up Provisional until bench-measured. Vacuum single-particle " +
+      "optics: no space charge, no CX chain (optional single-generation CX via " +
+      "`options.cx_sigma_m2`); neutron rates are floors. Deterministic. Cost scales with " +
+      "grid × particles × passes — defaults run in seconds.",
+    inputSchema: simulateChargedParticlesSchema,
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.particleSimulate(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify(a.options ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+  {
+    name: "optimize_electrodes",
+    pack: null,
+    description:
+      "Design electrodes by gradient ascent: optimize named device-spec parameters (e.g. " +
+      "shield ampere-turns, ring spacing) against predicted D-D yield per ion, with " +
+      "multi-start FD search (the yield landscape is multimodal — single starts stall on " +
+      "the recirculation hill at ~3x lower yield). Returns the best parameter set, its " +
+      "yield, per-start results, and the ascent history. Candidate configurations that " +
+      "fail to resolve or converge score 0 rather than aborting. Follow with " +
+      "simulate_charged_particles at the winning parameters for full claims. Cost ≈ " +
+      "evals × one simulation; defaults run in tens of seconds.",
+    inputSchema: optimizeElectrodesSchema,
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.particleOptimize(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify({
+          variables: a.variables,
+          ...(a.options as Json | undefined),
+        }),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -246,6 +246,11 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
     }),
   },
   topology_optimize: { title: "Topology Optimize", annotations: RW },
+  simulate_charged_particles: {
+    title: "Simulate Charged Particles",
+    annotations: RO,
+  },
+  optimize_electrodes: { title: "Optimize Electrodes", annotations: RO },
   predict_physics: { title: "Predict Physics", annotations: RO },
   define_loon: { title: "Define Loon Macro", annotations: RW },
   call_loon: { title: "Call Loon Macro", annotations: RW },


### PR DESCRIPTION
## What

New WIP kernel crate `vcad-kernel-particle`: a differentiable design instrument for the electrode-geometry device family (fusors, magnetically shielded-grid IEC, ion traps, thruster grids, e-beam optics). Nine commits walk the full M0–M6 roadmap in `docs/particle-optics-m0.md`:

- **M0** — axisymmetric Laplace solver (SOR, Chebyshev omega, Dirichlet wire-ring masks), exact ring-coil B via AGM elliptic integrals, Boris tracer with adaptive stepping, electrode figures of merit (interception = the simulated cathode ammeter, recirculation, transparency), FD optimizer with an adjoint-shaped API.
- **M1** — Bosch–Hale D-D cross sections integrated along every trace (predicted neutron rates), conservative field sampling (`e_at` is the exact gradient of the bilinear potential patch, so integrator energy error is set by dt alone), near-wire dt refinement, scale-invariant optimizer stopping.
- **M1.5** — coil B grid-cached (analytic within 8 wire radii to preserve the shielding sheath), charge-exchange model (survival-weighted ion channel + fast-neutral channel), censoring-aware stats.
- **M2** — discrete adjoint of the yield objective w.r.t. every electrode potential and coil ampere-turns: reverse Boris chain with PIC-style deposits, adjoint Poisson solve via the radial-weight symmetrization of the axisym operator. FD-validated to 0.1% (dJ/dI) and 0.8% (dJ/dV) plus a gauge-invariance check.
- **M3** — `DeviceSpec` serde seam: named .vcad-style parameters, fail-closed resolution, adjoint-vs-FD role classification per parameter.
- **M4** — receipt claims (`vcad.particle-claims/1`): neutron rate, fusion power (both D-D branches), Q, and `distance_to_lawson`, all with solver provenance and spelled-out caveats. Fail-closed (a no-fusion device reads 99 orders).
- **M5** — analytic physics benchmarks (magnetic-mirror loss cone, oscillation period vs solved well curvature), grid-convergence study, arXiv paper draft (`docs/particle-optics-paper-draft.md`).
- **M6** — experiment pack (`docs/shielded-grid-experiment.md`): COTS BOM, staged commissioning bound to the simulated curves, and `receipt::compare` binding bench measurements to claims with Holds / Violated / Unmeasured verdicts.

## Why

Executes the plan from the project-ideas session: make vcad the design tool for charged-particle devices (the SIMION-shaped gap) with the shielded-grid IEC experiment (arXiv:1510.01788, unbuilt since 2015) as the flagship application, and receipts as the through-line.

## Headline physics results (all reproducible via the examples)

- The magnetically-shielded-grid effect reproduced from first principles; runs in CI as an integration test.
- The r_L ∝ sqrt(V) commissioning law falls out of the sweep (commission cold with pulsed copper, then climb).
- The yield landscape is **multimodal** (recirculation hill ~26 kA·t vs energy-quality basin ~165 kA·t) — single-start gradient ascent stalls at 3x lower yield; past the optimum the cusp reflects ions off the fusion core itself.
- Classic fusor beam-on-background floor: 1.9e5 n/s at 30 kV / 10 mA / 2 mTorr (~25x under the amateur record, correct for the conservative channel); receipt card reads Q = 4.1e-10, distance-to-Lawson 9.39 orders.
- On chaotic horizons FD under-reads gradients 3–4x — the adjoint is the only trustworthy gradient there (measured, documented, regression-tested).

## Reviewer notes

- Zero new external dependencies beyond workspace `serde` (+ `serde_json` dev-only). No WASM artifacts touched.
- 43 tests, `cargo clippy --workspace`-clean for the crate (`-D warnings`), fmt clean. Test suite stays coarse-grid (whole crate ~8s debug).
- Deliberately **not** in this PR (flagged in the docs): vcad-receipt schema registration + MCP tool exposure (cross-crate + TS codegen, own PR), SIMION cross-validation (external), the CX chain model.
- `docs/particle-optics-m0.md` is the map; each milestone section records what was validated and the lessons encoded as tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)