### PR TITLE
vcad-kernel-tolerance: dimensional tolerance stackup engine (M0+)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7464,6 +7464,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-kernel-tolerance"
+version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "vcad-kernel-topo"
 version = "0.9.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "crates/vcad-kernel-topopt",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
+    "crates/vcad-kernel-tolerance",
     "crates/vcad-crdt",
     "crates/vcad-app",
     "crates/vcad-chat",
@@ -117,6 +118,7 @@ default-members = [
     "crates/vcad-kernel-topopt",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
+    "crates/vcad-kernel-tolerance",
     "crates/vcad-crdt",
     "crates/vcad-app",
     "crates/vcad-chat",
@@ -202,6 +204,7 @@ wasmosis-macro = { path = "crates/wasmosis/wasmosis-macro", version = "0.9.4" }
 vcad-slicer = { path = "crates/vcad-slicer", version = "0.9.4" }
 vcad-kernel-cost = { path = "crates/vcad-kernel-cost", version = "0.9.4" }
 vcad-kernel-dfm = { path = "crates/vcad-kernel-dfm", version = "0.9.4" }
+vcad-kernel-tolerance = { path = "crates/vcad-kernel-tolerance", version = "0.9.4" }
 vcad-slicer-gcode = { path = "crates/vcad-slicer-gcode", version = "0.9.4" }
 vcad-slicer-bambu = { path = "crates/vcad-slicer-bambu", version = "0.9.4" }
 vcad-kernel-cam = { path = "crates/vcad-kernel-cam", version = "0.9.4" }

--- a/crates/vcad-kernel-tolerance/Cargo.toml
+++ b/crates/vcad-kernel-tolerance/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vcad-kernel-tolerance"
+description = "Dimensional tolerance stackup analysis: worst-case, RSS, and seeded Monte Carlo over assembly chains, with exact sensitivities, process capability, GD&T bonus tolerance, and cost-based tolerance allocation"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vcad-kernel-tolerance/examples/bearing_stack.rs
+++ b/crates/vcad-kernel-tolerance/examples/bearing_stack.rs
@@ -1,0 +1,176 @@
+//! A realistic shaft/bearing/housing axial stackup, analyzed three ways.
+//!
+//! The assembly: a gearbox input shaft rides in two 6205-pattern ball
+//! bearings inside a housing bore; a machined shoulder and a ground
+//! spacer set the inner-race spacing, and a circlip closes the stack.
+//! The gap of interest is the **axial play** left after assembly:
+//!
+//! ```text
+//! play = housing_depth − bearing_A − shoulder − spacer − bearing_B − circlip
+//! ```
+//!
+//! Requirement: 0.05 mm ≤ play ≤ 0.75 mm (never jammed, never rattling).
+//!
+//! Distributions are deliberately mixed, the way real BOMs are:
+//! machined dimensions carry ISO 2768-m general tolerances as centered
+//! normals (±tol = 3σ); purchased bearing widths are unilateral
+//! (+0/−0.12, the normal-class width tolerance pattern for this size —
+//! cf. ISO 492) and modeled uniform across the vendor band; the spacer
+//! comes from two suppliers with distinct grinding setups — a two-point
+//! mix inside the drawing band.
+//!
+//! Run: `cargo run -p vcad-kernel-tolerance --example bearing_stack`
+
+use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+use vcad_kernel_tolerance::dist::{Distribution, SigmaConvention};
+use vcad_kernel_tolerance::sensitivity::sensitivities;
+use vcad_kernel_tolerance::stackup::{iso2768, Contributor, Iso2768Class, Requirement, Stackup};
+
+fn build() -> Stackup {
+    let conv = SigmaConvention::ThreeSigma;
+    let t_housing = iso2768(62.0, Iso2768Class::M).expect("in table"); // ±0.3
+    let t_shoulder = iso2768(18.0, Iso2768Class::M).expect("in table"); // ±0.2
+    Stackup {
+        name: "input-shaft axial stack".into(),
+        contributors: vec![
+            Contributor::normal("housing bore depth", 1.0, 62.0, t_housing, conv),
+            Contributor::uniform("bearing A width", -1.0, 15.0, 0.12, 0.0),
+            Contributor::normal("shaft shoulder", -1.0, 18.0, t_shoulder, conv),
+            Contributor::with_dist(
+                "spacer (2 suppliers)",
+                -1.0,
+                12.0,
+                0.10,
+                0.10,
+                Distribution::TwoPoint {
+                    a: -0.03, // supplier A grinds low
+                    b: 0.04,  // supplier B grinds high
+                    p_b: 0.4, // 40% of stock is supplier B
+                },
+            ),
+            Contributor::uniform("bearing B width", -1.0, 15.0, 0.12, 0.0),
+            Contributor::normal("circlip thickness", -1.0, 1.6, 0.06, conv),
+        ],
+        requirement: Requirement::between("axial play", 0.05, 0.75),
+    }
+}
+
+fn main() {
+    let s = build();
+    s.validate().expect("valid stackup");
+
+    println!("== {} ==", s.name);
+    println!(
+        "requirement: {} ∈ [{:.2}, {:.2}] mm\n",
+        s.requirement.name,
+        s.requirement.lower_mm.unwrap(),
+        s.requirement.upper_mm.unwrap()
+    );
+
+    println!("contributors (mm):");
+    println!(
+        "  {:<22} {:>6} {:>9} {:>8} {:>8}  distribution",
+        "name", "coeff", "nominal", "tol−", "tol+"
+    );
+    for c in &s.contributors {
+        println!(
+            "  {:<22} {:>6.1} {:>9.3} {:>8.3} {:>8.3}  {:?}",
+            c.name, c.coeff, c.nominal, c.tol_minus, c.tol_plus, c.dist
+        );
+    }
+
+    // Worst case: every part at its worst drawing limit simultaneously.
+    let wc = worst_case(&s).unwrap();
+    println!("\n-- worst case (interval over drawing limits) --");
+    println!("  gap ∈ [{:.3}, {:.3}] mm", wc.min_gap, wc.max_gap);
+    println!(
+        "  margin to lower = {:.3} mm, to upper = {:.3} mm → {}",
+        wc.margin_lower.unwrap(),
+        wc.margin_upper.unwrap(),
+        if wc.passes { "PASSES" } else { "FAILS" }
+    );
+
+    // RSS: exact moments, Φ-based yield.
+    let r = rss(&s).unwrap();
+    println!("\n-- RSS (linear variance propagation) --");
+    println!(
+        "  gap: μ = {:.4} mm, σ = {:.4} mm (moments exact under independence)",
+        r.mean_gap, r.sigma_gap
+    );
+    println!(
+        "  Cp = {:.3}, Cpk = {:.3}, predicted yield = {:.4}%{}",
+        r.cp.unwrap(),
+        r.cpk.unwrap(),
+        100.0 * r.yield_estimate,
+        if r.all_normal {
+            ""
+        } else {
+            "  (yield via CLT: chain has non-normal contributors)"
+        }
+    );
+
+    // Monte Carlo: the check on the CLT step, with error bars.
+    let mc = monte_carlo(
+        &s,
+        &McOptions {
+            n: 200_000,
+            seed: 0xBEA_121C,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    println!("\n-- Monte Carlo (n = {}, seed = {:#x}) --", mc.n, mc.seed);
+    println!(
+        "  gap: μ = {:.4} ± {:.4} mm, σ = {:.4} ± {:.4} mm",
+        mc.mean_gap, mc.mean_gap_se, mc.sigma_gap, mc.sigma_gap_se
+    );
+    println!(
+        "  fit probability = {:.4} ± {:.4}  ({} of {} fit; batch-SE {:.4})",
+        mc.fit.p, mc.fit.standard_error, mc.fit.successes, mc.fit.n, mc.fit_se_batch
+    );
+    println!(
+        "  sampled gap range: [{:.3}, {:.3}] mm (WC bounds [{:.3}, {:.3}])",
+        mc.min_sample, mc.max_sample, wc.min_gap, wc.max_gap
+    );
+
+    // Sensitivities: which dimension is killing the yield.
+    let rows = sensitivities(&s).unwrap();
+    println!("\n-- exact sensitivities, ranked by variance share --");
+    println!(
+        "  {:<22} {:>7} {:>8} {:>10} {:>12} {:>12}",
+        "name", "∂G/∂nom", "σᵢ", "var share", "∂Y/∂nom", "∂Y/∂σᵢ"
+    );
+    for row in &rows {
+        println!(
+            "  {:<22} {:>7.1} {:>8.4} {:>9.1}% {:>12.4} {:>12.4}",
+            row.name,
+            row.d_gap_d_nominal,
+            row.sigma,
+            100.0 * row.variance_share,
+            row.d_yield_d_nominal,
+            row.d_yield_d_sigma
+        );
+    }
+
+    // The compass in action: the yield gradient says the mean sits too
+    // high (unilateral bearing bands push the play up). Re-center by
+    // lengthening the spacer to put μ at the middle of the requirement.
+    let mid = 0.5 * (s.requirement.lower_mm.unwrap() + s.requirement.upper_mm.unwrap());
+    let shift = r.mean_gap - mid; // spacer has coeff −1: grow it by this
+    let mut recentered = s.clone();
+    recentered.contributors[3].nominal += shift;
+    let r2 = rss(&recentered).unwrap();
+    println!(
+        "\n-- re-centering move (from ∂Y/∂nominal signs) --\n  \
+         spacer {:.3} → {:.3} mm puts μ at {:.3}; yield {:.2}% → {:.2}%",
+        s.contributors[3].nominal,
+        recentered.contributors[3].nominal,
+        r2.mean_gap,
+        100.0 * r.yield_estimate,
+        100.0 * r2.yield_estimate
+    );
+    println!(
+        "  (allocation — tightening the right σ's to hit a yield target \
+         at minimum cost — is milestone M2)"
+    );
+}

--- a/crates/vcad-kernel-tolerance/examples/comparison.rs
+++ b/crates/vcad-kernel-tolerance/examples/comparison.rs
@@ -1,0 +1,203 @@
+//! The WC-vs-RSS-vs-MC comparison study (M5), plus the allocation
+//! finale on the bearing stack. The numbers printed here feed
+//! `docs/tolerance-paper-draft.md`.
+//!
+//! Run: `cargo run -p vcad-kernel-tolerance --example comparison`
+
+use vcad_kernel_tolerance::allocate::{allocate, AllocationVar, CostModel};
+use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+use vcad_kernel_tolerance::dist::{Distribution, SigmaConvention};
+use vcad_kernel_tolerance::stackup::{Contributor, Requirement, Stackup};
+
+/// n equal ±0.1 normal contributors consuming from an opening sized so
+/// the nominal gap is 1.0; requirement 1.0 ± 0.3.
+fn equal_chain(n: usize) -> Stackup {
+    let t = 0.1;
+    let mut contributors = vec![Contributor::with_dist(
+        "opening",
+        1.0,
+        n as f64 + 1.0,
+        0.0,
+        0.0,
+        Distribution::Normal {
+            mean: 0.0,
+            sigma: 0.0,
+        },
+    )];
+    for i in 0..n {
+        contributors.push(Contributor::normal(
+            &format!("dim{i}"),
+            -1.0,
+            1.0,
+            t,
+            SigmaConvention::ThreeSigma,
+        ));
+    }
+    Stackup {
+        name: format!("equal-{n}"),
+        contributors,
+        requirement: Requirement::between("gap", 0.69, 1.31),
+    }
+}
+
+fn main() {
+    println!("== study 1: WC vs RSS vs MC over chain length ==");
+    println!("(n equal ±0.1 contributors, requirement gap = 1.0 ± 0.31)\n");
+    println!(
+        "{:>3} {:>12} {:>9} {:>8} {:>10} {:>20} {:>7}",
+        "n", "WC interval", "WC pass", "σ_G", "RSS yield", "MC fit ± SE", "√n"
+    );
+    for n in 2..=10 {
+        let s = equal_chain(n);
+        let wc = worst_case(&s).unwrap();
+        let r = rss(&s).unwrap();
+        let mc = monte_carlo(
+            &s,
+            &McOptions {
+                n: 100_000,
+                seed: 1000 + n as u64,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        let ratio = 0.5 * (wc.max_gap - wc.min_gap) / (3.0 * r.sigma_gap);
+        println!(
+            "{:>3} [{:>4.2},{:>4.2}] {:>9} {:>8.4} {:>10.6} {:>13.5} ± {:.5} {:>7.3}",
+            n,
+            wc.min_gap,
+            wc.max_gap,
+            if wc.passes { "yes" } else { "NO" },
+            r.sigma_gap,
+            r.yield_estimate,
+            mc.fit.p,
+            mc.fit.standard_error,
+            ratio
+        );
+    }
+    println!(
+        "\nThe WC/RSS width ratio IS √n (asserted to 1e-12 in \
+         tests/benchmarks.rs): worst-case\nanalysis prices the ±0.31 \
+         requirement as unbuildable from n = 4 on, while the actual\n\
+         yield never drops below 99.5%. That gap is the entire economic \
+         argument for\nstatistical tolerancing."
+    );
+
+    // ── Study 2: the bearing stack, re-centered, then allocated. ──
+    println!("\n== study 2: allocation finale on the bearing stack ==");
+    let conv = SigmaConvention::ThreeSigma;
+    let s = Stackup {
+        name: "input-shaft axial stack (re-centered)".into(),
+        contributors: vec![
+            Contributor::normal("housing bore depth", 1.0, 62.0, 0.3, conv),
+            Contributor::uniform("bearing A width", -1.0, 15.0, 0.12, 0.0),
+            Contributor::normal("shaft shoulder", -1.0, 18.0, 0.2, conv),
+            Contributor::with_dist(
+                "spacer (2 suppliers)",
+                -1.0,
+                12.122, // the M0 re-centering move
+                0.10,
+                0.10,
+                Distribution::TwoPoint {
+                    a: -0.03,
+                    b: 0.04,
+                    p_b: 0.4,
+                },
+            ),
+            Contributor::uniform("bearing B width", -1.0, 15.0, 0.12, 0.0),
+            Contributor::normal("circlip thickness", -1.0, 1.6, 0.06, conv),
+        ],
+        requirement: Requirement::between("axial play", 0.05, 0.75),
+    };
+    let r0 = rss(&s).unwrap();
+    println!(
+        "re-centered baseline: μ = {:.4}, σ = {:.4}, yield = {:.4}%",
+        r0.mean_gap,
+        r0.sigma_gap,
+        100.0 * r0.yield_estimate
+    );
+
+    // Allocate the two machined dims (the circlip is purchased; the
+    // bearings and spacer are vendor parts — not ours to re-spec).
+    let vars = vec![
+        AllocationVar {
+            contributor: "housing bore depth".into(),
+            cost: CostModel::Reciprocal { a: 4.0, b: 2.0 },
+            t_min: 0.05,
+            t_max: 0.5,
+        },
+        AllocationVar {
+            contributor: "shaft shoulder".into(),
+            cost: CostModel::Reciprocal { a: 2.0, b: 0.8 },
+            t_min: 0.03,
+            t_max: 0.4,
+        },
+    ];
+    let target = 0.9973;
+    let a = allocate(&s, &vars, target).unwrap();
+    println!(
+        "\nallocated to yield ≥ {:.2}% (σ_max = {:.4} mm):",
+        100.0 * target,
+        a.sigma_max
+    );
+    println!(
+        "  {:<22} {:>8} {:>8} {:>9}",
+        "contributor", "t before", "t after", "cost/part"
+    );
+    let before = [0.3, 0.2];
+    for ((name, t, cost), b) in a.tolerances.iter().zip(before) {
+        println!("  {name:<22} {b:>8.3} {t:>8.3} {cost:>9.3}");
+    }
+    println!(
+        "  total cost {:.3} vs proportional-scaling baseline {:.3} \
+         (saving {:.1}%)",
+        a.cost,
+        a.cost_proportional_baseline,
+        100.0 * (1.0 - a.cost / a.cost_proportional_baseline)
+    );
+    println!(
+        "  allocated chain: σ = {:.4}, RSS yield = {:.4}%",
+        a.sigma_gap,
+        100.0 * a.predicted_yield
+    );
+    let mc = monte_carlo(
+        &a.stackup,
+        &McOptions {
+            n: 200_000,
+            seed: 0xA110C,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    println!(
+        "  Monte Carlo check: fit = {:.4} ± {:.4}",
+        mc.fit.p, mc.fit.standard_error
+    );
+
+    // The same target with strongly unequal cost scales: allocation's
+    // edge over proportional scaling grows with cost asymmetry.
+    let vars2 = vec![
+        AllocationVar {
+            contributor: "housing bore depth".into(),
+            cost: CostModel::Reciprocal { a: 4.0, b: 6.0 },
+            t_min: 0.05,
+            t_max: 0.5,
+        },
+        AllocationVar {
+            contributor: "shaft shoulder".into(),
+            cost: CostModel::Reciprocal { a: 2.0, b: 0.2 },
+            t_min: 0.03,
+            t_max: 0.4,
+        },
+    ];
+    let a2 = allocate(&s, &vars2, target).unwrap();
+    println!(
+        "\nwith 30× cost asymmetry (boring is dear, turning is cheap): \
+         total {:.3} vs proportional {:.3} (saving {:.1}%)",
+        a2.cost,
+        a2.cost_proportional_baseline,
+        100.0 * (1.0 - a2.cost / a2.cost_proportional_baseline)
+    );
+    for (name, t, _) in &a2.tolerances {
+        println!("  {name:<22} t = {t:.3}");
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/allocate.rs
+++ b/crates/vcad-kernel-tolerance/src/allocate.rs
@@ -1,0 +1,731 @@
+//! Tolerance allocation (M2): spend tolerance where it's cheap, save
+//! it where it's expensive.
+//!
+//! The problem: choose drawing tolerances tᵢ for the allocatable
+//! contributors to **minimize manufacturing cost subject to a yield
+//! floor**,
+//!
+//! ```text
+//! min Σ Cᵢ(tᵢ)   s.t.   yield(σ_G) ≥ Y_target,   tᵢ ∈ [tᵢ_min, tᵢ_max]
+//! ```
+//!
+//! with σ_G² = Σ_alloc (aᵢ/kᵢ)²tᵢ² + Σ_fixed aⱼ²σⱼ² under each
+//! contributor's stated tolerance-to-σ convention.
+//!
+//! Cost-vs-tolerance models are the classical families from the
+//! allocation literature (Chase & Greenwood, *Manufacturing Review*
+//! 1(1), 1988, survey the lineage): **reciprocal** and
+//! **reciprocal-squared** (Spotts, *J. Eng. Industry* 95, 1973)
+//! `C = a + b/tᵖ`, and **exponential** (Speckhart, *J. Eng. Industry*
+//! 94, 1972) `C = a + b·e^(−t/τ)`. `vcad-kernel-cost` models
+//! process-level cost (material + machine minutes + setup), not
+//! cost-vs-tolerance, so these curves live here and take their
+//! coefficients from quotes or shop data.
+//!
+//! The exact gradients make the optimization clean: yield is monotone
+//! in σ_G, so the constraint is σ_G ≤ σ_max (σ_max found by bisection
+//! on the exact Φ yield), and the KKT stationarity condition
+//!
+//! ```text
+//! dCᵢ/dtᵢ + λ · 2wᵢtᵢ = 0,   wᵢ = (aᵢ/kᵢ)²
+//! ```
+//!
+//! has per-contributor **closed forms** for the reciprocal families
+//! (tᵢ = (bᵢ/(2λwᵢ))^(1/3), (bᵢ/(λwᵢ))^(1/4)) and a monotone 1-D root
+//! for the exponential. The outer loop is a single bisection on λ with
+//! box clamping (water-filling style); the solution is exact to
+//! bisection tolerance, deterministic, and dependency-free. Costs
+//! decrease in t, so the yield constraint is active at the optimum
+//! unless every tolerance hits its box maximum first.
+
+use serde::{Deserialize, Serialize};
+
+use crate::analysis::rss;
+use crate::capability::yield_within;
+use crate::dist::{Distribution, DistributionSource};
+use crate::stackup::{Stackup, StackupError};
+
+/// A cost-vs-tolerance model, dollars (or any consistent unit) per
+/// part as a function of the ± tolerance in mm.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CostModel {
+    /// C(t) = a + b/t — the workhorse reciprocal law.
+    Reciprocal {
+        /// Fixed cost floor.
+        a: f64,
+        /// Tightness cost scale (> 0).
+        b: f64,
+    },
+    /// C(t) = a + b/t² (Spotts 1973) — steeper penalty for precision
+    /// processes.
+    ReciprocalSquared {
+        /// Fixed cost floor.
+        a: f64,
+        /// Tightness cost scale (> 0).
+        b: f64,
+    },
+    /// C(t) = a + b·e^(−t/τ) (Speckhart 1972) — saturating cost with a
+    /// characteristic tolerance τ.
+    Exponential {
+        /// Fixed cost floor.
+        a: f64,
+        /// Cost at t = 0 above the floor (> 0).
+        b: f64,
+        /// Characteristic tolerance, mm (> 0).
+        tau: f64,
+    },
+}
+
+impl CostModel {
+    /// Cost at tolerance `t` (> 0).
+    pub fn cost(&self, t: f64) -> f64 {
+        match *self {
+            CostModel::Reciprocal { a, b } => a + b / t,
+            CostModel::ReciprocalSquared { a, b } => a + b / (t * t),
+            CostModel::Exponential { a, b, tau } => a + b * (-t / tau).exp(),
+        }
+    }
+
+    /// Exact dC/dt (< 0: looser is always cheaper in these families).
+    pub fn d_cost_d_tol(&self, t: f64) -> f64 {
+        match *self {
+            CostModel::Reciprocal { b, .. } => -b / (t * t),
+            CostModel::ReciprocalSquared { b, .. } => -2.0 * b / (t * t * t),
+            CostModel::Exponential { b, tau, .. } => -(b / tau) * (-t / tau).exp(),
+        }
+    }
+
+    fn check(&self) -> Result<(), String> {
+        let ok = match *self {
+            CostModel::Reciprocal { a, b } | CostModel::ReciprocalSquared { a, b } => {
+                a.is_finite() && b.is_finite() && b > 0.0
+            }
+            CostModel::Exponential { a, b, tau } => {
+                a.is_finite() && b.is_finite() && tau.is_finite() && b > 0.0 && tau > 0.0
+            }
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(format!("invalid cost model {self:?}"))
+        }
+    }
+
+    /// Solve dC/dt + 2λwt = 0 for t > 0 (the KKT stationarity point at
+    /// multiplier λ > 0, weight w > 0). Closed form for the reciprocal
+    /// families; monotone bisection for the exponential.
+    fn stationary_t(&self, lambda: f64, w: f64) -> f64 {
+        match *self {
+            CostModel::Reciprocal { b, .. } => (b / (2.0 * lambda * w)).cbrt(),
+            CostModel::ReciprocalSquared { b, .. } => (b / (lambda * w)).powf(0.25),
+            CostModel::Exponential { b, tau, .. } => {
+                // g(t) = (b/τ)e^(−t/τ) − 2λwt: strictly decreasing,
+                // g(0) > 0 → unique root; bracket by doubling.
+                let g = |t: f64| (b / tau) * (-t / tau).exp() - 2.0 * lambda * w * t;
+                let mut hi = tau.max(1e-9);
+                while g(hi) > 0.0 {
+                    hi *= 2.0;
+                    if hi > 1e12 {
+                        return hi; // λ→0 pathology; caller clamps to box
+                    }
+                }
+                let mut lo = 0.0;
+                for _ in 0..200 {
+                    let mid = 0.5 * (lo + hi);
+                    if g(mid) > 0.0 {
+                        lo = mid;
+                    } else {
+                        hi = mid;
+                    }
+                }
+                0.5 * (lo + hi)
+            }
+        }
+    }
+}
+
+/// One allocatable contributor: which chain member, its cost curve,
+/// and the box its tolerance may move in.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AllocationVar {
+    /// Name of the contributor in the stackup (must be a centered-or-
+    /// shifted **normal** contributor with an `Assumed` convention —
+    /// allocating a vendor-band uniform or a measured distribution is
+    /// a category error and fails closed).
+    pub contributor: String,
+    /// Cost-vs-tolerance model for this dimension.
+    pub cost: CostModel,
+    /// Tightest tolerance the process can hold, mm (> 0).
+    pub t_min: f64,
+    /// Loosest tolerance the function allows, mm (≥ t_min).
+    pub t_max: f64,
+}
+
+/// The allocation result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AllocationResult {
+    /// Allocated ± tolerances, in `vars` order: (contributor, t, cost).
+    pub tolerances: Vec<(String, f64, f64)>,
+    /// Total cost at the allocation.
+    pub cost: f64,
+    /// Baseline: cost of the idealized proportional policy (scale all
+    /// allocatable tolerances by one factor to hit the same σ target,
+    /// no boxes). The allocator must never lose to this inside the
+    /// same boxes; the gap is what optimization bought.
+    pub cost_proportional_baseline: f64,
+    /// KKT multiplier at the solution (0 ⇒ yield constraint inactive:
+    /// everything at t_max already meets the target).
+    pub lambda: f64,
+    /// σ_G of the allocated chain, mm.
+    pub sigma_gap: f64,
+    /// The σ_G ceiling that enforces the yield target, mm.
+    pub sigma_max: f64,
+    /// RSS yield of the allocated chain (≥ target to bisection
+    /// tolerance when the constraint binds).
+    pub predicted_yield: f64,
+    /// The requested yield floor.
+    pub target_yield: f64,
+    /// The allocated stackup: drawing limits and σ updated together
+    /// under each contributor's stated convention.
+    pub stackup: Stackup,
+}
+
+/// Find σ_max such that the RSS yield equals `target` at fixed mean
+/// (yield is strictly decreasing in σ when the mean is inside the
+/// limits). Fail-closed when the target is unreachable even at σ → 0.
+fn sigma_for_yield(
+    mean: f64,
+    lower: Option<f64>,
+    upper: Option<f64>,
+    target: f64,
+) -> Result<f64, StackupError> {
+    if !(0.0..1.0).contains(&target) {
+        return Err(StackupError::BadRequirement(format!(
+            "target yield must be in [0, 1), got {target}"
+        )));
+    }
+    // σ → 0 limit: indicator of the mean being inside the limits.
+    let best = yield_within(mean, 0.0, lower, upper);
+    if best < target {
+        return Err(StackupError::Infeasible {
+            target_yield: target,
+            best_yield: best,
+        });
+    }
+    let mut lo = 0.0f64;
+    // Bracket: grow until yield < target.
+    let scale = (upper.unwrap_or(mean) - lower.unwrap_or(mean))
+        .abs()
+        .max(1.0);
+    let mut hi = 1e-6 * scale;
+    while yield_within(mean, hi, lower, upper) >= target {
+        hi *= 2.0;
+        if hi > 1e12 * scale {
+            // Target ≤ the asymptotic yield (e.g. 0 for two-sided) —
+            // effectively unconstrained.
+            return Ok(hi);
+        }
+    }
+    for _ in 0..200 {
+        let mid = 0.5 * (lo + hi);
+        if yield_within(mean, mid, lower, upper) >= target {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+    Ok(0.5 * (lo + hi))
+}
+
+/// Allocate tolerances: minimize Σ cost subject to RSS yield ≥ target.
+///
+/// Nominals are held fixed (re-centering is a separate, free move —
+/// see the sensitivity module); only the named normal contributors'
+/// tolerances move, each keeping its stated σ convention so drawing
+/// limits and process σ stay consistent.
+pub fn allocate(
+    s: &Stackup,
+    vars: &[AllocationVar],
+    target_yield: f64,
+) -> Result<AllocationResult, StackupError> {
+    s.validate()?;
+    if vars.is_empty() {
+        return Err(StackupError::Empty);
+    }
+
+    // Resolve each var to (index, weight w = (a/k)², cost model, box).
+    struct V {
+        idx: usize,
+        w: f64,
+        k: f64,
+        cost: CostModel,
+        t_min: f64,
+        t_max: f64,
+    }
+    let mut resolved: Vec<V> = Vec::with_capacity(vars.len());
+    let mut seen = std::collections::BTreeSet::new();
+    for v in vars {
+        if !seen.insert(v.contributor.as_str()) {
+            return Err(StackupError::BadName(v.contributor.clone()));
+        }
+        let idx = s
+            .contributors
+            .iter()
+            .position(|c| c.name == v.contributor)
+            .ok_or_else(|| {
+                StackupError::NotAllocatable(format!("no contributor named {:?}", v.contributor))
+            })?;
+        let c = &s.contributors[idx];
+        let k = match (&c.dist, &c.source) {
+            (Distribution::Normal { .. }, DistributionSource::Assumed { convention }) => {
+                convention.k()
+            }
+            _ => {
+                return Err(StackupError::NotAllocatable(format!(
+                    "{:?} is not an assumed-normal contributor (vendor bands and \
+                     measured distributions are not yours to re-spec)",
+                    v.contributor
+                )))
+            }
+        };
+        v.cost
+            .check()
+            .map_err(|reason| StackupError::InvalidDistribution {
+                contributor: v.contributor.clone(),
+                reason,
+            })?;
+        if !(v.t_min.is_finite() && v.t_max.is_finite()) || v.t_min <= 0.0 || v.t_max < v.t_min {
+            return Err(StackupError::BadRequirement(format!(
+                "bad tolerance box [{}, {}] on {:?}",
+                v.t_min, v.t_max, v.contributor
+            )));
+        }
+        resolved.push(V {
+            idx,
+            w: (c.coeff / k) * (c.coeff / k),
+            k,
+            cost: v.cost,
+            t_min: v.t_min,
+            t_max: v.t_max,
+        });
+    }
+
+    // Fixed variance from everything not being allocated.
+    let alloc_idx: std::collections::BTreeSet<usize> = resolved.iter().map(|v| v.idx).collect();
+    let fixed_var: f64 = s
+        .contributors
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !alloc_idx.contains(i))
+        .map(|(_, c)| c.coeff * c.coeff * c.dist.variance())
+        .sum();
+
+    // Keep each allocated contributor's centering error in the mean.
+    let mean = s.mean_gap();
+    let sigma_max = sigma_for_yield(
+        mean,
+        s.requirement.lower_mm,
+        s.requirement.upper_mm,
+        target_yield,
+    )?;
+    let budget = sigma_max * sigma_max - fixed_var;
+    let floor: f64 = resolved.iter().map(|v| v.w * v.t_min * v.t_min).sum();
+    if budget < floor {
+        // Even every allocatable at its tightest cannot reach the
+        // target: report the best achievable yield, fail closed.
+        let sigma_best = (fixed_var + floor).sqrt();
+        return Err(StackupError::Infeasible {
+            target_yield,
+            best_yield: yield_within(
+                mean,
+                sigma_best,
+                s.requirement.lower_mm,
+                s.requirement.upper_mm,
+            ),
+        });
+    }
+
+    // S(λ): allocated variance with box clamping; strictly
+    // nonincreasing in λ.
+    let clamped = |v: &V, lambda: f64| -> f64 {
+        if lambda <= 0.0 {
+            return v.t_max;
+        }
+        v.cost.stationary_t(lambda, v.w).clamp(v.t_min, v.t_max)
+    };
+    let s_of = |lambda: f64| -> f64 {
+        resolved
+            .iter()
+            .map(|v| {
+                let t = clamped(v, lambda);
+                v.w * t * t
+            })
+            .sum()
+    };
+
+    // Constraint inactive at λ = 0 (everything at t_max)?
+    let (lambda, ts): (f64, Vec<f64>) = if s_of(0.0) <= budget {
+        (0.0, resolved.iter().map(|v| v.t_max).collect())
+    } else {
+        // Bracket λ: double until S(λ) < budget.
+        let mut lo = 0.0f64;
+        let mut hi = 1e-9;
+        while s_of(hi) > budget {
+            lo = hi;
+            hi *= 4.0;
+            if hi > 1e30 {
+                return Err(StackupError::BadRequirement(
+                    "lambda bracket blew up (degenerate cost models?)".into(),
+                ));
+            }
+        }
+        for _ in 0..200 {
+            let mid = 0.5 * (lo + hi);
+            if s_of(mid) > budget {
+                lo = mid;
+            } else {
+                hi = mid;
+            }
+        }
+        let l = 0.5 * (lo + hi);
+        (l, resolved.iter().map(|v| clamped(v, l)).collect())
+    };
+
+    // Build the allocated stackup: drawing limits and σ move together.
+    let mut out = s.clone();
+    for (v, &t) in resolved.iter().zip(&ts) {
+        let c = &mut out.contributors[v.idx];
+        c.tol_minus = t;
+        c.tol_plus = t;
+        if let Distribution::Normal { sigma, .. } = &mut c.dist {
+            *sigma = t / v.k;
+        }
+    }
+    let r = rss(&out)?;
+
+    // Idealized proportional baseline: one scale factor on the current
+    // tolerances to hit the same budget, no boxes (documented as the
+    // policy every hand allocation actually uses).
+    let current_alloc_var: f64 = resolved
+        .iter()
+        .map(|v| {
+            let c = &s.contributors[v.idx];
+            c.coeff * c.coeff * c.dist.variance()
+        })
+        .sum();
+    let scale = (budget / current_alloc_var).sqrt();
+    let cost_proportional_baseline: f64 = resolved
+        .iter()
+        .map(|v| {
+            let c = &s.contributors[v.idx];
+            // Current t from σ under the convention.
+            let t0 = c.dist.sigma() * v.k;
+            v.cost.cost(t0 * scale)
+        })
+        .sum();
+
+    let tolerances: Vec<(String, f64, f64)> = resolved
+        .iter()
+        .zip(&ts)
+        .map(|(v, &t)| (s.contributors[v.idx].name.clone(), t, v.cost.cost(t)))
+        .collect();
+    let cost = tolerances.iter().map(|(_, _, c)| c).sum();
+
+    Ok(AllocationResult {
+        tolerances,
+        cost,
+        cost_proportional_baseline,
+        lambda,
+        sigma_gap: r.sigma_gap,
+        sigma_max,
+        predicted_yield: r.yield_estimate,
+        target_yield,
+        stackup: out,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dist::SigmaConvention;
+    use crate::stackup::{Contributor, Requirement};
+
+    fn chain() -> Stackup {
+        let conv = SigmaConvention::ThreeSigma;
+        Stackup {
+            name: "alloc".into(),
+            contributors: vec![
+                Contributor::normal("cheap", 1.0, 30.0, 0.3, conv),
+                Contributor::normal("mid", -1.0, 20.0, 0.2, conv),
+                Contributor::normal("pricey", -1.0, 9.0, 0.1, conv),
+            ],
+            requirement: Requirement::between("gap", 0.4, 1.6),
+        }
+    }
+
+    fn vars() -> Vec<AllocationVar> {
+        vec![
+            AllocationVar {
+                contributor: "cheap".into(),
+                cost: CostModel::Reciprocal { a: 1.0, b: 0.05 },
+                t_min: 0.02,
+                t_max: 0.8,
+            },
+            AllocationVar {
+                contributor: "mid".into(),
+                cost: CostModel::Reciprocal { a: 1.0, b: 0.2 },
+                t_min: 0.02,
+                t_max: 0.8,
+            },
+            AllocationVar {
+                contributor: "pricey".into(),
+                cost: CostModel::Reciprocal { a: 1.0, b: 0.8 },
+                t_min: 0.02,
+                t_max: 0.8,
+            },
+        ]
+    }
+
+    #[test]
+    fn cost_models_and_gradients() {
+        let models = [
+            CostModel::Reciprocal { a: 1.0, b: 0.5 },
+            CostModel::ReciprocalSquared { a: 1.0, b: 0.05 },
+            CostModel::Exponential {
+                a: 1.0,
+                b: 5.0,
+                tau: 0.1,
+            },
+        ];
+        for m in models {
+            // Decreasing cost; exact gradient matches FD.
+            let h = 1e-7;
+            for t in [0.02, 0.1, 0.5] {
+                assert!(m.cost(t) > m.cost(t + 0.01), "{m:?} not decreasing");
+                let fd = (m.cost(t + h) - m.cost(t - h)) / (2.0 * h);
+                let exact = m.d_cost_d_tol(t);
+                assert!(
+                    (fd - exact).abs() < 1e-4 * exact.abs(),
+                    "{m:?} at {t}: fd {fd} vs exact {exact}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reciprocal_family_matches_closed_form_lagrange() {
+        // Pure reciprocal costs, no boxes binding: KKT gives
+        // tᵢ = (bᵢ/(2λwᵢ))^(1/3); with all aᵢ² = 1, k = 3:
+        // w = 1/9 for every i, so tᵢ ∝ bᵢ^(1/3) and λ comes from
+        // Σ w tᵢ² = budget. Verify the allocator lands on it.
+        let s = chain();
+        let target = 0.9973;
+        let r = allocate(&s, &vars(), target).unwrap();
+        assert!(r.lambda > 0.0, "constraint must bind");
+        let w = 1.0 / 9.0;
+        let bs = [0.05f64, 0.2, 0.8];
+        // λ from the constraint in closed form:
+        // Σ w (b/(2λw))^(2/3) = budget →
+        // λ^(2/3) = Σ w (b/(2w))^(2/3) / budget.
+        let budget = r.sigma_max * r.sigma_max;
+        let num: f64 = bs.iter().map(|b| w * (b / (2.0 * w)).powf(2.0 / 3.0)).sum();
+        let lambda_cf = (num / budget).powf(1.5);
+        assert!(
+            (r.lambda - lambda_cf).abs() / lambda_cf < 1e-6,
+            "λ {} vs closed form {lambda_cf}",
+            r.lambda
+        );
+        for ((_, t, _), b) in r.tolerances.iter().zip(bs) {
+            let t_cf = (b / (2.0 * lambda_cf * w)).cbrt();
+            assert!(
+                (t - t_cf).abs() / t_cf < 1e-6,
+                "t {t} vs closed form {t_cf}"
+            );
+        }
+        // KKT stationarity residual ≈ 0 for interior points.
+        for (v, (_, t, _)) in vars().iter().zip(&r.tolerances) {
+            let resid = v.cost.d_cost_d_tol(*t) + 2.0 * r.lambda * w * t;
+            assert!(
+                resid.abs() < 1e-6 * v.cost.d_cost_d_tol(*t).abs(),
+                "KKT residual {resid}"
+            );
+        }
+        // The yield constraint is met to bisection accuracy.
+        assert!(r.predicted_yield >= target - 1e-9, "{}", r.predicted_yield);
+        assert!((r.sigma_gap - r.sigma_max).abs() < 1e-9 * r.sigma_max);
+    }
+
+    #[test]
+    fn allocation_beats_proportional_scaling() {
+        // With unequal b's the optimizer must beat the one-knob policy
+        // at the same yield: it loosens the cheap dim and tightens the
+        // pricey one.
+        let s = chain();
+        let r = allocate(&s, &vars(), 0.9973).unwrap();
+        assert!(
+            r.cost < r.cost_proportional_baseline - 1e-6,
+            "allocated {} vs proportional {}",
+            r.cost,
+            r.cost_proportional_baseline
+        );
+        // The cheap contributor should get a looser tolerance than the
+        // pricey one scaled by the b-ratio direction.
+        let t_cheap = r.tolerances[0].1;
+        let t_pricey = r.tolerances[2].1;
+        assert!(
+            t_cheap < t_pricey,
+            "reciprocal optimum: t ∝ b^(1/3), so bigger b ⇒ looser: {t_cheap} vs {t_pricey}"
+        );
+    }
+
+    #[test]
+    fn boxes_clamp_and_the_rest_compensate() {
+        let s = chain();
+        let free = allocate(&s, &vars(), 0.9973).unwrap();
+        // Free optimum (t ∝ b^(1/3)): cheap ≈ 0.19, pricey ≈ 0.48.
+
+        // Case 1 — t_min binds: the cheap dim's process can't hold
+        // tighter than 0.25 (free optimum wants 0.19). It's forced
+        // looser than optimal, eating variance budget, so the others
+        // must TIGHTEN to keep the yield.
+        let mut v = vars();
+        v[0].t_min = 0.25;
+        let boxed = allocate(&s, &v, 0.9973).unwrap();
+        assert!(free.tolerances[0].1 < 0.25, "sanity: floor binds");
+        assert!((boxed.tolerances[0].1 - 0.25).abs() < 1e-9);
+        assert!(boxed.tolerances[1].1 < free.tolerances[1].1);
+        assert!(boxed.tolerances[2].1 < free.tolerances[2].1);
+        assert!(boxed.predicted_yield >= 0.9973 - 1e-9);
+        assert!(boxed.cost > free.cost, "boxes never help");
+
+        // Case 2 — t_max binds: the pricey dim's drawing caps at 0.30
+        // (free optimum wants ≈ 0.48). It's forced tighter than
+        // optimal, freeing budget, so the others go LOOSER.
+        let mut v = vars();
+        v[2].t_max = 0.30;
+        let boxed = allocate(&s, &v, 0.9973).unwrap();
+        assert!(free.tolerances[2].1 > 0.30, "sanity: cap binds");
+        assert!((boxed.tolerances[2].1 - 0.30).abs() < 1e-9);
+        assert!(boxed.tolerances[0].1 > free.tolerances[0].1);
+        assert!(boxed.tolerances[1].1 > free.tolerances[1].1);
+        assert!(boxed.predicted_yield >= 0.9973 - 1e-9);
+        assert!(boxed.cost > free.cost);
+    }
+
+    #[test]
+    fn exponential_model_allocates_and_meets_kkt() {
+        let s = chain();
+        let v: Vec<AllocationVar> = vars()
+            .into_iter()
+            .map(|mut v| {
+                v.cost = CostModel::Exponential {
+                    a: 1.0,
+                    b: match v.contributor.as_str() {
+                        "cheap" => 2.0,
+                        "mid" => 6.0,
+                        _ => 20.0,
+                    },
+                    tau: 0.08,
+                };
+                v
+            })
+            .collect();
+        let r = allocate(&s, &v, 0.9973).unwrap();
+        assert!(r.predicted_yield >= 0.9973 - 1e-9);
+        let w = 1.0 / 9.0;
+        for (var, (_, t, _)) in v.iter().zip(&r.tolerances) {
+            if *t > var.t_min + 1e-9 && *t < var.t_max - 1e-9 {
+                let resid = var.cost.d_cost_d_tol(*t) + 2.0 * r.lambda * w * t;
+                assert!(
+                    resid.abs() < 1e-5 * var.cost.d_cost_d_tol(*t).abs().max(1e-12),
+                    "KKT residual {resid} at t {t}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn inactive_constraint_returns_all_loose() {
+        // A very lax target: everything sits at t_max, λ = 0.
+        let s = chain();
+        let r = allocate(&s, &vars(), 0.5).unwrap();
+        assert_eq!(r.lambda, 0.0);
+        for (v, (_, t, _)) in vars().iter().zip(&r.tolerances) {
+            assert_eq!(*t, v.t_max);
+        }
+        assert!(r.predicted_yield >= 0.5);
+    }
+
+    #[test]
+    fn mixed_chain_allocates_only_the_normals() {
+        // Fixed vendor bands stay fixed; their variance eats budget.
+        let conv = SigmaConvention::ThreeSigma;
+        let s = Stackup {
+            name: "mixed".into(),
+            contributors: vec![
+                Contributor::normal("machined", 1.0, 30.0, 0.3, conv),
+                Contributor::uniform("vendor", -1.0, 15.0, 0.12, 0.0),
+                Contributor::normal("machined2", -1.0, 14.4, 0.2, conv),
+            ],
+            requirement: Requirement::between("gap", 0.2, 1.0),
+        };
+        let v = vec![
+            AllocationVar {
+                contributor: "machined".into(),
+                cost: CostModel::Reciprocal { a: 0.0, b: 0.1 },
+                t_min: 0.02,
+                t_max: 0.6,
+            },
+            AllocationVar {
+                contributor: "machined2".into(),
+                cost: CostModel::Reciprocal { a: 0.0, b: 0.1 },
+                t_min: 0.02,
+                t_max: 0.6,
+            },
+        ];
+        let r = allocate(&s, &v, 0.99).unwrap();
+        assert!(r.predicted_yield >= 0.99 - 1e-9);
+        // The vendor band is untouched.
+        assert_eq!(r.stackup.contributors[1], s.contributors[1]);
+        // Allocating the vendor band is a category error.
+        let bad = vec![AllocationVar {
+            contributor: "vendor".into(),
+            cost: CostModel::Reciprocal { a: 0.0, b: 0.1 },
+            t_min: 0.02,
+            t_max: 0.6,
+        }];
+        assert!(matches!(
+            allocate(&s, &bad, 0.99),
+            Err(StackupError::NotAllocatable(_))
+        ));
+    }
+
+    #[test]
+    fn infeasible_targets_fail_closed_with_the_best_yield() {
+        let s = chain();
+        let mut v = vars();
+        for var in &mut v {
+            var.t_min = 0.25; // can't tighten below current-ish levels
+            var.t_max = 0.4;
+        }
+        let err = allocate(&s, &v, 0.999999999).unwrap_err();
+        match err {
+            StackupError::Infeasible {
+                target_yield,
+                best_yield,
+            } => {
+                assert!(target_yield > best_yield);
+                assert!(best_yield > 0.9, "still a real yield: {best_yield}");
+            }
+            other => panic!("wrong error: {other:?}"),
+        }
+        // A mean outside the limits can't reach any yield ≥ 0.5.
+        let mut hopeless = chain();
+        hopeless.requirement = Requirement::between("gap", 2.0, 3.0);
+        assert!(matches!(
+            allocate(&hopeless, &vars(), 0.9),
+            Err(StackupError::Infeasible { .. })
+        ));
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/analysis.rs
+++ b/crates/vcad-kernel-tolerance/src/analysis.rs
@@ -1,0 +1,424 @@
+//! The three stackup analyses: worst-case, RSS, and Monte Carlo.
+//!
+//! - **Worst-case** is interval arithmetic over the drawing limits:
+//!   every part simultaneously at its worst extreme. Guaranteed bounds,
+//!   brutally pessimistic for chains of more than a few contributors
+//!   (the width grows as Σtᵢ while real scatter grows as √Σtᵢ²).
+//! - **RSS** (root-sum-square) is exact linear variance propagation:
+//!   σ_G² = Σ aᵢ²σᵢ². The *yield* derived from it assumes the gap is
+//!   normal — exact when every contributor is normal, a central-limit
+//!   approximation otherwise (flagged on the result).
+//! - **Monte Carlo** samples whole virtual assemblies with a seeded
+//!   deterministic generator. It is the check on RSS's normality
+//!   assumption, and every probability it reports carries a standard
+//!   error — the [`ProbabilityEstimate`] type has no error-bar-free
+//!   constructor, deliberately.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability;
+use crate::rng::Rng;
+use crate::stackup::{Stackup, StackupError};
+
+/// Minimum Monte Carlo sample count (below this, standard errors on
+/// interesting yields are so wide the number is noise).
+pub const MIN_MC_SAMPLES: usize = 100;
+
+/// A probability with its standard error. There is no way to build one
+/// without the error bar: fit probabilities without uncertainty are
+/// unrepresentable in this API.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ProbabilityEstimate {
+    /// Point estimate p̂ = successes/n.
+    pub p: f64,
+    /// Standard error of p̂, from the Agresti–Coull adjusted count
+    /// (Agresti & Coull, *The American Statistician* 52(2), 1998):
+    /// p̃ = (k+2)/(n+4), SE = √(p̃(1−p̃)/(n+4)). Unlike the raw binomial
+    /// formula it never reports SE = 0 at k = 0 or k = n — "we saw no
+    /// failures in n samples" is not certainty.
+    pub standard_error: f64,
+    /// Sample count.
+    pub n: usize,
+    /// Success count.
+    pub successes: usize,
+}
+
+impl ProbabilityEstimate {
+    /// Build from counts; the standard error is computed here and
+    /// cannot be omitted.
+    pub fn from_counts(successes: usize, n: usize) -> Self {
+        assert!(n > 0, "probability of zero samples");
+        assert!(successes <= n);
+        let p = successes as f64 / n as f64;
+        let n_adj = n as f64 + 4.0;
+        let p_adj = (successes as f64 + 2.0) / n_adj;
+        let standard_error = (p_adj * (1.0 - p_adj) / n_adj).sqrt();
+        Self {
+            p,
+            standard_error,
+            n,
+            successes,
+        }
+    }
+}
+
+/// Worst-case (interval) analysis result.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct WorstCaseAnalysis {
+    /// Smallest possible gap with every part at its worst limit, mm.
+    pub min_gap: f64,
+    /// Largest possible gap, mm.
+    pub max_gap: f64,
+    /// `min_gap − lower` when a lower bound exists (negative = the
+    /// worst-case assembly violates it), mm.
+    pub margin_lower: Option<f64>,
+    /// `upper − max_gap` when an upper bound exists, mm.
+    pub margin_upper: Option<f64>,
+    /// True iff every present margin is ≥ 0.
+    pub passes: bool,
+}
+
+impl WorstCaseAnalysis {
+    /// The binding margin: the smallest of the present margins, mm.
+    pub fn worst_margin(&self) -> f64 {
+        match (self.margin_lower, self.margin_upper) {
+            (Some(a), Some(b)) => a.min(b),
+            (Some(a), None) => a,
+            (None, Some(b)) => b,
+            (None, None) => f64::NAN, // unreachable post-validate
+        }
+    }
+}
+
+/// Worst-case analysis: interval arithmetic over drawing limits.
+pub fn worst_case(s: &Stackup) -> Result<WorstCaseAnalysis, StackupError> {
+    s.validate()?;
+    let (mut min_gap, mut max_gap) = (0.0, 0.0);
+    for c in &s.contributors {
+        let e1 = c.coeff * (c.nominal - c.tol_minus);
+        let e2 = c.coeff * (c.nominal + c.tol_plus);
+        min_gap += e1.min(e2);
+        max_gap += e1.max(e2);
+    }
+    let margin_lower = s.requirement.lower_mm.map(|l| min_gap - l);
+    let margin_upper = s.requirement.upper_mm.map(|u| u - max_gap);
+    let passes = margin_lower.unwrap_or(0.0) >= 0.0 && margin_upper.unwrap_or(0.0) >= 0.0;
+    Ok(WorstCaseAnalysis {
+        min_gap,
+        max_gap,
+        margin_lower,
+        margin_upper,
+        passes,
+    })
+}
+
+/// RSS (linear variance propagation) analysis result.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct RssAnalysis {
+    /// Mean gap (nominals + process centering errors), mm.
+    pub mean_gap: f64,
+    /// Gap standard deviation √(Σ aᵢ²σᵢ²), mm. Exact under
+    /// independence — no normality needed for the moments.
+    pub sigma_gap: f64,
+    /// Φ-based fit probability. Exact under the model when
+    /// `all_normal`, a central-limit approximation otherwise.
+    pub yield_estimate: f64,
+    /// Cp = (USL−LSL)/(6σ_G); `None` for one-sided requirements.
+    pub cp: Option<f64>,
+    /// Cpk = min distance-to-limit/(3σ_G); `None` only when σ_G = 0
+    /// (rejected earlier as [`StackupError::DegenerateChain`]).
+    pub cpk: Option<f64>,
+    /// Whether every contributor is normal (yield exact under the
+    /// model) or not (yield leans on the CLT).
+    pub all_normal: bool,
+}
+
+/// RSS analysis: exact second-moment propagation, Φ-based yield.
+pub fn rss(s: &Stackup) -> Result<RssAnalysis, StackupError> {
+    s.validate()?;
+    let variance = s.variance_gap();
+    if variance == 0.0 {
+        return Err(StackupError::DegenerateChain);
+    }
+    let mean_gap = s.mean_gap();
+    let sigma_gap = variance.sqrt();
+    let lower = s.requirement.lower_mm;
+    let upper = s.requirement.upper_mm;
+    let yield_estimate = capability::yield_within(mean_gap, sigma_gap, lower, upper);
+    let all_normal = s
+        .contributors
+        .iter()
+        .all(|c| matches!(c.dist, crate::dist::Distribution::Normal { .. }));
+    Ok(RssAnalysis {
+        mean_gap,
+        sigma_gap,
+        yield_estimate,
+        cp: capability::cp(sigma_gap, lower, upper),
+        cpk: capability::cpk(mean_gap, sigma_gap, lower, upper),
+        all_normal,
+    })
+}
+
+/// Monte Carlo analysis result. Every probability carries its standard
+/// error; the batch cross-check exposes estimator health.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MonteCarloAnalysis {
+    /// Sample count.
+    pub n: usize,
+    /// PRNG seed (xoshiro256++ via SplitMix64) — reproducibility
+    /// provenance.
+    pub seed: u64,
+    /// Fit probability with Agresti–Coull standard error.
+    pub fit: ProbabilityEstimate,
+    /// Cross-check: standard error of the fit probability from batch
+    /// means (spread of per-batch p̂ over [`Self::batches`] disjoint
+    /// batches). Should agree with `fit.standard_error` within a small
+    /// factor for healthy i.i.d. sampling.
+    pub fit_se_batch: f64,
+    /// Number of batches behind `fit_se_batch`.
+    pub batches: usize,
+    /// Sample mean gap, mm.
+    pub mean_gap: f64,
+    /// Standard error of the mean gap: s/√n, mm.
+    pub mean_gap_se: f64,
+    /// Bessel-corrected sample standard deviation of the gap, mm.
+    pub sigma_gap: f64,
+    /// Standard error of `sigma_gap` under normal theory,
+    /// ≈ s/√(2(n−1)) (large-sample; e.g. Kenney & Keeping,
+    /// *Mathematics of Statistics*), mm.
+    pub sigma_gap_se: f64,
+    /// Smallest sampled gap, mm.
+    pub min_sample: f64,
+    /// Largest sampled gap, mm.
+    pub max_sample: f64,
+}
+
+/// Options for [`monte_carlo`].
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct McOptions {
+    /// Number of virtual assemblies to build.
+    pub n: usize,
+    /// PRNG seed. Same seed + same stackup = bit-identical result.
+    pub seed: u64,
+    /// Batches for the batch-mean SE cross-check.
+    pub batches: usize,
+}
+
+impl Default for McOptions {
+    fn default() -> Self {
+        Self {
+            n: 100_000,
+            seed: 0x5EED_7015,
+            batches: 16,
+        }
+    }
+}
+
+/// Monte Carlo analysis: seeded, deterministic, error-barred.
+pub fn monte_carlo(s: &Stackup, opts: &McOptions) -> Result<MonteCarloAnalysis, StackupError> {
+    s.validate()?;
+    if s.variance_gap() == 0.0 {
+        return Err(StackupError::DegenerateChain);
+    }
+    if opts.n < MIN_MC_SAMPLES {
+        return Err(StackupError::TooFewSamples {
+            n: opts.n,
+            min: MIN_MC_SAMPLES,
+        });
+    }
+    let batches = opts.batches.max(2).min(opts.n);
+    let mut rng = Rng::new(opts.seed);
+    let lower = s.requirement.lower_mm;
+    let upper = s.requirement.upper_mm;
+
+    // Welford one-pass moments + extrema + per-batch fit counts.
+    let mut mean = 0.0f64;
+    let mut m2 = 0.0f64;
+    let mut fits = 0usize;
+    let (mut min_sample, mut max_sample) = (f64::INFINITY, f64::NEG_INFINITY);
+    let mut batch_fit = vec![0usize; batches];
+    let mut batch_n = vec![0usize; batches];
+    for i in 0..opts.n {
+        let g = s.sample_gap(&mut rng);
+        let k = (i + 1) as f64;
+        let delta = g - mean;
+        mean += delta / k;
+        m2 += delta * (g - mean);
+        min_sample = min_sample.min(g);
+        max_sample = max_sample.max(g);
+        let ok = lower.is_none_or(|l| g >= l) && upper.is_none_or(|u| g <= u);
+        let b = i * batches / opts.n; // contiguous batches of ~equal size
+        batch_n[b] += 1;
+        if ok {
+            fits += 1;
+            batch_fit[b] += 1;
+        }
+    }
+    let n_f = opts.n as f64;
+    let var = m2 / (n_f - 1.0);
+    let sigma = var.sqrt();
+
+    // Batch-mean SE of the fit probability: sd of per-batch p̂ / √B.
+    let batch_ps: Vec<f64> = batch_fit
+        .iter()
+        .zip(&batch_n)
+        .filter(|&(_, &bn)| bn > 0)
+        .map(|(&bf, &bn)| bf as f64 / bn as f64)
+        .collect();
+    let nb = batch_ps.len() as f64;
+    let bp_mean = batch_ps.iter().sum::<f64>() / nb;
+    let bp_var = batch_ps.iter().map(|p| (p - bp_mean).powi(2)).sum::<f64>() / (nb - 1.0);
+    let fit_se_batch = (bp_var / nb).sqrt();
+
+    Ok(MonteCarloAnalysis {
+        n: opts.n,
+        seed: opts.seed,
+        fit: ProbabilityEstimate::from_counts(fits, opts.n),
+        fit_se_batch,
+        batches,
+        mean_gap: mean,
+        mean_gap_se: sigma / n_f.sqrt(),
+        sigma_gap: sigma,
+        sigma_gap_se: sigma / (2.0 * (n_f - 1.0)).sqrt(),
+        min_sample,
+        max_sample,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dist::SigmaConvention;
+    use crate::stackup::{Contributor, Requirement};
+
+    fn two_block() -> Stackup {
+        // Slot 30 ±0.3, block 29 ±0.4 → gap 1.0, WC [0.3, 1.7],
+        // σ_G = √(0.01 + 0.4²/9)… with 3σ: σ = 0.1 and 0.1333…
+        Stackup {
+            name: "two-block".into(),
+            contributors: vec![
+                Contributor::normal("slot", 1.0, 30.0, 0.3, SigmaConvention::ThreeSigma),
+                Contributor::normal("block", -1.0, 29.0, 0.4, SigmaConvention::ThreeSigma),
+            ],
+            requirement: Requirement::between("clearance", 0.2, 1.8),
+        }
+    }
+
+    #[test]
+    fn worst_case_interval_arithmetic_exact() {
+        let wc = worst_case(&two_block()).unwrap();
+        assert!((wc.min_gap - 0.3).abs() < 1e-12);
+        assert!((wc.max_gap - 1.7).abs() < 1e-12);
+        assert!((wc.margin_lower.unwrap() - 0.1).abs() < 1e-12);
+        assert!((wc.margin_upper.unwrap() - 0.1).abs() < 1e-12);
+        assert!(wc.passes);
+        assert!((wc.worst_margin() - 0.1).abs() < 1e-12);
+
+        // Tighten the requirement: fails, margins go negative.
+        let mut s = two_block();
+        s.requirement = Requirement::between("tight", 0.4, 1.6);
+        let wc = worst_case(&s).unwrap();
+        assert!(!wc.passes);
+        assert!((wc.worst_margin() + 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn worst_case_handles_negative_and_scaled_coefficients() {
+        // A lever-ratio contributor (coeff 2.5) and a negative-nominal
+        // direction: interval endpoints must be taken per-sign.
+        let s = Stackup {
+            name: "levers".into(),
+            contributors: vec![
+                Contributor::normal("a", 2.5, 10.0, 0.1, SigmaConvention::ThreeSigma),
+                Contributor::normal("b", -2.5, 9.0, 0.1, SigmaConvention::ThreeSigma),
+            ],
+            requirement: Requirement::at_least("gap", 0.0),
+        };
+        let wc = worst_case(&s).unwrap();
+        assert!((wc.min_gap - (2.5 * 9.9 - 2.5 * 9.1)).abs() < 1e-12);
+        assert!((wc.max_gap - (2.5 * 10.1 - 2.5 * 8.9)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rss_moments_and_capability() {
+        let r = rss(&two_block()).unwrap();
+        assert!((r.mean_gap - 1.0).abs() < 1e-12);
+        let sigma = (0.1f64.powi(2) + (0.4f64 / 3.0).powi(2)).sqrt();
+        assert!((r.sigma_gap - sigma).abs() < 1e-12);
+        assert!(r.all_normal);
+        // Cp = 1.6/(6σ), Cpk = 0.8/(3σ) — symmetric here.
+        assert!((r.cp.unwrap() - 1.6 / (6.0 * sigma)).abs() < 1e-12);
+        assert!((r.cpk.unwrap() - 0.8 / (3.0 * sigma)).abs() < 1e-12);
+        // Yield: symmetric two-sided at z = 0.8/σ = 4.8 → ~1 − 2Φ(−4.8).
+        assert!(r.yield_estimate > 0.999_99);
+    }
+
+    #[test]
+    fn monte_carlo_is_deterministic_and_error_barred() {
+        let s = two_block();
+        let opts = McOptions {
+            n: 50_000,
+            seed: 42,
+            batches: 16,
+        };
+        let a = monte_carlo(&s, &opts).unwrap();
+        let b = monte_carlo(&s, &opts).unwrap();
+        assert_eq!(a, b, "same seed must be bit-identical");
+
+        // Moments agree with RSS (exact under the model) within SE.
+        let r = rss(&s).unwrap();
+        assert!((a.mean_gap - r.mean_gap).abs() < 5.0 * a.mean_gap_se);
+        assert!((a.sigma_gap - r.sigma_gap).abs() < 5.0 * a.sigma_gap_se);
+
+        // The two SE estimates for the fit probability agree in order.
+        assert!(a.fit_se_batch < 5.0 * a.fit.standard_error + 1e-9);
+
+        // Different seed differs (statistically certain at n=50k).
+        let c = monte_carlo(&s, &McOptions { seed: 43, ..opts }).unwrap();
+        assert_ne!(a.mean_gap.to_bits(), c.mean_gap.to_bits());
+    }
+
+    #[test]
+    fn probability_estimate_never_reports_zero_se() {
+        let p = ProbabilityEstimate::from_counts(0, 1000);
+        assert_eq!(p.p, 0.0);
+        assert!(p.standard_error > 0.0, "0/1000 is not certainty");
+        let p = ProbabilityEstimate::from_counts(1000, 1000);
+        assert_eq!(p.p, 1.0);
+        assert!(p.standard_error > 0.0);
+        // And the SE shrinks with n.
+        let big = ProbabilityEstimate::from_counts(0, 100_000);
+        assert!(big.standard_error < p.standard_error);
+    }
+
+    #[test]
+    fn fail_closed_paths() {
+        let s = two_block();
+        assert!(matches!(
+            monte_carlo(
+                &s,
+                &McOptions {
+                    n: 10,
+                    ..Default::default()
+                }
+            ),
+            Err(StackupError::TooFewSamples { .. })
+        ));
+
+        // All-zero-variance chain: statistical analyses refuse.
+        let mut d = two_block();
+        for c in &mut d.contributors {
+            c.dist = crate::dist::Distribution::Normal {
+                mean: 0.0,
+                sigma: 0.0,
+            };
+        }
+        assert_eq!(rss(&d), Err(StackupError::DegenerateChain));
+        assert!(matches!(
+            monte_carlo(&d, &McOptions::default()),
+            Err(StackupError::DegenerateChain)
+        ));
+        // Worst case still works — that's its job.
+        assert!(worst_case(&d).is_ok());
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/capability.rs
+++ b/crates/vcad-kernel-tolerance/src/capability.rs
@@ -1,0 +1,151 @@
+//! Process capability: Φ-based yield, Cp/Cpk, and the hand-rolled erf
+//! they stand on.
+//!
+//! The error function uses the Abramowitz & Stegun rational
+//! approximation 7.1.26 (Handbook of Mathematical Functions, 1964;
+//! originally Hastings 1955), with stated maximum absolute error
+//! **1.5×10⁻⁷**. That error propagates directly into yield estimates:
+//! a claimed yield of 0.9973000 is really 0.9973000 ± 1.5e-7 from the
+//! approximation alone — far below Monte Carlo error at any practical
+//! sample count, which is why the RSS and MC paths can check each other.
+
+/// Error function via Abramowitz & Stegun 7.1.26. Max |error| 1.5e-7.
+pub fn erf(x: f64) -> f64 {
+    // Constants from A&S 7.1.26.
+    const P: f64 = 0.327_591_1;
+    const A1: f64 = 0.254_829_592;
+    const A2: f64 = -0.284_496_736;
+    const A3: f64 = 1.421_413_741;
+    const A4: f64 = -1.453_152_027;
+    const A5: f64 = 1.061_405_429;
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + P * x);
+    let poly = ((((A5 * t + A4) * t + A3) * t + A2) * t + A1) * t;
+    sign * (1.0 - poly * (-x * x).exp())
+}
+
+/// Standard normal CDF: Φ(z) = ½(1 + erf(z/√2)).
+pub fn phi(z: f64) -> f64 {
+    0.5 * (1.0 + erf(z / std::f64::consts::SQRT_2))
+}
+
+/// Standard normal PDF: φ(z) = e^(−z²/2)/√(2π). Exact (no
+/// approximation); used by the exact yield sensitivities.
+pub fn phi_pdf(z: f64) -> f64 {
+    (-0.5 * z * z).exp() / (2.0 * std::f64::consts::PI).sqrt()
+}
+
+/// Probability that a Normal(mean, sigma) falls within the requirement
+/// bounds. With `sigma == 0` this degenerates honestly to a 0/1
+/// indicator on the mean.
+pub fn yield_within(mean: f64, sigma: f64, lower: Option<f64>, upper: Option<f64>) -> f64 {
+    if sigma == 0.0 {
+        let ok_lower = lower.is_none_or(|l| mean >= l);
+        let ok_upper = upper.is_none_or(|u| mean <= u);
+        return if ok_lower && ok_upper { 1.0 } else { 0.0 };
+    }
+    let hi = upper.map_or(1.0, |u| phi((u - mean) / sigma));
+    let lo = lower.map_or(0.0, |l| phi((l - mean) / sigma));
+    (hi - lo).max(0.0)
+}
+
+/// Process capability Cp = (USL − LSL)/(6σ). Needs both limits; a
+/// one-sided requirement has no Cp (that's what Cpk is for).
+pub fn cp(sigma: f64, lower: Option<f64>, upper: Option<f64>) -> Option<f64> {
+    match (lower, upper) {
+        (Some(l), Some(u)) if sigma > 0.0 => Some((u - l) / (6.0 * sigma)),
+        _ => None,
+    }
+}
+
+/// Process capability index Cpk = min over present limits of
+/// (distance from mean to limit)/(3σ). `None` when σ = 0 (capability
+/// of a deterministic chain is not a meaningful ratio).
+pub fn cpk(mean: f64, sigma: f64, lower: Option<f64>, upper: Option<f64>) -> Option<f64> {
+    if sigma <= 0.0 {
+        return None;
+    }
+    let from_lower = lower.map(|l| (mean - l) / (3.0 * sigma));
+    let from_upper = upper.map(|u| (u - mean) / (3.0 * sigma));
+    match (from_lower, from_upper) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn erf_matches_reference_values() {
+        // Reference values (A&S Table 7.1 / standard math libraries),
+        // checked to the approximation's stated 1.5e-7 bound.
+        let cases = [
+            (0.0, 0.0),
+            (0.5, 0.520_499_877_8),
+            (1.0, 0.842_700_792_9),
+            (1.5, 0.966_105_146_5),
+            (2.0, 0.995_322_265_0),
+            (3.0, 0.999_977_909_5),
+        ];
+        for (x, want) in cases {
+            assert!(
+                (erf(x) - want).abs() <= 1.5e-7,
+                "erf({x}) = {} want {want}",
+                erf(x)
+            );
+            // Odd symmetry.
+            assert!((erf(-x) + want).abs() <= 1.5e-7);
+        }
+    }
+
+    #[test]
+    fn phi_matches_reference_values() {
+        let cases = [
+            (0.0, 0.5),
+            (1.0, 0.841_344_746_1),
+            (2.0, 0.977_249_868_1),
+            (3.0, 0.998_650_101_968),
+            (-1.0, 0.158_655_253_9),
+        ];
+        for (z, want) in cases {
+            assert!(
+                (phi(z) - want).abs() <= 1.5e-7,
+                "phi({z}) = {} want {want}",
+                phi(z)
+            );
+        }
+    }
+
+    #[test]
+    fn phi_pdf_is_exact() {
+        assert!((phi_pdf(0.0) - 0.398_942_280_401).abs() < 1e-12);
+        assert!((phi_pdf(1.0) - 0.241_970_724_519).abs() < 1e-12);
+    }
+
+    #[test]
+    fn yield_and_capability_closed_forms() {
+        // Centered process filling ±3σ: yield 99.73%, Cp = Cpk = 1.
+        let y = yield_within(0.0, 1.0, Some(-3.0), Some(3.0));
+        assert!((y - 0.997_300_2).abs() < 1e-6, "{y}");
+        assert_eq!(cp(1.0, Some(-3.0), Some(3.0)), Some(1.0));
+        assert_eq!(cpk(0.0, 1.0, Some(-3.0), Some(3.0)), Some(1.0));
+
+        // Shifted process: Cpk reflects the nearer limit.
+        let k = cpk(1.0, 1.0, Some(-3.0), Some(3.0)).unwrap();
+        assert!((k - 2.0 / 3.0).abs() < 1e-12);
+
+        // One-sided: no Cp, Cpk from the single limit.
+        assert_eq!(cp(1.0, Some(0.0), None), None);
+        assert_eq!(cpk(3.0, 1.0, Some(0.0), None), Some(1.0));
+
+        // Degenerate σ = 0: yield is an indicator, capability is None.
+        assert_eq!(yield_within(0.5, 0.0, Some(0.0), Some(1.0)), 1.0);
+        assert_eq!(yield_within(2.0, 0.0, Some(0.0), Some(1.0)), 0.0);
+        assert_eq!(cpk(0.5, 0.0, Some(0.0), Some(1.0)), None);
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/dist.rs
+++ b/crates/vcad-kernel-tolerance/src/dist.rs
@@ -1,0 +1,342 @@
+//! Statistical models of dimensional deviation, and the tolerance-to-σ
+//! convention that links drawing limits to process statistics.
+//!
+//! Every distribution here describes the **deviation from nominal** of
+//! one contributor, in millimeters. The worst-case analysis never looks
+//! at the distribution — it uses the drawing limits on the contributor —
+//! while RSS and Monte Carlo use only the distribution. The two are tied
+//! together by [`SigmaConvention`], and that tie is an *assumption*:
+//! see the honesty section in `docs/tolerance-m0.md`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::rng::Rng;
+
+/// How a ± drawing tolerance maps to the standard deviation of the
+/// assumed normal process.
+///
+/// **This convention buries more products than any solver bug.** The
+/// default ±tol = 3σ says the process exactly fills the drawing band at
+/// Cp = 1.00 and ships 0.27% of parts outside the limits; a supplier
+/// running Cp = 1.33 is at ±tol = 4σ, and a Six Sigma process at ±tol =
+/// 6σ (before mean shift). Every yield number downstream inherits
+/// whichever convention you pick, so the receipt records it as
+/// provenance rather than letting it default silently.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Default)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SigmaConvention {
+    /// ±tol = 3σ — the industry default assumption for an uncontrolled
+    /// but capable process (Cp = 1.00).
+    #[default]
+    ThreeSigma,
+    /// ±tol = k·σ for a stated k (4 for a Cp = 1.33 supplier agreement,
+    /// 6 for a Six Sigma process).
+    KSigma {
+        /// Number of standard deviations covered by the tolerance.
+        k: f64,
+    },
+}
+
+impl SigmaConvention {
+    /// The number of σ the ± tolerance spans on each side of nominal.
+    pub fn k(self) -> f64 {
+        match self {
+            SigmaConvention::ThreeSigma => 3.0,
+            SigmaConvention::KSigma { k } => k,
+        }
+    }
+}
+
+/// Where a contributor's distribution came from.
+///
+/// Distributions are **assumptions until measured**. The receipt carries
+/// this per contributor so a claimed yield can be audited: a chain of
+/// `Assumed` sources is a paper prediction; `Measured` sources tie it to
+/// coupon data (see the `measure` module).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DistributionSource {
+    /// Derived from the drawing tolerance under a stated convention.
+    Assumed {
+        /// The tolerance-to-σ convention used.
+        convention: SigmaConvention,
+    },
+    /// Fitted from measured samples (calipers on printed coupons, CMM
+    /// data, supplier SPC exports).
+    Measured {
+        /// Number of samples behind the fit.
+        n_samples: usize,
+        /// Instrument or data-source provenance.
+        instrument: String,
+    },
+}
+
+impl Default for DistributionSource {
+    fn default() -> Self {
+        DistributionSource::Assumed {
+            convention: SigmaConvention::ThreeSigma,
+        }
+    }
+}
+
+/// Statistical model of one contributor's deviation from nominal (mm).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Distribution {
+    /// Normal deviation: `mean` is the process centering error (usually
+    /// 0), `sigma` the process standard deviation. Support is unbounded —
+    /// under the 3σ convention, 0.27% of parts genuinely fall outside
+    /// the drawing limits, and Monte Carlo will sample them.
+    Normal {
+        /// Process centering error, mm.
+        mean: f64,
+        /// Process standard deviation, mm (≥ 0; 0 is a fixed offset).
+        sigma: f64,
+    },
+    /// Uniform on [lo, hi] — the honest model when nothing is known
+    /// beyond "the vendor ships anywhere in the band" (bearing width
+    /// grades, purchased stock).
+    Uniform {
+        /// Lower deviation bound, mm.
+        lo: f64,
+        /// Upper deviation bound, mm.
+        hi: f64,
+    },
+    /// Two-state ("Bernoulli-shifted"): deviation `a` with probability
+    /// 1 − `p_b`, deviation `b` with probability `p_b`. Models two-state
+    /// realities a normal cannot: two suppliers, two mold cavities, a
+    /// seated-vs-cocked retaining ring.
+    TwoPoint {
+        /// First state's deviation, mm.
+        a: f64,
+        /// Second state's deviation, mm.
+        b: f64,
+        /// Probability of state `b` (in [0, 1]).
+        p_b: f64,
+    },
+}
+
+impl Distribution {
+    /// Mean deviation from nominal, mm.
+    pub fn mean(&self) -> f64 {
+        match *self {
+            Distribution::Normal { mean, .. } => mean,
+            Distribution::Uniform { lo, hi } => 0.5 * (lo + hi),
+            Distribution::TwoPoint { a, b, p_b } => a * (1.0 - p_b) + b * p_b,
+        }
+    }
+
+    /// Variance of the deviation, mm².
+    pub fn variance(&self) -> f64 {
+        match *self {
+            Distribution::Normal { sigma, .. } => sigma * sigma,
+            Distribution::Uniform { lo, hi } => {
+                let w = hi - lo;
+                w * w / 12.0
+            }
+            Distribution::TwoPoint { a, b, p_b } => {
+                let d = b - a;
+                d * d * p_b * (1.0 - p_b)
+            }
+        }
+    }
+
+    /// Standard deviation of the deviation, mm.
+    pub fn sigma(&self) -> f64 {
+        self.variance().sqrt()
+    }
+
+    /// Support bounds, when the distribution is bounded. `None` for
+    /// [`Distribution::Normal`] — its tails are infinite, which is
+    /// exactly why worst-case analysis uses drawing limits instead.
+    pub fn support(&self) -> Option<(f64, f64)> {
+        match *self {
+            Distribution::Normal { .. } => None,
+            Distribution::Uniform { lo, hi } => Some((lo, hi)),
+            Distribution::TwoPoint { a, b, .. } => Some((a.min(b), a.max(b))),
+        }
+    }
+
+    /// Draw one deviation sample.
+    pub fn sample(&self, rng: &mut Rng) -> f64 {
+        match *self {
+            Distribution::Normal { mean, sigma } => mean + sigma * rng.next_normal(),
+            Distribution::Uniform { lo, hi } => lo + (hi - lo) * rng.next_f64(),
+            Distribution::TwoPoint { a, b, p_b } => {
+                if rng.next_f64() < p_b {
+                    b
+                } else {
+                    a
+                }
+            }
+        }
+    }
+
+    /// Structural validity: finite parameters, σ ≥ 0, lo ≤ hi,
+    /// p_b ∈ [0, 1]. Returns a human-readable reason on failure.
+    pub(crate) fn check(&self) -> Result<(), String> {
+        match *self {
+            Distribution::Normal { mean, sigma } => {
+                if !mean.is_finite() || !sigma.is_finite() {
+                    return Err("normal parameters must be finite".into());
+                }
+                if sigma < 0.0 {
+                    return Err(format!("sigma must be >= 0, got {sigma}"));
+                }
+            }
+            Distribution::Uniform { lo, hi } => {
+                if !lo.is_finite() || !hi.is_finite() {
+                    return Err("uniform bounds must be finite".into());
+                }
+                if lo > hi {
+                    return Err(format!("uniform requires lo <= hi, got [{lo}, {hi}]"));
+                }
+            }
+            Distribution::TwoPoint { a, b, p_b } => {
+                if !a.is_finite() || !b.is_finite() || !p_b.is_finite() {
+                    return Err("two-point parameters must be finite".into());
+                }
+                if !(0.0..=1.0).contains(&p_b) {
+                    return Err(format!("p_b must be in [0, 1], got {p_b}"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moments_match_closed_forms() {
+        let n = Distribution::Normal {
+            mean: 0.1,
+            sigma: 0.05,
+        };
+        assert_eq!(n.mean(), 0.1);
+        assert!((n.variance() - 0.0025).abs() < 1e-15);
+
+        let u = Distribution::Uniform { lo: -0.12, hi: 0.0 };
+        assert!((u.mean() + 0.06).abs() < 1e-15);
+        assert!((u.variance() - 0.12 * 0.12 / 12.0).abs() < 1e-15);
+
+        let t = Distribution::TwoPoint {
+            a: -0.03,
+            b: 0.04,
+            p_b: 0.4,
+        };
+        assert!((t.mean() - (-0.03 * 0.6 + 0.04 * 0.4)).abs() < 1e-15);
+        assert!((t.variance() - 0.07 * 0.07 * 0.4 * 0.6).abs() < 1e-15);
+    }
+
+    #[test]
+    fn sample_means_converge_to_analytic_means() {
+        let dists = [
+            Distribution::Normal {
+                mean: 0.02,
+                sigma: 0.1,
+            },
+            Distribution::Uniform { lo: -0.2, hi: 0.1 },
+            Distribution::TwoPoint {
+                a: -1.0,
+                b: 2.0,
+                p_b: 0.25,
+            },
+        ];
+        let mut rng = Rng::new(2024);
+        for d in dists {
+            let n = 100_000;
+            let mut sum = 0.0;
+            let mut sum_sq = 0.0;
+            for _ in 0..n {
+                let x = d.sample(&mut rng);
+                sum += x;
+                sum_sq += x * x;
+            }
+            let mean = sum / n as f64;
+            let var = sum_sq / n as f64 - mean * mean;
+            let se_mean = d.sigma() / (n as f64).sqrt();
+            assert!(
+                (mean - d.mean()).abs() < 5.0 * se_mean,
+                "{d:?}: mean {mean} vs {}",
+                d.mean()
+            );
+            assert!(
+                (var - d.variance()).abs() / d.variance() < 0.05,
+                "{d:?}: var {var} vs {}",
+                d.variance()
+            );
+        }
+    }
+
+    #[test]
+    fn support_is_honest_about_normal_tails() {
+        assert_eq!(
+            Distribution::Normal {
+                mean: 0.0,
+                sigma: 1.0
+            }
+            .support(),
+            None
+        );
+        assert_eq!(
+            Distribution::Uniform { lo: -1.0, hi: 2.0 }.support(),
+            Some((-1.0, 2.0))
+        );
+        assert_eq!(
+            Distribution::TwoPoint {
+                a: 3.0,
+                b: -1.0,
+                p_b: 0.5
+            }
+            .support(),
+            Some((-1.0, 3.0))
+        );
+    }
+
+    #[test]
+    fn check_rejects_bad_parameters() {
+        assert!(Distribution::Normal {
+            mean: 0.0,
+            sigma: -1.0
+        }
+        .check()
+        .is_err());
+        assert!(Distribution::Uniform { lo: 1.0, hi: 0.0 }.check().is_err());
+        assert!(Distribution::TwoPoint {
+            a: 0.0,
+            b: 1.0,
+            p_b: 1.5
+        }
+        .check()
+        .is_err());
+        assert!(Distribution::Normal {
+            mean: f64::NAN,
+            sigma: 1.0
+        }
+        .check()
+        .is_err());
+    }
+
+    #[test]
+    fn sigma_convention_k() {
+        assert_eq!(SigmaConvention::ThreeSigma.k(), 3.0);
+        assert_eq!(SigmaConvention::KSigma { k: 4.5 }.k(), 4.5);
+        assert_eq!(SigmaConvention::default(), SigmaConvention::ThreeSigma);
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let d = Distribution::TwoPoint {
+            a: -0.03,
+            b: 0.04,
+            p_b: 0.4,
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        assert!(json.contains("two_point"), "{json}");
+        let back: Distribution = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, d);
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/gdt.rs
+++ b/crates/vcad-kernel-tolerance/src/gdt.rs
@@ -1,0 +1,713 @@
+//! GD&T semantics that move fits: position at MMC with bonus
+//! tolerance, virtual condition, and form-tolerance contributor
+//! generators (M1).
+//!
+//! **Scoped subset, stated:** this module owns the position-tolerance
+//! fit problem for patterns of cylindrical features (pins into holes —
+//! the overwhelmingly common case), plus generators that turn flatness
+//! and perpendicularity callouts into gap contributors. It does not
+//! simulate datum reference frames, composite frames, or profile
+//! tolerances; that is the full-3D-gauge feature set (3DCS/CETOL
+//! territory) and a later milestone if ever.
+//!
+//! ## The honest bonus-tolerance model
+//!
+//! At MMC (ASME Y14.5 Ⓜ modifier), a feature departing from maximum
+//! material condition earns *bonus* position tolerance: allowed zone
+//! Ø = stated + |size − MMC|. Three facts the model keeps separate,
+//! because conflating them is how stackup spreadsheets lie:
+//!
+//! 1. **Bonus changes conformance, not physics.** The process's
+//!    position scatter ([`PositionedFeature::sigma_pos`]) is a process
+//!    property; a big hole doesn't move differently, it just *passes a
+//!    gauge* it would otherwise fail — and fits more easily because the
+//!    extra clearance is physically real.
+//! 2. **Fit is about actual geometry.** The Monte Carlo fit model uses
+//!    actual sampled sizes and actual radial misalignments; MMC bonus
+//!    is "included" automatically because a larger hole genuinely
+//!    clears a worse position error. No bonus bookkeeping can make a
+//!    fit analysis more honest than sampling the joint reality.
+//! 3. **Inspection truncates.** If parts are 100% gauged, the shipped
+//!    population is conditioned on conformance. The classic theorem —
+//!    encoded and tested here — is that gauging both parts at MMC
+//!    makes fit **guaranteed** whenever the virtual conditions are
+//!    compatible (hole VC ≥ pin VC): the gauge *is* the worst-case
+//!    counterpart.
+//!
+//! Position scatter convention (stated, configurable): per-axis
+//! position error is Normal(0, σ) with σ = (zone Ø/2)/k under the
+//! chosen [`SigmaConvention`] — "the process hits the stated zone
+//! radius at kσ per axis." The radial error is then Rayleigh(σ), and
+//! every closed form below follows from the Rayleigh CDF
+//! 1 − e^(−r²/2σ²).
+
+use serde::{Deserialize, Serialize};
+
+use crate::analysis::ProbabilityEstimate;
+use crate::dist::{Distribution, SigmaConvention};
+use crate::rng::Rng;
+use crate::stackup::{Contributor, StackupError};
+
+/// Internal (hole) or external (pin/boss) feature of size.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FeatureOf {
+    /// Internal feature — MMC is the smallest size.
+    Internal,
+    /// External feature — MMC is the largest size.
+    External,
+}
+
+/// Material-condition modifier on a position tolerance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Modifier {
+    /// Regardless of feature size: the stated zone, no bonus.
+    Rfs,
+    /// Maximum material condition: stated zone + |size − MMC| bonus.
+    Mmc,
+}
+
+/// A cylindrical feature of size with a position tolerance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PositionedFeature {
+    /// Feature name.
+    pub name: String,
+    /// Hole or pin.
+    pub kind: FeatureOf,
+    /// Nominal diameter, mm.
+    pub size_nominal: f64,
+    /// Lower drawing limit on diameter (deviation below nominal ≥ 0), mm.
+    pub size_tol_minus: f64,
+    /// Upper drawing limit on diameter (deviation above nominal ≥ 0), mm.
+    pub size_tol_plus: f64,
+    /// Diameter deviation distribution.
+    pub size_dist: Distribution,
+    /// Position tolerance zone diameter as stated in the feature
+    /// control frame (at MMC when `modifier` is Mmc), mm.
+    pub zone_dia: f64,
+    /// Modifier on the position tolerance.
+    pub modifier: Modifier,
+    /// Per-axis position-error standard deviation, mm. A process
+    /// property — see the module docs for the stated convention.
+    pub sigma_pos: f64,
+}
+
+impl PositionedFeature {
+    /// Per-axis σ from the stated zone under a convention: the process
+    /// hits the zone *radius* at kσ per axis.
+    pub fn sigma_from_zone(zone_dia: f64, convention: SigmaConvention) -> f64 {
+        0.5 * zone_dia / convention.k()
+    }
+
+    /// Maximum-material size: smallest hole / largest pin, mm.
+    pub fn mmc_size(&self) -> f64 {
+        match self.kind {
+            FeatureOf::Internal => self.size_nominal - self.size_tol_minus,
+            FeatureOf::External => self.size_nominal + self.size_tol_plus,
+        }
+    }
+
+    /// Least-material size, mm.
+    pub fn lmc_size(&self) -> f64 {
+        match self.kind {
+            FeatureOf::Internal => self.size_nominal + self.size_tol_plus,
+            FeatureOf::External => self.size_nominal - self.size_tol_minus,
+        }
+    }
+
+    /// Virtual condition: the fixed gauge boundary (ASME Y14.5).
+    /// Internal: MMC − zone; external: MMC + zone. Fit against the
+    /// mating part's VC is the worst-case guarantee.
+    pub fn virtual_condition(&self) -> f64 {
+        match self.kind {
+            FeatureOf::Internal => self.mmc_size() - self.zone_dia,
+            FeatureOf::External => self.mmc_size() + self.zone_dia,
+        }
+    }
+
+    /// Allowed position-zone diameter for an actual size: the stated
+    /// zone, plus bonus at MMC.
+    pub fn allowed_zone_dia(&self, actual_size: f64) -> f64 {
+        match self.modifier {
+            Modifier::Rfs => self.zone_dia,
+            Modifier::Mmc => {
+                let departure = match self.kind {
+                    FeatureOf::Internal => actual_size - self.mmc_size(),
+                    FeatureOf::External => self.mmc_size() - actual_size,
+                };
+                self.zone_dia + departure.max(0.0)
+            }
+        }
+    }
+
+    /// Sample one made feature: (actual diameter, position error x, y).
+    pub fn sample(&self, rng: &mut Rng) -> (f64, f64, f64) {
+        let size = self.size_nominal + self.size_dist.sample(rng);
+        let ex = self.sigma_pos * rng.next_normal();
+        let ey = self.sigma_pos * rng.next_normal();
+        (size, ex, ey)
+    }
+
+    /// Whether a made feature passes its position gauge (the dynamic,
+    /// bonus-widened zone at MMC; the fixed zone at RFS).
+    pub fn conforms(&self, actual_size: f64, ex: f64, ey: f64) -> bool {
+        let r2 = ex * ex + ey * ey;
+        let allowed_r = 0.5 * self.allowed_zone_dia(actual_size);
+        // Size must also be in its own band.
+        let in_band = actual_size >= self.size_nominal - self.size_tol_minus - 1e-12
+            && actual_size <= self.size_nominal + self.size_tol_plus + 1e-12;
+        in_band && r2 <= allowed_r * allowed_r
+    }
+
+    /// Monte Carlo conformance probability — the honest bonus model:
+    /// joint over the size distribution and the 2-D position scatter.
+    /// At RFS this converges to the Rayleigh CDF at the fixed zone
+    /// radius; at MMC it is strictly higher for any size distribution
+    /// with spread (the bonus admits real parts).
+    pub fn conformance_probability(&self, n: usize, seed: u64) -> ProbabilityEstimate {
+        let mut rng = Rng::new(seed);
+        let mut pass = 0usize;
+        for _ in 0..n {
+            let (size, ex, ey) = self.sample(&mut rng);
+            if self.conforms(size, ex, ey) {
+                pass += 1;
+            }
+        }
+        ProbabilityEstimate::from_counts(pass, n)
+    }
+
+    fn check(&self) -> Result<(), StackupError> {
+        let bad = |field: &'static str| StackupError::NonFinite {
+            contributor: self.name.clone(),
+            field,
+        };
+        if !self.size_nominal.is_finite() {
+            return Err(bad("size_nominal"));
+        }
+        if !self.zone_dia.is_finite() || self.zone_dia < 0.0 {
+            return Err(bad("zone_dia"));
+        }
+        if !self.sigma_pos.is_finite() || self.sigma_pos < 0.0 {
+            return Err(bad("sigma_pos"));
+        }
+        if self.size_tol_minus < 0.0 || self.size_tol_plus < 0.0 {
+            return Err(StackupError::NegativeTolerance(self.name.clone()));
+        }
+        self.size_dist
+            .check()
+            .map_err(|reason| StackupError::InvalidDistribution {
+                contributor: self.name.clone(),
+                reason,
+            })
+    }
+}
+
+/// A pattern fit: `n_features` pins (all drawn from the pin spec) must
+/// simultaneously enter `n_features` holes (all drawn from the hole
+/// spec). Pin and hole position errors are independent per feature —
+/// the floating relative-misalignment case; a rigid common shift adds
+/// correlation and is future work, stated.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PatternFit {
+    /// The pin (external) spec.
+    pub pin: PositionedFeature,
+    /// The hole (internal) spec.
+    pub hole: PositionedFeature,
+    /// Number of features in the pattern (≥ 1).
+    pub n_features: usize,
+}
+
+/// Worst-case (virtual condition) verdict for a pattern fit.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct VcFit {
+    /// Hole virtual condition (fixed gauge boundary), mm.
+    pub hole_vc: f64,
+    /// Pin virtual condition, mm.
+    pub pin_vc: f64,
+    /// hole_vc − pin_vc: ≥ 0 means fit is guaranteed for conforming
+    /// parts, mm.
+    pub margin: f64,
+    /// Whether worst-case fit is guaranteed.
+    pub guaranteed: bool,
+}
+
+/// Monte Carlo fit result for a pattern.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PatternFitResult {
+    /// Assembly-level fit probability (all features seat).
+    pub fit: ProbabilityEstimate,
+    /// Fraction of *assemblies* where every pin conformed to its gauge.
+    pub pin_conformance: ProbabilityEstimate,
+    /// Fraction of assemblies where every hole conformed.
+    pub hole_conformance: ProbabilityEstimate,
+    /// Whether sampling was conditioned on conformance (100%
+    /// inspection): non-conforming parts re-drawn, so `fit` describes
+    /// the shipped population.
+    pub inspected: bool,
+    /// Sample count (assemblies).
+    pub n: usize,
+    /// Seed.
+    pub seed: u64,
+}
+
+impl PatternFit {
+    fn check(&self) -> Result<(), StackupError> {
+        self.pin.check()?;
+        self.hole.check()?;
+        if self.pin.kind != FeatureOf::External || self.hole.kind != FeatureOf::Internal {
+            return Err(StackupError::BadRequirement(
+                "PatternFit needs an external pin and an internal hole".into(),
+            ));
+        }
+        if self.n_features == 0 {
+            return Err(StackupError::Empty);
+        }
+        Ok(())
+    }
+
+    /// The worst-case gauge check: fit is guaranteed iff the hole's
+    /// virtual condition is at least the pin's (fixed-fastener
+    /// formula: H_mmc − T_hole ≥ F_mmc + T_pin, cf. ASME Y14.5
+    /// appendix fastener formulas).
+    pub fn worst_case(&self) -> Result<VcFit, StackupError> {
+        self.check()?;
+        let hole_vc = self.hole.virtual_condition();
+        let pin_vc = self.pin.virtual_condition();
+        let margin = hole_vc - pin_vc;
+        Ok(VcFit {
+            hole_vc,
+            pin_vc,
+            margin,
+            guaranteed: margin >= 0.0,
+        })
+    }
+
+    /// Monte Carlo over the exact joint model. `inspected` conditions
+    /// each part on passing its position gauge (rejection sampling) —
+    /// the shipped-population model. A feature seats iff the relative
+    /// radial misalignment ≤ (hole − pin)/2 for its sampled sizes.
+    pub fn monte_carlo(
+        &self,
+        n: usize,
+        seed: u64,
+        inspected: bool,
+    ) -> Result<PatternFitResult, StackupError> {
+        self.check()?;
+        if n < crate::analysis::MIN_MC_SAMPLES {
+            return Err(StackupError::TooFewSamples {
+                n,
+                min: crate::analysis::MIN_MC_SAMPLES,
+            });
+        }
+        let mut rng = Rng::new(seed);
+        let mut fit_count = 0usize;
+        let mut pin_conf_count = 0usize;
+        let mut hole_conf_count = 0usize;
+        // Rejection cap: if conformance is below ~1%, inspected
+        // sampling would spin; fail loudly instead of silently looping.
+        let max_draws = 1000usize;
+        for _ in 0..n {
+            let mut all_fit = true;
+            let mut all_pin_conf = true;
+            let mut all_hole_conf = true;
+            for _ in 0..self.n_features {
+                let (pin_d, pex, pey, pin_conf) = {
+                    let mut draws = 0;
+                    loop {
+                        let (d, x, y) = self.pin.sample(&mut rng);
+                        let conf = self.pin.conforms(d, x, y);
+                        if !inspected || conf {
+                            break (d, x, y, conf);
+                        }
+                        draws += 1;
+                        if draws > max_draws {
+                            return Err(StackupError::BadRequirement(format!(
+                                "inspected sampling: pin {:?} conformance too low \
+                                 (>{max_draws} rejections)",
+                                self.pin.name
+                            )));
+                        }
+                    }
+                };
+                let (hole_d, hex, hey, hole_conf) = {
+                    let mut draws = 0;
+                    loop {
+                        let (d, x, y) = self.hole.sample(&mut rng);
+                        let conf = self.hole.conforms(d, x, y);
+                        if !inspected || conf {
+                            break (d, x, y, conf);
+                        }
+                        draws += 1;
+                        if draws > max_draws {
+                            return Err(StackupError::BadRequirement(format!(
+                                "inspected sampling: hole {:?} conformance too low \
+                                 (>{max_draws} rejections)",
+                                self.hole.name
+                            )));
+                        }
+                    }
+                };
+                all_pin_conf &= pin_conf;
+                all_hole_conf &= hole_conf;
+                // Relative misalignment vs actual radial clearance.
+                let dx = hex - pex;
+                let dy = hey - pey;
+                let c = 0.5 * (hole_d - pin_d);
+                if c < 0.0 || dx * dx + dy * dy > c * c {
+                    all_fit = false;
+                }
+            }
+            if all_fit {
+                fit_count += 1;
+            }
+            if all_pin_conf {
+                pin_conf_count += 1;
+            }
+            if all_hole_conf {
+                hole_conf_count += 1;
+            }
+        }
+        Ok(PatternFitResult {
+            fit: ProbabilityEstimate::from_counts(fit_count, n),
+            pin_conformance: ProbabilityEstimate::from_counts(pin_conf_count, n),
+            hole_conformance: ProbabilityEstimate::from_counts(hole_conf_count, n),
+            inspected,
+            n,
+            seed,
+        })
+    }
+}
+
+/// Flatness callout → gap contributor at a clamped interface.
+///
+/// Assumption (stated): high spots hold the mating faces apart, so a
+/// flatness error of up to `t` consumes 0..t of gap, modeled Uniform(0,
+/// t) — nothing is known about where in the band a surface lands, and
+/// the error is one-sided by construction. `coeff` is +1 if the
+/// separation opens the measured gap, −1 if it consumes it.
+pub fn flatness_contributor(name: &str, coeff: f64, t: f64) -> Contributor {
+    Contributor {
+        name: name.to_string(),
+        coeff,
+        nominal: 0.0,
+        tol_minus: 0.0,
+        tol_plus: t,
+        dist: Distribution::Uniform { lo: 0.0, hi: t },
+        source: crate::dist::DistributionSource::Assumed {
+            convention: SigmaConvention::ThreeSigma,
+        },
+    }
+}
+
+/// Perpendicularity callout → gap contributor for a feature engaged
+/// over part of its control length.
+///
+/// A perpendicularity zone of width `t` over control length `l`
+/// permits a tilt of up to t/l; at engagement height `h` the lateral
+/// displacement is up to `t·h/l`, modeled Uniform(0, t·h/l), one-sided
+/// (tilt direction unknown but displacement magnitude is what a gap
+/// chain consumes). First-order small-angle, same bound as the loops
+/// module.
+pub fn perpendicularity_contributor(
+    name: &str,
+    coeff: f64,
+    t: f64,
+    control_len: f64,
+    engagement: f64,
+) -> Contributor {
+    let span = t * engagement / control_len;
+    Contributor {
+        name: name.to_string(),
+        coeff,
+        nominal: 0.0,
+        tol_minus: 0.0,
+        tol_plus: span,
+        dist: Distribution::Uniform { lo: 0.0, hi: span },
+        source: crate::dist::DistributionSource::Assumed {
+            convention: SigmaConvention::ThreeSigma,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pin() -> PositionedFeature {
+        PositionedFeature {
+            name: "pin".into(),
+            kind: FeatureOf::External,
+            size_nominal: 6.0,
+            size_tol_minus: 0.02,
+            size_tol_plus: 0.0,
+            size_dist: Distribution::Uniform { lo: -0.02, hi: 0.0 },
+            zone_dia: 0.05,
+            modifier: Modifier::Mmc,
+            sigma_pos: PositionedFeature::sigma_from_zone(0.05, SigmaConvention::ThreeSigma),
+        }
+    }
+
+    fn hole() -> PositionedFeature {
+        PositionedFeature {
+            name: "hole".into(),
+            kind: FeatureOf::Internal,
+            size_nominal: 6.12,
+            size_tol_minus: 0.02,
+            size_tol_plus: 0.03,
+            size_dist: Distribution::Uniform {
+                lo: -0.02,
+                hi: 0.03,
+            },
+            zone_dia: 0.1,
+            modifier: Modifier::Mmc,
+            sigma_pos: PositionedFeature::sigma_from_zone(0.1, SigmaConvention::ThreeSigma),
+        }
+    }
+
+    #[test]
+    fn mmc_lmc_and_virtual_condition_arithmetic() {
+        let p = pin();
+        let h = hole();
+        assert!((p.mmc_size() - 6.0).abs() < 1e-12);
+        assert!((p.lmc_size() - 5.98).abs() < 1e-12);
+        assert!((h.mmc_size() - 6.10).abs() < 1e-12);
+        assert!((h.lmc_size() - 6.15).abs() < 1e-12);
+        // VC: pin 6.00 + 0.05 = 6.05; hole 6.10 − 0.10 = 6.00.
+        assert!((p.virtual_condition() - 6.05).abs() < 1e-12);
+        assert!((h.virtual_condition() - 6.00).abs() < 1e-12);
+        // Fixed-fastener margin: 6.00 − 6.05 = −0.05 → not guaranteed.
+        let fit = PatternFit {
+            pin: p,
+            hole: h,
+            n_features: 4,
+        };
+        let wc = fit.worst_case().unwrap();
+        assert!((wc.margin + 0.05).abs() < 1e-12);
+        assert!(!wc.guaranteed);
+    }
+
+    #[test]
+    fn bonus_tolerance_arithmetic() {
+        let h = hole();
+        // At MMC size: no bonus. At LMC: bonus = 0.05.
+        assert!((h.allowed_zone_dia(6.10) - 0.1).abs() < 1e-12);
+        assert!((h.allowed_zone_dia(6.15) - 0.15).abs() < 1e-12);
+        // RFS: never a bonus.
+        let mut rfs = h.clone();
+        rfs.modifier = Modifier::Rfs;
+        assert!((rfs.allowed_zone_dia(6.15) - 0.1).abs() < 1e-12);
+        // A pin's bonus grows as it shrinks.
+        let p = pin();
+        assert!((p.allowed_zone_dia(6.0) - 0.05).abs() < 1e-12);
+        assert!((p.allowed_zone_dia(5.98) - 0.07).abs() < 1e-12);
+    }
+
+    #[test]
+    fn rfs_conformance_matches_rayleigh_closed_form() {
+        // At RFS with a fixed zone, conformance = Rayleigh CDF at the
+        // zone radius: 1 − e^(−r²/2σ²); with r = 3σ per the
+        // convention, that's 1 − e^(−4.5) = 0.98889.
+        let mut f = hole();
+        f.modifier = Modifier::Rfs;
+        let p = f.conformance_probability(200_000, 77);
+        let want = 1.0 - (-4.5f64).exp();
+        assert!(
+            (p.p - want).abs() < 4.0 * p.standard_error,
+            "MC {} ± {} vs Rayleigh {}",
+            p.p,
+            p.standard_error,
+            want
+        );
+    }
+
+    #[test]
+    fn mmc_bonus_raises_conformance_by_the_predicted_amount() {
+        // MMC conformance = E over size of Rayleigh CDF at the
+        // bonus-widened radius. Uniform size across [MMC, LMC] with
+        // zone 0.1 and bonus up to 0.05: integrate numerically and
+        // compare with MC — the honest model, checked both ways.
+        let h = hole();
+        let mc = h.conformance_probability(200_000, 78);
+        let m = 2000;
+        let sigma = h.sigma_pos;
+        let mut acc = 0.0;
+        for i in 0..m {
+            let size = 6.10 + 0.05 * (i as f64 + 0.5) / m as f64;
+            let r = 0.5 * h.allowed_zone_dia(size);
+            acc += 1.0 - (-r * r / (2.0 * sigma * sigma)).exp();
+        }
+        let want = acc / m as f64;
+        assert!(
+            (mc.p - want).abs() < 4.0 * mc.standard_error,
+            "MC {} ± {} vs integral {}",
+            mc.p,
+            mc.standard_error,
+            want
+        );
+        // And the bonus is worth something real vs RFS.
+        let mut rfs = h.clone();
+        rfs.modifier = Modifier::Rfs;
+        let rfs_p = rfs.conformance_probability(200_000, 79);
+        assert!(
+            mc.p > rfs_p.p + 3.0 * (mc.standard_error + rfs_p.standard_error),
+            "bonus must raise conformance: MMC {} vs RFS {}",
+            mc.p,
+            rfs_p.p
+        );
+    }
+
+    #[test]
+    fn mmc_gauging_guarantees_fit_when_virtual_conditions_are_compatible() {
+        // The Y14.5 theorem, reproduced by simulation: shrink the pin's
+        // zone so hole VC ≥ pin VC, inspect both parts at MMC, and NO
+        // assembly can fail — the gauge is the worst-case counterpart.
+        let mut p = pin();
+        p.zone_dia = 0.05;
+        let mut h = hole();
+        h.zone_dia = 0.05; // hole VC = 6.05 = pin VC → margin 0
+                           // Widen position scatter so plenty of non-conforming parts are
+                           // made (the theorem is about the shipped population).
+        p.sigma_pos = 0.05;
+        h.sigma_pos = 0.05;
+        let fit = PatternFit {
+            pin: p,
+            hole: h,
+            n_features: 4,
+        };
+        let wc = fit.worst_case().unwrap();
+        assert!(wc.guaranteed, "margin {}", wc.margin);
+        let r = fit.monte_carlo(50_000, 5150, true).unwrap();
+        assert_eq!(
+            r.fit.successes, r.n,
+            "inspected + compatible VCs must fit every single time"
+        );
+        // Sanity: the theorem needed inspection — uninspected, with
+        // this much scatter, some assemblies genuinely fail.
+        let raw = fit.monte_carlo(50_000, 5151, false).unwrap();
+        assert!(
+            raw.fit.p < 0.999,
+            "uninspected population should show failures: {}",
+            raw.fit.p
+        );
+    }
+
+    #[test]
+    fn pattern_fit_monte_carlo_brackets_the_m0_bolt_circle() {
+        // RFS, no inspection, zone Ø0.15: the same fixture as
+        // tests/bolt_circle.rs — the API path must land on the same
+        // ~90% assembly fit rate (cross-module consistency).
+        let p = PositionedFeature {
+            name: "pin".into(),
+            kind: FeatureOf::External,
+            size_nominal: 6.0,
+            size_tol_minus: 0.02,
+            size_tol_plus: 0.0,
+            size_dist: Distribution::Uniform { lo: -0.02, hi: 0.0 },
+            zone_dia: 0.0,
+            modifier: Modifier::Rfs,
+            sigma_pos: 0.0, // fixture: pins perfectly positioned
+        };
+        let h = PositionedFeature {
+            name: "hole".into(),
+            kind: FeatureOf::Internal,
+            size_nominal: 6.10,
+            size_tol_minus: 0.0,
+            size_tol_plus: 0.05,
+            size_dist: Distribution::Uniform { lo: 0.0, hi: 0.05 },
+            zone_dia: 0.15,
+            modifier: Modifier::Rfs,
+            sigma_pos: PositionedFeature::sigma_from_zone(0.15, SigmaConvention::ThreeSigma),
+        };
+        let sigma = h.sigma_pos;
+        let fit = PatternFit {
+            pin: p,
+            hole: h,
+            n_features: 4,
+        };
+        let r = fit.monte_carlo(200_000, 90210, false).unwrap();
+        // Reference: per-pin fit = E over both size bands of the
+        // Rayleigh CDF at c = (hole − pin)/2, to the fourth power —
+        // the same integral tests/bolt_circle.rs validates. (Note it
+        // is the mean of the CDF, not the CDF at the mean clearance:
+        // Jensen's inequality costs ~3 points here.)
+        let m = 400;
+        let mut acc = 0.0;
+        for i in 0..m {
+            let hole_d = 6.10 + 0.05 * (i as f64 + 0.5) / m as f64;
+            for j in 0..m {
+                let pin_d = 5.98 + 0.02 * (j as f64 + 0.5) / m as f64;
+                let c = 0.5 * (hole_d - pin_d);
+                acc += 1.0 - (-c * c / (2.0 * sigma * sigma)).exp();
+            }
+        }
+        let want = (acc / (m * m) as f64).powi(4);
+        assert!(
+            (r.fit.p - want).abs() < 4.0 * r.fit.standard_error,
+            "API path {} ± {} vs closed-form {}",
+            r.fit.p,
+            r.fit.standard_error,
+            want
+        );
+    }
+
+    #[test]
+    fn form_generators_have_stated_moments_and_compose() {
+        let f = flatness_contributor("face flatness", -1.0, 0.05);
+        assert_eq!(f.dist.support(), Some((0.0, 0.05)));
+        assert!((f.dist.mean() - 0.025).abs() < 1e-15);
+        assert_eq!(f.tol_plus, 0.05);
+        assert_eq!(f.tol_minus, 0.0);
+
+        // Perpendicularity 0.1 over 20 mm, engaged 8 mm: span 0.04.
+        let p = perpendicularity_contributor("post tilt", -1.0, 0.1, 20.0, 8.0);
+        assert_eq!(p.dist.support(), Some((0.0, 0.04)));
+
+        // They validate inside a stackup.
+        let s = crate::stackup::Stackup {
+            name: "with-form".into(),
+            contributors: vec![
+                Contributor::normal("depth", 1.0, 10.0, 0.1, SigmaConvention::ThreeSigma),
+                f,
+                p,
+            ],
+            requirement: crate::stackup::Requirement::at_least("gap", 9.8),
+        };
+        s.validate().unwrap();
+        let r = crate::analysis::rss(&s).unwrap();
+        assert!(r.mean_gap < 10.0, "form errors consume gap: {}", r.mean_gap);
+    }
+
+    #[test]
+    fn fail_closed_paths() {
+        let mut f = PatternFit {
+            pin: pin(),
+            hole: hole(),
+            n_features: 0,
+        };
+        assert!(f.worst_case().is_err(), "zero features");
+        f.n_features = 4;
+        std::mem::swap(&mut f.pin.kind, &mut f.hole.kind);
+        assert!(f.worst_case().is_err(), "swapped kinds");
+
+        let mut g = PatternFit {
+            pin: pin(),
+            hole: hole(),
+            n_features: 1,
+        };
+        g.pin.zone_dia = f64::NAN;
+        assert!(g.worst_case().is_err(), "NaN zone");
+
+        // Inspected sampling with hopeless conformance errors loudly.
+        let mut h = PatternFit {
+            pin: pin(),
+            hole: hole(),
+            n_features: 1,
+        };
+        h.hole.sigma_pos = 50.0; // conformance ~1e-6
+        assert!(
+            h.monte_carlo(1_000, 1, true).is_err(),
+            "rejection cap must fire"
+        );
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -68,6 +68,7 @@ pub mod capability;
 pub mod dist;
 pub mod gdt;
 pub mod loops;
+pub mod measure;
 pub mod receipt;
 pub mod rng;
 pub mod sensitivity;

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -65,6 +65,7 @@
 pub mod analysis;
 pub mod capability;
 pub mod dist;
+pub mod gdt;
 pub mod loops;
 pub mod rng;
 pub mod sensitivity;

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -1,0 +1,71 @@
+#![warn(missing_docs)]
+
+//! Dimensional tolerance stackup analysis for the vcad kernel (M0).
+//!
+//! Answers the question every assembly drawing begs and almost no tool
+//! answers honestly: **"does this fit, and at what yield?"** The
+//! incumbent workflow is a spreadsheet and prayer; this crate is a
+//! deterministic, receipt-native stackup engine that lives next to the
+//! geometry it prices.
+//!
+//! The pipeline:
+//!
+//! 1. [`stackup::Stackup`] — a linear chain of dimensional
+//!    contributors, each with a nominal, a signed coefficient, drawing
+//!    limits, and a deviation distribution
+//!    ([`dist::Distribution`]: normal, uniform, or two-point) whose
+//!    provenance ([`dist::DistributionSource`]) records whether it is
+//!    an assumption or a measurement.
+//! 2. [`analysis`] — the three classic analyses over the chain:
+//!    worst-case (interval arithmetic over drawing limits), RSS (exact
+//!    linear variance propagation), and seeded Monte Carlo (hand-rolled
+//!    xoshiro256++, batch statistics, and a standard error on every
+//!    probability — error-bar-free probabilities are unrepresentable).
+//! 3. [`capability`] — predicted gap distribution vs the requirement:
+//!    Φ-based yield (hand-rolled erf, A&S 7.1.26, max error 1.5e-7),
+//!    Cp and Cpk.
+//! 4. [`sensitivity`] — the design compass: **exact closed-form**
+//!    derivatives of the gap, σ_gap, and yield with respect to every
+//!    nominal and every σ. Linear chains make these exact — no
+//!    adjoint machinery, no finite differences, and we say so proudly.
+//! 5. [`loops`] — 2D/3D vector loops projected onto a measure
+//!    direction: exactly linear for translational legs, first-order
+//!    (small-angle, bound stated) for rotations.
+//!
+//! Later milestones stack on this base (see `docs/tolerance-m0.md` for
+//! the ladder): GD&T semantics (position at MMC with bonus, M1),
+//! cost-based tolerance allocation (M2), the `.vcad` named-parameter
+//! seam (M3), `vcad.tolerance-claims/1` receipt claims (M4), published
+//! benchmarks + paper draft (M5), and the measurement pack binding the
+//! 3DP print-then-measure loop (M6).
+//!
+//! **Scope and honesty (M0):**
+//!
+//! - **Linear chains.** The gap is G = Σ aᵢxᵢ. Exact for 1-D stacks;
+//!   vector loops are linearized with a stated small-angle bound.
+//!   Genuinely nonlinear mechanisms (radial fits are the everyday
+//!   case — see `tests/bolt_circle.rs`) get the exact treatment in the
+//!   GD&T module or a Monte Carlo over the true model, not a silent
+//!   linearization.
+//! - **Independence.** Contributors are assumed statistically
+//!   independent. Two dimensions cut in one fixture setup are not, and
+//!   both RSS and Monte Carlo will be wrong about their sum. Correlation
+//!   modeling is future work.
+//! - **The ±tol ↔ σ convention is an assumption** — the default
+//!   ±tol = 3σ ([`dist::SigmaConvention`]) buries more products than
+//!   any solver bug, so it is recorded as provenance on every receipt,
+//!   never defaulted silently.
+//! - **Distributions are assumptions until measured.** Every
+//!   contributor carries its [`dist::DistributionSource`]; the M6
+//!   measurement pack replaces assumptions with fitted coupon data.
+//!
+//! Units: millimeters throughout (vcad convention); probabilities are
+//! dimensionless in [0, 1]; angles enter rotation legs in radians.
+
+pub mod analysis;
+pub mod capability;
+pub mod dist;
+pub mod loops;
+pub mod rng;
+pub mod sensitivity;
+pub mod stackup;

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -62,6 +62,7 @@
 //! Units: millimeters throughout (vcad convention); probabilities are
 //! dimensionless in [0, 1]; angles enter rotation legs in radians.
 
+pub mod allocate;
 pub mod analysis;
 pub mod capability;
 pub mod dist;

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -70,4 +70,5 @@ pub mod gdt;
 pub mod loops;
 pub mod rng;
 pub mod sensitivity;
+pub mod spec;
 pub mod stackup;

--- a/crates/vcad-kernel-tolerance/src/lib.rs
+++ b/crates/vcad-kernel-tolerance/src/lib.rs
@@ -68,6 +68,7 @@ pub mod capability;
 pub mod dist;
 pub mod gdt;
 pub mod loops;
+pub mod receipt;
 pub mod rng;
 pub mod sensitivity;
 pub mod spec;

--- a/crates/vcad-kernel-tolerance/src/loops.rs
+++ b/crates/vcad-kernel-tolerance/src/loops.rs
@@ -1,0 +1,388 @@
+//! 2D/3D vector loops with linearized closure.
+//!
+//! A [`VectorLoop`] is a closed chain of dimensioned legs in 2D/3D; the
+//! gap of interest is the loop-closure error **projected onto a measure
+//! direction** d̂. For a leg with unit direction v̂ᵢ and scalar length
+//! xᵢ, the projected contribution is (v̂ᵢ·d̂)·xᵢ — so projection turns a
+//! vector loop into an exactly linear [`Stackup`] with coefficients
+//! aᵢ = v̂ᵢ·d̂. This is **exact for translational legs** (the directions
+//! themselves carry no tolerance) and **first-order for rotational
+//! contributors**, which enter as displacement ≈ r·θ along the motion
+//! direction.
+//!
+//! **Small-angle validity bound:** linearizing a rotation drops the
+//! second-order transverse term r·(1 − cos θ) ≈ r·θ²/2 — a relative
+//! error of θ/2 against the first-order term. For |θ| ≤ 2° (35 mrad)
+//! the dropped term is ≤ 1.7% of the kept one; beyond ~5° you should
+//! stop trusting linearized loops and model the mechanism.
+//!
+//! **What projection cannot see:** a leg perpendicular to d̂ contributes
+//! zero *to first order* and is dropped from the projected chain. For
+//! genuinely radial (2-D magnitude) requirements — pin in hole — the
+//! magnitude of a 2-D error is Rayleigh-, not normal-, distributed, and
+//! a single projection is optimistic. `tests/bolt_circle.rs` quantifies
+//! this against the exact closed form; the GD&T module (M1) owns the
+//! radial fit problem.
+
+use serde::{Deserialize, Serialize};
+
+use crate::dist::{Distribution, DistributionSource};
+use crate::stackup::{Contributor, Requirement, Stackup, StackupError};
+
+/// One leg of a vector loop: a dimension along a fixed direction.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LoopLeg {
+    /// Leg name (unique within the loop).
+    pub name: String,
+    /// Direction of the dimension (need not be unit; normalized at
+    /// projection time).
+    pub direction: [f64; 3],
+    /// Nominal length along `direction`, mm.
+    pub nominal: f64,
+    /// Lower drawing limit (deviation below nominal, ≥ 0), mm.
+    pub tol_minus: f64,
+    /// Upper drawing limit (deviation above nominal, ≥ 0), mm.
+    pub tol_plus: f64,
+    /// Deviation distribution along the leg direction.
+    pub dist: Distribution,
+    /// Distribution provenance.
+    #[serde(default)]
+    pub source: DistributionSource,
+}
+
+impl LoopLeg {
+    /// A rotational contributor, linearized: a joint/feature at lever
+    /// arm `lever_arm_mm` whose angular error `angle_dist` (radians)
+    /// displaces the point of interest by ≈ r·θ along
+    /// `motion_direction`. Small-angle: see the module docs for the
+    /// validity bound. `tol_rad` are the drawing limits on the angle.
+    pub fn from_rotation(
+        name: &str,
+        lever_arm_mm: f64,
+        motion_direction: [f64; 3],
+        angle_dist: Distribution,
+        tol_minus_rad: f64,
+        tol_plus_rad: f64,
+    ) -> Self {
+        // Scale the angular distribution by the lever arm to get mm.
+        let dist = match angle_dist {
+            Distribution::Normal { mean, sigma } => Distribution::Normal {
+                mean: mean * lever_arm_mm,
+                sigma: sigma * lever_arm_mm,
+            },
+            Distribution::Uniform { lo, hi } => Distribution::Uniform {
+                lo: lo * lever_arm_mm,
+                hi: hi * lever_arm_mm,
+            },
+            Distribution::TwoPoint { a, b, p_b } => Distribution::TwoPoint {
+                a: a * lever_arm_mm,
+                b: b * lever_arm_mm,
+                p_b,
+            },
+        };
+        Self {
+            name: name.to_string(),
+            direction: motion_direction,
+            nominal: 0.0,
+            tol_minus: tol_minus_rad * lever_arm_mm,
+            tol_plus: tol_plus_rad * lever_arm_mm,
+            dist,
+            source: DistributionSource::default(),
+        }
+    }
+}
+
+/// A vector loop: legs, a measure direction, and the requirement on the
+/// projected gap.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct VectorLoop {
+    /// Loop name.
+    pub name: String,
+    /// The legs.
+    pub legs: Vec<LoopLeg>,
+    /// Direction along which the gap is measured (normalized at
+    /// projection time).
+    pub measure_direction: [f64; 3],
+    /// Requirement on the projected gap, mm.
+    pub requirement: Requirement,
+}
+
+fn norm(v: [f64; 3]) -> f64 {
+    (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt()
+}
+
+/// Threshold below which a projected coefficient is treated as zero
+/// (the leg is perpendicular to the measure direction to first order).
+pub const PERPENDICULAR_EPS: f64 = 1e-12;
+
+impl VectorLoop {
+    /// Project the loop onto the measure direction, producing an
+    /// exactly linear [`Stackup`] with aᵢ = v̂ᵢ·d̂. Perpendicular legs
+    /// (|aᵢ| < [`PERPENDICULAR_EPS`]) contribute zero to first order
+    /// and are dropped — see the module docs for what that misses.
+    pub fn project(&self) -> Result<Stackup, StackupError> {
+        let dn = norm(self.measure_direction);
+        if !dn.is_finite() || dn == 0.0 {
+            return Err(StackupError::BadRequirement(
+                "measure_direction must be a nonzero finite vector".into(),
+            ));
+        }
+        let d = self.measure_direction.map(|c| c / dn);
+        let mut contributors = Vec::new();
+        for leg in &self.legs {
+            let vn = norm(leg.direction);
+            if !vn.is_finite() || vn == 0.0 {
+                return Err(StackupError::NonFinite {
+                    contributor: leg.name.clone(),
+                    field: "direction",
+                });
+            }
+            let v = leg.direction.map(|c| c / vn);
+            let coeff = v[0] * d[0] + v[1] * d[1] + v[2] * d[2];
+            if coeff.abs() < PERPENDICULAR_EPS {
+                continue; // perpendicular: zero to first order
+            }
+            contributors.push(Contributor {
+                name: leg.name.clone(),
+                coeff,
+                nominal: leg.nominal,
+                tol_minus: leg.tol_minus,
+                tol_plus: leg.tol_plus,
+                dist: leg.dist,
+                source: leg.source.clone(),
+            });
+        }
+        let s = Stackup {
+            name: self.name.clone(),
+            contributors,
+            requirement: self.requirement.clone(),
+        };
+        s.validate()?;
+        Ok(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{monte_carlo, rss, McOptions};
+    use crate::dist::SigmaConvention;
+    use crate::stackup::Contributor as C;
+
+    /// An L-bracket loop: horizontal leg, vertical leg, and a diagonal
+    /// measured horizontally — coefficients are direction cosines.
+    #[test]
+    fn projection_reduces_to_linear_chain_with_direction_cosines() {
+        let vl = VectorLoop {
+            name: "L".into(),
+            legs: vec![
+                LoopLeg {
+                    name: "base".into(),
+                    direction: [1.0, 0.0, 0.0],
+                    nominal: 40.0,
+                    tol_minus: 0.2,
+                    tol_plus: 0.2,
+                    dist: Distribution::Normal {
+                        mean: 0.0,
+                        sigma: 0.2 / 3.0,
+                    },
+                    source: DistributionSource::default(),
+                },
+                LoopLeg {
+                    name: "upright".into(),
+                    direction: [0.0, 0.0, 1.0],
+                    nominal: 30.0,
+                    tol_minus: 0.2,
+                    tol_plus: 0.2,
+                    dist: Distribution::Normal {
+                        mean: 0.0,
+                        sigma: 0.2 / 3.0,
+                    },
+                    source: DistributionSource::default(),
+                },
+                LoopLeg {
+                    name: "diagonal".into(),
+                    direction: [-3.0, 0.0, -4.0], // unit: (−0.6, 0, −0.8)
+                    nominal: 50.0,
+                    tol_minus: 0.3,
+                    tol_plus: 0.3,
+                    dist: Distribution::Normal {
+                        mean: 0.0,
+                        sigma: 0.1,
+                    },
+                    source: DistributionSource::default(),
+                },
+            ],
+            measure_direction: [1.0, 0.0, 0.0],
+            requirement: Requirement::between("closure-x", -1.0, 1.0),
+        };
+        let s = vl.project().unwrap();
+        // upright ⟂ x drops; base coeff 1; diagonal coeff −0.6.
+        assert_eq!(s.contributors.len(), 2);
+        assert_eq!(s.contributors[0].name, "base");
+        assert!((s.contributors[0].coeff - 1.0).abs() < 1e-15);
+        assert_eq!(s.contributors[1].name, "diagonal");
+        assert!((s.contributors[1].coeff + 0.6).abs() < 1e-15);
+        // Nominal closure: 40 − 0.6·50 = 10.
+        assert!((s.nominal_gap() - 10.0).abs() < 1e-12);
+        // σ_G² = (1·0.0667)² + (0.6·0.1)².
+        let want = ((0.2f64 / 3.0).powi(2) + 0.06f64.powi(2)).sqrt();
+        assert!((rss(&s).unwrap().sigma_gap - want).abs() < 1e-12);
+    }
+
+    #[test]
+    fn projected_chain_agrees_with_direct_3d_monte_carlo() {
+        // Sample the loop in full 3D (sum vector legs, project the
+        // closure), and compare with the projected chain's MC: they are
+        // the same model, so they must agree within error bars.
+        let vl = VectorLoop {
+            name: "loop".into(),
+            legs: vec![
+                LoopLeg {
+                    name: "a".into(),
+                    direction: [1.0, 0.0, 0.0],
+                    nominal: 20.0,
+                    tol_minus: 0.15,
+                    tol_plus: 0.15,
+                    dist: Distribution::Normal {
+                        mean: 0.0,
+                        sigma: 0.05,
+                    },
+                    source: DistributionSource::default(),
+                },
+                LoopLeg {
+                    name: "b".into(),
+                    direction: [0.6, 0.8, 0.0],
+                    nominal: 25.0,
+                    tol_minus: 0.15,
+                    tol_plus: 0.15,
+                    dist: Distribution::Uniform {
+                        lo: -0.15,
+                        hi: 0.15,
+                    },
+                    source: DistributionSource::default(),
+                },
+            ],
+            measure_direction: [1.0, 0.0, 0.0],
+            requirement: Requirement::between("x-closure", 34.0, 36.0),
+        };
+        let s = vl.project().unwrap();
+        let mc = monte_carlo(
+            &s,
+            &McOptions {
+                n: 60_000,
+                seed: 7,
+                batches: 16,
+            },
+        )
+        .unwrap();
+
+        // Direct 3D sampling with an independent stream.
+        let mut rng = crate::rng::Rng::new(1234);
+        let n = 60_000;
+        let mut mean = 0.0;
+        for i in 0..n {
+            let mut x = 0.0;
+            for leg in &vl.legs {
+                let vn = norm(leg.direction);
+                let len = leg.nominal + leg.dist.sample(&mut rng);
+                x += leg.direction[0] / vn * len;
+            }
+            mean += (x - mean) / (i + 1) as f64;
+        }
+        assert!(
+            (mean - mc.mean_gap).abs() < 5.0 * mc.mean_gap_se + 5.0 * mc.mean_gap_se,
+            "3D mean {mean} vs projected {}",
+            mc.mean_gap
+        );
+    }
+
+    #[test]
+    fn rotation_leg_linearizes_with_lever_arm() {
+        // 100 mm lever, ±0.5° (8.727 mrad) angular tolerance, normal 3σ.
+        let t = 0.5f64.to_radians();
+        let leg = LoopLeg::from_rotation(
+            "tilt",
+            100.0,
+            [1.0, 0.0, 0.0],
+            Distribution::Normal {
+                mean: 0.0,
+                sigma: t / 3.0,
+            },
+            t,
+            t,
+        );
+        // Displacement tolerance = r·θ = 0.8727 mm; σ = that / 3.
+        assert!((leg.tol_plus - 100.0 * t).abs() < 1e-12);
+        assert!((leg.dist.sigma() - 100.0 * t / 3.0).abs() < 1e-12);
+        // And it composes into a stackup like any other leg.
+        let vl = VectorLoop {
+            name: "arm".into(),
+            legs: vec![leg],
+            measure_direction: [1.0, 0.0, 0.0],
+            requirement: Requirement::between("tip-x", -1.0, 1.0),
+        };
+        let s = vl.project().unwrap();
+        assert_eq!(s.contributors.len(), 1);
+        let r = rss(&s).unwrap();
+        assert!((r.sigma_gap - 100.0 * t / 3.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn projection_composes_with_plain_contributors() {
+        // A projected loop stackup can be extended with plain 1-D
+        // contributors (mixed modeling is the common real case).
+        let vl = VectorLoop {
+            name: "mixed".into(),
+            legs: vec![LoopLeg {
+                name: "strut".into(),
+                direction: [0.0, 0.6, 0.8],
+                nominal: 50.0,
+                tol_minus: 0.2,
+                tol_plus: 0.2,
+                dist: Distribution::Normal {
+                    mean: 0.0,
+                    sigma: 0.2 / 3.0,
+                },
+                source: DistributionSource::default(),
+            }],
+            measure_direction: [0.0, 0.0, 1.0],
+            requirement: Requirement::at_least("z-gap", 39.0),
+        };
+        let mut s = vl.project().unwrap();
+        s.contributors.push(C::normal(
+            "shim",
+            1.0,
+            0.5,
+            0.05,
+            SigmaConvention::ThreeSigma,
+        ));
+        s.validate().unwrap();
+        assert!((s.nominal_gap() - (0.8 * 50.0 + 0.5)).abs() < 1e-12);
+    }
+
+    #[test]
+    fn bad_directions_fail_closed() {
+        let mut vl = VectorLoop {
+            name: "bad".into(),
+            legs: vec![LoopLeg {
+                name: "z".into(),
+                direction: [0.0, 0.0, 0.0],
+                nominal: 1.0,
+                tol_minus: 0.1,
+                tol_plus: 0.1,
+                dist: Distribution::Normal {
+                    mean: 0.0,
+                    sigma: 0.03,
+                },
+                source: DistributionSource::default(),
+            }],
+            measure_direction: [1.0, 0.0, 0.0],
+            requirement: Requirement::at_least("g", 0.0),
+        };
+        assert!(vl.project().is_err(), "zero leg direction");
+        vl.legs[0].direction = [1.0, 0.0, 0.0];
+        vl.measure_direction = [0.0, 0.0, 0.0];
+        assert!(vl.project().is_err(), "zero measure direction");
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/measure.rs
+++ b/crates/vcad-kernel-tolerance/src/measure.rs
@@ -1,0 +1,345 @@
+//! The measurement pack (M6): measured dimensional scatter becomes the
+//! distribution input, and predicted-vs-measured yield closes the loop.
+//!
+//! Distributions are assumptions until measured. This module is the
+//! flip: fit a normal to caliper/CMM samples of a real dimension
+//! (Bessel-corrected, with standard errors on both fitted parameters),
+//! swap it into the contributor, and mark the provenance
+//! [`DistributionSource::Measured`]. The drawing limits stay put — the
+//! drawing didn't change, reality did — so worst-case analysis is
+//! untouched while RSS/MC re-price on facts.
+//!
+//! ## Binding to the repo's 3DP print-then-measure loop
+//!
+//! vcad's `predict_print` tool declares per-part measurables (bounding
+//! box dims per print axis, hole diameters, mass) and
+//! `record_measurement` binds one printed part's caliper values to
+//! them. Print a **batch** of coupons and each measurable id yields a
+//! sample vector across coupons; the adapter contract is:
+//!
+//! 1. one stackup contributor ↔ one measurable id (same physical
+//!    dimension, same axis),
+//! 2. collect that measurable's value from every coupon's
+//!    `record_measurement` call into `samples` (absolute mm, as
+//!    calipers read),
+//! 3. [`apply_measurement`] fits the deviation distribution against
+//!    the contributor's nominal and flips its source to `Measured`
+//!    with the coupon count and instrument recorded.
+//!
+//! Assembly-level truth binds the other end of the loop: an assembly
+//! trial (k of n built units fit) becomes a `fit_probability`
+//! [`Measurement`] via [`Measurement::from_trial`], and
+//! [`crate::receipt::compare`] issues Holds/Violated/Unmeasured — the
+//! test suite demonstrates the full circle: an optimistic assumed
+//! model is **Violated** by the trial while the coupon-measured model
+//! **Holds** on the same data.
+
+use crate::analysis::ProbabilityEstimate;
+use crate::dist::{Distribution, DistributionSource};
+use crate::receipt::Measurement;
+use crate::stackup::{Stackup, StackupError};
+
+/// Minimum samples to fit a distribution. Five is a floor, not a
+/// recommendation — at n = 5 the σ standard error is ~35% of σ.
+pub const MIN_FIT_SAMPLES: usize = 5;
+
+/// A normal fitted to measured samples, with standard errors.
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FittedNormal {
+    /// Sample mean, mm.
+    pub mean: f64,
+    /// Bessel-corrected sample standard deviation, mm.
+    pub sigma: f64,
+    /// Standard error of the mean: s/√n, mm.
+    pub se_mean: f64,
+    /// Standard error of σ (normal theory, large-sample):
+    /// s/√(2(n−1)), mm.
+    pub se_sigma: f64,
+    /// Sample count.
+    pub n: usize,
+}
+
+/// Fit a normal to samples, fail-closed on tiny or degenerate input.
+pub fn fit_normal(samples: &[f64]) -> Result<FittedNormal, StackupError> {
+    if samples.len() < MIN_FIT_SAMPLES {
+        return Err(StackupError::TooFewSamples {
+            n: samples.len(),
+            min: MIN_FIT_SAMPLES,
+        });
+    }
+    if samples.iter().any(|s| !s.is_finite()) {
+        return Err(StackupError::BadRequirement(
+            "non-finite measurement sample".into(),
+        ));
+    }
+    let n = samples.len() as f64;
+    let mean = samples.iter().sum::<f64>() / n;
+    let ss: f64 = samples.iter().map(|s| (s - mean) * (s - mean)).sum();
+    let sigma = (ss / (n - 1.0)).sqrt();
+    Ok(FittedNormal {
+        mean,
+        sigma,
+        se_mean: sigma / n.sqrt(),
+        se_sigma: sigma / (2.0 * (n - 1.0)).sqrt(),
+        n: samples.len(),
+    })
+}
+
+/// Fit the named contributor's deviation distribution from measured
+/// **absolute** dimensions (mm, as calipers read them), flip its
+/// source to [`DistributionSource::Measured`], and return the fit.
+/// Drawing limits are untouched. Fails closed if the fitted mean sits
+/// outside the drawing band — measurements saying the process center
+/// is out of spec are a finding, not an input to silently accept.
+pub fn apply_measurement(
+    s: &mut Stackup,
+    contributor: &str,
+    samples: &[f64],
+    instrument: &str,
+) -> Result<FittedNormal, StackupError> {
+    s.validate()?;
+    let c = s
+        .contributors
+        .iter_mut()
+        .find(|c| c.name == contributor)
+        .ok_or_else(|| StackupError::NotAllocatable(format!("no contributor {contributor:?}")))?;
+    let fit = fit_normal(samples)?;
+    let dev_mean = fit.mean - c.nominal;
+    if dev_mean < -c.tol_minus || dev_mean > c.tol_plus {
+        return Err(StackupError::BadRequirement(format!(
+            "measured mean of {contributor:?} deviates {dev_mean:.4} mm from nominal, \
+             outside the drawing band [-{}, +{}] — fix the process or the drawing \
+             before re-pricing yield",
+            c.tol_minus, c.tol_plus
+        )));
+    }
+    c.dist = Distribution::Normal {
+        mean: dev_mean,
+        sigma: fit.sigma,
+    };
+    c.source = DistributionSource::Measured {
+        n_samples: fit.n,
+        instrument: instrument.to_string(),
+    };
+    Ok(fit)
+}
+
+impl Measurement {
+    /// A `fit_probability` measurement from an assembly trial: `fits`
+    /// of `total` built units met the requirement. The uncertainty is
+    /// the Agresti–Coull standard error — an error-bar-free trial
+    /// result is as unrepresentable as an error-bar-free prediction.
+    pub fn from_trial(fits: usize, total: usize, band_abs: f64, instrument: &str) -> Self {
+        let est = ProbabilityEstimate::from_counts(fits, total);
+        Measurement {
+            name: "fit_probability".into(),
+            value: est.p,
+            uncertainty: est.standard_error,
+            instrument: instrument.to_string(),
+            band_abs,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{monte_carlo, rss, worst_case, McOptions};
+    use crate::dist::SigmaConvention;
+    use crate::receipt::{compare, predicted_claims, Verdict};
+    use crate::rng::Rng;
+    use crate::stackup::{Contributor, Requirement};
+
+    #[test]
+    fn fit_normal_recovers_known_parameters() {
+        // Samples from Normal(10.05, 0.12), seeded.
+        let mut rng = Rng::new(606);
+        let n = 400;
+        let samples: Vec<f64> = (0..n).map(|_| 10.05 + 0.12 * rng.next_normal()).collect();
+        let fit = fit_normal(&samples).unwrap();
+        assert!((fit.mean - 10.05).abs() < 4.0 * fit.se_mean, "{fit:?}");
+        assert!((fit.sigma - 0.12).abs() < 4.0 * fit.se_sigma, "{fit:?}");
+        // SE scaling: 4× samples → half the SE (within tolerance).
+        let fit_small = fit_normal(&samples[..100]).unwrap();
+        let ratio = fit_small.se_mean / fit.se_mean;
+        assert!((1.4..2.9).contains(&ratio), "SE scaling ratio {ratio}");
+    }
+
+    #[test]
+    fn fit_normal_fails_closed() {
+        assert!(matches!(
+            fit_normal(&[1.0, 2.0]),
+            Err(StackupError::TooFewSamples { .. })
+        ));
+        assert!(fit_normal(&[1.0, 2.0, f64::NAN, 3.0, 4.0]).is_err());
+        // Identical samples: σ = 0 is legal (a very repeatable
+        // process), SEs are 0 — honest degenerate.
+        let fit = fit_normal(&[5.0; 10]).unwrap();
+        assert_eq!(fit.sigma, 0.0);
+    }
+
+    fn chain() -> Stackup {
+        let conv = SigmaConvention::ThreeSigma;
+        Stackup {
+            name: "coupon-chain".into(),
+            contributors: vec![
+                Contributor::normal("printed boss", 1.0, 20.0, 0.3, conv),
+                Contributor::normal("mating plate", -1.0, 19.5, 0.15, conv),
+            ],
+            requirement: Requirement::between("gap", 0.15, 0.85),
+        }
+    }
+
+    #[test]
+    fn apply_measurement_flips_provenance_and_repricing() {
+        let mut s = chain();
+        // 30 printed coupons, true process shifted +0.08 and wider
+        // (σ 0.15) than the ±0.3 = 3σ assumption (σ 0.1).
+        let mut rng = Rng::new(707);
+        let samples: Vec<f64> = (0..30).map(|_| 20.08 + 0.15 * rng.next_normal()).collect();
+        let y_assumed = rss(&s).unwrap().yield_estimate;
+        let fit = apply_measurement(&mut s, "printed boss", &samples, "calipers, coupon batch A")
+            .unwrap();
+        assert_eq!(fit.n, 30);
+        // Provenance flipped; drawing limits untouched.
+        let c = &s.contributors[0];
+        assert!(matches!(
+            c.source,
+            DistributionSource::Measured { n_samples: 30, .. }
+        ));
+        assert_eq!(c.tol_minus, 0.3);
+        assert_eq!(c.tol_plus, 0.3);
+        // The measured model re-prices the yield downward (worse
+        // process than assumed).
+        let y_measured = rss(&s).unwrap().yield_estimate;
+        assert!(
+            y_measured < y_assumed - 0.005,
+            "measured {y_measured} vs assumed {y_assumed}"
+        );
+        s.validate().unwrap();
+    }
+
+    #[test]
+    fn out_of_band_process_center_is_a_finding_not_an_input() {
+        let mut s = chain();
+        let samples: Vec<f64> = (0..20).map(|i| 20.45 + 0.001 * i as f64).collect();
+        let err = apply_measurement(&mut s, "printed boss", &samples, "calipers").unwrap_err();
+        assert!(matches!(err, StackupError::BadRequirement(_)), "{err:?}");
+        // Untouched on failure.
+        assert!(matches!(
+            s.contributors[0].source,
+            DistributionSource::Assumed { .. }
+        ));
+    }
+
+    /// The M6 money shot: the full predicted → printed → measured →
+    /// verdict circle. An optimistic assumed model is Violated by the
+    /// assembly trial; the coupon-measured model Holds on the same
+    /// trial data.
+    #[test]
+    fn closed_loop_assumed_violated_measured_holds() {
+        let assumed = chain();
+        // The TRUE process for the printed boss: +0.10 shift, σ 0.15.
+        let true_boss = Distribution::Normal {
+            mean: 0.10,
+            sigma: 0.15,
+        };
+
+        // Predicted claims from the assumed model.
+        let wc = worst_case(&assumed).unwrap();
+        let r = rss(&assumed).unwrap();
+        let mc = monte_carlo(
+            &assumed,
+            &McOptions {
+                n: 100_000,
+                seed: 42_000,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        let claims_assumed = predicted_claims(&assumed, &wc, &r, &mc).unwrap();
+
+        // Reality: build 400 assemblies from the true process and
+        // count fits (seeded, deterministic).
+        let mut rng = Rng::new(42_001);
+        let mut fits = 0usize;
+        let total = 400;
+        for _ in 0..total {
+            let boss = 20.0 + true_boss.sample(&mut rng);
+            let plate = 19.5 + assumed.contributors[1].dist.sample(&mut rng);
+            let gap = boss - plate;
+            if (0.15..=0.85).contains(&gap) {
+                fits += 1;
+            }
+        }
+        let trial = Measurement::from_trial(fits, total, 0.01, "assembly trial, batch A");
+
+        // The assumed receipt is VIOLATED by reality.
+        let report = compare(&claims_assumed, std::slice::from_ref(&trial)).unwrap();
+        let verdict = |rep: &crate::receipt::ComparisonReport, name: &str| {
+            rep.entries.iter().find(|e| e.name == name).unwrap().verdict
+        };
+        assert_eq!(verdict(&report, "fit_probability"), Verdict::Violated);
+        assert!(!report.all_hold);
+
+        // Measure 30 coupons, refit, re-predict: the measured-basis
+        // receipt HOLDS against the same trial.
+        let mut measured = assumed.clone();
+        let mut crng = Rng::new(42_002);
+        let coupons: Vec<f64> = (0..30)
+            .map(|_| 20.0 + true_boss.sample(&mut crng))
+            .collect();
+        apply_measurement(&mut measured, "printed boss", &coupons, "calipers").unwrap();
+        let wc2 = worst_case(&measured).unwrap();
+        let r2 = rss(&measured).unwrap();
+        let mc2 = monte_carlo(
+            &measured,
+            &McOptions {
+                n: 100_000,
+                seed: 42_003,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        let claims_measured = predicted_claims(&measured, &wc2, &r2, &mc2).unwrap();
+        let report2 = compare(&claims_measured, &[trial]).unwrap();
+        assert_eq!(verdict(&report2, "fit_probability"), Verdict::Holds);
+        // Provenance on the receipt says which basis this is.
+        assert!(claims_measured
+            .provenance
+            .contributors
+            .iter()
+            .any(|c| matches!(c.source, DistributionSource::Measured { .. })));
+
+        // Sanity on the magnitudes: assumed predicted ≫ reality;
+        // measured predicted ≈ reality.
+        let p_assumed = claims_assumed
+            .claims
+            .iter()
+            .find(|c| c.name == "fit_probability")
+            .unwrap()
+            .value;
+        let p_measured = claims_measured
+            .claims
+            .iter()
+            .find(|c| c.name == "fit_probability")
+            .unwrap()
+            .value;
+        let p_real = fits as f64 / total as f64;
+        assert!(p_assumed > p_real + 0.03, "{p_assumed} vs real {p_real}");
+        assert!(
+            (p_measured - p_real).abs() < 0.03,
+            "{p_measured} vs {p_real}"
+        );
+    }
+
+    #[test]
+    fn trial_measurements_carry_error_bars() {
+        let m = Measurement::from_trial(190, 200, 0.02, "trial");
+        assert!((m.value - 0.95).abs() < 1e-12);
+        assert!(m.uncertainty > 0.0);
+        // Zero-failure trials still carry uncertainty.
+        let m = Measurement::from_trial(200, 200, 0.02, "trial");
+        assert!(m.uncertainty > 0.0, "200/200 is not certainty");
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/receipt.rs
+++ b/crates/vcad-kernel-tolerance/src/receipt.rs
@@ -1,0 +1,549 @@
+//! Predicted tolerance claims for the design receipt (M4).
+//!
+//! Emits a serializable claim set — fit probability (with Monte Carlo
+//! standard error), RSS yield, Cp/Cpk, gap moments, worst-case margin —
+//! with full provenance (sample count, seed, per-contributor
+//! distribution sources and conventions, analyses run), in the spirit
+//! of `vcad.receipt/1`: every number carries how it was produced, and
+//! nothing is defaulted silently.
+//!
+//! These are `basis: "predicted"` claims. Binding them to measurements
+//! (assembly trials, coupon dimensions from the 3DP
+//! print-then-measure loop) is the measurement pack's job (M6), through
+//! [`compare`] — fail-closed: an unmeasured receipt never passes, and a
+//! measurement matching no claim is a bookkeeping error. Wiring this
+//! family into `crates/vcad-receipt` + the MCP surface is the flagged
+//! follow-up PR (it touches the cross-crate schema and TS codegen —
+//! type names must be unique across `vcad-ir` and `vcad-receipt`).
+//!
+//! **Completeness is structural:** [`predicted_claims`] requires all
+//! three analyses. You cannot emit a claim set without Monte Carlo
+//! error bars, and a consistency tripwire rejects analyses that don't
+//! describe the same chain (mixing results from different stackups is
+//! the receipt-level version of a unit error).
+
+use serde::{Deserialize, Serialize};
+
+use crate::analysis::{MonteCarloAnalysis, RssAnalysis, WorstCaseAnalysis};
+use crate::stackup::{Stackup, StackupError};
+
+/// Schema tag for this claim family.
+pub const CLAIM_SCHEMA: &str = "vcad.tolerance-claims/1";
+
+/// Schema tag for the comparison report.
+pub const COMPARE_SCHEMA: &str = "vcad.tolerance-compare/1";
+
+/// Per-contributor provenance: what the distribution was and where it
+/// came from.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContributorProvenance {
+    /// Contributor name.
+    pub name: String,
+    /// The deviation distribution used.
+    pub dist: crate::dist::Distribution,
+    /// Assumption or measurement.
+    pub source: crate::dist::DistributionSource,
+    /// Chain coefficient.
+    pub coeff: f64,
+    /// Drawing limits (tol_minus, tol_plus), mm.
+    pub limits: (f64, f64),
+}
+
+/// How the numbers were produced.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Provenance {
+    /// Monte Carlo sample count.
+    pub n_samples: usize,
+    /// PRNG seed (xoshiro256++ via SplitMix64).
+    pub seed: u64,
+    /// Batch count behind the batch-SE cross-check.
+    pub batches: usize,
+    /// Whether every contributor is normal (RSS yield exact under the
+    /// model) or the RSS yield leans on the CLT.
+    pub all_normal: bool,
+    /// The requirement being priced, as stated.
+    pub requirement: crate::stackup::Requirement,
+    /// Every contributor's distribution and its source.
+    pub contributors: Vec<ContributorProvenance>,
+    /// Analyses that fed this claim set.
+    pub analyses: Vec<String>,
+}
+
+/// One predicted claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Claim {
+    /// Claim name (snake_case).
+    pub name: String,
+    /// Value.
+    pub value: f64,
+    /// One-sigma uncertainty on the value, when the producing path has
+    /// one (Monte Carlo estimates always do; closed-form RSS values
+    /// carry the erf approximation bound instead of pretending to be
+    /// exact).
+    pub uncertainty: Option<f64>,
+    /// Unit ("1" for dimensionless, "mm" for gaps).
+    pub unit: String,
+    /// Claim basis — always `"predicted"` here.
+    pub basis: String,
+    /// Assumptions and caveats, spelled out.
+    pub note: String,
+}
+
+/// The full claim set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClaimSet {
+    /// Schema tag ([`CLAIM_SCHEMA`]).
+    pub schema: String,
+    /// Full provenance.
+    pub provenance: Provenance,
+    /// The claims.
+    pub claims: Vec<Claim>,
+}
+
+fn claim(name: &str, value: f64, uncertainty: Option<f64>, unit: &str, note: &str) -> Claim {
+    Claim {
+        name: name.to_string(),
+        value,
+        uncertainty,
+        unit: unit.to_string(),
+        basis: "predicted".to_string(),
+        note: note.to_string(),
+    }
+}
+
+/// Build the predicted claim set for one analyzed stackup. Requires
+/// all three analyses (completeness is structural) and cross-checks
+/// that they describe the same chain.
+pub fn predicted_claims(
+    s: &Stackup,
+    wc: &WorstCaseAnalysis,
+    r: &RssAnalysis,
+    mc: &MonteCarloAnalysis,
+) -> Result<ClaimSet, StackupError> {
+    s.validate()?;
+    // Tripwire: the three analyses must be of the same stackup. The
+    // means of RSS and MC are estimates of the same exact quantity, so
+    // an 8-SE disagreement means someone mixed results.
+    if (mc.mean_gap - r.mean_gap).abs() > 8.0 * mc.mean_gap_se {
+        return Err(StackupError::BadRequirement(format!(
+            "analyses disagree on the mean gap ({} vs {} ± {}); \
+             were they run on the same stackup?",
+            r.mean_gap, mc.mean_gap, mc.mean_gap_se
+        )));
+    }
+    let rss_note = if r.all_normal {
+        "Phi-based; exact under the all-normal model and the stated \
+         sigma conventions"
+    } else {
+        "Phi-based via the CLT (chain has non-normal contributors); \
+         the Monte Carlo claim is the check"
+    };
+    let mut claims = vec![
+        claim(
+            "fit_probability",
+            mc.fit.p,
+            Some(mc.fit.standard_error),
+            "1",
+            "Monte Carlo fraction of virtual assemblies meeting the \
+             requirement; uncertainty is the Agresti-Coull standard error",
+        ),
+        claim("rss_yield", r.yield_estimate, Some(1.5e-7), "1", rss_note),
+        claim(
+            "mean_gap_mm",
+            r.mean_gap,
+            None,
+            "mm",
+            "exact under independence: sum of coefficient-weighted mean \
+             dimensions",
+        ),
+        claim(
+            "sigma_gap_mm",
+            r.sigma_gap,
+            None,
+            "mm",
+            "exact under independence: root-sum-square of \
+             coefficient-weighted sigmas",
+        ),
+        claim(
+            "worst_case_margin_mm",
+            wc.worst_margin(),
+            None,
+            "mm",
+            "binding margin with every part at its worst drawing limit; \
+             negative means worst-case assemblies violate the requirement \
+             even when the statistical yield is high",
+        ),
+    ];
+    if let Some(cpk) = r.cpk {
+        claims.push(claim(
+            "cpk",
+            cpk,
+            None,
+            "1",
+            "min distance from mean gap to a limit over 3 sigma_gap",
+        ));
+    }
+    if let Some(cp) = r.cp {
+        claims.push(claim(
+            "cp",
+            cp,
+            None,
+            "1",
+            "requirement width over 6 sigma_gap (two-sided requirements only)",
+        ));
+    }
+    Ok(ClaimSet {
+        schema: CLAIM_SCHEMA.to_string(),
+        provenance: Provenance {
+            n_samples: mc.n,
+            seed: mc.seed,
+            batches: mc.batches,
+            all_normal: r.all_normal,
+            requirement: s.requirement.clone(),
+            contributors: s
+                .contributors
+                .iter()
+                .map(|c| ContributorProvenance {
+                    name: c.name.clone(),
+                    dist: c.dist,
+                    source: c.source.clone(),
+                    coeff: c.coeff,
+                    limits: (c.tol_minus, c.tol_plus),
+                })
+                .collect(),
+            analyses: vec![
+                "worst_case".to_string(),
+                "rss".to_string(),
+                "monte_carlo".to_string(),
+            ],
+        },
+        claims,
+    })
+}
+
+/// A measurement to bind against a predicted claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Measurement {
+    /// Claim name this measures (must match a claim).
+    pub name: String,
+    /// Measured value, in the claim's unit.
+    pub value: f64,
+    /// One-sigma absolute uncertainty of the measurement, same unit.
+    pub uncertainty: f64,
+    /// Instrument provenance ("assembly trial n=50", "CMM s/n ...").
+    pub instrument: String,
+    /// Acceptance half-width, absolute, same unit: the claim holds when
+    /// |measured − predicted| ≤ band_abs + measurement uncertainty +
+    /// the claim's own uncertainty. Additive (not multiplicative)
+    /// because gap margins live near zero and can be negative.
+    pub band_abs: f64,
+}
+
+/// Verdict for one claim, in the repo's receipt vocabulary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Verdict {
+    /// Measurement inside the stated band.
+    Holds,
+    /// Measurement outside the stated band.
+    Violated,
+    /// No measurement bound to this claim (fail-closed: unmeasured is
+    /// never silently passing).
+    Unmeasured,
+}
+
+/// One row of the predicted-vs-measured comparison.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComparisonEntry {
+    /// Claim name.
+    pub name: String,
+    /// Predicted value.
+    pub predicted: f64,
+    /// Measured value (`None` when unmeasured).
+    pub measured: Option<f64>,
+    /// measured − predicted (`None` when unmeasured).
+    pub delta: Option<f64>,
+    /// Verdict.
+    pub verdict: Verdict,
+}
+
+/// The comparison report: every claim gets a row; measurements that
+/// match no claim are an error.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ComparisonReport {
+    /// Schema tag ([`COMPARE_SCHEMA`]).
+    pub schema: String,
+    /// Per-claim rows.
+    pub entries: Vec<ComparisonEntry>,
+    /// True only when every measured claim holds AND at least one
+    /// measurement exists — an unmeasured receipt never passes.
+    pub all_hold: bool,
+}
+
+/// Bind measurements to a claim set, fail-closed.
+pub fn compare(
+    claims: &ClaimSet,
+    measurements: &[Measurement],
+) -> Result<ComparisonReport, String> {
+    for m in measurements {
+        if !claims.claims.iter().any(|c| c.name == m.name) {
+            return Err(format!("measurement {:?} matches no claim", m.name));
+        }
+        let bands_ok = m.uncertainty.is_finite()
+            && m.uncertainty >= 0.0
+            && m.band_abs.is_finite()
+            && m.band_abs >= 0.0;
+        if !bands_ok {
+            return Err(format!(
+                "measurement {:?} has invalid uncertainty/band",
+                m.name
+            ));
+        }
+    }
+    let mut entries = Vec::with_capacity(claims.claims.len());
+    let mut measured_any = false;
+    let mut all_hold = true;
+    for c in &claims.claims {
+        let m = measurements.iter().find(|m| m.name == c.name);
+        let entry = match m {
+            None => ComparisonEntry {
+                name: c.name.clone(),
+                predicted: c.value,
+                measured: None,
+                delta: None,
+                verdict: Verdict::Unmeasured,
+            },
+            Some(m) => {
+                measured_any = true;
+                let delta = m.value - c.value;
+                let band = m.band_abs + m.uncertainty + c.uncertainty.unwrap_or(0.0);
+                let holds = delta.abs() <= band;
+                if !holds {
+                    all_hold = false;
+                }
+                ComparisonEntry {
+                    name: c.name.clone(),
+                    predicted: c.value,
+                    measured: Some(m.value),
+                    delta: Some(delta),
+                    verdict: if holds {
+                        Verdict::Holds
+                    } else {
+                        Verdict::Violated
+                    },
+                }
+            }
+        };
+        entries.push(entry);
+    }
+    Ok(ComparisonReport {
+        schema: COMPARE_SCHEMA.to_string(),
+        entries,
+        all_hold: all_hold && measured_any,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::{monte_carlo, rss, worst_case, McOptions};
+    use crate::dist::SigmaConvention;
+    use crate::stackup::{Contributor, Requirement};
+
+    fn build() -> (Stackup, ClaimSet) {
+        let conv = SigmaConvention::ThreeSigma;
+        let s = Stackup {
+            name: "receipt-chain".into(),
+            contributors: vec![
+                Contributor::normal("pocket", 1.0, 20.0, 0.15, conv),
+                Contributor::uniform("bushing", -1.0, 12.0, 0.1, 0.0),
+                Contributor::normal("shim", -1.0, 7.5, 0.05, conv),
+            ],
+            requirement: Requirement::between("protrusion", 0.35, 0.75),
+        };
+        let wc = worst_case(&s).unwrap();
+        let r = rss(&s).unwrap();
+        let mc = monte_carlo(
+            &s,
+            &McOptions {
+                n: 100_000,
+                seed: 314,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        let set = predicted_claims(&s, &wc, &r, &mc).unwrap();
+        (s, set)
+    }
+
+    fn get<'a>(set: &'a ClaimSet, name: &str) -> &'a Claim {
+        set.claims
+            .iter()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("missing claim {name}"))
+    }
+
+    #[test]
+    fn claims_are_complete_consistent_and_error_barred() {
+        let (_, set) = build();
+        assert_eq!(set.schema, CLAIM_SCHEMA);
+        // fit_probability structurally carries its MC standard error.
+        let fit = get(&set, "fit_probability");
+        assert!(fit.uncertainty.unwrap() > 0.0);
+        // RSS and MC agree (they're the same chain).
+        let rss_y = get(&set, "rss_yield");
+        assert!((fit.value - rss_y.value).abs() < 5.0 * fit.uncertainty.unwrap());
+        // The worst-case margin is present and negative here (the
+        // bushing band makes WC fail while statistics pass) — honesty
+        // on the same receipt.
+        let wcm = get(&set, "worst_case_margin_mm");
+        assert!(wcm.value < 0.0, "wc margin {}", wcm.value);
+        assert!(fit.value > 0.95, "fit {}", fit.value);
+        // Provenance names every contributor and its source.
+        assert_eq!(set.provenance.contributors.len(), 3);
+        assert_eq!(set.provenance.n_samples, 100_000);
+        assert_eq!(set.provenance.seed, 314);
+        assert!(!set.provenance.all_normal);
+        assert!(set
+            .provenance
+            .contributors
+            .iter()
+            .all(|c| matches!(c.source, crate::dist::DistributionSource::Assumed { .. })));
+    }
+
+    #[test]
+    fn mismatched_analyses_trip_the_wire() {
+        let (s, _) = build();
+        let wc = worst_case(&s).unwrap();
+        let r = rss(&s).unwrap();
+        // MC from a different chain (shifted nominal): the means
+        // disagree by far more than 8 SE.
+        let mut other = s.clone();
+        other.contributors[0].nominal += 0.3;
+        let mc = monte_carlo(
+            &other,
+            &McOptions {
+                n: 100_000,
+                seed: 315,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        assert!(predicted_claims(&s, &wc, &r, &mc).is_err());
+    }
+
+    #[test]
+    fn serializes_with_schema_and_provenance() {
+        let (_, set) = build();
+        let json = serde_json::to_string_pretty(&set).unwrap();
+        assert!(json.contains("vcad.tolerance-claims/1"));
+        assert!(json.contains("fit_probability"));
+        assert!(json.contains("assumed"));
+        assert!(json.contains("three_sigma"));
+        let back: ClaimSet = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.schema, set.schema);
+        assert_eq!(back.claims.len(), set.claims.len());
+        for (a, b) in back.claims.iter().zip(&set.claims) {
+            assert_eq!(a.name, b.name);
+            let scale = b.value.abs().max(1e-300);
+            assert!((a.value - b.value).abs() / scale < 1e-12);
+        }
+    }
+
+    #[test]
+    fn compare_binds_measurements_fail_closed() {
+        let (_, set) = build();
+        // Unmeasured receipt never passes.
+        let empty = compare(&set, &[]).unwrap();
+        assert!(!empty.all_hold);
+        assert!(empty
+            .entries
+            .iter()
+            .all(|e| e.verdict == Verdict::Unmeasured));
+
+        // A measurement of nothing is an error.
+        let bogus = Measurement {
+            name: "warp_factor".into(),
+            value: 9.0,
+            uncertainty: 0.1,
+            instrument: "vibes".into(),
+            band_abs: 1.0,
+        };
+        assert!(compare(&set, &[bogus]).is_err());
+
+        // An assembly trial agreeing within band → Holds; a wildly
+        // off sigma → Violated; the rest stay Unmeasured.
+        let fit_pred = get(&set, "fit_probability").value;
+        let ok = Measurement {
+            name: "fit_probability".into(),
+            value: (fit_pred - 0.01).clamp(0.0, 1.0),
+            uncertainty: 0.02,
+            instrument: "assembly trial n=200".into(),
+            band_abs: 0.02,
+        };
+        let bad = Measurement {
+            name: "sigma_gap_mm".into(),
+            value: get(&set, "sigma_gap_mm").value * 3.0,
+            uncertainty: 0.001,
+            instrument: "CMM coupon set".into(),
+            band_abs: 0.01,
+        };
+        let report = compare(&set, &[ok, bad]).unwrap();
+        assert!(!report.all_hold);
+        let verdict = |name: &str| {
+            report
+                .entries
+                .iter()
+                .find(|e| e.name == name)
+                .unwrap()
+                .verdict
+        };
+        assert_eq!(verdict("fit_probability"), Verdict::Holds);
+        assert_eq!(verdict("sigma_gap_mm"), Verdict::Violated);
+        assert_eq!(verdict("cpk"), Verdict::Unmeasured);
+
+        // All-measured-and-holding passes.
+        let good = Measurement {
+            name: "sigma_gap_mm".into(),
+            value: get(&set, "sigma_gap_mm").value * 1.02,
+            uncertainty: 0.005,
+            instrument: "CMM coupon set".into(),
+            band_abs: 0.01,
+        };
+        let ok2 = Measurement {
+            name: "fit_probability".into(),
+            value: (fit_pred - 0.01).clamp(0.0, 1.0),
+            uncertainty: 0.02,
+            instrument: "assembly trial n=200".into(),
+            band_abs: 0.02,
+        };
+        let report = compare(&set, &[ok2, good]).unwrap();
+        assert!(report.all_hold, "{report:?}");
+    }
+
+    #[test]
+    fn negative_margins_and_bands_behave() {
+        // Additive bands work at negative predicted values (WC margin).
+        let (_, set) = build();
+        let wcm = get(&set, "worst_case_margin_mm").value;
+        assert!(wcm < 0.0);
+        let m = Measurement {
+            name: "worst_case_margin_mm".into(),
+            value: wcm - 0.005,
+            uncertainty: 0.002,
+            instrument: "gauge study".into(),
+            band_abs: 0.005,
+        };
+        let report = compare(&set, &[m]).unwrap();
+        assert_eq!(report.entries.len(), set.claims.len());
+        assert!(report.all_hold);
+        // Invalid measurement uncertainty is an error, not a pass.
+        let bad = Measurement {
+            name: "worst_case_margin_mm".into(),
+            value: wcm,
+            uncertainty: f64::NAN,
+            instrument: "broken".into(),
+            band_abs: 0.005,
+        };
+        assert!(compare(&set, &[bad]).is_err());
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/rng.rs
+++ b/crates/vcad-kernel-tolerance/src/rng.rs
@@ -1,0 +1,181 @@
+//! Deterministic pseudo-random numbers for Monte Carlo analysis.
+//!
+//! Hand-rolled **xoshiro256++** (Blackman & Vigna, "Scrambled linear
+//! pseudorandom number generators", ACM Trans. Math. Softw. 47(4), 2021;
+//! public-domain reference implementation at prng.di.unimi.it), seeded
+//! through **SplitMix64** (Steele, Lea & Flood, OOPSLA 2014) as the
+//! authors recommend. No `rand` dependency: the reproducibility of a
+//! tolerance receipt must not hinge on a third-party crate's version
+//! bump.
+//!
+//! Determinism contract: the same seed produces the same sample stream
+//! on every platform — the generator uses only wrapping `u64` arithmetic
+//! and IEEE-754 double conversion.
+
+/// Deterministic xoshiro256++ generator.
+#[derive(Debug, Clone)]
+pub struct Rng {
+    s: [u64; 4],
+    /// Spare normal deviate from the Marsaglia polar method.
+    spare_normal: Option<f64>,
+}
+
+impl Rng {
+    /// Create a generator from a 64-bit seed via SplitMix64 expansion.
+    ///
+    /// SplitMix64 guarantees the four state words are well mixed even
+    /// for adjacent or zero seeds (xoshiro must never be seeded with an
+    /// all-zero state; SplitMix64 output is never all-zero across four
+    /// consecutive draws).
+    pub fn new(seed: u64) -> Self {
+        let mut x = seed;
+        let mut next = || {
+            x = x.wrapping_add(0x9E37_79B9_7F4A_7C15);
+            let mut z = x;
+            z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+            z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+            z ^ (z >> 31)
+        };
+        let s = [next(), next(), next(), next()];
+        Self {
+            s,
+            spare_normal: None,
+        }
+    }
+
+    /// Next raw 64-bit output (xoshiro256++ scrambler).
+    pub fn next_u64(&mut self) -> u64 {
+        let result = self.s[0]
+            .wrapping_add(self.s[3])
+            .rotate_left(23)
+            .wrapping_add(self.s[0]);
+        let t = self.s[1] << 17;
+        self.s[2] ^= self.s[0];
+        self.s[3] ^= self.s[1];
+        self.s[1] ^= self.s[2];
+        self.s[0] ^= self.s[3];
+        self.s[2] ^= t;
+        self.s[3] = self.s[3].rotate_left(45);
+        result
+    }
+
+    /// Uniform double in [0, 1): the top 53 bits scaled by 2⁻⁵³
+    /// (the standard full-precision conversion from the xoshiro paper).
+    pub fn next_f64(&mut self) -> f64 {
+        const SCALE: f64 = 1.0 / 9_007_199_254_740_992.0; // 2⁻⁵³
+        (self.next_u64() >> 11) as f64 * SCALE
+    }
+
+    /// Standard normal deviate via the **Marsaglia polar method**
+    /// (Marsaglia & Bray, SIAM Review 6(3), 1964): rejection sampling in
+    /// the unit disk, no trigonometry. Each accepted pair yields two
+    /// deviates; the spare is cached, so the amortized cost is ~1.27
+    /// uniform pairs per normal pair. Rejection makes the *count* of
+    /// underlying draws sample-dependent, but the stream stays fully
+    /// deterministic for a given seed.
+    pub fn next_normal(&mut self) -> f64 {
+        if let Some(z) = self.spare_normal.take() {
+            return z;
+        }
+        loop {
+            let u = 2.0 * self.next_f64() - 1.0;
+            let v = 2.0 * self.next_f64() - 1.0;
+            let s = u * u + v * v;
+            if s > 0.0 && s < 1.0 {
+                let f = (-2.0 * s.ln() / s).sqrt();
+                self.spare_normal = Some(v * f);
+                return u * f;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_seed_same_stream() {
+        let mut a = Rng::new(42);
+        let mut b = Rng::new(42);
+        for _ in 0..1000 {
+            assert_eq!(a.next_u64(), b.next_u64());
+        }
+        // Normals too (rejection count is part of the deterministic stream).
+        let mut a = Rng::new(7);
+        let mut b = Rng::new(7);
+        for _ in 0..1000 {
+            assert_eq!(a.next_normal().to_bits(), b.next_normal().to_bits());
+        }
+    }
+
+    #[test]
+    fn different_seeds_differ() {
+        let mut a = Rng::new(1);
+        let mut b = Rng::new(2);
+        let same = (0..64).filter(|_| a.next_u64() == b.next_u64()).count();
+        assert_eq!(same, 0, "adjacent seeds must decorrelate via SplitMix64");
+    }
+
+    #[test]
+    fn zero_seed_is_fine() {
+        // xoshiro would be stuck at an all-zero state; SplitMix64 seeding
+        // must prevent that.
+        let mut r = Rng::new(0);
+        let first = r.next_u64();
+        assert_ne!(first, 0);
+        assert_ne!(first, r.next_u64());
+    }
+
+    #[test]
+    fn uniform_moments() {
+        let mut r = Rng::new(123);
+        let n = 200_000;
+        let (mut sum, mut sum_sq) = (0.0, 0.0);
+        for _ in 0..n {
+            let x = r.next_f64();
+            assert!((0.0..1.0).contains(&x));
+            sum += x;
+            sum_sq += x * x;
+        }
+        let mean = sum / n as f64;
+        let var = sum_sq / n as f64 - mean * mean;
+        // SE(mean) ≈ 1/(√12·√n) ≈ 6.5e-4; allow 5 SE.
+        assert!((mean - 0.5).abs() < 3.3e-3, "mean = {mean}");
+        assert!((var - 1.0 / 12.0).abs() < 2e-3, "var = {var}");
+    }
+
+    #[test]
+    fn normal_moments_and_tails() {
+        let mut r = Rng::new(99);
+        let n = 200_000usize;
+        let (mut sum, mut sum_sq) = (0.0, 0.0);
+        let (mut beyond_1, mut beyond_2, mut beyond_3) = (0usize, 0usize, 0usize);
+        for _ in 0..n {
+            let z = r.next_normal();
+            sum += z;
+            sum_sq += z * z;
+            let a = z.abs();
+            if a > 1.0 {
+                beyond_1 += 1;
+            }
+            if a > 2.0 {
+                beyond_2 += 1;
+            }
+            if a > 3.0 {
+                beyond_3 += 1;
+            }
+        }
+        let mean = sum / n as f64;
+        let var = sum_sq / n as f64 - mean * mean;
+        assert!(mean.abs() < 0.01, "mean = {mean}");
+        assert!((var - 1.0).abs() < 0.02, "var = {var}");
+        // Two-sided tail masses: 31.73%, 4.55%, 0.27%.
+        let f1 = beyond_1 as f64 / n as f64;
+        let f2 = beyond_2 as f64 / n as f64;
+        let f3 = beyond_3 as f64 / n as f64;
+        assert!((f1 - 0.3173).abs() < 0.01, "P(|z|>1) = {f1}");
+        assert!((f2 - 0.0455).abs() < 0.005, "P(|z|>2) = {f2}");
+        assert!((f3 - 0.0027).abs() < 0.001, "P(|z|>3) = {f3}");
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/sensitivity.rs
+++ b/crates/vcad-kernel-tolerance/src/sensitivity.rs
@@ -1,0 +1,199 @@
+//! Exact sensitivities: the design compass.
+//!
+//! For a linear chain G = Σ aᵢxᵢ these are **closed forms, not
+//! adjoints, not finite differences** — linearity hands us every
+//! derivative exactly, and we take the win:
+//!
+//! - ∂G/∂nominalᵢ = aᵢ
+//! - ∂σ_G/∂σᵢ = aᵢ²σᵢ/σ_G          (from σ_G² = Σ aᵢ²σᵢ²)
+//! - variance share = aᵢ²σᵢ²/σ_G²   (Σ over i = 1, the ranking metric)
+//! - ∂Y/∂μ_G = [φ(z_L) − φ(z_U)]/σ_G, chained: ∂Y/∂nominalᵢ = aᵢ·∂Y/∂μ_G
+//! - ∂Y/∂σ_G = [z_L·φ(z_L) − z_U·φ(z_U)]/σ_G, chained through ∂σ_G/∂σᵢ
+//!
+//! where Y = Φ(z_U) − Φ(z_L), z = (limit − μ_G)/σ_G, φ the standard
+//! normal PDF (absent limits contribute 0). The yield derivatives
+//! inherit the RSS normality assumption; the moment derivatives do not.
+//!
+//! Rows are ranked by variance share: the first row is the dimension
+//! that is killing the yield.
+
+use serde::{Deserialize, Serialize};
+
+use crate::capability::phi_pdf;
+use crate::stackup::{Stackup, StackupError};
+
+/// Exact sensitivities for one contributor.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SensitivityRow {
+    /// Contributor name.
+    pub name: String,
+    /// ∂gap/∂nominal = the chain coefficient aᵢ (mm/mm). Exact.
+    pub d_gap_d_nominal: f64,
+    /// Contributor standard deviation σᵢ, mm.
+    pub sigma: f64,
+    /// ∂σ_G/∂σᵢ = aᵢ²σᵢ/σ_G (mm/mm). Exact.
+    pub d_sigma_gap_d_sigma: f64,
+    /// Share of gap variance: aᵢ²σᵢ²/σ_G², in [0, 1]. The ranking
+    /// metric.
+    pub variance_share: f64,
+    /// ∂yield/∂nominalᵢ (per mm). Exact under the RSS normal-gap model.
+    /// The re-centering compass: move nominals down its gradient.
+    pub d_yield_d_nominal: f64,
+    /// ∂yield/∂σᵢ (per mm of σ). Exact under the RSS normal-gap model;
+    /// ≤ 0 always (scatter never helps). The allocation compass.
+    pub d_yield_d_sigma: f64,
+    /// Worst-case span |aᵢ|·(tol₋ + tol₊): this contributor's share of
+    /// the worst-case interval width, mm.
+    pub wc_span: f64,
+}
+
+/// Compute exact sensitivities, ranked by variance share (descending).
+pub fn sensitivities(s: &Stackup) -> Result<Vec<SensitivityRow>, StackupError> {
+    s.validate()?;
+    let var_g = s.variance_gap();
+    if var_g == 0.0 {
+        return Err(StackupError::DegenerateChain);
+    }
+    let sigma_g = var_g.sqrt();
+    let mean_g = s.mean_gap();
+
+    // ∂Y/∂μ_G and ∂Y/∂σ_G from the Φ-based yield.
+    let z_l = s.requirement.lower_mm.map(|l| (l - mean_g) / sigma_g);
+    let z_u = s.requirement.upper_mm.map(|u| (u - mean_g) / sigma_g);
+    let pdf_l = z_l.map_or(0.0, phi_pdf);
+    let pdf_u = z_u.map_or(0.0, phi_pdf);
+    let dy_dmean = (pdf_l - pdf_u) / sigma_g;
+    let dy_dsigma_g =
+        (z_l.map_or(0.0, |z| z * phi_pdf(z)) - z_u.map_or(0.0, |z| z * phi_pdf(z))) / sigma_g;
+
+    let mut rows: Vec<SensitivityRow> = s
+        .contributors
+        .iter()
+        .map(|c| {
+            let sigma_i = c.dist.sigma();
+            let a2 = c.coeff * c.coeff;
+            let d_sigma_gap_d_sigma = a2 * sigma_i / sigma_g;
+            SensitivityRow {
+                name: c.name.clone(),
+                d_gap_d_nominal: c.coeff,
+                sigma: sigma_i,
+                d_sigma_gap_d_sigma,
+                variance_share: a2 * sigma_i * sigma_i / var_g,
+                d_yield_d_nominal: c.coeff * dy_dmean,
+                d_yield_d_sigma: dy_dsigma_g * d_sigma_gap_d_sigma,
+                wc_span: c.coeff.abs() * (c.tol_minus + c.tol_plus),
+            }
+        })
+        .collect();
+    rows.sort_by(|a, b| {
+        b.variance_share
+            .partial_cmp(&a.variance_share)
+            .expect("variance shares are finite")
+    });
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::rss;
+    use crate::dist::SigmaConvention;
+    use crate::stackup::{Contributor, Requirement};
+
+    fn chain() -> Stackup {
+        Stackup {
+            name: "s".into(),
+            contributors: vec![
+                Contributor::normal("big", 1.0, 50.0, 0.3, SigmaConvention::ThreeSigma),
+                Contributor::normal("small", -1.0, 20.0, 0.1, SigmaConvention::ThreeSigma),
+                Contributor::normal("lever", 2.0, 5.0, 0.06, SigmaConvention::ThreeSigma),
+            ],
+            requirement: Requirement::between("gap", 39.5, 40.5),
+        }
+    }
+
+    #[test]
+    fn closed_forms_are_exact() {
+        let s = chain();
+        let rows = sensitivities(&s).unwrap();
+        // σᵢ: 0.1, 0.0333.., 0.02; aᵢ²σᵢ²: 0.01, 0.001111, 0.0016.
+        let var_g: f64 = 0.01 + 0.1f64 / 3.0 * (0.1 / 3.0) + 4.0 * 0.02 * 0.02;
+        let sigma_g = var_g.sqrt();
+        // Ranked: big, lever, small.
+        assert_eq!(rows[0].name, "big");
+        assert_eq!(rows[1].name, "lever");
+        assert_eq!(rows[2].name, "small");
+        assert!((rows[0].variance_share - 0.01 / var_g).abs() < 1e-12);
+        assert!((rows[1].variance_share - 0.0016 / var_g).abs() < 1e-12);
+        // Shares sum to 1.
+        let total: f64 = rows.iter().map(|r| r.variance_share).sum();
+        assert!((total - 1.0).abs() < 1e-12);
+        // ∂σ_G/∂σᵢ exact.
+        assert!((rows[0].d_sigma_gap_d_sigma - 0.1 / sigma_g).abs() < 1e-12);
+        assert!((rows[1].d_sigma_gap_d_sigma - 4.0 * 0.02 / sigma_g).abs() < 1e-12);
+        // ∂gap/∂nominal is the coefficient.
+        assert_eq!(rows[1].d_gap_d_nominal, 2.0);
+        // WC spans.
+        assert!((rows[1].wc_span - 2.0 * 0.12).abs() < 1e-12);
+    }
+
+    #[test]
+    fn yield_derivatives_match_finite_differences() {
+        // The exact forms must agree with FD on the Φ-based yield —
+        // this validates the chain rule, not an approximation of it.
+        let s = chain();
+        let rows = sensitivities(&s).unwrap();
+        let base = rss(&s).unwrap().yield_estimate;
+        let h = 1e-6;
+        for row in &rows {
+            // Nominal FD.
+            let mut sp = s.clone();
+            let c = sp
+                .contributors
+                .iter_mut()
+                .find(|c| c.name == row.name)
+                .unwrap();
+            c.nominal += h;
+            let fd = (rss(&sp).unwrap().yield_estimate - base) / h;
+            assert!(
+                (fd - row.d_yield_d_nominal).abs() < 1e-4 * (1.0 + fd.abs()),
+                "{}: fd {fd} vs exact {}",
+                row.name,
+                row.d_yield_d_nominal
+            );
+            // Sigma FD.
+            let mut sp = s.clone();
+            let c = sp
+                .contributors
+                .iter_mut()
+                .find(|c| c.name == row.name)
+                .unwrap();
+            if let crate::dist::Distribution::Normal { sigma, .. } = &mut c.dist {
+                *sigma += h;
+            }
+            let fd = (rss(&sp).unwrap().yield_estimate - base) / h;
+            assert!(
+                (fd - row.d_yield_d_sigma).abs() < 1e-4 * (1.0 + fd.abs()),
+                "{}: fd {fd} vs exact {}",
+                row.name,
+                row.d_yield_d_sigma
+            );
+            // Scatter never helps.
+            assert!(row.d_yield_d_sigma <= 0.0);
+        }
+    }
+
+    #[test]
+    fn one_sided_requirement_yields_signed_compass() {
+        // Clearance-only requirement: increasing the gap-opening nominal
+        // must increase yield; increasing a consuming nominal must
+        // decrease it.
+        let mut s = chain();
+        s.requirement = Requirement::at_least("clearance", 39.9);
+        let rows = sensitivities(&s).unwrap();
+        let big = rows.iter().find(|r| r.name == "big").unwrap();
+        let small = rows.iter().find(|r| r.name == "small").unwrap();
+        assert!(big.d_yield_d_nominal > 0.0);
+        assert!(small.d_yield_d_nominal < 0.0);
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/spec.rs
+++ b/crates/vcad-kernel-tolerance/src/spec.rs
@@ -1,0 +1,559 @@
+//! The `.vcad` seam: a serde stackup schema with named parameters (M3).
+//!
+//! A [`StackupSpec`] is the serialization contract between vcad
+//! documents and this crate. Every numeric field is a [`ParamValue`]:
+//! either a literal, or the **name** of a document parameter supplied
+//! at resolve time. Resolution is fail-closed — an unbound name is an
+//! error, never a default — and the resolved [`Stackup`] is validated
+//! before it is returned, so a spec that resolves to nonsense (negative
+//! tolerance via a bad binding, say) also errors instead of analyzing.
+//!
+//! ## The adapter contract (vcad side of the seam)
+//!
+//! BRep/document extraction deliberately does not live here — it lands
+//! on the vcad side, emitting this schema (the same division of labor
+//! as `vcad-kernel-particle::spec` and `document_parameter_gradient`):
+//!
+//! - **Dimensions come from sketches.** A document's sketch dimensions
+//!   and feature parameters are the natural [`ParamValue::Named`]
+//!   bindings; the adapter walks the parametric DAG and emits one
+//!   [`ContributorSpec`] per chain member, with `nominal` named after
+//!   the driving document parameter so the stackup re-prices when the
+//!   design moves.
+//! - **Requirements come from clearance assertions.** The document's
+//!   labeled `check_clearance` assertions (min distance between part
+//!   groups, re-verified as Holds/Stale/Violated on the receipt) map
+//!   onto [`RequirementSpec`]: the assertion's minimum distance is
+//!   `lower_mm` and its label is the requirement name. A tolerance
+//!   claim then *prices the probability* that the clearance assertion
+//!   holds in production — the two verdicts talk about the same gap.
+//!
+//! Tolerance-to-σ consistency by construction: the
+//! [`DistSpec::NormalFromTol`] variant derives σ from the contributor's
+//! own resolved drawing tolerance under a stated convention, so a
+//! drawing-driven spec cannot drift its statistical model away from its
+//! limits.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::dist::{Distribution, DistributionSource, SigmaConvention};
+use crate::stackup::{Contributor, Requirement, Stackup, StackupError};
+
+/// A literal value or the name of a document parameter.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ParamValue {
+    /// A literal number.
+    Literal(f64),
+    /// The name of a parameter bound at [`StackupSpec::resolve`] time.
+    Named(String),
+}
+
+impl From<f64> for ParamValue {
+    fn from(v: f64) -> Self {
+        ParamValue::Literal(v)
+    }
+}
+
+impl ParamValue {
+    fn resolve(&self, params: &BTreeMap<String, f64>) -> Result<f64, SpecError> {
+        match self {
+            ParamValue::Literal(v) => Ok(*v),
+            ParamValue::Named(name) => params
+                .get(name)
+                .copied()
+                .ok_or_else(|| SpecError::UnknownParameter(name.clone())),
+        }
+    }
+
+    fn name(&self) -> Option<&str> {
+        match self {
+            ParamValue::Literal(_) => None,
+            ParamValue::Named(n) => Some(n),
+        }
+    }
+}
+
+/// Distribution spec with parameterizable fields.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum DistSpec {
+    /// Normal with explicit (possibly named) mean and σ.
+    Normal {
+        /// Centering error, mm.
+        mean: ParamValue,
+        /// Standard deviation, mm.
+        sigma: ParamValue,
+    },
+    /// σ derived from the contributor's own resolved drawing tolerance
+    /// under a stated convention (requires a symmetric ± band —
+    /// asymmetric limits with this variant are an error, fail-closed).
+    /// The drawing and the statistics cannot drift apart.
+    NormalFromTol {
+        /// The tolerance-to-σ convention.
+        convention: SigmaConvention,
+    },
+    /// Uniform on [lo, hi] deviations.
+    Uniform {
+        /// Lower deviation bound, mm.
+        lo: ParamValue,
+        /// Upper deviation bound, mm.
+        hi: ParamValue,
+    },
+    /// Two-state mix.
+    TwoPoint {
+        /// First state's deviation, mm.
+        a: ParamValue,
+        /// Second state's deviation, mm.
+        b: ParamValue,
+        /// Probability of state `b`.
+        p_b: ParamValue,
+    },
+}
+
+/// One contributor in the spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContributorSpec {
+    /// Contributor name.
+    pub name: String,
+    /// Signed chain coefficient.
+    pub coeff: ParamValue,
+    /// Nominal dimension, mm — typically named after the driving
+    /// document parameter.
+    pub nominal: ParamValue,
+    /// Lower drawing limit (deviation ≥ 0), mm.
+    pub tol_minus: ParamValue,
+    /// Upper drawing limit (deviation ≥ 0), mm.
+    pub tol_plus: ParamValue,
+    /// Deviation distribution.
+    pub dist: DistSpec,
+    /// Distribution provenance (defaults to assumed 3σ).
+    #[serde(default)]
+    pub source: DistributionSource,
+}
+
+/// Requirement spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequirementSpec {
+    /// Requirement name — the adapter contract uses the clearance
+    /// assertion's label here.
+    pub name: String,
+    /// Minimum acceptable gap, mm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lower_mm: Option<ParamValue>,
+    /// Maximum acceptable gap, mm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upper_mm: Option<ParamValue>,
+}
+
+/// Serializable stackup with named parameters.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StackupSpec {
+    /// Stackup name.
+    pub name: String,
+    /// The chain.
+    pub contributors: Vec<ContributorSpec>,
+    /// The requirement.
+    pub requirement: RequirementSpec,
+}
+
+/// Resolution failures.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SpecError {
+    /// A named parameter had no binding.
+    UnknownParameter(String),
+    /// [`DistSpec::NormalFromTol`] on an asymmetric ± band.
+    AsymmetricNormalFromTol {
+        /// Contributor name.
+        contributor: String,
+        /// Resolved (tol_minus, tol_plus).
+        limits: (f64, f64),
+    },
+    /// The resolved stackup failed validation.
+    Invalid(StackupError),
+}
+
+impl std::fmt::Display for SpecError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SpecError::UnknownParameter(name) => {
+                write!(f, "unbound stackup parameter: {name:?}")
+            }
+            SpecError::AsymmetricNormalFromTol {
+                contributor,
+                limits,
+            } => write!(
+                f,
+                "normal_from_tol requires a symmetric band on {contributor:?}, got {limits:?}"
+            ),
+            SpecError::Invalid(e) => write!(f, "resolved stackup is invalid: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SpecError {}
+
+impl From<StackupError> for SpecError {
+    fn from(e: StackupError) -> Self {
+        SpecError::Invalid(e)
+    }
+}
+
+impl StackupSpec {
+    /// Resolve every field against `params` and validate the result,
+    /// fail-closed on unbound names and on invalid resolved models.
+    pub fn resolve(&self, params: &BTreeMap<String, f64>) -> Result<Stackup, SpecError> {
+        let contributors = self
+            .contributors
+            .iter()
+            .map(|c| {
+                let tol_minus = c.tol_minus.resolve(params)?;
+                let tol_plus = c.tol_plus.resolve(params)?;
+                let dist = match &c.dist {
+                    DistSpec::Normal { mean, sigma } => Distribution::Normal {
+                        mean: mean.resolve(params)?,
+                        sigma: sigma.resolve(params)?,
+                    },
+                    DistSpec::NormalFromTol { convention } => {
+                        if (tol_minus - tol_plus).abs() > 1e-12 {
+                            return Err(SpecError::AsymmetricNormalFromTol {
+                                contributor: c.name.clone(),
+                                limits: (tol_minus, tol_plus),
+                            });
+                        }
+                        Distribution::Normal {
+                            mean: 0.0,
+                            sigma: tol_plus / convention.k(),
+                        }
+                    }
+                    DistSpec::Uniform { lo, hi } => Distribution::Uniform {
+                        lo: lo.resolve(params)?,
+                        hi: hi.resolve(params)?,
+                    },
+                    DistSpec::TwoPoint { a, b, p_b } => Distribution::TwoPoint {
+                        a: a.resolve(params)?,
+                        b: b.resolve(params)?,
+                        p_b: p_b.resolve(params)?,
+                    },
+                };
+                Ok(Contributor {
+                    name: c.name.clone(),
+                    coeff: c.coeff.resolve(params)?,
+                    nominal: c.nominal.resolve(params)?,
+                    tol_minus,
+                    tol_plus,
+                    dist,
+                    source: c.source.clone(),
+                })
+            })
+            .collect::<Result<Vec<_>, SpecError>>()?;
+        let requirement = Requirement {
+            name: self.requirement.name.clone(),
+            lower_mm: self
+                .requirement
+                .lower_mm
+                .as_ref()
+                .map(|v| v.resolve(params))
+                .transpose()?,
+            upper_mm: self
+                .requirement
+                .upper_mm
+                .as_ref()
+                .map(|v| v.resolve(params))
+                .transpose()?,
+        };
+        let s = Stackup {
+            name: self.name.clone(),
+            contributors,
+            requirement,
+        };
+        s.validate()?;
+        Ok(s)
+    }
+
+    /// A literal (parameter-free) spec mirroring `stackup` — the
+    /// round-trip starting point for documents that don't parameterize.
+    pub fn from_stackup(s: &Stackup) -> Self {
+        Self {
+            name: s.name.clone(),
+            contributors: s
+                .contributors
+                .iter()
+                .map(|c| ContributorSpec {
+                    name: c.name.clone(),
+                    coeff: c.coeff.into(),
+                    nominal: c.nominal.into(),
+                    tol_minus: c.tol_minus.into(),
+                    tol_plus: c.tol_plus.into(),
+                    dist: match c.dist {
+                        Distribution::Normal { mean, sigma } => DistSpec::Normal {
+                            mean: mean.into(),
+                            sigma: sigma.into(),
+                        },
+                        Distribution::Uniform { lo, hi } => DistSpec::Uniform {
+                            lo: lo.into(),
+                            hi: hi.into(),
+                        },
+                        Distribution::TwoPoint { a, b, p_b } => DistSpec::TwoPoint {
+                            a: a.into(),
+                            b: b.into(),
+                            p_b: p_b.into(),
+                        },
+                    },
+                    source: c.source.clone(),
+                })
+                .collect(),
+            requirement: RequirementSpec {
+                name: s.requirement.name.clone(),
+                lower_mm: s.requirement.lower_mm.map(Into::into),
+                upper_mm: s.requirement.upper_mm.map(Into::into),
+            },
+        }
+    }
+
+    /// Every named parameter referenced by this spec — what the
+    /// document must supply.
+    pub fn parameter_names(&self) -> BTreeSet<String> {
+        let mut names = BTreeSet::new();
+        let mut put = |v: &ParamValue| {
+            if let Some(n) = v.name() {
+                names.insert(n.to_string());
+            }
+        };
+        for c in &self.contributors {
+            put(&c.coeff);
+            put(&c.nominal);
+            put(&c.tol_minus);
+            put(&c.tol_plus);
+            match &c.dist {
+                DistSpec::Normal { mean, sigma } => {
+                    put(mean);
+                    put(sigma);
+                }
+                DistSpec::NormalFromTol { .. } => {}
+                DistSpec::Uniform { lo, hi } => {
+                    put(lo);
+                    put(hi);
+                }
+                DistSpec::TwoPoint { a, b, p_b } => {
+                    put(a);
+                    put(b);
+                    put(p_b);
+                }
+            }
+        }
+        if let Some(v) = &self.requirement.lower_mm {
+            put(v);
+        }
+        if let Some(v) = &self.requirement.upper_mm {
+            put(v);
+        }
+        names
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::analysis::rss;
+    use crate::dist::SigmaConvention;
+
+    fn params(pairs: &[(&str, f64)]) -> BTreeMap<String, f64> {
+        pairs.iter().map(|(k, v)| (k.to_string(), *v)).collect()
+    }
+
+    #[test]
+    fn json_round_trip_with_named_parameters() {
+        let json = r#"{
+            "name": "pocket-stack",
+            "contributors": [
+                {
+                    "name": "pocket",
+                    "coeff": 1.0,
+                    "nominal": "pocket_depth",
+                    "tol_minus": 0.15,
+                    "tol_plus": 0.15,
+                    "dist": { "type": "normal_from_tol",
+                              "convention": { "type": "three_sigma" } }
+                },
+                {
+                    "name": "bushing",
+                    "coeff": -1.0,
+                    "nominal": "bushing_len",
+                    "tol_minus": 0.10,
+                    "tol_plus": 0.10,
+                    "dist": { "type": "normal",
+                              "mean": 0.0, "sigma": "bushing_sigma" }
+                }
+            ],
+            "requirement": {
+                "name": "protrusion",
+                "lower_mm": 0.2,
+                "upper_mm": "max_protrusion"
+            }
+        }"#;
+        let spec: StackupSpec = serde_json::from_str(json).expect("parse");
+        assert_eq!(
+            spec.parameter_names(),
+            [
+                "pocket_depth",
+                "bushing_len",
+                "bushing_sigma",
+                "max_protrusion"
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+        );
+        let s = spec
+            .resolve(&params(&[
+                ("pocket_depth", 20.0),
+                ("bushing_len", 19.5),
+                ("bushing_sigma", 0.03),
+                ("max_protrusion", 0.8),
+            ]))
+            .expect("resolve");
+        assert!((s.nominal_gap() - 0.5).abs() < 1e-12);
+        // NormalFromTol derived σ = 0.15/3 = 0.05.
+        assert!((s.contributors[0].dist.sigma() - 0.05).abs() < 1e-12);
+        // The resolved model analyzes.
+        let r = rss(&s).unwrap();
+        assert!(r.yield_estimate > 0.9);
+
+        // Serialize → parse: identical spec.
+        let round = serde_json::to_string(&spec).expect("serialize");
+        let spec2: StackupSpec = serde_json::from_str(&round).expect("reparse");
+        assert_eq!(spec, spec2);
+    }
+
+    #[test]
+    fn resolution_is_fail_closed_on_unbound_names() {
+        let spec = StackupSpec {
+            name: "s".into(),
+            contributors: vec![ContributorSpec {
+                name: "a".into(),
+                coeff: 1.0.into(),
+                nominal: ParamValue::Named("missing".into()),
+                tol_minus: 0.1.into(),
+                tol_plus: 0.1.into(),
+                dist: DistSpec::NormalFromTol {
+                    convention: SigmaConvention::ThreeSigma,
+                },
+                source: DistributionSource::default(),
+            }],
+            requirement: RequirementSpec {
+                name: "gap".into(),
+                lower_mm: Some(0.0.into()),
+                upper_mm: None,
+            },
+        };
+        assert_eq!(
+            spec.resolve(&BTreeMap::new()).unwrap_err(),
+            SpecError::UnknownParameter("missing".into())
+        );
+    }
+
+    #[test]
+    fn resolved_nonsense_is_fail_closed_too() {
+        // A binding that makes a tolerance negative: resolution
+        // succeeds numerically but validation must reject it.
+        let mut spec = StackupSpec {
+            name: "s".into(),
+            contributors: vec![ContributorSpec {
+                name: "a".into(),
+                coeff: 1.0.into(),
+                nominal: 10.0.into(),
+                tol_minus: ParamValue::Named("t".into()),
+                tol_plus: ParamValue::Named("t".into()),
+                dist: DistSpec::NormalFromTol {
+                    convention: SigmaConvention::ThreeSigma,
+                },
+                source: DistributionSource::default(),
+            }],
+            requirement: RequirementSpec {
+                name: "gap".into(),
+                lower_mm: Some(9.0.into()),
+                upper_mm: None,
+            },
+        };
+        let err = spec.resolve(&params(&[("t", -0.1)])).unwrap_err();
+        assert!(matches!(err, SpecError::Invalid(_)), "{err:?}");
+
+        // NormalFromTol on an asymmetric band is its own loud error.
+        spec.contributors[0].tol_minus = 0.2.into();
+        spec.contributors[0].tol_plus = 0.1.into();
+        let err = spec.resolve(&BTreeMap::new()).unwrap_err();
+        assert!(
+            matches!(err, SpecError::AsymmetricNormalFromTol { .. }),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn from_stackup_round_trips_and_analyzes() {
+        let conv = SigmaConvention::ThreeSigma;
+        let s = Stackup {
+            name: "rt".into(),
+            contributors: vec![
+                Contributor::normal("a", 1.0, 30.0, 0.3, conv),
+                Contributor::uniform("b", -1.0, 29.2, 0.1, 0.0),
+            ],
+            requirement: Requirement::between("gap", 0.3, 1.4),
+        };
+        let spec = StackupSpec::from_stackup(&s);
+        assert!(spec.parameter_names().is_empty());
+        let resolved = spec.resolve(&BTreeMap::new()).expect("literal resolve");
+        assert_eq!(resolved, s);
+        // And it still analyzes.
+        assert!(rss(&resolved).unwrap().yield_estimate > 0.5);
+    }
+
+    #[test]
+    fn one_parameter_drives_many_fields() {
+        // The point of the seam: one document parameter re-prices the
+        // whole stackup. A shared "wall_tol" drives two contributors'
+        // limits (and, via NormalFromTol, their σ).
+        let spec = StackupSpec {
+            name: "shared".into(),
+            contributors: vec![
+                ContributorSpec {
+                    name: "wall_a".into(),
+                    coeff: 1.0.into(),
+                    nominal: 10.0.into(),
+                    tol_minus: ParamValue::Named("wall_tol".into()),
+                    tol_plus: ParamValue::Named("wall_tol".into()),
+                    dist: DistSpec::NormalFromTol {
+                        convention: SigmaConvention::ThreeSigma,
+                    },
+                    source: DistributionSource::default(),
+                },
+                ContributorSpec {
+                    name: "wall_b".into(),
+                    coeff: (-1.0).into(),
+                    nominal: 9.4.into(),
+                    tol_minus: ParamValue::Named("wall_tol".into()),
+                    tol_plus: ParamValue::Named("wall_tol".into()),
+                    dist: DistSpec::NormalFromTol {
+                        convention: SigmaConvention::ThreeSigma,
+                    },
+                    source: DistributionSource::default(),
+                },
+            ],
+            requirement: RequirementSpec {
+                name: "gap".into(),
+                lower_mm: Some(0.3.into()),
+                upper_mm: Some(0.9.into()),
+            },
+        };
+        let tight = spec.resolve(&params(&[("wall_tol", 0.1)])).unwrap();
+        let loose = spec.resolve(&params(&[("wall_tol", 0.3)])).unwrap();
+        let y_tight = rss(&tight).unwrap().yield_estimate;
+        let y_loose = rss(&loose).unwrap().yield_estimate;
+        assert!(
+            y_tight > y_loose + 0.01,
+            "tighter walls must raise yield: {y_tight} vs {y_loose}"
+        );
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/stackup.rs
+++ b/crates/vcad-kernel-tolerance/src/stackup.rs
@@ -1,0 +1,571 @@
+//! The stackup model: contributors, the gap requirement, and fail-closed
+//! validation.
+//!
+//! A [`Stackup`] models a **linear** dimension chain: the gap of
+//! interest is
+//!
+//! ```text
+//! G = Σᵢ aᵢ · xᵢ
+//! ```
+//!
+//! where `xᵢ` is contributor *i*'s actual dimension and `aᵢ` its signed
+//! sensitivity coefficient (+1 for dimensions that open the gap, −1 for
+//! dimensions that consume it, any real value for lever ratios or
+//! projected vector-loop legs — see the `loops` module). Linearity is
+//! the M0 scope boundary and it is exact for 1-D chains; vector loops
+//! are linearized (small-angle) before they get here.
+//!
+//! Contributors are assumed **statistically independent**. Correlated
+//! contributors (two dimensions cut in one fixture setup) violate RSS
+//! and Monte Carlo alike; modeling correlation is future work and the
+//! docs say so rather than pretending otherwise.
+
+use serde::{Deserialize, Serialize};
+
+use crate::dist::{Distribution, DistributionSource, SigmaConvention};
+use crate::rng::Rng;
+
+/// One dimensional contributor in the chain.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Contributor {
+    /// Human-readable name (unique within a stackup).
+    pub name: String,
+    /// Signed sensitivity coefficient `aᵢ` (∂gap/∂dimension, exact for
+    /// linear chains): +1 opens the gap, −1 consumes it.
+    pub coeff: f64,
+    /// Nominal dimension, mm.
+    pub nominal: f64,
+    /// Lower drawing limit as a deviation: the dimension may be up to
+    /// this much *below* nominal (≥ 0), mm.
+    pub tol_minus: f64,
+    /// Upper drawing limit as a deviation: the dimension may be up to
+    /// this much *above* nominal (≥ 0), mm.
+    pub tol_plus: f64,
+    /// Statistical model of the deviation from nominal. Worst-case
+    /// analysis ignores this and uses the drawing limits above.
+    pub dist: Distribution,
+    /// Where the distribution came from (assumption vs measurement).
+    #[serde(default)]
+    pub source: DistributionSource,
+}
+
+impl Contributor {
+    /// Symmetric ± tolerance, centered normal process under `convention`
+    /// (σ = tol / k). The standard machined-dimension contributor.
+    pub fn normal(
+        name: &str,
+        coeff: f64,
+        nominal: f64,
+        tol: f64,
+        convention: SigmaConvention,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            coeff,
+            nominal,
+            tol_minus: tol,
+            tol_plus: tol,
+            dist: Distribution::Normal {
+                mean: 0.0,
+                sigma: tol / convention.k(),
+            },
+            source: DistributionSource::Assumed { convention },
+        }
+    }
+
+    /// Asymmetric drawing limits with a uniform deviation spanning the
+    /// whole band — the honest vendor-lot model (e.g. bearing width
+    /// 15.0 +0/−0.12).
+    pub fn uniform(name: &str, coeff: f64, nominal: f64, tol_minus: f64, tol_plus: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            coeff,
+            nominal,
+            tol_minus,
+            tol_plus,
+            dist: Distribution::Uniform {
+                lo: -tol_minus,
+                hi: tol_plus,
+            },
+            source: DistributionSource::Assumed {
+                convention: SigmaConvention::ThreeSigma,
+            },
+        }
+    }
+
+    /// General constructor: explicit drawing limits and an explicit
+    /// deviation distribution (e.g. a two-point supplier mix inside a
+    /// wider drawing band).
+    pub fn with_dist(
+        name: &str,
+        coeff: f64,
+        nominal: f64,
+        tol_minus: f64,
+        tol_plus: f64,
+        dist: Distribution,
+    ) -> Self {
+        Self {
+            name: name.to_string(),
+            coeff,
+            nominal,
+            tol_minus,
+            tol_plus,
+            dist,
+            source: DistributionSource::Assumed {
+                convention: SigmaConvention::ThreeSigma,
+            },
+        }
+    }
+
+    /// Mean actual dimension: nominal plus the process centering error.
+    pub fn mean_dimension(&self) -> f64 {
+        self.nominal + self.dist.mean()
+    }
+}
+
+/// ISO 2768-1 general tolerance class (linear dimensions).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Iso2768Class {
+    /// Fine.
+    F,
+    /// Medium — the default on most machine-shop drawings.
+    M,
+    /// Coarse.
+    C,
+}
+
+/// ISO 2768-1:1989 Table 1 general tolerances for linear dimensions:
+/// the ± tolerance for a nominal dimension under the given class.
+/// Returns `None` outside the table's domain (below 0.5 mm the
+/// standard requires an explicit tolerance; above 4000 mm it is
+/// silent) — fail-closed, never an extrapolation.
+pub fn iso2768(nominal_mm: f64, class: Iso2768Class) -> Option<f64> {
+    if !nominal_mm.is_finite() || nominal_mm < 0.5 {
+        return None;
+    }
+    // Band upper edges and ± values per class (f, m, c).
+    const BANDS: [(f64, f64, f64, f64); 8] = [
+        (3.0, 0.05, 0.1, 0.2),
+        (6.0, 0.05, 0.1, 0.3),
+        (30.0, 0.1, 0.2, 0.5),
+        (120.0, 0.15, 0.3, 0.8),
+        (400.0, 0.2, 0.5, 1.2),
+        (1000.0, 0.3, 0.8, 2.0),
+        (2000.0, 0.5, 1.2, 3.0),
+        (4000.0, f64::NAN, 2.0, 4.0), // class f is unspecified here
+    ];
+    for (hi, f, m, c) in BANDS {
+        if nominal_mm <= hi {
+            let t = match class {
+                Iso2768Class::F => f,
+                Iso2768Class::M => m,
+                Iso2768Class::C => c,
+            };
+            return if t.is_nan() { None } else { Some(t) };
+        }
+    }
+    None
+}
+
+/// The gap requirement: at least one of the bounds must be present
+/// (fail-closed — a stackup with nothing to check is a modeling error,
+/// not a trivially passing one).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Requirement {
+    /// What the gap means ("axial play", "radial clearance").
+    pub name: String,
+    /// Minimum acceptable gap, mm (e.g. 0.05 so parts never jam).
+    pub lower_mm: Option<f64>,
+    /// Maximum acceptable gap, mm (e.g. 0.75 so the shaft can't rattle).
+    pub upper_mm: Option<f64>,
+}
+
+impl Requirement {
+    /// Two-sided requirement.
+    pub fn between(name: &str, lower_mm: f64, upper_mm: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            lower_mm: Some(lower_mm),
+            upper_mm: Some(upper_mm),
+        }
+    }
+
+    /// One-sided minimum-clearance requirement.
+    pub fn at_least(name: &str, lower_mm: f64) -> Self {
+        Self {
+            name: name.to_string(),
+            lower_mm: Some(lower_mm),
+            upper_mm: None,
+        }
+    }
+}
+
+/// A complete stackup: the chain plus its requirement.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Stackup {
+    /// Assembly-level name.
+    pub name: String,
+    /// The dimension chain.
+    pub contributors: Vec<Contributor>,
+    /// The gap requirement.
+    pub requirement: Requirement,
+}
+
+/// Validation failures. Every analysis validates first; a malformed
+/// stackup never produces a number.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StackupError {
+    /// The chain has no contributors.
+    Empty,
+    /// A contributor name is empty or duplicated.
+    BadName(String),
+    /// A numeric field is NaN or infinite.
+    NonFinite {
+        /// Contributor name.
+        contributor: String,
+        /// Field description.
+        field: &'static str,
+    },
+    /// A coefficient is exactly zero — a dead contributor is a modeling
+    /// bug, not a harmless no-op.
+    ZeroCoefficient(String),
+    /// A drawing tolerance is negative.
+    NegativeTolerance(String),
+    /// A distribution's parameters are structurally invalid.
+    InvalidDistribution {
+        /// Contributor name.
+        contributor: String,
+        /// Reason from the distribution check.
+        reason: String,
+    },
+    /// A bounded distribution puts mass outside the drawing limits: the
+    /// statistical model contradicts the drawing.
+    DistributionExceedsLimits {
+        /// Contributor name.
+        contributor: String,
+        /// Offending support bound (deviation, mm).
+        support: (f64, f64),
+        /// Drawing limits as deviations (−tol_minus, +tol_plus), mm.
+        limits: (f64, f64),
+    },
+    /// The requirement has neither a lower nor an upper bound.
+    UnboundedRequirement,
+    /// The requirement bounds are inverted or non-finite.
+    BadRequirement(String),
+    /// Every contributor has zero variance — statistical analysis is
+    /// meaningless (worst-case still works; use that).
+    DegenerateChain,
+    /// Monte Carlo sample count too small for meaningful error bars.
+    TooFewSamples {
+        /// Requested sample count.
+        n: usize,
+        /// Minimum accepted.
+        min: usize,
+    },
+}
+
+impl std::fmt::Display for StackupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StackupError::Empty => write!(f, "stackup has no contributors"),
+            StackupError::BadName(n) => write!(f, "bad contributor name: {n:?}"),
+            StackupError::NonFinite { contributor, field } => {
+                write!(f, "non-finite {field} on contributor {contributor:?}")
+            }
+            StackupError::ZeroCoefficient(n) => {
+                write!(f, "contributor {n:?} has zero coefficient")
+            }
+            StackupError::NegativeTolerance(n) => {
+                write!(f, "contributor {n:?} has a negative drawing tolerance")
+            }
+            StackupError::InvalidDistribution {
+                contributor,
+                reason,
+            } => write!(f, "invalid distribution on {contributor:?}: {reason}"),
+            StackupError::DistributionExceedsLimits {
+                contributor,
+                support,
+                limits,
+            } => write!(
+                f,
+                "distribution support {support:?} exceeds drawing limits {limits:?} on {contributor:?}"
+            ),
+            StackupError::UnboundedRequirement => {
+                write!(f, "requirement needs at least one bound")
+            }
+            StackupError::BadRequirement(r) => write!(f, "bad requirement: {r}"),
+            StackupError::DegenerateChain => {
+                write!(f, "every contributor has zero variance; statistical analysis is meaningless")
+            }
+            StackupError::TooFewSamples { n, min } => {
+                write!(f, "monte carlo needs at least {min} samples, got {n}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StackupError {}
+
+impl Stackup {
+    /// Validate the model, fail-closed. Called by every analysis.
+    pub fn validate(&self) -> Result<(), StackupError> {
+        if self.contributors.is_empty() {
+            return Err(StackupError::Empty);
+        }
+        let mut seen = std::collections::BTreeSet::new();
+        for c in &self.contributors {
+            if c.name.is_empty() || !seen.insert(c.name.as_str()) {
+                return Err(StackupError::BadName(c.name.clone()));
+            }
+            for (v, field) in [
+                (c.coeff, "coeff"),
+                (c.nominal, "nominal"),
+                (c.tol_minus, "tol_minus"),
+                (c.tol_plus, "tol_plus"),
+            ] {
+                if !v.is_finite() {
+                    return Err(StackupError::NonFinite {
+                        contributor: c.name.clone(),
+                        field,
+                    });
+                }
+            }
+            if c.coeff == 0.0 {
+                return Err(StackupError::ZeroCoefficient(c.name.clone()));
+            }
+            if c.tol_minus < 0.0 || c.tol_plus < 0.0 {
+                return Err(StackupError::NegativeTolerance(c.name.clone()));
+            }
+            c.dist
+                .check()
+                .map_err(|reason| StackupError::InvalidDistribution {
+                    contributor: c.name.clone(),
+                    reason,
+                })?;
+            if let Some((lo, hi)) = c.dist.support() {
+                // Small slack so exactly-at-the-limit supports pass in
+                // the presence of float noise.
+                let eps = 1e-9;
+                if lo < -c.tol_minus - eps || hi > c.tol_plus + eps {
+                    return Err(StackupError::DistributionExceedsLimits {
+                        contributor: c.name.clone(),
+                        support: (lo, hi),
+                        limits: (-c.tol_minus, c.tol_plus),
+                    });
+                }
+            }
+        }
+        match (self.requirement.lower_mm, self.requirement.upper_mm) {
+            (None, None) => return Err(StackupError::UnboundedRequirement),
+            (Some(l), Some(u)) => {
+                if !l.is_finite() || !u.is_finite() {
+                    return Err(StackupError::BadRequirement("non-finite bound".into()));
+                }
+                if l >= u {
+                    return Err(StackupError::BadRequirement(format!(
+                        "lower {l} must be < upper {u}"
+                    )));
+                }
+            }
+            (Some(b), None) | (None, Some(b)) => {
+                if !b.is_finite() {
+                    return Err(StackupError::BadRequirement("non-finite bound".into()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Nominal gap: Σ aᵢ·nominalᵢ, mm.
+    pub fn nominal_gap(&self) -> f64 {
+        self.contributors.iter().map(|c| c.coeff * c.nominal).sum()
+    }
+
+    /// Mean gap including process centering errors: Σ aᵢ·(nominalᵢ + μᵢ), mm.
+    pub fn mean_gap(&self) -> f64 {
+        self.contributors
+            .iter()
+            .map(|c| c.coeff * c.mean_dimension())
+            .sum()
+    }
+
+    /// Gap variance under independence: Σ aᵢ²·σᵢ², mm².
+    pub fn variance_gap(&self) -> f64 {
+        self.contributors
+            .iter()
+            .map(|c| c.coeff * c.coeff * c.dist.variance())
+            .sum()
+    }
+
+    /// Draw one virtual assembly's gap.
+    pub fn sample_gap(&self, rng: &mut Rng) -> f64 {
+        self.contributors
+            .iter()
+            .map(|c| c.coeff * (c.nominal + c.dist.sample(rng)))
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chain() -> Stackup {
+        Stackup {
+            name: "test".into(),
+            contributors: vec![
+                Contributor::normal("housing", 1.0, 62.0, 0.3, SigmaConvention::ThreeSigma),
+                Contributor::uniform("bearing", -1.0, 15.0, 0.12, 0.0),
+                Contributor::with_dist(
+                    "spacer",
+                    -1.0,
+                    12.0,
+                    0.1,
+                    0.1,
+                    Distribution::TwoPoint {
+                        a: -0.03,
+                        b: 0.04,
+                        p_b: 0.4,
+                    },
+                ),
+            ],
+            requirement: Requirement::between("gap", 0.05, 0.75),
+        }
+    }
+
+    #[test]
+    fn valid_chain_validates_and_computes_moments() {
+        let s = chain();
+        s.validate().expect("valid");
+        assert!((s.nominal_gap() - 35.0).abs() < 1e-12);
+        // mean = 35 + 0 − (−0.06) − (−0.03·0.6 + 0.04·0.4) = 35.06 + 0.002
+        assert!((s.mean_gap() - 35.062).abs() < 1e-12, "{}", s.mean_gap());
+        let var = 0.01 + 0.12 * 0.12 / 12.0 + 0.07 * 0.07 * 0.4 * 0.6;
+        assert!((s.variance_gap() - var).abs() < 1e-15);
+    }
+
+    #[test]
+    fn validation_is_fail_closed() {
+        let mut s = chain();
+        s.contributors.clear();
+        assert_eq!(s.validate(), Err(StackupError::Empty));
+
+        let mut s = chain();
+        s.contributors[1].name = "housing".into();
+        assert!(matches!(s.validate(), Err(StackupError::BadName(_))));
+
+        let mut s = chain();
+        s.contributors[0].coeff = 0.0;
+        assert!(matches!(
+            s.validate(),
+            Err(StackupError::ZeroCoefficient(_))
+        ));
+
+        let mut s = chain();
+        s.contributors[0].tol_plus = -0.1;
+        assert!(matches!(
+            s.validate(),
+            Err(StackupError::NegativeTolerance(_))
+        ));
+
+        let mut s = chain();
+        s.contributors[0].nominal = f64::INFINITY;
+        assert!(matches!(s.validate(), Err(StackupError::NonFinite { .. })));
+
+        let mut s = chain();
+        s.requirement.lower_mm = None;
+        s.requirement.upper_mm = None;
+        assert_eq!(s.validate(), Err(StackupError::UnboundedRequirement));
+
+        let mut s = chain();
+        s.requirement.lower_mm = Some(1.0);
+        s.requirement.upper_mm = Some(0.5);
+        assert!(matches!(s.validate(), Err(StackupError::BadRequirement(_))));
+    }
+
+    #[test]
+    fn drawing_limits_must_contain_bounded_support() {
+        // A uniform wider than the drawing band: the model contradicts
+        // the drawing — error, never a silent clip.
+        let mut s = chain();
+        s.contributors[1].dist = Distribution::Uniform { lo: -0.2, hi: 0.0 };
+        assert!(matches!(
+            s.validate(),
+            Err(StackupError::DistributionExceedsLimits { .. })
+        ));
+        // Normal is unbounded by design and passes (documented).
+        let mut s = chain();
+        s.contributors[0].dist = Distribution::Normal {
+            mean: 0.0,
+            sigma: 10.0,
+        };
+        s.validate()
+            .expect("normal tails are not a limits violation");
+    }
+
+    #[test]
+    fn sampling_matches_moments() {
+        let s = chain();
+        let mut rng = Rng::new(11);
+        let n = 100_000;
+        let mut sum = 0.0;
+        let mut sum_sq = 0.0;
+        for _ in 0..n {
+            let g = s.sample_gap(&mut rng);
+            sum += g;
+            sum_sq += g * g;
+        }
+        let mean = sum / n as f64;
+        let var = sum_sq / n as f64 - mean * mean;
+        let se = (s.variance_gap() / n as f64).sqrt();
+        assert!((mean - s.mean_gap()).abs() < 5.0 * se);
+        assert!((var - s.variance_gap()).abs() / s.variance_gap() < 0.05);
+    }
+
+    #[test]
+    fn iso2768_table_values() {
+        // Spot checks against ISO 2768-1:1989 Table 1.
+        assert_eq!(iso2768(25.0, Iso2768Class::M), Some(0.2));
+        assert_eq!(iso2768(62.0, Iso2768Class::M), Some(0.3));
+        assert_eq!(iso2768(62.0, Iso2768Class::F), Some(0.15));
+        assert_eq!(iso2768(62.0, Iso2768Class::C), Some(0.8));
+        assert_eq!(iso2768(1.6, Iso2768Class::M), Some(0.1));
+        assert_eq!(iso2768(350.0, Iso2768Class::M), Some(0.5));
+        assert_eq!(iso2768(3000.0, Iso2768Class::M), Some(2.0));
+        // Fail-closed outside the domain.
+        assert_eq!(iso2768(0.4, Iso2768Class::M), None);
+        assert_eq!(iso2768(3000.0, Iso2768Class::F), None);
+        assert_eq!(iso2768(5000.0, Iso2768Class::C), None);
+        assert_eq!(iso2768(f64::NAN, Iso2768Class::M), None);
+    }
+
+    #[test]
+    fn serde_round_trip() {
+        let s = chain();
+        let json = serde_json::to_string_pretty(&s).unwrap();
+        let back: Stackup = serde_json::from_str(&json).unwrap();
+        // serde_json's default float parse can move the last ULP (the
+        // `float_roundtrip` feature trades speed for exactness) — same
+        // lesson as vcad-kernel-particle: compare structurally with a
+        // relative tolerance, not bitwise.
+        assert_eq!(back.name, s.name);
+        assert_eq!(back.requirement, s.requirement);
+        assert_eq!(back.contributors.len(), s.contributors.len());
+        for (a, b) in back.contributors.iter().zip(&s.contributors) {
+            assert_eq!(a.name, b.name);
+            assert_eq!(a.source, b.source);
+            let close = |x: f64, y: f64| (x - y).abs() <= 1e-12 * (1.0 + y.abs());
+            assert!(close(a.coeff, b.coeff));
+            assert!(close(a.nominal, b.nominal));
+            assert!(close(a.dist.mean(), b.dist.mean()));
+            assert!(
+                close(a.dist.sigma(), b.dist.sigma()),
+                "{} sigma drifted: {} vs {}",
+                a.name,
+                a.dist.sigma(),
+                b.dist.sigma()
+            );
+        }
+    }
+}

--- a/crates/vcad-kernel-tolerance/src/stackup.rs
+++ b/crates/vcad-kernel-tolerance/src/stackup.rs
@@ -263,6 +263,17 @@ pub enum StackupError {
         /// Minimum accepted.
         min: usize,
     },
+    /// A tolerance-allocation target yield cannot be met even with
+    /// every allocatable tolerance at its tightest.
+    Infeasible {
+        /// The requested yield floor.
+        target_yield: f64,
+        /// The best yield achievable inside the boxes.
+        best_yield: f64,
+    },
+    /// A contributor named for allocation cannot be allocated (not an
+    /// assumed-normal contributor, or not in the chain).
+    NotAllocatable(String),
 }
 
 impl std::fmt::Display for StackupError {
@@ -300,6 +311,16 @@ impl std::fmt::Display for StackupError {
             }
             StackupError::TooFewSamples { n, min } => {
                 write!(f, "monte carlo needs at least {min} samples, got {n}")
+            }
+            StackupError::Infeasible {
+                target_yield,
+                best_yield,
+            } => write!(
+                f,
+                "target yield {target_yield} is infeasible; best achievable is {best_yield}"
+            ),
+            StackupError::NotAllocatable(name) => {
+                write!(f, "contributor {name:?} is not allocatable")
             }
         }
     }

--- a/crates/vcad-kernel-tolerance/tests/benchmarks.rs
+++ b/crates/vcad-kernel-tolerance/tests/benchmarks.rs
@@ -1,0 +1,222 @@
+//! M5 benchmarks: exact analytic ground truth.
+//!
+//! Published worked examples get transcription errors; closed forms
+//! don't. These benchmarks pin the engine against mathematics that can
+//! be checked by hand:
+//!
+//! - **Irwin–Hall**: the sum of n standard uniforms has the exact CDF
+//!   F_n(x) = (1/n!) Σ_{k≤x} (−1)^k C(n,k)(x−k)^n (Irwin 1927; Hall
+//!   1927). A chain of equal-width uniform contributors maps affinely
+//!   onto it, giving an EXACT yield to compare all three analyses
+//!   against — including the size and sign of the RSS/CLT error.
+//! - **The √n law**: for n equal contributors, the worst-case
+//!   half-width over the RSS 3σ half-width is exactly √n. This ratio
+//!   is the entire economic argument for statistical tolerancing, so
+//!   it gets asserted to 1e-12, not just talked about.
+//!
+//! (External published-fixture cross-validation — e.g. the classic
+//! Fortini/Chase–Greenwood one-way clutch — needs the source tables in
+//! hand and is flagged in the paper draft, not faked from memory.)
+
+use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+use vcad_kernel_tolerance::dist::SigmaConvention;
+use vcad_kernel_tolerance::stackup::{Contributor, Requirement, Stackup};
+
+/// Exact CDF of the sum of `n` independent U(0,1) (Irwin–Hall).
+fn irwin_hall_cdf(x: f64, n: u32) -> f64 {
+    if x <= 0.0 {
+        return 0.0;
+    }
+    if x >= n as f64 {
+        return 1.0;
+    }
+    let fact = |m: u32| -> f64 { (1..=m).map(|v| v as f64).product::<f64>().max(1.0) };
+    let choose = |n: u32, k: u32| fact(n) / (fact(k) * fact(n - k));
+    let mut acc = 0.0;
+    for k in 0..=(x.floor() as u32) {
+        let sign = if k % 2 == 0 { 1.0 } else { -1.0 };
+        acc += sign * choose(n, k) * (x - k as f64).powi(n as i32);
+    }
+    acc / fact(n)
+}
+
+/// A chain of `n` uniform contributors, each deviation U(−w/2, w/2),
+/// consuming from an opening dimension so the nominal gap is `gap0`.
+fn uniform_chain(n: usize, w: f64, gap0: f64, lower: f64, upper: f64) -> Stackup {
+    let mut contributors = vec![Contributor::with_dist(
+        "opening",
+        1.0,
+        gap0,
+        0.0,
+        0.0,
+        vcad_kernel_tolerance::dist::Distribution::Normal {
+            mean: 0.0,
+            sigma: 0.0,
+        },
+    )];
+    for i in 0..n {
+        contributors.push(Contributor::uniform(
+            &format!("u{i}"),
+            -1.0,
+            0.0,
+            w / 2.0,
+            w / 2.0,
+        ));
+    }
+    Stackup {
+        name: format!("irwin-hall-{n}"),
+        contributors,
+        requirement: Requirement::between("gap", lower, upper),
+    }
+}
+
+/// Exact yield of `uniform_chain` via Irwin–Hall: the gap is
+/// gap0 − Σ devᵢ with devᵢ ~ U(−w/2, w/2), so
+/// gap = gap0 + n·w/2 − w·IHₙ and
+/// P(L ≤ gap ≤ U) = F((gap0 + n·w/2 − L)/w) − F((gap0 + n·w/2 − U)/w).
+fn exact_yield(n: u32, w: f64, gap0: f64, lower: f64, upper: f64) -> f64 {
+    let hi = (gap0 + n as f64 * w / 2.0 - lower) / w;
+    let lo = (gap0 + n as f64 * w / 2.0 - upper) / w;
+    irwin_hall_cdf(hi, n) - irwin_hall_cdf(lo, n)
+}
+
+#[test]
+fn irwin_hall_cdf_sanity() {
+    // n = 1: uniform CDF. n = 2: triangular — F(1) = 1/2 by symmetry,
+    // F(0.5) = 0.5²/2 = 0.125. n = 3: F(1.5) = 1/2, and
+    // F(1) = 1/6 (the unit simplex volume x³/6 at x = 1).
+    assert!((irwin_hall_cdf(0.3, 1) - 0.3).abs() < 1e-12);
+    assert!((irwin_hall_cdf(1.0, 2) - 0.5).abs() < 1e-12);
+    assert!((irwin_hall_cdf(0.5, 2) - 0.125).abs() < 1e-12);
+    assert!((irwin_hall_cdf(1.5, 3) - 0.5).abs() < 1e-12);
+    assert!((irwin_hall_cdf(1.0, 3) - 1.0 / 6.0).abs() < 1e-12);
+    // Symmetry: F(x) + F(n − x) = 1.
+    for n in [2u32, 3, 5] {
+        for x in [0.3, 0.9, 1.4] {
+            let s = irwin_hall_cdf(x, n) + irwin_hall_cdf(n as f64 - x, n);
+            assert!((s - 1.0).abs() < 1e-12, "n={n} x={x}: {s}");
+        }
+    }
+}
+
+#[test]
+fn three_uniform_chain_exact_vs_mc_vs_rss() {
+    // 3 contributors, w = 0.2 (±0.1), nominal gap 1.0, requirement
+    // [0.75, 1.25] — cuts into the Irwin–Hall body where the CLT
+    // error is visible.
+    let (n, w, gap0, lo, hi) = (3usize, 0.2, 1.0, 0.75, 1.25);
+    let s = uniform_chain(n, w, gap0, lo, hi);
+    let exact = exact_yield(n as u32, w, gap0, lo, hi);
+
+    // Monte Carlo lands on the exact value within error bars.
+    let mc = monte_carlo(
+        &s,
+        &McOptions {
+            n: 400_000,
+            seed: 27_1828,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    assert!(
+        (mc.fit.p - exact).abs() <= 4.0 * mc.fit.standard_error,
+        "MC {} ± {} vs exact {exact}",
+        mc.fit.p,
+        mc.fit.standard_error
+    );
+
+    // RSS moments are exact for any distribution mix…
+    let r = rss(&s).unwrap();
+    let sigma_exact = (n as f64 * w * w / 12.0).sqrt();
+    assert!((r.sigma_gap - sigma_exact).abs() < 1e-12);
+    assert!((r.mean_gap - 1.0).abs() < 1e-12);
+    // …but the Φ yield is a CLT approximation: the error must be real
+    // (this is a benchmark, not a tautology) and bounded. With n = 3
+    // uniforms at a ±2.5σ requirement the CLT error is ~7e-3, and its
+    // SIGN is fixed: the bounded uniform sum has no mass beyond ±2.5σ
+    // worth of normal tail, so the Φ model UNDERestimates the yield —
+    // RSS is conservative in the tails of bounded chains.
+    let clt_err = (r.yield_estimate - exact).abs();
+    assert!(clt_err < 1.2e-2, "CLT error too large: {clt_err}");
+    assert!(clt_err > 2e-4, "CLT error suspiciously small: {clt_err}");
+    assert!(
+        r.yield_estimate < exact,
+        "Φ must under-read a bounded chain here: {} vs {exact}",
+        r.yield_estimate
+    );
+    // Beyond the exact support the uniform sum has NO tail: a
+    // requirement at the worst-case bounds has exact yield 1 while the
+    // normal model still leaks — RSS is conservative there.
+    let wc = worst_case(&s).unwrap();
+    let exact_at_wc = exact_yield(n as u32, w, gap0, wc.min_gap, wc.max_gap);
+    assert!((exact_at_wc - 1.0).abs() < 1e-12);
+    let mut s_wc = s.clone();
+    s_wc.requirement = Requirement::between("wc", wc.min_gap, wc.max_gap);
+    let r_wc = rss(&s_wc).unwrap();
+    assert!(
+        r_wc.yield_estimate < 1.0 - 1e-4,
+        "normal tails leak: {}",
+        r_wc.yield_estimate
+    );
+}
+
+#[test]
+fn two_uniform_triangular_hand_computed() {
+    // n = 2, w = 0.2: the gap is triangular on [0.8, 1.2]. Requirement
+    // [0.9, 1.3]: P = 1 − P(gap < 0.9) − P(gap > 1.3) = 1 − 0.125 − 0
+    // = 0.875 by the triangle-corner area, hand-computed.
+    let s = uniform_chain(2, 0.2, 1.0, 0.9, 1.3);
+    let exact = exact_yield(2, 0.2, 1.0, 0.9, 1.3);
+    assert!((exact - 0.875).abs() < 1e-12, "hand computation: {exact}");
+    let mc = monte_carlo(
+        &s,
+        &McOptions {
+            n: 200_000,
+            seed: 31_4159,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    assert!((mc.fit.p - 0.875).abs() <= 4.0 * mc.fit.standard_error);
+}
+
+#[test]
+fn sqrt_n_law_exact() {
+    // n equal normal contributors ±t at 3σ: WC half-width = n·t,
+    // RSS 3σ half-width = 3·√n·(t/3) = √n·t. Ratio = √n exactly.
+    let t = 0.1;
+    for n in [4usize, 9, 16, 25] {
+        let contributors: Vec<Contributor> = (0..n)
+            .map(|i| {
+                Contributor::normal(&format!("c{i}"), -1.0, 1.0, t, SigmaConvention::ThreeSigma)
+            })
+            .chain(std::iter::once(Contributor::with_dist(
+                "opening",
+                1.0,
+                n as f64 + 1.0,
+                0.0,
+                0.0,
+                vcad_kernel_tolerance::dist::Distribution::Normal {
+                    mean: 0.0,
+                    sigma: 0.0,
+                },
+            )))
+            .collect();
+        let s = Stackup {
+            name: format!("sqrt-{n}"),
+            contributors,
+            requirement: Requirement::between("gap", 0.5, 1.5),
+        };
+        let wc = worst_case(&s).unwrap();
+        let r = rss(&s).unwrap();
+        let wc_half = 0.5 * (wc.max_gap - wc.min_gap);
+        let rss_half = 3.0 * r.sigma_gap;
+        assert!((wc_half - n as f64 * t).abs() < 1e-12);
+        assert!(
+            (wc_half / rss_half - (n as f64).sqrt()).abs() < 1e-12,
+            "n={n}: ratio {} vs √n {}",
+            wc_half / rss_half,
+            (n as f64).sqrt()
+        );
+    }
+}

--- a/crates/vcad-kernel-tolerance/tests/bolt_circle.rs
+++ b/crates/vcad-kernel-tolerance/tests/bolt_circle.rs
@@ -1,0 +1,140 @@
+//! The classic non-collinear worked example: a bolt-circle pin fit.
+//!
+//! Four pins pressed into a base must enter four holes in a plate.
+//! Hole positions carry a Ø0.15 position tolerance (RFS at M0; the MMC
+//! bonus is milestone M1), hole and pin diameters carry their own
+//! bands. A pin enters iff its radial position error ≤ the radial
+//! clearance c = (D_hole − d_pin)/2; the plate assembles iff **all**
+//! pins enter.
+//!
+//! This is the everyday case that is NOT a linear chain — the fit
+//! condition is on the **magnitude** of a 2-D error — and the test
+//! quantifies exactly what the linearized treatment misses:
+//!
+//! - Exact model: with per-axis position error x, y ~ N(0, σ²), the
+//!   radial error is Rayleigh-distributed; P(fit | c) = 1 − e^(−c²/2σ²)
+//!   (Rayleigh CDF). Monte Carlo over the true model must land on the
+//!   semi-analytic value (Rayleigh CDF integrated over the diameter
+//!   distributions) within error bars.
+//! - Linearized model: projecting the position error onto one direction
+//!   gives P(|e_d| ≤ c) = 2Φ(c/σ) − 1, which is strictly LARGER than
+//!   the Rayleigh probability at the same c — a single projection is
+//!   optimistic about a radial fit, so the crate's vector-loop module
+//!   refuses to be used for it silently (see `loops` module docs).
+//! - Worst case: the ASME Y14.5-style virtual-condition check — fit is
+//!   guaranteed iff hole MMC − pin MMC ≥ position zone Ø. Here it
+//!   fails while the statistical fit rate is ~90%: the entire reason
+//!   MMC/statistical analysis exists.
+//!
+//! Position-tolerance σ convention (stated, as always): the Ø0.15 zone
+//! means radial error ≤ 0.075; we model each axis as N(0, σ) with
+//! σ = 0.075/3 — the process hits the zone radius at 3σ per axis.
+
+use vcad_kernel_tolerance::capability::phi;
+use vcad_kernel_tolerance::rng::Rng;
+
+const N_PINS: usize = 4;
+const ZONE_RADIUS: f64 = 0.075; // Ø0.15 position tolerance
+const SIGMA_POS: f64 = ZONE_RADIUS / 3.0;
+// Hole Ø 6.10 +0.05/0 (uniform), pin Ø 6.00 0/−0.02 (uniform).
+const HOLE_LO: f64 = 6.10;
+const HOLE_HI: f64 = 6.15;
+const PIN_LO: f64 = 5.98;
+const PIN_HI: f64 = 6.00;
+
+/// P(one pin fits) integrated over the clearance distribution:
+/// E_c[1 − e^(−c²/2σ²)] with c = (D_hole − d_pin)/2, both uniform.
+/// Deterministic 2-D midpoint quadrature — the reference value.
+fn per_pin_fit_probability_analytic() -> f64 {
+    let m = 400;
+    let mut acc = 0.0;
+    for i in 0..m {
+        let hole = HOLE_LO + (HOLE_HI - HOLE_LO) * (i as f64 + 0.5) / m as f64;
+        for j in 0..m {
+            let pin = PIN_LO + (PIN_HI - PIN_LO) * (j as f64 + 0.5) / m as f64;
+            let c = 0.5 * (hole - pin);
+            acc += 1.0 - (-c * c / (2.0 * SIGMA_POS * SIGMA_POS)).exp();
+        }
+    }
+    acc / (m * m) as f64
+}
+
+#[test]
+fn exact_monte_carlo_matches_rayleigh_closed_form() {
+    let p_pin = per_pin_fit_probability_analytic();
+    let p_all_analytic = p_pin.powi(N_PINS as i32);
+
+    // Monte Carlo over the true 2-D model.
+    let mut rng = Rng::new(0xB0117);
+    let n = 200_000;
+    let mut fits = 0usize;
+    for _ in 0..n {
+        let mut all = true;
+        for _ in 0..N_PINS {
+            let hole = HOLE_LO + (HOLE_HI - HOLE_LO) * rng.next_f64();
+            let pin = PIN_LO + (PIN_HI - PIN_LO) * rng.next_f64();
+            let c = 0.5 * (hole - pin);
+            let x = SIGMA_POS * rng.next_normal();
+            let y = SIGMA_POS * rng.next_normal();
+            if x * x + y * y > c * c {
+                all = false;
+                break;
+            }
+        }
+        if all {
+            fits += 1;
+        }
+    }
+    let p_mc = fits as f64 / n as f64;
+    let se = (p_mc * (1.0 - p_mc) / n as f64).sqrt();
+    assert!(
+        (p_mc - p_all_analytic).abs() < 4.0 * se,
+        "MC {p_mc} ± {se} vs Rayleigh-integral {p_all_analytic}"
+    );
+    // And the regime is the interesting one: real losses, far from 0/1.
+    assert!(
+        p_all_analytic > 0.85 && p_all_analytic < 0.97,
+        "fixture drifted out of the interesting regime: {p_all_analytic}"
+    );
+}
+
+#[test]
+fn linearized_projection_is_optimistic_for_radial_fits() {
+    // At any clearance c > 0: P(|e_d| ≤ c) = 2Φ(c/σ)−1 (1-D projection)
+    // vs P(√(x²+y²) ≤ c) = 1 − e^(−c²/2σ²) (Rayleigh). The projection
+    // must always be larger — quantify at the fixture's mean clearance.
+    let c = 0.5 * ((HOLE_LO + HOLE_HI) / 2.0 - (PIN_LO + PIN_HI) / 2.0);
+    let p_1d = 2.0 * phi(c / SIGMA_POS) - 1.0;
+    let p_2d = 1.0 - (-c * c / (2.0 * SIGMA_POS * SIGMA_POS)).exp();
+    // At this fixture's c/σ = 2.7 the gap is ~1.9 percentage points —
+    // material for a fit-probability claim.
+    assert!(
+        p_1d > p_2d + 0.015,
+        "projection {p_1d} should exceed Rayleigh {p_2d} materially"
+    );
+    // Sweep: the inequality is uniform in c (sanity that it's not a
+    // fixture accident).
+    for i in 1..=20 {
+        let c = 0.01 * i as f64;
+        let p_1d = 2.0 * phi(c / SIGMA_POS) - 1.0;
+        let p_2d = 1.0 - (-c * c / (2.0 * SIGMA_POS * SIGMA_POS)).exp();
+        assert!(p_1d >= p_2d, "c = {c}: {p_1d} < {p_2d}");
+    }
+}
+
+#[test]
+fn virtual_condition_worst_case_fails_while_statistics_ship() {
+    // Floating-fastener-style virtual condition: guaranteed fit iff
+    // (hole MMC − pin MMC) ≥ position zone diameter.
+    let hole_mmc = HOLE_LO; // smallest hole
+    let pin_mmc = PIN_HI; // largest pin
+    let diametral_clearance_mmc = hole_mmc - pin_mmc; // 0.10
+    let zone_dia = 2.0 * ZONE_RADIUS; // 0.15
+    assert!(
+        diametral_clearance_mmc < zone_dia,
+        "fixture: WC must fail ({diametral_clearance_mmc} < {zone_dia})"
+    );
+    // …and yet the statistical fit rate is high — computed above.
+    let p_all = per_pin_fit_probability_analytic().powi(N_PINS as i32);
+    assert!(p_all > 0.85, "statistical fit rate {p_all}");
+}

--- a/crates/vcad-kernel-tolerance/tests/validation.rs
+++ b/crates/vcad-kernel-tolerance/tests/validation.rs
@@ -1,0 +1,265 @@
+//! The M0 validation ladder (see `docs/tolerance-m0.md`).
+//!
+//! 1. RSS agrees with Monte Carlo within MC error bars on a
+//!    5-contributor chain (self-consistency of the two paths).
+//! 2. Worst-case bounds contain every MC sample (fixed seeds —
+//!    deterministic, never flaky).
+//! 3. A textbook-style chain with hand-computed answers asserted
+//!    exactly.
+//! 4. Φ/erf-based yield against known normal-table values.
+//! 5. Monte Carlo error scales as 1/√N (empirically, across disjoint
+//!    seeds).
+//!
+//! Every test uses fixed seeds and wide, stated acceptance bands: a
+//! failure here is a real regression, not sampling noise.
+
+use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+use vcad_kernel_tolerance::capability::yield_within;
+use vcad_kernel_tolerance::dist::{Distribution, SigmaConvention};
+use vcad_kernel_tolerance::stackup::{Contributor, Requirement, Stackup};
+
+/// A 5-contributor all-normal chain: RSS yield is exact under the
+/// model, so MC must agree within its own error bars.
+fn five_normal_chain() -> Stackup {
+    let conv = SigmaConvention::ThreeSigma;
+    Stackup {
+        name: "five-normal".into(),
+        contributors: vec![
+            Contributor::normal("a", 1.0, 40.0, 0.30, conv),
+            Contributor::normal("b", -1.0, 12.0, 0.20, conv),
+            Contributor::normal("c", -1.0, 10.0, 0.15, conv),
+            Contributor::normal("d", -1.0, 8.0, 0.15, conv),
+            Contributor::normal("e", -1.0, 9.5, 0.10, conv),
+        ],
+        requirement: Requirement::between("gap", 0.20, 0.85),
+    }
+}
+
+/// Mixed-distribution chain (normal + uniform + two-point), the shape
+/// real BOMs have.
+fn mixed_chain() -> Stackup {
+    Stackup {
+        name: "mixed".into(),
+        contributors: vec![
+            Contributor::normal("plate", 1.0, 25.0, 0.2, SigmaConvention::ThreeSigma),
+            Contributor::uniform("bushing", -1.0, 10.0, 0.1, 0.0),
+            Contributor::with_dist(
+                "washer",
+                -1.0,
+                2.0,
+                0.05,
+                0.05,
+                Distribution::TwoPoint {
+                    a: -0.02,
+                    b: 0.03,
+                    p_b: 0.3,
+                },
+            ),
+            Contributor::uniform("ring", -1.0, 12.4, 0.15, 0.15),
+        ],
+        requirement: Requirement::between("gap", 0.30, 1.05),
+    }
+}
+
+#[test]
+fn ladder_1_rss_agrees_with_mc_within_error_bars() {
+    let s = five_normal_chain();
+    let r = rss(&s).unwrap();
+    assert!(r.all_normal, "this rung requires the exact-normal case");
+    let mc = monte_carlo(
+        &s,
+        &McOptions {
+            n: 200_000,
+            seed: 1001,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    // Yield: |p_mc − p_rss| within 4 standard errors (fixed seed, so
+    // this is a deterministic regression bound, not a flaky assertion;
+    // the erf approximation contributes ≤ 1.5e-7 of the gap).
+    let diff = (mc.fit.p - r.yield_estimate).abs();
+    assert!(
+        diff <= 4.0 * mc.fit.standard_error,
+        "RSS yield {} vs MC {} ± {} (diff {diff})",
+        r.yield_estimate,
+        mc.fit.p,
+        mc.fit.standard_error
+    );
+    // Moments agree within their own error bars.
+    assert!((mc.mean_gap - r.mean_gap).abs() <= 4.0 * mc.mean_gap_se);
+    assert!((mc.sigma_gap - r.sigma_gap).abs() <= 4.0 * mc.sigma_gap_se);
+
+    // The mixed chain leans on the CLT for the RSS yield: hold it to a
+    // wider, stated band (absolute 0.005 at these variance ratios).
+    let s = mixed_chain();
+    let r = rss(&s).unwrap();
+    assert!(!r.all_normal);
+    let mc = monte_carlo(
+        &s,
+        &McOptions {
+            n: 200_000,
+            seed: 1002,
+            batches: 16,
+        },
+    )
+    .unwrap();
+    assert!(
+        (mc.fit.p - r.yield_estimate).abs() < 5e-3,
+        "CLT band: RSS {} vs MC {}",
+        r.yield_estimate,
+        mc.fit.p
+    );
+}
+
+#[test]
+fn ladder_2_worst_case_bounds_contain_every_mc_sample() {
+    for (s, seed) in [(five_normal_chain(), 7u64), (mixed_chain(), 8u64)] {
+        let wc = worst_case(&s).unwrap();
+        let mc = monte_carlo(
+            &s,
+            &McOptions {
+                n: 200_000,
+                seed,
+                batches: 16,
+            },
+        )
+        .unwrap();
+        // For bounded distributions this is a theorem; for normal
+        // contributors the WC interval sits ~6–7 σ_G out, so a fixed
+        // seed makes the assertion deterministic and effectively
+        // certain (P(violation) ~ 1e-11 per sample).
+        assert!(
+            mc.min_sample >= wc.min_gap && mc.max_sample <= wc.max_gap,
+            "{}: samples [{}, {}] escaped WC [{}, {}]",
+            s.name,
+            mc.min_sample,
+            mc.max_sample,
+            wc.min_gap,
+            wc.max_gap
+        );
+    }
+}
+
+#[test]
+fn ladder_3_textbook_chain_hand_computed() {
+    // Shaft in a bushing pocket: pocket depth 20.00 ±0.15, bushing
+    // 12.00 ±0.10, shim 7.50 ±0.05, all normal at ±tol = 3σ.
+    // Requirement: protrusion gap ∈ [0.20, 0.80].
+    //
+    // Hand computation:
+    //   nominal gap  = 20 − 12 − 7.5              = 0.5
+    //   σ            = √((0.05)² + (0.0333…)² + (0.0166…)²)
+    //                = √(0.0025 + 0.001111… + 0.000277…)
+    //                = √0.0038888… = 0.06236095644623235…
+    //   WC           = [0.5 − 0.30, 0.5 + 0.30] = [0.20, 0.80]  (exact)
+    //   Cp = Cpk     = 0.30/(3σ) = 1.603567451474546…
+    //   z            = 0.30/σ = 4.810702354423638
+    //   yield        = Φ(z) − Φ(−z) = 1 − 2Φ(−4.8107…) ≈ 0.99999849…
+    let conv = SigmaConvention::ThreeSigma;
+    let s = Stackup {
+        name: "textbook".into(),
+        contributors: vec![
+            Contributor::normal("pocket", 1.0, 20.0, 0.15, conv),
+            Contributor::normal("bushing", -1.0, 12.0, 0.10, conv),
+            Contributor::normal("shim", -1.0, 7.5, 0.05, conv),
+        ],
+        requirement: Requirement::between("protrusion", 0.20, 0.80),
+    };
+    let sigma = (0.0025f64 + 0.1f64 * 0.1 / 9.0 + 0.05f64 * 0.05 / 9.0).sqrt();
+
+    let wc = worst_case(&s).unwrap();
+    assert!((wc.min_gap - 0.20).abs() < 1e-12);
+    assert!((wc.max_gap - 0.80).abs() < 1e-12);
+    assert!(wc.passes, "WC lands exactly on the limits");
+
+    let r = rss(&s).unwrap();
+    assert!((r.mean_gap - 0.5).abs() < 1e-12);
+    assert!((r.sigma_gap - sigma).abs() < 1e-15);
+    assert!((r.cp.unwrap() - 0.6 / (6.0 * sigma)).abs() < 1e-12);
+    assert!((r.cpk.unwrap() - 0.3 / (3.0 * sigma)).abs() < 1e-12);
+    assert!((r.cp.unwrap() - r.cpk.unwrap()).abs() < 1e-12, "centered");
+    // Yield to the erf approximation's honesty band.
+    let z = 0.3 / sigma;
+    let want = yield_within(0.0, 1.0, Some(-z), Some(z));
+    assert!((r.yield_estimate - want).abs() < 1e-12);
+    assert!(r.yield_estimate > 0.999_997 && r.yield_estimate < 0.999_999_5);
+}
+
+#[test]
+fn ladder_4_yield_matches_normal_table() {
+    // Symmetric two-sided intervals at textbook z values.
+    let cases = [
+        (1.0, 0.682_689_49),
+        (1.959_964, 0.95),
+        (2.0, 0.954_499_74),
+        (2.575_829, 0.99),
+        (3.0, 0.997_300_20),
+    ];
+    for (z, want) in cases {
+        let y = yield_within(0.0, 1.0, Some(-z), Some(z));
+        assert!(
+            (y - want).abs() < 1e-6,
+            "±{z}σ: yield {y} want {want} (erf approx bound 1.5e-7 per tail)"
+        );
+    }
+    // One-sided: Φ(3) tail.
+    let y = yield_within(0.0, 1.0, Some(-3.0), None);
+    assert!((y - 0.998_650_10).abs() < 1e-6);
+}
+
+#[test]
+fn ladder_5_mc_error_scales_as_inverse_sqrt_n() {
+    // Empirical 1/√N: run K disjoint seeds at N and 4N; the spread of
+    // p̂ across seeds must halve (within a stated band), and the
+    // reported per-run SE must match the empirical spread.
+    let s = five_normal_chain();
+    let k = 24;
+    let spread = |n: usize, seed0: u64| -> (f64, f64) {
+        let ps: Vec<f64> = (0..k)
+            .map(|i| {
+                monte_carlo(
+                    &s,
+                    &McOptions {
+                        n,
+                        seed: seed0 + i as u64,
+                        batches: 8,
+                    },
+                )
+                .unwrap()
+            })
+            .map(|m| m.fit.p)
+            .collect();
+        let mean = ps.iter().sum::<f64>() / k as f64;
+        let var = ps.iter().map(|p| (p - mean).powi(2)).sum::<f64>() / (k as f64 - 1.0);
+        // Also return one run's reported SE for the match check.
+        let reported = monte_carlo(
+            &s,
+            &McOptions {
+                n,
+                seed: seed0,
+                batches: 8,
+            },
+        )
+        .unwrap()
+        .fit
+        .standard_error;
+        (var.sqrt(), reported)
+    };
+    let (sd_small, se_small) = spread(4_000, 100);
+    let (sd_big, se_big) = spread(16_000, 200);
+    let ratio = sd_small / sd_big;
+    assert!(
+        (1.4..=2.9).contains(&ratio),
+        "4× samples should ≈ halve the spread: {sd_small} → {sd_big} (ratio {ratio})"
+    );
+    // Reported SE tracks the empirical spread within a factor of 1.8
+    // (24 seeds estimate the spread itself to ~±15%).
+    for (sd, se) in [(sd_small, se_small), (sd_big, se_big)] {
+        let f = sd / se;
+        assert!(
+            (1.0 / 1.8..=1.8).contains(&f),
+            "reported SE {se} vs empirical sd {sd} (factor {f})"
+        );
+    }
+}

--- a/docs/tolerance-m0.md
+++ b/docs/tolerance-m0.md
@@ -1,0 +1,183 @@
+# Tolerance stackup M0: worst-case, RSS, and Monte Carlo over assembly chains
+
+`vcad-kernel-tolerance` makes vcad answer the question every assembly
+drawing begs and almost no tool answers honestly: **does this fit, and at
+what yield?** The incumbent workflow is a spreadsheet and prayer — a
+column of ±'s summed two ways and a gut call. The commercial tools that do
+better (CETOL, 3DCS, VisVSA) are expensive bolt-ons to CAD systems that
+don't share their math; there is no good open tool in this space at all.
+This crate is the M0 of a deterministic, receipt-native stackup engine
+that lives inside the kernel next to the geometry it prices, and its
+deliverable claim is the portfolio's purest product sentence: *"this
+assembly fits with 99.7% yield."*
+
+## M0 scope (and honesty)
+
+**In scope:** linear dimension chains, analyzed three ways.
+
+- **Model** (`stackup`): contributors with a nominal, a signed
+  coefficient, drawing limits, and a deviation distribution — Normal
+  (machined dims), Uniform (vendor lots), or TwoPoint /
+  "Bernoulli-shifted" (two suppliers, two mold cavities, seated-or-not).
+  Each contributor records its distribution's **provenance**
+  ([`DistributionSource`]): assumption or measurement.
+- **Worst-case**: interval arithmetic over drawing limits. Guaranteed
+  bounds; width grows as Σtᵢ while real scatter grows as √Σtᵢ² — the
+  gap between those two laws is this whole field.
+- **RSS**: exact linear variance propagation (μ_G = Σaᵢμᵢ,
+  σ_G² = Σaᵢ²σᵢ²) — the *moments* are exact under independence for any
+  distribution mix; the Φ-based *yield* is exact when all contributors
+  are normal and a CLT approximation otherwise (the result carries an
+  `all_normal` flag rather than letting you forget).
+- **Monte Carlo**: seeded deterministic sampling (hand-rolled
+  xoshiro256++ seeded via SplitMix64 — Blackman & Vigna 2021, Steele,
+  Lea & Flood 2014; no `rand` dependency, reproducibility must not
+  hinge on someone else's version bump). Fit probabilities carry an
+  Agresti–Coull standard error (Agresti & Coull 1998 — never reports
+  SE = 0 at k = 0 or n, because "no failures observed" is not
+  certainty), plus a batch-means SE cross-check. **Probabilities
+  without error bars are unrepresentable in the API** — the
+  `ProbabilityEstimate` type has no error-bar-free constructor.
+- **Capability** (`capability`): predicted gap distribution (μ, σ),
+  Cp/Cpk against the requirement, Φ-based yield on a hand-rolled erf
+  (Abramowitz & Stegun 7.1.26, max |error| 1.5×10⁻⁷ — cited, and the
+  bound is asserted against reference values in the tests).
+- **Exact sensitivities** (`sensitivity`): ∂G/∂nominalᵢ = aᵢ,
+  ∂σ_G/∂σᵢ = aᵢ²σᵢ/σ_G, per-contributor variance shares, and exact
+  ∂yield/∂nominalᵢ, ∂yield/∂σᵢ via the Φ chain rule. **These are closed
+  forms, not adjoints** — linearity hands us every derivative exactly,
+  and the FD cross-check in the tests validates the algebra, not an
+  approximation. Ranked output = "which dimension is killing the
+  yield."
+- **Vector loops** (`loops`): 2D/3D legs projected onto a measure
+  direction (aᵢ = v̂ᵢ·d̂) — exact for translational legs, first-order
+  small-angle for rotations (dropped term ~ r·θ²/2; at |θ| ≤ 2° the
+  error is ≤ 1.7% of the kept term; past ~5°, model the mechanism).
+- **ISO 2768-1 general tolerances** (`iso2768`): the f/m/c linear-dim
+  table bundled and cited, fail-closed outside its domain.
+
+**The honesty section** (each of these is stated in API docs, not just
+here):
+
+- **The ±tol ↔ σ convention buries more products than any solver bug.**
+  The default ±tol = 3σ (`SigmaConvention::ThreeSigma`) assumes a
+  Cp = 1.00 process that ships 0.27% of parts out of limits. A Cp = 1.33
+  supplier is 4σ; Six Sigma is 6σ. Every yield number downstream
+  inherits this choice, so it is provenance on the receipt (M4), never a
+  silent default.
+- **Independence is assumed.** Two dimensions cut in one fixture setup
+  are correlated, and RSS and MC are both wrong about their sum.
+  Correlation modeling is future work.
+- **Distributions are assumptions until measured.** M6 binds the repo's
+  3DP print-then-measure loop so coupon scatter replaces assumptions.
+- **Worst-case containment of normal tails is conventional.** A normal
+  contributor genuinely exceeds its drawing limits 0.27% of the time
+  (that's what the convention *means*); the WC interval still contains
+  every MC sample in practice because a chain-level escape needs every
+  contributor near the same-signed extreme simultaneously (~6–7 σ_G
+  out; P ≈ 1e-11) — the ladder asserts it with fixed seeds.
+- **Linear projection is optimistic for radial fits.** The magnitude of
+  a 2-D position error is Rayleigh-distributed; projecting onto one
+  direction overstates fit probability (at c/σ = 2.7, by ~1.9
+  percentage points). `tests/bolt_circle.rs` quantifies it against the
+  exact closed form; radial fits belong to the GD&T module (M1), not a
+  silent linearization.
+
+## Validation ladder (all in `cargo test -p vcad-kernel-tolerance`)
+
+- xoshiro256++/SplitMix64: seed determinism (bit-exact streams),
+  adjacent-seed decorrelation, zero-seed health, uniform and normal
+  moments + tail masses (31.73/4.55/0.27% at 1/2/3σ).
+- erf/Φ against reference values at the cited 1.5×10⁻⁷ bound; yield at
+  textbook z (±1σ, ±1.96σ, ±2.576σ, ±3σ).
+- Distribution moments vs closed forms; sampling convergence.
+- **RSS vs MC self-consistency** (`tests/validation.rs`): 5-contributor
+  all-normal chain agrees within 4 standard errors at n = 200k; a mixed
+  normal/uniform/two-point chain holds a stated CLT band (5×10⁻³).
+- **WC contains every MC sample** on both chains, fixed seeds.
+- **Textbook chain hand-computed**: 3-contributor stack asserted to
+  1e-12 on μ/σ/WC/Cp/Cpk, yield to the erf bound.
+- **1/√N scaling**: p̂ spread across 24 disjoint seeds halves from
+  n = 4k → 16k (band [1.4, 2.9]), and the reported SE matches the
+  empirical spread within ×1.8.
+- **Bolt-circle** (`tests/bolt_circle.rs`): exact-model MC lands on the
+  Rayleigh-CDF integral within error bars; the linearized projection is
+  proven optimistic across the clearance sweep; the virtual-condition
+  worst case fails while the statistical fit rate is ~90% — the entire
+  reason MMC/statistical analysis exists, reproduced from first
+  principles.
+- Fail-closed paths: empty chains, duplicate names, zero coefficients,
+  negative tolerances, distributions wider than their drawing band,
+  unbounded requirements, degenerate (all-σ = 0) chains, and too-few
+  MC samples are all errors, never defaults.
+
+## Benchmark: the bearing stack
+
+`cargo run -p vcad-kernel-tolerance --example bearing_stack`
+
+A gearbox input-shaft axial stack: housing bore depth (ISO 2768-m
+normal), two unilateral vendor-band bearing widths (uniform), a machined
+shoulder (2768-m normal), a two-supplier ground spacer (two-point mix
+inside its band), and a circlip (normal). Requirement: axial play ∈
+[0.05, 0.75] mm.
+
+| analysis | result |
+|---|---|
+| Worst case | gap ∈ [−0.260, 1.300] mm — **fails both ends** (jam and rattle both "possible") |
+| RSS | μ = 0.5220 mm, σ = 0.1357 mm, Cp = 0.86, Cpk = 0.56, yield **95.33%** |
+| Monte Carlo (n = 200k) | fit = 95.39% ± 0.05%, μ = 0.5217 ± 0.0003, σ = 0.1356 ± 0.0002 — brackets RSS |
+
+Sensitivity ranking: housing bore depth owns **54.3%** of the gap
+variance (σ = 0.1), the shaft shoulder 24.1%; everything else is single
+digits. The exact yield gradient (∂Y/∂nominal = +0.71/mm on every
+gap-consuming member) points at the real defect — the unilateral bearing
+bands push the mean 0.122 mm above the requirement center — and the
+worked re-centering move (spacer 12.000 → 12.122 mm) lifts yield from
+95.33% to 99.01% **without tightening a single tolerance**. Tightening
+the *right* σ's at minimum cost is M2.
+
+The story in one sentence: worst-case says redesign it, statistics says
+ship it and here is the number, and the sensitivity table says what to
+fix first if the number isn't good enough.
+
+## Milestone ladder
+
+- **M1 — GD&T semantics that move fits.** Position tolerance at MMC
+  with bonus tolerance modeled honestly (size distribution → effective
+  zone), virtual-condition worst case, flatness/perpendicularity as
+  contributor generators. Scoped subset, stated.
+- **M2 — tolerance allocation.** Minimize manufacturing cost subject to
+  yield ≥ target over per-contributor cost-vs-tolerance curves
+  (reciprocal/exponential families, Chase–Greenwood lineage). The exact
+  gradients make this a clean constrained optimization: Lagrange
+  bisection with per-contributor closed forms + KKT box clamping.
+  (`vcad-kernel-cost` models process-level cost — material + machine
+  time — not cost-vs-tolerance, so the curves are bundled here and the
+  seam documented.)
+- **M3 — parameter seam.** Serde `StackupSpec` where every numeric is a
+  literal or a **named document parameter**, fail-closed resolution
+  (mirrors `vcad-kernel-particle::spec`); the documented adapter
+  contract from vcad documents — dims from sketches, and existing
+  `check_clearance` assertions become requirements. BRep extraction
+  lands vcad-side, emitting this schema.
+- **M4 — receipt claims.** `vcad.tolerance-claims/1`: fit_probability
+  (with MC standard error), cpk, worst_case_margin_mm, sigma_gap — with
+  provenance (n samples, seed, sigma convention, per-contributor
+  distribution sources) and fail-closed `compare()`
+  (Holds/Violated/Unmeasured; an unmeasured receipt never passes).
+- **M5 — benchmarks + paper draft.** Exact-analytic fixtures (uniform
+  convolutions have closed-form CDFs; √n WC/RSS width law), the
+  WC-vs-RSS-vs-MC comparison study, `docs/tolerance-paper-draft.md`
+  positioned as the missing open GD&T engine.
+- **M6 — measurement pack.** Measured dimensional scatter (the repo's
+  `predict_print`/`record_measurement` loop) fitted into contributor
+  distributions (`DistributionSource::Measured`), predicted-vs-measured
+  yield closed through `compare()`.
+
+## Non-goals
+
+This crate does not do full 3-D tolerance zone simulation (surface-level
+GD&T with datum reference frames and simulated gauges — the 3DCS/CETOL
+feature set) at M0, and says so. It prices the chains engineers actually
+write down, exactly, with error bars, and it refuses to produce a number
+without its assumptions attached.

--- a/docs/tolerance-paper-draft.md
+++ b/docs/tolerance-paper-draft.md
@@ -1,0 +1,177 @@
+# An open, receipt-native tolerance stackup engine (draft)
+
+**Working title:** *The missing open GD&T engine: deterministic tolerance
+stackup analysis with exact sensitivities, honest bonus tolerance, and
+fail-closed yield claims*
+
+**Status:** draft skeleton with all current numbers; prose to be
+tightened. Everything quantitative below reproduces with fixed seeds from
+`vcad-kernel-tolerance` (tests + `bearing_stack` / `comparison`
+examples).
+
+## Abstract
+
+Every assembly drawing implies a probability: the chance that parts made
+to its tolerances actually fit and function. Industry answers this with
+spreadsheets (two columns of ±'s and a gut call) or with closed
+commercial bolt-ons (CETOL, 3DCS, VisVSA) whose math cannot be audited.
+There is no good open tool in this space. We present an open stackup
+engine that computes worst-case, RSS, and seeded Monte Carlo analyses
+over assembly chains; reports **exact closed-form sensitivities** (the
+gap, σ, and yield derivatives every allocation decision needs — linear
+chains make adjoint machinery unnecessary, a fact we exploit rather than
+apologize for); models position tolerance at MMC with the bonus handled
+honestly (bonus changes conformance, not physics); allocates tolerances
+by minimizing cited cost models under a yield floor via an exact KKT
+bisection; and emits every result as a fail-closed claim set
+(`vcad.tolerance-claims/1`) carrying its provenance: sample count, seed,
+tolerance-to-σ convention, and per-contributor distribution sources.
+Probabilities without error bars are unrepresentable in the API.
+
+## 1. The problem and the incumbents
+
+- The stackup spreadsheet: WC and RSS columns, no yield, no
+  sensitivities, no provenance; the ±tol ↔ σ link is implicit and
+  usually wrong.
+- Commercial tolerance CAE: capable but closed, expensive, and
+  disconnected from open CAD kernels; results are unauditable numbers.
+- The open-source landscape: effectively empty (a survey belongs here —
+  flagged).
+- Our claim: the deliverable of tolerance analysis is a *receipt* — a
+  yield claim with error bars, assumptions, and the ranked list of which
+  dimension is killing it — and it should live inside the kernel, next
+  to the geometry, under version control.
+
+## 2. Model
+
+Linear chains G = Σ aᵢxᵢ (§honesty for what linearity excludes);
+contributors carry nominal, signed coefficient, drawing limits, a
+deviation distribution (Normal / Uniform / TwoPoint), and a
+**provenance tag** (assumed-under-convention vs measured). The
+tolerance-to-σ convention (default ±tol = 3σ) is data, not folklore:
+it appears on every receipt. ISO 2768-1 f/m/c general tolerances are
+bundled and cited for defaults. 2D/3D vector loops project onto a
+measure direction (exact for translations; small-angle for rotations
+with the r·θ²/2 bound stated); the Rayleigh structure of radial fits is
+handled exactly in the GD&T module, never silently linearized —
+projection provably overstates radial fit probability (~1.9 points at
+c/σ = 2.7 in our fixture).
+
+## 3. Analyses
+
+- **Worst-case:** interval arithmetic over drawing limits.
+- **RSS:** exact moment propagation for any distribution mix; the
+  Φ-based yield is exact for all-normal chains and CLT otherwise — the
+  result carries an `all_normal` flag.
+- **Monte Carlo:** hand-rolled xoshiro256++ (Blackman & Vigna 2021)
+  seeded via SplitMix64; Marsaglia-polar normals; Agresti–Coull (1998)
+  standard errors on every probability plus a batch-means cross-check.
+  Same seed, same bits, any platform.
+- **Capability:** Cp/Cpk and yield on the A&S 7.1.26 erf (max abs error
+  1.5×10⁻⁷ — the approximation bound rides on the claim as its stated
+  uncertainty).
+- **Exact sensitivities:** ∂G/∂nomᵢ = aᵢ; ∂σ_G/∂σᵢ = aᵢ²σᵢ/σ_G;
+  variance shares; ∂Y/∂nomᵢ and ∂Y/∂σᵢ by the Φ chain rule. Validated
+  against finite differences (validating the algebra, not approximating
+  it).
+
+## 4. GD&T at MMC, honestly
+
+Bonus tolerance changes **conformance, not physics**: the position
+scatter of a process does not improve because the hole came out big —
+but the big hole really does clear a worse misalignment, and inspection
+against the dynamic gauge truncates the shipped population. Keeping
+those three statements separate lets us reproduce, by simulation, the
+Y14.5 theorem that gauged parts with compatible virtual conditions fit
+**every single time** (50,000/50,000 in the test), while the ungauged
+population genuinely fails at the predicted rate. Fixed-fastener
+virtual-condition worst case sits beside the statistical fit rate on
+the same receipt: in our bolt-circle fixture the VC check fails by
+0.05 mm while the true assembly fit rate is 87.0% — the entire reason
+MMC and statistical tolerancing exist.
+
+## 5. Allocation
+
+Minimize Σ Cᵢ(tᵢ) subject to yield ≥ Y over cited cost families
+(reciprocal, reciprocal-squared — Spotts 1973; exponential — Speckhart
+1972; survey lineage Chase & Greenwood 1988). Yield is monotone in σ_G,
+so the constraint is σ_G ≤ σ_max (bisection on the exact Φ); KKT
+stationarity has closed forms per contributor for the reciprocal
+families; one outer λ-bisection with box clamping solves the whole
+problem deterministically. Verified against the closed-form Lagrange
+solution (λ and every tᵢ to 1e-6) and the proportional-scaling
+baseline.
+
+## 6. Validation ladder (all in `cargo test`)
+
+- PRNG determinism, decorrelation, moments, tail masses.
+- erf/Φ vs reference values at the stated 1.5e-7 bound.
+- RSS ≡ MC within error bars (all-normal); stated CLT band (mixed).
+- WC contains every MC sample (fixed seeds; bounded dists by theorem,
+  normal chains at ~6.7σ_G).
+- Hand-computed textbook chain at 1e-12.
+- 1/√N error scaling across 24 disjoint seeds.
+- **Irwin–Hall exact benchmarks**: a 3-uniform chain against the exact
+  CDF — MC lands within error bars; the RSS/CLT error is measured
+  (7×10⁻³ at a ±2.5σ requirement) and its **sign is proven**: Φ
+  under-reads bounded chains at the tails (RSS is conservative there),
+  and at the worst-case bounds the exact yield is 1 while the normal
+  model still leaks. A triangular (n = 2) case is hand-computed
+  (0.875 exactly).
+- **The √n law** — WC half-width over RSS 3σ half-width equals √n —
+  asserted to 1e-12 for n = 4, 9, 16, 25. This ratio is the economic
+  argument for the whole field, so it is a test, not a slogan.
+- Rayleigh closed forms for radial fits (bolt circle, conformance,
+  MMC bonus quadrature).
+
+## 7. Results
+
+**Comparison study** (n equal ±0.1 contributors, requirement 1.0 ±
+0.31): worst-case declares the design unbuildable from n = 4 on; the
+true yield at n = 10 is still 99.67 ± 0.02%. The WC/RSS ratio column
+reads √n to machine precision.
+
+**Bearing stack** (housing + 2 vendor bearings + shoulder + two-supplier
+spacer + circlip, ISO 2768-m defaults, mixed distributions): WC fails
+both ends (−0.26 mm jam margin, +1.30 vs 0.75 rattle limit); RSS/MC
+agree on 95.33%/95.39 ± 0.05% yield; the housing bore owns 54.3% of the
+variance; the exact yield gradient's *free* re-centering move (spacer
++0.122 mm) lifts yield to 99.01% without tightening anything; the
+allocator then buys 99.73% at minimum cost (housing 0.300 → 0.237,
+shoulder 0.200 → 0.175), beating proportional scaling by 0.2% at equal
+cost coefficients and by 6.6% under 30× cost asymmetry — allocation's
+edge grows exactly where hand methods are blindest.
+
+**Receipts:** every result above emits as `vcad.tolerance-claims/1`
+with n, seed, convention, and per-contributor sources; `compare()`
+binds measurements with Holds/Violated/Unmeasured verdicts and an
+unmeasured receipt never passes.
+
+## 8. Honesty / limitations
+
+Linear chains (stated small-angle bound for loops); independence
+assumed (fixture-correlated dims are future work); distributions are
+assumptions until measured (the measurement pack flips sources to
+`measured`); the ±tol ↔ σ convention is the biggest lie in most stackups
+and is therefore receipt provenance; no datum reference frames, no
+composite frames, no profile simulation (the full-3D-gauge feature set
+is out of scope and named as such).
+
+## 9. External follow-ups (flagged, not faked)
+
+- Cross-validation against published worked examples (the
+  Fortini/Chase–Greenwood one-way clutch) with the source tables in
+  hand — not reconstructed from memory.
+- Cross-validation against a commercial tool run (CETOL/3DCS licenses
+  required).
+- The `vcad-receipt` schema registration + MCP tools
+  (`analyze_tolerance`, `allocate_tolerance`) — cross-crate codegen PR.
+- Correlated contributors; truncated-normal (post-inspection)
+  distributions as first-class citizens.
+
+## 10. Availability
+
+`crates/vcad-kernel-tolerance` in the vcad repository. Zero
+dependencies beyond serde; every number in this draft regenerates from
+fixed seeds via `cargo test -p vcad-kernel-tolerance` and the two
+examples.


### PR DESCRIPTION
## Summary

New crate `crates/vcad-kernel-tolerance` — the portfolio's pure-CAD entry: dimensional tolerance stackup analysis over assembly chains. The incumbent is spreadsheets and prayer; the commercial tools (CETOL, 3DCS) are closed bolt-ons; there is no good open tool in this space. The deliverable claim is **"this assembly fits with 99.7% yield"**, aimed straight at the existing clearance-assertion receipts and the 3DP print-then-measure loop.

Follows the `vcad-kernel-particle` playbook discipline: milestone ladder (all seven rungs in this PR, one commit each), validation-ladder tests with fixed seeds (never flaky), fail-closed everything, every claim names its assumptions.

## The ladder (M0–M6, all green)

- **M0 — engine.** Linear chains of contributors (nominal, signed coefficient, drawing limits, Normal/Uniform/TwoPoint deviation distribution, provenance tag); worst-case interval arithmetic; RSS with exact moments (`all_normal` flag on the CLT yield step); seeded Monte Carlo (hand-rolled xoshiro256++/SplitMix64, zero deps) with Agresti–Coull standard errors — **probabilities without error bars are unrepresentable**; Cp/Cpk + Φ yield on cited A&S erf (1.5e-7 bound asserted); **exact closed-form sensitivities** (no adjoint machinery needed — linear chains hand us every derivative, FD-validated): ∂G/∂nom, ∂σ_G/∂σᵢ, variance shares, ∂Y/∂nom, ∂Y/∂σᵢ; vector loops with stated small-angle bound; ISO 2768-1 f/m/c table bundled + cited; `bearing_stack` example.
- **M1 — GD&T subset.** Position at MMC with the bonus modeled honestly (bonus changes conformance, not physics; fit samples actual joint geometry; inspection truncates), virtual-condition worst case, and the Y14.5 theorem reproduced by simulation: gauged parts with compatible VCs fit 50,000/50,000 while the ungauged population fails at the predicted rate. Rayleigh closed forms for conformance; flatness/perpendicularity contributor generators.
- **M2 — allocation.** Min cost s.t. yield ≥ target over cited cost families (Spotts 1973, Speckhart 1972, Chase–Greenwood lineage): exact KKT stationarity (closed forms for reciprocal families), one λ-bisection with box clamping. Verified against the closed-form Lagrange solution and the proportional-scaling baseline; infeasible targets fail closed with the best achievable yield.
- **M3 — parameter seam.** `StackupSpec`: every numeric a literal or named document parameter, fail-closed resolution + post-resolve validation; `NormalFromTol` keeps drawing limits and σ consistent by construction. Adapter contract documented: sketch dims → contributors, `check_clearance` assertion labels → requirements (extraction lands vcad-side).
- **M4 — receipts.** `vcad.tolerance-claims/1`: fit_probability (SE structurally required), rss_yield (erf bound as uncertainty), gap moments, cpk/cp, worst_case_margin — with provenance (n, seed, batches, per-contributor distributions + sources) and a consistency tripwire against mixing analyses from different chains. `compare()`: Holds/Violated/Unmeasured, additive bands, unmeasured never passes.
- **M5 — benchmarks + paper.** Irwin–Hall exact CDFs as ground truth (MC within error bars; the RSS/CLT error measured at ~7e-3 with its **sign proven** — Φ under-reads bounded chains); the √n WC/RSS law asserted to 1e-12; `comparison` example (WC declares the design unbuildable from n=4 while true yield stays ≥99.5%; allocation beats proportional scaling by 6.6% under 30× cost asymmetry); `docs/tolerance-paper-draft.md`.
- **M6 — measurement pack.** `fit_normal` (Bessel + SEs on both parameters), `apply_measurement` flips provenance Assumed→Measured (out-of-band process centers are a finding that errors, not an input), `Measurement::from_trial` for k-of-n assembly trials, binding contract to `predict_print`/`record_measurement` documented. Closed-loop test: the optimistic assumed model is **Violated** by a 400-unit trial while the 30-coupon measured model **Holds** on the same data.

## Headline demo (bearing_stack)

WC fails both ends (−0.26 mm jam margin) → RSS/MC agree on 95.33%/95.39 ± 0.05% → housing bore owns 54.3% of variance → the exact yield gradient's free re-centering move (spacer +0.122 mm) lifts yield to 99.01% → the allocator buys 99.73% at minimum cost. Worst-case says redesign it; statistics says ship it with a number; the sensitivity table says what to fix first.

## Flagged follow-ups (deliberately not in this PR)

- Register the claim family in `crates/vcad-receipt` + MCP tools (`analyze_tolerance`, `allocate_tolerance`) — cross-crate schema + TS codegen + fixture regen.
- Published-fixture cross-validation (Fortini clutch) with source tables in hand; commercial-tool comparison.
- Correlated contributors; truncated-normal post-inspection distributions.

## Test plan

- `cargo test -p vcad-kernel-tolerance` — **79 tests** across lib + validation ladder + bolt_circle + benchmarks (all fixed seeds)
- `cargo clippy -p vcad-kernel-tolerance --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Root-manifest diff minimal (members + default-members + one workspace.dependencies line) for trivial merges with parallel sibling-crate branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
