### PR TITLE
fusor_codesign: five solver domains, one Provisional DesignReceipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7348,6 +7348,10 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-kernel-em",
+ "vcad-kernel-neutronics",
+ "vcad-kernel-thermal",
+ "vcad-kernel-tolerance",
  "vcad-receipt",
 ]
 

--- a/crates/vcad-kernel-particle/Cargo.toml
+++ b/crates/vcad-kernel-particle/Cargo.toml
@@ -12,3 +12,7 @@ vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+vcad-kernel-em = { workspace = true }
+vcad-kernel-thermal = { workspace = true }
+vcad-kernel-neutronics = { workspace = true }
+vcad-kernel-tolerance = { workspace = true }

--- a/crates/vcad-kernel-particle/examples/fusor_codesign.rs
+++ b/crates/vcad-kernel-particle/examples/fusor_codesign.rs
@@ -1,0 +1,387 @@
+//! One machine, one receipt, five solver domains.
+//!
+//! Prices the shielded-grid IEC experiment (docs/shielded-grid-experiment.md)
+//! across five kernel crates and assembles every prediction into a single
+//! unified [`vcad_receipt::DesignReceipt`]:
+//!
+//! - **particle** — yield, interception, Q, distance-to-Lawson
+//! - **em** — shield-coil inductance, stored energy, inter-coil force
+//! - **thermal** — cathode temperature under interception heating
+//! - **neutronics** — operator dose behind the HDPE shield (with MC error)
+//! - **tolerance** — does the cusp geometry survive real machining scatter?
+//!
+//! The domains are wired, not stapled: particle's interception fraction
+//! sets thermal's heat load, particle's neutron rate is neutronics' source
+//! term, and em's inter-coil force is the load the tolerance-checked mounts
+//! must carry. Every claim is `basis: predicted`, so the receipt rolls up
+//! **Provisional** — the bench signs it, nothing else does.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example fusor_codesign`
+
+use std::collections::BTreeMap;
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::stats;
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::receipt as particle_receipt;
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_receipt::{ClaimBasis, ClaimQuantity, DesignReceipt, OracleRef, ReceiptClaim};
+
+// ── The experiment configuration (phase B of the experiment doc) ──────
+const CHAMBER_R_MM: f64 = 150.0;
+const RING_R_MM: f64 = 45.0;
+const RING_Z_MM: f64 = 25.0;
+const WIRE_A_MM: f64 = 3.0;
+const CATHODE_V: f64 = -30_000.0;
+const SHIELD_AT: f64 = 160_000.0; // ampere-turns per ring, opposed
+const COIL_TURNS: f64 = 400.0; // realization: 400 t × 400 A pulsed
+const ION_CURRENT_A: f64 = 0.010;
+const PRESSURE_MTORR: f64 = 2.0;
+const SHIELD_HDPE_MM: f64 = 100.0;
+const OPERATOR_MM: f64 = 2_000.0;
+
+/// Fold a domain crate's `{name, value, unit, note}` claim into the
+/// unified receipt (basis `predicted`; the crates' own adapters will
+/// supersede this once MCP wave 2 lands them).
+fn unified(
+    domain: &str,
+    oracle: &OracleRef,
+    name: &str,
+    value: f64,
+    unit: &str,
+    note: &str,
+) -> ReceiptClaim {
+    let q = if unit == "1" || unit.is_empty() {
+        ClaimQuantity::bare(value)
+    } else {
+        ClaimQuantity::new(value, unit)
+    };
+    ReceiptClaim::pass(format!("{domain}.{name}"), domain, note, oracle.clone())
+        .with_basis(ClaimBasis::Predicted)
+        .with_measured(q)
+}
+
+fn main() {
+    let mut all: Vec<ReceiptClaim> = Vec::new();
+
+    // ── 1. particle: the machine itself ───────────────────────────────
+    let device = Device::shielded_two_ring(
+        CHAMBER_R_MM,
+        RING_R_MM,
+        RING_Z_MM,
+        WIRE_A_MM,
+        CATHODE_V,
+        SHIELD_AT,
+    );
+    let sopts = SolveOptions::default();
+    let sol = solve(&device, 121, 241, &sopts).expect("particle poisson");
+    let fields = FieldMap::new(&device, &sol);
+    let topts = TraceOptions {
+        max_passes: 30,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, topts);
+    let pstats = stats(&tracer.launch_ensemble(DEUTERON, 64));
+    let op = particle_receipt::OperatingPoint {
+        ion_current_a: ION_CURRENT_A,
+        d2_pressure_mtorr: PRESSURE_MTORR,
+        temperature_k: 300.0,
+    };
+    let pset = particle_receipt::predicted_claims(
+        &pstats,
+        &sol,
+        &topts,
+        sopts.tol,
+        device.max_potential_drop_v(),
+        &op,
+    );
+    let neutron_rate = pset
+        .claims
+        .iter()
+        .find(|c| c.name == "ddn_neutron_rate")
+        .map(|c| c.value)
+        .expect("neutron rate claim");
+    all.extend(particle_receipt::design_claims(&pset));
+    println!(
+        "particle   ✓ interception {:.2}, {:.2e} n/s predicted",
+        pstats.interception_fraction, neutron_rate
+    );
+
+    // ── 2. em: the shield coils as electromagnets ─────────────────────
+    use vcad_kernel_em::axisym::{Annulus, AxisymMagnetostatics, Coil};
+    let coil_region = |z0: f64| Annulus {
+        r_inner_mm: RING_R_MM - WIRE_A_MM,
+        r_outer_mm: RING_R_MM + WIRE_A_MM,
+        z_min_mm: z0 - WIRE_A_MM,
+        z_max_mm: z0 + WIRE_A_MM,
+    };
+    let mut em_dev = AxisymMagnetostatics::new(CHAMBER_R_MM, -CHAMBER_R_MM, CHAMBER_R_MM);
+    em_dev.coils.push(Coil {
+        region: coil_region(RING_Z_MM),
+        turns: COIL_TURNS,
+        current_a: SHIELD_AT / COIL_TURNS,
+    });
+    em_dev.coils.push(Coil {
+        region: coil_region(-RING_Z_MM),
+        turns: COIL_TURNS,
+        current_a: -SHIELD_AT / COIL_TURNS,
+    });
+    let em_opts = vcad_kernel_em::grid::SolveOptions::default();
+    let em_sol = em_dev.solve(129, 257, &em_opts).expect("em solve");
+    let em_oracle = OracleRef::new("vcad-kernel-em/axisym", env!("CARGO_PKG_VERSION"));
+    let l_set = vcad_kernel_em::receipt::axisym_inductance_claims(&em_sol, 0, em_opts.tol, None);
+    let f_set = vcad_kernel_em::receipt::axisym_force_claims(
+        &em_sol,
+        0,
+        em_opts.tol,
+        Some((70.0, 5.0, 45.0, 96)),
+    );
+    let coil_force_n = f_set
+        .claims
+        .iter()
+        .find(|c| c.name == "force_n")
+        .map(|c| c.value)
+        .unwrap_or(0.0);
+    for set in [&l_set, &f_set] {
+        for c in &set.claims {
+            all.push(unified(
+                "em", &em_oracle, &c.name, c.value, &c.unit, &c.note,
+            ));
+        }
+    }
+    println!(
+        "em         ✓ per-coil L {:.2e} H, inter-coil force {:.1} N",
+        l_set.claims[0].value, coil_force_n
+    );
+
+    // ── 3. thermal: interception heating of the cathode rings ─────────
+    use vcad_kernel_thermal::model::{
+        Axis, FixedTemperature, MaterialRegion, PowerSource, Shape, ThermalModel,
+    };
+    // The cross-domain wire: the ions particle says still hit the wires
+    // arrive as heat. P = interception × beam power.
+    let intercept_power_w = pstats.interception_fraction * ION_CURRENT_A * CATHODE_V.abs();
+    let ring_tube = |z0: f64| Shape::Tube {
+        axis: Axis::Z,
+        center_mm: [60.0, 60.0],
+        inner_radius_mm: RING_R_MM - WIRE_A_MM,
+        outer_radius_mm: RING_R_MM + WIRE_A_MM,
+        span_mm: [60.0 + z0 - WIRE_A_MM, 60.0 + z0 + WIRE_A_MM],
+    };
+    // One support post at the ring radius, spanning both rings up to the
+    // cooled feedthrough flange — the only conduction path out (vacuum:
+    // radiation is deliberately unmodeled, so T_max is a floor).
+    let stalk = Shape::Box {
+        min_mm: [57.0, 100.0, 60.0 - RING_Z_MM - WIRE_A_MM],
+        size_mm: [6.0, 6.0, 120.0 - (60.0 - RING_Z_MM - WIRE_A_MM)],
+    };
+    let mut tm = ThermalModel::new([0.0, 0.0, 0.0], [120.0, 120.0, 120.0], [48, 48, 48]);
+    tm.materials
+        .push(MaterialRegion::isotropic(ring_tube(RING_Z_MM), 390.0)); // copper
+    tm.materials
+        .push(MaterialRegion::isotropic(ring_tube(-RING_Z_MM), 390.0));
+    tm.materials
+        .push(MaterialRegion::isotropic(stalk.clone(), 16.0)); // stainless stalk
+    tm.sources.push(PowerSource {
+        name: "ion-interception-upper".into(),
+        shape: ring_tube(RING_Z_MM),
+        power_w: 0.5 * intercept_power_w,
+    });
+    tm.sources.push(PowerSource {
+        name: "ion-interception-lower".into(),
+        shape: ring_tube(-RING_Z_MM),
+        power_w: 0.5 * intercept_power_w,
+    });
+    tm.fixed.push(FixedTemperature {
+        shape: Shape::Box {
+            min_mm: [54.0, 97.0, 114.0],
+            size_mm: [12.0, 12.0, 6.0],
+        },
+        temperature_c: 25.0,
+    });
+    tm.reference_c = Some(25.0);
+    let th_opts = vcad_kernel_thermal::solve::SolveOptions::default();
+    let th_sol = vcad_kernel_thermal::solve::solve_steady(&tm, &th_opts).expect("thermal");
+    let th_set = vcad_kernel_thermal::receipt::predicted_claims(&tm, &th_sol, &th_opts);
+    let th_oracle = OracleRef::new("vcad-kernel-thermal/steady", env!("CARGO_PKG_VERSION"));
+    for c in &th_set.claims {
+        all.push(unified(
+            "thermal", &th_oracle, &c.name, c.value, &c.unit, &c.note,
+        ));
+    }
+    println!(
+        "thermal    ✓ {:.0} W interception heat → T_max {:.0} °C (conduction-only floor)",
+        intercept_power_w, th_sol.t_max_c
+    );
+
+    // ── 4. neutronics: the operator's dose behind the shield ──────────
+    use vcad_kernel_neutronics::spec::{
+        DetectorSpec, LayerSpec, ParamValue, RunSpec, ShieldSpec, SourceSpec,
+    };
+    // Cross-domain wire #2: the source term is particle's predicted rate.
+    let shield = ShieldSpec {
+        layers: vec![
+            LayerSpec {
+                material: "air".into(),
+                thickness_mm: ParamValue::Literal(1_000.0),
+            },
+            LayerSpec {
+                material: "hdpe".into(),
+                thickness_mm: ParamValue::Literal(SHIELD_HDPE_MM),
+            },
+            LayerSpec {
+                material: "air".into(),
+                thickness_mm: ParamValue::Literal(OPERATOR_MM - 1_000.0 - SHIELD_HDPE_MM + 200.0),
+            },
+        ],
+        source: SourceSpec {
+            rate_n_per_s: ParamValue::Literal(neutron_rate),
+            energy_ev: ParamValue::Literal(2.45e6),
+        },
+        detectors: vec![DetectorSpec {
+            label: "operator".into(),
+            radius_mm: ParamValue::Literal(OPERATOR_MM),
+            half_width_mm: ParamValue::Literal(20.0),
+        }],
+        run: RunSpec::default(),
+    };
+    let n_set = vcad_kernel_neutronics::receipt::predicted_claims(&shield, &BTreeMap::new())
+        .expect("neutronics");
+    let n_oracle = OracleRef::new("vcad-kernel-neutronics/mc", env!("CARGO_PKG_VERSION"));
+    for c in &n_set.claims {
+        let note = format!("{} (rse {:.1}%)", c.note, c.rse * 100.0);
+        all.push(unified(
+            "neutronics",
+            &n_oracle,
+            &c.name,
+            c.value,
+            &c.unit,
+            &note,
+        ));
+    }
+    if let Some(d) = n_set
+        .claims
+        .iter()
+        .find(|c| c.name.starts_with("dose_rate"))
+    {
+        println!(
+            "neutronics ✓ operator dose {:.3} µSv/h ± {:.0}% behind {} mm HDPE",
+            d.value,
+            d.rse * 100.0,
+            SHIELD_HDPE_MM
+        );
+    }
+
+    // ── 5. tolerance: does the cusp survive real parts? ───────────────
+    use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+    use vcad_kernel_tolerance::dist::SigmaConvention;
+    use vcad_kernel_tolerance::stackup::{Contributor, Requirement, Stackup};
+    // Ring-to-ring gap chain, symmetric mounts: flange datum → feedthrough
+    // → mount → ring seat, both sides. Cusp physics wants the 50 mm gap
+    // held to ±1 mm (the M0 sweep's ring-spacing sensitivity).
+    let side = |tag: &str, sign: f64| {
+        vec![
+            Contributor::normal(
+                &format!("feedthrough-length-{tag}"),
+                sign,
+                60.0,
+                0.30,
+                SigmaConvention::ThreeSigma,
+            ),
+            Contributor::normal(
+                &format!("mount-spacer-{tag}"),
+                -sign,
+                47.5,
+                0.20,
+                SigmaConvention::ThreeSigma,
+            ),
+            Contributor::normal(
+                &format!("ring-seat-{tag}"),
+                sign,
+                12.5,
+                0.15,
+                SigmaConvention::ThreeSigma,
+            ),
+        ]
+    };
+    let mut contributors = side("upper", 1.0);
+    contributors.extend(side("lower", 1.0));
+    let stack = Stackup {
+        name: "cusp-ring-gap".into(),
+        contributors,
+        requirement: Requirement::between("ring-gap", 49.0, 51.0),
+    };
+    let wc = worst_case(&stack).expect("wc");
+    let rs = rss(&stack).expect("rss");
+    let mc = monte_carlo(&stack, &McOptions::default()).expect("mc");
+    let t_set =
+        vcad_kernel_tolerance::receipt::predicted_claims(&stack, &wc, &rs, &mc).expect("claims");
+    let t_oracle = OracleRef::new("vcad-kernel-tolerance/stackup", env!("CARGO_PKG_VERSION"));
+    for c in &t_set.claims {
+        let note = match c.uncertainty {
+            Some(u) => format!("{} (± {u:.2e})", c.note),
+            None => c.note.clone(),
+        };
+        all.push(unified(
+            "tolerance",
+            &t_oracle,
+            &c.name,
+            c.value,
+            &c.unit,
+            &note,
+        ));
+    }
+    println!(
+        "tolerance  ✓ gap requirement 49–51 mm: RSS yield {:.4}, WC margin {:.2} mm",
+        rs.yield_estimate,
+        wc.worst_margin()
+    );
+
+    // ── The receipt ───────────────────────────────────────────────────
+    let mut receipt = DesignReceipt::with_claims(all);
+    receipt.document_id = Some("shielded-grid-experiment/rev-a".into());
+    let domains: std::collections::BTreeSet<&str> =
+        receipt.claims.iter().map(|c| c.domain.as_str()).collect();
+    println!(
+        "\n════ DesignReceipt: {} claims across {} domains ({}) ════",
+        receipt.claims.len(),
+        domains.len(),
+        domains.into_iter().collect::<Vec<_>>().join(", ")
+    );
+    println!(
+        "verdict: {:?} — every number is a prediction; the bench signs the receipt.",
+        receipt.verdict()
+    );
+
+    // Co-design findings — the contradictions only a multi-domain receipt
+    // can surface (each is invisible from inside its own domain):
+    println!("\n──── co-design findings ────");
+    if th_sol.t_max_c > 1_085.0 {
+        println!(
+            "· THERMAL VETO: T_max {:.0} °C ≫ copper melt (1085 °C) — steady-state \
+             at {:.0} mA is excluded; duty-cycle below {:.1}% or water-cool the stalk",
+            th_sol.t_max_c,
+            ION_CURRENT_A * 1e3,
+            100.0 * (1_085.0 - 25.0) / (th_sol.t_max_c - 25.0)
+        );
+    }
+    println!(
+        "· MECHANICAL: opposed shield coils repel with {:.1} kN — mounts are a \
+         structural part, not clips",
+        coil_force_n.abs() / 1e3
+    );
+    if wc.worst_margin() < 0.0 {
+        println!(
+            "· TOLERANCE: worst-case gap margin {:.2} mm < 0 while RSS yield reads \
+             {:.4} — statistically fine, deterministically violable; tighten the \
+             feedthrough tolerance or widen the requirement",
+            wc.worst_margin(),
+            rs.yield_estimate
+        );
+    }
+    println!(
+        "\n{}",
+        serde_json::to_string_pretty(&receipt).expect("json")
+    );
+}

--- a/crates/vcad-kernel-particle/tests/codesign.rs
+++ b/crates/vcad-kernel-particle/tests/codesign.rs
@@ -1,0 +1,229 @@
+//! The convergence contract: five solver domains price one machine and
+//! land in one unified receipt, wired (particle's interception feeds
+//! thermal's heat load; particle's neutron rate feeds neutronics' source),
+//! and the all-predicted receipt rolls up Provisional — never verified.
+//!
+//! Coarse settings throughout: this guards the composition contract, not
+//! the numbers (the `fusor_codesign` example is the full-fidelity run).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::stats;
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::receipt as particle_receipt;
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_receipt::{ClaimBasis, ClaimQuantity, DesignReceipt, OracleRef, ReceiptClaim};
+
+fn unified(domain: &str, oracle: &OracleRef, name: &str, value: f64, unit: &str) -> ReceiptClaim {
+    ReceiptClaim::pass(format!("{domain}.{name}"), domain, name, oracle.clone())
+        .with_basis(ClaimBasis::Predicted)
+        .with_measured(ClaimQuantity::new(value, unit))
+}
+
+#[test]
+fn five_domains_one_receipt_provisional() {
+    let mut all: Vec<ReceiptClaim> = Vec::new();
+
+    // particle (coarse)
+    let device = Device::shielded_two_ring(120.0, 40.0, 22.0, 4.0, -20_000.0, 40_000.0);
+    let sopts = SolveOptions::default();
+    let sol = solve(&device, 61, 121, &sopts).unwrap();
+    let fields = FieldMap::new(&device, &sol);
+    let topts = TraceOptions {
+        max_passes: 8,
+        ..TraceOptions::default()
+    };
+    let tracer = Tracer::new(&device, &fields, &sol, topts);
+    let pstats = stats(&tracer.launch_ensemble(DEUTERON, 12));
+    let op = particle_receipt::OperatingPoint {
+        ion_current_a: 0.010,
+        d2_pressure_mtorr: 2.0,
+        temperature_k: 300.0,
+    };
+    let pset = particle_receipt::predicted_claims(
+        &pstats,
+        &sol,
+        &topts,
+        sopts.tol,
+        device.max_potential_drop_v(),
+        &op,
+    );
+    let neutron_rate = pset
+        .claims
+        .iter()
+        .find(|c| c.name == "ddn_neutron_rate")
+        .map(|c| c.value)
+        .unwrap();
+    all.extend(particle_receipt::design_claims(&pset));
+
+    // em (coarse): the two shield coils.
+    use vcad_kernel_em::axisym::{Annulus, AxisymMagnetostatics, Coil};
+    let region = |z0: f64| Annulus {
+        r_inner_mm: 36.0,
+        r_outer_mm: 44.0,
+        z_min_mm: z0 - 4.0,
+        z_max_mm: z0 + 4.0,
+    };
+    let mut em_dev = AxisymMagnetostatics::new(120.0, -120.0, 120.0);
+    em_dev.coils.push(Coil {
+        region: region(22.0),
+        turns: 100.0,
+        current_a: 400.0,
+    });
+    em_dev.coils.push(Coil {
+        region: region(-22.0),
+        turns: 100.0,
+        current_a: -400.0,
+    });
+    let em_opts = vcad_kernel_em::grid::SolveOptions::default();
+    let em_sol = em_dev.solve(65, 129, &em_opts).unwrap();
+    let em_oracle = OracleRef::new("vcad-kernel-em/axisym", "test");
+    let l_set = vcad_kernel_em::receipt::axisym_inductance_claims(&em_sol, 0, em_opts.tol, None);
+    for c in &l_set.claims {
+        all.push(unified("em", &em_oracle, &c.name, c.value, &c.unit));
+    }
+
+    // thermal (coarse): interception heat through a post to a cold flange.
+    use vcad_kernel_thermal::model::{
+        Axis, FixedTemperature, MaterialRegion, PowerSource, Shape, ThermalModel,
+    };
+    let intercept_power_w = pstats.interception_fraction * 0.010 * 20_000.0;
+    assert!(
+        intercept_power_w > 0.0,
+        "control config must intercept ions for the thermal wire to exist"
+    );
+    let ring = Shape::Tube {
+        axis: Axis::Z,
+        center_mm: [50.0, 50.0],
+        inner_radius_mm: 36.0,
+        outer_radius_mm: 44.0,
+        span_mm: [68.0, 76.0],
+    };
+    let post = Shape::Box {
+        min_mm: [47.0, 84.0, 68.0],
+        size_mm: [6.0, 6.0, 32.0],
+    };
+    let mut tm = ThermalModel::new([0.0, 0.0, 0.0], [100.0, 100.0, 100.0], [40, 40, 40]);
+    tm.materials
+        .push(MaterialRegion::isotropic(ring.clone(), 390.0));
+    tm.materials
+        .push(MaterialRegion::isotropic(post.clone(), 16.0));
+    tm.sources.push(PowerSource {
+        name: "ion-interception".into(),
+        shape: ring,
+        power_w: intercept_power_w,
+    });
+    tm.fixed.push(FixedTemperature {
+        shape: Shape::Box {
+            min_mm: [44.0, 81.0, 95.0],
+            size_mm: [12.0, 12.0, 5.0],
+        },
+        temperature_c: 25.0,
+    });
+    tm.reference_c = Some(25.0);
+    let th_opts = vcad_kernel_thermal::solve::SolveOptions::default();
+    let th_sol = vcad_kernel_thermal::solve::solve_steady(&tm, &th_opts).unwrap();
+    let th_set = vcad_kernel_thermal::receipt::predicted_claims(&tm, &th_sol, &th_opts);
+    let th_oracle = OracleRef::new("vcad-kernel-thermal/steady", "test");
+    for c in &th_set.claims {
+        all.push(unified("thermal", &th_oracle, &c.name, c.value, &c.unit));
+    }
+    // The cross-domain wire is literal: the deposited power is the
+    // particle result, and the solver's own energy balance reports it.
+    let total_source_w: f64 = th_sol.sources.iter().map(|s| s.power_w).sum();
+    assert!(
+        (total_source_w - intercept_power_w).abs() < 1e-9 * intercept_power_w.max(1.0),
+        "thermal heat load must equal interception × beam power"
+    );
+
+    // neutronics (coarse): particle's rate is the source term.
+    use vcad_kernel_neutronics::spec::{
+        DetectorSpec, LayerSpec, ParamValue, RunSpec, ShieldSpec, SourceSpec,
+    };
+    let shield = ShieldSpec {
+        layers: vec![
+            LayerSpec {
+                material: "air".into(),
+                thickness_mm: ParamValue::Literal(500.0),
+            },
+            LayerSpec {
+                material: "hdpe".into(),
+                thickness_mm: ParamValue::Literal(50.0),
+            },
+            LayerSpec {
+                material: "air".into(),
+                thickness_mm: ParamValue::Literal(600.0),
+            },
+        ],
+        source: SourceSpec {
+            rate_n_per_s: ParamValue::Literal(neutron_rate.max(1.0)),
+            energy_ev: ParamValue::Literal(2.45e6),
+        },
+        detectors: vec![DetectorSpec {
+            label: "operator".into(),
+            radius_mm: ParamValue::Literal(1_000.0),
+            half_width_mm: ParamValue::Literal(20.0),
+        }],
+        run: RunSpec {
+            histories_per_batch: 2_000,
+            batches: 10,
+            seed: 7,
+        },
+    };
+    let n_set =
+        vcad_kernel_neutronics::receipt::predicted_claims(&shield, &BTreeMap::new()).unwrap();
+    let n_oracle = OracleRef::new("vcad-kernel-neutronics/mc", "test");
+    let mut saw_finite_rse = false;
+    for c in &n_set.claims {
+        assert!(c.rse.is_finite(), "every MC claim carries its uncertainty");
+        saw_finite_rse = true;
+        all.push(unified("neutronics", &n_oracle, &c.name, c.value, &c.unit));
+    }
+    assert!(saw_finite_rse);
+
+    // tolerance (fast): the ring-gap chain.
+    use vcad_kernel_tolerance::analysis::{monte_carlo, rss, worst_case, McOptions};
+    use vcad_kernel_tolerance::dist::SigmaConvention;
+    use vcad_kernel_tolerance::stackup::{Contributor, Requirement, Stackup};
+    let stack = Stackup {
+        name: "cusp-ring-gap".into(),
+        contributors: vec![
+            Contributor::normal("feedthrough", 1.0, 44.0, 0.3, SigmaConvention::ThreeSigma),
+            Contributor::normal("spacer", -1.0, 20.0, 0.2, SigmaConvention::ThreeSigma),
+            Contributor::normal("seat", 1.0, 20.0, 0.15, SigmaConvention::ThreeSigma),
+        ],
+        requirement: Requirement::between("ring-gap", 43.0, 45.0),
+    };
+    let wc = worst_case(&stack).unwrap();
+    let rs = rss(&stack).unwrap();
+    let mc = monte_carlo(&stack, &McOptions::default()).unwrap();
+    let t_set = vcad_kernel_tolerance::receipt::predicted_claims(&stack, &wc, &rs, &mc).unwrap();
+    let t_oracle = OracleRef::new("vcad-kernel-tolerance/stackup", "test");
+    for c in &t_set.claims {
+        all.push(unified("tolerance", &t_oracle, &c.name, c.value, &c.unit));
+    }
+
+    // ── the contract ──────────────────────────────────────────────────
+    let receipt = DesignReceipt::with_claims(all);
+    let domains: BTreeSet<&str> = receipt.claims.iter().map(|c| c.domain.as_str()).collect();
+    assert_eq!(
+        domains,
+        BTreeSet::from(["particle", "em", "thermal", "neutronics", "tolerance"]),
+        "one receipt must span all five domains"
+    );
+    assert!(
+        receipt.claims.len() >= 18,
+        "expected a substantive claim set, got {}",
+        receipt.claims.len()
+    );
+    for c in &receipt.claims {
+        assert_eq!(c.effective_basis(), ClaimBasis::Predicted);
+    }
+    assert_eq!(
+        receipt.verdict(),
+        vcad_receipt::ReceiptVerdict::Provisional,
+        "an all-predicted multi-domain receipt must roll up Provisional, never Pass"
+    );
+}


### PR DESCRIPTION
## What

The convergence demo the seven-crate wave was building toward: `cargo run --release -p vcad-kernel-particle --example fusor_codesign` prices the shielded-grid IEC experiment across **five kernel crates** — particle (yield, interception, distance-to-Lawson), em (shield-coil L, stored energy, inter-coil force), thermal (cathode temperature under interception heating), neutronics (operator dose with MC error bars), tolerance (cusp-gap stackup) — and assembles everything into **one unified `DesignReceipt`**: 26 claims, five domains, verdict **Provisional** (all claims `basis: predicted`; the bench signs the receipt, nothing else does).

The domains are wired, not stapled: particle's interception fraction × beam power **is** thermal's heat source; particle's predicted neutron rate **is** neutronics' source term; em's inter-coil force is the mount load for the tolerance chain.

## The finding (why this matters)

First full run surfaced three design vetoes that are invisible from inside any single domain:

1. **Thermal veto** — 178 W of interception heat, conduction-only mount → T_max ≈ 25,000 °C, ~23× past copper melt: steady-state at 10 mA is excluded (duty-cycle < 4.2% or water-cool the stalk).
2. **Mechanical** — the opposed 160 kA·turn shield coils repel with **14.9 kN**: mounts are a structural part.
3. **Tolerance** — worst-case ring-gap margin **−0.30 mm** while RSS yield reads 1.0000: the classic WC/RSS tension, caught before any metal is cut.

## Verification

- `tests/codesign.rs` guards the composition contract at coarse settings (~1.3 s): all five domains present in one receipt, every claim `basis=predicted`, thermal heat load numerically equals interception × beam power, every neutronics claim carries finite MC uncertainty, rollup is Provisional — never Pass.
- Full crate suite: 48 tests green; clippy `-D warnings` clean; fmt clean.
- Changes are dev-deps + example + test only; no crate APIs touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)