### PR TITLE
MCP wave 2: six physics solvers land as agent tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7139,15 +7139,19 @@ name = "vcad-kernel"
 version = "0.9.4"
 dependencies = [
  "serde_json",
+ "vcad-kernel-antenna",
  "vcad-kernel-booleans",
  "vcad-kernel-cam",
  "vcad-kernel-constraints",
  "vcad-kernel-cost",
  "vcad-kernel-dfm",
+ "vcad-kernel-em",
  "vcad-kernel-fillet",
  "vcad-kernel-geom",
  "vcad-kernel-math",
+ "vcad-kernel-neutronics",
  "vcad-kernel-particle",
+ "vcad-kernel-photonics",
  "vcad-kernel-primitives",
  "vcad-kernel-sheet",
  "vcad-kernel-shell",
@@ -7157,6 +7161,8 @@ dependencies = [
  "vcad-kernel-sweep",
  "vcad-kernel-tessellate",
  "vcad-kernel-text",
+ "vcad-kernel-thermal",
+ "vcad-kernel-tolerance",
  "vcad-kernel-topo",
  "vcad-kernel-topopt",
 ]
@@ -7167,6 +7173,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7282,6 +7289,7 @@ dependencies = [
  "serde",
  "serde_json",
  "vcad-kernel-particle",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7331,6 +7339,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7358,6 +7367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "vcad-gdsii",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7513,6 +7523,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-receipt",
 ]
 
 [[package]]
@@ -7521,6 +7532,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "vcad-receipt",
 ]
 
 [[package]]

--- a/changelog/entries/2026-07-17-solver-mcp-wave-2.json
+++ b/changelog/entries/2026-07-17-solver-mcp-wave-2.json
@@ -1,0 +1,26 @@
+{
+  "id": "2026-07-17-solver-mcp-wave-2",
+  "version": "0.9.4",
+  "date": "2026-07-17",
+  "category": "feat",
+  "title": "Six physics solvers land as MCP tools",
+  "summary": "EM, photonics, antenna, thermal, neutronics, and tolerance-stackup solvers are now callable by AI agents over MCP, each returning predicted claim sets that roll up Provisional on the unified receipt.",
+  "features": [
+    "em",
+    "photonics",
+    "antenna",
+    "thermal",
+    "neutronics",
+    "tolerance",
+    "receipts",
+    "mcp"
+  ],
+  "mcpTools": [
+    "simulate_em",
+    "simulate_photonics",
+    "analyze_antenna",
+    "solve_thermal",
+    "simulate_neutron_shield",
+    "analyze_tolerance_stackup"
+  ]
+}

--- a/crates/vcad-kernel-antenna/Cargo.toml
+++ b/crates/vcad-kernel-antenna/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-antenna/src/receipt.rs
+++ b/crates/vcad-kernel-antenna/src/receipt.rs
@@ -435,6 +435,65 @@ pub fn compare(
     })
 }
 
+/// Domain tag for antenna claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "antenna";
+
+/// The oracle reference for this crate's thin-wire MoM solver.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-antenna/mom", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// MoM solve ran for real, but the claims describe an antenna that has
+/// not been measured, so a receipt built from these **rolls up
+/// Provisional, never Pass** (the same contract as
+/// `predict_physics`/`predict_print`). The computed value rides in
+/// `measured` ("what the oracle computed"); mesh, band, and the
+/// thin-wire validity-gate margins ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "{} segments / {} bases, quad {}x{}, band {:.4e}..{:.4e} Hz x{}, z0 {} ohm, ground_plane {}, gates: seg/4a {:.2} seg/(lambda/8) {:.2} ka {:.3}, env {}",
+        set.provenance.segments,
+        set.provenance.bases,
+        set.provenance.quad_outer,
+        set.provenance.quad_inner,
+        set.provenance.band.f_lo_hz,
+        set.provenance.band.f_hi_hz,
+        set.provenance.band.points,
+        set.reference_ohm,
+        set.provenance.ground_plane,
+        set.provenance.min_seg_len_over_4a,
+        set.provenance.max_seg_len_over_lambda8,
+        set.provenance.max_ka,
+        set.provenance.environment,
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("antenna.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(provenance.clone())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -458,6 +517,28 @@ mod tests {
             &SolveOptions::default(),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let set = dipole_claims();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("antenna."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            let details = c.details.as_deref().unwrap_or("");
+            assert!(details.contains("30 segments"));
+            assert!(details.contains("z0 50 ohm"));
+        }
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted antenna claims must never read as verified"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-em/Cargo.toml
+++ b/crates/vcad-kernel-em/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-em/src/receipt.rs
+++ b/crates/vcad-kernel-em/src/receipt.rs
@@ -364,6 +364,63 @@ pub fn compare(
     })
 }
 
+/// Domain tag for EM claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "em";
+
+/// The oracle reference for this crate's finite-volume field solver.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-em/fv", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// field solve ran for real, but the claims describe hardware that has
+/// not been measured, so a receipt built from these **rolls up
+/// Provisional, never Pass** (the same contract as
+/// `predict_physics`/`predict_print`). The computed value rides in
+/// `measured` ("what the oracle computed"); formulation, grid, and the
+/// two-independent-routes residual ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let mut provenance = format!(
+        "{}, grid {}x{}, sor tol {:.1e} sweeps {}",
+        set.provenance.formulation,
+        set.provenance.grid[0],
+        set.provenance.grid[1],
+        set.provenance.sor_tol,
+        set.provenance.sor_sweeps,
+    );
+    if let Some(r) = set.provenance.cross_route_residual {
+        provenance.push_str(&format!("; cross_route_residual {r:.3e}"));
+    }
+    if let Some(n) = set.provenance.nonlinear_iterations {
+        provenance.push_str(&format!("; picard_iterations {n}"));
+    }
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("em.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(provenance.clone())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -388,6 +445,28 @@ mod tests {
         let opts = SolveOptions::default();
         let sol = dev.solve(41, 7, &opts).unwrap();
         axisym_inductance_claims(&sol, 0, opts.tol, None)
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let set = solenoid_claims();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("em."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            let details = c.details.as_deref().unwrap_or("");
+            assert!(details.contains("axisym-magnetostatics"));
+            assert!(details.contains("cross_route_residual"));
+        }
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted em claims must never read as verified"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-neutronics/Cargo.toml
+++ b/crates/vcad-kernel-neutronics/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-neutronics/src/receipt.rs
+++ b/crates/vcad-kernel-neutronics/src/receipt.rs
@@ -355,3 +355,99 @@ pub fn compare(
         all_hold: all_hold && measured_any,
     })
 }
+
+/// Domain tag for neutronics claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "neutronics";
+
+/// The oracle reference for this crate's Monte Carlo transport solver.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-neutronics/mc", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// transport ran for real, but the claims describe a shield that has not
+/// been measured, so a receipt built from these **rolls up Provisional,
+/// never Pass** (the same contract as `predict_physics`/`predict_print`).
+/// The computed value rides in `measured` ("what the oracle computed");
+/// run provenance and the per-claim Monte Carlo relative standard error
+/// ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "mc {}x{} histories seed {}, {} groups, {}, library {}; source {:.3e} n/s @ {:.3e} eV",
+        set.provenance.histories_per_batch,
+        set.provenance.batches,
+        set.provenance.seed,
+        set.provenance.groups,
+        set.provenance.energy_model,
+        set.provenance.library,
+        set.source.rate_n_per_s,
+        set.source.energy_ev,
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("neutronics.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(format!("{provenance}; rse {:.4}", c.rse))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::ShieldSpec;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let spec: ShieldSpec = serde_json::from_str(
+            r#"{
+              "layers": [
+                {"material": "air",  "thickness_mm": 100},
+                {"material": "hdpe", "thickness_mm": 100},
+                {"material": "air",  "thickness_mm": 400}
+              ],
+              "source": {"rate_n_per_s": 1.0e6, "energy_ev": 2.45e6},
+              "detectors": [{"label": "operator", "radius_mm": 400}],
+              "run": {"histories_per_batch": 500, "batches": 4, "seed": 7}
+            }"#,
+        )
+        .unwrap();
+        let set = predicted_claims(&spec, &BTreeMap::new()).unwrap();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("neutronics."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            let details = c.details.as_deref().unwrap_or("");
+            assert!(details.contains("mc 500x4 histories seed 7"));
+            assert!(details.contains("rse "));
+        }
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted neutronics claims must never read as verified"
+        );
+    }
+}

--- a/crates/vcad-kernel-photonics/Cargo.toml
+++ b/crates/vcad-kernel-photonics/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 vcad-gdsii = { workspace = true }
 
 [dev-dependencies]

--- a/crates/vcad-kernel-photonics/src/receipt.rs
+++ b/crates/vcad-kernel-photonics/src/receipt.rs
@@ -370,11 +370,7 @@ mod tests {
             assert_eq!(c.domain, RECEIPT_DOMAIN);
             assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
             assert!(c.measured.is_some());
-            assert!(c
-                .details
-                .as_deref()
-                .unwrap_or("")
-                .contains("grid 300x200"));
+            assert!(c.details.as_deref().unwrap_or("").contains("grid 300x200"));
         }
         let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
         assert_eq!(

--- a/crates/vcad-kernel-photonics/src/receipt.rs
+++ b/crates/vcad-kernel-photonics/src/receipt.rs
@@ -278,6 +278,62 @@ pub fn splitter_claims(
     })
 }
 
+/// Domain tag for photonics claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "photonics";
+
+/// The oracle reference for this crate's 2D FDTD solver.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-photonics/fdtd", env!("CARGO_PKG_VERSION"))
+}
+
+fn receipt_quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// FDTD run happened for real, but the claims describe a device that has
+/// not been measured, so a receipt built from these **rolls up
+/// Provisional, never Pass** (the same contract as
+/// `predict_physics`/`predict_print`). The computed value rides in
+/// `measured` ("what the oracle computed"); grid, step count, and the
+/// dispersion error ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "grid {}x{} delta {:.4}, {:.1} cells/lambda ({:.1} in core), courant {}, steps {}, cpml {:?}, pol {}, dispersion k_rel_err {:.2e}",
+        set.provenance.grid[0],
+        set.provenance.grid[1],
+        set.provenance.delta,
+        set.provenance.cells_per_lambda,
+        set.provenance.cells_per_lambda_core,
+        set.provenance.courant,
+        set.provenance.steps,
+        set.provenance.cpml_cells,
+        set.provenance.polarization,
+        set.provenance.dispersion_k_rel_error,
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("photonics.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(receipt_quantity(c.value, &c.unit))
+            .with_details(provenance.clone())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,6 +352,36 @@ mod tests {
             polarization: "TM".into(),
             dispersion_k_rel_error: 3.6e-3,
         }
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let meas = [SplitterMeasurement {
+            freq: 0.6452,
+            p_in: 2.0,
+            p_arm_a: 1.0,
+            p_arm_b: 1.0,
+        }];
+        let set = splitter_claims(&meas, 0.6452, prov(), None).unwrap();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("photonics."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            assert!(c
+                .details
+                .as_deref()
+                .unwrap_or("")
+                .contains("grid 300x200"));
+        }
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted photonics claims must never read as verified"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-thermal/Cargo.toml
+++ b/crates/vcad-kernel-thermal/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-thermal/src/receipt.rs
+++ b/crates/vcad-kernel-thermal/src/receipt.rs
@@ -373,6 +373,62 @@ pub fn compare(
     })
 }
 
+/// Domain tag for thermal claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "thermal";
+
+/// The oracle reference for this crate's steady-conduction solver.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-thermal/solve", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// solver ran for real, but the claims describe hardware that has not
+/// been measured, so a receipt built from these **rolls up Provisional,
+/// never Pass** (the same contract as `predict_physics`/`predict_print`).
+/// The computed value rides in `measured` ("what the oracle computed");
+/// solver provenance rides in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "grid {}x{}x{}, voxel {:.3}x{:.3}x{:.3} mm, cg tol {:.1e} iters {} residual {:.3e}, {}, bc [{}]",
+        set.provenance.grid[0],
+        set.provenance.grid[1],
+        set.provenance.grid[2],
+        set.provenance.voxel_mm[0],
+        set.provenance.voxel_mm[1],
+        set.provenance.voxel_mm[2],
+        set.provenance.cg_tol,
+        set.provenance.cg_iterations,
+        set.provenance.cg_residual_rel,
+        set.provenance.anisotropy,
+        set.provenance.bc_set.join("; "),
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            vcad_receipt::ReceiptClaim::pass(
+                format!("thermal.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(provenance.clone())
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -411,6 +467,29 @@ mod tests {
             .find(|c| c.name == name)
             .unwrap_or_else(|| panic!("missing claim {name}"))
             .value
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let m = chip_model();
+        let opts = SolveOptions::default();
+        let sol = solve_steady(&m, &opts).unwrap();
+        let set = predicted_claims(&m, &sol, &opts);
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("thermal."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            assert!(c.details.as_deref().unwrap_or("").contains("grid 30x30x2"));
+        }
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted thermal claims must never read as verified"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-tolerance/Cargo.toml
+++ b/crates/vcad-kernel-tolerance/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel-tolerance/src/receipt.rs
+++ b/crates/vcad-kernel-tolerance/src/receipt.rs
@@ -446,11 +446,7 @@ mod tests {
             assert_eq!(c.domain, RECEIPT_DOMAIN);
             assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
             assert!(c.measured.is_some());
-            assert!(c
-                .details
-                .as_deref()
-                .unwrap_or("")
-                .contains("monte_carlo"));
+            assert!(c.details.as_deref().unwrap_or("").contains("monte_carlo"));
         }
         // fit_probability carries its MC standard error into details.
         let fit = claims

--- a/crates/vcad-kernel-tolerance/src/receipt.rs
+++ b/crates/vcad-kernel-tolerance/src/receipt.rs
@@ -342,6 +342,60 @@ pub fn compare(
     })
 }
 
+/// Domain tag for tolerance claims in the unified [`vcad_receipt`] schema.
+pub const RECEIPT_DOMAIN: &str = "tolerance";
+
+/// The oracle reference for this crate's analysis pipeline.
+pub fn oracle() -> vcad_receipt::OracleRef {
+    vcad_receipt::OracleRef::new("vcad-kernel-tolerance/analysis", env!("CARGO_PKG_VERSION"))
+}
+
+fn quantity(value: f64, unit: &str) -> vcad_receipt::ClaimQuantity {
+    if unit == "1" {
+        vcad_receipt::ClaimQuantity::bare(value)
+    } else {
+        vcad_receipt::ClaimQuantity::new(value, unit)
+    }
+}
+
+/// Translate a predicted [`ClaimSet`] into unified-receipt claims.
+///
+/// Every claim lands with [`vcad_receipt::ClaimBasis::Predicted`] — the
+/// analyses ran for real, but they describe parts that have not been
+/// measured, so a receipt built from these **rolls up Provisional, never
+/// Pass** (the same contract as `predict_physics`/`predict_print`). The
+/// computed value rides in `measured` ("what the oracle computed");
+/// provenance and per-claim one-sigma uncertainty ride in `details`.
+pub fn design_claims(set: &ClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    let oracle = oracle();
+    let provenance = format!(
+        "analyses [{}]; mc n {} seed {} batches {}; all_normal {}",
+        set.provenance.analyses.join(", "),
+        set.provenance.n_samples,
+        set.provenance.seed,
+        set.provenance.batches,
+        set.provenance.all_normal,
+    );
+    set.claims
+        .iter()
+        .map(|c| {
+            let details = match c.uncertainty {
+                Some(u) => format!("{provenance}; one_sigma {u:.3e}"),
+                None => provenance.clone(),
+            };
+            vcad_receipt::ReceiptClaim::pass(
+                format!("tolerance.{}", c.name),
+                RECEIPT_DOMAIN,
+                c.note.clone(),
+                oracle.clone(),
+            )
+            .with_basis(vcad_receipt::ClaimBasis::Predicted)
+            .with_measured(quantity(c.value, &c.unit))
+            .with_details(details)
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -380,6 +434,38 @@ mod tests {
             .iter()
             .find(|c| c.name == name)
             .unwrap_or_else(|| panic!("missing claim {name}"))
+    }
+
+    #[test]
+    fn design_claims_ride_the_unified_receipt_as_provisional() {
+        let (_, set) = build();
+        let claims = design_claims(&set);
+        assert_eq!(claims.len(), set.claims.len());
+        for c in &claims {
+            assert!(c.id.starts_with("tolerance."));
+            assert_eq!(c.domain, RECEIPT_DOMAIN);
+            assert_eq!(c.basis, Some(vcad_receipt::ClaimBasis::Predicted));
+            assert!(c.measured.is_some());
+            assert!(c
+                .details
+                .as_deref()
+                .unwrap_or("")
+                .contains("monte_carlo"));
+        }
+        // fit_probability carries its MC standard error into details.
+        let fit = claims
+            .iter()
+            .find(|c| c.id == "tolerance.fit_probability")
+            .unwrap();
+        assert!(fit.details.as_deref().unwrap().contains("one_sigma"));
+        // The fail-closed contract: an all-pass predicted receipt rolls up
+        // Provisional, never Pass.
+        let receipt = vcad_receipt::DesignReceipt::with_claims(claims);
+        assert_eq!(
+            receipt.verdict(),
+            vcad_receipt::ReceiptVerdict::Provisional,
+            "predicted tolerance claims must never read as verified"
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -7550,3 +7550,1254 @@ pub fn particle_optimize(
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
 }
+
+// ---------------------------------------------------------------------------
+// Tolerance stackup analysis (vcad-kernel-tolerance)
+// ---------------------------------------------------------------------------
+
+/// Options for [`tolerance_analyze`] (all fields optional in JSON).
+#[derive(serde::Deserialize)]
+#[serde(default)]
+struct ToleranceOptions {
+    n: usize,
+    seed: u64,
+    batches: usize,
+}
+
+impl Default for ToleranceOptions {
+    fn default() -> Self {
+        Self {
+            n: 100_000,
+            seed: 0x5EED_7015,
+            batches: 16,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct WasmToleranceWorstCase {
+    min_gap: f64,
+    max_gap: f64,
+    margin_lower: Option<f64>,
+    margin_upper: Option<f64>,
+    passes: bool,
+}
+
+#[derive(serde::Serialize)]
+struct WasmToleranceRss {
+    mean_gap: f64,
+    sigma_gap: f64,
+    yield_estimate: f64,
+    cp: Option<f64>,
+    cpk: Option<f64>,
+    all_normal: bool,
+}
+
+#[derive(serde::Serialize)]
+struct WasmToleranceMc {
+    n: usize,
+    seed: u64,
+    batches: usize,
+    fit_probability: f64,
+    fit_standard_error: f64,
+    mean_gap: f64,
+    mean_gap_se: f64,
+    sigma_gap: f64,
+    sigma_gap_se: f64,
+    min_sample: f64,
+    max_sample: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmToleranceSensitivity {
+    name: String,
+    d_gap_d_nominal: f64,
+    sigma: f64,
+    variance_share: f64,
+    d_yield_d_nominal: f64,
+    d_yield_d_sigma: f64,
+    wc_span: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmToleranceAnalysis {
+    worst_case: WasmToleranceWorstCase,
+    rss: WasmToleranceRss,
+    monte_carlo: WasmToleranceMc,
+    sensitivities: Vec<WasmToleranceSensitivity>,
+    claim_set: vcad_kernel::vcad_kernel_tolerance::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Tolerance stackup analysis: worst-case, RSS, and seeded Monte Carlo over
+/// a linear assembly chain, plus exact sensitivities and predicted claims.
+///
+/// `spec_json` is a `vcad_kernel_tolerance::spec::StackupSpec` (named
+/// parameters allowed), `params_json` a `{name: value}` map binding them
+/// (fail-closed: unbound names error), `options_json` a
+/// [`ToleranceOptions`]. Returns all three analyses +
+/// `vcad.tolerance-claims/1` + unified-receipt claims (basis `predicted`).
+#[wasm_bindgen(js_name = toleranceAnalyze)]
+pub fn tolerance_analyze(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_tolerance as tk;
+    let spec: tk::spec::StackupSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: ToleranceOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    let stackup = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let wc = tk::analysis::worst_case(&stackup).map_err(|e| JsError::new(&e.to_string()))?;
+    let rss = tk::analysis::rss(&stackup).map_err(|e| JsError::new(&e.to_string()))?;
+    let mc_opts = tk::analysis::McOptions {
+        n: opts.n,
+        seed: opts.seed,
+        batches: opts.batches,
+    };
+    let mc =
+        tk::analysis::monte_carlo(&stackup, &mc_opts).map_err(|e| JsError::new(&e.to_string()))?;
+    let rows =
+        tk::sensitivity::sensitivities(&stackup).map_err(|e| JsError::new(&e.to_string()))?;
+    let claim_set = tk::receipt::predicted_claims(&stackup, &wc, &rss, &mc)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let receipt_claims = tk::receipt::design_claims(&claim_set);
+    let out = WasmToleranceAnalysis {
+        worst_case: WasmToleranceWorstCase {
+            min_gap: wc.min_gap,
+            max_gap: wc.max_gap,
+            margin_lower: wc.margin_lower,
+            margin_upper: wc.margin_upper,
+            passes: wc.passes,
+        },
+        rss: WasmToleranceRss {
+            mean_gap: rss.mean_gap,
+            sigma_gap: rss.sigma_gap,
+            yield_estimate: rss.yield_estimate,
+            cp: rss.cp,
+            cpk: rss.cpk,
+            all_normal: rss.all_normal,
+        },
+        monte_carlo: WasmToleranceMc {
+            n: mc.n,
+            seed: mc.seed,
+            batches: mc.batches,
+            fit_probability: mc.fit.p,
+            fit_standard_error: mc.fit.standard_error,
+            mean_gap: mc.mean_gap,
+            mean_gap_se: mc.mean_gap_se,
+            sigma_gap: mc.sigma_gap,
+            sigma_gap_se: mc.sigma_gap_se,
+            min_sample: mc.min_sample,
+            max_sample: mc.max_sample,
+        },
+        sensitivities: rows
+            .into_iter()
+            .map(|r| WasmToleranceSensitivity {
+                name: r.name,
+                d_gap_d_nominal: r.d_gap_d_nominal,
+                sigma: r.sigma,
+                variance_share: r.variance_share,
+                d_yield_d_nominal: r.d_yield_d_nominal,
+                d_yield_d_sigma: r.d_yield_d_sigma,
+                wc_span: r.wc_span,
+            })
+            .collect(),
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Heat-conduction FEA (vcad-kernel-thermal)
+// ---------------------------------------------------------------------------
+
+/// Options for [`thermal_solve`] (all fields optional in JSON).
+#[derive(serde::Deserialize)]
+#[serde(default)]
+struct ThermalOptions {
+    tol: f64,
+    max_iters: usize,
+}
+
+impl Default for ThermalOptions {
+    fn default() -> Self {
+        Self {
+            tol: 1e-8,
+            max_iters: 50_000,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct WasmThermalSource {
+    name: String,
+    power_w: f64,
+    t_max_c: f64,
+    t_max_at_mm: [f64; 3],
+    theta_c_per_w: Option<f64>,
+}
+
+#[derive(serde::Serialize)]
+struct WasmThermalEnergy {
+    source_w: f64,
+    fixed_face_out_w: f64,
+    convection_out_w: f64,
+    fixed_region_out_w: f64,
+    net_out_w: f64,
+    residual_rel: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmThermalSolve {
+    divisions: [usize; 3],
+    voxel_mm: [f64; 3],
+    t_max_c: f64,
+    t_max_at_mm: [f64; 3],
+    reference_c: Option<f64>,
+    sources: Vec<WasmThermalSource>,
+    energy: WasmThermalEnergy,
+    iterations: usize,
+    residual_rel: f64,
+    claim_set: vcad_kernel::vcad_kernel_thermal::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Steady heat-conduction solve on a voxel grid: temperature summary,
+/// per-source T_max and theta (junction-to-ambient), energy balance, and
+/// predicted claims. The full temperature field is not returned (use the
+/// claims + summaries; fields are grid-sized).
+///
+/// `spec_json` is a `vcad_kernel_thermal::spec::ThermalSpec` (named
+/// parameters allowed), `params_json` a `{name: value}` map binding them,
+/// `options_json` a [`ThermalOptions`].
+#[wasm_bindgen(js_name = thermalSolve)]
+pub fn thermal_solve(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_thermal as th;
+    let spec: th::spec::ThermalSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: ThermalOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    let model = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let n_voxels: usize = model.divisions.iter().product();
+    if n_voxels > 2_000_000 {
+        return Err(JsError::new(&format!(
+            "grid too large for the MCP tier: {n_voxels} voxels (cap 2,000,000) — lower `divisions`"
+        )));
+    }
+    let sopts = th::solve::SolveOptions {
+        tol: opts.tol,
+        max_iters: opts.max_iters,
+    };
+    let sol = th::solve::solve_steady(&model, &sopts).map_err(|e| JsError::new(&e.to_string()))?;
+    let claim_set = th::receipt::predicted_claims(&model, &sol, &sopts);
+    let receipt_claims = th::receipt::design_claims(&claim_set);
+    let out = WasmThermalSolve {
+        divisions: sol.divisions,
+        voxel_mm: sol.voxel_mm,
+        t_max_c: sol.t_max_c,
+        t_max_at_mm: sol.t_max_at_mm,
+        reference_c: sol.reference_c,
+        sources: sol
+            .sources
+            .iter()
+            .map(|s| WasmThermalSource {
+                name: s.name.clone(),
+                power_w: s.power_w,
+                t_max_c: s.t_max_c,
+                t_max_at_mm: s.t_max_at_mm,
+                theta_c_per_w: s.theta_c_per_w,
+            })
+            .collect(),
+        energy: WasmThermalEnergy {
+            source_w: sol.energy.source_w,
+            fixed_face_out_w: sol.energy.fixed_face_out_w,
+            convection_out_w: sol.energy.convection_out_w,
+            fixed_region_out_w: sol.energy.fixed_region_out_w,
+            net_out_w: sol.energy.net_out_w,
+            residual_rel: sol.energy.residual_rel,
+        },
+        iterations: sol.iterations,
+        residual_rel: sol.residual_rel,
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Electromagnetic field solver (vcad-kernel-em)
+// ---------------------------------------------------------------------------
+
+/// Problem-class tag read from the spec JSON before full deserialization.
+#[derive(serde::Deserialize)]
+struct EmProblemTag {
+    problem: String,
+}
+
+/// Wire shape for the electrostatic problem class (literal-only DTO — the
+/// crate's serde seam covers only the magnetostatic classes).
+#[derive(serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WasmEmShape {
+    Rect {
+        x_min_mm: f64,
+        x_max_mm: f64,
+        y_min_mm: f64,
+        y_max_mm: f64,
+    },
+    Circle {
+        cx_mm: f64,
+        cy_mm: f64,
+        radius_mm: f64,
+    },
+    CircleShell {
+        cx_mm: f64,
+        cy_mm: f64,
+        r_inner_mm: f64,
+        r_outer_mm: f64,
+    },
+}
+
+impl WasmEmShape {
+    fn to_shape(&self) -> vcad_kernel::vcad_kernel_em::electro::Shape {
+        use vcad_kernel::vcad_kernel_em::electro::Shape;
+        match *self {
+            WasmEmShape::Rect {
+                x_min_mm,
+                x_max_mm,
+                y_min_mm,
+                y_max_mm,
+            } => Shape::Rect {
+                x_min_mm,
+                x_max_mm,
+                y_min_mm,
+                y_max_mm,
+            },
+            WasmEmShape::Circle {
+                cx_mm,
+                cy_mm,
+                radius_mm,
+            } => Shape::Circle {
+                cx_mm,
+                cy_mm,
+                radius_mm,
+            },
+            WasmEmShape::CircleShell {
+                cx_mm,
+                cy_mm,
+                r_inner_mm,
+                r_outer_mm,
+            } => Shape::CircleShell {
+                cx_mm,
+                cy_mm,
+                r_inner_mm,
+                r_outer_mm,
+            },
+        }
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct WasmElectrodeSpec {
+    shape: WasmEmShape,
+    potential_v: f64,
+}
+
+#[derive(serde::Deserialize)]
+struct WasmDielectricSpec {
+    shape: WasmEmShape,
+    eps_r: f64,
+}
+
+#[derive(serde::Deserialize)]
+struct WasmElectroSpec {
+    /// "axisymmetric" (x = radius, x_min must be 0) or "planar".
+    geometry: String,
+    x_min_mm: f64,
+    x_max_mm: f64,
+    y_min_mm: f64,
+    y_max_mm: f64,
+    electrodes: Vec<WasmElectrodeSpec>,
+    #[serde(default)]
+    dielectrics: Vec<WasmDielectricSpec>,
+}
+
+/// Stress-tensor probe for the axisym force cross-check.
+#[derive(serde::Deserialize)]
+struct WasmEmStressProbe {
+    r_mm: f64,
+    z_lo_mm: f64,
+    z_hi_mm: f64,
+    #[serde(default = "em_stress_panels")]
+    panels: usize,
+}
+
+fn em_stress_panels() -> usize {
+    64
+}
+
+/// Torque extraction request for the planar problem class.
+#[derive(serde::Deserialize)]
+struct WasmEmTorqueSpec {
+    cx_mm: f64,
+    cy_mm: f64,
+    r_mean_m: f64,
+    depth_m: f64,
+    #[serde(default)]
+    stress_line_y_mm: Option<f64>,
+}
+
+/// Options for [`em_simulate`] (all fields optional in JSON except the
+/// planar class's `torque`).
+#[derive(serde::Deserialize)]
+#[serde(default)]
+struct EmSimOptions {
+    nx: usize,
+    ny: usize,
+    tol: f64,
+    max_sweeps: usize,
+    /// Axisym: which coil the inductance claim is priced for.
+    drive_coil: usize,
+    /// Axisym: also emit force claims for this coil.
+    force_coil: Option<usize>,
+    /// Axisym: Maxwell-stress cylinder for the force cross-route residual.
+    stress_probe: Option<WasmEmStressProbe>,
+    /// Planar: torque center/radius/depth (required for planar claims).
+    torque: Option<WasmEmTorqueSpec>,
+    /// Electrostatics: index of the driven (nonzero-potential) electrode.
+    hot: usize,
+}
+
+impl Default for EmSimOptions {
+    fn default() -> Self {
+        Self {
+            nx: 81,
+            ny: 81,
+            tol: 1e-8,
+            max_sweeps: 200_000,
+            drive_coil: 0,
+            force_coil: None,
+            stress_probe: None,
+            torque: None,
+            hot: 0,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct WasmEmPicard {
+    iterations: usize,
+    max_rel_delta: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmEmSim {
+    problem: String,
+    sweeps: usize,
+    residual: f64,
+    picard: Option<WasmEmPicard>,
+    qois: serde_json::Value,
+    claim_sets: Vec<vcad_kernel::vcad_kernel_em::receipt::ClaimSet>,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+fn em_solve_options(opts: &EmSimOptions) -> vcad_kernel::vcad_kernel_em::grid::SolveOptions {
+    vcad_kernel::vcad_kernel_em::grid::SolveOptions {
+        omega: 0.0,
+        tol: opts.tol,
+        max_sweeps: opts.max_sweeps,
+    }
+}
+
+/// Electromagnetic field simulation: 2D/axisymmetric finite-volume
+/// magnetostatics and electrostatics with L / force / torque / C
+/// extraction and predicted claims.
+///
+/// `spec_json` must carry a `problem` tag: `axisym_magnetostatics`
+/// (rest of spec = `vcad_kernel_em::spec::AxisymSpec`, named parameters
+/// allowed), `planar_magnetostatics` (`PlanarSpec`, named parameters
+/// allowed), or `electrostatics` (a literal-only electrode/dielectric
+/// DTO — the crate has no serde seam for that class yet). `params_json`
+/// binds named parameters; `options_json` is [`EmSimOptions`].
+#[wasm_bindgen(js_name = emSimulate)]
+pub fn em_simulate(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_em as em;
+    let tag: EmProblemTag = serde_json::from_str(spec_json)
+        .map_err(|e| JsError::new(&format!("bad spec (need a `problem` tag): {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: EmSimOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    if opts.nx * opts.ny > 4_000_000 {
+        return Err(JsError::new(
+            "grid too large for the MCP tier: nx*ny capped at 4,000,000 nodes",
+        ));
+    }
+    let sopts = em_solve_options(&opts);
+
+    match tag.problem.as_str() {
+        "axisym_magnetostatics" => {
+            let spec: em::spec::AxisymSpec = serde_json::from_str(spec_json)
+                .map_err(|e| JsError::new(&format!("bad axisym spec: {e}")))?;
+            let dev = spec
+                .resolve(&params)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            if dev.coils.is_empty() {
+                return Err(JsError::new("axisym_magnetostatics needs at least one coil"));
+            }
+            if opts.drive_coil >= dev.coils.len() {
+                return Err(JsError::new(&format!(
+                    "drive_coil {} out of range ({} coils)",
+                    opts.drive_coil,
+                    dev.coils.len()
+                )));
+            }
+            let nonlinear = dev.materials.iter().any(|m| m.sat.is_some());
+            let (sol, picard) = if nonlinear {
+                let popts = em::axisym::PicardOptions::default();
+                let (sol, report) = dev
+                    .solve_nonlinear(opts.nx, opts.ny, &sopts, &popts)
+                    .map_err(|e| JsError::new(&e.to_string()))?;
+                (
+                    sol,
+                    Some(WasmEmPicard {
+                        iterations: report.iterations,
+                        max_rel_delta: report.max_rel_delta,
+                    }),
+                )
+            } else {
+                (
+                    dev.solve(opts.nx, opts.ny, &sopts)
+                        .map_err(|e| JsError::new(&e.to_string()))?,
+                    None,
+                )
+            };
+            let n_coils = dev.coils.len();
+            let flux_linkages: Vec<f64> = (0..n_coils).map(|k| sol.flux_linkage(k)).collect();
+            let forces: Vec<f64> = (0..n_coils).map(|k| sol.axial_force_on_coil(k)).collect();
+            let energy = sol.energy();
+            let mut claim_sets = vec![em::receipt::axisym_inductance_claims(
+                &sol,
+                opts.drive_coil,
+                sopts.tol,
+                None,
+            )];
+            if let Some(k) = opts.force_coil {
+                if k >= n_coils {
+                    return Err(JsError::new(&format!(
+                        "force_coil {k} out of range ({n_coils} coils)"
+                    )));
+                }
+                let probe = opts
+                    .stress_probe
+                    .as_ref()
+                    .map(|p| (p.r_mm, p.z_lo_mm, p.z_hi_mm, p.panels));
+                claim_sets.push(em::receipt::axisym_force_claims(&sol, k, sopts.tol, probe));
+            }
+            let receipt_claims: Vec<vcad_receipt::ReceiptClaim> = claim_sets
+                .iter()
+                .flat_map(em::receipt::design_claims)
+                .collect();
+            let out = WasmEmSim {
+                problem: tag.problem,
+                sweeps: sol.sweeps,
+                residual: sol.residual,
+                picard,
+                qois: serde_json::json!({
+                    "self_inductance_h": sol.self_inductance(opts.drive_coil),
+                    "flux_linkages_wb_t": flux_linkages,
+                    "axial_forces_n": forces,
+                    "field_energy_j": energy.field,
+                    "source_energy_j": energy.source,
+                    "energy_residual": energy.residual,
+                }),
+                claim_sets,
+                receipt_claims,
+            };
+            let ser = serde_wasm_bindgen::Serializer::json_compatible();
+            serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+        }
+        "planar_magnetostatics" => {
+            let spec: em::spec::PlanarSpec = serde_json::from_str(spec_json)
+                .map_err(|e| JsError::new(&format!("bad planar spec: {e}")))?;
+            let dev = spec
+                .resolve(&params)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            let torque = opts.torque.as_ref().ok_or_else(|| {
+                JsError::new(
+                    "planar_magnetostatics requires options.torque \
+                     ({cx_mm, cy_mm, r_mean_m, depth_m}) — the crate's planar claim \
+                     family prices torque",
+                )
+            })?;
+            let nonlinear = dev.materials.iter().any(|m| m.sat.is_some());
+            let (sol, picard) = if nonlinear {
+                let popts = em::axisym::PicardOptions::default();
+                let (sol, report) = dev
+                    .solve_nonlinear(opts.nx, opts.ny, &sopts, &popts)
+                    .map_err(|e| JsError::new(&e.to_string()))?;
+                (
+                    sol,
+                    Some(WasmEmPicard {
+                        iterations: report.iterations,
+                        max_rel_delta: report.max_rel_delta,
+                    }),
+                )
+            } else {
+                (
+                    dev.solve(opts.nx, opts.ny, &sopts)
+                        .map_err(|e| JsError::new(&e.to_string()))?,
+                    None,
+                )
+            };
+            let conductor_forces: Vec<[f64; 2]> = (0..dev.conductors.len())
+                .map(|k| {
+                    let (fx, fy) = sol.force_on_conductor(k);
+                    [fx, fy]
+                })
+                .collect();
+            let magnet_forces: Vec<[f64; 2]> = (0..dev.magnets.len())
+                .map(|k| {
+                    let (fx, fy) = sol.force_on_magnet(k);
+                    [fx, fy]
+                })
+                .collect();
+            let energy = sol.energy_per_m();
+            let claim_sets = vec![em::receipt::planar_torque_claims(
+                &sol,
+                torque.cx_mm,
+                torque.cy_mm,
+                torque.r_mean_m,
+                torque.depth_m,
+                sopts.tol,
+                torque.stress_line_y_mm,
+            )];
+            let receipt_claims: Vec<vcad_receipt::ReceiptClaim> = claim_sets
+                .iter()
+                .flat_map(em::receipt::design_claims)
+                .collect();
+            let out = WasmEmSim {
+                problem: tag.problem,
+                sweeps: sol.sweeps,
+                residual: sol.residual,
+                picard,
+                qois: serde_json::json!({
+                    "conductor_forces_n_per_m": conductor_forces,
+                    "magnet_forces_n_per_m": magnet_forces,
+                    "field_energy_j_per_m": energy.field,
+                    "source_energy_j_per_m": energy.source,
+                    "energy_residual": energy.residual,
+                }),
+                claim_sets,
+                receipt_claims,
+            };
+            let ser = serde_wasm_bindgen::Serializer::json_compatible();
+            serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+        }
+        "electrostatics" => {
+            let spec: WasmElectroSpec = serde_json::from_str(spec_json)
+                .map_err(|e| JsError::new(&format!("bad electrostatics spec: {e}")))?;
+            let geometry = match spec.geometry.as_str() {
+                "axisymmetric" => {
+                    if spec.x_min_mm != 0.0 {
+                        return Err(JsError::new(
+                            "axisymmetric electrostatics requires x_min_mm == 0 (x is radius)",
+                        ));
+                    }
+                    em::electro::Geometry::Axisymmetric
+                }
+                "planar" => em::electro::Geometry::Planar,
+                other => {
+                    return Err(JsError::new(&format!(
+                        "unknown electrostatics geometry `{other}` (use \"axisymmetric\" or \"planar\")"
+                    )))
+                }
+            };
+            if spec.electrodes.len() < 2 {
+                return Err(JsError::new(
+                    "electrostatics needs at least two electrodes (a driven one and a return)",
+                ));
+            }
+            if opts.hot >= spec.electrodes.len() {
+                return Err(JsError::new(&format!(
+                    "hot electrode {} out of range ({} electrodes)",
+                    opts.hot,
+                    spec.electrodes.len()
+                )));
+            }
+            if spec.electrodes[opts.hot].potential_v == 0.0 {
+                return Err(JsError::new(
+                    "the hot electrode must have a nonzero potential",
+                ));
+            }
+            let mut dev = em::electro::Electrostatics::new(
+                geometry,
+                spec.x_min_mm,
+                spec.x_max_mm,
+                spec.y_min_mm,
+                spec.y_max_mm,
+            );
+            for e in &spec.electrodes {
+                dev.electrodes.push(em::electro::Electrode {
+                    shape: e.shape.to_shape(),
+                    potential_v: e.potential_v,
+                });
+            }
+            for d in &spec.dielectrics {
+                dev.dielectrics.push(em::electro::Dielectric {
+                    shape: d.shape.to_shape(),
+                    eps_r: d.eps_r,
+                });
+            }
+            let sol = dev
+                .solve(opts.nx, opts.ny, &sopts)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            let cap = sol.capacitance_two_terminal(opts.hot);
+            let charges: Vec<f64> = (0..spec.electrodes.len()).map(|k| sol.charge(k)).collect();
+            let claim_sets = vec![em::receipt::capacitance_claims(&sol, opts.hot, sopts.tol)];
+            let receipt_claims: Vec<vcad_receipt::ReceiptClaim> = claim_sets
+                .iter()
+                .flat_map(em::receipt::design_claims)
+                .collect();
+            let out = WasmEmSim {
+                problem: tag.problem,
+                sweeps: sol.sweeps,
+                residual: sol.residual,
+                picard: None,
+                qois: serde_json::json!({
+                    "capacitance_f": cap.from_charge,
+                    "capacitance_from_energy_f": cap.from_energy,
+                    "capacitance_route_mismatch": cap.mismatch(),
+                    "charges": charges,
+                    "field_energy": sol.energy(),
+                }),
+                claim_sets,
+                receipt_claims,
+            };
+            let ser = serde_wasm_bindgen::Serializer::json_compatible();
+            serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+        }
+        other => Err(JsError::new(&format!(
+            "unknown em problem `{other}` (use axisym_magnetostatics, planar_magnetostatics, or electrostatics)"
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Thin-wire MoM antenna solver (vcad-kernel-antenna)
+// ---------------------------------------------------------------------------
+
+/// Options for [`antenna_analyze`]. `band` is required; the rest default.
+#[derive(serde::Deserialize)]
+struct AntennaOptions {
+    band: vcad_kernel::vcad_kernel_antenna::receipt::FrequencyBand,
+    #[serde(default = "antenna_z0")]
+    z0: f64,
+    #[serde(default = "antenna_quad")]
+    quad_outer: usize,
+    #[serde(default = "antenna_quad")]
+    quad_inner: usize,
+    /// Also return the per-frequency sweep rows (Z_in, S11). Default true.
+    #[serde(default = "antenna_sweep_default")]
+    sweep: bool,
+}
+
+fn antenna_z0() -> f64 {
+    50.0
+}
+fn antenna_quad() -> usize {
+    6
+}
+fn antenna_sweep_default() -> bool {
+    true
+}
+
+#[derive(serde::Serialize)]
+struct WasmAntennaSweepRow {
+    freq_hz: f64,
+    z_re_ohm: f64,
+    z_im_ohm: f64,
+    s11_db: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmAntennaAnalysis {
+    segments: usize,
+    bases: usize,
+    feed_basis: usize,
+    sweep: Vec<WasmAntennaSweepRow>,
+    claim_set: vcad_kernel::vcad_kernel_antenna::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Thin-wire MoM antenna analysis: sweep Z_in and S11 over a band, find
+/// the in-band resonance, scan the far-field pattern for peak gain, and
+/// return the `vcad.antenna-claims/1` set + unified-receipt claims.
+///
+/// `spec_json` is a `vcad_kernel_antenna::spec::AntennaSpec` (named
+/// parameters allowed), `params_json` a `{name: value}` map binding them,
+/// `options_json` an [`AntennaOptions`] (the frequency `band` is
+/// required).
+#[wasm_bindgen(js_name = antennaAnalyze)]
+pub fn antenna_analyze(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_antenna as ak;
+    let spec: ak::spec::AntennaSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: AntennaOptions = serde_json::from_str(options_json)
+        .map_err(|e| JsError::new(&format!("bad options (a frequency band is required): {e}")))?;
+    if opts.band.points < 2 || opts.band.points > 2000 {
+        return Err(JsError::new("band.points must be in 2..=2000"));
+    }
+    if !(opts.band.f_lo_hz > 0.0 && opts.band.f_hi_hz > opts.band.f_lo_hz) {
+        return Err(JsError::new("band must satisfy 0 < f_lo_hz < f_hi_hz"));
+    }
+    let (mesh, feed) = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    if mesh.segments.len() > 600 {
+        return Err(JsError::new(&format!(
+            "mesh too large for the MCP tier: {} segments (cap 600; MoM cost is O(N^3) per frequency)",
+            mesh.segments.len()
+        )));
+    }
+    let sopts = ak::mom::SolveOptions {
+        quad_outer: opts.quad_outer,
+        quad_inner: opts.quad_inner,
+    };
+    let claim_set = ak::receipt::predicted_claims(&mesh, feed, opts.band, opts.z0, &sopts)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let receipt_claims = ak::receipt::design_claims(&claim_set);
+    let sweep_rows = if opts.sweep {
+        let n = opts.band.points;
+        let freqs: Vec<f64> = (0..n)
+            .map(|i| {
+                opts.band.f_lo_hz
+                    + (opts.band.f_hi_hz - opts.band.f_lo_hz) * i as f64 / (n - 1) as f64
+            })
+            .collect();
+        ak::mom::sweep(&mesh, feed, &freqs, opts.z0, &sopts)
+            .map_err(|e| JsError::new(&e.to_string()))?
+            .into_iter()
+            .map(|p| WasmAntennaSweepRow {
+                freq_hz: p.freq_hz,
+                z_re_ohm: p.z_in.re,
+                z_im_ohm: p.z_in.im,
+                s11_db: p.s11_db,
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let out = WasmAntennaAnalysis {
+        segments: mesh.segments.len(),
+        bases: mesh.bases.len(),
+        feed_basis: feed,
+        sweep: sweep_rows,
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// 2D FDTD photonics (vcad-kernel-photonics)
+// ---------------------------------------------------------------------------
+
+/// Slab-mode line source for [`photonics_simulate`].
+#[derive(serde::Deserialize)]
+struct WasmPhotonicsSource {
+    x_um: f64,
+    #[serde(default)]
+    center_y_um: Option<f64>,
+    half_width_um: f64,
+}
+
+/// Output flux monitor (vertical line at `x_um`, optional y-window).
+#[derive(serde::Deserialize)]
+struct WasmPhotonicsMonitor {
+    x_um: f64,
+    #[serde(default)]
+    y_lo_um: Option<f64>,
+    #[serde(default)]
+    y_hi_um: Option<f64>,
+}
+
+/// Forward FDTD device spec for [`photonics_simulate`] (literal-only DTO —
+/// the crate's serde seam covers only topology-optimization problems; a
+/// forward run is assembled imperatively from this shape).
+#[derive(serde::Deserialize)]
+struct WasmPhotonicsSpec {
+    /// Vacuum wavelength; 1 length unit = 1 um throughout.
+    wavelength_um: f64,
+    n_core: f64,
+    n_clad: f64,
+    /// Domain size [lx, ly] in um.
+    size_um: [f64; 2],
+    /// Core rectangles [x0, y0, x1, y1] painted at n_core^2.
+    core_rects_um: Vec<[f64; 4]>,
+    source: WasmPhotonicsSource,
+    /// Input-power flux monitor x position (between source and device).
+    monitor_in_x_um: f64,
+    /// One or two output monitors (two = splitter arms).
+    outputs: Vec<WasmPhotonicsMonitor>,
+}
+
+/// Options for [`photonics_simulate`] (all fields optional in JSON).
+#[derive(serde::Deserialize)]
+#[serde(default)]
+struct PhotonicsOptions {
+    /// Cells per vacuum wavelength.
+    resolution: usize,
+    steps: usize,
+    cpml_cells: usize,
+    courant: f64,
+    /// Number of monitor frequencies (forced odd so the center lands
+    /// exactly); 1 = center frequency only.
+    n_freqs: usize,
+    /// Fractional bandwidth spanned when n_freqs > 1.
+    band_frac: f64,
+}
+
+impl Default for PhotonicsOptions {
+    fn default() -> Self {
+        Self {
+            resolution: 20,
+            steps: 3000,
+            cpml_cells: 12,
+            courant: 0.5,
+            n_freqs: 1,
+            band_frac: 0.2,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct WasmPhotonicsSim {
+    grid: [usize; 2],
+    delta_um: f64,
+    n_eff: f64,
+    freqs: Vec<f64>,
+    claim_set: vcad_kernel::vcad_kernel_photonics::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Forward 2D TM FDTD run of a rect-composed photonic device: slab-mode
+/// line source, input + output flux monitors, transmission spectrum, and
+/// predicted claims (the splitter claim family; a single-output device
+/// reads arm B as zero).
+#[wasm_bindgen(js_name = photonicsSimulate)]
+pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_photonics as ph;
+    let spec: WasmPhotonicsSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let opts: PhotonicsOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    if !(spec.wavelength_um > 0.0) {
+        return Err(JsError::new("wavelength_um must be positive"));
+    }
+    if !(spec.n_core > spec.n_clad && spec.n_clad >= 1.0) {
+        return Err(JsError::new("need n_core > n_clad >= 1"));
+    }
+    if opts.resolution < 8 {
+        return Err(JsError::new("resolution must be >= 8 cells per wavelength"));
+    }
+    if opts.steps == 0 || opts.steps > 100_000 {
+        return Err(JsError::new("steps must be in 1..=100000"));
+    }
+    if !(opts.courant > 0.0 && opts.courant <= 1.0) {
+        return Err(JsError::new("courant must be in (0, 1]"));
+    }
+    if spec.outputs.is_empty() || spec.outputs.len() > 2 {
+        return Err(JsError::new("outputs must have one or two monitors"));
+    }
+    let delta = spec.wavelength_um / opts.resolution as f64;
+    let nx = (spec.size_um[0] / delta).round() as usize;
+    let ny = (spec.size_um[1] / delta).round() as usize;
+    if nx * ny > 2_000_000 {
+        return Err(JsError::new(&format!(
+            "grid too large for the MCP tier: {nx}x{ny} cells (cap 2,000,000) — lower resolution or size"
+        )));
+    }
+    let margin = opts.cpml_cells + 2;
+    if nx < 2 * margin + 8 || ny < 2 * margin + 8 {
+        return Err(JsError::new(
+            "domain too small for the CPML margins — grow size_um or shrink cpml_cells",
+        ));
+    }
+    let f0 = 1.0 / spec.wavelength_um;
+    let k = if opts.n_freqs <= 1 {
+        1
+    } else {
+        opts.n_freqs.min(41) | 1
+    };
+    let freqs: Vec<f64> = if k == 1 {
+        vec![f0]
+    } else {
+        let b = opts.band_frac;
+        (0..k)
+            .map(|i| {
+                if i == k / 2 {
+                    f0
+                } else {
+                    f0 * (1.0 - b / 2.0 + b * i as f64 / (k - 1) as f64)
+                }
+            })
+            .collect()
+    };
+    let mode = ph::solve_slab_mode_even(
+        spec.n_core,
+        spec.n_clad,
+        spec.source.half_width_um,
+        spec.wavelength_um,
+        ph::Polarization::Tm,
+    )
+    .map_err(|e| JsError::new(&format!("slab mode: {e}")))?;
+
+    let to_i = |x_um: f64| -> Result<usize, JsError> {
+        let i = (x_um / delta).round() as isize;
+        if i < margin as isize || i as usize >= nx - margin {
+            return Err(JsError::new(&format!(
+                "x = {x_um} um lands at cell {i}, outside the usable interior [{margin}, {}]",
+                nx - margin - 1
+            )));
+        }
+        Ok(i as usize)
+    };
+    let j_lo_default = margin;
+    let j_hi_default = ny - margin - 1;
+    let to_j_window = |lo: Option<f64>, hi: Option<f64>| -> Result<(usize, usize), JsError> {
+        let j0 = match lo {
+            Some(y) => ((y / delta).round() as isize).max(j_lo_default as isize) as usize,
+            None => j_lo_default,
+        };
+        let j1 = match hi {
+            Some(y) => ((y / delta).round() as isize).min(j_hi_default as isize) as usize,
+            None => j_hi_default,
+        };
+        if j0 >= j1 {
+            return Err(JsError::new("monitor y-window is empty"));
+        }
+        Ok((j0, j1))
+    };
+
+    let mut sim =
+        ph::sim::Simulation::new(ph::grid::GridSpec::new(nx, ny, delta), ph::Polarization::Tm);
+    sim.set_cpml(ph::CpmlSpec::uniform(opts.cpml_cells));
+    sim.set_courant(opts.courant);
+    sim.fill_epsilon(spec.n_clad * spec.n_clad);
+    for r in &spec.core_rects_um {
+        if !(r[2] > r[0] && r[3] > r[1]) {
+            return Err(JsError::new(
+                "core rect must have x1 > x0 and y1 > y0 (um coordinates)",
+            ));
+        }
+        sim.paint(
+            &ph::material::Shape2::rect(r[0], r[1], r[2], r[3]),
+            spec.n_core * spec.n_core,
+        );
+    }
+    let jc = spec.source.center_y_um.unwrap_or(spec.size_um[1] / 2.0) / delta;
+    let src_i = to_i(spec.source.x_um)?;
+    let (sj0, sj1) = (j_lo_default, j_hi_default);
+    let profile: Vec<f64> = (sj0..=sj1)
+        .map(|j| mode.profile((j as f64 - jc) * delta))
+        .collect();
+    sim.add_source(ph::source::Source::line_profile(
+        src_i,
+        sj0,
+        profile,
+        ph::Waveform::gaussian(f0, f0 / 4.0),
+    ));
+    let in_i = to_i(spec.monitor_in_x_um)?;
+    let f_in = sim.add_flux(ph::monitor::FluxSpec::Vertical {
+        i: in_i,
+        j0: sj0,
+        j1: sj1,
+        freqs: freqs.clone(),
+    });
+    let mut f_outs = Vec::new();
+    for m in &spec.outputs {
+        let (j0, j1) = to_j_window(m.y_lo_um, m.y_hi_um)?;
+        let i = to_i(m.x_um)?;
+        f_outs.push(sim.add_flux(ph::monitor::FluxSpec::Vertical {
+            i,
+            j0,
+            j1,
+            freqs: freqs.clone(),
+        }));
+    }
+    sim.run(opts.steps);
+
+    let p_in = sim.flux_power(f_in);
+    let p_a = sim.flux_power(f_outs[0]);
+    let p_b = f_outs.get(1).map(|id| sim.flux_power(*id));
+    let meas: Vec<ph::receipt::SplitterMeasurement> = (0..freqs.len())
+        .map(|i| ph::receipt::SplitterMeasurement {
+            freq: freqs[i],
+            p_in: p_in[i].1,
+            p_arm_a: p_a[i].1,
+            p_arm_b: p_b.as_ref().map(|p| p[i].1).unwrap_or(0.0),
+        })
+        .collect();
+    let provenance =
+        ph::receipt::SolverProvenance::from_sim(&sim, spec.wavelength_um, spec.n_core, opts.steps);
+    let claim_set = ph::receipt::splitter_claims(&meas, f0, provenance, None)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let receipt_claims = ph::receipt::design_claims(&claim_set);
+    let out = WasmPhotonicsSim {
+        grid: [nx, ny],
+        delta_um: delta,
+        n_eff: mode.n_eff,
+        freqs,
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Monte Carlo neutron shielding (vcad-kernel-neutronics)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct WasmNeutronicsEstimate {
+    mean: f64,
+    rse: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmNeutronicsDetector {
+    label: String,
+    dose_usv_per_h: f64,
+    rse: f64,
+}
+
+#[derive(serde::Serialize)]
+struct WasmNeutronicsSim {
+    detectors: Vec<WasmNeutronicsDetector>,
+    absorbed: WasmNeutronicsEstimate,
+    leaked_out: WasmNeutronicsEstimate,
+    balance_max_dev: f64,
+    total_histories: u64,
+    claim_set: vcad_kernel::vcad_kernel_neutronics::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Monte Carlo neutron shielding run: spherical layer stack, D-D-band
+/// point source, dose at detector shells WITH statistical error bars, and
+/// predicted claims (fail-closed: truncated histories or unscored tallies
+/// refuse to price claims).
+///
+/// `spec_json` is a `vcad_kernel_neutronics::spec::ShieldSpec` (named
+/// parameters allowed; histories/batches/seed ride inside its `run`
+/// block), `params_json` a `{name: value}` map binding them.
+#[wasm_bindgen(js_name = neutronicsSimulate)]
+pub fn neutronics_simulate(spec_json: &str, params_json: &str) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_neutronics as nk;
+    let spec: nk::spec::ShieldSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let total_requested = spec
+        .run
+        .histories_per_batch
+        .saturating_mul(spec.run.batches);
+    if total_requested > 5_000_000 {
+        return Err(JsError::new(&format!(
+            "too many histories for the MCP tier: {total_requested} (cap 5,000,000) — error bars scale as 1/sqrt(N)"
+        )));
+    }
+    let (doses, result) =
+        nk::spec::evaluate(&spec, &params).map_err(|e| JsError::new(&e.to_string()))?;
+    let resolved = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let claim_set =
+        nk::receipt::claims_from_run(&spec, &resolved.detector_regions, &doses, &result, &params)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+    let receipt_claims = nk::receipt::design_claims(&claim_set);
+    let out = WasmNeutronicsSim {
+        detectors: doses
+            .iter()
+            .map(|d| WasmNeutronicsDetector {
+                label: d.label.clone(),
+                dose_usv_per_h: d.dose_usv_per_h.mean,
+                rse: d.dose_usv_per_h.rse,
+            })
+            .collect(),
+        absorbed: WasmNeutronicsEstimate {
+            mean: result.absorbed.mean,
+            rse: result.absorbed.rse,
+        },
+        leaked_out: WasmNeutronicsEstimate {
+            mean: result.leaked_out.mean,
+            rse: result.leaked_out.rse,
+        },
+        balance_max_dev: result.balance_max_dev,
+        total_histories: result.total_histories,
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -8548,7 +8548,7 @@ pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue
         serde_json::from_str(options_json)
             .map_err(|e| JsError::new(&format!("bad options: {e}")))?
     };
-    if !(spec.wavelength_um > 0.0) {
+    if spec.wavelength_um.is_nan() || spec.wavelength_um <= 0.0 {
         return Err(JsError::new("wavelength_um must be positive"));
     }
     if !(spec.n_core > spec.n_clad && spec.n_clad >= 1.0) {

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -27,6 +27,12 @@ vcad-kernel-cam = { workspace = true }
 vcad-kernel-stocksim = { workspace = true }
 vcad-kernel-topopt = { workspace = true }
 vcad-kernel-particle = { workspace = true }
+vcad-kernel-antenna = { workspace = true }
+vcad-kernel-em = { workspace = true }
+vcad-kernel-neutronics = { workspace = true }
+vcad-kernel-photonics = { workspace = true }
+vcad-kernel-thermal = { workspace = true }
+vcad-kernel-tolerance = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -17,15 +17,19 @@
 
 use std::path::Path;
 
+pub use vcad_kernel_antenna;
 pub use vcad_kernel_booleans;
 pub use vcad_kernel_cam;
 pub use vcad_kernel_constraints;
 pub use vcad_kernel_cost;
 pub use vcad_kernel_dfm;
+pub use vcad_kernel_em;
 pub use vcad_kernel_fillet;
 pub use vcad_kernel_geom;
 pub use vcad_kernel_math;
+pub use vcad_kernel_neutronics;
 pub use vcad_kernel_particle;
+pub use vcad_kernel_photonics;
 pub use vcad_kernel_primitives;
 pub use vcad_kernel_sheet;
 pub use vcad_kernel_shell;
@@ -35,6 +39,8 @@ pub use vcad_kernel_stocksim;
 pub use vcad_kernel_sweep;
 pub use vcad_kernel_tessellate;
 pub use vcad_kernel_text;
+pub use vcad_kernel_thermal;
+pub use vcad_kernel_tolerance;
 pub use vcad_kernel_topo;
 pub use vcad_kernel_topopt;
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -454,6 +454,34 @@ export interface KernelModule {
     paramsJson: string,
     optimizeJson: string,
   ) => unknown;
+  /** Tolerance stackup analysis (StackupSpec/params/options JSON). */
+  toleranceAnalyze?: (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
+  /** Steady heat-conduction solve (ThermalSpec/params/options JSON). */
+  thermalSolve?: (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
+  /** EM field simulation (problem-tagged spec/params/options JSON). */
+  emSimulate?: (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
+  /** Thin-wire MoM antenna analysis (AntennaSpec/params/options JSON). */
+  antennaAnalyze?: (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
+  /** Forward 2D FDTD photonics run (device spec/options JSON). */
+  photonicsSimulate?: (specJson: string, optionsJson: string) => unknown;
+  /** Monte Carlo neutron shielding run (ShieldSpec/params JSON). */
+  neutronicsSimulate?: (specJson: string, paramsJson: string) => unknown;
   /** Static structural analysis of a box solid. */
   analyzeStaticsBox?: (
     specJson: string,
@@ -829,6 +857,12 @@ export class Engine {
       topologyOptimizeMesh: (wasmModule as Record<string, unknown>).topologyOptimizeMesh as KernelModule["topologyOptimizeMesh"],
       particleSimulate: (wasmModule as Record<string, unknown>).particleSimulate as KernelModule["particleSimulate"],
       particleOptimize: (wasmModule as Record<string, unknown>).particleOptimize as KernelModule["particleOptimize"],
+      toleranceAnalyze: (wasmModule as Record<string, unknown>).toleranceAnalyze as KernelModule["toleranceAnalyze"],
+      thermalSolve: (wasmModule as Record<string, unknown>).thermalSolve as KernelModule["thermalSolve"],
+      emSimulate: (wasmModule as Record<string, unknown>).emSimulate as KernelModule["emSimulate"],
+      antennaAnalyze: (wasmModule as Record<string, unknown>).antennaAnalyze as KernelModule["antennaAnalyze"],
+      photonicsSimulate: (wasmModule as Record<string, unknown>).photonicsSimulate as KernelModule["photonicsSimulate"],
+      neutronicsSimulate: (wasmModule as Record<string, unknown>).neutronicsSimulate as KernelModule["neutronicsSimulate"],
       analyzeStaticsBox: (wasmModule as Record<string, unknown>).analyzeStaticsBox as KernelModule["analyzeStaticsBox"],
       analyzeStaticsMesh: (wasmModule as Record<string, unknown>).analyzeStaticsMesh as KernelModule["analyzeStaticsMesh"],
     }, compiledWasmModule);
@@ -1111,6 +1145,117 @@ export class Engine {
       );
     }
     return fn(specJson, paramsJson, optimizeJson);
+  }
+
+  /**
+   * Tolerance stackup analysis: worst-case, RSS, seeded Monte Carlo, and
+   * exact sensitivities over a linear assembly chain, plus predicted
+   * receipt claims. Inputs are JSON strings (StackupSpec, named parameter
+   * bindings, options); see `vcad-kernel-tolerance`.
+   */
+  toleranceAnalyze(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.toleranceAnalyze;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "toleranceAnalyze is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * Steady heat-conduction solve on a voxel grid: T_max, per-source theta
+   * (junction-to-ambient), energy balance, and predicted receipt claims.
+   * Inputs are JSON strings (ThermalSpec, named parameter bindings,
+   * options); see `vcad-kernel-thermal`.
+   */
+  thermalSolve(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.thermalSolve;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "thermalSolve is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * EM field simulation (2D/axisymmetric finite-volume magnetostatics or
+   * electrostatics): inductance, force, torque, capacitance extraction and
+   * predicted receipt claims. The spec JSON carries a `problem` tag; see
+   * `vcad-kernel-em`.
+   */
+  emSimulate(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.emSimulate;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "emSimulate is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * Thin-wire MoM antenna analysis: Z_in/S11 sweep, in-band resonance,
+   * peak gain, and predicted receipt claims. Inputs are JSON strings
+   * (AntennaSpec, named parameter bindings, options with the required
+   * frequency band); see `vcad-kernel-antenna`.
+   */
+  antennaAnalyze(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.antennaAnalyze;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "antennaAnalyze is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * Forward 2D TM FDTD photonics run: rect-composed device, slab-mode
+   * source, transmission spectrum, and predicted receipt claims. Inputs
+   * are JSON strings (device spec, options); see `vcad-kernel-photonics`.
+   */
+  photonicsSimulate(specJson: string, optionsJson: string): unknown {
+    const fn = this.kernel.photonicsSimulate;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "photonicsSimulate is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, optionsJson);
+  }
+
+  /**
+   * Monte Carlo neutron shielding run: dose at detector shells with
+   * statistical error bars and predicted receipt claims. Inputs are JSON
+   * strings (ShieldSpec, named parameter bindings); see
+   * `vcad-kernel-neutronics`.
+   */
+  neutronicsSimulate(specJson: string, paramsJson: string): unknown {
+    const fn = this.kernel.neutronicsSimulate;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "neutronicsSimulate is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, paramsJson);
   }
 
   topologyOptimizeBox(

--- a/packages/mcp/src/__tests__/antenna-tools.test.ts
+++ b/packages/mcp/src/__tests__/antenna-tools.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the antenna analysis tool: the real server, the
+ * real WASM kernel (CI builds it from source), a coarse dipole sweep.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * antenna bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasAntenna =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { antennaAnalyze?: unknown };
+    }
+  ).kernel?.antennaAnalyze === "function";
+
+const DIPOLE = {
+  elements: [
+    {
+      type: "wire",
+      start_mm: [0, 0, "neg_half_len"],
+      end_mm: [0, 0, "half_len"],
+      radius_mm: 1.0,
+      segments: 20,
+    },
+  ],
+  feed_mm: [0, 0, 0],
+};
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasAntenna)("antenna analysis tool", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "antenna-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("analyze_antenna sweeps a dipole and finds its resonance", async () => {
+    const res = (await client.callTool({
+      name: "analyze_antenna",
+      arguments: {
+        spec: DIPOLE,
+        parameters: { half_len: 500, neg_half_len: -500 },
+        band: { f_lo_hz: 120e6, f_hi_hz: 165e6, points: 10 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.segments).toBe(20);
+    expect(out.sweep.length).toBe(10);
+    for (const row of out.sweep) {
+      expect(row.freq_hz).toBeGreaterThanOrEqual(120e6);
+      expect(row.freq_hz).toBeLessThanOrEqual(165e6);
+      expect(Number.isFinite(row.z_re_ohm)).toBe(true);
+      expect(row.s11_db).toBeLessThanOrEqual(0);
+    }
+
+    expect(out.claim_set.schema).toBe("vcad.antenna-claims/1");
+    const claims = Object.fromEntries(
+      out.claim_set.claims.map((c: { name: string; value: number }) => [
+        c.name,
+        c.value,
+      ]),
+    );
+    // Half-wave dipole: resonance near 143-145 MHz, R_in 60-80 ohm.
+    expect(claims.resonance_in_band).toBe(1);
+    expect(claims.resonant_frequency).toBeGreaterThan(135e6);
+    expect(claims.resonant_frequency).toBeLessThan(155e6);
+    expect(claims.gain_dbi).toBeGreaterThan(1.5);
+    expect(claims.radiation_efficiency).toBeGreaterThan(0.95);
+
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("antenna");
+      expect(c.id.startsWith("antenna.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("thin-wire validity gates fail closed", async () => {
+    // 1 mm radius with 2 segments over 1 m: segment length fine, but at
+    // 1.5 GHz the segment >> lambda/8 sampling gate must refuse.
+    const res = (await client.callTool({
+      name: "analyze_antenna",
+      arguments: {
+        spec: DIPOLE,
+        parameters: { half_len: 500, neg_half_len: -500 },
+        band: { f_lo_hz: 1.4e9, f_hi_hz: 1.6e9, points: 3 },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/em-tools.test.ts
+++ b/packages/mcp/src/__tests__/em-tools.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the EM field-solver tool: the real server, the
+ * real WASM kernel (CI builds it from source), coarse grids per class.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the em
+ * bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasEm =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { emSimulate?: unknown };
+    }
+  ).kernel?.emSimulate === "function";
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasEm)("em field-solver tool", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "em-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("axisym magnetostatics prices inductance with a cross-route residual", async () => {
+    const res = (await client.callTool({
+      name: "simulate_em",
+      arguments: {
+        spec: {
+          problem: "axisym_magnetostatics",
+          r_max_mm: 40,
+          z_min_mm: 0,
+          z_max_mm: 100,
+          bc_r_outer: "neumann",
+          bc_z_low: "neumann",
+          bc_z_high: "neumann",
+          coils: [
+            {
+              region: {
+                x_min_mm: 20,
+                x_max_mm: 22,
+                y_min_mm: 0,
+                y_max_mm: 100,
+              },
+              turns: 1000,
+              current_a: "drive",
+            },
+          ],
+        },
+        parameters: { drive: 1.0 },
+        options: { nx: 41, ny: 21 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    // A long 1000-turn solenoid: mu0 n^2 pi R^2 l ~ 17 mH.
+    expect(out.qois.self_inductance_h).toBeGreaterThan(0.005);
+    expect(out.qois.self_inductance_h).toBeLessThan(0.05);
+    expect(out.claim_sets.length).toBe(1);
+    expect(out.claim_sets[0].schema).toBe("vcad.em-claims/1");
+    const names = out.claim_sets[0].claims.map(
+      (c: { name: string }) => c.name,
+    );
+    expect(names).toContain("inductance_h");
+    expect(names).toContain("stored_energy_j");
+    expect(out.claim_sets[0].provenance.cross_route_residual).not.toBeNull();
+
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("em");
+      expect(c.id.startsWith("em.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("electrostatics prices a two-terminal capacitance", async () => {
+    const res = (await client.callTool({
+      name: "simulate_em",
+      arguments: {
+        spec: {
+          problem: "electrostatics",
+          geometry: "axisymmetric",
+          x_min_mm: 0,
+          x_max_mm: 40,
+          y_min_mm: 0,
+          y_max_mm: 20,
+          electrodes: [
+            {
+              shape: {
+                type: "rect",
+                x_min_mm: 0,
+                x_max_mm: 10,
+                y_min_mm: -1,
+                y_max_mm: 21,
+              },
+              potential_v: 1,
+            },
+            {
+              shape: {
+                type: "rect",
+                x_min_mm: 30,
+                x_max_mm: 41,
+                y_min_mm: -1,
+                y_max_mm: 21,
+              },
+              potential_v: 0,
+            },
+          ],
+        },
+        options: { nx: 81, ny: 9, hot: 0 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.qois.capacitance_f).toBeGreaterThan(0);
+    // Two independent routes agree to a few percent on a coarse grid.
+    expect(out.qois.capacitance_route_mismatch).toBeLessThan(0.1);
+    const names = out.claim_sets[0].claims.map(
+      (c: { name: string }) => c.name,
+    );
+    expect(names).toContain("capacitance_f");
+    expect(out.receipt_claims.every((c: { domain: string }) => c.domain === "em")).toBe(
+      true,
+    );
+  });
+
+  it("planar magnetostatics without a torque block fails closed", async () => {
+    const res = (await client.callTool({
+      name: "simulate_em",
+      arguments: {
+        spec: {
+          problem: "planar_magnetostatics",
+          x_min_mm: 0,
+          x_max_mm: 60,
+          y_min_mm: 0,
+          y_max_mm: 24,
+          conductors: [
+            {
+              region: {
+                x_min_mm: 3,
+                x_max_mm: 9,
+                y_min_mm: 4,
+                y_max_mm: 7,
+              },
+              total_current_a: 4,
+            },
+          ],
+        },
+        options: { nx: 31, ny: 17 },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("torque");
+  });
+});

--- a/packages/mcp/src/__tests__/neutronics-tools.test.ts
+++ b/packages/mcp/src/__tests__/neutronics-tools.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the neutron shielding tool: the real server, the
+ * real WASM kernel (CI builds it from source), a small-history HDPE stack.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * neutronics bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasNeutronics =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { neutronicsSimulate?: unknown };
+    }
+  ).kernel?.neutronicsSimulate === "function";
+
+const SPEC = {
+  layers: [
+    { material: "air", thickness_mm: 100 },
+    { material: "hdpe", thickness_mm: "shield_t" },
+    { material: "air", thickness_mm: 400 },
+  ],
+  source: { rate_n_per_s: 1.0e6, energy_ev: 2.45e6 },
+  detectors: [{ label: "operator", radius_mm: 400 }],
+  run: { histories_per_batch: 500, batches: 4, seed: 7 },
+};
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasNeutronics)("neutron shielding tool", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "neutronics-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("simulate_neutron_shield returns dose with error bars + provisional claims", async () => {
+    const res = (await client.callTool({
+      name: "simulate_neutron_shield",
+      arguments: {
+        spec: SPEC,
+        parameters: { shield_t: 100 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.detectors.length).toBe(1);
+    expect(out.detectors[0].label).toBe("operator");
+    expect(out.detectors[0].dose_usv_per_h).toBeGreaterThan(0);
+    // Batch statistics produce a real, finite relative standard error.
+    expect(out.detectors[0].rse).toBeGreaterThan(0);
+    expect(Number.isFinite(out.detectors[0].rse)).toBe(true);
+    expect(out.total_histories).toBe(2000);
+    // Analog transport conserves neutrons to machine precision.
+    expect(out.balance_max_dev).toBeLessThan(1e-9);
+
+    expect(out.claim_set.schema).toBe("vcad.neutronics-claims/1");
+    const names = out.claim_set.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("dose_rate:operator");
+    expect(names).toContain("attenuation_factor:operator");
+    expect(names).toContain("absorbed_fraction");
+    expect(out.claim_set.caveats.length).toBeGreaterThan(0);
+
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("neutronics");
+      expect(c.id.startsWith("neutronics.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("unbound named parameters and D-T energies fail closed", async () => {
+    const unbound = (await client.callTool({
+      name: "simulate_neutron_shield",
+      arguments: { spec: SPEC },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(unbound.isError).toBe(true);
+    expect(unbound.content[0].text).toContain("shield_t");
+
+    const dt = (await client.callTool({
+      name: "simulate_neutron_shield",
+      arguments: {
+        spec: {
+          ...SPEC,
+          source: { rate_n_per_s: 1.0e6, energy_ev: 14.1e6 },
+        },
+        parameters: { shield_t: 100 },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(dt.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/photonics-tools.test.ts
+++ b/packages/mcp/src/__tests__/photonics-tools.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the photonics FDTD tool: the real server, the
+ * real WASM kernel (CI builds it from source), the crate's validated
+ * straight-waveguide transmission case at test scale.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * photonics bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasPhotonics =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { photonicsSimulate?: unknown };
+    }
+  ).kernel?.photonicsSimulate === "function";
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasPhotonics)("photonics FDTD tool", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "photonics-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("simulate_photonics transmits a straight SOI waveguide", async () => {
+    const res = (await client.callTool({
+      name: "simulate_photonics",
+      arguments: {
+        spec: {
+          wavelength_um: 1.55,
+          n_core: 3.48,
+          n_clad: 1.44,
+          size_um: [5.6, 2.5],
+          core_rects_um: [[-1, 1.14, 99, 1.36]],
+          source: { x_um: 0.97, half_width_um: 0.11 },
+          monitor_in_x_um: 1.94,
+          outputs: [{ x_um: 4.85 }],
+        },
+        options: { resolution: 40, steps: 2500 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    // SOI slab mode: n_eff between cladding and core indices.
+    expect(out.n_eff).toBeGreaterThan(1.44);
+    expect(out.n_eff).toBeLessThan(3.48);
+
+    expect(out.claim_set.schema).toBe("vcad.photonics-claims/1");
+    const claims = Object.fromEntries(
+      out.claim_set.claims.map((c: { name: string; value: number }) => [
+        c.name,
+        c.value,
+      ]),
+    );
+    // A straight guide transmits nearly everything; arm B is empty.
+    expect(claims.transmission_arm_a).toBeGreaterThan(0.8);
+    expect(claims.transmission_arm_a).toBeLessThan(1.1);
+    expect(claims.transmission_arm_b).toBe(0);
+    expect(claims.insertion_loss_db).toBeLessThan(1);
+
+    expect(out.claim_set.spectrum.length).toBe(1);
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("photonics");
+      expect(c.id.startsWith("photonics.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("oversized grids fail closed with a cost hint", async () => {
+    const res = (await client.callTool({
+      name: "simulate_photonics",
+      arguments: {
+        spec: {
+          wavelength_um: 1.55,
+          n_core: 3.48,
+          n_clad: 1.44,
+          size_um: [4000, 4000],
+          core_rects_um: [[0, 0, 4000, 1]],
+          source: { x_um: 100, half_width_um: 0.11 },
+          monitor_in_x_um: 200,
+          outputs: [{ x_um: 3000 }],
+        },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("grid too large");
+  });
+});

--- a/packages/mcp/src/__tests__/thermal-tools.test.ts
+++ b/packages/mcp/src/__tests__/thermal-tools.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the thermal solve tool: the real server, the real
+ * WASM kernel (CI builds it from source), a coarse chip-on-board grid.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * thermal bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasThermal =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { thermalSolve?: unknown };
+    }
+  ).kernel?.thermalSolve === "function";
+
+const SPEC = {
+  origin_mm: [0, 0, 0],
+  size_mm: [40, 40, 1.6],
+  divisions: [20, 20, 2],
+  materials: [
+    {
+      shape: { type: "Box", min_mm: [0, 0, 0], size_mm: [40, 40, 1.6] },
+      k_w_mk: [15, 15, 0.5],
+    },
+  ],
+  sources: [
+    {
+      name: "die",
+      shape: { type: "Box", min_mm: [15, 15, 0], size_mm: [10, 10, 1.6] },
+      power_w: "p_die",
+    },
+  ],
+  domain_faces: [
+    { type: "Adiabatic" },
+    { type: "Adiabatic" },
+    { type: "Adiabatic" },
+    { type: "Adiabatic" },
+    { type: "Convection", h_w_m2k: 12, ambient_c: 25 },
+    { type: "Convection", h_w_m2k: 12, ambient_c: 25 },
+  ],
+};
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasThermal)("thermal solve tool", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "thermal-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("solve_thermal returns T_max, theta, energy audit + provisional claims", async () => {
+    const res = (await client.callTool({
+      name: "solve_thermal",
+      arguments: {
+        spec: SPEC,
+        parameters: { p_die: 2.0 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    // 2 W into a small board over h=12 convection: well above ambient.
+    expect(out.t_max_c).toBeGreaterThan(30);
+    expect(out.sources.length).toBe(1);
+    expect(out.sources[0].name).toBe("die");
+    expect(out.sources[0].theta_c_per_w).toBeGreaterThan(0);
+    // Energy balance closes.
+    expect(Math.abs(out.energy.residual_rel)).toBeLessThan(1e-6);
+
+    expect(out.claim_set.schema).toBe("vcad.thermal-claims/1");
+    const names = out.claim_set.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("t_max_c");
+    expect(names).toContain("theta_ja_c_per_w");
+    expect(names).toContain("energy_balance_residual");
+
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("thermal");
+      expect(c.id.startsWith("thermal.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("an all-adiabatic (ungrounded) domain fails closed", async () => {
+    const res = (await client.callTool({
+      name: "solve_thermal",
+      arguments: {
+        spec: {
+          ...SPEC,
+          sources: [
+            {
+              name: "die",
+              shape: {
+                type: "Box",
+                min_mm: [15, 15, 0],
+                size_mm: [10, 10, 1.6],
+              },
+              power_w: 2,
+            },
+          ],
+          domain_faces: [
+            { type: "Adiabatic" },
+            { type: "Adiabatic" },
+            { type: "Adiabatic" },
+            { type: "Adiabatic" },
+            { type: "Adiabatic" },
+            { type: "Adiabatic" },
+          ],
+        },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tolerance-tools.test.ts
+++ b/packages/mcp/src/__tests__/tolerance-tools.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the tolerance stackup tool: the real server, the
+ * real WASM kernel (CI builds it from source), fast MC sample counts.
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the
+ * tolerance bindings — the checked-in artifacts are refreshed only on main
+ * by wasm-refresh.yml. Locally: `npm run build -w vcad-kernel-wasm` to
+ * exercise these for real.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasTolerance =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { toleranceAnalyze?: unknown };
+    }
+  ).kernel?.toleranceAnalyze === "function";
+
+const SPEC = {
+  name: "receipt-chain",
+  contributors: [
+    {
+      name: "pocket",
+      coeff: 1.0,
+      nominal: 20.0,
+      tol_minus: 0.15,
+      tol_plus: 0.15,
+      dist: { type: "normal_from_tol", convention: { type: "three_sigma" } },
+    },
+    {
+      name: "bushing",
+      coeff: -1.0,
+      nominal: 12.0,
+      tol_minus: 0.1,
+      tol_plus: 0.0,
+      dist: { type: "uniform", lo: -0.1, hi: 0.0 },
+    },
+    {
+      name: "shim",
+      coeff: -1.0,
+      nominal: "shim_nominal",
+      tol_minus: 0.05,
+      tol_plus: 0.05,
+      dist: { type: "normal_from_tol", convention: { type: "three_sigma" } },
+    },
+  ],
+  requirement: { name: "protrusion", lower_mm: 0.35, upper_mm: 0.75 },
+};
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasTolerance)("tolerance stackup tools", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "tolerance-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("analyze_tolerance_stackup returns all three analyses + provisional claims", async () => {
+    const res = (await client.callTool({
+      name: "analyze_tolerance_stackup",
+      arguments: {
+        spec: SPEC,
+        parameters: { shim_nominal: 7.5 },
+        options: { n: 20000, seed: 314, batches: 8 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    // Nominal gap = 20 - 12 - 7.5 = 0.5 mm, inside [0.35, 0.75] — but the
+    // worst-case extremes (0.30, 0.80) violate both limits while the
+    // statistical fit stays high: the classic WC-vs-RSS story.
+    expect(out.worst_case.passes).toBe(false);
+    expect(out.worst_case.min_gap).toBeCloseTo(0.3, 6);
+    expect(out.worst_case.max_gap).toBeCloseTo(0.8, 6);
+    expect(out.rss.mean_gap).toBeGreaterThan(0.4);
+    expect(out.rss.mean_gap).toBeLessThan(0.6);
+    expect(out.monte_carlo.n).toBe(20000);
+    expect(out.monte_carlo.fit_probability).toBeGreaterThan(0.9);
+    expect(out.monte_carlo.fit_standard_error).toBeGreaterThan(0);
+
+    // Sensitivities rank by variance share and sum to ~1.
+    expect(out.sensitivities.length).toBe(3);
+    const shares = out.sensitivities.map(
+      (s: { variance_share: number }) => s.variance_share,
+    );
+    expect(shares.reduce((a: number, b: number) => a + b, 0)).toBeCloseTo(
+      1,
+      6,
+    );
+
+    expect(out.claim_set.schema).toBe("vcad.tolerance-claims/1");
+    const names = out.claim_set.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("fit_probability");
+    expect(names).toContain("worst_case_margin_mm");
+
+    expect(out.receipt_claims.length).toBe(out.claim_set.claims.length);
+    for (const c of out.receipt_claims) {
+      expect(c.domain).toBe("tolerance");
+      expect(c.id.startsWith("tolerance.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("unbound named parameters fail closed", async () => {
+    const res = (await client.callTool({
+      name: "analyze_tolerance_stackup",
+      arguments: {
+        spec: SPEC,
+        options: { n: 1000, batches: 4 },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("shim_nominal");
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -2228,6 +2228,2100 @@
     }
   },
   {
+    "name": "simulate_em",
+    "title": "Simulate EM Fields",
+    "description": "Electromagnetic field solve (finite-volume SOR, the differentiable FEMM replacement): axisymmetric magnetostatics (coil inductance, stored energy, axial force — solenoids, coaxial coil pairs), planar magnetostatics (motor cross-section torque and forces per meter of depth, permanent magnets, optional saturable B-H iron), or electrostatics (two-terminal capacitance) — as data plus `vcad.em-claims/1` sets and unified-receipt claims, each with a two-independent-routes cross-check residual (energy vs linkage, JxB vs Maxwell stress, charge vs energy). Predictions carry basis \"predicted\" and roll up Provisional until measured. Static/2D only: no eddy currents or AC here, no 3D end effects, planar results are per meter of depth. Deterministic. Cost ~O((nx*ny)^1.5) SOR sweeps; the 81x81 default runs in well under a second — raise the grid for tight tolerances.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "problem"
+          ],
+          "description": "Problem-tagged EM spec. `axisym_magnetostatics`: chamber `r_max_mm`/`z_min_mm`/`z_max_mm` + `coils` [{region, turns, current_a}] + `materials` [{region, mu_r, js_t?}] (js_t enables the saturable B-H law; named parameters allowed). `planar_magnetostatics`: `x_min_mm`/`x_max_mm`/`y_min_mm`/`y_max_mm` + `conductors` [{region, total_current_a}] + `magnets` [{region, br_x_t, br_y_t, mu_r}] + `materials` + `periodic_x` (named parameters allowed). `electrostatics`: `geometry` (\"axisymmetric\"|\"planar\") + domain bounds + `electrodes` [{shape, potential_v}] (>= 2) + `dielectrics` [{shape, eps_r}] — literal numbers only for this class.",
+          "properties": {
+            "problem": {
+              "type": "string",
+              "enum": [
+                "axisym_magnetostatics",
+                "planar_magnetostatics",
+                "electrostatics"
+              ]
+            },
+            "r_max_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "z_min_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "z_max_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "coils": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "region"
+                ],
+                "properties": {
+                  "region": {
+                    "type": "object",
+                    "required": [
+                      "x_min_mm",
+                      "x_max_mm",
+                      "y_min_mm",
+                      "y_max_mm"
+                    ],
+                    "description": "Rectangular region (x = radius in the axisym class, y = z there).",
+                    "properties": {
+                      "x_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "x_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "turns": {
+                    "description": "Winding turns. Default 1.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "current_a": {
+                    "description": "Coil current, A.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "x_min_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "x_max_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "y_min_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "y_max_mm": {
+              "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "conductors": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "region"
+                ],
+                "properties": {
+                  "region": {
+                    "type": "object",
+                    "required": [
+                      "x_min_mm",
+                      "x_max_mm",
+                      "y_min_mm",
+                      "y_max_mm"
+                    ],
+                    "description": "Rectangular region (x = radius in the axisym class, y = z there).",
+                    "properties": {
+                      "x_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "x_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "total_current_a": {
+                    "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "magnets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "region"
+                ],
+                "properties": {
+                  "region": {
+                    "type": "object",
+                    "required": [
+                      "x_min_mm",
+                      "x_max_mm",
+                      "y_min_mm",
+                      "y_max_mm"
+                    ],
+                    "description": "Rectangular region (x = radius in the axisym class, y = z there).",
+                    "properties": {
+                      "x_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "x_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "br_x_t": {
+                    "description": "Remanence x, tesla.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "br_y_t": {
+                    "description": "Remanence y, tesla.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "mu_r": {
+                    "description": "Recoil mu_r. Default 1.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "periodic_x": {
+              "type": "boolean"
+            },
+            "materials": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "region",
+                  "mu_r"
+                ],
+                "properties": {
+                  "region": {
+                    "type": "object",
+                    "required": [
+                      "x_min_mm",
+                      "x_max_mm",
+                      "y_min_mm",
+                      "y_max_mm"
+                    ],
+                    "description": "Rectangular region (x = radius in the axisym class, y = z there).",
+                    "properties": {
+                      "x_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "x_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_min_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "y_max_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "mu_r": {
+                    "description": "A number, or the name of a named parameter bound via `parameters` (magnetostatic classes only).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "js_t": {
+                    "description": "Saturation polarization, tesla — presence switches this region to the nonlinear B-H law (Picard outer loop).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "bc_r_outer": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_z_low": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_z_high": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_x_low": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_x_high": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_y_low": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "bc_y_high": {
+              "type": "string",
+              "enum": [
+                "zero",
+                "neumann"
+              ],
+              "description": "Outer boundary condition. Default zero (far-field)."
+            },
+            "geometry": {
+              "type": "string",
+              "enum": [
+                "axisymmetric",
+                "planar"
+              ]
+            },
+            "electrodes": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "shape",
+                  "potential_v"
+                ],
+                "properties": {
+                  "shape": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "description": "Electrode/dielectric shape: `{\"type\":\"rect\",...}`, `{\"type\":\"circle\",\"cx_mm\",\"cy_mm\",\"radius_mm\"}`, or `{\"type\":\"circle_shell\",\"cx_mm\",\"cy_mm\",\"r_inner_mm\",\"r_outer_mm\"}`. Literal numbers only.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "rect",
+                          "circle",
+                          "circle_shell"
+                        ]
+                      },
+                      "x_min_mm": {
+                        "type": "number"
+                      },
+                      "x_max_mm": {
+                        "type": "number"
+                      },
+                      "y_min_mm": {
+                        "type": "number"
+                      },
+                      "y_max_mm": {
+                        "type": "number"
+                      },
+                      "cx_mm": {
+                        "type": "number"
+                      },
+                      "cy_mm": {
+                        "type": "number"
+                      },
+                      "radius_mm": {
+                        "type": "number"
+                      },
+                      "r_inner_mm": {
+                        "type": "number"
+                      },
+                      "r_outer_mm": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "potential_v": {
+                    "type": "number"
+                  }
+                }
+              }
+            },
+            "dielectrics": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "shape",
+                  "eps_r"
+                ],
+                "properties": {
+                  "shape": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "description": "Electrode/dielectric shape: `{\"type\":\"rect\",...}`, `{\"type\":\"circle\",\"cx_mm\",\"cy_mm\",\"radius_mm\"}`, or `{\"type\":\"circle_shell\",\"cx_mm\",\"cy_mm\",\"r_inner_mm\",\"r_outer_mm\"}`. Literal numbers only.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "rect",
+                          "circle",
+                          "circle_shell"
+                        ]
+                      },
+                      "x_min_mm": {
+                        "type": "number"
+                      },
+                      "x_max_mm": {
+                        "type": "number"
+                      },
+                      "y_min_mm": {
+                        "type": "number"
+                      },
+                      "y_max_mm": {
+                        "type": "number"
+                      },
+                      "cx_mm": {
+                        "type": "number"
+                      },
+                      "cy_mm": {
+                        "type": "number"
+                      },
+                      "radius_mm": {
+                        "type": "number"
+                      },
+                      "r_inner_mm": {
+                        "type": "number"
+                      },
+                      "r_outer_mm": {
+                        "type": "number"
+                      }
+                    }
+                  },
+                  "eps_r": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters (magnetostatic classes)."
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "nx": {
+              "type": "number",
+              "description": "Grid nodes in x (r for axisym). Default 81."
+            },
+            "ny": {
+              "type": "number",
+              "description": "Grid nodes in y (z for axisym). Default 81."
+            },
+            "tol": {
+              "type": "number",
+              "description": "SOR relative tolerance. Default 1e-8."
+            },
+            "max_sweeps": {
+              "type": "number",
+              "description": "SOR sweep cap. Default 200000."
+            },
+            "drive_coil": {
+              "type": "number",
+              "description": "Axisym: coil index the inductance claim is priced for. Default 0."
+            },
+            "force_coil": {
+              "type": "number",
+              "description": "Axisym: also emit force claims for this coil index."
+            },
+            "stress_probe": {
+              "type": "object",
+              "description": "Axisym force cross-check: Maxwell-stress cylinder {r_mm, z_lo_mm, z_hi_mm, panels?}.",
+              "properties": {
+                "r_mm": {
+                  "type": "number"
+                },
+                "z_lo_mm": {
+                  "type": "number"
+                },
+                "z_hi_mm": {
+                  "type": "number"
+                },
+                "panels": {
+                  "type": "number"
+                }
+              }
+            },
+            "torque": {
+              "type": "object",
+              "description": "Planar (required for that class): torque center + mean airgap radius + stack depth {cx_mm, cy_mm, r_mean_m, depth_m, stress_line_y_mm?}.",
+              "properties": {
+                "cx_mm": {
+                  "type": "number"
+                },
+                "cy_mm": {
+                  "type": "number"
+                },
+                "r_mean_m": {
+                  "type": "number"
+                },
+                "depth_m": {
+                  "type": "number"
+                },
+                "stress_line_y_mm": {
+                  "type": "number"
+                }
+              }
+            },
+            "hot": {
+              "type": "number",
+              "description": "Electrostatics: index of the driven electrode. Default 0."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "simulate_photonics",
+    "title": "Simulate Photonics",
+    "description": "Forward 2D TM FDTD photonics run (validated Yee grid + CPML, dispersion error ~5e-8 at 40 cells/lambda): rect-composed device, analytically-solved slab-mode line source, input/output flux monitors, transmission spectrum, insertion loss, and splitting ratio — as data plus `vcad.photonics-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until the chip is measured. 2D TM only: quantitative for the 2D problem, qualitative for a 3D chip (no out-of-plane loss); lossless dielectrics; rect geometry only in this tool. Deterministic. Cost ~grid cells x steps (caps 2M cells / 100k steps); the default 20 cells/lambda x 3000 steps on a 10x5 um domain runs in a few seconds. Raise `resolution` toward 40 for publication-grade numbers.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "wavelength_um",
+            "n_core",
+            "n_clad",
+            "size_um",
+            "core_rects_um",
+            "source",
+            "monitor_in_x_um",
+            "outputs"
+          ],
+          "description": "2D device in the xy plane, 1 unit = 1 um, propagation along +x. Cladding fills the domain; `core_rects_um` are painted at n_core^2 with sub-pixel averaging. Literal numbers only.",
+          "properties": {
+            "wavelength_um": {
+              "type": "number",
+              "description": "Vacuum wavelength, um (e.g. 1.55)."
+            },
+            "n_core": {
+              "type": "number"
+            },
+            "n_clad": {
+              "type": "number"
+            },
+            "size_um": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "type": "number"
+              },
+              "description": "Domain size [lx, ly], um."
+            },
+            "core_rects_um": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "array",
+                "minItems": 4,
+                "maxItems": 4,
+                "items": {
+                  "type": "number"
+                }
+              },
+              "description": "Core rectangles [x0, y0, x1, y1], um."
+            },
+            "source": {
+              "type": "object",
+              "required": [
+                "x_um",
+                "half_width_um"
+              ],
+              "description": "Slab-mode line source: the even TM mode of a guide with this half-width is solved analytically and injected as a line profile.",
+              "properties": {
+                "x_um": {
+                  "type": "number"
+                },
+                "center_y_um": {
+                  "type": "number",
+                  "description": "Mode center. Default domain mid-height."
+                },
+                "half_width_um": {
+                  "type": "number",
+                  "description": "Guide half-width the source mode is solved for."
+                }
+              }
+            },
+            "monitor_in_x_um": {
+              "type": "number",
+              "description": "Input-power monitor x (between source and device; full-height)."
+            },
+            "outputs": {
+              "type": "array",
+              "minItems": 1,
+              "maxItems": 2,
+              "items": {
+                "type": "object",
+                "required": [
+                  "x_um"
+                ],
+                "properties": {
+                  "x_um": {
+                    "type": "number"
+                  },
+                  "y_lo_um": {
+                    "type": "number",
+                    "description": "Window low edge. Default full interior height."
+                  },
+                  "y_hi_um": {
+                    "type": "number",
+                    "description": "Window high edge. Default full interior height."
+                  }
+                }
+              },
+              "description": "One or two output flux monitors. Two = splitter arms (use y windows to separate them); one = simple transmission (arm B claims read zero)."
+            }
+          }
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "resolution": {
+              "type": "number",
+              "description": "Cells per vacuum wavelength (>= 8). Default 20."
+            },
+            "steps": {
+              "type": "number",
+              "description": "FDTD time steps. Default 3000."
+            },
+            "cpml_cells": {
+              "type": "number",
+              "description": "Absorber thickness per side. Default 12."
+            },
+            "courant": {
+              "type": "number",
+              "description": "Courant factor (0, 1]. Default 0.5."
+            },
+            "n_freqs": {
+              "type": "number",
+              "description": "Monitor frequencies (forced odd, center exact). Default 1."
+            },
+            "band_frac": {
+              "type": "number",
+              "description": "Fractional bandwidth spanned when n_freqs > 1. Default 0.2."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "analyze_antenna",
+    "title": "Analyze Antenna",
+    "description": "Thin-wire method-of-moments antenna analysis over a frequency band: per-frequency Z_in and S11 sweep rows, minimum-S11 point, in-band resonance (Im Z = 0), -10 dB bandwidth, far-field peak gain (37x72 pattern scan), and a radiation-efficiency energy cross-check — as data plus `vcad.antenna-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until a VNA sweep is bound. Free-space PEC wires (optional infinite ground plane): no dielectric substrate (PCB antennas read a few percent high in frequency), no conductor loss (gain = directivity), thin-wire validity gates enforced fail-closed (segment >= 4a, segment <= lambda/8, ka <= 0.1). Deterministic. Cost ~O(segments^3) per frequency x band points (segment cap 600); a 30-segment dipole over 46 points runs in seconds.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "elements",
+            "feed_mm"
+          ],
+          "description": "Thin-wire antenna: straight wires, polyline paths, and closed loops, with a delta-gap feed at the basis nearest `feed_mm`. Units mm. Any numeric field may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "ground_plane": {
+              "type": "boolean",
+              "description": "Infinite PEC ground at z=0 (monopoles). Default false (free space)."
+            },
+            "elements": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "description": "Element: `{\"type\":\"wire\",\"start_mm\",\"end_mm\",\"radius_mm\",\"segments\"}`, `{\"type\":\"path\",\"points_mm\",\"radius_mm\",\"segments_per_leg\"}` (len = points-1), or `{\"type\":\"loop\",...}` (segments_per_leg len = points, closing leg included).",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "wire",
+                      "path",
+                      "loop"
+                    ]
+                  },
+                  "start_mm": {
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "[x, y, z] in mm (Z-up; ground plane, when on, is z=0)."
+                  },
+                  "end_mm": {
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "[x, y, z] in mm (Z-up; ground plane, when on, is z=0)."
+                  },
+                  "points_mm": {
+                    "type": "array",
+                    "items": {
+                      "type": "array",
+                      "minItems": 3,
+                      "maxItems": 3,
+                      "items": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "description": "[x, y, z] in mm (Z-up; ground plane, when on, is z=0)."
+                    }
+                  },
+                  "radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "segments": {
+                    "type": "number"
+                  },
+                  "segments_per_leg": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            },
+            "feed_mm": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "description": "A number, or the name of a named parameter bound via `parameters`.",
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              },
+              "description": "[x, y, z] in mm (Z-up; ground plane, when on, is z=0)."
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        },
+        "band": {
+          "type": "object",
+          "required": [
+            "f_lo_hz",
+            "f_hi_hz",
+            "points"
+          ],
+          "description": "Frequency band to sweep and make claims over.",
+          "properties": {
+            "f_lo_hz": {
+              "type": "number"
+            },
+            "f_hi_hz": {
+              "type": "number"
+            },
+            "points": {
+              "type": "number",
+              "description": "Sweep points across the band (2..2000)."
+            }
+          }
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "z0": {
+              "type": "number",
+              "description": "S11 reference impedance, ohm. Default 50."
+            },
+            "quad_outer": {
+              "type": "number",
+              "description": "Outer Gauss-Legendre order. Default 6."
+            },
+            "quad_inner": {
+              "type": "number",
+              "description": "Inner Gauss-Legendre order. Default 6."
+            },
+            "sweep": {
+              "type": "boolean",
+              "description": "Return per-frequency sweep rows (Z_in, S11). Default true."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec",
+        "band"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "solve_thermal",
+    "title": "Solve Thermal",
+    "description": "Steady heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, returning T_max and its location, per-source theta_ja (K/W, junction-to-ambient), reservoir loads, and an energy-balance audit — as data plus `vcad.thermal-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until hardware is measured. Conduction only: convection enters as film coefficients you supply (h values are the dominant uncertainty), no radiation, no fluid flow, steady state only. The full temperature field is not returned (summaries + claims are). Cost scales with voxel count (capped at 2M); a 20x20x2 board solves instantly, 100x100x13 in seconds.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "origin_mm",
+            "size_mm",
+            "divisions",
+            "materials"
+          ],
+          "description": "Voxelized conduction domain: an axis-aligned box discretized into `divisions` voxels, with material regions (per-axis k), power sources, optional fixed-temperature regions, and per-face boundary conditions `[-x,+x,-y,+y,-z,+z]`. Units mm / W / degC. Any numeric field (except `divisions`) may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "origin_mm": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "description": "A number, or the name of a named parameter bound via `parameters`.",
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "size_mm": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "description": "A number, or the name of a named parameter bound via `parameters`.",
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ]
+              }
+            },
+            "divisions": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "number"
+              },
+              "description": "Voxel counts per axis (plain integers, the cost knob)."
+            },
+            "materials": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "shape",
+                  "k_w_mk"
+                ],
+                "properties": {
+                  "shape": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "description": "Region shape: `{\"type\":\"Box\",\"min_mm\":[..],\"size_mm\":[..]}` or `{\"type\":\"Tube\",\"axis\":\"Z\",\"center_mm\":[..2],\"span_mm\":[..2],\"outer_radius_mm\":..,\"inner_radius_mm\":..}`.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "Box",
+                          "Tube"
+                        ]
+                      },
+                      "min_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "size_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "axis": {
+                        "type": "string",
+                        "enum": [
+                          "X",
+                          "Y",
+                          "Z"
+                        ]
+                      },
+                      "center_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "span_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "outer_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "inner_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "k_w_mk": {
+                    "type": "array",
+                    "minItems": 3,
+                    "maxItems": 3,
+                    "items": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "Per-axis conductivity, W/(m*K)."
+                  }
+                }
+              }
+            },
+            "sources": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "shape",
+                  "power_w"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "shape": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "description": "Region shape: `{\"type\":\"Box\",\"min_mm\":[..],\"size_mm\":[..]}` or `{\"type\":\"Tube\",\"axis\":\"Z\",\"center_mm\":[..2],\"span_mm\":[..2],\"outer_radius_mm\":..,\"inner_radius_mm\":..}`.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "Box",
+                          "Tube"
+                        ]
+                      },
+                      "min_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "size_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "axis": {
+                        "type": "string",
+                        "enum": [
+                          "X",
+                          "Y",
+                          "Z"
+                        ]
+                      },
+                      "center_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "span_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "outer_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "inner_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "power_w": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "fixed": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "shape",
+                  "temperature_c"
+                ],
+                "properties": {
+                  "shape": {
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "description": "Region shape: `{\"type\":\"Box\",\"min_mm\":[..],\"size_mm\":[..]}` or `{\"type\":\"Tube\",\"axis\":\"Z\",\"center_mm\":[..2],\"span_mm\":[..2],\"outer_radius_mm\":..,\"inner_radius_mm\":..}`.",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "Box",
+                          "Tube"
+                        ]
+                      },
+                      "min_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "size_mm": {
+                        "type": "array",
+                        "minItems": 3,
+                        "maxItems": 3,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "axis": {
+                        "type": "string",
+                        "enum": [
+                          "X",
+                          "Y",
+                          "Z"
+                        ]
+                      },
+                      "center_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "span_mm": {
+                        "type": "array",
+                        "minItems": 2,
+                        "maxItems": 2,
+                        "items": {
+                          "description": "A number, or the name of a named parameter bound via `parameters`.",
+                          "anyOf": [
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      },
+                      "outer_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "inner_radius_mm": {
+                        "description": "A number, or the name of a named parameter bound via `parameters`.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "temperature_c": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "domain_faces": {
+              "type": "array",
+              "minItems": 6,
+              "maxItems": 6,
+              "items": {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "description": "Boundary condition: `{\"type\":\"Adiabatic\"}`, `{\"type\":\"FixedTemperature\",\"temperature_c\":..}`, or `{\"type\":\"Convection\",\"h_w_m2k\":..,\"ambient_c\":..}`.",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Adiabatic",
+                      "FixedTemperature",
+                      "Convection"
+                    ]
+                  },
+                  "temperature_c": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "h_w_m2k": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "ambient_c": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              },
+              "description": "Boundary per domain face `[-x,+x,-y,+y,-z,+z]`. Default all adiabatic — ground the system with at least one non-adiabatic face or fixed region."
+            },
+            "exposed": {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "description": "Boundary applied to interior void-facing surfaces. Default adiabatic.",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Adiabatic",
+                    "FixedTemperature",
+                    "Convection"
+                  ]
+                },
+                "temperature_c": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "h_w_m2k": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "ambient_c": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            "reference_c": {
+              "description": "Explicit theta reference temperature; usually inferred from the single ambient.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "tol": {
+              "type": "number",
+              "description": "PCG relative tolerance. Default 1e-8."
+            },
+            "max_iters": {
+              "type": "number",
+              "description": "PCG iteration cap. Default 50000."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "simulate_neutron_shield",
+    "title": "Simulate Neutron Shield",
+    "description": "Monte Carlo neutron shielding run (analog transport, 5-group multigroup library with exact elastic kinematics): spherical layer stack around a point source (D-D band), H*(10) dose rate at each detector shell WITH 1-sigma batch error bars (rse), attenuation factor vs bare source, thermal flux, and absorbed/leakage balance — as data plus `vcad.neutronics-claims/1` and unified-receipt claims. Fail-closed: truncated histories or a tally that scored nothing refuses claims (raise histories). Predictions carry basis \"predicted\" and roll up Provisional until surveyed. Design-estimate physics: 5-group library (not ENDF continuous-energy), spherical geometry only, no gamma dose, no activation, source energy capped at 3 MeV (no D-T). Deterministic per seed. Cost ~histories (cap 5M); error bars shrink as 1/sqrt(N). The 400k default runs in seconds.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "layers",
+            "source",
+            "detectors"
+          ],
+          "description": "Spherical shield: concentric layers from r=0 outward around a point source, with detector shells that must each sit strictly inside one layer (put them in air gaps). Units mm. Any numeric field may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "layers": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "material",
+                  "thickness_mm"
+                ],
+                "properties": {
+                  "material": {
+                    "type": "string",
+                    "description": "Built-in library material: hdpe, paraffin, borated-hdpe-5, water, lead, concrete, air, void."
+                  },
+                  "thickness_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "source": {
+              "type": "object",
+              "required": [
+                "rate_n_per_s",
+                "energy_ev"
+              ],
+              "description": "Isotropic point source at r=0. Energy must lie in the 5-group structure [1e-4, 3e6] eV — D-D 2.45e6 eV is in range; D-T 14.1 MeV is rejected.",
+              "properties": {
+                "rate_n_per_s": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "energy_ev": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            "detectors": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "label",
+                  "radius_mm"
+                ],
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "radius_mm": {
+                    "description": "A number, or the name of a named parameter bound via `parameters`.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "half_width_mm": {
+                    "description": "Shell half-thickness. Default 20 mm.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "run": {
+              "type": "object",
+              "description": "Monte Carlo controls (deterministic for a given seed).",
+              "properties": {
+                "histories_per_batch": {
+                  "type": "number",
+                  "description": "Default 20000."
+                },
+                "batches": {
+                  "type": "number",
+                  "description": "Error-bar batches (>= 2). Default 20."
+                },
+                "seed": {
+                  "type": "number",
+                  "description": "Default 20260717."
+                }
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "analyze_tolerance_stackup",
+    "title": "Analyze Tolerance Stackup",
+    "description": "Dimensional tolerance stackup analysis over a linear assembly chain: worst-case extremes, RSS statistics (yield, Cp/Cpk), seeded Monte Carlo fit probability with batch error bars, and exact per-contributor sensitivities (variance share, d yield/d nominal) — as data plus `vcad.tolerance-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until parts are measured. Linear 1D chains only: no 3D kinematic loops here (project those to a chain first), distributions are the declared ones (assumed 3-sigma unless stated). Deterministic for a given seed. Cost is O(n samples); the 100k default runs in well under a second.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "spec": {
+          "type": "object",
+          "required": [
+            "name",
+            "contributors",
+            "requirement"
+          ],
+          "description": "Linear tolerance stackup: gap = sum(coeff_i * x_i) over contributor dimensions, graded against a fit requirement. Units mm. Any numeric field may instead be a string naming a parameter supplied in `parameters` (fail-closed: unbound names error).",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "contributors": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "name",
+                  "coeff",
+                  "nominal",
+                  "tol_minus",
+                  "tol_plus",
+                  "dist"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "coeff": {
+                    "description": "Direction coefficient (+1 adds to the gap, -1 subtracts).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "nominal": {
+                    "description": "Nominal dimension, mm.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "tol_minus": {
+                    "description": "Lower tolerance magnitude, mm (>= 0).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "tol_plus": {
+                    "description": "Upper tolerance magnitude, mm (>= 0).",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "dist": {
+                    "type": "object",
+                    "description": "Contributor distribution. `normal_from_tol` derives sigma from the (symmetric) tolerance band via the convention; `uniform`/`two_point` must lie within the drawing limits.",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "normal",
+                          "normal_from_tol",
+                          "uniform",
+                          "two_point"
+                        ]
+                      },
+                      "mean": {
+                        "description": "normal: mean offset, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "sigma": {
+                        "description": "normal: one sigma, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "convention": {
+                        "type": "object",
+                        "description": "normal_from_tol: `{\"type\":\"three_sigma\"}` or `{\"type\":\"k_sigma\",\"k\":4}`.",
+                        "properties": {
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "three_sigma",
+                              "k_sigma"
+                            ]
+                          },
+                          "k": {
+                            "type": "number"
+                          }
+                        }
+                      },
+                      "lo": {
+                        "description": "uniform: lower offset, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "hi": {
+                        "description": "uniform: upper offset, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "a": {
+                        "description": "two_point: first offset, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "b": {
+                        "description": "two_point: second offset, mm.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
+                      "p_b": {
+                        "description": "two_point: probability of b.",
+                        "anyOf": [
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "requirement": {
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "description": "Fit requirement on the closing gap; at least one bound required.",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "lower_mm": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                },
+                "upper_mm": {
+                  "description": "A number, or the name of a named parameter bound via `parameters`.",
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Bindings for named spec parameters, `{name: value}`."
+        },
+        "options": {
+          "type": "object",
+          "properties": {
+            "n": {
+              "type": "number",
+              "description": "Monte Carlo samples. Default 100000 (min 100)."
+            },
+            "seed": {
+              "type": "number",
+              "description": "MC seed (deterministic). Default 0x5EED7015."
+            },
+            "batches": {
+              "type": "number",
+              "description": "MC error-bar batches. Default 16."
+            }
+          }
+        }
+      },
+      "required": [
+        "spec"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
     "name": "predict_physics",
     "title": "Predict Physics",
     "description": "Fast static structural analysis (voxel FEA): max displacement, max von Mises stress, and compliance for a part or box under world-frame loads (N) and supports, in ~100 ms at fidelity=predict. Pass max_displacement_mm / max_von_mises_mpa limits to get receipt claims: predict-tier claims carry basis=predicted and roll up as a PROVISIONAL receipt — use them to iterate on a design cheaply. When the design settles, re-run with fidelity=verify (same solver, fine grid) to upgrade the claims to basis=verified and a certifiable pass. Loads/supports are box regions (mm, Z-up); zero-thickness boxes select a face. Voxel FEA smears stress concentrations — treat stress as an estimate near fillets.",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -130,6 +130,12 @@ import { toolDefs as verifySpecToolDefs } from "./tools/verify-spec.js";
 import { toolDefs as clearanceToolDefs } from "./tools/clearance.js";
 import { toolDefs as topoptToolDefs } from "./tools/topopt.js";
 import { toolDefs as particleToolDefs } from "./tools/particle.js";
+import { toolDefs as toleranceToolDefs } from "./tools/tolerance.js";
+import { toolDefs as thermalToolDefs } from "./tools/thermal.js";
+import { toolDefs as emToolDefs } from "./tools/em.js";
+import { toolDefs as antennaToolDefs } from "./tools/antenna.js";
+import { toolDefs as photonicsToolDefs } from "./tools/photonics.js";
+import { toolDefs as neutronicsToolDefs } from "./tools/neutronics.js";
 import { toolDefs as physicsToolDefs } from "./tools/physics.js";
 import { toolDefs as loonMacroToolDefs } from "./tools/loon-macros.js";
 import { toolDefs as dfmToolDefs } from "./tools/dfm.js";
@@ -309,6 +315,12 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...clearanceToolDefs,
   ...topoptToolDefs,
   ...particleToolDefs,
+  ...toleranceToolDefs,
+  ...thermalToolDefs,
+  ...emToolDefs,
+  ...antennaToolDefs,
+  ...photonicsToolDefs,
+  ...neutronicsToolDefs,
   ...physicsToolDefs,
   ...loonMacroToolDefs,
   ...dfmToolDefs,
@@ -392,6 +404,13 @@ const LIST_TOOL_ORDER: readonly string[] = [
   // ── Charged-particle optics (fusor / IEC / trap family) ────
   "simulate_charged_particles",
   "optimize_electrodes",
+  // ── Physics solver wave 2 (predicted claims, Provisional) ──
+  "simulate_em",
+  "simulate_photonics",
+  "analyze_antenna",
+  "solve_thermal",
+  "simulate_neutron_shield",
+  "analyze_tolerance_stackup",
   // ── Two-tier static physics (predict fast, verify to certify) ──
   "predict_physics",
   // ── Print-then-measure calibration loop (3DP) ──────────────

--- a/packages/mcp/src/tools/antenna.ts
+++ b/packages/mcp/src/tools/antenna.ts
@@ -1,0 +1,158 @@
+/**
+ * Antenna solver tools — the `vcad-kernel-antenna` crate over MCP.
+ *
+ * `analyze_antenna` runs the thin-wire method-of-moments solver over a
+ * frequency band: Z_in/S11 sweep, in-band resonance, far-field peak
+ * gain, radiation-efficiency cross-check, and the
+ * `vcad.antenna-claims/1` set plus unified-receipt claims. Predictions
+ * carry `basis: "predicted"` and roll up Provisional — never verified —
+ * until a VNA measurement is bound.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters`.",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const pointSpec = {
+  type: "array" as const,
+  minItems: 3,
+  maxItems: 3,
+  items: paramValue,
+  description: "[x, y, z] in mm (Z-up; ground plane, when on, is z=0).",
+};
+
+const antennaSpecSchema = {
+  type: "object" as const,
+  required: ["elements", "feed_mm"],
+  description:
+    "Thin-wire antenna: straight wires, polyline paths, and closed loops, " +
+    "with a delta-gap feed at the basis nearest `feed_mm`. Units mm. Any " +
+    "numeric field may instead be a string naming a parameter supplied in " +
+    "`parameters` (fail-closed: unbound names error).",
+  properties: {
+    ground_plane: {
+      type: "boolean" as const,
+      description:
+        "Infinite PEC ground at z=0 (monopoles). Default false (free space).",
+    },
+    elements: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["type"],
+        description:
+          'Element: `{"type":"wire","start_mm","end_mm","radius_mm",' +
+          '"segments"}`, `{"type":"path","points_mm","radius_mm",' +
+          '"segments_per_leg"}` (len = points-1), or `{"type":"loop",...}` ' +
+          "(segments_per_leg len = points, closing leg included).",
+        properties: {
+          type: { type: "string" as const, enum: ["wire", "path", "loop"] },
+          start_mm: pointSpec,
+          end_mm: pointSpec,
+          points_mm: { type: "array" as const, items: pointSpec },
+          radius_mm: paramValue,
+          segments: { type: "number" as const },
+          segments_per_leg: {
+            type: "array" as const,
+            items: { type: "number" as const },
+          },
+        },
+      },
+    },
+    feed_mm: pointSpec,
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "analyze_antenna",
+    pack: null,
+    description:
+      "Thin-wire method-of-moments antenna analysis over a frequency band: per-frequency " +
+      "Z_in and S11 sweep rows, minimum-S11 point, in-band resonance (Im Z = 0), -10 dB " +
+      "bandwidth, far-field peak gain (37x72 pattern scan), and a radiation-efficiency " +
+      "energy cross-check — as data plus `vcad.antenna-claims/1` and unified-receipt " +
+      "claims. Predictions carry basis \"predicted\" and roll up Provisional until a VNA " +
+      "sweep is bound. Free-space PEC wires (optional infinite ground plane): no " +
+      "dielectric substrate (PCB antennas read a few percent high in frequency), no " +
+      "conductor loss (gain = directivity), thin-wire validity gates enforced " +
+      "fail-closed (segment >= 4a, segment <= lambda/8, ka <= 0.1). Deterministic. Cost " +
+      "~O(segments^3) per frequency x band points (segment cap 600); a 30-segment " +
+      "dipole over 46 points runs in seconds.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec", "band"],
+      properties: {
+        spec: antennaSpecSchema,
+        parameters: {
+          type: "object" as const,
+          additionalProperties: { type: "number" as const },
+          description: "Bindings for named spec parameters, `{name: value}`.",
+        },
+        band: {
+          type: "object" as const,
+          required: ["f_lo_hz", "f_hi_hz", "points"],
+          description: "Frequency band to sweep and make claims over.",
+          properties: {
+            f_lo_hz: { type: "number" as const },
+            f_hi_hz: { type: "number" as const },
+            points: {
+              type: "number" as const,
+              description: "Sweep points across the band (2..2000).",
+            },
+          },
+        },
+        options: {
+          type: "object" as const,
+          properties: {
+            z0: {
+              type: "number" as const,
+              description: "S11 reference impedance, ohm. Default 50.",
+            },
+            quad_outer: {
+              type: "number" as const,
+              description: "Outer Gauss-Legendre order. Default 6.",
+            },
+            quad_inner: {
+              type: "number" as const,
+              description: "Inner Gauss-Legendre order. Default 6.",
+            },
+            sweep: {
+              type: "boolean" as const,
+              description:
+                "Return per-frequency sweep rows (Z_in, S11). Default true.",
+            },
+          },
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.antennaAnalyze(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify({ band: a.band, ...(a.options as Json | undefined) }),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/em.ts
+++ b/packages/mcp/src/tools/em.ts
@@ -1,0 +1,306 @@
+/**
+ * EM field-solver tools — the `vcad-kernel-em` crate over MCP.
+ *
+ * `simulate_em` solves one of three finite-volume problem classes
+ * (axisymmetric magnetostatics, planar magnetostatics, electrostatics)
+ * and extracts inductance / force / torque / capacitance with the
+ * `vcad.em-claims/1` sets plus unified-receipt claims. Every claim
+ * family carries a cross-route residual (two independent extraction
+ * routes must agree). Predictions carry `basis: "predicted"` and roll up
+ * Provisional — never verified — until the hardware is measured.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters` " +
+    "(magnetostatic classes only).",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const rectRegion = {
+  type: "object" as const,
+  required: ["x_min_mm", "x_max_mm", "y_min_mm", "y_max_mm"],
+  description:
+    "Rectangular region (x = radius in the axisym class, y = z there).",
+  properties: {
+    x_min_mm: paramValue,
+    x_max_mm: paramValue,
+    y_min_mm: paramValue,
+    y_max_mm: paramValue,
+  },
+};
+
+const bcSchema = {
+  type: "string" as const,
+  enum: ["zero", "neumann"],
+  description: "Outer boundary condition. Default zero (far-field).",
+};
+
+const electroShape = {
+  type: "object" as const,
+  required: ["type"],
+  description:
+    'Electrode/dielectric shape: `{"type":"rect",...}`, `{"type":"circle",' +
+    '"cx_mm","cy_mm","radius_mm"}`, or `{"type":"circle_shell","cx_mm",' +
+    '"cy_mm","r_inner_mm","r_outer_mm"}`. Literal numbers only.',
+  properties: {
+    type: {
+      type: "string" as const,
+      enum: ["rect", "circle", "circle_shell"],
+    },
+    x_min_mm: { type: "number" as const },
+    x_max_mm: { type: "number" as const },
+    y_min_mm: { type: "number" as const },
+    y_max_mm: { type: "number" as const },
+    cx_mm: { type: "number" as const },
+    cy_mm: { type: "number" as const },
+    radius_mm: { type: "number" as const },
+    r_inner_mm: { type: "number" as const },
+    r_outer_mm: { type: "number" as const },
+  },
+};
+
+const emSpecSchema = {
+  type: "object" as const,
+  required: ["problem"],
+  description:
+    "Problem-tagged EM spec. `axisym_magnetostatics`: chamber `r_max_mm`/" +
+    "`z_min_mm`/`z_max_mm` + `coils` [{region, turns, current_a}] + " +
+    "`materials` [{region, mu_r, js_t?}] (js_t enables the saturable B-H " +
+    "law; named parameters allowed). `planar_magnetostatics`: `x_min_mm`/" +
+    "`x_max_mm`/`y_min_mm`/`y_max_mm` + `conductors` [{region, " +
+    "total_current_a}] + `magnets` [{region, br_x_t, br_y_t, mu_r}] + " +
+    "`materials` + `periodic_x` (named parameters allowed). " +
+    "`electrostatics`: `geometry` (\"axisymmetric\"|\"planar\") + domain " +
+    "bounds + `electrodes` [{shape, potential_v}] (>= 2) + `dielectrics` " +
+    "[{shape, eps_r}] — literal numbers only for this class.",
+  properties: {
+    problem: {
+      type: "string" as const,
+      enum: [
+        "axisym_magnetostatics",
+        "planar_magnetostatics",
+        "electrostatics",
+      ],
+    },
+    // axisym magnetostatics
+    r_max_mm: paramValue,
+    z_min_mm: paramValue,
+    z_max_mm: paramValue,
+    coils: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["region"],
+        properties: {
+          region: rectRegion,
+          turns: { ...paramValue, description: "Winding turns. Default 1." },
+          current_a: { ...paramValue, description: "Coil current, A." },
+        },
+      },
+    },
+    // planar magnetostatics
+    x_min_mm: paramValue,
+    x_max_mm: paramValue,
+    y_min_mm: paramValue,
+    y_max_mm: paramValue,
+    conductors: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["region"],
+        properties: {
+          region: rectRegion,
+          total_current_a: paramValue,
+        },
+      },
+    },
+    magnets: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["region"],
+        properties: {
+          region: rectRegion,
+          br_x_t: { ...paramValue, description: "Remanence x, tesla." },
+          br_y_t: { ...paramValue, description: "Remanence y, tesla." },
+          mu_r: { ...paramValue, description: "Recoil mu_r. Default 1." },
+        },
+      },
+    },
+    periodic_x: { type: "boolean" as const },
+    // shared magnetostatics
+    materials: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["region", "mu_r"],
+        properties: {
+          region: rectRegion,
+          mu_r: paramValue,
+          js_t: {
+            ...paramValue,
+            description:
+              "Saturation polarization, tesla — presence switches this " +
+              "region to the nonlinear B-H law (Picard outer loop).",
+          },
+        },
+      },
+    },
+    bc_r_outer: bcSchema,
+    bc_z_low: bcSchema,
+    bc_z_high: bcSchema,
+    bc_x_low: bcSchema,
+    bc_x_high: bcSchema,
+    bc_y_low: bcSchema,
+    bc_y_high: bcSchema,
+    // electrostatics
+    geometry: {
+      type: "string" as const,
+      enum: ["axisymmetric", "planar"],
+    },
+    electrodes: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["shape", "potential_v"],
+        properties: {
+          shape: electroShape,
+          potential_v: { type: "number" as const },
+        },
+      },
+    },
+    dielectrics: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["shape", "eps_r"],
+        properties: {
+          shape: electroShape,
+          eps_r: { type: "number" as const },
+        },
+      },
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "simulate_em",
+    pack: null,
+    description:
+      "Electromagnetic field solve (finite-volume SOR, the differentiable FEMM " +
+      "replacement): axisymmetric magnetostatics (coil inductance, stored energy, axial " +
+      "force — solenoids, coaxial coil pairs), planar magnetostatics (motor cross-section " +
+      "torque and forces per meter of depth, permanent magnets, optional saturable B-H " +
+      "iron), or electrostatics (two-terminal capacitance) — as data plus " +
+      "`vcad.em-claims/1` sets and unified-receipt claims, each with a two-independent-" +
+      "routes cross-check residual (energy vs linkage, JxB vs Maxwell stress, charge vs " +
+      "energy). Predictions carry basis \"predicted\" and roll up Provisional until " +
+      "measured. Static/2D only: no eddy currents or AC here, no 3D end effects, planar " +
+      "results are per meter of depth. Deterministic. Cost ~O((nx*ny)^1.5) SOR sweeps; " +
+      "the 81x81 default runs in well under a second — raise the grid for tight " +
+      "tolerances.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec"],
+      properties: {
+        spec: emSpecSchema,
+        parameters: {
+          type: "object" as const,
+          additionalProperties: { type: "number" as const },
+          description:
+            "Bindings for named spec parameters (magnetostatic classes).",
+        },
+        options: {
+          type: "object" as const,
+          properties: {
+            nx: {
+              type: "number" as const,
+              description: "Grid nodes in x (r for axisym). Default 81.",
+            },
+            ny: {
+              type: "number" as const,
+              description: "Grid nodes in y (z for axisym). Default 81.",
+            },
+            tol: {
+              type: "number" as const,
+              description: "SOR relative tolerance. Default 1e-8.",
+            },
+            max_sweeps: {
+              type: "number" as const,
+              description: "SOR sweep cap. Default 200000.",
+            },
+            drive_coil: {
+              type: "number" as const,
+              description:
+                "Axisym: coil index the inductance claim is priced for. " +
+                "Default 0.",
+            },
+            force_coil: {
+              type: "number" as const,
+              description:
+                "Axisym: also emit force claims for this coil index.",
+            },
+            stress_probe: {
+              type: "object" as const,
+              description:
+                "Axisym force cross-check: Maxwell-stress cylinder " +
+                "{r_mm, z_lo_mm, z_hi_mm, panels?}.",
+              properties: {
+                r_mm: { type: "number" as const },
+                z_lo_mm: { type: "number" as const },
+                z_hi_mm: { type: "number" as const },
+                panels: { type: "number" as const },
+              },
+            },
+            torque: {
+              type: "object" as const,
+              description:
+                "Planar (required for that class): torque center + mean " +
+                "airgap radius + stack depth " +
+                "{cx_mm, cy_mm, r_mean_m, depth_m, stress_line_y_mm?}.",
+              properties: {
+                cx_mm: { type: "number" as const },
+                cy_mm: { type: "number" as const },
+                r_mean_m: { type: "number" as const },
+                depth_m: { type: "number" as const },
+                stress_line_y_mm: { type: "number" as const },
+              },
+            },
+            hot: {
+              type: "number" as const,
+              description:
+                "Electrostatics: index of the driven electrode. Default 0.",
+            },
+          },
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.emSimulate(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify(a.options ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/neutronics.ts
+++ b/packages/mcp/src/tools/neutronics.ts
@@ -1,0 +1,146 @@
+/**
+ * Neutronics tools — the `vcad-kernel-neutronics` crate over MCP.
+ *
+ * `simulate_neutron_shield` runs analog Monte Carlo neutron transport
+ * through a spherical shield stack and returns dose rates at detector
+ * shells WITH batch-statistics error bars, plus the
+ * `vcad.neutronics-claims/1` set and unified-receipt claims. Fail-closed
+ * throughout: truncated histories or unscored tallies refuse to price
+ * claims (the fix is more histories). Predictions carry
+ * `basis: "predicted"` and roll up Provisional — never verified — until
+ * a survey meter measurement is bound.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters`.",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const shieldSpecSchema = {
+  type: "object" as const,
+  required: ["layers", "source", "detectors"],
+  description:
+    "Spherical shield: concentric layers from r=0 outward around a point " +
+    "source, with detector shells that must each sit strictly inside one " +
+    "layer (put them in air gaps). Units mm. Any numeric field may " +
+    "instead be a string naming a parameter supplied in `parameters` " +
+    "(fail-closed: unbound names error).",
+  properties: {
+    layers: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["material", "thickness_mm"],
+        properties: {
+          material: {
+            type: "string" as const,
+            description:
+              "Built-in library material: hdpe, paraffin, borated-hdpe-5, " +
+              "water, lead, concrete, air, void.",
+          },
+          thickness_mm: paramValue,
+        },
+      },
+    },
+    source: {
+      type: "object" as const,
+      required: ["rate_n_per_s", "energy_ev"],
+      description:
+        "Isotropic point source at r=0. Energy must lie in the 5-group " +
+        "structure [1e-4, 3e6] eV — D-D 2.45e6 eV is in range; D-T 14.1 " +
+        "MeV is rejected.",
+      properties: {
+        rate_n_per_s: paramValue,
+        energy_ev: paramValue,
+      },
+    },
+    detectors: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["label", "radius_mm"],
+        properties: {
+          label: { type: "string" as const },
+          radius_mm: paramValue,
+          half_width_mm: {
+            ...paramValue,
+            description: "Shell half-thickness. Default 20 mm.",
+          },
+        },
+      },
+    },
+    run: {
+      type: "object" as const,
+      description: "Monte Carlo controls (deterministic for a given seed).",
+      properties: {
+        histories_per_batch: {
+          type: "number" as const,
+          description: "Default 20000.",
+        },
+        batches: {
+          type: "number" as const,
+          description: "Error-bar batches (>= 2). Default 20.",
+        },
+        seed: { type: "number" as const, description: "Default 20260717." },
+      },
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "simulate_neutron_shield",
+    pack: null,
+    description:
+      "Monte Carlo neutron shielding run (analog transport, 5-group multigroup library " +
+      "with exact elastic kinematics): spherical layer stack around a point source (D-D " +
+      "band), H*(10) dose rate at each detector shell WITH 1-sigma batch error bars " +
+      "(rse), attenuation factor vs bare source, thermal flux, and absorbed/leakage " +
+      "balance — as data plus `vcad.neutronics-claims/1` and unified-receipt claims. " +
+      "Fail-closed: truncated histories or a tally that scored nothing refuses claims " +
+      "(raise histories). Predictions carry basis \"predicted\" and roll up Provisional " +
+      "until surveyed. Design-estimate physics: 5-group library (not ENDF continuous-" +
+      "energy), spherical geometry only, no gamma dose, no activation, source energy " +
+      "capped at 3 MeV (no D-T). Deterministic per seed. Cost ~histories (cap 5M); " +
+      "error bars shrink as 1/sqrt(N). The 400k default runs in seconds.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec"],
+      properties: {
+        spec: shieldSpecSchema,
+        parameters: {
+          type: "object" as const,
+          additionalProperties: { type: "number" as const },
+          description: "Bindings for named spec parameters, `{name: value}`.",
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.neutronicsSimulate(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/photonics.ts
+++ b/packages/mcp/src/tools/photonics.ts
@@ -1,0 +1,186 @@
+/**
+ * Photonics FDTD tools — the `vcad-kernel-photonics` crate over MCP.
+ *
+ * `simulate_photonics` runs a forward 2D TM FDTD transmission analysis
+ * of a rect-composed device (straight guides, tapers, splitters) with a
+ * slab-mode line source and flux monitors, returning the transmission
+ * spectrum and the `vcad.photonics-claims/1` set plus unified-receipt
+ * claims. Predictions carry `basis: "predicted"` and roll up Provisional
+ * — never verified — until the chip is measured.
+ *
+ * The crate's adjoint inverse-design loop is deliberately NOT exposed
+ * here: its device wiring (objectives, arm monitors, beta schedule)
+ * lives in example code rather than a library seam. When that seam
+ * lands in-crate, an `optimize_photonics` tool follows.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const photonicsSpecSchema = {
+  type: "object" as const,
+  required: [
+    "wavelength_um",
+    "n_core",
+    "n_clad",
+    "size_um",
+    "core_rects_um",
+    "source",
+    "monitor_in_x_um",
+    "outputs",
+  ],
+  description:
+    "2D device in the xy plane, 1 unit = 1 um, propagation along +x. " +
+    "Cladding fills the domain; `core_rects_um` are painted at n_core^2 " +
+    "with sub-pixel averaging. Literal numbers only.",
+  properties: {
+    wavelength_um: {
+      type: "number" as const,
+      description: "Vacuum wavelength, um (e.g. 1.55).",
+    },
+    n_core: { type: "number" as const },
+    n_clad: { type: "number" as const },
+    size_um: {
+      type: "array" as const,
+      minItems: 2,
+      maxItems: 2,
+      items: { type: "number" as const },
+      description: "Domain size [lx, ly], um.",
+    },
+    core_rects_um: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "array" as const,
+        minItems: 4,
+        maxItems: 4,
+        items: { type: "number" as const },
+      },
+      description: "Core rectangles [x0, y0, x1, y1], um.",
+    },
+    source: {
+      type: "object" as const,
+      required: ["x_um", "half_width_um"],
+      description:
+        "Slab-mode line source: the even TM mode of a guide with this " +
+        "half-width is solved analytically and injected as a line profile.",
+      properties: {
+        x_um: { type: "number" as const },
+        center_y_um: {
+          type: "number" as const,
+          description: "Mode center. Default domain mid-height.",
+        },
+        half_width_um: {
+          type: "number" as const,
+          description: "Guide half-width the source mode is solved for.",
+        },
+      },
+    },
+    monitor_in_x_um: {
+      type: "number" as const,
+      description:
+        "Input-power monitor x (between source and device; full-height).",
+    },
+    outputs: {
+      type: "array" as const,
+      minItems: 1,
+      maxItems: 2,
+      items: {
+        type: "object" as const,
+        required: ["x_um"],
+        properties: {
+          x_um: { type: "number" as const },
+          y_lo_um: {
+            type: "number" as const,
+            description: "Window low edge. Default full interior height.",
+          },
+          y_hi_um: {
+            type: "number" as const,
+            description: "Window high edge. Default full interior height.",
+          },
+        },
+      },
+      description:
+        "One or two output flux monitors. Two = splitter arms (use y " +
+        "windows to separate them); one = simple transmission (arm B " +
+        "claims read zero).",
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "simulate_photonics",
+    pack: null,
+    description:
+      "Forward 2D TM FDTD photonics run (validated Yee grid + CPML, dispersion error " +
+      "~5e-8 at 40 cells/lambda): rect-composed device, analytically-solved slab-mode " +
+      "line source, input/output flux monitors, transmission spectrum, insertion loss, " +
+      "and splitting ratio — as data plus `vcad.photonics-claims/1` and unified-receipt " +
+      "claims. Predictions carry basis \"predicted\" and roll up Provisional until the " +
+      "chip is measured. 2D TM only: quantitative for the 2D problem, qualitative for a " +
+      "3D chip (no out-of-plane loss); lossless dielectrics; rect geometry only in this " +
+      "tool. Deterministic. Cost ~grid cells x steps (caps 2M cells / 100k steps); the " +
+      "default 20 cells/lambda x 3000 steps on a 10x5 um domain runs in a few seconds. " +
+      "Raise `resolution` toward 40 for publication-grade numbers.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec"],
+      properties: {
+        spec: photonicsSpecSchema,
+        options: {
+          type: "object" as const,
+          properties: {
+            resolution: {
+              type: "number" as const,
+              description: "Cells per vacuum wavelength (>= 8). Default 20.",
+            },
+            steps: {
+              type: "number" as const,
+              description: "FDTD time steps. Default 3000.",
+            },
+            cpml_cells: {
+              type: "number" as const,
+              description: "Absorber thickness per side. Default 12.",
+            },
+            courant: {
+              type: "number" as const,
+              description: "Courant factor (0, 1]. Default 0.5.",
+            },
+            n_freqs: {
+              type: "number" as const,
+              description:
+                "Monitor frequencies (forced odd, center exact). Default 1.",
+            },
+            band_frac: {
+              type: "number" as const,
+              description:
+                "Fractional bandwidth spanned when n_freqs > 1. Default 0.2.",
+            },
+          },
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.photonicsSimulate(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.options ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/thermal.ts
+++ b/packages/mcp/src/tools/thermal.ts
@@ -1,0 +1,220 @@
+/**
+ * Thermal FEA tools — the `vcad-kernel-thermal` crate over MCP.
+ *
+ * `solve_thermal` runs a steady heat-conduction solve on a voxel grid
+ * (harmonic-mean finite volumes + PCG) and returns the temperature
+ * summary, per-source theta (junction-to-ambient), the energy-balance
+ * audit, and the `vcad.thermal-claims/1` set plus unified-receipt claims.
+ * Predictions carry `basis: "predicted"` and roll up Provisional — never
+ * verified — until the hardware is measured.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters`.",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const paramVec3 = {
+  type: "array" as const,
+  minItems: 3,
+  maxItems: 3,
+  items: paramValue,
+};
+
+const shapeSchema = {
+  type: "object" as const,
+  required: ["type"],
+  description:
+    'Region shape: `{"type":"Box","min_mm":[..],"size_mm":[..]}` or ' +
+    '`{"type":"Tube","axis":"Z","center_mm":[..2],"span_mm":[..2],' +
+    '"outer_radius_mm":..,"inner_radius_mm":..}`.',
+  properties: {
+    type: { type: "string" as const, enum: ["Box", "Tube"] },
+    min_mm: paramVec3,
+    size_mm: paramVec3,
+    axis: { type: "string" as const, enum: ["X", "Y", "Z"] },
+    center_mm: {
+      type: "array" as const,
+      minItems: 2,
+      maxItems: 2,
+      items: paramValue,
+    },
+    span_mm: {
+      type: "array" as const,
+      minItems: 2,
+      maxItems: 2,
+      items: paramValue,
+    },
+    outer_radius_mm: paramValue,
+    inner_radius_mm: paramValue,
+  },
+};
+
+const boundarySchema = {
+  type: "object" as const,
+  required: ["type"],
+  description:
+    'Boundary condition: `{"type":"Adiabatic"}`, ' +
+    '`{"type":"FixedTemperature","temperature_c":..}`, or ' +
+    '`{"type":"Convection","h_w_m2k":..,"ambient_c":..}`.',
+  properties: {
+    type: {
+      type: "string" as const,
+      enum: ["Adiabatic", "FixedTemperature", "Convection"],
+    },
+    temperature_c: paramValue,
+    h_w_m2k: paramValue,
+    ambient_c: paramValue,
+  },
+};
+
+const thermalSpecSchema = {
+  type: "object" as const,
+  required: ["origin_mm", "size_mm", "divisions", "materials"],
+  description:
+    "Voxelized conduction domain: an axis-aligned box discretized into " +
+    "`divisions` voxels, with material regions (per-axis k), power " +
+    "sources, optional fixed-temperature regions, and per-face boundary " +
+    "conditions `[-x,+x,-y,+y,-z,+z]`. Units mm / W / degC. Any numeric " +
+    "field (except `divisions`) may instead be a string naming a " +
+    "parameter supplied in `parameters` (fail-closed: unbound names " +
+    "error).",
+  properties: {
+    origin_mm: paramVec3,
+    size_mm: paramVec3,
+    divisions: {
+      type: "array" as const,
+      minItems: 3,
+      maxItems: 3,
+      items: { type: "number" as const },
+      description: "Voxel counts per axis (plain integers, the cost knob).",
+    },
+    materials: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["shape", "k_w_mk"],
+        properties: {
+          shape: shapeSchema,
+          k_w_mk: {
+            ...paramVec3,
+            description: "Per-axis conductivity, W/(m*K).",
+          },
+        },
+      },
+    },
+    sources: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["name", "shape", "power_w"],
+        properties: {
+          name: { type: "string" as const },
+          shape: shapeSchema,
+          power_w: paramValue,
+        },
+      },
+    },
+    fixed: {
+      type: "array" as const,
+      items: {
+        type: "object" as const,
+        required: ["shape", "temperature_c"],
+        properties: {
+          shape: shapeSchema,
+          temperature_c: paramValue,
+        },
+      },
+    },
+    domain_faces: {
+      type: "array" as const,
+      minItems: 6,
+      maxItems: 6,
+      items: boundarySchema,
+      description:
+        "Boundary per domain face `[-x,+x,-y,+y,-z,+z]`. Default all " +
+        "adiabatic — ground the system with at least one non-adiabatic " +
+        "face or fixed region.",
+    },
+    exposed: {
+      ...boundarySchema,
+      description:
+        "Boundary applied to interior void-facing surfaces. Default adiabatic.",
+    },
+    reference_c: {
+      ...paramValue,
+      description:
+        "Explicit theta reference temperature; usually inferred from the " +
+        "single ambient.",
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "solve_thermal",
+    pack: null,
+    description:
+      "Steady heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, " +
+      "returning T_max and its location, per-source theta_ja (K/W, junction-to-ambient), " +
+      "reservoir loads, and an energy-balance audit — as data plus " +
+      "`vcad.thermal-claims/1` and unified-receipt claims. Predictions carry basis " +
+      "\"predicted\" and roll up Provisional until hardware is measured. Conduction only: " +
+      "convection enters as film coefficients you supply (h values are the dominant " +
+      "uncertainty), no radiation, no fluid flow, steady state only. The full temperature " +
+      "field is not returned (summaries + claims are). Cost scales with voxel count " +
+      "(capped at 2M); a 20x20x2 board solves instantly, 100x100x13 in seconds.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec"],
+      properties: {
+        spec: thermalSpecSchema,
+        parameters: {
+          type: "object" as const,
+          additionalProperties: { type: "number" as const },
+          description: "Bindings for named spec parameters, `{name: value}`.",
+        },
+        options: {
+          type: "object" as const,
+          properties: {
+            tol: {
+              type: "number" as const,
+              description: "PCG relative tolerance. Default 1e-8.",
+            },
+            max_iters: {
+              type: "number" as const,
+              description: "PCG iteration cap. Default 50000.",
+            },
+          },
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.thermalSolve(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify(a.options ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/tolerance.ts
+++ b/packages/mcp/src/tools/tolerance.ts
@@ -1,0 +1,177 @@
+/**
+ * Tolerance stackup tools — the `vcad-kernel-tolerance` crate over MCP.
+ *
+ * `analyze_tolerance_stackup` runs worst-case, RSS, and seeded Monte
+ * Carlo over a linear assembly chain, computes exact sensitivities, and
+ * returns the `vcad.tolerance-claims/1` set plus unified-receipt claims.
+ * Predictions carry `basis: "predicted"` and roll up Provisional — never
+ * verified — until the parts are measured.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const paramValue = {
+  description:
+    "A number, or the name of a named parameter bound via `parameters`.",
+  anyOf: [{ type: "number" as const }, { type: "string" as const }],
+};
+
+const distSchema = {
+  type: "object" as const,
+  description:
+    "Contributor distribution. `normal_from_tol` derives sigma from the " +
+    "(symmetric) tolerance band via the convention; `uniform`/`two_point` " +
+    "must lie within the drawing limits.",
+  required: ["type"],
+  properties: {
+    type: {
+      type: "string" as const,
+      enum: ["normal", "normal_from_tol", "uniform", "two_point"],
+    },
+    mean: { ...paramValue, description: "normal: mean offset, mm." },
+    sigma: { ...paramValue, description: "normal: one sigma, mm." },
+    convention: {
+      type: "object" as const,
+      description:
+        'normal_from_tol: `{"type":"three_sigma"}` or `{"type":"k_sigma","k":4}`.',
+      properties: {
+        type: {
+          type: "string" as const,
+          enum: ["three_sigma", "k_sigma"],
+        },
+        k: { type: "number" as const },
+      },
+    },
+    lo: { ...paramValue, description: "uniform: lower offset, mm." },
+    hi: { ...paramValue, description: "uniform: upper offset, mm." },
+    a: { ...paramValue, description: "two_point: first offset, mm." },
+    b: { ...paramValue, description: "two_point: second offset, mm." },
+    p_b: { ...paramValue, description: "two_point: probability of b." },
+  },
+};
+
+const stackupSpecSchema = {
+  type: "object" as const,
+  required: ["name", "contributors", "requirement"],
+  description:
+    "Linear tolerance stackup: gap = sum(coeff_i * x_i) over contributor " +
+    "dimensions, graded against a fit requirement. Units mm. Any numeric " +
+    "field may instead be a string naming a parameter supplied in " +
+    "`parameters` (fail-closed: unbound names error).",
+  properties: {
+    name: { type: "string" as const },
+    contributors: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: [
+          "name",
+          "coeff",
+          "nominal",
+          "tol_minus",
+          "tol_plus",
+          "dist",
+        ],
+        properties: {
+          name: { type: "string" as const },
+          coeff: {
+            ...paramValue,
+            description:
+              "Direction coefficient (+1 adds to the gap, -1 subtracts).",
+          },
+          nominal: { ...paramValue, description: "Nominal dimension, mm." },
+          tol_minus: {
+            ...paramValue,
+            description: "Lower tolerance magnitude, mm (>= 0).",
+          },
+          tol_plus: {
+            ...paramValue,
+            description: "Upper tolerance magnitude, mm (>= 0).",
+          },
+          dist: distSchema,
+        },
+      },
+    },
+    requirement: {
+      type: "object" as const,
+      required: ["name"],
+      description:
+        "Fit requirement on the closing gap; at least one bound required.",
+      properties: {
+        name: { type: "string" as const },
+        lower_mm: paramValue,
+        upper_mm: paramValue,
+      },
+    },
+  },
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "analyze_tolerance_stackup",
+    pack: null,
+    description:
+      "Dimensional tolerance stackup analysis over a linear assembly chain: worst-case " +
+      "extremes, RSS statistics (yield, Cp/Cpk), seeded Monte Carlo fit probability with " +
+      "batch error bars, and exact per-contributor sensitivities (variance share, " +
+      "d yield/d nominal) — as data plus `vcad.tolerance-claims/1` and unified-receipt " +
+      "claims. Predictions carry basis \"predicted\" and roll up Provisional until parts " +
+      "are measured. Linear 1D chains only: no 3D kinematic loops here (project those to " +
+      "a chain first), distributions are the declared ones (assumed 3-sigma unless " +
+      "stated). Deterministic for a given seed. Cost is O(n samples); the 100k default " +
+      "runs in well under a second.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["spec"],
+      properties: {
+        spec: stackupSpecSchema,
+        parameters: {
+          type: "object" as const,
+          additionalProperties: { type: "number" as const },
+          description: "Bindings for named spec parameters, `{name: value}`.",
+        },
+        options: {
+          type: "object" as const,
+          properties: {
+            n: {
+              type: "number" as const,
+              description: "Monte Carlo samples. Default 100000 (min 100).",
+            },
+            seed: {
+              type: "number" as const,
+              description: "MC seed (deterministic). Default 0x5EED7015.",
+            },
+            batches: {
+              type: "number" as const,
+              description: "MC error-bar batches. Default 16.",
+            },
+          },
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const out = ctx.engine.toleranceAnalyze(
+        JSON.stringify(a.spec),
+        JSON.stringify(a.parameters ?? {}),
+        JSON.stringify(a.options ?? {}),
+      );
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -251,6 +251,18 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
     annotations: RO,
   },
   optimize_electrodes: { title: "Optimize Electrodes", annotations: RO },
+  simulate_em: { title: "Simulate EM Fields", annotations: RO },
+  simulate_photonics: { title: "Simulate Photonics", annotations: RO },
+  analyze_antenna: { title: "Analyze Antenna", annotations: RO },
+  solve_thermal: { title: "Solve Thermal", annotations: RO },
+  simulate_neutron_shield: {
+    title: "Simulate Neutron Shield",
+    annotations: RO,
+  },
+  analyze_tolerance_stackup: {
+    title: "Analyze Tolerance Stackup",
+    annotations: RO,
+  },
   predict_physics: { title: "Predict Physics", annotations: RO },
   define_loon: { title: "Define Loon Macro", annotations: RW },
   call_loon: { title: "Call Loon Macro", annotations: RW },


### PR DESCRIPTION
Six solver crates that merged as bare kernels (#555–#560) get their MCP tool surfaces, following the particle template (#554) end-to-end: in-crate unified-receipt adapter → WASM binding (`json_compatible` serialization) → engine wrapper → tool def → integration test through the real server + freshly-built wasm.

Every tool returns its crate's native claim set **and** unified-receipt claims via a new in-crate `design_claims` adapter (copied from `vcad-kernel-particle/src/receipt.rs`): basis `predicted`, rolls up **Provisional, never Pass**, provenance and error bars in `details`. Zero receipt-schema changes.

## The tools

| Tool | Crate | One-line example |
|---|---|---|
| `simulate_em` | vcad-kernel-em | `{spec: {problem: "axisym_magnetostatics", r_max_mm: 40, z_min_mm: 0, z_max_mm: 100, coils: [{region: {x_min_mm: 20, x_max_mm: 22, y_min_mm: 0, y_max_mm: 100}, turns: 1000, current_a: 1}]}}` → L = 17 mH + cross-route residual |
| `simulate_photonics` | vcad-kernel-photonics | `{spec: {wavelength_um: 1.55, n_core: 3.48, n_clad: 1.44, size_um: [5.6, 2.5], core_rects_um: [[-1, 1.14, 99, 1.36]], source: {x_um: 0.97, half_width_um: 0.11}, monitor_in_x_um: 1.94, outputs: [{x_um: 4.85}]}}` → T ≈ 0.99 |
| `analyze_antenna` | vcad-kernel-antenna | `{spec: {elements: [{type: "wire", start_mm: [0,0,-500], end_mm: [0,0,500], radius_mm: 1, segments: 20}], feed_mm: [0,0,0]}, band: {f_lo_hz: 120e6, f_hi_hz: 165e6, points: 46}}` → resonance 144 MHz, Z_in 72 Ω, sweep rows |
| `solve_thermal` | vcad-kernel-thermal | `{spec: {origin_mm: [0,0,0], size_mm: [40,40,1.6], divisions: [20,20,2], materials: [...], sources: [{name: "die", power_w: 2, ...}], domain_faces: [...convection...]}}` → T_max, θ_ja per source, energy audit |
| `simulate_neutron_shield` | vcad-kernel-neutronics | `{spec: {layers: [{material: "air", thickness_mm: 100}, {material: "hdpe", thickness_mm: 100}, {material: "air", thickness_mm: 2000}], source: {rate_n_per_s: 1e6, energy_ev: 2.45e6}, detectors: [{label: "operator", radius_mm: 500}]}}` → dose ± rse |
| `analyze_tolerance_stackup` | vcad-kernel-tolerance | `{spec: {name: "chain", contributors: [{name: "pocket", coeff: 1, nominal: 20, tol_minus: 0.15, tol_plus: 0.15, dist: {type: "normal_from_tol", convention: {type: "three_sigma"}}}, ...], requirement: {name: "protrusion", lower_mm: 0.35, upper_mm: 0.75}}}` → WC/RSS/MC + sensitivities |

All six support the fail-closed named-parameter seam (`"power_w": "p_die"` + `parameters: {p_die: 2}`) where the crate has one; every numeric knob that isn't a named parameter is validated in front of the kernel's panicking paths (panics poison the WASM instance), and grid/segment/history caps keep the MCP tier from wedging.

## Decisions worth reviewing

- **`optimize_photonics` deliberately not shipped**: the crate's inverse-design loop has no library seam — objectives/arm monitors/beta schedule live in `examples/splitter_inverse_design.rs` closures. Wiring it from the wasm layer would mean forking ~250 lines of example code. It follows when that seam lands in-crate (noted in the tool-file header).
- **EM electrostatics + photonics forward runs use wasm-local DTOs** (literal-only, documented in the schemas): those problem classes have no serde spec in their crates (deliberate M0 scoping). Magnetostatics rides the crates' own `AxisymSpec`/`PlanarSpec` named-parameter seams.
- **EM returns `claim_sets` (plural)**: inductance and force claims are separate crate claim families with separate cross-route residuals; `receipt_claims` flattens all of them.
- **Thermal returns summaries, not the field**: `t_c` is grid-sized; T_max/θ/energy-audit + claims are the MCP-tier value.
- **Tolerance test chain is the WC-vs-RSS story**: worst case violates both limits (0.30/0.80 vs [0.35, 0.75]) while MC fit ≈ 0.999 — asserted as such.

## Verification

- Six crates: `cargo test` green (adapter tests assert Provisional roll-up via `DesignReceipt::verdict()`), `cargo clippy -D warnings` clean, `cargo fmt` clean
- `vcad-kernel-wasm` + `vcad-kernel`: clippy `-D warnings` clean
- `packages/mcp`: full vitest suite **74 files / 865 passed** against wasm built from source (`npm run build -w vcad-kernel-wasm`); the six new test files use the `describe.skipIf(!wasmHas…)` stale-artifact guard
- `tsc --noEmit` clean on `@vcad/engine` and `@vcad/mcp`; tool-surface fixture regenerated (`UPDATE_TOOL_SURFACE=1`)
- Checked-in wasm artifacts untouched (wasm-refresh.yml owns them on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)