### PR TITLE
Tier 2 complete + tier 3 opened: joint repair, tree-to-tree, off-grid vias, BGA escape, resume ratchet, GPU frontier compaction (record 0.939)

### DIFF
--- a/crates/vcad-ecad-pcb/examples/cm5_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_bench.rs
@@ -42,8 +42,16 @@ fn main() {
         .unwrap_or(usize::MAX);
     let out_json = args.next();
 
-    let text = std::fs::read_to_string(&path).expect("read kicad_pcb");
-    let mut pcb = parse_kicad_pcb(&text).expect("parse kicad_pcb");
+    let text = std::fs::read_to_string(&path).expect("read board file");
+    // Resume mode: a .pcb.json saved by a previous run loads with its routed
+    // copper intact — the session seeds from it, the ratsnest re-lists only
+    // the still-unrouted nets, and the run costs minutes instead of hours.
+    let resume = path.ends_with(".json");
+    let mut pcb = if resume {
+        serde_json::from_str(&text).expect("parse pcb json")
+    } else {
+        parse_kicad_pcb(&text).expect("parse kicad_pcb")
+    };
 
     // Ground truth: the human routing we are about to strip.
     let human_traces = pcb.traces.len();
@@ -68,11 +76,14 @@ fn main() {
         human_nets.len()
     );
 
-    // Strip everything the autorouter is expected to produce. Zones stay: a
-    // poured plane is design intent (the router stitches to it, not through it).
-    pcb.traces.clear();
-    pcb.trace_arcs.clear();
-    pcb.vias.clear();
+    // Strip everything the autorouter is expected to produce (fresh runs
+    // only — resume keeps its own previous routing). Zones stay: a poured
+    // plane is design intent (the router stitches to it, not through it).
+    if !resume {
+        pcb.traces.clear();
+        pcb.trace_arcs.clear();
+        pcb.vias.clear();
+    }
 
     // Optional subset: the N nets with the most pads (the hard ones first).
     // Keyed by the pad net strings — the exact names the router's pad-derived

--- a/crates/vcad-ecad-pcb/examples/cm5_gap.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_gap.rs
@@ -130,7 +130,11 @@ fn main() {
         }
     }
     gaps.sort_by(f64::total_cmp);
-    let pct = |q: f64| gaps.get((gaps.len() as f64 * q) as usize).copied().unwrap_or(f64::NAN);
+    let pct = |q: f64| {
+        gaps.get((gaps.len() as f64 * q) as usize)
+            .copied()
+            .unwrap_or(f64::NAN)
+    };
     println!(
         "\nhuman spacing on stuck-net copper: min={:.3}mm p5={:.3} p25={:.3} median={:.3} (our calibrated clearance: {:.3}mm)",
         min_gap,

--- a/crates/vcad-ecad-pcb/examples/cm5_gap.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_gap.rs
@@ -103,4 +103,40 @@ fn main() {
         println!("  {a:?}..{b:?}: {c} vias");
     }
     println!("\ntotal human vias on stuck nets: {total_human_vias}");
+
+    // How tightly did the human actually space copper? Probe every stuck
+    // net's trace segments against the rest of the board with a huge
+    // clearance and report the min air gap observed — the real fab limit,
+    // vs. the clearance our importer calibrated.
+    let session = vcad_ecad_pcb::session::RouteSession::from_pcb(&human);
+    let mut min_gap = f64::INFINITY;
+    let mut gaps: Vec<f64> = Vec::new();
+    for net in &stuck {
+        for t in human.traces.iter().filter(|t| t.net == *net) {
+            let pr = session.probe(
+                &vcad_ecad_pcb::spatial::CopperGeom::Segment {
+                    a: t.start,
+                    b: t.end,
+                    half_w: t.width / 2.0,
+                },
+                t.layer,
+                net,
+                10.0,
+            );
+            if pr.min_clearance.is_finite() {
+                gaps.push(pr.min_clearance);
+                min_gap = min_gap.min(pr.min_clearance);
+            }
+        }
+    }
+    gaps.sort_by(f64::total_cmp);
+    let pct = |q: f64| gaps.get((gaps.len() as f64 * q) as usize).copied().unwrap_or(f64::NAN);
+    println!(
+        "\nhuman spacing on stuck-net copper: min={:.3}mm p5={:.3} p25={:.3} median={:.3} (our calibrated clearance: {:.3}mm)",
+        min_gap,
+        pct(0.05),
+        pct(0.25),
+        pct(0.5),
+        human.rules.default_rules.clearance,
+    );
 }

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1102,7 +1102,10 @@ fn search_route(
     }
     if r3.success && r3.segments.is_empty() && r3.vias.is_empty() {
         // The two components already touch (earlier commits joined them):
-        // the connection is satisfied with zero new copper.
+        // the connection is satisfied with zero new copper. Log it so a
+        // resume run's "routed" count can be read honestly (these repeat on
+        // every resume because the ratsnest keys completion off traces).
+        log::debug!("{net}: connection already satisfied by existing copper contact");
         return Some(Candidate {
             net: net.to_string(),
             from,

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -903,10 +903,31 @@ fn route_batch(
             .collect();
         for (((net, from, to), attempts), cand) in batch.into_iter().zip(candidates) {
             match cand {
-                None => {
-                    fail_cache.insert(conn_key(&net, from, to), session.epoch());
-                    unrouted.push((net, from, to));
-                }
+                // Speculative search failed: give the connection the full
+                // sequential arsenal (including the escape stage, which only
+                // runs inside try_route) before declaring it unrouted.
+                None => match try_route(
+                    session,
+                    pcb,
+                    width,
+                    &net,
+                    from,
+                    to,
+                    placed,
+                    cong,
+                    use_push_shove,
+                    max_expansions,
+                ) {
+                    Some(p) => {
+                        committed += 1;
+                        fail_cache.remove(&conn_key(&net, from, to));
+                        placed.push(p);
+                    }
+                    None => {
+                        fail_cache.insert(conn_key(&net, from, to), session.epoch());
+                        unrouted.push((net, from, to));
+                    }
+                },
                 Some(c) => match validate_and_commit(session, pcb, c, placed) {
                     Some(p) => {
                         committed += 1;

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -22,6 +22,7 @@ use crate::session::{RouteSession, SpanId};
 use crate::spatial::{point_in_polygon, CopperElement, CopperGeom};
 
 use super::congestion::Congestion;
+use super::escape;
 use super::global::plan_corridors;
 use super::maze::route_net_maze3d;
 use super::push_shove::{Obstacle, PushShoveRouter};
@@ -986,7 +987,7 @@ fn try_route(
     use_push_shove: bool,
     max_expansions: usize,
 ) -> Option<Placed> {
-    let cand = search_route(
+    if let Some(cand) = search_route(
         session,
         pcb,
         width,
@@ -998,8 +999,119 @@ fn try_route(
         max_expansions,
         true,
         None,
-    )?;
-    validate_and_commit(session, pcb, cand, placed)
+    ) {
+        return validate_and_commit(session, pcb, cand, placed);
+    }
+    // Both direct maze attempts (coarse + fine retry) failed. If an endpoint
+    // sits inside a dense pin field (BGA / fine-pitch lattice), plan a
+    // flow-based escape out of the field and re-search from the egress point.
+    try_route_escape(
+        session,
+        pcb,
+        width,
+        net,
+        from,
+        to,
+        placed,
+        cong,
+        use_push_shove,
+        max_expansions,
+    )
+}
+
+/// Escape-assisted retry for a connection the direct maze could not place
+/// (tier-2 BGA escape stage; see [`super::escape`]).
+///
+/// When an endpoint lies inside a detected dense pin field, the min-cost
+/// max-flow escape planner assigns it an interstitial polyline from the pad
+/// to an egress point just outside the field; the maze is then re-run from
+/// the egress point(s) and the escape copper is prepended to the candidate,
+/// so [`validate_and_commit`] probes escape and route as one unit. Tried
+/// escalating: escape `from` only, then `to` only, then both. Commits
+/// nothing on failure.
+#[allow(clippy::too_many_arguments)]
+fn try_route_escape(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    width: f64,
+    net: &str,
+    from: Vec2,
+    to: Vec2,
+    placed: &[Placed],
+    cong: &Congestion,
+    use_push_shove: bool,
+    max_expansions: usize,
+) -> Option<Placed> {
+    let fields = escape::detect_pin_fields(pcb);
+    if fields.is_empty() {
+        return None;
+    }
+    let from_field = escape::field_containing(&fields, from);
+    let to_field = escape::field_containing(&fields, to);
+    if from_field.is_none() && to_field.is_none() {
+        return None;
+    }
+
+    for (esc_from, esc_to) in [(true, false), (false, true), (true, true)] {
+        let ef = if esc_from {
+            let Some(field) = from_field else { continue };
+            let Some(plan) = escape::plan_escape(session, pcb, field, net, from, width) else {
+                continue;
+            };
+            Some(plan)
+        } else {
+            None
+        };
+        let et = if esc_to {
+            let Some(field) = to_field else { continue };
+            let Some(plan) = escape::plan_escape(session, pcb, field, net, to, width) else {
+                continue;
+            };
+            Some(plan)
+        } else {
+            None
+        };
+
+        let f2 = ef.as_ref().map(|p| p.egress).unwrap_or(from);
+        let t2 = et.as_ref().map(|p| p.egress).unwrap_or(to);
+        let Some(mut cand) = search_route(
+            session,
+            pcb,
+            width,
+            net,
+            f2,
+            t2,
+            cong,
+            use_push_shove,
+            max_expansions,
+            true,
+            None,
+        ) else {
+            continue;
+        };
+        // Prepend/append the escape copper so validate_and_commit probes the
+        // whole connection (pad → egress → route → egress → pad) as one unit.
+        let mut segments: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
+        if let Some(p) = &ef {
+            segments.extend(p.segments.iter().map(|&(a, b)| (a, b, p.layer)));
+        }
+        segments.append(&mut cand.segments);
+        if let Some(p) = &et {
+            segments.extend(p.segments.iter().map(|&(a, b)| (a, b, p.layer)));
+        }
+        cand.segments = segments;
+        cand.from = from;
+        cand.to = to;
+        if let Some(placed_conn) = validate_and_commit(session, pcb, cand, placed) {
+            log::info!(
+                "escape: {net} routed via pin-field escape (from={} to={})",
+                esc_from,
+                esc_to
+            );
+            return Some(placed_conn);
+        }
+    }
+    None
 }
 
 /// A route found by [`search_route`] but not yet committed: the copper it
@@ -2357,6 +2469,110 @@ mod tests {
                 net: v.net.clone(),
                 source: None,
             });
+        }
+    }
+
+    #[test]
+    fn escape_rescues_pad_ringed_by_dense_field() {
+        // A source pad boxed in by a tight ring of other-net pads (a dense pin
+        // field), passable only through a single two-pad gap. With a small
+        // expansion budget the direct maze fails inside the field; the
+        // flow-based escape planner must get the connection out through the
+        // gap and try_route must then succeed.
+        let pitch = 0.65;
+        let pad_d = 0.3;
+        let n = 14;
+        let origin = Vec2::new(20.0, 10.0);
+        let mut pads = Vec::new();
+        // Two-pad gap in the top-RIGHT of the wall; the target sits up-LEFT
+        // of the box, so the direct maze floods the scatter labyrinth toward
+        // the sealed left wall while the flow planner walks to the top-right
+        // egress, from which the outside path to the target runs above the
+        // box and never tempts the search back inside.
+        let gaps = [(11usize, 13usize), (12, 13)];
+        let mut push = |i: usize, j: usize, net: &str, num: String| {
+            pads.push(Pad {
+                number: num,
+                pad_type: PadType::SMD,
+                shape: PadShape::Circle { diameter: pad_d },
+                position: Vec2::new(i as f64 * pitch, j as f64 * pitch),
+                rotation: 0.0,
+                drill: None,
+                net: Some(net.into()),
+                layers: vec![PcbLayer::FCu],
+            });
+        };
+        for j in 0..n {
+            for i in 0..n {
+                let perimeter = i == 0 || j == 0 || i == n - 1 || j == n - 1;
+                if !perimeter || gaps.contains(&(i, j)) {
+                    continue;
+                }
+                push(i, j, "B", format!("W{i}_{j}"));
+            }
+        }
+        // The trapped source pad at the box center.
+        push(6, 6, "S", "S".into());
+        let field_fp = Footprint {
+            reference: "U1".into(),
+            value: "ring".into(),
+            footprint_name: "RING".into(),
+            position: origin,
+            rotation: 0.0,
+            front: true,
+            pads,
+            graphics: vec![],
+            model_3d: None,
+            properties: Default::default(),
+        };
+        // Free-standing target pad left of the box, outside the field.
+        let target = fp(
+            "R1",
+            origin.x - 5.0,
+            origin.y + 14.0 * pitch + 1.5,
+            vec![pad("1", 0.0, 0.0, "S")],
+        );
+        let pcb = board(vec![field_fp, target]);
+        let from = Vec2::new(origin.x + 6.0 * pitch, origin.y + 6.0 * pitch);
+        let to = Vec2::new(origin.x - 5.0, origin.y + 14.0 * pitch + 1.5);
+
+        let mut session = RouteSession::from_pcb(&pcb);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let _ = env_logger::builder().is_test(true).try_init();
+        // Small budget: the direct maze exhausts it inside the pin field.
+        let budget = 400;
+        assert!(
+            search_route(&session, &pcb, 0.25, "S", from, to, &cong, false, budget, true, None)
+                .is_none(),
+            "direct maze must fail with a small expansion budget"
+        );
+        let placed = try_route(
+            &mut session,
+            &pcb,
+            0.25,
+            "S",
+            from,
+            to,
+            &[],
+            &cong,
+            false,
+            budget,
+        );
+        let placed = placed.expect("try_route must succeed via the pin-field escape");
+        assert!(!placed.segments.is_empty());
+        // Every committed segment must be clearance-legal against the pads
+        // (probe on a fresh session so the route's own copper doesn't mask).
+        let fresh = RouteSession::from_pcb(&pcb);
+        for (a, b, l) in &placed.segments {
+            let seg = CopperGeom::Segment {
+                a: *a,
+                b: *b,
+                half_w: placed.width / 2.0,
+            };
+            assert!(
+                fresh.probe(&seg, *l, "S", fresh.clearance_for("S")).legal,
+                "escape-assisted route emitted illegal copper: {a:?}->{b:?}"
+            );
         }
     }
 

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -408,6 +408,21 @@ pub fn route_all_with_opts(
         }
     }
 
+    // Escalating-window joint repair: the last-resort untangler for local
+    // knots that per-net rip-up and negotiation provably cannot solve (they
+    // require deciding a clique of routes together).
+    if !still_unrouted.is_empty() {
+        still_unrouted = joint_window_repair(
+            &mut session,
+            pcb,
+            width,
+            &mut placed,
+            still_unrouted,
+            &cong,
+            opts.effective_expansions(),
+        );
+    }
+
     // Stitch the planed nets' pads down to their planes (issue #289 part 2).
     // Runs after signal routing so each stitching via avoids the routed copper
     // and is probed on every copper layer it spans before being committed.
@@ -1935,62 +1950,216 @@ fn ripup_pass(
             still.push((net, from, to));
         }
 
-        // Re-route every victim — speculatively parallel, like the greedy
-        // pass. A victim that can't find a NEW route gets its ORIGINAL copper
-        // restored when that copper is still legal (the stuck net may not
-        // have taken its space after all) — rip-up is then non-destructive
-        // by construction; only a victim whose exact old path was genuinely
-        // claimed becomes unrouted.
-        let mut originals: HashMap<ConnKey, Placed> = victims
-            .iter()
-            .map(|v| (conn_key(&v.net, v.from, v.to), v.clone()))
-            .collect();
-        let victim_conns: Vec<Conn> = victims.into_iter().map(|v| (v.net, v.from, v.to)).collect();
-        for (net, from, to) in route_batch(
+        // Re-route every victim; failures restore their original copper.
+        still.extend(reroute_victims_with_restore(
             session,
             pcb,
             width,
-            victim_conns,
+            victims,
             placed,
             cong,
             use_push_shove,
             max_expansions,
-            true,
             fail_cache,
             corridors,
-        ) {
-            let restored = originals
-                .remove(&conn_key(&net, from, to))
-                // A fan-out victim's dog-bone stubs can't ride a Candidate;
-                // restoring without them would report a broken route as
-                // placed. Those (rare) victims stay unrouted instead.
-                .filter(|orig| orig.stubs.is_empty())
-                .and_then(|orig| {
-                    validate_and_commit(
-                        session,
-                        pcb,
-                        Candidate {
-                            net: orig.net.clone(),
-                            from: orig.from,
-                            to: orig.to,
-                            width: orig.width,
-                            segments: orig.segments.clone(),
-                            vias: orig.via_pts.clone(),
-                        },
-                        placed,
-                    )
-                });
-            match restored {
-                Some(p) => {
-                    log::debug!("ripup: restored original route for {}", p.net);
-                    placed.push(p);
-                }
-                None => still.push((net, from, to)),
-            }
-        }
+        ));
     }
 
     still
+}
+
+/// Re-route ripped victims (speculatively parallel), restoring each failed
+/// victim's ORIGINAL copper when it is still legal — so ripping is
+/// non-destructive by construction. Returns the connections that neither
+/// re-routed nor restored. Fan-out victims (dog-bone stubs can't ride a
+/// Candidate) are never restored broken; they come back as unrouted.
+#[allow(clippy::too_many_arguments)]
+fn reroute_victims_with_restore(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    width: f64,
+    victims: Vec<Placed>,
+    placed: &mut Vec<Placed>,
+    cong: &Congestion,
+    use_push_shove: bool,
+    max_expansions: usize,
+    fail_cache: &mut FailCache,
+    corridors: &HashMap<ConnKey, (Vec2, Vec2)>,
+) -> Vec<Conn> {
+    let mut originals: HashMap<ConnKey, Placed> = victims
+        .iter()
+        .map(|v| (conn_key(&v.net, v.from, v.to), v.clone()))
+        .collect();
+    let victim_conns: Vec<Conn> = victims.into_iter().map(|v| (v.net, v.from, v.to)).collect();
+    let mut lost = Vec::new();
+    for (net, from, to) in route_batch(
+        session,
+        pcb,
+        width,
+        victim_conns,
+        placed,
+        cong,
+        use_push_shove,
+        max_expansions,
+        true,
+        fail_cache,
+        corridors,
+    ) {
+        let restored = originals
+            .remove(&conn_key(&net, from, to))
+            .filter(|orig| orig.stubs.is_empty())
+            .and_then(|orig| {
+                validate_and_commit(
+                    session,
+                    pcb,
+                    Candidate {
+                        net: orig.net.clone(),
+                        from: orig.from,
+                        to: orig.to,
+                        width: orig.width,
+                        segments: orig.segments.clone(),
+                        vias: orig.via_pts.clone(),
+                    },
+                    placed,
+                )
+            });
+        match restored {
+            Some(p) => {
+                log::debug!("restored original route for {}", p.net);
+                placed.push(p);
+            }
+            None => lost.push((net, from, to)),
+        }
+    }
+    lost
+}
+
+/// Escalating-window joint reroute — the "when negotiation stalls" rescue
+/// (TritonRoute's search-and-repair, adapted): group still-unrouted
+/// connections whose neighborhoods overlap, rip EVERY placed route
+/// intersecting the group's window, and re-route the whole clique jointly —
+/// stuck connections first, victims after, failed victims restored. If a
+/// group still has failures, escalate to a larger window and try again.
+///
+/// This is the treatment for local knots (e.g. a short crossing bus between
+/// two components) where per-net rip-up thrashes: the routes must be decided
+/// TOGETHER, and the window guarantees every entangled neighbor is in play.
+#[allow(clippy::too_many_arguments)]
+fn joint_window_repair(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    width: f64,
+    placed: &mut Vec<Placed>,
+    pending: Vec<Conn>,
+    cong: &Congestion,
+    max_expansions: usize,
+) -> Vec<Conn> {
+    const ESCALATIONS: [f64; 3] = [3.0, 6.0, 12.0];
+    let mut pending = pending;
+    let mut fail_cache = FailCache::new();
+    for (round, margin) in ESCALATIONS.iter().enumerate() {
+        if pending.is_empty() {
+            break;
+        }
+        let sw = Stopwatch::start();
+        // Group pending connections into overlapping windows.
+        let win = |c: &Conn| -> ([f64; 2], [f64; 2]) {
+            (
+                [c.1.x.min(c.2.x) - margin, c.1.y.min(c.2.y) - margin],
+                [c.1.x.max(c.2.x) + margin, c.1.y.max(c.2.y) + margin],
+            )
+        };
+        let overlaps = |a: &([f64; 2], [f64; 2]), b: &([f64; 2], [f64; 2])| -> bool {
+            a.0[0] <= b.1[0] && b.0[0] <= a.1[0] && a.0[1] <= b.1[1] && b.0[1] <= a.1[1]
+        };
+        let mut groups: Vec<(([f64; 2], [f64; 2]), Vec<Conn>)> = Vec::new();
+        'conn: for c in pending.drain(..) {
+            let w = win(&c);
+            for (gw, gc) in groups.iter_mut() {
+                if overlaps(gw, &w) {
+                    gw.0[0] = gw.0[0].min(w.0[0]);
+                    gw.0[1] = gw.0[1].min(w.0[1]);
+                    gw.1[0] = gw.1[0].max(w.1[0]);
+                    gw.1[1] = gw.1[1].max(w.1[1]);
+                    gc.push(c);
+                    continue 'conn;
+                }
+            }
+            groups.push((w, vec![c]));
+        }
+
+        let mut still = Vec::new();
+        let n_groups = groups.len();
+        for (gw, stuck) in groups {
+            // Rip every placed route whose copper enters the window.
+            let in_window = |p: &Placed| {
+                p.segments.iter().any(|(a, b, _)| {
+                    let lo = [a.x.min(b.x), a.y.min(b.y)];
+                    let hi = [a.x.max(b.x), a.y.max(b.y)];
+                    lo[0] <= gw.1[0] && gw.0[0] <= hi[0] && lo[1] <= gw.1[1] && gw.0[1] <= hi[1]
+                })
+            };
+            let mut victims = Vec::new();
+            let mut kept = Vec::new();
+            for p in std::mem::take(placed) {
+                if in_window(&p) {
+                    for &s in &p.spans {
+                        session.remove(s);
+                    }
+                    victims.push(p);
+                } else {
+                    kept.push(p);
+                }
+            }
+            *placed = kept;
+            let n_stuck = stuck.len();
+            let n_victims = victims.len();
+
+            // Joint re-route: stuck first (they get first pick), then victims
+            // with original-copper restore.
+            let mut lost = route_batch(
+                session,
+                pcb,
+                width,
+                stuck,
+                placed,
+                cong,
+                true,
+                max_expansions,
+                true,
+                &mut fail_cache,
+                &HashMap::new(),
+            );
+            lost.extend(reroute_victims_with_restore(
+                session,
+                pcb,
+                width,
+                victims,
+                placed,
+                cong,
+                true,
+                max_expansions,
+                &mut fail_cache,
+                &HashMap::new(),
+            ));
+            log::debug!(
+                "joint repair window ({:.0},{:.0})..({:.0},{:.0}): stuck={n_stuck} victims={n_victims} lost={}",
+                gw.0[0], gw.0[1], gw.1[0], gw.1[1],
+                lost.len(),
+            );
+            still.extend(lost);
+        }
+        log::info!(
+            "joint repair round {} (margin {margin}mm): {n_groups} windows -> {} still unrouted in {:.1}s",
+            round + 1,
+            still.len(),
+            sw.ms() / 1000.0,
+        );
+        pending = still;
+        // Fresh failure cache per escalation: the windows change shape.
+        fail_cache = FailCache::new();
+    }
+    pending
 }
 
 /// Synthesize a netlist from pad net assignments for ratsnest computation.

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -217,6 +217,9 @@ fn conn_region(from: Vec2, to: Vec2) -> ([f64; 2], [f64; 2]) {
 /// search failed: skip re-searching until copper actually changes nearby.
 type FailCache = HashMap<ConnKey, u64>;
 
+/// An axis-aligned window (mm) used by the joint-repair grouping.
+type RepairWindow = ([f64; 2], [f64; 2]);
+
 /// The product of one routing pass: the grown session, the placed connections,
 /// and the connections still unrouted after rip-up.
 type Pass = (RouteSession, Vec<Placed>, Vec<Conn>);
@@ -1066,6 +1069,10 @@ fn search_route(
             pitch_scale,
             window,
             &tree_goals,
+            // Off-grid via candidates cost up to 16 extra probes per cache
+            // miss — reserved for the searches that need them (fine retry
+            // and repair passes), out of the greedy hot path.
+            pitch_scale < 1.0 || fine_retry,
         )
     };
     // Corridor-first: the global plan says where this connection FITS —
@@ -2067,16 +2074,16 @@ fn joint_window_repair(
         }
         let sw = Stopwatch::start();
         // Group pending connections into overlapping windows.
-        let win = |c: &Conn| -> ([f64; 2], [f64; 2]) {
+        let win = |c: &Conn| -> RepairWindow {
             (
                 [c.1.x.min(c.2.x) - margin, c.1.y.min(c.2.y) - margin],
                 [c.1.x.max(c.2.x) + margin, c.1.y.max(c.2.y) + margin],
             )
         };
-        let overlaps = |a: &([f64; 2], [f64; 2]), b: &([f64; 2], [f64; 2])| -> bool {
+        let overlaps = |a: &RepairWindow, b: &RepairWindow| -> bool {
             a.0[0] <= b.1[0] && b.0[0] <= a.1[0] && a.0[1] <= b.1[1] && b.0[1] <= a.1[1]
         };
-        let mut groups: Vec<(([f64; 2], [f64; 2]), Vec<Conn>)> = Vec::new();
+        let mut groups: Vec<(RepairWindow, Vec<Conn>)> = Vec::new();
         'conn: for c in pending.drain(..) {
             let w = win(&c);
             for (gw, gc) in groups.iter_mut() {

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -2055,6 +2055,10 @@ fn joint_window_repair(
     max_expansions: usize,
 ) -> Vec<Conn> {
     const ESCALATIONS: [f64; 3] = [3.0, 6.0, 12.0];
+    /// Never let coalesced windows exceed this area (mm²): a quadrant-sized
+    /// rip is a demolition, not a repair (measured: one mega-window took the
+    /// CM5 from 0.93 to 0.69 before this cap + transactions existed).
+    const MAX_WINDOW_AREA: f64 = 400.0;
     let mut pending = pending;
     let mut fail_cache = FailCache::new();
     for (round, margin) in ESCALATIONS.iter().enumerate() {
@@ -2077,10 +2081,15 @@ fn joint_window_repair(
             let w = win(&c);
             for (gw, gc) in groups.iter_mut() {
                 if overlaps(gw, &w) {
-                    gw.0[0] = gw.0[0].min(w.0[0]);
-                    gw.0[1] = gw.0[1].min(w.0[1]);
-                    gw.1[0] = gw.1[0].max(w.1[0]);
-                    gw.1[1] = gw.1[1].max(w.1[1]);
+                    let merged = (
+                        [gw.0[0].min(w.0[0]), gw.0[1].min(w.0[1])],
+                        [gw.1[0].max(w.1[0]), gw.1[1].max(w.1[1])],
+                    );
+                    let area = (merged.1[0] - merged.0[0]) * (merged.1[1] - merged.0[1]);
+                    if area > MAX_WINDOW_AREA {
+                        continue; // stay a separate window; transactions make overlap safe
+                    }
+                    *gw = merged;
                     gc.push(c);
                     continue 'conn;
                 }
@@ -2091,6 +2100,13 @@ fn joint_window_repair(
         let mut still = Vec::new();
         let n_groups = groups.len();
         for (gw, stuck) in groups {
+            // Transactional: snapshot the world; a window that ends
+            // net-negative is rolled back wholesale, so this stage can only
+            // ever improve the board.
+            let session_snapshot = session.clone();
+            let placed_snapshot = placed.clone();
+            let stuck_backup = stuck.clone();
+            let placed_before = placed.len();
             // Rip every placed route whose copper enters the window.
             let in_window = |p: &Placed| {
                 p.segments.iter().any(|(a, b, _)| {
@@ -2142,12 +2158,24 @@ fn joint_window_repair(
                 &mut fail_cache,
                 &HashMap::new(),
             ));
-            log::debug!(
-                "joint repair window ({:.0},{:.0})..({:.0},{:.0}): stuck={n_stuck} victims={n_victims} lost={}",
-                gw.0[0], gw.0[1], gw.1[0], gw.1[1],
-                lost.len(),
-            );
-            still.extend(lost);
+            if placed.len() <= placed_before {
+                // Net-negative (or neutral): roll back the entire window.
+                *session = session_snapshot;
+                *placed = placed_snapshot;
+                log::debug!(
+                    "joint repair window ({:.0},{:.0})..({:.0},{:.0}): rolled back (stuck={n_stuck} victims={n_victims})",
+                    gw.0[0], gw.0[1], gw.1[0], gw.1[1],
+                );
+                still.extend(stuck_backup);
+            } else {
+                log::debug!(
+                    "joint repair window ({:.0},{:.0})..({:.0},{:.0}): stuck={n_stuck} victims={n_victims} gained={} lost={}",
+                    gw.0[0], gw.0[1], gw.1[0], gw.1[1],
+                    placed.len() - placed_before,
+                    lost.len(),
+                );
+                still.extend(lost);
+            }
         }
         log::info!(
             "joint repair round {} (margin {margin}mm): {n_groups} windows -> {} still unrouted in {:.1}s",

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1103,15 +1103,13 @@ fn search_route(
     if r3.success && r3.segments.is_empty() && r3.vias.is_empty() {
         // The two components already touch (earlier commits joined them):
         // the connection is satisfied with zero new copper.
-        return Some(Placed {
+        return Some(Candidate {
             net: net.to_string(),
             from,
             to,
             width: w,
             segments: Vec::new(),
-            stubs: Vec::new(),
-            via_pts: Vec::new(),
-            spans: Vec::new(),
+            vias: Vec::new(),
         });
     }
     let (segments, route_vias) = if r3.success && !r3.segments.is_empty() {

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1052,6 +1052,8 @@ fn search_route(
     // analysis showed the human spending ~2/3 of the board's vias on the nets
     // our pad-pair decomposition could not close.)
     let tree_goals = to_component(session, net, to);
+    // The symmetric source set: copper already connected to the FROM pad.
+    let tree_sources = to_component(session, net, from);
     let maze = |pitch_scale: f64, window: Option<(Vec2, Vec2)>| {
         route_net_maze3d(
             session,
@@ -1069,6 +1071,7 @@ fn search_route(
             pitch_scale,
             window,
             &tree_goals,
+            &tree_sources,
             // Off-grid via candidates cost up to 16 extra probes per cache
             // miss — reserved for the searches that need them (fine retry
             // and repair passes), out of the greedy hot path.
@@ -1096,6 +1099,20 @@ fn search_route(
             0.5,
             Some((Vec2::new(lo[0], lo[1]), Vec2::new(hi[0], hi[1]))),
         );
+    }
+    if r3.success && r3.segments.is_empty() && r3.vias.is_empty() {
+        // The two components already touch (earlier commits joined them):
+        // the connection is satisfied with zero new copper.
+        return Some(Placed {
+            net: net.to_string(),
+            from,
+            to,
+            width: w,
+            segments: Vec::new(),
+            stubs: Vec::new(),
+            via_pts: Vec::new(),
+            spans: Vec::new(),
+        });
     }
     let (segments, route_vias) = if r3.success && !r3.segments.is_empty() {
         (r3.segments, r3.vias)

--- a/crates/vcad-ecad-pcb/src/router/escape.rs
+++ b/crates/vcad-ecad-pcb/src/router/escape.rs
@@ -1,0 +1,855 @@
+//! Flow-based pin-field (BGA/fine-pitch) escape routing.
+//!
+//! Dense pin fields defeat per-net maze search: the interstitial channels
+//! between pads carry only so many tracks, and greedy per-net routing
+//! discovers the contention one failure at a time. The literature answer
+//! (Fang & Wong, DAC'09) is a dedicated escape phase that solves pin-field
+//! egress as a min-cost max-flow problem over the field's interstitial grid,
+//! *before* (or here: as a rescue for) maze routing.
+//!
+//! This module detects dense pin fields, builds a flow network whose nodes
+//! are the gaps between adjacent pads, solves min-cost max-flow with
+//! successive shortest paths, and turns each unit of flow into a concrete
+//! escape polyline (pad → assigned egress point just outside the field) on
+//! the pad's layer. Every returned polyline is clearance-probed against the
+//! [`RouteSession`] — an unprobeable escape returns `None` for that
+//! connection. Nothing here mutates the session; committing is the caller's
+//! job (see `try_route_escape` in `auto.rs`).
+
+use vcad_ir::ecad::{PadShape, Pcb, PcbLayer};
+use vcad_ir::Vec2;
+
+use crate::geometry::pad_world_position;
+use crate::session::RouteSession;
+use crate::spatial::{point_in_polygon, CopperGeom};
+
+/// Minimum pad count for a footprint to qualify as a dense pin field.
+const MIN_FIELD_PADS: usize = 40;
+/// Maximum nearest-neighbor pad pitch (mm) for a footprint to qualify.
+const MAX_FIELD_PITCH: f64 = 1.0;
+/// Cap on tracks assigned through any single interstitial gap.
+const MAX_GAP_TRACKS: i64 = 4;
+/// Fixed-point scale for integer flow costs (mm → cost units).
+const COST_SCALE: f64 = 1000.0;
+
+/// One pad of a detected field: world position and a conservative radius.
+#[derive(Debug, Clone)]
+struct FieldPad {
+    pos: Vec2,
+    r: f64,
+}
+
+/// A detected dense pin field (one fine-pitch footprint's pad lattice).
+#[derive(Debug, Clone)]
+pub struct PinField {
+    /// Pads (world coordinates, conservative circumradius).
+    pads: Vec<FieldPad>,
+    /// Field bounding box, min corner (pad centers, mm).
+    min: Vec2,
+    /// Field bounding box, max corner (mm).
+    max: Vec2,
+    /// Nearest-neighbor pad pitch (mm) — the lattice spacing.
+    pitch: f64,
+    /// Copper layer the field's pads (and thus escapes) live on.
+    layer: PcbLayer,
+}
+
+impl PinField {
+    /// Whether `p` lies inside the field (bbox inflated by one pitch) — the
+    /// gate for "this endpoint needs an escape".
+    pub fn contains(&self, p: Vec2) -> bool {
+        p.x >= self.min.x - self.pitch
+            && p.x <= self.max.x + self.pitch
+            && p.y >= self.min.y - self.pitch
+            && p.y <= self.max.y + self.pitch
+    }
+}
+
+/// A planned escape for one connection endpoint: a polyline from the pad to
+/// its assigned egress point just outside the field, on `layer`.
+#[derive(Debug, Clone)]
+pub struct EscapePlan {
+    /// Polyline segments, pad-first. Fully clearance-probed at plan time.
+    pub segments: Vec<(Vec2, Vec2)>,
+    /// The egress point (last polyline vertex) — the new routing terminal.
+    pub egress: Vec2,
+    /// Layer the escape copper lives on.
+    pub layer: PcbLayer,
+}
+
+/// Conservative circumradius of a pad shape (half the largest extent).
+fn pad_radius(shape: &PadShape) -> f64 {
+    match shape {
+        PadShape::Circle { diameter } => diameter / 2.0,
+        PadShape::Rect { width, height }
+        | PadShape::Oval { width, height }
+        | PadShape::RoundRect { width, height, .. } => width.max(*height) / 2.0,
+        PadShape::Custom { vertices } => {
+            let mut r: f64 = 0.0;
+            for v in vertices {
+                r = r.max((v.x * v.x + v.y * v.y).sqrt());
+            }
+            r
+        }
+    }
+}
+
+/// Detect dense pin fields: footprints with at least [`MIN_FIELD_PADS`] pads
+/// whose nearest-neighbor pitch is at most [`MAX_FIELD_PITCH`].
+pub fn detect_pin_fields(pcb: &Pcb) -> Vec<PinField> {
+    let mut fields = Vec::new();
+    for fp in &pcb.footprints {
+        if fp.pads.len() < MIN_FIELD_PADS {
+            continue;
+        }
+        let pads: Vec<FieldPad> = fp
+            .pads
+            .iter()
+            .map(|p| FieldPad {
+                pos: pad_world_position(fp, p),
+                r: pad_radius(&p.shape),
+            })
+            .collect();
+        // Nearest-neighbor pitch: min over pads of the distance to the
+        // closest other pad. O(n²) — fields are a few hundred pads.
+        let mut pitch = f64::INFINITY;
+        for i in 0..pads.len() {
+            let mut best = f64::INFINITY;
+            for j in 0..pads.len() {
+                if i != j {
+                    let d = dist(pads[i].pos, pads[j].pos);
+                    if d < best {
+                        best = d;
+                    }
+                }
+            }
+            if best < pitch {
+                pitch = best;
+            }
+        }
+        if !pitch.is_finite() || pitch > MAX_FIELD_PITCH {
+            continue;
+        }
+        let (mut min, mut max) = (pads[0].pos, pads[0].pos);
+        for p in &pads {
+            min.x = min.x.min(p.pos.x);
+            min.y = min.y.min(p.pos.y);
+            max.x = max.x.max(p.pos.x);
+            max.y = max.y.max(p.pos.y);
+        }
+        let layer = fp
+            .pads
+            .iter()
+            .flat_map(|p| p.layers.first())
+            .next()
+            .copied()
+            .unwrap_or(PcbLayer::FCu);
+        log::info!(
+            "escape: dense pin field {} ({} pads, pitch {:.3} mm, bbox {:.1}x{:.1} mm)",
+            fp.reference,
+            pads.len(),
+            pitch,
+            max.x - min.x,
+            max.y - min.y,
+        );
+        fields.push(PinField {
+            pads,
+            min,
+            max,
+            pitch,
+            layer,
+        });
+    }
+    fields
+}
+
+/// The field containing point `p`, if any.
+pub fn field_containing(fields: &[PinField], p: Vec2) -> Option<&PinField> {
+    fields.iter().find(|f| f.contains(p))
+}
+
+fn dist(a: Vec2, b: Vec2) -> f64 {
+    ((a.x - b.x).powi(2) + (a.y - b.y).powi(2)).sqrt()
+}
+
+/// Distance from point `p` to segment `ab`.
+fn dist_point_seg(p: Vec2, a: Vec2, b: Vec2) -> f64 {
+    let (dx, dy) = (b.x - a.x, b.y - a.y);
+    let len2 = dx * dx + dy * dy;
+    if len2 <= 1e-12 {
+        return dist(p, a);
+    }
+    let t = (((p.x - a.x) * dx + (p.y - a.y) * dy) / len2).clamp(0.0, 1.0);
+    dist(p, Vec2::new(a.x + t * dx, a.y + t * dy))
+}
+
+// ---------------------------------------------------------------------------
+// Min-cost max-flow (successive shortest paths, SPFA). Networks are small
+// (hundreds of nodes), so simplicity beats asymptotics here.
+// ---------------------------------------------------------------------------
+
+struct FlowEdge {
+    to: usize,
+    cap: i64,
+    cost: i64,
+    flow: i64,
+}
+
+struct FlowNet {
+    /// Edge storage; adjacency holds indices. Edge `2k+1` is `2k`'s reverse.
+    edges: Vec<FlowEdge>,
+    adj: Vec<Vec<usize>>,
+}
+
+impl FlowNet {
+    fn new(n: usize) -> Self {
+        Self {
+            edges: Vec::new(),
+            adj: vec![Vec::new(); n],
+        }
+    }
+
+    fn add_edge(&mut self, from: usize, to: usize, cap: i64, cost: i64) -> usize {
+        let id = self.edges.len();
+        self.edges.push(FlowEdge {
+            to,
+            cap,
+            cost,
+            flow: 0,
+        });
+        self.edges.push(FlowEdge {
+            to: from,
+            cap: 0,
+            cost: -cost,
+            flow: 0,
+        });
+        self.adj[from].push(id);
+        self.adj[to].push(id + 1);
+        id
+    }
+
+    /// Push up to `want` units from `s` to `t`; returns the units placed.
+    fn mcmf(&mut self, s: usize, t: usize, want: i64) -> i64 {
+        let n = self.adj.len();
+        let mut total = 0i64;
+        while total < want {
+            // SPFA shortest path by cost on the residual graph.
+            let mut dist = vec![i64::MAX; n];
+            let mut in_q = vec![false; n];
+            let mut prev_edge = vec![usize::MAX; n];
+            dist[s] = 0;
+            let mut q = std::collections::VecDeque::new();
+            q.push_back(s);
+            in_q[s] = true;
+            while let Some(u) = q.pop_front() {
+                in_q[u] = false;
+                for &eid in &self.adj[u] {
+                    let e = &self.edges[eid];
+                    if e.cap - e.flow <= 0 || dist[u] == i64::MAX {
+                        continue;
+                    }
+                    let nd = dist[u] + e.cost;
+                    if nd < dist[e.to] {
+                        dist[e.to] = nd;
+                        prev_edge[e.to] = eid;
+                        if !in_q[e.to] {
+                            q.push_back(e.to);
+                            in_q[e.to] = true;
+                        }
+                    }
+                }
+            }
+            if dist[t] == i64::MAX {
+                break;
+            }
+            // Bottleneck along the path.
+            let mut push = want - total;
+            let mut v = t;
+            while v != s {
+                let eid = prev_edge[v];
+                push = push.min(self.edges[eid].cap - self.edges[eid].flow);
+                v = self.edges[eid ^ 1].to;
+            }
+            let mut v = t;
+            while v != s {
+                let eid = prev_edge[v];
+                self.edges[eid].flow += push;
+                self.edges[eid ^ 1].flow -= push;
+                v = self.edges[eid ^ 1].to;
+            }
+            total += push;
+        }
+        total
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Escape planning
+// ---------------------------------------------------------------------------
+
+/// The interstitial grid over a field: nodes at the centers of pad quads
+/// (offset half a pitch from the pad lattice), plus one ring outside the
+/// field bbox (the egress ring).
+struct Grid {
+    nx: usize,
+    ny: usize,
+    origin: Vec2,
+    pitch: f64,
+}
+
+impl Grid {
+    fn for_field(field: &PinField) -> Grid {
+        let pitch = field.pitch;
+        // One ring of nodes outside the pad bbox on every side; nodes sit at
+        // origin + (i + 0.5, j + 0.5) * pitch, i.e. between lattice rows.
+        let origin = Vec2::new(field.min.x - 2.0 * pitch, field.min.y - 2.0 * pitch);
+        let nx = (((field.max.x - origin.x) + 2.0 * pitch) / pitch).ceil() as usize;
+        let ny = (((field.max.y - origin.y) + 2.0 * pitch) / pitch).ceil() as usize;
+        Grid {
+            nx,
+            ny,
+            origin,
+            pitch,
+        }
+    }
+
+    fn pos(&self, i: usize, j: usize) -> Vec2 {
+        Vec2::new(
+            self.origin.x + (i as f64 + 0.5) * self.pitch,
+            self.origin.y + (j as f64 + 0.5) * self.pitch,
+        )
+    }
+
+    fn idx(&self, i: usize, j: usize) -> usize {
+        j * self.nx + i
+    }
+}
+
+/// How many tracks of width `w` at clearance `clr` fit through a copper gap
+/// of width `gap` (copper-to-copper): `n·w + (n+1)·clr ≤ gap`.
+fn tracks_fit(gap: f64, w: f64, clr: f64) -> i64 {
+    if gap <= 0.0 {
+        return 0;
+    }
+    (((gap - clr) / (w + clr)).floor() as i64).clamp(0, MAX_GAP_TRACKS)
+}
+
+/// Free channel width (copper-to-copper) around point `p` given the field's
+/// pads: twice the distance from `p` to the nearest pad edge.
+fn channel_at_point(field: &PinField, p: Vec2) -> f64 {
+    let mut d = f64::INFINITY;
+    for pad in &field.pads {
+        d = d.min(dist(p, pad.pos) - pad.r);
+    }
+    (2.0 * d).max(0.0)
+}
+
+/// Free channel width across segment `ab` (the constriction a track routed
+/// along the segment must pass).
+fn channel_along_seg(field: &PinField, a: Vec2, b: Vec2) -> f64 {
+    let mut d = f64::INFINITY;
+    for pad in &field.pads {
+        d = d.min(dist_point_seg(pad.pos, a, b) - pad.r);
+    }
+    (2.0 * d).max(0.0)
+}
+
+/// Plan escapes for a batch of connection endpoints inside `field`.
+///
+/// `endpoints` are `(net, pad_position)` pairs; the result is index-aligned:
+/// `Some(plan)` when the flow solver assigned the endpoint an egress and the
+/// resulting polyline probed clean, `None` otherwise. Plans in one batch are
+/// vertex-disjoint on the interstitial grid (node capacities), so they do not
+/// cross each other; each is additionally probed against `session`.
+pub fn plan_field_escapes(
+    session: &RouteSession,
+    pcb: &Pcb,
+    field: &PinField,
+    endpoints: &[(String, Vec2)],
+    width: f64,
+) -> Vec<Option<EscapePlan>> {
+    let mut out: Vec<Option<EscapePlan>> = vec![None; endpoints.len()];
+    if endpoints.is_empty() {
+        return out;
+    }
+    let grid = Grid::for_field(field);
+    let n_grid = grid.nx * grid.ny;
+    if n_grid == 0 || n_grid > 40_000 {
+        return out;
+    }
+
+    // Conservative geometry: plan with the widest requirements in the batch
+    // so one network serves all endpoints (per-net widths differ rarely
+    // inside a BGA).
+    let w = endpoints
+        .iter()
+        .map(|(net, _)| session.width_for(net, width))
+        .fold(width, f64::max);
+    let clr = endpoints
+        .iter()
+        .map(|(net, _)| session.clearance_for(net))
+        .fold(0.0, f64::max);
+
+    // Node layout: [grid in 0..n][grid out n..2n][pad nodes][S][T].
+    let pad_base = 2 * n_grid;
+    let s = pad_base + endpoints.len();
+    let t = s + 1;
+    let mut net = FlowNet::new(t + 1);
+
+    let in_board = |p: Vec2| -> bool {
+        pcb.outline.vertices.len() < 3 || point_in_polygon(p, &pcb.outline.vertices)
+    };
+    let inside_bbox = |p: Vec2| -> bool {
+        p.x >= field.min.x && p.x <= field.max.x && p.y >= field.min.y && p.y <= field.max.y
+    };
+
+    // Grid nodes: capacity from the local channel; the egress ring (nodes
+    // outside the pad bbox) feeds the super-sink.
+    let mut node_cap = vec![0i64; n_grid];
+    for j in 0..grid.ny {
+        for i in 0..grid.nx {
+            let p = grid.pos(i, j);
+            if !in_board(p) {
+                continue;
+            }
+            let cap = tracks_fit(channel_at_point(field, p), w, clr);
+            if cap <= 0 {
+                continue;
+            }
+            let id = grid.idx(i, j);
+            node_cap[id] = cap;
+            // Node-split arc capped at 1: plans in a batch are then
+            // vertex-disjoint on the grid, so they can never cross.
+            net.add_edge(id, n_grid + id, 1, 0);
+            if !inside_bbox(p) {
+                // Egress ring: each ring node accepts one escape so egress
+                // points stay distinct.
+                net.add_edge(n_grid + id, t, 1, 0);
+            }
+        }
+    }
+    // Grid edges (4-neighborhood): capacity = tracks through the pad gap the
+    // edge crosses; cost = edge length.
+    for j in 0..grid.ny {
+        for i in 0..grid.nx {
+            let a_id = grid.idx(i, j);
+            if node_cap[a_id] == 0 {
+                continue;
+            }
+            let a = grid.pos(i, j);
+            for (di, dj) in [(1isize, 0isize), (0, 1)] {
+                let (ni, nj) = (i as isize + di, j as isize + dj);
+                if ni < 0 || nj < 0 || ni >= grid.nx as isize || nj >= grid.ny as isize {
+                    continue;
+                }
+                let b_id = grid.idx(ni as usize, nj as usize);
+                if node_cap[b_id] == 0 {
+                    continue;
+                }
+                let b = grid.pos(ni as usize, nj as usize);
+                let cap = tracks_fit(channel_along_seg(field, a, b), w, clr);
+                if cap <= 0 {
+                    continue;
+                }
+                let cost = (dist(a, b) * COST_SCALE) as i64;
+                net.add_edge(n_grid + a_id, b_id, cap, cost);
+                net.add_edge(n_grid + b_id, a_id, cap, cost);
+            }
+        }
+    }
+    // Endpoint pads: S → pad node (cap 1) → nearby usable grid nodes. Each
+    // first hop is clearance-probed here so the flow only ever uses legal
+    // pad exits (the pad's own copper is same-net and doesn't block).
+    for (k, (conn_net, pad_pt)) in endpoints.iter().enumerate() {
+        let pad_node = pad_base + k;
+        net.add_edge(s, pad_node, 1, 0);
+        let clearance = session.clearance_for(conn_net);
+        let hw = session.width_for(conn_net, width) / 2.0;
+        let fi = ((pad_pt.x - grid.origin.x) / grid.pitch - 0.5).round() as isize;
+        let fj = ((pad_pt.y - grid.origin.y) / grid.pitch - 0.5).round() as isize;
+        for (di, dj) in [
+            (0isize, 0isize),
+            (-1, 0),
+            (0, -1),
+            (-1, -1),
+            (1, 0),
+            (0, 1),
+            (1, 1),
+            (-1, 1),
+            (1, -1),
+        ] {
+            let (i, j) = (fi + di, fj + dj);
+            if i < 0 || j < 0 || i >= grid.nx as isize || j >= grid.ny as isize {
+                continue;
+            }
+            let id = grid.idx(i as usize, j as usize);
+            if node_cap[id] == 0 {
+                continue;
+            }
+            let gp = grid.pos(i as usize, j as usize);
+            let hop = CopperGeom::Segment {
+                a: *pad_pt,
+                b: gp,
+                half_w: hw,
+            };
+            if !session.probe(&hop, field.layer, conn_net, clearance).legal {
+                continue;
+            }
+            let cost = (dist(*pad_pt, gp) * COST_SCALE) as i64;
+            net.add_edge(pad_node, id, 1, cost);
+        }
+    }
+
+    let placed = net.mcmf(s, t, endpoints.len() as i64);
+    log::info!(
+        "escape: field flow placed {placed}/{} escapes (grid {}x{}, w={w:.2} clr={clr:.2})",
+        endpoints.len(),
+        grid.nx,
+        grid.ny,
+    );
+    if placed == 0 {
+        return out;
+    }
+
+    // Decompose flow into per-endpoint paths, then probe each polyline.
+    for (k, (conn_net, pad_pt)) in endpoints.iter().enumerate() {
+        let pad_node = pad_base + k;
+        // Did this endpoint's unit make it into the network?
+        let mut cur = usize::MAX;
+        for &eid in &net.adj[pad_node] {
+            let e = &net.edges[eid];
+            if eid % 2 == 0 && e.flow > 0 {
+                cur = e.to;
+                net.edges[eid].flow -= 1;
+                break;
+            }
+        }
+        if cur == usize::MAX {
+            continue;
+        }
+        // Walk grid flow (consuming it, so units through shared arcs are
+        // claimed once) until we exit to the sink.
+        let mut pts: Vec<Vec2> = vec![*pad_pt];
+        let mut reached_sink = false;
+        let mut guard = 0;
+        while guard < 4 * n_grid {
+            guard += 1;
+            let gid = cur % n_grid; // in-node or out-node → grid cell
+            let (i, j) = (gid % grid.nx, gid / grid.nx);
+            if pts.last().map(|p| dist(*p, grid.pos(i, j)) > 1e-9) == Some(true) {
+                pts.push(grid.pos(i, j));
+            }
+            // Traverse the node-split arc if we're on the in-node.
+            let from = if cur < n_grid { n_grid + gid } else { cur };
+            let mut advanced = false;
+            for &eid in &net.adj[from] {
+                if eid % 2 != 0 {
+                    continue;
+                }
+                let (to, flow) = (net.edges[eid].to, net.edges[eid].flow);
+                if flow <= 0 {
+                    continue;
+                }
+                if to == t {
+                    net.edges[eid].flow -= 1;
+                    reached_sink = true;
+                } else {
+                    net.edges[eid].flow -= 1;
+                    cur = to;
+                    advanced = true;
+                }
+                break;
+            }
+            if reached_sink || !advanced {
+                break;
+            }
+        }
+        if !reached_sink || pts.len() < 2 {
+            continue;
+        }
+        let segments: Vec<(Vec2, Vec2)> = pts.windows(2).map(|p| (p[0], p[1])).collect();
+        // Probe every segment against the live session before trusting the plan.
+        let clearance = session.clearance_for(conn_net);
+        let ww = session.width_for(conn_net, width);
+        let legal = segments.iter().all(|(a, b)| {
+            session
+                .probe(
+                    &CopperGeom::Segment {
+                        a: *a,
+                        b: *b,
+                        half_w: ww / 2.0,
+                    },
+                    field.layer,
+                    conn_net,
+                    clearance,
+                )
+                .legal
+        });
+        if !legal {
+            log::info!("escape: planned escape for {conn_net} failed session probe — dropped");
+            continue;
+        }
+        let egress = *pts.last().expect("polyline has >= 2 points");
+        out[k] = Some(EscapePlan {
+            segments,
+            egress,
+            layer: field.layer,
+        });
+    }
+    out
+}
+
+/// Plan an escape for a single endpoint (the integration entry point).
+pub fn plan_escape(
+    session: &RouteSession,
+    pcb: &Pcb,
+    field: &PinField,
+    net: &str,
+    pad_pt: Vec2,
+    width: f64,
+) -> Option<EscapePlan> {
+    plan_field_escapes(session, pcb, field, &[(net.to_string(), pad_pt)], width).remove(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_ir::ecad::*;
+
+    fn pad(num: &str, x: f64, y: f64, net: &str, size: f64) -> Pad {
+        Pad {
+            number: num.into(),
+            pad_type: PadType::SMD,
+            shape: PadShape::Circle { diameter: size },
+            position: Vec2::new(x, y),
+            rotation: 0.0,
+            drill: None,
+            net: Some(net.into()),
+            layers: vec![PcbLayer::FCu],
+        }
+    }
+
+    fn board(footprints: Vec<Footprint>, width: f64, clearance: f64) -> Pcb {
+        Pcb {
+            outline: BoardOutline {
+                vertices: vec![
+                    Vec2::new(0.0, 0.0),
+                    Vec2::new(60.0, 0.0),
+                    Vec2::new(60.0, 60.0),
+                    Vec2::new(0.0, 60.0),
+                ],
+                cutouts: vec![],
+                thickness: 1.6,
+            },
+            stackup: LayerStackup {
+                layers: vec![
+                    StackupLayer {
+                        layer: PcbLayer::FCu,
+                        copper_thickness: Some(0.035),
+                        dielectric_thickness: Some(1.5),
+                        dielectric_er: Some(4.5),
+                        material: Some("FR4".into()),
+                    },
+                    StackupLayer {
+                        layer: PcbLayer::BCu,
+                        copper_thickness: Some(0.035),
+                        dielectric_thickness: None,
+                        dielectric_er: None,
+                        material: None,
+                    },
+                ],
+            },
+            nets: vec![],
+            rules: DesignRules {
+                default_rules: NetClassRules {
+                    name: "Default".into(),
+                    trace_width: width,
+                    clearance,
+                    via_diameter: 0.4,
+                    via_drill: 0.2,
+                    diff_pair_gap: None,
+                    diff_pair_width: None,
+                },
+                class_rules: vec![],
+                net_class_assignments: Default::default(),
+                edge_clearance: 0.5,
+                hole_to_hole: 0.5,
+                min_annular_ring: 0.15,
+                min_drill: 0.2,
+            },
+            footprints,
+            traces: vec![],
+            trace_arcs: vec![],
+            vias: vec![],
+            zones: vec![],
+            keepouts: vec![],
+            net_ties: vec![],
+        }
+    }
+
+    fn bga(nx: usize, ny: usize, pitch: f64, pad_d: f64, origin: Vec2) -> Footprint {
+        let mut pads = Vec::new();
+        for j in 0..ny {
+            for i in 0..nx {
+                pads.push(pad(
+                    &format!("P{i}_{j}"),
+                    i as f64 * pitch,
+                    j as f64 * pitch,
+                    &format!("N{i}_{j}"),
+                    pad_d,
+                ));
+            }
+        }
+        Footprint {
+            reference: "U1".into(),
+            value: "bga".into(),
+            footprint_name: "BGA".into(),
+            position: origin,
+            rotation: 0.0,
+            front: true,
+            pads,
+            graphics: vec![],
+            model_3d: None,
+            properties: Default::default(),
+        }
+    }
+
+    /// Proper segment intersection (excluding shared endpoints).
+    fn segs_cross(a: (Vec2, Vec2), b: (Vec2, Vec2)) -> bool {
+        let d = |p: Vec2, q: Vec2, r: Vec2| (q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x);
+        let (p1, p2) = a;
+        let (p3, p4) = b;
+        let (d1, d2) = (d(p3, p4, p1), d(p3, p4, p2));
+        let (d3, d4) = (d(p1, p2, p3), d(p1, p2, p4));
+        d1 * d2 < -1e-12 && d3 * d4 < -1e-12
+    }
+
+    #[test]
+    fn detects_dense_field() {
+        let pcb = board(vec![bga(8, 8, 0.65, 0.3, Vec2::new(25.0, 25.0))], 0.1, 0.1);
+        let fields = detect_pin_fields(&pcb);
+        assert_eq!(fields.len(), 1);
+        assert!((fields[0].pitch - 0.65).abs() < 1e-9);
+        assert!(fields[0].contains(Vec2::new(27.0, 27.0)));
+        assert!(!fields[0].contains(Vec2::new(5.0, 5.0)));
+    }
+
+    #[test]
+    fn eight_inner_pads_escape_without_crossing() {
+        // Synthetic 8x8 BGA at 0.65 mm pitch, 0.3 mm pads. The 8 pads of the
+        // inner region must all find probed, mutually non-crossing escapes.
+        let pcb = board(vec![bga(8, 8, 0.65, 0.3, Vec2::new(25.0, 25.0))], 0.1, 0.1);
+        let fields = detect_pin_fields(&pcb);
+        let field = &fields[0];
+        let session = RouteSession::from_pcb(&pcb);
+
+        // 8 inner pads (rows 2..=3, cols 2..=5 — well inside the field).
+        let mut eps = Vec::new();
+        for j in 2..=3usize {
+            for i in 2..=5usize {
+                eps.push((
+                    format!("N{i}_{j}"),
+                    Vec2::new(25.0 + i as f64 * 0.65, 25.0 + j as f64 * 0.65),
+                ));
+            }
+        }
+        let plans = plan_field_escapes(&session, &pcb, field, &eps, 0.1);
+        let ok: Vec<&EscapePlan> = plans.iter().flatten().collect();
+        assert_eq!(ok.len(), 8, "all 8 inner pads must escape");
+        for p in &ok {
+            let outside = p.egress.x < field.min.x
+                || p.egress.x > field.max.x
+                || p.egress.y < field.min.y
+                || p.egress.y > field.max.y;
+            assert!(
+                outside,
+                "egress must be outside the pad bbox: {:?}",
+                p.egress
+            );
+        }
+        // Pairwise non-crossing.
+        for (a, pa) in ok.iter().enumerate() {
+            for pb in ok.iter().skip(a + 1) {
+                for sa in &pa.segments {
+                    for sb in &pb.segments {
+                        assert!(
+                            !segs_cross(*sa, *sb),
+                            "escapes must not cross: {sa:?} {sb:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn capacity_respected_through_gap_wall() {
+        // A closed box of wall pads with exactly 3 single-pad gaps; 20 source
+        // pads inside. Each gap channel fits exactly one track, so at most 3
+        // escapes can be planned — the flow model must not cram 20 through.
+        let pitch = 0.65;
+        let pad_d = 0.3;
+        let n = 14; // 14x14 perimeter box
+        let origin = Vec2::new(25.0, 25.0);
+        let mut pads = Vec::new();
+        // Gap positions on the perimeter (skip these wall pads). Each gap is
+        // two missing pads wide: the interstitial grid nodes sit half a pitch
+        // off the pad lattice, so a channel must straddle a lattice line
+        // between two missing pads to carry a grid edge.
+        let gaps = [(0usize, 4usize), (0, 5), (13, 7), (13, 8), (6, 13), (7, 13)];
+        for j in 0..n {
+            for i in 0..n {
+                let perimeter = i == 0 || j == 0 || i == n - 1 || j == n - 1;
+                if !perimeter || gaps.contains(&(i, j)) {
+                    continue;
+                }
+                pads.push(pad(
+                    &format!("W{i}_{j}"),
+                    i as f64 * pitch,
+                    j as f64 * pitch,
+                    "WALL",
+                    pad_d,
+                ));
+            }
+        }
+        // 20 source pads inside, sparse (2-pitch spacing keeps interior open).
+        let mut eps = Vec::new();
+        for k in 0..20usize {
+            let (i, j) = (2 + 2 * (k % 5), 2 + 2 * (k / 5));
+            let name = format!("S{k}");
+            pads.push(pad(&name, i as f64 * pitch, j as f64 * pitch, &name, pad_d));
+            eps.push((
+                name,
+                Vec2::new(origin.x + i as f64 * pitch, origin.y + j as f64 * pitch),
+            ));
+        }
+        assert!(pads.len() >= MIN_FIELD_PADS);
+        let fp = Footprint {
+            reference: "U1".into(),
+            value: "walled".into(),
+            footprint_name: "WALL".into(),
+            position: origin,
+            rotation: 0.0,
+            front: true,
+            pads,
+            graphics: vec![],
+            model_3d: None,
+            properties: Default::default(),
+        };
+        // Rules where a single-pad gap (2·pitch − pad_d = 1.0 mm channel)
+        // fits exactly one 0.25 mm track at 0.2 mm clearance.
+        let pcb = board(vec![fp], 0.25, 0.2);
+        // The un-gapped wall itself is impassable at these rules.
+        assert_eq!(tracks_fit(pitch - pad_d, 0.25, 0.2), 0);
+        let fields = detect_pin_fields(&pcb);
+        assert_eq!(fields.len(), 1);
+        let session = RouteSession::from_pcb(&pcb);
+        let plans = plan_field_escapes(&session, &pcb, &fields[0], &eps, 0.25);
+        let ok = plans.iter().flatten().count();
+        assert!(ok > 0, "some escapes must be planned");
+        assert!(
+            ok <= 6,
+            "20 pins cannot all escape a 3-gap wall (planned {ok})"
+        );
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/escape.rs
+++ b/crates/vcad-ecad-pcb/src/router/escape.rs
@@ -118,7 +118,10 @@ pub fn detect_pin_fields(pcb: &Pcb) -> Vec<PinField> {
             for j in 0..pads.len() {
                 if i != j {
                     let d = dist(pads[i].pos, pads[j].pos);
-                    if d < best {
+                    // Coincident pads (stacked pad/drill artifacts at one
+                    // position) are not lattice spacing — skip them or the
+                    // pitch degenerates to 0 and the interstitial grid with it.
+                    if d > 1e-6 && d < best {
                         best = d;
                     }
                 }
@@ -127,7 +130,9 @@ pub fn detect_pin_fields(pcb: &Pcb) -> Vec<PinField> {
                 pitch = best;
             }
         }
-        if !pitch.is_finite() || pitch > MAX_FIELD_PITCH {
+        // Reject non-lattices: sub-manufacturable "pitch" means the footprint
+        // isn't a pin field the flow model can grid.
+        if !pitch.is_finite() || pitch > MAX_FIELD_PITCH || pitch < 0.1 {
             continue;
         }
         let (mut min, mut max) = (pads[0].pos, pads[0].pos);

--- a/crates/vcad-ecad-pcb/src/router/escape.rs
+++ b/crates/vcad-ecad-pcb/src/router/escape.rs
@@ -132,7 +132,7 @@ pub fn detect_pin_fields(pcb: &Pcb) -> Vec<PinField> {
         }
         // Reject non-lattices: sub-manufacturable "pitch" means the footprint
         // isn't a pin field the flow model can grid.
-        if !pitch.is_finite() || pitch > MAX_FIELD_PITCH || pitch < 0.1 {
+        if !pitch.is_finite() || !(0.1..=MAX_FIELD_PITCH).contains(&pitch) {
             continue;
         }
         let (mut min, mut max) = (pads[0].pos, pads[0].pos);

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -296,8 +296,35 @@ pub fn route_net_maze3d(
     let mut came: Vec<usize> = vec![usize::MAX; n];
     let mut closed = vec![false; n];
     // Memoized via legality per (cell, span pair) — spans are (lo, hi)
-    // layer-index pairs, lo < hi.
+    // layer-index pairs, lo < hi — and the via POSITION chosen for the cell:
+    // the cell centre when it clears, otherwise an off-grid candidate found
+    // by ring search. Grid-quantized via sites lose exactly the positions a
+    // human uses inside a BGA field (between the balls); the candidates
+    // recover them.
     let mut via_cache: Vec<i8> = vec![-1; plane * nl * nl];
+    let mut via_pos: Vec<Vec2> = vec![Vec2::new(0.0, 0.0); plane * nl * nl];
+    // A candidate must clear its span AND connect legally to the cell centre
+    // on both endpoint layers (the search continues from the cell node).
+    let find_via_site = |center: Vec2, lo: usize, hi: usize| -> Option<Vec2> {
+        if via_ok(center, lo, hi) {
+            return Some(center);
+        }
+        let r1 = grid.pitch / 3.0;
+        let r2 = grid.pitch / 2.0;
+        for r in [r1, r2] {
+            for k in 0..8 {
+                let a = std::f64::consts::TAU * k as f64 / 8.0;
+                let p = Vec2::new(center.x + r * a.cos(), center.y + r * a.sin());
+                if via_ok(p, lo, hi)
+                    && legal_step(center, p, layers[lo])
+                    && legal_step(center, p, layers[hi])
+                {
+                    return Some(p);
+                }
+            }
+        }
+        None
+    };
     // Occupancy raster: O(1) cell passability, and WIDE↔WIDE edges are legal
     // without touching the oracle at all.
     let sw_raster = Stopwatch::start();
@@ -436,7 +463,13 @@ pub fn route_net_maze3d(
                 let (lo, hi) = (li.min(lj), li.max(lj));
                 let key = cell * nl * nl + lo * nl + hi;
                 if via_cache[key] < 0 {
-                    via_cache[key] = i8::from(via_ok(grid.world(ix, iy), lo, hi));
+                    match find_via_site(grid.world(ix, iy), lo, hi) {
+                        Some(p) => {
+                            via_cache[key] = 1;
+                            via_pos[key] = p;
+                        }
+                        None => via_cache[key] = 0,
+                    }
                 }
                 if via_cache[key] != 1 {
                     continue;
@@ -527,11 +560,21 @@ pub fn route_net_maze3d(
         let (li, cell) = (node / plane, node % plane);
         let w = grid.world_of(cell);
         if li != run_layer {
-            // Layer change: the via sits at the last point of the finished
-            // run, spanning exactly the two layers it connects.
-            let at = *run.last().expect("run always starts non-empty");
-            flush_run(&mut run, layers[run_layer], &mut segments);
+            // Layer change: the via sits at the position the search chose for
+            // this (cell, span) — the cell centre, or an off-grid candidate
+            // between obstacles. Route the old-layer run to it and start the
+            // new-layer run from it.
             let (lo, hi) = (run_layer.min(li), run_layer.max(li));
+            let key = cell * nl * nl + lo * nl + hi;
+            let at = if via_cache[key] == 1 {
+                via_pos[key]
+            } else {
+                *run.last().expect("run always starts non-empty")
+            };
+            if run.last().map(|p| dist(*p, at) > 1e-9).unwrap_or(true) {
+                run.push(at);
+            }
+            flush_run(&mut run, layers[run_layer], &mut segments);
             if vias
                 .last()
                 .map(|&(v, _, _)| dist(v, at) > 1e-9)

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -240,6 +240,7 @@ pub fn route_net_maze3d(
     pitch_scale: f64,
     window: Option<(Vec2, Vec2)>,
     tree_goals: &[(CopperGeom, [f64; 2], [f64; 2], PcbLayer)],
+    tree_sources: &[(CopperGeom, [f64; 2], [f64; 2], PcbLayer)],
     offgrid_vias: bool,
 ) -> RouteResult3d {
     let nl = layers.len();
@@ -377,35 +378,9 @@ pub fn route_net_maze3d(
     // ending there is electrically joined). Terminating on the tree needs no
     // endpoint via: the copper is already on that layer.
     let mut tree_goal = vec![false; n];
-    for (geom, emin, emax, glayer) in tree_goals {
-        let Some(li) = layers.iter().position(|l| l == glayer) else {
-            continue;
-        };
-        let ix0 = (((emin[0] - grid.origin.x) / grid.pitch).floor()).max(0.0) as usize;
-        let iy0 = (((emin[1] - grid.origin.y) / grid.pitch).floor()).max(0.0) as usize;
-        let ix1 = ((((emax[0] - grid.origin.x) / grid.pitch).ceil()) as usize)
-            .min(grid.nx.saturating_sub(1));
-        let iy1 = ((((emax[1] - grid.origin.y) / grid.pitch).ceil()) as usize)
-            .min(grid.ny.saturating_sub(1));
-        for iy in iy0..=iy1 {
-            for ix in ix0..=ix1 {
-                let probe_pt = CopperGeom::Disc {
-                    center: grid.world(ix, iy),
-                    r: 0.0,
-                };
-                // Strict overlap certificate: a trace disc (radius half_w) at
-                // this cell centre physically overlaps the tree element, so
-                // terminating here is guaranteed electrical contact. Elements
-                // smaller than a grid cell may mark no cells — that is the
-                // safe direction (degrades to the exact pad goal); loosening
-                // the test would let routes "connect" to copper they never
-                // touch.
-                if geom.distance_to(&probe_pt) < half_w {
-                    tree_goal[li * plane + grid.index(ix, iy)] = true;
-                }
-            }
-        }
-    }
+    let mut tree_source = vec![false; n];
+    mark_tree_cells(&grid, layers, plane, half_w, tree_goals, &mut tree_goal);
+    mark_tree_cells(&grid, layers, plane, half_w, tree_sources, &mut tree_source);
     let is_goal = |node: usize| {
         (node % plane == goal_cell && end_lis.contains(&(node / plane))) || tree_goal[node]
     };
@@ -418,11 +393,33 @@ pub fn route_net_maze3d(
             node,
         });
     }
+    // Multi-source: the search may depart from ANY copper of the from-pad's
+    // connected component (GAMER-style tree-to-tree routing) — every marked
+    // source cell is a zero-cost seed.
+    for (node, &is_src) in tree_source.iter().enumerate() {
+        if is_src && g[node] > 0.0 {
+            g[node] = 0.0;
+            heap.push(State {
+                f: heuristic(node),
+                node,
+            });
+        }
+    }
 
     let mut found: Option<usize> = None;
     let mut pops: usize = 0;
     while let Some(State { node, .. }) = heap.pop() {
         if is_goal(node) {
+            // A zero-cost seed that is already a goal means the components
+            // touch: success with no copper to add.
+            if g[node] == 0.0 && tree_source[node] && tree_goal[node] {
+                return RouteResult3d {
+                    net: net.to_string(),
+                    segments: Vec::new(),
+                    vias: Vec::new(),
+                    success: true,
+                };
+            }
             found = Some(node);
             break;
         }
@@ -564,7 +561,15 @@ pub fn route_net_maze3d(
 
     let mut segments: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
     let mut vias: Vec<(Vec2, PcbLayer, PcbLayer)> = Vec::new();
-    let mut run: Vec<Vec2> = vec![start];
+    // If the chain roots on source copper away from the start pad, the run
+    // begins there (the copper is the connection); otherwise at the pad.
+    let root_cell = nodes[0] % plane;
+    let rooted_on_tree = tree_source[nodes[0]] && root_cell != grid.index(sx, sy);
+    let mut run: Vec<Vec2> = if rooted_on_tree {
+        vec![grid.world_of(root_cell)]
+    } else {
+        vec![start]
+    };
     let mut run_layer = nodes[0] / plane;
 
     // Taut pull: greedy line-of-sight shortcutting over a run's points. A
@@ -760,6 +765,41 @@ impl Raster {
     #[inline]
     fn state(&self, cell: usize, li: usize) -> u8 {
         self.states[li * self.plane + cell]
+    }
+}
+
+/// Mark every (cell, layer) whose centre lies ON one of `elems` (overlap
+/// within `half_w`, the strict electrical-contact certificate) — used for
+/// both route-to-tree goals and multi-source seeds.
+fn mark_tree_cells(
+    grid: &Grid,
+    layers: &[PcbLayer],
+    plane: usize,
+    half_w: f64,
+    elems: &[(CopperGeom, [f64; 2], [f64; 2], PcbLayer)],
+    marks: &mut [bool],
+) {
+    for (geom, emin, emax, glayer) in elems {
+        let Some(li) = layers.iter().position(|l| l == glayer) else {
+            continue;
+        };
+        let ix0 = (((emin[0] - grid.origin.x) / grid.pitch).floor()).max(0.0) as usize;
+        let iy0 = (((emin[1] - grid.origin.y) / grid.pitch).floor()).max(0.0) as usize;
+        let ix1 = ((((emax[0] - grid.origin.x) / grid.pitch).ceil()) as usize)
+            .min(grid.nx.saturating_sub(1));
+        let iy1 = ((((emax[1] - grid.origin.y) / grid.pitch).ceil()) as usize)
+            .min(grid.ny.saturating_sub(1));
+        for iy in iy0..=iy1 {
+            for ix in ix0..=ix1 {
+                let probe_pt = CopperGeom::Disc {
+                    center: grid.world(ix, iy),
+                    r: 0.0,
+                };
+                if geom.distance_to(&probe_pt) < half_w {
+                    marks[li * plane + grid.index(ix, iy)] = true;
+                }
+            }
+        }
     }
 }
 
@@ -1247,6 +1287,7 @@ mod tests {
             1.0,
             None,
             &[],
+            &[],
             true,
         );
         assert!(r.success);
@@ -1280,6 +1321,7 @@ mod tests {
             0,
             1.0,
             None,
+            &[],
             &[],
             true,
         );
@@ -1342,6 +1384,7 @@ mod tests {
             1.0,
             None,
             &[],
+            &[],
             true,
         );
         assert!(r.success);
@@ -1376,6 +1419,7 @@ mod tests {
             0,
             1.0,
             None,
+            &[],
             &[],
             true,
         );

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -240,6 +240,7 @@ pub fn route_net_maze3d(
     pitch_scale: f64,
     window: Option<(Vec2, Vec2)>,
     tree_goals: &[(CopperGeom, [f64; 2], [f64; 2], PcbLayer)],
+    offgrid_vias: bool,
 ) -> RouteResult3d {
     let nl = layers.len();
     if nl == 0 {
@@ -292,9 +293,43 @@ pub fn route_net_maze3d(
         (dx * dx + dy * dy).sqrt() * grid.pitch
     };
 
-    let mut g = vec![f64::INFINITY; n];
-    let mut came: Vec<usize> = vec![usize::MAX; n];
-    let mut closed = vec![false; n];
+    // Per-thread buffer arena: the search working set is ~30MB at full grid
+    // size, and allocating it per connection dominated allocator time. The
+    // guard returns the buffers on every exit path (including early fails).
+    struct ArenaGuard {
+        g: Vec<f64>,
+        came: Vec<usize>,
+        closed: Vec<bool>,
+    }
+    thread_local! {
+        static ARENA: std::cell::RefCell<(Vec<f64>, Vec<usize>, Vec<bool>)> =
+            const { std::cell::RefCell::new((Vec::new(), Vec::new(), Vec::new())) };
+    }
+    impl Drop for ArenaGuard {
+        fn drop(&mut self) {
+            ARENA.with(|a| {
+                let mut a = a.borrow_mut();
+                a.0 = std::mem::take(&mut self.g);
+                a.1 = std::mem::take(&mut self.came);
+                a.2 = std::mem::take(&mut self.closed);
+            });
+        }
+    }
+    let mut arena = ARENA.with(|a| {
+        let mut a = a.borrow_mut();
+        ArenaGuard {
+            g: std::mem::take(&mut a.0),
+            came: std::mem::take(&mut a.1),
+            closed: std::mem::take(&mut a.2),
+        }
+    });
+    arena.g.clear();
+    arena.g.resize(n, f64::INFINITY);
+    arena.came.clear();
+    arena.came.resize(n, usize::MAX);
+    arena.closed.clear();
+    arena.closed.resize(n, false);
+    let ArenaGuard { g, came, closed } = &mut arena;
     // Memoized via legality per (cell, span pair) — spans are (lo, hi)
     // layer-index pairs, lo < hi — and the via POSITION chosen for the cell:
     // the cell centre when it clears, otherwise an off-grid candidate found
@@ -308,6 +343,9 @@ pub fn route_net_maze3d(
     let find_via_site = |center: Vec2, lo: usize, hi: usize| -> Option<Vec2> {
         if via_ok(center, lo, hi) {
             return Some(center);
+        }
+        if !offgrid_vias {
+            return None;
         }
         let r1 = grid.pitch / 3.0;
         let r2 = grid.pitch / 2.0;
@@ -475,7 +513,14 @@ pub fn route_net_maze3d(
                     continue;
                 }
                 let span_frac = (hi - lo) as f64 / (nl - 1).max(1) as f64;
-                let tentative = g[node] + VIA_COST * (0.4 + 0.6 * span_frac);
+                // Long connections amortize their vias: the reference design
+                // runs 30-50mm nets as inner-layer highways with a handful of
+                // vias, while a flat via price makes the dive look expensive
+                // relative to a short net's budget. Scale the price down as
+                // the airwire grows (floor 0.3 at >= ~20mm).
+                let haul = dist(start, end);
+                let haul_scale = (6.0 / haul.max(1.0)).clamp(0.3, 1.0);
+                let tentative = g[node] + VIA_COST * haul_scale * (0.4 + 0.6 * span_frac);
                 if tentative < g[nb] {
                     g[nb] = tentative;
                     came[nb] = node;
@@ -873,9 +918,43 @@ fn astar(
         (dx * dx + dy * dy).sqrt() * grid.pitch
     };
 
-    let mut g = vec![f64::INFINITY; n];
-    let mut came: Vec<usize> = vec![usize::MAX; n];
-    let mut closed = vec![false; n];
+    // Per-thread buffer arena: the search working set is ~30MB at full grid
+    // size, and allocating it per connection dominated allocator time. The
+    // guard returns the buffers on every exit path (including early fails).
+    struct ArenaGuard {
+        g: Vec<f64>,
+        came: Vec<usize>,
+        closed: Vec<bool>,
+    }
+    thread_local! {
+        static ARENA: std::cell::RefCell<(Vec<f64>, Vec<usize>, Vec<bool>)> =
+            const { std::cell::RefCell::new((Vec::new(), Vec::new(), Vec::new())) };
+    }
+    impl Drop for ArenaGuard {
+        fn drop(&mut self) {
+            ARENA.with(|a| {
+                let mut a = a.borrow_mut();
+                a.0 = std::mem::take(&mut self.g);
+                a.1 = std::mem::take(&mut self.came);
+                a.2 = std::mem::take(&mut self.closed);
+            });
+        }
+    }
+    let mut arena = ARENA.with(|a| {
+        let mut a = a.borrow_mut();
+        ArenaGuard {
+            g: std::mem::take(&mut a.0),
+            came: std::mem::take(&mut a.1),
+            closed: std::mem::take(&mut a.2),
+        }
+    });
+    arena.g.clear();
+    arena.g.resize(n, f64::INFINITY);
+    arena.came.clear();
+    arena.came.resize(n, usize::MAX);
+    arena.closed.clear();
+    arena.closed.resize(n, false);
+    let ArenaGuard { g, came, closed } = &mut arena;
     let mut heap = BinaryHeap::new();
     g[start] = 0.0;
     heap.push(State {
@@ -948,7 +1027,7 @@ const NEIGHBORS: [(i64, i64); 8] = [
     (-1, -1),
 ];
 
-fn reconstruct(came: Vec<usize>, start: usize, goal: usize) -> Vec<usize> {
+fn reconstruct(came: &[usize], start: usize, goal: usize) -> Vec<usize> {
     let mut path = vec![goal];
     let mut cur = goal;
     while cur != start {
@@ -1168,6 +1247,7 @@ mod tests {
             1.0,
             None,
             &[],
+            true,
         );
         assert!(r.success);
         assert!(r.vias.is_empty(), "no reason to leave the start layer");
@@ -1201,6 +1281,7 @@ mod tests {
             1.0,
             None,
             &[],
+            true,
         );
         assert!(r.success, "3D search must cross under the wall");
         assert!(
@@ -1261,6 +1342,7 @@ mod tests {
             1.0,
             None,
             &[],
+            true,
         );
         assert!(r.success);
         assert!(!r.vias.is_empty());
@@ -1295,6 +1377,7 @@ mod tests {
             1.0,
             None,
             &[],
+            true,
         );
         assert!(r.success);
         assert!(!r.vias.is_empty(), "front→back must place a via");

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -41,6 +41,7 @@ impl Stopwatch {
 
 pub mod congestion;
 pub mod diff_pair;
+pub(crate) mod escape;
 pub mod global;
 pub mod grid;
 pub mod length_match;

--- a/crates/vcad-kernel-gpu/src/shaders/wavefront.wgsl
+++ b/crates/vcad-kernel-gpu/src/shaders/wavefront.wgsl
@@ -8,6 +8,18 @@
 // Ping-pong buffering: reads `dist_in`, writes `dist_out`. The host
 // swaps the buffers between iterations and stops when a sweep makes
 // no improvement (the `changed` flag stays 0).
+//
+// A second, frontier-compacted path lives in the same module
+// (`frontier_prep` + `relax_compacted`): instead of sweeping every node,
+// each iteration relaxes only the nodes touched last iteration. The
+// frontier is a compacted list of node indices with an atomic counter;
+// duplicates are suppressed with an epoch-stamped `stamp` buffer
+// (a node is appended at most once per iteration: the first thread to
+// atomicMax the stamp up to the current epoch wins the append).
+// `frontier_prep` runs single-threaded before each iteration to turn the
+// counter into DispatchIndirect workgroup counts, reset the outgoing
+// counter, and bump the epoch — so the host never reads counters back
+// inside the loop.
 
 struct Params {
     nx: u32,
@@ -16,9 +28,20 @@ struct Params {
     step_cost: u32,
     diag_cost: u32,
     via_cost: u32,
-    _pad0: u32,
+    // Frontier parity for the compacted path: 0 = frontier A is input,
+    // 1 = frontier B is input. Unused by the full-sweep `relax` kernel.
+    parity: u32,
     _pad1: u32,
 }
+
+// Layout of the compacted-path `meta` buffer (all atomic u32):
+//   [0..3) DispatchIndirect args (x, y, z) for `relax_compacted`
+//   [3]    epoch (bumped once per iteration by `frontier_prep`)
+//   [4]    frontier A length
+//   [5]    frontier B length
+const META_DISPATCH_X: u32 = 0u;
+const META_EPOCH: u32 = 3u;
+const META_COUNT_A: u32 = 4u;
 
 const INF: u32 = 0xffffffffu;
 
@@ -95,5 +118,100 @@ fn relax(@builtin(global_invocation_id) gid: vec3<u32>) {
     dist_out[idx] = best;
     if best < cur {
         atomicStore(&changed, 1u);
+    }
+}
+
+// ---- Frontier-compacted path ----------------------------------------
+
+// Distances, updated in place with atomicMin (deterministic final field
+// regardless of relaxation order).
+@group(0) @binding(5) var<storage, read_write> dist: array<atomic<u32>>;
+// Compacted frontier node lists (ping-pong; parity picks which is input).
+@group(0) @binding(6) var<storage, read> frontier_in: array<u32>;
+@group(0) @binding(7) var<storage, read_write> frontier_out: array<u32>;
+// Per-node epoch stamp for duplicate suppression.
+@group(0) @binding(8) var<storage, read_write> stamp: array<atomic<u32>>;
+// Dispatch args + epoch + frontier lengths; see layout above.
+@group(0) @binding(9) var<storage, read_write> fmeta: array<atomic<u32>>;
+
+// Single-threaded per-iteration bookkeeping: publish the input frontier
+// length as indirect workgroup counts, clear the output counter, and
+// advance the epoch.
+@compute @workgroup_size(1)
+fn frontier_prep() {
+    let n = atomicLoad(&fmeta[META_COUNT_A + params.parity]);
+    atomicStore(&fmeta[META_DISPATCH_X], (n + 255u) / 256u);
+    atomicStore(&fmeta[META_DISPATCH_X + 1u], 1u);
+    atomicStore(&fmeta[META_DISPATCH_X + 2u], 1u);
+    atomicStore(&fmeta[META_COUNT_A + (1u - params.parity)], 0u);
+    atomicAdd(&fmeta[META_EPOCH], 1u);
+}
+
+// Relax one neighbor: lower its distance with atomicMin and, if this is
+// the first improvement of the node this iteration (epoch stamp), append
+// it to the outgoing frontier.
+fn try_relax(idx: u32, nd: u32, epoch: u32) {
+    if occupancy[idx] != 0u {
+        return;
+    }
+    let old = atomicMin(&dist[idx], nd);
+    if nd < old {
+        if atomicMax(&stamp[idx], epoch) < epoch {
+            let slot = atomicAdd(&fmeta[META_COUNT_A + (1u - params.parity)], 1u);
+            frontier_out[slot] = idx;
+        }
+    }
+}
+
+// One thread per entry of the input frontier: relax all neighbors of the
+// frontier node. Improved neighbors join the next frontier (deduped).
+@compute @workgroup_size(256)
+fn relax_compacted(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let n = atomicLoad(&fmeta[META_COUNT_A + params.parity]);
+    if gid.x >= n {
+        return;
+    }
+    let idx = frontier_in[gid.x];
+    let d = atomicLoad(&dist[idx]);
+    if d == INF {
+        return;
+    }
+    let epoch = atomicLoad(&fmeta[META_EPOCH]);
+
+    let x = i32(idx % params.nx);
+    let y = i32((idx / params.nx) % params.ny);
+    let l = idx / (params.nx * params.ny);
+
+    for (var dy = -1; dy <= 1; dy += 1) {
+        for (var dx = -1; dx <= 1; dx += 1) {
+            if dx == 0 && dy == 0 {
+                continue;
+            }
+            let px = x + dx;
+            let py = y + dy;
+            if px < 0 || py < 0 || u32(px) >= params.nx || u32(py) >= params.ny {
+                continue;
+            }
+            var cost = params.step_cost;
+            if dx != 0 && dy != 0 {
+                cost = params.diag_cost;
+            }
+            let nd = d + cost;
+            if nd < d {
+                continue; // overflow guard
+            }
+            try_relax(node_index(u32(px), u32(py), l), nd, epoch);
+        }
+    }
+
+    let nd_via = d + params.via_cost;
+    if nd_via >= d {
+        let cell = idx % (params.nx * params.ny);
+        if l > 0u {
+            try_relax((l - 1u) * params.nx * params.ny + cell, nd_via, epoch);
+        }
+        if l + 1u < params.nl {
+            try_relax((l + 1u) * params.nx * params.ny + cell, nd_via, epoch);
+        }
     }
 }

--- a/crates/vcad-kernel-gpu/src/wavefront.rs
+++ b/crates/vcad-kernel-gpu/src/wavefront.rs
@@ -6,10 +6,14 @@
 //! adjacent layers. Ping-pong buffering keeps each sweep deterministic;
 //! a `changed` flag lets the host stop once the field is settled.
 //!
-//! [`distance_field`] runs on the GPU (falling back to an error when no
-//! adapter exists); [`distance_field_cpu`] is the exact-integer Dijkstra
-//! reference used by tests and as a CPU fallback. [`extract_path`] walks
-//! either field downhill from a goal back to a source.
+//! [`distance_field`] runs the full-sweep path on the GPU (falling back
+//! to an error when no adapter exists); [`distance_field_compacted`] is
+//! the frontier-compacted variant, which relaxes only the nodes touched
+//! last iteration (indirect dispatch, no per-iteration readback) and is
+//! the fast path at router scale. [`distance_field_cpu`] is the
+//! exact-integer Dijkstra reference used by tests and as a CPU fallback.
+//! All three produce bit-identical fields. [`extract_path`] walks any of
+//! them downhill from a goal back to a source.
 
 use crate::context::{GpuContext, GpuError};
 use bytemuck::{Pod, Zeroable};
@@ -68,7 +72,7 @@ struct WavefrontParams {
     step_cost: u32,
     diag_cost: u32,
     via_cost: u32,
-    _pad0: u32,
+    parity: u32,
     _pad1: u32,
 }
 
@@ -144,7 +148,7 @@ pub async fn distance_field_async(
         step_cost: costs.step,
         diag_cost: costs.diag,
         via_cost: costs.via,
-        _pad0: 0,
+        parity: 0,
         _pad1: 0,
     };
 
@@ -334,6 +338,300 @@ pub async fn distance_field_async(
     Ok(dist)
 }
 
+/// Frontier length checks per batch of compacted iterations. Each
+/// iteration in a batch is two tiny dispatches (prep + indirect relax),
+/// so batching amortizes the host round-trip.
+const ITERS_PER_READBACK: usize = 64;
+
+/// Frontier-compacted variant of [`distance_field`].
+///
+/// Produces the same field bit-exactly, but each iteration relaxes only
+/// the frontier (the nodes improved last iteration) instead of the whole
+/// grid: a prep kernel converts the frontier counter into indirect
+/// dispatch args, and the relax kernel appends improved neighbors to the
+/// next frontier with epoch-stamped deduplication. The host only reads
+/// back the frontier length every [`ITERS_PER_READBACK`] iterations to
+/// detect termination.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn distance_field_compacted(
+    grid: &WavefrontGrid,
+    sources: &[usize],
+    costs: &WavefrontCosts,
+) -> Result<Vec<u32>, GpuError> {
+    pollster::block_on(distance_field_compacted_async(grid, sources, costs))
+}
+
+/// Async variant of [`distance_field_compacted`].
+pub async fn distance_field_compacted_async(
+    grid: &WavefrontGrid,
+    sources: &[usize],
+    costs: &WavefrontCosts,
+) -> Result<Vec<u32>, GpuError> {
+    let total = grid.len();
+    if total == 0 {
+        return Ok(Vec::new());
+    }
+
+    let ctx = GpuContext::init().await?;
+
+    let occupancy: Vec<u32> = grid.blocked.iter().map(|&b| u32::from(b)).collect();
+    let mut init_dist = vec![UNREACHABLE; total];
+    let mut init_frontier: Vec<u32> = Vec::with_capacity(sources.len());
+    for &s in sources {
+        if init_dist[s] != 0 {
+            init_dist[s] = 0;
+            init_frontier.push(s as u32);
+        }
+    }
+    let source_count = init_frontier.len() as u32;
+    // Frontier buffers hold node indices; dedup bounds each frontier by
+    // the node count, so `total` entries is always enough.
+    init_frontier.resize(total, 0);
+
+    let byte_len = (total * std::mem::size_of::<u32>()) as u64;
+
+    let make_storage = |label: &str, contents: &[u32]| {
+        ctx.device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(label),
+                contents: bytemuck::cast_slice(contents),
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            })
+    };
+
+    let occupancy_buffer = make_storage("Wavefront Occupancy Buffer", &occupancy);
+    let dist_buffer = make_storage("Wavefront Atomic Dist Buffer", &init_dist);
+    let stamp_buffer = make_storage("Wavefront Stamp Buffer", &vec![0u32; total]);
+    let frontier_buffers = [
+        make_storage("Wavefront Frontier Buffer A", &init_frontier),
+        make_storage("Wavefront Frontier Buffer B", &vec![0u32; total]),
+    ];
+
+    // meta = [dispatch x, y, z, epoch, count A, count B].
+    let meta_init = [0u32, 1, 1, 0, source_count, 0];
+    let meta_buffer = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Wavefront Meta Buffer"),
+            contents: bytemuck::cast_slice(&meta_init),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::INDIRECT
+                | wgpu::BufferUsages::COPY_SRC,
+        });
+
+    // Per-parity params (parity selects which frontier/count is input).
+    let params_buffers: [wgpu::Buffer; 2] = std::array::from_fn(|parity| {
+        let params = WavefrontParams {
+            nx: grid.nx as u32,
+            ny: grid.ny as u32,
+            nl: grid.layers as u32,
+            step_cost: costs.step,
+            diag_cost: costs.diag,
+            via_cost: costs.via,
+            parity: parity as u32,
+            _pad1: 0,
+        };
+        ctx.device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Wavefront Compacted Params Buffer"),
+                contents: bytemuck::bytes_of(&params),
+                usage: wgpu::BufferUsages::UNIFORM,
+            })
+    });
+
+    let shader = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Wavefront Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("shaders/wavefront.wgsl").into()),
+        });
+
+    let storage_entry = |binding: u32, read_only: bool| wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    };
+
+    let bind_group_layout = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("Wavefront Compacted Bind Group Layout"),
+            entries: &[
+                storage_entry(0, true),
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                storage_entry(5, false),
+                storage_entry(6, true),
+                storage_entry(7, false),
+                storage_entry(8, false),
+                storage_entry(9, false),
+            ],
+        });
+
+    let make_bind_group = |parity: usize| {
+        ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Wavefront Compacted Bind Group"),
+            layout: &bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: occupancy_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: params_buffers[parity].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: dist_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 6,
+                    resource: frontier_buffers[parity].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 7,
+                    resource: frontier_buffers[1 - parity].as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 8,
+                    resource: stamp_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 9,
+                    resource: meta_buffer.as_entire_binding(),
+                },
+            ],
+        })
+    };
+    let bind_groups = [make_bind_group(0), make_bind_group(1)];
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("Wavefront Compacted Pipeline Layout"),
+            bind_group_layouts: &[&bind_group_layout],
+            push_constant_ranges: &[],
+        });
+    let make_pipeline = |entry: &str| {
+        ctx.device
+            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+                label: Some(entry),
+                layout: Some(&pipeline_layout),
+                module: &shader,
+                entry_point: Some(entry),
+                compilation_options: Default::default(),
+                cache: None,
+            })
+    };
+    let prep_pipeline = make_pipeline("frontier_prep");
+    let relax_pipeline = make_pipeline("relax_compacted");
+
+    let count_staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Wavefront Count Staging"),
+        size: std::mem::size_of::<u32>() as u64,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+
+    // Each iteration expands the wavefront by at least one hop, so
+    // `total` iterations bounds convergence.
+    let max_iters = total;
+    let mut iters_done = 0usize;
+    while iters_done < max_iters {
+        let batch = ITERS_PER_READBACK.min(max_iters - iters_done);
+
+        let mut encoder = ctx
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Wavefront Compacted Encoder"),
+            });
+        for i in 0..batch {
+            let parity = (iters_done + i) % 2;
+            // Prep and relax in separate passes so the indirect-args
+            // write is ordered before the indirect dispatch consumes it.
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("Wavefront Frontier Prep Pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&prep_pipeline);
+                pass.set_bind_group(0, &bind_groups[parity], &[]);
+                pass.dispatch_workgroups(1, 1, 1);
+            }
+            {
+                let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("Wavefront Compacted Relax Pass"),
+                    timestamp_writes: None,
+                });
+                pass.set_pipeline(&relax_pipeline);
+                pass.set_bind_group(0, &bind_groups[parity], &[]);
+                pass.dispatch_workgroups_indirect(&meta_buffer, 0);
+            }
+        }
+        iters_done += batch;
+        // The next iteration's input count lives at meta[4 + parity].
+        let next_parity = iters_done % 2;
+        encoder.copy_buffer_to_buffer(
+            &meta_buffer,
+            ((4 + next_parity) * std::mem::size_of::<u32>()) as u64,
+            &count_staging,
+            0,
+            std::mem::size_of::<u32>() as u64,
+        );
+        ctx.queue.submit(std::iter::once(encoder.finish()));
+
+        if read_u32(ctx, &count_staging)? == 0 {
+            break;
+        }
+    }
+
+    // Read back the settled distance field.
+    let dist_staging = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Wavefront Compacted Dist Staging"),
+        size: byte_len,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Wavefront Compacted Readback Encoder"),
+        });
+    encoder.copy_buffer_to_buffer(&dist_buffer, 0, &dist_staging, 0, byte_len);
+    ctx.queue.submit(std::iter::once(encoder.finish()));
+
+    let buffer_slice = dist_staging.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+        tx.send(result).unwrap();
+    });
+    ctx.device.poll(wgpu::Maintain::Wait);
+    rx.recv()
+        .map_err(|_| GpuError::BufferMapping)?
+        .map_err(|_| GpuError::BufferMapping)?;
+
+    let data = buffer_slice.get_mapped_range();
+    let dist: Vec<u32> = bytemuck::cast_slice(&data).to_vec();
+    drop(data);
+    dist_staging.unmap();
+
+    Ok(dist)
+}
+
 fn read_u32(ctx: &GpuContext, staging: &wgpu::Buffer) -> Result<u32, GpuError> {
     let slice = staging.slice(..);
     let (tx, rx) = std::sync::mpsc::channel();
@@ -481,8 +779,8 @@ mod tests {
     fn cpu_empty_grid_straight_line() {
         let g = grid(10, 1, 1);
         let dist = distance_field_cpu(&g, &[0], &COSTS);
-        for x in 0..10 {
-            assert_eq!(dist[x], x as u32 * 1000);
+        for (x, &d) in dist.iter().enumerate() {
+            assert_eq!(d, x as u32 * 1000);
         }
     }
 
@@ -587,10 +885,98 @@ mod tests {
         let gpu = distance_field(&g, &[src], &COSTS).expect("gpu");
         let gpu_time = t0.elapsed();
         let t1 = std::time::Instant::now();
+        let gpu_compact = distance_field_compacted(&g, &[src], &COSTS).expect("gpu compacted");
+        let compact_time = t1.elapsed();
+        let t2 = std::time::Instant::now();
         let cpu = distance_field_cpu(&g, &[src], &COSTS);
-        let cpu_time = t1.elapsed();
+        let cpu_time = t2.elapsed();
         assert_eq!(gpu, cpu);
-        println!("400x400x10: gpu={gpu_time:?} cpu={cpu_time:?}");
+        assert_eq!(gpu_compact, cpu);
+        println!(
+            "400x400x10: gpu-full={gpu_time:?} gpu-compacted={compact_time:?} cpu={cpu_time:?}"
+        );
+    }
+
+    #[test]
+    fn gpu_compacted_matches_cpu_on_walled_grid() {
+        let g = walled_grid();
+        let src = g.index(0, 2, 0);
+        let gpu = match distance_field_compacted(&g, &[src], &COSTS) {
+            Ok(d) => d,
+            Err(GpuError::NoAdapter) => return, // headless CI without a GPU
+            Err(e) => panic!("GPU error: {e}"),
+        };
+        let cpu = distance_field_cpu(&g, &[src], &COSTS);
+        assert_eq!(gpu, cpu);
+    }
+
+    #[test]
+    fn gpu_compacted_matches_cpu_multi_source_random_obstacles() {
+        let mut g = grid(32, 24, 3);
+        let mut state = 0x2545f491u32;
+        let mut rand = move || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state
+        };
+        for b in g.blocked.iter_mut() {
+            *b = rand() % 5 == 0;
+        }
+        let sources: Vec<usize> = [(1, 1, 0), (30, 22, 2)]
+            .iter()
+            .map(|&(x, y, l)| (l * g.ny + y) * g.nx + x)
+            .collect();
+        for &s in &sources {
+            g.blocked[s] = false;
+        }
+
+        let gpu = match distance_field_compacted(&g, &sources, &COSTS) {
+            Ok(d) => d,
+            Err(GpuError::NoAdapter) => return,
+            Err(e) => panic!("GPU error: {e}"),
+        };
+        let cpu = distance_field_cpu(&g, &sources, &COSTS);
+        assert_eq!(gpu, cpu);
+    }
+
+    /// Router-reality-shaped benchmark: CM5-scale board raster, 40%
+    /// blocked, corner-to-corner query. Run manually:
+    /// `cargo test -p vcad-kernel-gpu --release -- --ignored bench_wavefront --nocapture`
+    #[test]
+    #[ignore = "benchmark; run manually with --ignored"]
+    fn bench_wavefront_344x250x10_dense() {
+        let mut g = grid(344, 250, 10);
+        let mut state = 0x1234_5678u32;
+        let mut rand = move || {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            state
+        };
+        for b in g.blocked.iter_mut() {
+            *b = rand() % 10 < 4;
+        }
+        let src = g.index(0, 0, 0);
+        let goal = g.index(343, 249, 9);
+        g.blocked[src] = false;
+        g.blocked[goal] = false;
+
+        let t0 = std::time::Instant::now();
+        let gpu_full = distance_field(&g, &[src], &COSTS).expect("gpu full");
+        let full_time = t0.elapsed();
+        let t1 = std::time::Instant::now();
+        let gpu_compact = distance_field_compacted(&g, &[src], &COSTS).expect("gpu compacted");
+        let compact_time = t1.elapsed();
+        let t2 = std::time::Instant::now();
+        let cpu = distance_field_cpu(&g, &[src], &COSTS);
+        let cpu_time = t2.elapsed();
+        assert_eq!(gpu_full, cpu);
+        assert_eq!(gpu_compact, cpu);
+        println!(
+            "344x250x10 (40% blocked): gpu-full={full_time:?} gpu-compacted={compact_time:?} cpu={cpu_time:?} corner_dist={}",
+            cpu[goal]
+        );
     }
 
     #[test]

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -2945,7 +2945,12 @@ function detectStaleNets(pcb: Pcb): Set<string> {
       // anywhere on the pad body is anchored copper (route-to-tree terminates
       // on pad bodies, not only pad centres).
       const sh = pad.shape as { width?: number; height?: number; diameter?: number };
-      const halfExtent = Math.max(sh.width ?? 0, sh.height ?? 0, sh.diameter ?? 0) / 2;
+      // Half-DIAGONAL (bounding circle): a trace overlapping a rect pad's
+      // corner sits up to hypot(w,h)/2 from the centre — half the max
+      // dimension misses it and flags a covered pad as stale.
+      const halfExtent = sh.diameter
+        ? sh.diameter / 2
+        : Math.hypot(sh.width ?? 0, sh.height ?? 0) / 2;
       arr.push({ pos: padWorld(fp, pad), layers: pad.layers, halfExtent });
       padsByNet.set(pad.net, arr);
     }
@@ -2990,18 +2995,27 @@ function detectStaleNets(pcb: Pcb): Set<string> {
       return Math.hypot(p.x - (t.start.x + u * dx), p.y - (t.start.y + u * dy));
     };
     const onSegBody = (p: Vec2, t: Trace): boolean => segDist(p, t) <= t.width / 2 + 0.02;
-    // (1) Any loose trace endpoint?
-    const anchored = (p: Vec2, selfIdx: number): boolean => {
-      if (pads.some((q) => near(p, q.pos) || Math.hypot(p.x - q.pos.x, p.y - q.pos.y) <= q.halfExtent + 0.02)) return true;
-      if (vias.some((q) => near(p, q))) return true;
+    // (1) Any loose trace endpoint? Anchoring is copper-overlap: the
+    // endpoint's own trace disc (its half-width) may touch the anchor's
+    // body — multi-source/tree-terminated routes legally start and end
+    // wherever their copper overlaps the net's existing copper.
+    const anchored = (p: Vec2, selfIdx: number, halfW: number): boolean => {
+      if (
+        pads.some(
+          (q) => Math.hypot(p.x - q.pos.x, p.y - q.pos.y) <= q.halfExtent + halfW + 0.02,
+        )
+      )
+        return true;
+      if (vias.some((q) => Math.hypot(p.x - q.x, p.y - q.y) <= halfW + 0.42)) return true;
       for (let j = 0; j < traces.length; j++) {
         if (j === selfIdx) continue;
-        if (near(p, traces[j].start) || near(p, traces[j].end)) return true;
-        if (onSegBody(p, traces[j])) return true;
+        if (segDist(p, traces[j]) <= traces[j].width / 2 + halfW + 0.02) return true;
       }
       return false;
     };
-    let isStale = traces.some((t, i) => !anchored(t.start, i) || !anchored(t.end, i));
+    let isStale = traces.some(
+      (t, i) => !anchored(t.start, i, t.width / 2) || !anchored(t.end, i, t.width / 2),
+    );
 
     // (2) Any current pad uncovered by copper (and not on a same-net pour)?
     if (!isStale) {


### PR DESCRIPTION
Everything since #552's squash point, rebased onto main. Full-board CM5 record: **0.939** (370/408), with the resume ratchet converting 27 more historically-stuck nets → cumulative **~0.95**; the final 24 connections are proven structural (byte-stable at effort 20) and this PR ships the weapon aimed at them.

## Routability

- **Flow-based BGA escape stage** (tier-2 closer): min-cost max-flow over pin-field interstitial grids (Fang–Wong model), vertex-disjoint escape polylines, atomic escape+route validation. Proof test: a pad ringed by 84 blockers routes only via escape.
- **Tree-to-tree routing**: multi-source seeding (depart from anywhere on the from-component) joining the existing multi-goal termination; zero-copper "already connected" satisfactions handled first-class.
- **Off-grid via placement**: ring-searched candidate sites recover the between-the-balls via positions grid quantization loses (gated to rescue searches).
- **Escalating-window joint reroute**: transactional (session snapshot + rollback, 400mm² window cap — the untransactional first version measurably demolished the board, 0.93→0.69, and is the reason for the design).
- **Long-haul via pricing**: via cost amortizes over airwire length (the human routes 30–50mm nets as inner-layer highways).

## Speed / infrastructure

- **Resume ratchet**: `cm5_bench` accepts a previous run's `.pcb.json` — iterating on the stuck tail costs minutes, not the 2h full pass (this is how the 27 conversions were found).
- **GPU frontier compaction**: the wavefront kernel goes from parity to **60ms vs 114ms CPU** (400×400×10), epoch-deduped frontiers + indirect dispatch, bit-exact parity tests on Metal.
- Buffer arenas for both A* engines; off-grid search gated out of the greedy hot path.
- Stale-net detection understands route-to-tree endpoints (copper-overlap semantics — fixed a CI-caught spurious-ripup).

## Evidence trail

`cm5_gap` (in #552) drove every decision here: the via-span histogram exposed the power-tree MST failure (→ tree-to-tree), the RGMII zero-via cluster exposed the joint-knot class (→ joint repair), the off-grid ladder analysis exposed via quantization (→ ring search), and spacing statistics falsified the clearance hypothesis before we wasted a run on it.

Tests: 209/209 vcad-ecad-pcb, 10/10 vcad-kernel-gpu (Metal parity unignored), clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)