### PR TITLE
kernel: persistent topological naming M0–M2 — stable face/edge names survive parametric rebuilds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7149,6 +7149,7 @@ dependencies = [
  "vcad-kernel-fillet",
  "vcad-kernel-geom",
  "vcad-kernel-math",
+ "vcad-kernel-naming",
  "vcad-kernel-neutronics",
  "vcad-kernel-particle",
  "vcad-kernel-photonics",
@@ -7331,6 +7332,16 @@ version = "0.9.4"
 dependencies = [
  "robust",
  "tang",
+]
+
+[[package]]
+name = "vcad-kernel-naming"
+version = "0.9.4"
+dependencies = [
+ "vcad-kernel-geom",
+ "vcad-kernel-math",
+ "vcad-kernel-primitives",
+ "vcad-kernel-topo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/vcad-kernel-topo",
     "crates/vcad-kernel-geom",
     "crates/vcad-kernel-primitives",
+    "crates/vcad-kernel-naming",
     "crates/vcad-kernel-tessellate",
     "crates/vcad-kernel-booleans",
     "crates/vcad-kernel-nurbs",
@@ -92,6 +93,7 @@ default-members = [
     "crates/vcad-kernel-topo",
     "crates/vcad-kernel-geom",
     "crates/vcad-kernel-primitives",
+    "crates/vcad-kernel-naming",
     "crates/vcad-kernel-tessellate",
     "crates/vcad-kernel-booleans",
     "crates/vcad-kernel-nurbs",
@@ -194,6 +196,7 @@ vcad-kernel-math = { path = "crates/vcad-kernel-math", version = "0.9.4" }
 vcad-kernel-topo = { path = "crates/vcad-kernel-topo", version = "0.9.4" }
 vcad-kernel-geom = { path = "crates/vcad-kernel-geom", version = "0.9.4" }
 vcad-kernel-primitives = { path = "crates/vcad-kernel-primitives", version = "0.9.4" }
+vcad-kernel-naming = { path = "crates/vcad-kernel-naming", version = "0.9.4" }
 vcad-kernel-tessellate = { path = "crates/vcad-kernel-tessellate", version = "0.9.4" }
 vcad-kernel-booleans = { path = "crates/vcad-kernel-booleans", version = "0.9.4" }
 vcad-kernel-nurbs = { path = "crates/vcad-kernel-nurbs", version = "0.9.4" }

--- a/changelog/entries/2026-07-17-topological-naming.json
+++ b/changelog/entries/2026-07-17-topological-naming.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-17-topological-naming",
+  "version": "0.9.4",
+  "date": "2026-07-17",
+  "category": "feat",
+  "title": "Persistent topological naming for edge references",
+  "summary": "Fillets can reference edges by stable face names (EdgeQuery Named) that survive upstream parameter changes; unresolvable references fail closed instead of guessing.",
+  "features": ["kernel", "brep", "fillet", "parametric"]
+}

--- a/crates/vcad-app/src/evaluate.rs
+++ b/crates/vcad-app/src/evaluate.rs
@@ -192,8 +192,20 @@ fn evaluate_node(doc: &Document, node_id: NodeId) -> Result<Option<Solid>> {
             profile,
         } => {
             let c = evaluate_node(doc, *child)?;
-            let (query, keys) = kernel_blend_args(edges, profile);
-            c.map(|s| s.edge_blend(&query, &keys))
+            if let vcad_ir::EdgeQuery::Named { face_a, face_b } = edges {
+                let keys = kernel_blend_keys(profile);
+                match c {
+                    // Fail-closed: an unresolvable named edge is an error,
+                    // never a nearest-edge guess.
+                    Some(s) => Some(s.edge_blend_named(face_a, face_b, &keys).map_err(|e| {
+                        anyhow::anyhow!("named edge ('{face_a}' / '{face_b}'): {e}")
+                    })?),
+                    None => None,
+                }
+            } else {
+                let (query, keys) = kernel_blend_args(edges, profile);
+                c.map(|s| s.edge_blend(&query, &keys))
+            }
         }
         CsgOp::StepImport { path } => Solid::from_step(path).ok(),
         // STL meshes feed the physics path directly; the editor doesn't yet
@@ -218,6 +230,26 @@ fn evaluate_node(doc: &Document, node_id: NodeId) -> Result<Option<Solid>> {
         | CsgOp::SheetMetalBendRelief { .. } => None,
     };
 
+    // Primitives seed persistent face names under a kind scope; rewrite it
+    // to the document node id so names are DAG-unique and rebuild-stable
+    // ("cube:top" → "n3:top") — the same convention as vcad-eval.
+    let solid = match (&node.op, solid) {
+        (
+            CsgOp::Cube { .. }
+            | CsgOp::Cylinder { .. }
+            | CsgOp::Sphere { .. }
+            | CsgOp::Cone { .. }
+            | CsgOp::Torus { .. }
+            | CsgOp::Wedge { .. }
+            | CsgOp::Prism { .. },
+            Some(mut s),
+        ) => {
+            s.set_name_scope(&format!("n{node_id}"));
+            Some(s)
+        }
+        (_, solid) => solid,
+    };
+
     Ok(solid)
 }
 
@@ -239,7 +271,20 @@ fn kernel_blend_args(
             axis: vcad_kernel_math::Vec3::new(axis.x, axis.y, axis.z),
             tol_deg: *tol_deg,
         },
+        // Named queries resolve against the child solid's name map in the
+        // EdgeBlend arm and never reach this translation.
+        vcad_ir::EdgeQuery::Named { .. } => {
+            unreachable!("Named edge queries are handled before kernel_blend_args")
+        }
     };
+    (q, kernel_blend_keys(profile))
+}
+
+/// Convert an IR blend profile to kernel blend keys.
+fn kernel_blend_keys(
+    profile: &vcad_ir::BlendProfile,
+) -> Vec<vcad_kernel::vcad_kernel_fillet::BlendKey> {
+    use vcad_kernel::vcad_kernel_fillet as kf;
     let keys = match profile {
         vcad_ir::BlendProfile::Constant { size, shape } => vec![kf::BlendKey {
             t: 0.0,
@@ -259,5 +304,5 @@ fn kernel_blend_args(
             })
             .collect(),
     };
-    (q, keys)
+    keys
 }

--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -369,7 +369,8 @@ pub fn evaluate_node(
 
     let node = nodes.get(&node_id).ok_or(EvalError::MissingNode(node_id))?;
 
-    let result = evaluate_op(&node.op, nodes, cache)?;
+    let mut result = evaluate_op(&node.op, nodes, cache)?;
+    scope_primitive_names(node_id, &node.op, &mut result);
     cache.insert(node_id, result.clone());
     Ok(result)
 }
@@ -389,7 +390,8 @@ fn evaluate_node_timed(
     let node = nodes.get(&node_id).ok_or(EvalError::MissingNode(node_id))?;
 
     let t0 = clock.map(|c| c.now_ms());
-    let result = evaluate_op_timed(&node.op, nodes, cache, clock, timings)?;
+    let mut result = evaluate_op_timed(&node.op, nodes, cache, clock, timings)?;
+    scope_primitive_names(node_id, &node.op, &mut result);
     if let Some(t0) = t0 {
         let eval_ms = clock.unwrap().now_ms() - t0;
         timings.insert(
@@ -568,6 +570,20 @@ fn evaluate_op_timed(
             profile,
         } => {
             let c = eval_child(*child, cache)?;
+            if let vcad_ir::EdgeQuery::Named { face_a, face_b } = edges {
+                let keys = kernel_blend_keys(profile);
+                return match c {
+                    Some(s) => s
+                        .edge_blend_named(face_a, face_b, &keys)
+                        .map(Some)
+                        .map_err(|e| EvalError::NamedEdge {
+                            face_a: face_a.clone(),
+                            face_b: face_b.clone(),
+                            message: e.to_string(),
+                        }),
+                    None => Ok(None),
+                };
+            }
             let (query, keys) = kernel_blend_args(edges, profile);
             Ok(c.map(|s| s.edge_blend(&query, &keys)))
         }
@@ -1405,7 +1421,21 @@ fn kernel_blend_args(
             axis: vcad_kernel_math::Vec3::new(axis.x, axis.y, axis.z),
             tol_deg: *tol_deg,
         },
+        // Named queries carry no geometry — they resolve against the child
+        // solid's name map and never reach this translation (the EdgeBlend
+        // arm routes them through `Solid::edge_blend_named`).
+        vcad_ir::EdgeQuery::Named { .. } => {
+            unreachable!("Named edge queries are handled before kernel_blend_args")
+        }
     };
+    (q, kernel_blend_keys(profile))
+}
+
+/// Translate an IR blend profile into kernel blend keys.
+fn kernel_blend_keys(
+    profile: &vcad_ir::BlendProfile,
+) -> Vec<vcad_kernel::vcad_kernel_fillet::BlendKey> {
+    use vcad_kernel::vcad_kernel_fillet as kf;
     let keys = match profile {
         vcad_ir::BlendProfile::Constant { size, shape } => vec![kf::BlendKey {
             t: 0.0,
@@ -1425,7 +1455,30 @@ fn kernel_blend_args(
             })
             .collect(),
     };
-    (q, keys)
+    keys
+}
+
+/// After a primitive op evaluates, rewrite its face-name scope to the
+/// document node id so names stay unique across the DAG (`cube:top` →
+/// `n3:top`) and stable across rebuilds (node ids persist in the .vcad
+/// document).
+fn scope_primitive_names(node_id: NodeId, op: &CsgOp, result: &mut Option<Solid>) {
+    let is_primitive = matches!(
+        op,
+        CsgOp::Cube { .. }
+            | CsgOp::Cylinder { .. }
+            | CsgOp::Sphere { .. }
+            | CsgOp::Cone { .. }
+            | CsgOp::Torus { .. }
+            | CsgOp::Wedge { .. }
+            | CsgOp::Prism { .. }
+    );
+    if !is_primitive {
+        return;
+    }
+    if let Some(solid) = result {
+        solid.set_name_scope(&format!("n{node_id}"));
+    }
 }
 
 /// Get a short human-readable name for a CsgOp variant.
@@ -2165,6 +2218,116 @@ mod tests {
             vol > v_chamfer && vol < v_fillet,
             "loft volume {vol} not in ({v_chamfer}, {v_fillet})"
         );
+    }
+
+    /// M2 topological-naming regression: a fillet referencing the edge by
+    /// persistent face names (`n0:top` / `n0:right`) stays on the intended
+    /// edge when the parent box's dimension changes — the classic
+    /// FreeCAD-style breakage this scheme exists to prevent.
+    #[test]
+    fn named_edge_blend_survives_box_resize() {
+        let build = |sx: f64| {
+            let mut nodes: HashMap<NodeId, vcad_ir::Node> = HashMap::new();
+            nodes.insert(
+                0,
+                vcad_ir::Node {
+                    id: 0,
+                    name: None,
+                    op: CsgOp::Cube {
+                        size: vcad_ir::Vec3::new(sx, 10.0, 10.0),
+                    },
+                },
+            );
+            nodes.insert(
+                1,
+                vcad_ir::Node {
+                    id: 1,
+                    name: None,
+                    op: CsgOp::EdgeBlend {
+                        child: 0,
+                        edges: vcad_ir::EdgeQuery::Named {
+                            face_a: "n0:top".to_string(),
+                            face_b: "n0:right".to_string(),
+                        },
+                        profile: vcad_ir::BlendProfile::Constant {
+                            size: 2.0,
+                            shape: 1.0,
+                        },
+                    },
+                },
+            );
+            let mut cache = HashMap::new();
+            evaluate_node(1, &nodes, &mut cache)
+                .expect("eval ok")
+                .expect("solid produced")
+        };
+
+        for sx in [10.0, 14.0] {
+            let solid = build(sx);
+            // Filleting one edge of an sx×10×10 box with r=2 removes
+            // (4 − π)·r²/4 · 10 of material — from the intended edge.
+            let expected = sx * 10.0 * 10.0 - (1.0 - std::f64::consts::PI / 4.0) * 4.0 * 10.0;
+            let vol = solid.volume();
+            assert!(
+                (vol - expected).abs() < 0.5,
+                "volume {vol} != expected {expected} at sx={sx}"
+            );
+            // The blend landed on the x = sx / z = 10 edge: no vertex
+            // remains on that corner line, the opposite edge stays sharp.
+            let brep = solid.as_brep().expect("brep result");
+            let on_target = brep
+                .topology
+                .vertices
+                .iter()
+                .filter(|(_, v)| (v.point.x - sx).abs() < 1e-9 && (v.point.z - 10.0).abs() < 1e-9)
+                .count();
+            assert_eq!(on_target, 0, "blend must remove the named edge at sx={sx}");
+            let on_opposite = brep
+                .topology
+                .vertices
+                .iter()
+                .filter(|(_, v)| v.point.x.abs() < 1e-9 && (v.point.z - 10.0).abs() < 1e-9)
+                .count();
+            assert!(on_opposite >= 2, "opposite edge must stay sharp at sx={sx}");
+        }
+    }
+
+    /// Fail-closed at the IR level: a Named reference that cannot resolve
+    /// is an EvalError, never a silently rebound blend.
+    #[test]
+    fn named_edge_blend_fails_closed_on_lost_reference() {
+        let mut nodes: HashMap<NodeId, vcad_ir::Node> = HashMap::new();
+        nodes.insert(
+            0,
+            vcad_ir::Node {
+                id: 0,
+                name: None,
+                op: CsgOp::Cube {
+                    size: vcad_ir::Vec3::new(10.0, 10.0, 10.0),
+                },
+            },
+        );
+        nodes.insert(
+            1,
+            vcad_ir::Node {
+                id: 1,
+                name: None,
+                op: CsgOp::EdgeBlend {
+                    child: 0,
+                    edges: vcad_ir::EdgeQuery::Named {
+                        face_a: "n0:top".to_string(),
+                        face_b: "n0:no_such_face".to_string(),
+                    },
+                    profile: vcad_ir::BlendProfile::Constant {
+                        size: 2.0,
+                        shape: 1.0,
+                    },
+                },
+            },
+        );
+        let mut cache = HashMap::new();
+        let err = evaluate_node(1, &nodes, &mut cache).expect_err("must fail closed");
+        assert!(matches!(err, EvalError::NamedEdge { .. }), "got {err:?}");
     }
 
     #[test]

--- a/crates/vcad-eval/src/lib.rs
+++ b/crates/vcad-eval/src/lib.rs
@@ -93,6 +93,18 @@ pub enum EvalError {
     #[error("missing node: {0}")]
     MissingNode(vcad_ir::NodeId),
 
+    /// A named edge reference (`EdgeQuery::Named`) failed to resolve —
+    /// fail-closed: the blend is not applied to a guessed edge.
+    #[error("named edge ('{face_a}' / '{face_b}') failed to resolve: {message}")]
+    NamedEdge {
+        /// Name of one adjacent face, as written in the document.
+        face_a: String,
+        /// Name of the other adjacent face.
+        face_b: String,
+        /// What went wrong (no names, ambiguous, or lost).
+        message: String,
+    },
+
     /// A node referenced by ID was not found in the document; includes the
     /// dotted path that led to the dangling reference (e.g.
     /// `nodes[47].Translate.child`).

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -386,6 +386,21 @@ pub enum EdgeQuery {
         /// Angular tolerance in degrees.
         tol_deg: f64,
     },
+    /// The edge between two persistently named faces (topological naming).
+    ///
+    /// Face names are `scope:tag[.n]*` — the scope is `n<nodeId>` of the
+    /// generating primitive (e.g. `n1:top`, `n1:right`); primitives seed
+    /// tags from the generating operation (`top`/`bottom`/`front`/`back`/
+    /// `left`/`right` for a box, `side`+caps for a cylinder), and booleans
+    /// propagate them with deterministic split ordinals. Unlike the
+    /// geometric queries, resolution is fail-closed: an ambiguous or lost
+    /// reference is an evaluation error, never a nearest-edge guess.
+    Named {
+        /// Name of one adjacent face.
+        face_a: String,
+        /// Name of the other adjacent face.
+        face_b: String,
+    },
 }
 
 /// A blend-profile keyframe along an edge.

--- a/crates/vcad-kernel-fillet/src/blend_loft.rs
+++ b/crates/vcad-kernel-fillet/src/blend_loft.rs
@@ -376,6 +376,17 @@ pub enum EdgeQuery {
         /// Angular tolerance in degrees.
         tol_deg: f64,
     },
+    /// The single edge whose endpoint pair matches `(a, b)` exactly (to the
+    /// quantization used for edge relocation). Used by callers that resolved
+    /// an edge externally — e.g. persistent topological naming — and need
+    /// the blend applied to exactly that edge, fail-closed: no fuzzy
+    /// nearest-edge behavior, no match means no blend.
+    Endpoints {
+        /// One endpoint; the blend's start section applies here.
+        a: Point3,
+        /// The other endpoint.
+        b: Point3,
+    },
 }
 
 /// One edge matched by a query. `flip` is true when the blend's start
@@ -428,6 +439,26 @@ pub fn resolve_edge_query(brep: &BRepSolid, query: &EdgeQuery) -> Vec<ResolvedEd
                 }
             }
             best.map(|(r, _)| vec![r]).unwrap_or_default()
+        }
+        EdgeQuery::Endpoints { a, b } => {
+            let (qa, qb) = (crate::topology::quantize(*a), crate::topology::quantize(*b));
+            for e in edges.iter().filter(|e| planar(e)) {
+                let qs = crate::topology::quantize(topo.vertices[e.v_start].point);
+                let qe = crate::topology::quantize(topo.vertices[e.v_end].point);
+                if qs == qa && qe == qb {
+                    return vec![ResolvedEdge {
+                        edge_id: e.edge_id,
+                        flip: false,
+                    }];
+                }
+                if qs == qb && qe == qa {
+                    return vec![ResolvedEdge {
+                        edge_id: e.edge_id,
+                        flip: true,
+                    }];
+                }
+            }
+            Vec::new()
         }
         EdgeQuery::All | EdgeQuery::Direction { .. } => {
             let dir_filter = match query {

--- a/crates/vcad-kernel-naming/Cargo.toml
+++ b/crates/vcad-kernel-naming/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vcad-kernel-naming"
+description = "Persistent topological naming for the vcad BRep kernel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+vcad-kernel-math = { workspace = true }
+vcad-kernel-topo = { workspace = true }
+vcad-kernel-geom = { workspace = true }
+vcad-kernel-primitives = { workspace = true }

--- a/crates/vcad-kernel-naming/src/lib.rs
+++ b/crates/vcad-kernel-naming/src/lib.rs
@@ -1,0 +1,776 @@
+#![warn(missing_docs)]
+
+//! Persistent topological naming for the vcad BRep kernel.
+//!
+//! The classic "topological naming problem": downstream features (fillets,
+//! sketches-on-faces) reference topology by ephemeral arena keys, and when an
+//! upstream parameter changes and the model rebuilds, those keys mean nothing
+//! — the feature breaks or, worse, silently attaches to the wrong entity.
+//!
+//! This crate derives **stable names from generating operations** instead of
+//! arena indices:
+//!
+//! - A primitive's faces are named by their role in the generating op
+//!   (`cube:top`, `cylinder:side`, …) — see [`seed_names`]. Seeding is a pure
+//!   function of the face geometry, so two rebuilds of the same primitive (at
+//!   the same or a smoothly-changed parameter) produce the same names.
+//! - A boolean's result faces inherit the name of the input face whose
+//!   surface carries them ([`propagate_boolean`]) — the boolean splitter trims
+//!   faces but every kept face still lies on exactly one input surface. Faces
+//!   split into several pieces get a deterministic sibling ordinal appended
+//!   (`cube:top.0`, `cube:top.1`, ordered by quantized centroid).
+//! - Edges are named by their two adjacent faces ([`EdgeRef`]) — an edge
+//!   reference survives a rebuild as long as both faces resolve.
+//!
+//! Resolution ([`resolve_edge`]) is **fail-closed**: an edge reference
+//! resolves to exactly one edge by name, or falls back to geometric matching
+//! against a recorded [`EdgeHint`] (direction / midpoint / length), and every
+//! other outcome is reported explicitly as [`EdgeResolution::Ambiguous`] or
+//! [`EdgeResolution::Lost`] — never a silent rebind.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use vcad_kernel_geom::{
+    ConeSurface, CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind, TorusSurface,
+};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_topo::{EdgeId, FaceId};
+
+/// Absolute geometric tolerance (mm) for surface-identity matching.
+const SURF_TOL: f64 = 1e-6;
+
+/// Quantization step (mm) for deterministic centroid ordering.
+const QUANT: f64 = 1e-6;
+
+// =============================================================================
+// Names
+// =============================================================================
+
+/// A stable, human-readable face name derived from the generating operation.
+///
+/// Rendered as `scope:tag` with an optional dot-separated split path, e.g.
+/// `cube:top`, `n3:side.1`, `cube:top.0.2`. The `scope` identifies the
+/// operation that created the base face (primitive kind by default; callers
+/// evaluating a DAG should [`NameMap::rescope`] it to the node id so names
+/// stay unique across a multi-primitive document). The `path` records one
+/// sibling ordinal per boolean split generation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FaceName {
+    /// Operation scope (primitive kind, or a caller-assigned node id).
+    pub scope: String,
+    /// Face role within the generating operation (`top`, `side`, …).
+    pub tag: String,
+    /// Split lineage: one deterministic sibling ordinal per boolean that
+    /// split the face. Empty for an unsplit face.
+    pub path: Vec<u32>,
+}
+
+impl FaceName {
+    /// A fresh (unsplit) face name.
+    pub fn new(scope: impl Into<String>, tag: impl Into<String>) -> Self {
+        Self {
+            scope: scope.into(),
+            tag: tag.into(),
+            path: Vec::new(),
+        }
+    }
+
+    /// Parse the canonical `scope:tag[.n]*` form produced by `Display`.
+    ///
+    /// Returns `None` when the string is not in canonical form.
+    pub fn parse(s: &str) -> Option<Self> {
+        let (scope, rest) = s.split_once(':')?;
+        if scope.is_empty() || rest.is_empty() {
+            return None;
+        }
+        let mut segs = rest.split('.');
+        let tag = segs.next()?.to_string();
+        if tag.is_empty() {
+            return None;
+        }
+        let mut path = Vec::new();
+        for seg in segs {
+            path.push(seg.parse::<u32>().ok()?);
+        }
+        Some(Self {
+            scope: scope.to_string(),
+            tag,
+            path,
+        })
+    }
+}
+
+impl fmt::Display for FaceName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.scope, self.tag)?;
+        for p in &self.path {
+            write!(f, ".{p}")?;
+        }
+        Ok(())
+    }
+}
+
+/// Face-name side table for one `BRepSolid`.
+///
+/// Keys are that solid's `FaceId`s; the map is only meaningful next to the
+/// solid it was built for. Faces without an entry are anonymous (their
+/// provenance was lost fail-closed rather than guessed).
+#[derive(Debug, Clone, Default)]
+pub struct NameMap {
+    /// Face id → stable name.
+    pub faces: HashMap<FaceId, FaceName>,
+}
+
+impl NameMap {
+    /// An empty map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Look up the face carrying `name`, if exactly one does.
+    pub fn face_named(&self, name: &FaceName) -> Option<FaceId> {
+        let mut hits = self.faces.iter().filter(|(_, n)| *n == name);
+        let first = hits.next()?;
+        if hits.next().is_some() {
+            return None;
+        }
+        Some(*first.0)
+    }
+
+    /// Rewrite every name's scope — used by DAG evaluators to replace the
+    /// default primitive-kind scope with a document node id so names stay
+    /// unique when several primitives combine.
+    pub fn rescope(&mut self, scope: &str) {
+        for name in self.faces.values_mut() {
+            name.scope = scope.to_string();
+        }
+    }
+}
+
+// =============================================================================
+// Seeding (M0): names from the generating primitive
+// =============================================================================
+
+/// Name the faces of a freshly constructed solid from its geometry.
+///
+/// Tags are derived per face from the carrying surface, so the result is a
+/// pure function of the geometry — deterministic across rebuilds and stable
+/// under smooth parameter changes (a resized cube keeps its axis-aligned
+/// normals, so `cube:top` stays `cube:top`):
+///
+/// - axis-aligned planes → `bottom` / `top` / `front` / `back` / `left` /
+///   `right` (Z-up convention);
+/// - other planes → `plane`;
+/// - cylinders → `side`; cones → `cone`; spheres → `sphere`; tori → `torus`;
+/// - anything else → `face`.
+///
+/// When several faces share a tag (a prism's `side` walls, a segmented
+/// sphere's bands) they are disambiguated with a trailing ordinal assigned in
+/// quantized-centroid order (`side.0`, `side.1`, …), which is deterministic
+/// regardless of arena iteration order.
+pub fn seed_names(brep: &BRepSolid, scope: &str) -> NameMap {
+    let topo = &brep.topology;
+    let solid = &topo.solids[brep.solid_id];
+    let shell = &topo.shells[solid.outer_shell];
+
+    // (tag, quantized centroid, face) per shell face.
+    let mut entries: Vec<(String, [i64; 3], FaceId)> = Vec::new();
+    for &face_id in &shell.faces {
+        let face = &topo.faces[face_id];
+        let surface = &brep.geometry.surfaces[face.surface_index];
+        let tag = surface_tag(surface.as_ref());
+        let c = face_centroid(brep, face_id);
+        entries.push((tag, quantize(c), face_id));
+    }
+
+    let mut map = NameMap::new();
+    let mut by_tag: HashMap<String, Vec<([i64; 3], FaceId)>> = HashMap::new();
+    for (tag, qc, id) in entries {
+        by_tag.entry(tag).or_default().push((qc, id));
+    }
+    for (tag, mut group) in by_tag {
+        group.sort();
+        let solo = group.len() == 1;
+        for (i, (_, id)) in group.into_iter().enumerate() {
+            let mut name = FaceName::new(scope, tag.clone());
+            if !solo {
+                name.path.push(i as u32);
+            }
+            map.faces.insert(id, name);
+        }
+    }
+    map
+}
+
+/// Semantic tag for the surface carrying a face.
+fn surface_tag(surface: &dyn Surface) -> String {
+    match surface.surface_type() {
+        SurfaceKind::Plane => {
+            let Some(plane) = surface.as_any().downcast_ref::<Plane>() else {
+                return "plane".to_string();
+            };
+            let n: Vec3 = plane.normal_dir.into_inner();
+            let axes: [(Vec3, &str, &str); 3] = [
+                (Vec3::new(1.0, 0.0, 0.0), "right", "left"),
+                (Vec3::new(0.0, 1.0, 0.0), "back", "front"),
+                (Vec3::new(0.0, 0.0, 1.0), "top", "bottom"),
+            ];
+            for (axis, pos, neg) in axes {
+                let d = n.dot(axis);
+                if d > 1.0 - 1e-9 {
+                    return pos.to_string();
+                }
+                if d < -(1.0 - 1e-9) {
+                    return neg.to_string();
+                }
+            }
+            "plane".to_string()
+        }
+        SurfaceKind::Cylinder => "side".to_string(),
+        SurfaceKind::Cone => "cone".to_string(),
+        SurfaceKind::Sphere => "sphere".to_string(),
+        SurfaceKind::Torus => "torus".to_string(),
+        _ => "face".to_string(),
+    }
+}
+
+// =============================================================================
+// Boolean propagation (M0)
+// =============================================================================
+
+/// Derive names for a boolean result from its two named inputs.
+///
+/// Every face the boolean keeps still lies on exactly one input surface (the
+/// splitter trims loops but reuses the carrying surfaces), so each result
+/// face is matched to the input faces whose surface is geometrically
+/// identical (within [`SURF_TOL`]). Fail-closed rules:
+///
+/// - candidates carrying more than one distinct input name (e.g. two flush
+///   coplanar faces from A and B) → the result face stays anonymous;
+/// - no candidate (a genuinely new face, or an unnamed input face) → stays
+///   anonymous;
+/// - several result faces inheriting the same input name (a face split into
+///   pieces) → each gets a sibling ordinal appended, in quantized-centroid
+///   order, which is deterministic across rebuilds.
+pub fn propagate_boolean(
+    a: &BRepSolid,
+    names_a: &NameMap,
+    b: &BRepSolid,
+    names_b: &NameMap,
+    out: &BRepSolid,
+) -> NameMap {
+    // Collect (surface, name) for every named input face.
+    let mut inputs: Vec<(&dyn Surface, &FaceName)> = Vec::new();
+    for (brep, names) in [(a, names_a), (b, names_b)] {
+        for (face_id, name) in &names.faces {
+            let Some(face) = brep.topology.faces.get(*face_id) else {
+                continue;
+            };
+            inputs.push((brep.geometry.surfaces[face.surface_index].as_ref(), name));
+        }
+    }
+
+    // Inherit: result face → the unique input name on the same surface.
+    let mut inherited: Vec<(FaceName, [i64; 3], FaceId)> = Vec::new();
+    for (face_id, face) in &out.topology.faces {
+        let surface = out.geometry.surfaces[face.surface_index].as_ref();
+        let mut names = inputs
+            .iter()
+            .filter(|(s, _)| same_surface(surface, *s))
+            .map(|(_, n)| *n)
+            .collect::<Vec<_>>();
+        names.dedup();
+        names.sort();
+        names.dedup();
+        if let [name] = names.as_slice() {
+            let c = face_centroid(out, face_id);
+            inherited.push(((*name).clone(), quantize(c), face_id));
+        }
+    }
+
+    // Disambiguate split siblings with a deterministic ordinal.
+    let mut by_name: HashMap<FaceName, Vec<([i64; 3], FaceId)>> = HashMap::new();
+    for (name, qc, id) in inherited {
+        by_name.entry(name).or_default().push((qc, id));
+    }
+    let mut map = NameMap::new();
+    for (name, mut group) in by_name {
+        group.sort();
+        let solo = group.len() == 1;
+        for (i, (_, id)) in group.into_iter().enumerate() {
+            let mut n = name.clone();
+            if !solo {
+                n.path.push(i as u32);
+            }
+            map.faces.insert(id, n);
+        }
+    }
+    map
+}
+
+/// Geometric identity of two surfaces within [`SURF_TOL`].
+///
+/// Kind-wise comparison of the analytic parameters that determine the point
+/// set (parameterization details like `ref_dir` are ignored; axis sign is
+/// ignored where the point set is symmetric). Unsupported kinds compare
+/// not-equal — fail-closed.
+fn same_surface(x: &dyn Surface, y: &dyn Surface) -> bool {
+    if x.surface_type() != y.surface_type() {
+        return false;
+    }
+    match x.surface_type() {
+        SurfaceKind::Plane => {
+            let (Some(p), Some(q)) = (
+                x.as_any().downcast_ref::<Plane>(),
+                y.as_any().downcast_ref::<Plane>(),
+            ) else {
+                return false;
+            };
+            let np: Vec3 = p.normal_dir.into_inner();
+            let nq: Vec3 = q.normal_dir.into_inner();
+            // Same oriented plane: parallel normals (same sign — a boolean
+            // keeps the material side), coincident up to origin shift.
+            np.dot(nq) > 1.0 - SURF_TOL && (q.origin - p.origin).dot(np).abs() < SURF_TOL
+        }
+        SurfaceKind::Cylinder => {
+            let (Some(p), Some(q)) = (
+                x.as_any().downcast_ref::<CylinderSurface>(),
+                y.as_any().downcast_ref::<CylinderSurface>(),
+            ) else {
+                return false;
+            };
+            let ap: Vec3 = p.axis.into_inner();
+            let aq: Vec3 = q.axis.into_inner();
+            let d = q.center - p.center;
+            ap.dot(aq).abs() > 1.0 - SURF_TOL
+                && (p.radius - q.radius).abs() < SURF_TOL
+                && (d - ap * d.dot(ap)).norm() < SURF_TOL
+        }
+        SurfaceKind::Sphere => {
+            let (Some(p), Some(q)) = (
+                x.as_any().downcast_ref::<SphereSurface>(),
+                y.as_any().downcast_ref::<SphereSurface>(),
+            ) else {
+                return false;
+            };
+            (q.center - p.center).norm() < SURF_TOL && (p.radius - q.radius).abs() < SURF_TOL
+        }
+        SurfaceKind::Cone => {
+            let (Some(p), Some(q)) = (
+                x.as_any().downcast_ref::<ConeSurface>(),
+                y.as_any().downcast_ref::<ConeSurface>(),
+            ) else {
+                return false;
+            };
+            let ap: Vec3 = p.axis.into_inner();
+            let aq: Vec3 = q.axis.into_inner();
+            (q.apex - p.apex).norm() < SURF_TOL
+                && ap.dot(aq) > 1.0 - SURF_TOL
+                && (p.half_angle - q.half_angle).abs() < SURF_TOL
+        }
+        SurfaceKind::Torus => {
+            let (Some(p), Some(q)) = (
+                x.as_any().downcast_ref::<TorusSurface>(),
+                y.as_any().downcast_ref::<TorusSurface>(),
+            ) else {
+                return false;
+            };
+            let ap: Vec3 = p.axis.into_inner();
+            let aq: Vec3 = q.axis.into_inner();
+            (q.center - p.center).norm() < SURF_TOL
+                && ap.dot(aq).abs() > 1.0 - SURF_TOL
+                && (p.major_radius - q.major_radius).abs() < SURF_TOL
+                && (p.minor_radius - q.minor_radius).abs() < SURF_TOL
+        }
+        _ => false,
+    }
+}
+
+// =============================================================================
+// Edge references + resolution (M1)
+// =============================================================================
+
+/// Geometric snapshot of an edge, recorded when a reference is created.
+///
+/// Used as the fallback matcher when name-based resolution breaks across an
+/// edit (e.g. a face's provenance was lost in a boolean). Tolerances scale
+/// with the recorded length, so hints work at any model scale.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeHint {
+    /// Edge midpoint at record time.
+    pub midpoint: Point3,
+    /// Unit edge direction at record time (sign-insensitive on match).
+    pub direction: Vec3,
+    /// Edge length at record time.
+    pub length: f64,
+}
+
+/// A persistent edge reference: the names of its two adjacent faces, stored
+/// in canonical (sorted) order, plus an optional geometric hint.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EdgeRef {
+    /// Name of one adjacent face (lexicographically smaller).
+    pub face_a: FaceName,
+    /// Name of the other adjacent face.
+    pub face_b: FaceName,
+    /// Geometric snapshot for fallback matching.
+    pub hint: Option<EdgeHint>,
+}
+
+impl EdgeRef {
+    /// Build a reference to the edge between the two named faces, canonically
+    /// ordered, without a geometric hint.
+    pub fn new(a: FaceName, b: FaceName) -> Self {
+        let (face_a, face_b) = if a <= b { (a, b) } else { (b, a) };
+        Self {
+            face_a,
+            face_b,
+            hint: None,
+        }
+    }
+
+    /// Capture a reference to an existing edge of `brep`: its adjacent-face
+    /// names from `names` plus a geometric hint. Returns `None` when the
+    /// edge is degenerate or either adjacent face is anonymous.
+    pub fn capture(brep: &BRepSolid, names: &NameMap, edge: EdgeId) -> Option<Self> {
+        let (fa, fb) = edge_faces(brep, edge)?;
+        let na = names.faces.get(&fa)?.clone();
+        let nb = names.faces.get(&fb)?.clone();
+        let (a, b) = edge_endpoints(brep, edge)?;
+        let ev = b - a;
+        let len = ev.norm();
+        if len < 1e-12 {
+            return None;
+        }
+        let mut r = Self::new(na, nb);
+        r.hint = Some(EdgeHint {
+            midpoint: a + ev * 0.5,
+            direction: ev / len,
+            length: len,
+        });
+        Some(r)
+    }
+}
+
+/// How a resolved edge was found.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveMethod {
+    /// Both face names matched exactly — provenance intact.
+    ByName,
+    /// Name matching failed; the geometric hint matched exactly one edge.
+    ByGeometry,
+}
+
+/// Outcome of resolving an [`EdgeRef`] against a (re)built solid.
+///
+/// Fail-closed: only `Resolved` may be acted on; `Ambiguous` and `Lost`
+/// carry enough context to report, and must never be silently rebound.
+#[derive(Debug, Clone)]
+pub enum EdgeResolution {
+    /// Exactly one edge matched.
+    Resolved {
+        /// The matched edge in the current topology.
+        edge: EdgeId,
+        /// Current endpoint positions.
+        endpoints: (Point3, Point3),
+        /// Whether the match came from names or the geometric fallback.
+        method: ResolveMethod,
+    },
+    /// The geometric fallback matched more than one edge.
+    Ambiguous {
+        /// All candidate edges, for reporting.
+        candidates: Vec<EdgeId>,
+    },
+    /// No edge matched by name or geometry.
+    Lost {
+        /// Human-readable reason for the failure.
+        reason: String,
+    },
+}
+
+/// Resolve an edge reference against `brep` + its name map.
+///
+/// Name resolution first: find the unique faces carrying `face_a` / `face_b`
+/// and the unique manifold edge adjacent to both. When that fails and the
+/// reference carries an [`EdgeHint`], fall back to geometric matching:
+/// candidates must agree with the hint in direction (within ~18°), length
+/// (±25%), and midpoint (within 25% of the recorded length). Exactly one
+/// candidate resolves; zero is [`EdgeResolution::Lost`]; several are
+/// [`EdgeResolution::Ambiguous`].
+pub fn resolve_edge(brep: &BRepSolid, names: &NameMap, edge_ref: &EdgeRef) -> EdgeResolution {
+    // --- primary: by name -------------------------------------------------
+    let fa = names.face_named(&edge_ref.face_a);
+    let fb = names.face_named(&edge_ref.face_b);
+    if let (Some(fa), Some(fb)) = (fa, fb) {
+        let mut hits: Vec<EdgeId> = Vec::new();
+        for (edge_id, _) in &brep.topology.edges {
+            if let Some((x, y)) = edge_faces(brep, edge_id) {
+                if (x == fa && y == fb) || (x == fb && y == fa) {
+                    hits.push(edge_id);
+                }
+            }
+        }
+        match hits.as_slice() {
+            [edge] => {
+                if let Some(endpoints) = edge_endpoints(brep, *edge) {
+                    return EdgeResolution::Resolved {
+                        edge: *edge,
+                        endpoints,
+                        method: ResolveMethod::ByName,
+                    };
+                }
+            }
+            [] => {} // faces exist but no longer share an edge — try fallback
+            _ => {
+                // Two faces sharing several edges (e.g. through a slot):
+                // names alone cannot pick one — fall through to the hint.
+                if edge_ref.hint.is_none() {
+                    return EdgeResolution::Ambiguous { candidates: hits };
+                }
+            }
+        }
+    }
+
+    // --- fallback: by geometry -------------------------------------------
+    let Some(hint) = &edge_ref.hint else {
+        return EdgeResolution::Lost {
+            reason: format!(
+                "no edge between faces '{}' and '{}', and the reference has no geometric hint",
+                edge_ref.face_a, edge_ref.face_b
+            ),
+        };
+    };
+    let tol = hint.length * 0.25;
+    let mut candidates: Vec<EdgeId> = Vec::new();
+    for (edge_id, _) in &brep.topology.edges {
+        let Some((a, b)) = edge_endpoints(brep, edge_id) else {
+            continue;
+        };
+        let ev = b - a;
+        let len = ev.norm();
+        if len < 1e-12 || (len - hint.length).abs() > tol {
+            continue;
+        }
+        if (ev / len).dot(hint.direction).abs() < 0.95 {
+            continue;
+        }
+        if (a + ev * 0.5 - hint.midpoint).norm() > tol {
+            continue;
+        }
+        candidates.push(edge_id);
+    }
+    match candidates.as_slice() {
+        [edge] => {
+            let endpoints = edge_endpoints(brep, *edge).expect("candidate had endpoints");
+            EdgeResolution::Resolved {
+                edge: *edge,
+                endpoints,
+                method: ResolveMethod::ByGeometry,
+            }
+        }
+        [] => EdgeResolution::Lost {
+            reason: format!(
+                "no edge between faces '{}' and '{}', and no edge matches the geometric hint",
+                edge_ref.face_a, edge_ref.face_b
+            ),
+        },
+        _ => EdgeResolution::Ambiguous { candidates },
+    }
+}
+
+// =============================================================================
+// Topology helpers
+// =============================================================================
+
+/// The two faces adjacent to a manifold edge, or `None` at a non-manifold /
+/// un-twinned edge (boolean seams may leave those).
+pub fn edge_faces(brep: &BRepSolid, edge: EdgeId) -> Option<(FaceId, FaceId)> {
+    let topo = &brep.topology;
+    let he = topo.edges.get(edge)?.half_edge;
+    let h = topo.half_edges.get(he)?;
+    let fa = topo.loops.get(h.loop_id?)?.face?;
+    let twin = topo.half_edges.get(h.twin?)?;
+    let fb = topo.loops.get(twin.loop_id?)?.face?;
+    Some((fa, fb))
+}
+
+/// Endpoint positions of an edge (origin of the primary half-edge first).
+pub fn edge_endpoints(brep: &BRepSolid, edge: EdgeId) -> Option<(Point3, Point3)> {
+    let topo = &brep.topology;
+    let he = topo.edges.get(edge)?.half_edge;
+    let h = topo.half_edges.get(he)?;
+    let a = topo.vertices.get(h.origin)?.point;
+    let b = topo
+        .vertices
+        .get(topo.half_edge_dest(he))
+        .map(|v| v.point)?;
+    Some((a, b))
+}
+
+/// Centroid of a face's outer-loop vertices.
+fn face_centroid(brep: &BRepSolid, face: FaceId) -> Point3 {
+    let topo = &brep.topology;
+    let mut sum = Vec3::new(0.0, 0.0, 0.0);
+    let mut n = 0usize;
+    let outer = topo.faces[face].outer_loop;
+    for he in topo.loop_half_edges(outer) {
+        let p = topo.vertices[topo.half_edges[he].origin].point;
+        sum += Vec3::new(p.x, p.y, p.z);
+        n += 1;
+    }
+    if n == 0 {
+        return Point3::new(0.0, 0.0, 0.0);
+    }
+    let inv = 1.0 / n as f64;
+    Point3::new(sum.x * inv, sum.y * inv, sum.z * inv)
+}
+
+/// Quantize a point for deterministic ordering.
+fn quantize(p: Point3) -> [i64; 3] {
+    [
+        (p.x / QUANT).round() as i64,
+        (p.y / QUANT).round() as i64,
+        (p.z / QUANT).round() as i64,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_kernel_primitives::{make_cube, make_cylinder, make_prism};
+
+    fn names_of(map: &NameMap) -> Vec<String> {
+        let mut v: Vec<String> = map.faces.values().map(|n| n.to_string()).collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn face_name_roundtrip() {
+        for s in ["cube:top", "n3:side.1", "cube:top.0.2"] {
+            let n = FaceName::parse(s).expect("parses");
+            assert_eq!(n.to_string(), s);
+        }
+        assert!(FaceName::parse("noscope").is_none());
+        assert!(FaceName::parse(":tag").is_none());
+        assert!(FaceName::parse("scope:").is_none());
+        assert!(FaceName::parse("scope:tag.x").is_none());
+    }
+
+    #[test]
+    fn cube_seeding_is_semantic_and_deterministic() {
+        let c = make_cube(10.0, 20.0, 30.0);
+        let m = seed_names(&c, "cube");
+        assert_eq!(
+            names_of(&m),
+            vec![
+                "cube:back",
+                "cube:bottom",
+                "cube:front",
+                "cube:left",
+                "cube:right",
+                "cube:top"
+            ]
+        );
+        // A rebuild at a different parameter keeps every tag.
+        let c2 = make_cube(14.0, 20.0, 30.0);
+        let m2 = seed_names(&c2, "cube");
+        assert_eq!(names_of(&m), names_of(&m2));
+    }
+
+    #[test]
+    fn cylinder_seeding_names_caps_and_side() {
+        let c = make_cylinder(5.0, 10.0, 16);
+        let m = seed_names(&c, "cyl");
+        assert_eq!(names_of(&m), vec!["cyl:bottom", "cyl:side", "cyl:top"]);
+    }
+
+    #[test]
+    fn prism_sides_get_deterministic_ordinals() {
+        let p = make_prism(6, 5.0, 10.0);
+        let m1 = seed_names(&p, "prism");
+        let m2 = seed_names(&make_prism(6, 5.0, 12.0), "prism");
+        let n1 = names_of(&m1);
+        // 6 lateral walls + 2 caps, all uniquely named (axis-aligned walls
+        // get semantic tags, the rest get plane.N ordinals).
+        assert_eq!(n1.len(), 8);
+        assert_eq!(n1.iter().collect::<std::collections::HashSet<_>>().len(), 8);
+        assert!(n1.iter().any(|n| n.contains(":plane.")));
+        assert_eq!(n1, names_of(&m2));
+    }
+
+    #[test]
+    fn edge_resolution_by_name_survives_a_rebuild() {
+        let c = make_cube(10.0, 10.0, 10.0);
+        let names = seed_names(&c, "cube");
+        // The top-right edge: between "cube:top" and "cube:right".
+        let r = EdgeRef::new(FaceName::new("cube", "top"), FaceName::new("cube", "right"));
+        let EdgeResolution::Resolved {
+            endpoints, method, ..
+        } = resolve_edge(&c, &names, &r)
+        else {
+            panic!("expected resolution");
+        };
+        assert_eq!(method, ResolveMethod::ByName);
+        for p in [endpoints.0, endpoints.1] {
+            assert!((p.x - 10.0).abs() < 1e-9 && (p.z - 10.0).abs() < 1e-9);
+        }
+        // Rebuild wider: the same reference resolves to the moved edge.
+        let c2 = make_cube(14.0, 10.0, 10.0);
+        let names2 = seed_names(&c2, "cube");
+        let EdgeResolution::Resolved { endpoints, .. } = resolve_edge(&c2, &names2, &r) else {
+            panic!("expected resolution after rebuild");
+        };
+        for p in [endpoints.0, endpoints.1] {
+            assert!((p.x - 14.0).abs() < 1e-9 && (p.z - 10.0).abs() < 1e-9);
+        }
+    }
+
+    #[test]
+    fn resolution_falls_back_to_geometry_and_reports_lost() {
+        let c = make_cube(10.0, 10.0, 10.0);
+        let names = seed_names(&c, "cube");
+        // Capture a real edge, then break its names (simulating lost
+        // provenance): the hint must still find it.
+        let top_right = EdgeRef::new(FaceName::new("cube", "top"), FaceName::new("cube", "right"));
+        let EdgeResolution::Resolved { edge, .. } = resolve_edge(&c, &names, &top_right) else {
+            panic!("expected resolution");
+        };
+        let mut captured = EdgeRef::capture(&c, &names, edge).expect("capturable");
+        captured.face_a = FaceName::new("gone", "top");
+        captured.face_b = FaceName::new("gone", "right");
+        let EdgeResolution::Resolved { method, .. } = resolve_edge(&c, &names, &captured) else {
+            panic!("expected geometric fallback");
+        };
+        assert_eq!(method, ResolveMethod::ByGeometry);
+
+        // Without a hint, broken names are Lost — never rebound.
+        captured.hint = None;
+        assert!(matches!(
+            resolve_edge(&c, &names, &captured),
+            EdgeResolution::Lost { .. }
+        ));
+    }
+
+    #[test]
+    fn stale_hint_after_a_large_edit_is_lost_not_rebound() {
+        let c = make_cube(10.0, 10.0, 10.0);
+        let names = seed_names(&c, "cube");
+        let top_right = EdgeRef::new(FaceName::new("cube", "top"), FaceName::new("cube", "right"));
+        let EdgeResolution::Resolved { edge, .. } = resolve_edge(&c, &names, &top_right) else {
+            panic!("expected resolution");
+        };
+        let mut captured = EdgeRef::capture(&c, &names, edge).expect("capturable");
+        captured.face_a = FaceName::new("gone", "top");
+        captured.face_b = FaceName::new("gone", "right");
+        // Rebuild far away: the stale hint matches nothing.
+        let c2 = make_cube(100.0, 100.0, 100.0);
+        let names2 = seed_names(&c2, "cube");
+        assert!(matches!(
+            resolve_edge(&c2, &names2, &captured),
+            EdgeResolution::Lost { .. }
+        ));
+    }
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -1438,6 +1438,16 @@ impl Solid {
         }
         let spec: Spec = serde_json::from_str(spec_json)
             .map_err(|e| JsError::new(&format!("invalid edge blend spec: {e}")))?;
+        if let vcad_ir::EdgeQuery::Named { face_a, face_b } = &spec.edges {
+            // Fail-closed: an unresolvable named edge is an error, never a
+            // nearest-edge guess.
+            let keys = kernel_blend_keys(&spec.profile);
+            let inner = self
+                .inner
+                .edge_blend_named(face_a, face_b, &keys)
+                .map_err(|e| JsError::new(&format!("named edge ('{face_a}' / '{face_b}'): {e}")))?;
+            return Ok(Solid { inner });
+        }
         let (query, keys) = kernel_blend_args(&spec.edges, &spec.profile);
         Ok(Solid {
             inner: self.inner.edge_blend(&query, &keys),
@@ -3978,6 +3988,14 @@ fn ir_segment_to_wasm(seg: &vcad_ir::SketchSegment2D) -> WasmSketchSegment {
 }
 
 /// Recursively evaluate a node in the IR DAG.
+/// Rewrite a primitive's persistent face-name scope to the document node id
+/// ("cube:top" -> "n3:top") — same convention as the vcad-eval and vcad-app
+/// evaluators, so Named edge queries mean the same thing everywhere.
+fn scope_names(node_id: vcad_ir::NodeId, mut s: Solid) -> Solid {
+    s.inner.set_name_scope(&format!("n{node_id}"));
+    s
+}
+
 fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<Solid, JsError> {
     let node = doc
         .nodes
@@ -3985,7 +4003,7 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
         .ok_or_else(|| JsError::new(&format!("Node {} not found", node_id)))?;
 
     match &node.op {
-        vcad_ir::CsgOp::Cube { size } => Ok(Solid::cube(size.x, size.y, size.z)),
+        vcad_ir::CsgOp::Cube { size } => Ok(scope_names(node_id, Solid::cube(size.x, size.y, size.z))),
 
         vcad_ir::CsgOp::Cylinder {
             radius,
@@ -3997,7 +4015,7 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             } else {
                 Some(*segments)
             };
-            Ok(Solid::cylinder(*radius, *height, segs))
+            Ok(scope_names(node_id, Solid::cylinder(*radius, *height, segs)))
         }
 
         vcad_ir::CsgOp::Sphere { radius, segments } => {
@@ -4006,7 +4024,7 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             } else {
                 Some(*segments)
             };
-            Ok(Solid::sphere(*radius, segs))
+            Ok(scope_names(node_id, Solid::sphere(*radius, segs)))
         }
 
         vcad_ir::CsgOp::Cone {
@@ -4020,7 +4038,7 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             } else {
                 Some(*segments)
             };
-            Ok(Solid::cone(*radius_bottom, *radius_top, *height, segs))
+            Ok(scope_names(node_id, Solid::cone(*radius_bottom, *radius_top, *height, segs)))
         }
 
         vcad_ir::CsgOp::Torus {
@@ -4033,16 +4051,16 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             } else {
                 Some(*segments)
             };
-            Ok(Solid::torus(*major_radius, *minor_radius, segs))
+            Ok(scope_names(node_id, Solid::torus(*major_radius, *minor_radius, segs)))
         }
 
-        vcad_ir::CsgOp::Wedge { size } => Ok(Solid::wedge(size.x, size.y, size.z)),
+        vcad_ir::CsgOp::Wedge { size } => Ok(scope_names(node_id, Solid::wedge(size.x, size.y, size.z))),
 
         vcad_ir::CsgOp::Prism {
             sides,
             radius,
             height,
-        } => Ok(Solid::prism(*sides, *radius, *height)),
+        } => Ok(scope_names(node_id, Solid::prism(*sides, *radius, *height))),
 
         vcad_ir::CsgOp::Empty => Ok(Solid::empty()),
 
@@ -4149,6 +4167,15 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             profile,
         } => {
             let c = evaluate_node(doc, *child)?;
+            if let vcad_ir::EdgeQuery::Named { face_a, face_b } = edges {
+                // Fail-closed: an unresolvable named edge is an error,
+                // never a nearest-edge guess.
+                let keys = kernel_blend_keys(profile);
+                let inner = c.inner.edge_blend_named(face_a, face_b, &keys).map_err(|e| {
+                    JsError::new(&format!("named edge ('{face_a}' / '{face_b}'): {e}"))
+                })?;
+                return Ok(Solid { inner });
+            }
             let (query, keys) = kernel_blend_args(edges, profile);
             Ok(Solid {
                 inner: c.inner.edge_blend(&query, &keys),
@@ -7245,7 +7272,20 @@ fn kernel_blend_args(
             axis: vcad_kernel_math::Vec3::new(axis.x, axis.y, axis.z),
             tol_deg: *tol_deg,
         },
+        // Named queries resolve against the child solid's name map at the
+        // call sites and never reach this translation.
+        vcad_ir::EdgeQuery::Named { .. } => {
+            unreachable!("Named edge queries are handled before kernel_blend_args")
+        }
     };
+    (q, kernel_blend_keys(profile))
+}
+
+/// Convert an IR blend profile to kernel blend keys.
+fn kernel_blend_keys(
+    profile: &vcad_ir::BlendProfile,
+) -> Vec<vcad_kernel::vcad_kernel_fillet::BlendKey> {
+    use vcad_kernel::vcad_kernel_fillet as kf;
     let keys = match profile {
         vcad_ir::BlendProfile::Constant { size, shape } => vec![kf::BlendKey {
             t: 0.0,
@@ -7265,7 +7305,7 @@ fn kernel_blend_args(
             })
             .collect(),
     };
-    (q, keys)
+    keys
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -14,6 +14,7 @@ vcad-kernel-primitives = { workspace = true }
 vcad-kernel-tessellate = { workspace = true }
 vcad-kernel-booleans = { workspace = true }
 vcad-kernel-fillet = { workspace = true }
+vcad-kernel-naming = { workspace = true }
 vcad-kernel-sheet = { workspace = true }
 vcad-kernel-sketch = { workspace = true }
 vcad-kernel-sweep = { workspace = true }

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -99,6 +99,39 @@ impl From<StepError> for StepExportError {
     }
 }
 
+/// Why a named-edge reference failed to resolve (fail-closed: the caller
+/// must surface this, never fall back to a guessed edge).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NamedEdgeError {
+    /// The solid carries no name map (mesh-only, imported, or produced by an
+    /// operation without a name-propagation rule).
+    NoNames,
+    /// A face name string was not in canonical `scope:tag[.n]*` form.
+    BadName(String),
+    /// More than one edge matched the reference.
+    Ambiguous {
+        /// Number of candidate edges.
+        count: usize,
+    },
+    /// No edge matched by name or geometric hint.
+    Lost(String),
+}
+
+impl std::fmt::Display for NamedEdgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoNames => write!(f, "solid carries no persistent face names"),
+            Self::BadName(s) => write!(f, "invalid face name '{s}' (expected scope:tag[.n]*)"),
+            Self::Ambiguous { count } => {
+                write!(f, "edge reference is ambiguous ({count} candidate edges)")
+            }
+            Self::Lost(reason) => write!(f, "edge reference lost: {reason}"),
+        }
+    }
+}
+
+impl std::error::Error for NamedEdgeError {}
+
 /// The internal representation of a solid.
 #[derive(Debug, Clone)]
 enum SolidRepr {
@@ -119,6 +152,14 @@ pub struct Solid {
     repr: SolidRepr,
     /// Default tessellation segment count.
     segments: u32,
+    /// Persistent face names (topological naming), when this solid's
+    /// provenance supports them. Primitive constructors seed the map,
+    /// booleans propagate it, and rigid transforms carry it (topology keys
+    /// survive `apply_transform`'s clone). Operations that rebuild topology
+    /// without a propagation rule (fillet, shell, sweep, imports) drop it —
+    /// fail-closed: downstream name resolution reports Lost rather than
+    /// guessing.
+    names: Option<vcad_kernel_naming::NameMap>,
 }
 
 /// Fallback circular resolution when a curved primitive is created with
@@ -151,6 +192,7 @@ impl Solid {
     /// Create an empty solid.
     pub fn empty() -> Self {
         Self {
+            names: None,
             repr: SolidRepr::Empty,
             segments: 32,
         }
@@ -169,6 +211,7 @@ impl Solid {
     /// Create a solid from a triangle mesh.
     pub fn from_mesh(mesh: TriangleMesh) -> Self {
         Self {
+            names: None,
             repr: SolidRepr::Mesh(mesh),
             segments: 32,
         }
@@ -179,6 +222,7 @@ impl Solid {
     /// STEP import, custom topology builders, eval grader round-trip.
     pub fn from_brep(brep: BRepSolid) -> Self {
         Self {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         }
@@ -186,8 +230,10 @@ impl Solid {
 
     /// Create a box (cuboid) with corner at origin and dimensions `(sx, sy, sz)`.
     pub fn cube(sx: f64, sy: f64, sz: f64) -> Self {
+        let brep = vcad_kernel_primitives::make_cube(sx, sy, sz);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_cube(sx, sy, sz))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "cube")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         }
     }
@@ -195,10 +241,10 @@ impl Solid {
     /// Create a cylinder along Z axis with the given radius and height.
     pub fn cylinder(radius: f64, height: f64, segments: u32) -> Self {
         let segments = resolve_segments(segments);
+        let brep = vcad_kernel_primitives::make_cylinder(radius, height, segments);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_cylinder(
-                radius, height, segments,
-            ))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "cylinder")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments,
         }
     }
@@ -206,10 +252,10 @@ impl Solid {
     /// Create a sphere centered at origin with the given radius.
     pub fn sphere(radius: f64, segments: u32) -> Self {
         let segments = resolve_segments(segments);
+        let brep = vcad_kernel_primitives::make_sphere(radius, segments);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_sphere(
-                radius, segments,
-            ))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "sphere")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments,
         }
     }
@@ -217,13 +263,10 @@ impl Solid {
     /// Create a cone/frustum along Z axis.
     pub fn cone(radius_bottom: f64, radius_top: f64, height: f64, segments: u32) -> Self {
         let segments = resolve_segments(segments);
+        let brep = vcad_kernel_primitives::make_cone(radius_bottom, radius_top, height, segments);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_cone(
-                radius_bottom,
-                radius_top,
-                height,
-                segments,
-            ))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "cone")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments,
         }
     }
@@ -233,12 +276,10 @@ impl Solid {
     /// `major_radius` is the distance from the central axis to the tube center;
     /// `minor_radius` is the tube cross-section radius.
     pub fn torus(major_radius: f64, minor_radius: f64, segments: u32) -> Self {
+        let brep = vcad_kernel_primitives::make_torus(major_radius, minor_radius, segments);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_torus(
-                major_radius,
-                minor_radius,
-                segments,
-            ))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "torus")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments,
         }
     }
@@ -246,8 +287,10 @@ impl Solid {
     /// Create a right-triangular-prism wedge. See
     /// [`vcad_kernel_primitives::make_wedge`] for geometry details.
     pub fn wedge(sx: f64, sy: f64, sz: f64) -> Self {
+        let brep = vcad_kernel_primitives::make_wedge(sx, sy, sz);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_wedge(sx, sy, sz))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "wedge")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         }
     }
@@ -257,10 +300,10 @@ impl Solid {
     /// `sides` must be >= 3; the polygon's circumradius is `radius`, and the
     /// prism extrudes `height` along +Z.
     pub fn prism(sides: u32, radius: f64, height: f64) -> Self {
+        let brep = vcad_kernel_primitives::make_prism(sides, radius, height);
         Self {
-            repr: SolidRepr::BRep(Box::new(vcad_kernel_primitives::make_prism(
-                sides, radius, height,
-            ))),
+            names: Some(vcad_kernel_naming::seed_names(&brep, "prism")),
+            repr: SolidRepr::BRep(Box::new(brep)),
             segments: sides,
         }
     }
@@ -335,6 +378,7 @@ impl Solid {
                     let mut combined = self.to_mesh(segments);
                     combined.merge(&other.to_mesh(segments));
                     Solid {
+                        names: None,
                         repr: SolidRepr::Mesh(combined),
                         segments,
                     }
@@ -364,7 +408,18 @@ impl Solid {
                 let segments = resolve_segments(self.segments.max(other.segments));
                 let result = boolean_op(a.as_ref(), b.as_ref(), op, segments)?;
                 let BooleanResult::BRep(brep) = result;
+                let names = match (&self.names, &other.names) {
+                    (Some(na), Some(nb)) => Some(vcad_kernel_naming::propagate_boolean(
+                        a.as_ref(),
+                        na,
+                        b.as_ref(),
+                        nb,
+                        brep.as_ref(),
+                    )),
+                    _ => None,
+                };
                 Ok(Solid {
+                    names,
                     repr: SolidRepr::BRep(brep),
                     segments,
                 })
@@ -379,6 +434,7 @@ impl Solid {
                 let mut combined = mesh_a;
                 combined.merge(&mesh_b);
                 Ok(Solid {
+                    names: None,
                     repr: SolidRepr::Mesh(combined),
                     segments,
                 })
@@ -405,6 +461,7 @@ impl Solid {
                     return self.clone();
                 }
                 Solid {
+                    names: None,
                     repr: SolidRepr::BRep(Box::new(vcad_kernel_fillet::chamfer_all_edges(
                         brep, distance,
                     ))),
@@ -458,6 +515,7 @@ impl Solid {
                     return self.clone();
                 }
                 Solid {
+                    names: None,
                     repr: SolidRepr::BRep(Box::new(filleted)),
                     segments: self.segments,
                 }
@@ -513,9 +571,80 @@ impl Solid {
 
         let (blended, _outcome) = vcad_kernel_fillet::apply_edge_blend(brep, query, keys);
         Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(blended)),
             segments: self.segments,
         }
+    }
+
+    // =========================================================================
+    // Persistent topological naming
+    // =========================================================================
+
+    /// The face-name side table, when this solid's provenance supports one
+    /// (primitives seed it, booleans propagate it, transforms carry it).
+    pub fn names(&self) -> Option<&vcad_kernel_naming::NameMap> {
+        self.names.as_ref()
+    }
+
+    /// Rewrite the scope of every face name — DAG evaluators call this with
+    /// the document node id so names stay unique when several primitives
+    /// combine (`cube:top` → `n3:top`).
+    pub fn set_name_scope(&mut self, scope: &str) {
+        if let Some(names) = &mut self.names {
+            names.rescope(scope);
+        }
+    }
+
+    /// Resolve the edge between two named faces to its current endpoint
+    /// positions. Fail-closed: any outcome other than exactly one edge is an
+    /// error describing what happened (no names on this solid, ambiguous
+    /// match, or lost).
+    pub fn resolve_named_edge(
+        &self,
+        face_a: &str,
+        face_b: &str,
+    ) -> Result<(Point3, Point3), NamedEdgeError> {
+        let SolidRepr::BRep(brep) = &self.repr else {
+            return Err(NamedEdgeError::NoNames);
+        };
+        let Some(names) = &self.names else {
+            return Err(NamedEdgeError::NoNames);
+        };
+        let a = vcad_kernel_naming::FaceName::parse(face_a)
+            .ok_or_else(|| NamedEdgeError::BadName(face_a.to_string()))?;
+        let b = vcad_kernel_naming::FaceName::parse(face_b)
+            .ok_or_else(|| NamedEdgeError::BadName(face_b.to_string()))?;
+        let edge_ref = vcad_kernel_naming::EdgeRef::new(a, b);
+        match vcad_kernel_naming::resolve_edge(brep, names, &edge_ref) {
+            vcad_kernel_naming::EdgeResolution::Resolved { endpoints, .. } => Ok(endpoints),
+            vcad_kernel_naming::EdgeResolution::Ambiguous { candidates } => {
+                Err(NamedEdgeError::Ambiguous {
+                    count: candidates.len(),
+                })
+            }
+            vcad_kernel_naming::EdgeResolution::Lost { reason } => {
+                Err(NamedEdgeError::Lost(reason))
+            }
+        }
+    }
+
+    /// Apply a keyed blend to the single edge between two named faces.
+    ///
+    /// The name resolves against the current topology
+    /// ([`Solid::resolve_named_edge`]), then the blend targets exactly that
+    /// edge via [`vcad_kernel_fillet::EdgeQuery::Endpoints`]. Unlike the
+    /// geometric queries this path is fail-closed end to end: an
+    /// unresolvable or ambiguous name is an error, never a
+    /// nearest-edge guess.
+    pub fn edge_blend_named(
+        &self,
+        face_a: &str,
+        face_b: &str,
+        keys: &[vcad_kernel_fillet::BlendKey],
+    ) -> Result<Solid, NamedEdgeError> {
+        let (a, b) = self.resolve_named_edge(face_a, face_b)?;
+        Ok(self.edge_blend(&vcad_kernel_fillet::EdgeQuery::Endpoints { a, b }, keys))
     }
 
     /// Shell (hollow) the solid by offsetting all faces inward.
@@ -536,10 +665,12 @@ impl Solid {
         match &self.repr {
             SolidRepr::Empty => Solid::empty(),
             SolidRepr::BRep(brep) => Solid {
+                names: None,
                 repr: SolidRepr::BRep(Box::new(vcad_kernel_shell::shell_brep(brep, thickness))),
                 segments: self.segments,
             },
             SolidRepr::Mesh(mesh) => Solid {
+                names: None,
                 repr: SolidRepr::Mesh(vcad_kernel_shell::shell_mesh(mesh, thickness)),
                 segments: self.segments,
             },
@@ -649,6 +780,7 @@ impl Solid {
     ) -> Result<Self, vcad_kernel_sketch::SketchError> {
         let brep = vcad_kernel_sketch::extrude(&profile, direction)?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -667,6 +799,7 @@ impl Solid {
     ) -> Result<Self, vcad_kernel_sketch::SketchError> {
         let brep = vcad_kernel_sketch::extrude_with_holes(&profile, holes, direction)?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -697,6 +830,7 @@ impl Solid {
         };
         let brep = vcad_kernel_sketch::extrude_with_options(&profile, direction, options)?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -727,6 +861,7 @@ impl Solid {
         let brep =
             vcad_kernel_sketch::revolve(&profile, axis_origin, axis_dir, angle_deg.to_radians())?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -750,6 +885,7 @@ impl Solid {
     ) -> Result<Self, vcad_kernel_sweep::SweepError> {
         let brep = vcad_kernel_sweep::sweep(&profile, path, options)?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -771,6 +907,7 @@ impl Solid {
     ) -> Result<Self, vcad_kernel_sweep::LoftError> {
         let brep = vcad_kernel_sweep::loft(profiles, options)?;
         Ok(Solid {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -831,6 +968,7 @@ impl Solid {
                     }
                 }
                 Solid {
+                    names: self.names.clone(),
                     repr: SolidRepr::BRep(Box::new(new_brep)),
                     segments: self.segments,
                 }
@@ -853,6 +991,7 @@ impl Solid {
                     }
                 }
                 Solid {
+                    names: None,
                     repr: SolidRepr::Mesh(new_mesh),
                     segments: self.segments,
                 }
@@ -1056,6 +1195,7 @@ impl Solid {
         let solids = vcad_kernel_step::read_step(path)?;
         let brep = solids.into_iter().next().ok_or(StepError::NoSolids)?;
         Ok(Self {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -1079,6 +1219,7 @@ impl Solid {
         Ok(solids
             .into_iter()
             .map(|brep| Self {
+                names: None,
                 repr: SolidRepr::BRep(Box::new(brep)),
                 segments: 32,
             })
@@ -1098,6 +1239,7 @@ impl Solid {
         let solids = vcad_kernel_step::read_step_from_buffer(data)?;
         let brep = solids.into_iter().next().ok_or(StepError::NoSolids)?;
         Ok(Self {
+            names: None,
             repr: SolidRepr::BRep(Box::new(brep)),
             segments: 32,
         })
@@ -1121,6 +1263,7 @@ impl Solid {
         Ok(solids
             .into_iter()
             .map(|brep| Self {
+                names: None,
                 repr: SolidRepr::BRep(Box::new(brep)),
                 segments: 32,
             })

--- a/crates/vcad-kernel/tests/topo_naming.rs
+++ b/crates/vcad-kernel/tests/topo_naming.rs
@@ -1,0 +1,142 @@
+//! Persistent topological naming — kernel-level regression tests.
+//!
+//! M0: names survive boolean propagation and are deterministic across
+//! rebuilds. M1/M2: a named-edge reference resolves after an upstream
+//! parameter change and drives a blend onto the intended edge.
+
+use vcad_kernel::vcad_kernel_fillet::{BlendKey, BlendSection, EdgeQuery};
+use vcad_kernel::vcad_kernel_math::Point3;
+use vcad_kernel::Solid;
+
+fn sorted_names(s: &Solid) -> Vec<String> {
+    let mut v: Vec<String> = s
+        .names()
+        .expect("solid should carry names")
+        .faces
+        .values()
+        .map(|n| n.to_string())
+        .collect();
+    v.sort();
+    v
+}
+
+/// A through-hole difference keeps the cube's face names and imports the
+/// cylinder wall's name; two rebuilds at different radii agree on the name
+/// set (determinism does not depend on boolean iteration order).
+#[test]
+fn boolean_propagates_names_deterministically() {
+    let build = |r: f64| {
+        let cube = Solid::cube(20.0, 20.0, 20.0);
+        let hole = Solid::cylinder(r, 40.0, 16).translate(10.0, 10.0, -10.0);
+        cube.difference(&hole)
+    };
+    let a = build(5.0);
+    let names = sorted_names(&a);
+    // All six cube faces survive under their seeded names.
+    for tag in ["bottom", "top", "front", "back", "left", "right"] {
+        assert!(
+            names.contains(&format!("cube:{tag}")),
+            "missing cube:{tag} in {names:?}"
+        );
+    }
+    // The hole wall carries the cylinder's name.
+    assert!(
+        names.iter().any(|n| n.starts_with("cylinder:side")),
+        "missing cylinder wall name in {names:?}"
+    );
+
+    let b = build(6.0);
+    assert_eq!(names, sorted_names(&b), "name set must be rebuild-stable");
+}
+
+/// Scoping rewrites every name's scope — the DAG-evaluator hook.
+#[test]
+fn rescoping_names() {
+    let mut cube = Solid::cube(10.0, 10.0, 10.0);
+    cube.set_name_scope("n7");
+    assert!(sorted_names(&cube).contains(&"n7:top".to_string()));
+    assert!(cube.resolve_named_edge("n7:top", "n7:right").is_ok());
+    assert!(cube.resolve_named_edge("cube:top", "cube:right").is_err());
+}
+
+/// The M2 core: a named-edge fillet stays on the intended edge when the
+/// parent primitive's dimension changes.
+#[test]
+fn named_edge_blend_survives_parameter_change() {
+    let keys = [BlendKey {
+        t: 0.0,
+        section: BlendSection {
+            size: 2.0,
+            shape: 1.0,
+        },
+    }];
+    for sx in [10.0, 14.0] {
+        let cube = Solid::cube(sx, 10.0, 10.0);
+        // The reference resolves to the x = sx, z = 10 edge at either size.
+        let (a, b) = cube
+            .resolve_named_edge("cube:top", "cube:right")
+            .expect("edge resolves");
+        for p in [a, b] {
+            assert!((p.x - sx).abs() < 1e-9, "endpoint x at {sx}: {p:?}");
+            assert!((p.z - 10.0).abs() < 1e-9, "endpoint z: {p:?}");
+        }
+
+        let blended = cube
+            .edge_blend_named("cube:top", "cube:right", &keys)
+            .expect("blend applies");
+        let brep = blended.as_brep().expect("brep result");
+        // The intended corner line (x = sx, z = 10) is gone...
+        let on_target_corner = brep
+            .topology
+            .vertices
+            .iter()
+            .filter(|(_, v)| (v.point.x - sx).abs() < 1e-9 && (v.point.z - 10.0).abs() < 1e-9)
+            .count();
+        assert_eq!(on_target_corner, 0, "target edge must be blended at {sx}");
+        // ...while the opposite top edge (x = 0, z = 10) stays sharp.
+        let on_opposite_corner = brep
+            .topology
+            .vertices
+            .iter()
+            .filter(|(_, v)| v.point.x.abs() < 1e-9 && (v.point.z - 10.0).abs() < 1e-9)
+            .count();
+        assert!(
+            on_opposite_corner >= 2,
+            "opposite edge must remain sharp at {sx}"
+        );
+    }
+}
+
+/// Fail-closed: unresolvable references error out instead of guessing, and
+/// an `Endpoints` query that matches nothing blends nothing.
+#[test]
+fn unresolvable_references_fail_closed() {
+    let cube = Solid::cube(10.0, 10.0, 10.0);
+    assert!(cube.resolve_named_edge("cube:top", "cube:nope").is_err());
+    assert!(cube.resolve_named_edge("garbage", "cube:top").is_err());
+    // A name map is dropped by ops without a propagation rule.
+    let filleted = cube.fillet(1.0);
+    assert!(filleted.names().is_none());
+    assert!(filleted
+        .resolve_named_edge("cube:top", "cube:right")
+        .is_err());
+
+    // Endpoints query matching nothing → solid unchanged.
+    let keys = [BlendKey {
+        t: 0.0,
+        section: BlendSection {
+            size: 2.0,
+            shape: 1.0,
+        },
+    }];
+    let noop = cube.edge_blend(
+        &EdgeQuery::Endpoints {
+            a: Point3::new(99.0, 99.0, 99.0),
+            b: Point3::new(99.0, 99.0, 90.0),
+        },
+        &keys,
+    );
+    let before = cube.as_brep().unwrap().topology.faces.len();
+    let after = noop.as_brep().unwrap().topology.faces.len();
+    assert_eq!(before, after);
+}

--- a/docs/topo-naming-m0.md
+++ b/docs/topo-naming-m0.md
@@ -1,0 +1,203 @@
+# Persistent topological naming — M0→M2 design note
+
+The foundation for robust parametric editing: **stable names for BRep faces
+and edges derived from generating operations**, so a downstream feature (a
+fillet, a sketch-on-face) can survive an upstream parameter change instead of
+breaking or silently attaching to the wrong entity — the classic FreeCAD
+"topological naming problem". This note records the resolved ground truth,
+the design decisions and their reasons, and what each milestone gates.
+
+## What landed
+
+- `vcad-kernel-naming` (new crate) — the naming scheme itself: `FaceName`
+  (`scope:tag[.n]*`), the `NameMap` side table, geometry-derived seeding
+  (`seed_names`), boolean propagation by surface identity
+  (`propagate_boolean`), edge references by adjacent-face-name pair
+  (`EdgeRef`), and fail-closed resolution (`resolve_edge` →
+  `Resolved / Ambiguous / Lost`).
+- `vcad-kernel` — `Solid` carries an `Option<NameMap>`: primitive
+  constructors seed it, booleans propagate it, rigid transforms carry it,
+  and everything without a propagation rule drops it (fail-closed). Public
+  API: `names()`, `set_name_scope()`, `resolve_named_edge()`,
+  `edge_blend_named()` (+ `NamedEdgeError`).
+- `vcad-kernel-fillet` — `EdgeQuery::Endpoints`, an exact quantized
+  endpoint-pair selector: the deterministic handoff from a resolved named
+  edge into the existing blend pipeline (no fuzzy nearest-edge behavior).
+- `vcad-ir` + evaluators — `EdgeQuery::Named { face_a, face_b }` on
+  `CsgOp::EdgeBlend`, wired through all three Rust evaluators (`vcad-eval`,
+  `vcad-app`, `vcad-kernel-wasm`) with the same node-id scope convention;
+  unresolvable references are evaluation errors, never guesses.
+- Regression tests at every layer: `vcad-kernel-naming` unit tests,
+  `crates/vcad-kernel/tests/topo_naming.rs`, and the M2 gate in
+  `vcad-eval` (`named_edge_blend_survives_box_resize`).
+
+## Step 0 — resolved ground truth
+
+Surveyed before designing; three facts shaped everything:
+
+1. **No provenance exists anywhere.** The half-edge arena
+   (`vcad-kernel-topo`) stores slotmap keys only — no name, label, or
+   source-face field on any entity. Every pipeline stage (primitive →
+   boolean → fillet) produces a **fresh `BRepSolid` with brand-new keys**.
+   Greenfield: nothing to migrate, nothing to fight.
+2. **Primitive face construction is deterministic**, and face roles are
+   fully recoverable from geometry (a cube's six axis-aligned plane normals,
+   a cylinder's lateral surface + caps). So seeding does not need to thread
+   labels through the constructors at all — it can *derive* them.
+3. **The boolean pipeline computes the result→input face map and throws it
+   away** (`sew.rs::copy_faces` returns `HashMap<FaceId, FaceId>`; every
+   call site binds it to `_`), and the boolean's enumeration order is
+   **nondeterministic** (documented in `differentiable-seam-m0-m2.md`: cap
+   faces can swap between builds at nearby parameters). Split sub-faces,
+   however, always **inherit the parent face's carrying surface**.
+
+Fact 3 drove the central design decision: **propagation is a geometric
+post-pass, not a pipeline thread-through.** Matching each result face to the
+input face with the geometrically identical carrying surface (kind +
+analytic parameters within 1e-6 mm) recovers exactly the mapping the sewing
+stage discards, without touching the 15 kLOC boolean crate — and, unlike
+traversal order, it is deterministic by construction. The alternative
+(threading provenance through split → classify → sew) remains available as a
+later optimization; it would change *how* the same names are computed, not
+*what* they are.
+
+## The name scheme (M0)
+
+`scope:tag[.ordinal]*`, e.g. `n3:top`, `n1:side`, `n3:top.0`.
+
+- **scope** — the generating operation. Primitive constructors seed with
+  the primitive kind (`cube`, `cylinder`, …); the DAG evaluators rescope to
+  `n<nodeId>` immediately after evaluating a primitive node, because node
+  ids persist in the `.vcad` document (rebuild-stable) and are unique across
+  the DAG (two cubes in a union don't collide). All three evaluators use the
+  same convention, so a `Named` reference means the same thing in the app,
+  the CLI, and the browser.
+- **tag** — the face's role, derived from its carrying surface:
+  axis-aligned planes → `bottom/top/front/back/left/right` (Z-up), other
+  planes → `plane`, cylinders → `side`, cones/spheres/tori → kind name.
+  Repeated tags (a prism's walls) get ordinals in **quantized-centroid
+  order** — deterministic regardless of arena iteration order.
+- **path** — one sibling ordinal per boolean split generation. When a
+  boolean cuts `cube:top` into two pieces, they become `cube:top.0` /
+  `cube:top.1`, ordered by quantized centroid. A face that splits again in a
+  later boolean appends another ordinal.
+
+Edges are **not named independently**: an edge reference is the canonical
+(sorted) pair of its adjacent faces' names. This eliminates an entire
+propagation channel — edge identity rides on face identity.
+
+Fail-closed rules in propagation: a result face whose surface matches
+*no* named input face, or matches faces carrying *different* names (two
+flush coplanar faces from both operands), stays anonymous. Anonymous faces
+make downstream references report `Lost` — never a guess.
+
+## Resolution + fallback (M1)
+
+`resolve_edge(brep, names, EdgeRef) → EdgeResolution`:
+
+1. **By name**: find the unique face carrying each name, then the unique
+   manifold edge adjacent to both → `Resolved { method: ByName }`. This is
+   the path that survives parameter edits, because names re-derive
+   identically on rebuild.
+2. **By geometry** (only when names fail and the reference carries an
+   `EdgeHint` captured at reference time): candidates must agree with the
+   recorded direction (within ~18°, sign-insensitive), length (±25 %), and
+   midpoint (within 25 % of recorded length — all tolerances scale with the
+   edge, so the matcher is scale-free). Exactly one candidate →
+   `Resolved { method: ByGeometry }`.
+3. Anything else is explicit: several candidates → `Ambiguous { candidates }`,
+   none → `Lost { reason }`. Both are hard errors at every consumer — the
+   blend is *not* applied, the evaluator reports which reference broke and
+   why. A stale hint after a large edit is `Lost`, not rebound (gated by
+   `stale_hint_after_a_large_edit_is_lost_not_rebound`).
+
+Two faces sharing several edges (a through-slot) are `Ambiguous` by name
+alone; the hint disambiguates when present.
+
+## Consumer wired end-to-end (M2)
+
+`vcad-ir` gains `EdgeQuery::Named { face_a, face_b }` on `CsgOp::EdgeBlend`
+(serde-tagged, ts-rs exported; `npm run ir:gen` regenerated the TS types).
+Evaluation resolves the names against the child solid's map and hands the
+result to the fillet crate as `EdgeQuery::Endpoints` — an exact quantized
+endpoint match, so the blend lands on precisely the resolved edge (the
+pre-existing `Near` query has nearest-endpoint tie hazards that make it
+unsuitable as a resolution target).
+
+The M2 gate (`named_edge_blend_survives_box_resize`, in `vcad-eval`): a
+document with `Cube(sx, 10, 10)` → `EdgeBlend(Named("n0:top", "n0:right"),
+fillet r=2)` evaluates at `sx = 10` and `sx = 14`; at both sizes the blended
+volume matches the closed form `sx·100 − (1 − π/4)·r²·10` to < 0.5 mm³, no
+vertex remains on the intended corner line (x = sx, z = 10), and the
+opposite edge stays sharp. The fail-closed side is gated too: a `Named`
+reference to a nonexistent face is an `EvalError::NamedEdge`, and the
+kernel-level `unresolvable_references_fail_closed` covers bad names, dropped
+maps, and no-match `Endpoints` queries.
+
+Boolean propagation is gated by
+`boolean_propagates_names_deterministically` (kernel tests): cube −
+through-cylinder keeps all six `cube:*` names, imports `cylinder:side` for
+the hole wall, and two rebuilds at different radii produce the identical
+name set.
+
+## Design decisions and their reasons
+
+- **Side table, not a topology field.** `BRepSolid` has ~96 construction
+  sites across 20+ crates; a `name` field on `Face` would touch all of them
+  and force every topology-rebuilding op to have an opinion. The
+  `NameMap` lives on `vcad_kernel::Solid` (one crate, ~30 literal sites),
+  and ops that can't propagate simply drop it — absence is an honest,
+  fail-closed signal.
+- **Names are derived, not stored provenance.** Seeding from geometry and
+  propagating by surface identity makes naming a pure function of the
+  operation graph — the property that makes names *rebuild-stable*, which
+  stored arena-key lineage can never be (the boolean enumerates
+  nondeterministically).
+- **Determinism via quantized-centroid ordering** everywhere an ordinal is
+  assigned (1e-6 mm grid). Centroids of distinct sibling faces are far
+  apart relative to the quantum; hash-map iteration order never leaks into
+  a name.
+- **`Endpoints`, not `Near`, as the resolution handoff** — exact matching
+  keeps the fail-closed guarantee through the last hop into the blend
+  pipeline.
+
+## Known limitations (deliberate, in scope-fence order)
+
+- **Fillet/chamfer/shell/sweep outputs drop the map.** Blend faces need
+  generated names (`<edge-ref>:blend`) and trimmed neighbors need
+  carry-through — the same surface-identity post-pass would work (trimmed
+  faces keep their planes) and is the natural M3.
+- **Sketch-derived solids (extrude/revolve/loft) are unnamed.** Extrude
+  wants `side loop L, segment S` names seeded from the profile — M3/M4
+  territory, and the reason `FaceName.tag` is a free string rather than an
+  enum.
+- **Coplanar-merge ambiguity is resolved by anonymity.** A union of two
+  boxes sharing a face plane names the merged face neither `a:top` nor
+  `b:top`. Correct but lossy; a merge rule (`a:top+b:top`) could name it.
+- **Same-name symmetry under exact symmetry.** Two split siblings that are
+  perfectly symmetric about the centroid-ordering axes sort by the next
+  coordinate; a parameter change that swaps their sorted order renames
+  them (`.0` ↔ `.1`). The `EdgeHint` fallback catches the reference; a
+  parameter-continuity heuristic (nearest-previous-centroid) would be the
+  refinement.
+- **`surface_tag` classification can jump.** A plane rotated onto an axis
+  changes tag (`plane` → `top`). References through such an edit fall back
+  to the hint. Tag-from-op (rather than tag-from-geometry) seeding would
+  remove this; it costs threading labels through the primitive
+  constructors.
+- **App/WASM UI wiring is a follow-up.** The WASM evaluator resolves
+  `Named` queries (browser documents evaluate correctly), but there is no
+  UI for picking a named edge or displaying names yet, and no MCP tool
+  exposes name introspection. Follow-up milestone: `list_names` on the
+  inspect path + a picker that writes `Named` queries instead of `Near`.
+
+## What M3 needs from this
+
+Fillet-output propagation is the unblocking step: `apply_edge_blend`
+rebuilds topology via the same face-extraction helpers everywhere, and the
+surviving faces keep their carrying surfaces — so `propagate_boolean`'s
+surface-identity matcher generalizes as-is (rename it `propagate_rebuild`).
+With that, chained features (fillet-then-fillet, fillet-then-boolean)
+resolve, and `sketch-on-named-face` becomes the first non-edge consumer:
+`FaceRef` (a `FaceName` + planar fingerprint) resolving to an attachment
+plane, with the identical fail-closed reporting.

--- a/packages/docs/content/architecture/kernel-features.mdx
+++ b/packages/docs/content/architecture/kernel-features.mdx
@@ -34,6 +34,10 @@ The vcad kernel is a purpose-built BRep (boundary representation) modeling kerne
 
 `vcad-kernel-math` provides linear algebra, transforms, and Shewchuk's adaptive-precision predicates (`orient2d`, `orient3d`, `incircle`, `insphere`) via the `robust` crate. Geometric decisions — is this point above that plane? — are exact, not floating-point guesses, which is what keeps booleans from producing holes and inverted faces on near-degenerate input.
 
+### Persistent Topological Naming
+
+`vcad-kernel-naming` gives faces stable names derived from their generating operations (`n3:top`, `n1:side`, with deterministic split ordinals through booleans) instead of ephemeral arena keys, and names edges by their adjacent-face pair. Downstream references — `EdgeQuery::Named` on an edge blend — re-resolve after an upstream parameter change, so a fillet stays on the intended edge when the parent box is resized. Resolution is fail-closed: an ambiguous or lost reference is an explicit error (with a geometric-hint fallback matcher), never a silent rebind to the nearest edge.
+
 ## Operations
 
 ### Boolean Operations

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -1198,7 +1198,15 @@ axis: Vec3,
 /**
  * Angular tolerance in degrees.
  */
-tol_deg: number, };
+tol_deg: number, } | { "type": "Named", 
+/**
+ * Name of one adjacent face.
+ */
+face_a: string, 
+/**
+ * Name of the other adjacent face.
+ */
+face_b: string, };
 
 /**
  * An embroidery design for the IR.


### PR DESCRIPTION
## What

The foundation for robust parametric editing: faces and edges get **stable names derived from generating operations** instead of ephemeral arena keys, so a fillet referencing an edge survives an upstream parameter change — the classic FreeCAD "topological naming problem". Design note: `docs/topo-naming-m0.md`.

## Milestones

**M0 — the name scheme** (`vcad-kernel-naming`, new crate)
- `FaceName` = `scope:tag[.n]*` (`n3:top`, `n1:side`, split ordinals through booleans). Seeding is a pure function of geometry (axis-aligned plane normals → `top`/`bottom`/…, cylinder lateral → `side`), so rebuilds re-derive identical names.
- Boolean propagation is a geometric post-pass: each result face inherits the name of the unique input face with the geometrically identical carrying surface (the splitter reuses surfaces), with quantized-centroid ordinals for split siblings — deterministic despite the boolean's nondeterministic enumeration order, and zero changes to the 15 kLOC boolean crate.
- Edges are named by their adjacent-face pair — no separate edge-propagation channel.

**M1 — fail-closed resolution**
- `resolve_edge` → `Resolved { ByName | ByGeometry } / Ambiguous / Lost`. Geometric fallback matches a recorded `EdgeHint` (direction/length/midpoint, tolerances scaled by edge length). Ambiguous and Lost are explicit, reportable outcomes — never a silent rebind (gated: a stale hint after a large edit is `Lost`, not rebound).

**M2 — consumer wired end-to-end**
- `vcad-ir`: `EdgeQuery::Named { face_a, face_b }` on `EdgeBlend` (ts-rs regenerated, `ir:check` clean).
- All three Rust evaluators (`vcad-eval`, `vcad-app`, `vcad-kernel-wasm`) resolve names under the shared `n<nodeId>` scope convention and land the blend via the new exact `vcad-kernel-fillet::EdgeQuery::Endpoints` (no nearest-edge fuzziness). Unresolvable references are evaluation errors.
- Regression gate (`named_edge_blend_survives_box_resize`): box `sx×10×10` + fillet on `Named(n0:top, n0:right)` at `sx = 10` and `14` — volume matches the closed form at both sizes, the named edge is blended, the opposite edge stays sharp.

## Architecture notes

- Names live in a `NameMap` side table on `vcad_kernel::Solid` (not a topology field — `BRepSolid` has ~96 construction sites across 20+ crates). Primitives seed, booleans propagate, rigid transforms carry (topology keys survive the clone); every op without a propagation rule drops the map, which downstream reads as an honest `Lost`.
- Known limitations + M3 plan (fillet-output propagation, sketch-derived solids, UI/MCP surfacing) are documented in the design note.

## Verification

- `cargo test --workspace` green; `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` clean (desktop has pre-existing cocoa deprecation lints); `cargo fmt --all --check` clean.
- `npm run build --workspaces` + `npm test --workspaces` green; `ir:check` up to date; no wasm artifacts committed.
- New tests: 7 (naming crate) + 4 (kernel integration incl. boolean-propagation determinism) + 2 (vcad-eval M2 gate + fail-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)