### PR TITLE
Q-lane triple: TiD beam-target (records 197x), power ledger (honest Q), POPS harmonic well

### DIFF
--- a/crates/vcad-kernel-particle/examples/pops_harmonic_well.rs
+++ b/crates/vcad-kernel-particle/examples/pops_harmonic_well.rs
@@ -1,0 +1,124 @@
+//! POPS flagship: shape the well toward harmonic by electrode design.
+//!
+//! POPS coherent compression needs a harmonic well (bounce frequency
+//! independent of amplitude). A stock IEC well is anharmonic — it flattens
+//! away from center, so big-amplitude ions bounce slower and the cloud
+//! decoheres under a single drive. This example measures that, then lets
+//! the optimizer reshape the electrodes to maximize harmonicity — "design
+//! a quadratic well," a request only a differentiable field-solver can act
+//! on.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example pops_harmonic_well`
+
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::optimize::{maximize, FdOptions};
+use vcad_kernel_particle::poisson::SolveOptions;
+use vcad_kernel_particle::pops::harmonicity;
+use vcad_kernel_particle::trace::TraceOptions;
+
+// A three-electrode axisymmetric well: the cathode ring pair plus a
+// guard ring pair further out whose potential is the shaping knob. Two
+// free parameters — cathode ring radius and guard potential fraction —
+// give the optimizer room to flatten the anharmonicity.
+fn device_from(ring_r_mm: f64, guard_frac: f64) -> Device {
+    let cathode_v = -30_000.0;
+    let mut d = Device::shielded_two_ring(150.0, ring_r_mm, 25.0, 3.0, cathode_v, 0.0);
+    // Guard rings at 1.7× the cathode radius, ±40 mm, biased to a fraction
+    // of the cathode — a positive fraction convexifies the well.
+    for &z in &[40.0, -40.0] {
+        d.rings.push(vcad_kernel_particle::device::WireRing {
+            ring_radius_mm: ring_r_mm * 1.7,
+            z_mm: z,
+            wire_radius_mm: 3.0,
+            potential_v: cathode_v * guard_frac,
+            ampere_turns: 0.0,
+        });
+    }
+    d
+}
+
+fn measure(ring_r_mm: f64, guard_frac: f64) -> f64 {
+    let device = device_from(ring_r_mm, guard_frac);
+    harmonicity(
+        &device,
+        61,
+        121,
+        &SolveOptions::default(),
+        &TraceOptions {
+            max_passes: 16,
+            time_budget_factor: 25.0,
+            ..TraceOptions::default()
+        },
+        &[0.2, 0.35, 0.5, 0.65, 0.8],
+    )
+    .map(|r| r.harmonicity)
+    .unwrap_or(0.0)
+}
+
+fn main() {
+    let base_r = 45.0;
+    let baseline = measure(base_r, 0.0);
+    println!("# POPS harmonic-well inverse design");
+    println!("baseline (bare cathode, {base_r:.0} mm rings): harmonicity {baseline:.3}");
+
+    let mut evals = 0usize;
+    let mut objective = |x: &[f64]| {
+        evals += 1;
+        measure(x[0], x[1])
+    };
+    let result = maximize(
+        &mut objective,
+        &[base_r, 0.2],
+        &[30.0, 0.0],
+        &[70.0, 0.9],
+        &FdOptions {
+            max_iters: 10,
+            ..FdOptions::default()
+        },
+    );
+
+    println!(
+        "optimized: ring radius {:.1} mm, guard {:.2}× cathode -> harmonicity {:.3} ({} evals)",
+        result.x[0], result.x[1], result.value, evals
+    );
+    println!(
+        "improvement: {:.3} -> {:.3} ({:+.0}%)",
+        baseline,
+        result.value,
+        100.0 * (result.value - baseline) / baseline.max(1e-9)
+    );
+
+    // Report the frequency droop at both ends, the physical POPS signal.
+    for (label, r, g) in [
+        ("baseline", base_r, 0.0),
+        ("optimized", result.x[0], result.x[1]),
+    ] {
+        let device = device_from(r, g);
+        if let Ok(rep) = harmonicity(
+            &device,
+            61,
+            121,
+            &SolveOptions::default(),
+            &TraceOptions {
+                max_passes: 16,
+                time_budget_factor: 25.0,
+                ..TraceOptions::default()
+            },
+            &[0.2, 0.35, 0.5, 0.65, 0.8],
+        ) {
+            println!(
+                "  {label}: bounce-frequency droop small->large amplitude = {:+.1}% \
+                 ({} amplitudes clean)",
+                100.0 * rep.droop,
+                rep.frequencies.len()
+            );
+        }
+    }
+
+    println!(
+        "\nread: harmonicity 1.0 = every ion bounces at one frequency (POPS-ready, \
+         phase-lockable); lower = the cloud decoheres under a single drive. The \
+         optimizer is shaping the vacuum well; space-charge flattening (unmodeled \
+         here) is the next anharmonicity to fight. Perfect-well upper bound."
+    );
+}

--- a/crates/vcad-kernel-particle/examples/records_dial.rs
+++ b/crates/vcad-kernel-particle/examples/records_dial.rs
@@ -1,0 +1,108 @@
+//! The records dial: shield current tunes between two fusion regimes.
+//!
+//! A TiD-coated cathode makes every intercepted ion a beam-target
+//! reaction. The shield current then becomes a *dial*: low current →
+//! high interception → beam-target-dominated (solid density, huge yield);
+//! high current → low interception → gas-recirculation-dominated (what the
+//! ceiling hunt optimized). This example prices both channels vs shield
+//! current at the record-attempt operating point and reports the total —
+//! the instrument no other machine has.
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example records_dial`
+
+use vcad_kernel_particle::beam_target;
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::field::FieldMap;
+use vcad_kernel_particle::fom::{neutron_rate_per_s, stats};
+use vcad_kernel_particle::poisson::{solve, SolveOptions};
+use vcad_kernel_particle::trace::{TraceOptions, Tracer, DEUTERON};
+use vcad_kernel_particle::xsection::d2_deuteron_density_m3;
+
+const KV: f64 = 100.0;
+const ION_CURRENT_A: f64 = 0.030;
+const PRESSURE_MTORR: f64 = 4.0;
+const RECORD_N_PER_S: f64 = 5.0e6;
+
+fn main() {
+    println!(
+        "# records dial: {KV:.0} kV, {} mA onto TiD-coated rings",
+        ION_CURRENT_A * 1e3
+    );
+    println!("amp_turns,intercept,beam_target_n_per_s,gas_n_per_s,total_n_per_s,vs_record");
+    let n_d = d2_deuteron_density_m3(PRESSURE_MTORR, 300.0);
+
+    // Beam-target yield of the ions that hit the (TiD) wires, at full
+    // cathode energy. The intercepted current is interception × I.
+    let mut best = (0.0_f64, 0.0_f64);
+    for &at in &[0.0, 160_000.0, 400_000.0, 760_000.0, 1_170_000.0] {
+        let device = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, -KV * 1e3, at);
+        let sol = solve(&device, 121, 241, &SolveOptions::default()).expect("poisson");
+        let fields = FieldMap::new(&device, &sol);
+        let topts = TraceOptions {
+            max_passes: 40,
+            ..TraceOptions::default()
+        };
+        let tracer = Tracer::new(&device, &fields, &sol, topts);
+        let s = stats(&tracer.launch_ensemble(DEUTERON, 96));
+
+        let intercepted_a = s.interception_fraction * ION_CURRENT_A;
+        let beam_target = beam_target::neutron_rate_n_per_s(KV, intercepted_a, 1.0);
+        let gas = neutron_rate_per_s(s.mean_ddn_sigma_v_m3, ION_CURRENT_A, n_d);
+        let total = beam_target + gas;
+        println!(
+            "{:.0},{:.3},{:.3e},{:.3e},{:.3e},{:.0}",
+            at,
+            s.interception_fraction,
+            beam_target,
+            gas,
+            total,
+            total / RECORD_N_PER_S
+        );
+        if total > best.1 {
+            best = (at, total);
+        }
+    }
+
+    // The records play: minimize shield, maximize interception onto TiD.
+    let device = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, -KV * 1e3, 0.0);
+    let sol = solve(&device, 121, 241, &SolveOptions::default()).unwrap();
+    let fields = FieldMap::new(&device, &sol);
+    let tracer = Tracer::new(
+        &device,
+        &fields,
+        &sol,
+        TraceOptions {
+            max_passes: 40,
+            ..TraceOptions::default()
+        },
+    );
+    let s = stats(&tracer.launch_ensemble(DEUTERON, 96));
+    let full_beam = beam_target::neutron_rate_n_per_s(KV, ION_CURRENT_A, 1.0);
+
+    println!("\n──── the records card ────");
+    println!(
+        "unshielded TiD (100% to target): {:.2e} n/s = {:.0}× the amateur record",
+        full_beam,
+        full_beam / RECORD_N_PER_S
+    );
+    println!(
+        "beam-target Q at {KV:.0} keV: {:.2e} (stopping-power-capped — records lane, not gain)",
+        beam_target::q_beam_target(KV)
+    );
+    println!(
+        "anchor: the published Ti drive-in generator, {:.1e} n/s at {:.0} mA / {:.0} keV — \
+         this predicts the same physics at our current by cross-section ratio",
+        beam_target::CALIBRATION.neutron_rate_n_per_s,
+        beam_target::CALIBRATION.current_a * 1e3,
+        beam_target::CALIBRATION.energy_kev
+    );
+    println!(
+        "interception at zero shield: {:.2} — the dial's beam-target end",
+        s.interception_fraction
+    );
+    println!(
+        "\nhonesty: TiD loses D above ~250 C (pair with the thermal crate); \
+         monatomic-beam fraction and target loading are real derates; every \
+         number is a prediction — the bench signs the receipt."
+    );
+}

--- a/crates/vcad-kernel-particle/examples/sustained_q.rs
+++ b/crates/vcad-kernel-particle/examples/sustained_q.rs
@@ -1,0 +1,118 @@
+//! The honest Q of the virtual-cathode machine.
+//!
+//! The e-injection sweep showed the electron cloud boosts ion yield (×8.4
+//! at 10 A). This example prices that boost: it runs the neutralized
+//! machine, measures the electron confinement time, and feeds the full
+//! power ledger — because a sustained virtual cathode costs electron
+//! injection power, and in steady state that power is `I_e · V` (the
+//! injector replaces every lost electron, each carrying ~the well out).
+//! The verdict the yield claim can't dodge: does the boost survive its own
+//! power bill?
+//!
+//! Run: `cargo run --release -p vcad-kernel-particle --example sustained_q`
+
+use vcad_kernel_particle::confinement::confinement;
+use vcad_kernel_particle::device::Device;
+use vcad_kernel_particle::fom::neutron_rate_per_s;
+use vcad_kernel_particle::poisson::SolveOptions;
+use vcad_kernel_particle::power::LedgerInputs;
+use vcad_kernel_particle::space_charge::{neutralized, SelfConsistentOptions};
+use vcad_kernel_particle::trace::{TraceOptions, ELECTRON};
+use vcad_kernel_particle::xsection::d2_deuteron_density_m3;
+
+const KV: f64 = 100.0;
+const ION_CURRENT_A: f64 = 0.030;
+const PRESSURE_MTORR: f64 = 4.0;
+const RECORD_N_PER_S: f64 = 5.0e6;
+
+fn main() {
+    let device = Device::shielded_two_ring(150.0, 45.0, 25.0, 3.0, -KV * 1e3, 584_237.0);
+    let n_d = d2_deuteron_density_m3(PRESSURE_MTORR, 300.0);
+    let ion_topts = TraceOptions {
+        max_passes: 30,
+        ..TraceOptions::default()
+    };
+    let sc = SelfConsistentOptions {
+        iterations: 4,
+        relax: 0.25,
+        particles: 64,
+        ..SelfConsistentOptions::default()
+    };
+
+    // Electron confinement time in this cusp (B-on), reused across the
+    // current points: in-flight charge = I_e · τ, sustain power = I_e · V.
+    let conf = confinement(
+        &device,
+        ELECTRON,
+        61,
+        121,
+        &SolveOptions::default(),
+        &TraceOptions {
+            max_passes: 60,
+            time_budget_factor: 20.0,
+            launch_shell_fraction: 0.55,
+            ..TraceOptions::default()
+        },
+        24,
+    )
+    .expect("confinement");
+    let tau_e = conf.mean_time_s;
+    println!(
+        "# sustained Q at {KV:.0} kV, {} mA ions; e-confinement tau = {:.2e} s (enhancement {:.0}x, survivors {:.0}%)",
+        ION_CURRENT_A * 1e3,
+        tau_e,
+        conf.enhancement,
+        conf.survivor_fraction * 100.0
+    );
+    println!("e_current_a,neutron_n_per_s,vs_record,P_fus_W,P_ion_W,P_e_W,input_W,Q");
+
+    for &ie in &[0.03, 1.0, 3.0, 10.0] {
+        let r = neutralized(
+            &device,
+            121,
+            241,
+            &SolveOptions::default(),
+            &ion_topts,
+            ION_CURRENT_A,
+            ie,
+            0.55,
+            &sc,
+        )
+        .expect("neutralized");
+        let n_rate = neutron_rate_per_s(r.recovered_stats.mean_ddn_sigma_v_m3, ION_CURRENT_A, n_d);
+        let led = LedgerInputs {
+            neutron_rate_n_per_s: n_rate,
+            ion_current_a: ION_CURRENT_A,
+            voltage_v: KV * 1e3,
+            trapped_electron_charge_c: ie * tau_e,
+            electron_confinement_time_s: tau_e,
+            electron_loss_energy_ev: 0.0, // defaults to the full well
+            magnet_power_w: 0.0,          // flagged unpriced (see below)
+        }
+        .evaluate();
+        println!(
+            "{:.2},{:.3e},{:.0},{:.2e},{:.2e},{:.2e},{:.2e},{:.2e}",
+            ie,
+            n_rate,
+            n_rate / RECORD_N_PER_S,
+            led.fusion_power_w,
+            led.ion_beam_power_w,
+            led.electron_sustain_power_w,
+            led.input_power_w,
+            led.q
+        );
+    }
+
+    println!(
+        "\n──── the honest ledger ────\n\
+         The electron cloud that boosts yield costs I_e·V of injection power, \
+         and it dominates the input the moment I_e exceeds the ion current. The \
+         virtual cathode raises neutron RATE (a records-lane win) but not Q — \
+         Q falls as the cloud grows, because sustain power outruns fusion power. \
+         Plus the shield MAGNET term is unpriced here (dominant at MA-turns — \
+         needs the em+thermal crates), so even these Q values are over-estimates.\n\
+         Bottom line: neutralization is a NEUTRON-RATE lever (records + physics \
+         lanes), not a Q lever. The Q lane needs a different physics — direct \
+         energy recovery on the losses — which this ledger is now built to price."
+    );
+}

--- a/crates/vcad-kernel-particle/src/beam_target.rs
+++ b/crates/vcad-kernel-particle/src/beam_target.rs
@@ -1,0 +1,181 @@
+//! Beam-on-target D-D yield: the records lane.
+//!
+//! The gas-fusion machine's "interception loss" is a yield *channel* if the
+//! wires are coated in deuterided titanium (TiD): an ion that would have
+//! been a loss instead buries itself in a solid-density deuterium target
+//! and fuses on the way down. The published anchor is the titanium
+//! drive-in D-D generator: **1.9×10⁸ n/s from 7.6 mA at 94 keV**
+//! ([Reijonen et al., Ti drive-in target], see docs/research-log.md).
+//!
+//! Physics: a beam ion of energy `E₀` entering the target loses energy to
+//! electronic stopping and fuses against the bound deuterons with the
+//! Bosch–Hale cross section until it thermalizes. The **thick-target
+//! yield** per incident ion is
+//!
+//! ```text
+//! Y = n_D · ∫₀^{E₀} σ(E) / S(E) dE
+//! ```
+//!
+//! where `n_D` is the target deuteron density and `S(E) = −dE/dx` the
+//! stopping power. Rather than ship an uncertain first-principles stopping
+//! model, this module uses a one-parameter effective stopping calibrated
+//! **once** to the published anchor, then predicts other energies through
+//! the (steep, well-measured) cross-section energy dependence. The
+//! calibration constant and its provenance are public
+//! ([`CALIBRATION`]); a prediction is only ever a cross-section
+//! *ratio* away from a measured datum.
+//!
+//! Scope/honesty: solid-target neutron generators lose deuterium above
+//! ~250 °C (metal-hydride vapor pressure) — the thermal limit is a real
+//! operating ceiling this module does *not* enforce; pair it with the
+//! thermal crate. Beam-target Q is stopping-power-capped at ~10⁻⁴ (most
+//! ions stop without fusing) — this is a records-lane channel, never a
+//! path to gain, and the Q accounting says so.
+
+use crate::xsection::dd_n_sigma_m2;
+
+/// The published calibration anchor.
+#[derive(Debug, Clone, Copy)]
+pub struct Calibration {
+    /// Beam energy of the anchor datum, keV (lab frame).
+    pub energy_kev: f64,
+    /// Beam current, amperes.
+    pub current_a: f64,
+    /// Measured neutron rate, n/s.
+    pub neutron_rate_n_per_s: f64,
+    /// Monatomic-beam fraction assumed in the datum (D⁺ vs D₂⁺/D₃⁺); the
+    /// cited generator ran ~their stated efficiency, folded in here.
+    pub monatomic_fraction: f64,
+}
+
+/// The titanium drive-in D-D generator anchor (Reijonen et al.).
+pub const CALIBRATION: Calibration = Calibration {
+    energy_kev: 94.0,
+    current_a: 7.6e-3,
+    neutron_rate_n_per_s: 1.9e8,
+    monatomic_fraction: 1.0,
+};
+
+/// Effective-stopping thick-target yield **shape**: the cross-section
+/// integral ∫₀^E σ(E') dE' (units m²·keV), assuming stopping power roughly
+/// constant across the fusion-relevant band. Absolute yield is this times
+/// a single calibrated constant (see [`yield_per_ion`]). Trapezoidal in
+/// 1 keV steps — the integrand rises steeply so fine steps matter near E.
+fn sigma_integral_m2_kev(energy_kev: f64) -> f64 {
+    if energy_kev <= 0.0 {
+        return 0.0;
+    }
+    let steps = (energy_kev.ceil() as usize).max(2);
+    let de = energy_kev / steps as f64;
+    let mut acc = 0.0;
+    let mut prev = dd_n_sigma_m2(0.5 * 0.0); // σ at E_cm = 0
+    for k in 1..=steps {
+        let e = k as f64 * de;
+        // Beam-on-stationary-target: E_cm = E_lab / 2.
+        let cur = dd_n_sigma_m2(0.5 * e);
+        acc += 0.5 * (prev + cur) * de;
+        prev = cur;
+    }
+    acc
+}
+
+/// The single calibration constant `C` such that
+/// `Y(E) = C · ∫₀^E σ dE'`, fixed by the anchor:
+/// `C = (rate / (current/e)) / ∫₀^{E_anchor} σ dE'`, in units of
+/// (ions·m⁻²·keV⁻¹) folded with target density and stopping — i.e. it
+/// absorbs `n_D / S`. Recomputed from [`CALIBRATION`] so the anchor is the
+/// single source of truth.
+fn calibration_constant() -> f64 {
+    let ions_per_s = CALIBRATION.current_a * CALIBRATION.monatomic_fraction
+        / crate::constants::ELEMENTARY_CHARGE;
+    let yield_anchor = CALIBRATION.neutron_rate_n_per_s / ions_per_s;
+    yield_anchor / sigma_integral_m2_kev(CALIBRATION.energy_kev)
+}
+
+/// Thick-target D-D neutron yield per incident ion at beam energy
+/// `energy_kev`, calibrated to the published anchor.
+///
+/// This is a *ratio prediction*: at the anchor energy it returns the
+/// measured yield-per-ion by construction; elsewhere it scales by the
+/// cross-section integral (the steep, well-measured energy dependence).
+pub fn yield_per_ion(energy_kev: f64) -> f64 {
+    calibration_constant() * sigma_integral_m2_kev(energy_kev)
+}
+
+/// Neutron rate from a TiD-target beam: `Y(E) · (I·f / e)` n/s.
+///
+/// `monatomic_fraction` folds in the D⁺ vs molecular-ion mix of the real
+/// source (1.0 = ideal atomic beam).
+pub fn neutron_rate_n_per_s(energy_kev: f64, current_a: f64, monatomic_fraction: f64) -> f64 {
+    let ions_per_s = current_a * monatomic_fraction / crate::constants::ELEMENTARY_CHARGE;
+    yield_per_ion(energy_kev) * ions_per_s
+}
+
+/// Beam-target energy gain `Q = fusion power / beam power`.
+///
+/// Each D-D reaction releases 3.27 MeV (D(d,n)³He branch, both products);
+/// beam power is `I·V`. Stopping-power-capped at ~10⁻⁴ — the honest
+/// records-lane ceiling.
+pub fn q_beam_target(energy_kev: f64) -> f64 {
+    let e_ddn_j = 3.27e6 * crate::constants::ELEMENTARY_CHARGE;
+    let fusion_w_per_ion = yield_per_ion(energy_kev) * e_ddn_j;
+    let beam_w_per_ion = energy_kev * 1e3 * crate::constants::ELEMENTARY_CHARGE;
+    fusion_w_per_ion / beam_w_per_ion
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reproduces_the_calibration_anchor() {
+        // By construction, exact at the anchor.
+        let rate = neutron_rate_n_per_s(
+            CALIBRATION.energy_kev,
+            CALIBRATION.current_a,
+            CALIBRATION.monatomic_fraction,
+        );
+        assert!(
+            (rate - CALIBRATION.neutron_rate_n_per_s).abs() / CALIBRATION.neutron_rate_n_per_s
+                < 1e-9,
+            "anchor must reproduce exactly: {rate:.3e} vs {:.3e}",
+            CALIBRATION.neutron_rate_n_per_s
+        );
+    }
+
+    #[test]
+    fn yield_rises_steeply_but_saturates_relative_to_energy() {
+        // The cross-section integral grows fast through the fusor band…
+        assert!(yield_per_ion(94.0) > 10.0 * yield_per_ion(40.0));
+        // …and is monotonic.
+        let mut last = 0.0;
+        for e in [10.0, 30.0, 60.0, 94.0, 150.0] {
+            let y = yield_per_ion(e);
+            assert!(y > last, "yield must rise with energy at {e} keV");
+            last = y;
+        }
+    }
+
+    #[test]
+    fn q_is_capped_far_below_unity() {
+        // The whole honesty of the records lane: beam-target Q is tiny.
+        for e in [40.0, 94.0, 150.0, 300.0] {
+            let q = q_beam_target(e);
+            assert!(
+                q < 1e-3,
+                "beam-target Q must stay << 1 (stopping-power-capped): {q:.2e} at {e} keV"
+            );
+        }
+    }
+
+    #[test]
+    fn beats_the_gas_machine_at_the_same_current() {
+        // 30 mA at 100 keV onto TiD vs the gas ceiling (~15-17x record ~
+        // 8e7 n/s). Solid-density target must win by orders.
+        let tid = neutron_rate_n_per_s(100.0, 0.030, 1.0);
+        assert!(
+            tid > 5e8,
+            "TiD at 30 mA/100 keV should reach ~1e9 n/s (>>gas ceiling ~8e7): {tid:.3e}"
+        );
+    }
+}

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -35,6 +35,7 @@
 //! reported in electron-volts.
 
 pub mod adjoint;
+pub mod beam_target;
 pub mod confinement;
 pub mod device;
 pub mod elliptic;
@@ -42,6 +43,7 @@ pub mod field;
 pub mod fom;
 pub mod optimize;
 pub mod poisson;
+pub mod power;
 pub mod receipt;
 pub mod space_charge;
 pub mod spec;

--- a/crates/vcad-kernel-particle/src/lib.rs
+++ b/crates/vcad-kernel-particle/src/lib.rs
@@ -43,6 +43,7 @@ pub mod field;
 pub mod fom;
 pub mod optimize;
 pub mod poisson;
+pub mod pops;
 pub mod power;
 pub mod receipt;
 pub mod space_charge;

--- a/crates/vcad-kernel-particle/src/pops.rs
+++ b/crates/vcad-kernel-particle/src/pops.rs
@@ -1,0 +1,168 @@
+//! POPS readiness: is the well harmonic enough to phase-lock?
+//!
+//! POPS (the Periodically Oscillating Plasma Sphere) compresses an IEC
+//! core by driving the ion cloud on resonance so every ion collapses to
+//! center in phase — 10⁴ transient density in 1D PIC (see the research
+//! log). The physics gate is a **harmonic** well: only if the restoring
+//! force is ∝ r does every ion bounce at the *same* frequency regardless
+//! of amplitude, so one drive frequency phase-locks the whole population.
+//! Real IEC wells flatten away from center → bounce frequency falls with
+//! amplitude → the cloud decoheres and no coherent compression happens.
+//!
+//! This module measures that directly: trace on-axis ions from a ladder of
+//! amplitudes, recover each one's bounce frequency, and report the
+//! **harmonicity** = min/max frequency ∈ (0, 1]. 1.0 is a perfect
+//! oscillator (POPS-ready); lower is anharmonic. Harmonicity is exactly
+//! the figure of merit an electrode optimizer maximizes — "shape the well
+//! to be quadratic" — which is a sentence only a differentiable
+//! field-solver can act on.
+//!
+//! Scope: vacuum well (no space charge, which itself flattens the well —
+//! an anharmonicity the neutralized-cloud work would add). Single-particle
+//! bounce, on the wire-free axis of a ring device. M0 caveats apply.
+
+use crate::device::Device;
+use crate::field::FieldMap;
+use crate::poisson::{solve, Solution, SolveError, SolveOptions};
+use crate::trace::{TraceOptions, Tracer, DEUTERON};
+
+/// The POPS-readiness report for one device.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HarmonicityReport {
+    /// `(launch z in mm, bounce frequency in Hz)` for each amplitude that
+    /// produced a clean oscillation.
+    pub frequencies: Vec<(f64, f64)>,
+    /// min/max bounce frequency across amplitudes ∈ (0, 1]. 1.0 = harmonic
+    /// (POPS-ready); lower = anharmonic (decoheres under a single drive).
+    pub harmonicity: f64,
+    /// Fractional bounce-frequency droop from the smallest to the largest
+    /// amplitude, `1 − f(max)/f(min)` — the physical "well flattens with
+    /// amplitude" number (positive when it flattens).
+    pub droop: f64,
+}
+
+/// Bounce frequency of an on-axis ion launched at rest at `z0_m`, Hz, from
+/// its core-crossing count (two core entries per oscillation). `None` if
+/// the ion did not complete at least one full oscillation (hit a wire,
+/// escaped, or censored before two core passes).
+pub fn axial_bounce_frequency(
+    device: &Device,
+    sol: &Solution,
+    topts: &TraceOptions,
+    z0_m: f64,
+) -> Option<f64> {
+    let fields = FieldMap::new(device, sol);
+    let tracer = Tracer::new(device, &fields, sol, *topts);
+    let out = tracer.trace_from(DEUTERON, [0.0, 0.0, z0_m], [0.0, 0.0, 0.0]);
+    if out.core_passes < 2 || out.time_s <= 0.0 {
+        return None;
+    }
+    Some(out.core_passes as f64 / (2.0 * out.time_s))
+}
+
+/// Measure the well's harmonicity from a ladder of on-axis launch heights
+/// (as fractions of the chamber half-height).
+pub fn harmonicity(
+    device: &Device,
+    nr: usize,
+    nz: usize,
+    sopts: &SolveOptions,
+    topts: &TraceOptions,
+    amplitude_fractions: &[f64],
+) -> Result<HarmonicityReport, SolveError> {
+    let sol = solve(device, nr, nz, sopts)?;
+    let half_h = device.chamber_half_height_mm * 1e-3;
+
+    let mut frequencies = Vec::new();
+    for &frac in amplitude_fractions {
+        let z0 = frac * half_h;
+        if let Some(f) = axial_bounce_frequency(device, &sol, topts, z0) {
+            frequencies.push((z0 * 1e3, f));
+        }
+    }
+
+    let (harmonicity, droop) = if frequencies.len() >= 2 {
+        let fmin = frequencies
+            .iter()
+            .map(|(_, f)| *f)
+            .fold(f64::INFINITY, f64::min);
+        let fmax = frequencies.iter().map(|(_, f)| *f).fold(0.0_f64, f64::max);
+        // Droop: smallest-amplitude f vs largest-amplitude f.
+        let f_small = frequencies.first().map(|(_, f)| *f).unwrap_or(0.0);
+        let f_large = frequencies.last().map(|(_, f)| *f).unwrap_or(0.0);
+        let droop = if f_small > 0.0 {
+            1.0 - f_large / f_small
+        } else {
+            0.0
+        };
+        (fmin / fmax.max(1e-30), droop)
+    } else {
+        (0.0, 0.0)
+    };
+
+    Ok(HarmonicityReport {
+        frequencies,
+        harmonicity,
+        droop,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn budget() -> TraceOptions {
+        TraceOptions {
+            max_passes: 20,
+            time_budget_factor: 30.0,
+            ..TraceOptions::default()
+        }
+    }
+
+    #[test]
+    fn well_is_measurably_anharmonic() {
+        // A two-ring IEC well flattens with amplitude: harmonicity < 1 and
+        // the droop is positive (bigger swings bounce slower).
+        let device = Device::shielded_two_ring(120.0, 40.0, 22.0, 4.0, -20_000.0, 0.0);
+        let r = harmonicity(
+            &device,
+            81,
+            161,
+            &SolveOptions::default(),
+            &budget(),
+            &[0.2, 0.4, 0.6, 0.8],
+        )
+        .unwrap();
+        assert!(
+            r.frequencies.len() >= 2,
+            "must measure at least two amplitudes: {:?}",
+            r.frequencies
+        );
+        assert!(
+            r.harmonicity > 0.0 && r.harmonicity < 1.0,
+            "a real IEC well is anharmonic: {:.3}",
+            r.harmonicity
+        );
+    }
+
+    #[test]
+    fn frequencies_are_physical() {
+        // Deuteron bouncing in a ~20 kV well over ~10 cm: ~MHz.
+        let device = Device::shielded_two_ring(120.0, 40.0, 22.0, 4.0, -20_000.0, 0.0);
+        let r = harmonicity(
+            &device,
+            81,
+            161,
+            &SolveOptions::default(),
+            &budget(),
+            &[0.3, 0.6],
+        )
+        .unwrap();
+        for (_, f) in &r.frequencies {
+            assert!(
+                *f > 1e5 && *f < 1e9,
+                "bounce frequency must be ~MHz: {f:.3e}"
+            );
+        }
+    }
+}

--- a/crates/vcad-kernel-particle/src/power.rs
+++ b/crates/vcad-kernel-particle/src/power.rs
@@ -1,0 +1,167 @@
+//! The power ledger: an honest Q for the neutralized machine.
+//!
+//! The virtual-cathode result (ion yield ×8.4 at 10 A electron current)
+//! is a *yield* claim. A *Q* claim needs the full input-power ledger, and
+//! the electron cloud is not free: in steady state the injector must
+//! replace every electron lost through a cusp, and each carries out ~the
+//! well energy it fell through. This module prices every term so the
+//! neutralization lane can never quote a yield gain without its power cost.
+//!
+//! All terms are explicit and signed by their source (measured trace
+//! quantities or supplied hardware numbers) — nothing is defaulted. The
+//! electron sustaining current is derived from the **measured** loss rate
+//! (trapped charge / confinement time); because confinement times here are
+//! budget-capped *lower bounds*, the loss rate is an upper bound and the
+//! resulting Q is **conservative** (the honest direction).
+
+/// Inputs to the power ledger. Every field is a measured or supplied
+/// number with a stated origin — see [`PowerLedger::evaluate`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LedgerInputs {
+    /// D-D neutron rate of the machine, n/s (from the ion traces).
+    pub neutron_rate_n_per_s: f64,
+    /// Ion beam current, A.
+    pub ion_current_a: f64,
+    /// Accelerating voltage, V (absolute).
+    pub voltage_v: f64,
+    /// Trapped electron charge in flight, C (from the electron dwell).
+    pub trapped_electron_charge_c: f64,
+    /// Mean electron confinement time, s (budget-capped lower bound →
+    /// conservative loss rate).
+    pub electron_confinement_time_s: f64,
+    /// Mean energy a lost electron carries out, eV (≈ well depth it fell
+    /// through). If 0, defaults to the full `voltage_v`.
+    pub electron_loss_energy_ev: f64,
+    /// Ohmic/cryo power to sustain the shield magnet, W. The dominant term
+    /// at MA·turn scale — supply it from the em + thermal crates; 0 means
+    /// "not yet priced" and the ledger says so.
+    pub magnet_power_w: f64,
+}
+
+/// The evaluated ledger.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PowerLedger {
+    /// Fusion power, W (both D-D branches implied by the n-branch rate:
+    /// the p-branch adds ~equal energy, folded in at 7.3 MeV/neutron).
+    pub fusion_power_w: f64,
+    /// Ion beam power, W.
+    pub ion_beam_power_w: f64,
+    /// Electron sustaining power, W (loss current × loss energy).
+    pub electron_sustain_power_w: f64,
+    /// Magnet power, W (as supplied).
+    pub magnet_power_w: f64,
+    /// Total input power, W.
+    pub input_power_w: f64,
+    /// `fusion_power_w / input_power_w`.
+    pub q: f64,
+    /// Whether the magnet term was priced (false = Q is an over-estimate
+    /// missing the dominant cost).
+    pub magnet_priced: bool,
+}
+
+/// Energy per D-D reaction counting both branches, joules. The measured
+/// quantity is the *neutron* rate (n-branch); the p-branch (T + p, 4.03
+/// MeV) fires at ~equal probability, so total fusion energy ≈ 7.3 MeV per
+/// detected neutron.
+const E_PER_NEUTRON_J: f64 = 7.3e6 * crate::constants::ELEMENTARY_CHARGE;
+
+impl LedgerInputs {
+    /// Evaluate the ledger.
+    pub fn evaluate(&self) -> PowerLedger {
+        let fusion_power_w = self.neutron_rate_n_per_s * E_PER_NEUTRON_J;
+        let ion_beam_power_w = self.ion_current_a * self.voltage_v;
+
+        let loss_energy_ev = if self.electron_loss_energy_ev > 0.0 {
+            self.electron_loss_energy_ev
+        } else {
+            self.voltage_v
+        };
+        let electron_sustain_power_w = if self.electron_confinement_time_s > 0.0 {
+            let loss_current_a =
+                self.trapped_electron_charge_c.abs() / self.electron_confinement_time_s;
+            loss_current_a * loss_energy_ev
+        } else {
+            0.0
+        };
+
+        let input_power_w = ion_beam_power_w + electron_sustain_power_w + self.magnet_power_w;
+        PowerLedger {
+            fusion_power_w,
+            ion_beam_power_w,
+            electron_sustain_power_w,
+            magnet_power_w: self.magnet_power_w,
+            input_power_w,
+            q: if input_power_w > 0.0 {
+                fusion_power_w / input_power_w
+            } else {
+                0.0
+            },
+            magnet_priced: self.magnet_power_w > 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> LedgerInputs {
+        LedgerInputs {
+            neutron_rate_n_per_s: 8.0e7,
+            ion_current_a: 0.030,
+            voltage_v: 100_000.0,
+            trapped_electron_charge_c: 1.0e-9,
+            electron_confinement_time_s: 1.0e-7,
+            electron_loss_energy_ev: 0.0,
+            magnet_power_w: 0.0,
+        }
+    }
+
+    #[test]
+    fn q_is_tiny_and_input_dominated_by_beam() {
+        let l = base().evaluate();
+        assert!(
+            l.q > 0.0 && l.q < 1e-6,
+            "gas-machine Q must be tiny: {:.2e}",
+            l.q
+        );
+        assert!(l.ion_beam_power_w > 0.0);
+        assert!(!l.magnet_priced, "unpriced magnet must be flagged");
+    }
+
+    #[test]
+    fn electron_sustain_scales_with_loss_rate() {
+        let mut a = base();
+        a.trapped_electron_charge_c = 1.0e-6; // heavy cloud
+        a.electron_confinement_time_s = 1.0e-8; // leaky
+        let l = a.evaluate();
+        // Loss current 1e-6/1e-8 = 100 A, × 100 kV = 10 MW sustain.
+        assert!(
+            (l.electron_sustain_power_w - 1.0e7).abs() / 1.0e7 < 1e-6,
+            "sustain power = loss current × well: {:.3e}",
+            l.electron_sustain_power_w
+        );
+        // A leaky heavy cloud tanks Q vs the beam-only case.
+        assert!(l.q < base().evaluate().q);
+    }
+
+    #[test]
+    fn magnet_power_is_counted_when_priced() {
+        let mut a = base();
+        a.magnet_power_w = 5.0e4;
+        let l = a.evaluate();
+        assert!(l.magnet_priced);
+        assert!(l.input_power_w >= 5.0e4);
+        assert!(l.q < base().evaluate().q, "magnet cost must lower Q");
+    }
+
+    #[test]
+    fn confinement_time_governs_the_penalty() {
+        // Better confinement (longer τ) → lower loss current → higher Q.
+        let mut leaky = base();
+        leaky.electron_confinement_time_s = 1.0e-8;
+        let mut tight = base();
+        tight.electron_confinement_time_s = 1.0e-6;
+        assert!(tight.evaluate().q > leaky.evaluate().q);
+    }
+}

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -677,3 +677,37 @@ target.
 electron sustain + magnet. Key physics: in steady state electron sustain
 power = I_e · V (the injector replaces every cusp loss). `sustained_q`
 verdict logged next.
+
+## 2026-07-17 — the honest Q verdict: neutralization is a rate lever, not a Q lever
+
+`sustained_q` at 100 kV / 30 mA ions; electron confinement τ = 0.88 µs
+(enhancement **704×**, 83% survivors — strong cusp trapping confirmed at
+full field). Ledger vs electron current:
+
+| e-current | neutron n/s | vs record | P_fusion | P_e-sustain | Q |
+|---|---|---|---|---|---|
+| 30 mA | 8.4×10⁷ | 17× | 9.8×10⁻⁵ W | 3 kW | **1.6×10⁻⁸** |
+| 1 A | 9.4×10⁷ | 19× | 1.1×10⁻⁴ W | 100 kW | 1.1×10⁻⁹ |
+| 3 A | 1.7×10⁸ | 33× | 2.0×10⁻⁴ W | 300 kW | 6.4×10⁻¹⁰ |
+| 10 A | 7.0×10⁸ | **140×** | 8.2×10⁻⁴ W | 1 MW | 8.2×10⁻¹⁰ |
+
+- **The decisive result**: the virtual cathode raises neutron RATE up to
+  140× the record, but **Q falls ~20× as the cloud grows** — Q is *best*
+  at the smallest electron current. Electron sustain power (I_e · V)
+  dominates the input the moment I_e exceeds the ion current, and it grows
+  faster than fusion power. And the magnet term is still unpriced (MA·turn
+  scale — needs the em+thermal crates), so these Q's are over-estimates.
+- **Strategic redirect**: neutralization belongs to the records and
+  physics lanes (rate, density, the polywell story), **not** the Q lane.
+  The Q lane's real lever is **direct energy recovery on the losses**
+  (venetian-blind, 59–75% demonstrated) — recovering the ion/electron
+  power that currently exits to the walls. The ledger is now built to
+  price exactly that: add a recovery-efficiency term on the loss channels.
+- Cross-check: beam-target Q (~1.6×10⁻⁷) is the *highest* Q of any config
+  we've priced — an order above the best neutralized-gas Q — consistent
+  with "solid density beats everything on yield-per-input."
+
+Arc close: the Q-lane triple priced all three roads honestly. Records:
+197× (dial optimum), 140× (virtual cathode), 179× (bare TiD). Physics:
+harmonicity 0.545, optimizable. Q: no lever here moves it — direct
+recovery is the next module, and the ledger is ready for it.

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -637,3 +637,43 @@ AC, adjoint) plus the WASM `DeviceSpec`. Branch
   the triode/saturation boundary).
 - Next on the M1 ladder: transient adjoint, then the netlist-from-ecad
   seam so schematics simulate without re-entry.
+
+## 2026-07-17 — the Q-lane triple: records 197×, POPS quantified, honest Q (PR #575)
+
+Three lanes built on one branch, following the virtual-cathode arc.
+
+**Lane C — TiD beam-target (records lane).** `beam_target` calibrates
+thick-target D-D yield once to the published Ti drive-in anchor (1.9×10⁸
+n/s at 7.6 mA / 94 keV) and predicts by cross-section ratio. `records_dial`
+result at 100 kV / 30 mA onto TiD-coated rings:
+
+| shield A·t | interception | beam-target n/s | gas n/s | total | vs record |
+|---|---|---|---|---|---|
+| 0 | 1.00 | 8.9×10⁸ | 2.2×10⁷ | 9.2×10⁸ | 183× |
+| 160 k | 0.92 | 8.2×10⁸ | 1.6×10⁸ | **9.8×10⁸** | **197×** |
+| 400 k | 0.70 | 6.2×10⁸ | 2.0×10⁸ | 8.3×10⁸ | 166× |
+| 1.17 M | 0.08 | 7.5×10⁷ | 2.1×10⁸ | 2.8×10⁸ | 57× |
+
+- **The dial has a combined-channel optimum**: total yield peaks at a
+  *middle* shield current (160 kA·t → 197× the amateur record), where
+  residual interception still feeds the solid-density TiD target while the
+  shield boosts gas recirculation. No other machine has this knob.
+- Beam-target Q ≈ 1.6×10⁻⁷ — correctly tiny (stopping-power-capped). This
+  is a record/neutron-source lane, never a gain lane, and the module says
+  so.
+
+**Lane B — POPS harmonic well (physics lane).** `pops` measures the well's
+harmonicity (min/max bounce frequency across launch amplitudes). Baseline
+two-ring well: **harmonicity 0.545, 44% frequency droop** (big-amplitude
+ions bounce 44% slower — strongly anharmonic, so a single drive can't
+phase-lock the population → POPS-blocked). `pops_harmonic_well`: the
+optimizer maximizes harmonicity over electrode geometry (+9% with two
+knobs, 0.545→0.593); large gains need more electrode freedom. The finding:
+harmonicity is measurable, optimizable, and is now the concrete FoM for
+POPS electrode design — the thing only a differentiable field-solver can
+target.
+
+**Lane A — power ledger (honest Q).** `power` prices fusion vs ion beam +
+electron sustain + magnet. Key physics: in steady state electron sustain
+power = I_e · V (the injector replaces every cusp loss). `sustained_q`
+verdict logged next.


### PR DESCRIPTION
## What — three lanes, one branch

Following the merged Orbitron arc (virtual cathode ignites → 138× record, two asterisks). This PR builds all three lanes the arc pointed to.

### Lane C — TiD beam-target (the records lane)
`beam_target`: thick-target D-D yield calibrated **once** to the published titanium drive-in anchor (1.9×10⁸ n/s at 7.6 mA / 94 keV), predicting other energies by the steep, well-measured cross-section integral — a prediction is always one σ-ratio from a measured datum. `q_beam_target` confirms the honest cap (~1.6×10⁻⁷ — records lane, never gain).

`records_dial` example: the shield current **dials** between beam-target (low shield, high interception onto TiD) and gas recirculation (high shield). Total n/s is maximized at a *middle* shield — **197× the amateur record at 160 kA·t**, a combined-channel optimum only the dial exposes. Unshielded TiD alone is 179×.

### Lane A — power ledger (the honest Q)
`power`: the full input-power ledger for the neutralized machine — fusion vs ion beam + electron sustain (measured loss rate × well) + magnet. Electron sustain from budget-capped confinement is conservative (lower-bound Q); the unpriced magnet term is flagged, never silently zero. `sustained_q` example wires a virtual-cathode run + electron confinement through it.

### Lane B — POPS harmonic well (the physics lane)
`pops`: measures the well's **harmonicity** (min/max bounce frequency across amplitudes) — the physics gate for POPS coherent compression. Baseline two-ring well: 0.545, with a 44% bounce-frequency droop — strongly anharmonic (POPS-blocked), now quantified. `pops_harmonic_well` example: the optimizer maximizes harmonicity over electrode geometry — "design a quadratic well," a request only a differentiable field-solver can pose (+9% with two knobs; large gains need more electrode freedom).

## Verification

72 tests green; clippy `-D warnings` clean on all targets; fmt clean. Research-log entries land with the example outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)