### PR TITLE
test(mcp): fix flaky route_nets coil timeout in ecad.test.ts

### DIFF
--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -2463,6 +2463,14 @@ describe("route_nets idempotency", () => {
     expect(r.stale_nets_cleared).toBeUndefined();
   });
 
+  // Timeout raised above the 5s default: this is the only case in the suite that
+  // routes a board with a dense free coil present (~24 spiral segments become
+  // router obstacles), so each of the two route_nets passes runs the kernel
+  // autorouter ~200× longer than a pad-only board (~0.9s vs ~4ms locally, ~1.8s
+  // total). The autorouter is unchanged; the cost is inherent to the coil-as-
+  // obstacle case and sits near the 5s edge, so it flakes under loaded CI. The
+  // assertion is about correctness (coil copper survives the stale sweep), not
+  // speed — give it headroom rather than let wall-clock flake the correctness check.
   it("the stale sweep never rips coil/winding copper (free spiral, no pads)", async () => {
     const id = await buildBoard();
     // A standalone coil on its own net — a free spiral whose terminals dangle by
@@ -2491,7 +2499,7 @@ describe("route_nets idempotency", () => {
     const board = getPcbBoard(getSession(id));
     expect(board.traces.filter((t) => t.net === "COIL").length).toBe(coilTraces);
     expect((r.stale_nets_cleared as string[] | undefined) ?? []).not.toContain("COIL");
-  });
+  }, 20000);
 });
 
 describe("schematic label diagnostics", () => {


### PR DESCRIPTION
## What

Raise the vitest `testTimeout` to 20s for the `route_nets idempotency > the stale sweep never rips coil/winding copper (free spiral, no pads)` test in `packages/mcp/src/__tests__/ecad.test.ts`.

## Why

This test was failing consistently on `main` CI with `Test timed out in 5000ms`. It's a pre-existing flake, not caused by any single feature branch — it started failing at `e22ae3ff` (#574 fillet torture track) and passes on the commit before (`54efba18`).

Investigation:
- Profiled the test step-by-step: the entire cost is the two `route_nets` calls (~0.9s each). `buildBoard`/`addCoil` are <10ms.
- Sibling tests in the same block that route **without** a coil finish in 3–8ms. This is the only case that routes a board with a dense free coil present (~24 spiral segments become router obstacles), so the kernel autorouter runs ~200× longer (~1.8s total locally).
- The autorouter is **unchanged**: the Rust diff between `54efba18..e22ae3ff` is entirely fillet/tessellate/kernel-lib. #574 only recompiled the kernel WASM (+44KB), which marginally slowed instantiation/execution and tipped a borderline test past the 5s limit under loaded parallel CI.

Since `route_nets` did not algorithmically regress and the assertion is about **correctness** (coil copper survives the stale sweep) rather than speed, the honest fix is to give this inherently-expensive case headroom rather than reworking the autorouter (which would require a WASM rebuild disproportionate to a timeout flake).

## Reviewer notes

- One-line change (`}, 20000)`) plus an explanatory comment above the test.
- Verified locally: the full `route_nets idempotency` block passes (7 passed), coil test at ~1.8s, well under the 20s ceiling.
- No kernel-wasm artifacts touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)