### PR TITLE
test(mcp): fix CI-flaky timeout on the coil-rip route_nets test

### DIFF
--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -2491,7 +2491,11 @@ describe("route_nets idempotency", () => {
     const board = getPcbBoard(getSession(id));
     expect(board.traces.filter((t) => t.net === "COIL").length).toBe(coilTraces);
     expect((r.stale_nets_cleared as string[] | undefined) ?? []).not.toContain("COIL");
-  });
+    // A 4-turn coil (20+ spiral traces) routed twice is uniquely heavy — ~1.8 s
+    // locally, ~3.6 s under suite load, and it timed out at 5.2 s on the shared
+    // CI runner. Its siblings finish in single-digit ms; only this one needs the
+    // headroom. 20 s is far above any real run yet still catches a genuine hang.
+  }, 20_000);
 });
 
 describe("schematic label diagnostics", () => {


### PR DESCRIPTION
## What

`main`'s CI has been red since the fillet PR #574 — the TypeScript job fails on one test:

```
route_nets idempotency > the stale sweep never rips coil/winding copper (free spiral, no pads)
Error: Test timed out in 5000ms.
```

This blocks **every** open PR (they all inherit main's red on merge).

## Root cause: a slow test, not a logic bug

The test builds a **4-turn coil** (20+ spiral traces) and runs **two full `routeNets` passes** over that coil-laden board. Timings:

| where | duration |
|---|---|
| isolated (local, Apple Silicon) | ~1.8 s |
| full suite under load (local) | ~3.6 s |
| **shared CI runner (linux x64)** | **5.17 s → timeout** |

Its five sibling `route_nets idempotency` tests all finish in **3–24 ms** — only this one is heavy enough to matter. It's not an assertion failure (the stale sweep correctly skips `<2`-pad coil nets — verified), and it doesn't reproduce on faster hardware; the CI runner is simply slow enough to cross vitest's **5 s default** for a legitimately expensive end-to-end routing test.

## Fix

Give this one test a **20 s timeout** — 11× its isolated runtime and ~4× the observed CI time, so there's ample headroom, while a genuine hang would still fail. One line + an explanatory comment; no product code touched.

Verified: the test passes, `tsc --noEmit` on `@vcad/mcp` is clean.

Unblocks main (and thereby [#579](https://github.com/ecto/vcad/pull/579) and any other open PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)