### PR TITLE
Endgame arsenal: true shove, complete window router with proofs, escape hardening (first decision-procedure conversion)

### DIFF
--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -2336,12 +2336,15 @@ fn joint_window_repair(
             // Last resort for a small surviving clique: the COMPLETE window
             // router — either a joint routing the heuristics missed, or a
             // proof (named bottleneck cut) that none exists at these rules.
-            if !lost.is_empty() && lost.len() <= 6 {
+            if !lost.is_empty() && lost.len() <= 10 {
                 let win_w = gw.1[0] - gw.0[0];
                 let win_h = gw.1[1] - gw.0[1];
                 if win_w <= 20.0 && win_h <= 20.0 {
                     let copper = copper_layers(pcb);
-                    let cl: Vec<PcbLayer> = copper.into_iter().take(4).collect();
+                    // All copper layers: the flow pre-pass stays cheap and the
+                    // DFS budget-caps honestly (BudgetExhausted, never a fake
+                    // proof) if 10 layers is too much for exhaustion.
+                    let cl: Vec<PcbLayer> = copper;
                     match route_window_complete(
                         session,
                         (Vec2::new(gw.0[0], gw.0[1]), Vec2::new(gw.1[0], gw.1[1])),

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -21,6 +21,7 @@ use crate::ratsnest::{compute_ratsnest, NetConnection, Netlist, NetlistNet, Rats
 use crate::session::{RouteSession, SpanId};
 use crate::spatial::{point_in_polygon, CopperElement, CopperGeom};
 
+use super::complete::{route_window_complete, CompleteOutcome};
 use super::congestion::Congestion;
 use super::escape;
 use super::global::plan_corridors;
@@ -228,19 +229,19 @@ type Pass = (RouteSession, Vec<Placed>, Vec<Conn>);
 /// A connection that has been routed, plus the session spans it occupies —
 /// enough to rip it back out and re-route it.
 #[derive(Clone)]
-struct Placed {
-    net: String,
-    from: Vec2,
-    to: Vec2,
-    width: f64,
+pub(super) struct Placed {
+    pub(super) net: String,
+    pub(super) from: Vec2,
+    pub(super) to: Vec2,
+    pub(super) width: f64,
     /// Routed segments, each on its own copper layer (the 3D maze changes
     /// layers mid-route).
-    segments: Vec<(Vec2, Vec2, PcbLayer)>,
+    pub(super) segments: Vec<(Vec2, Vec2, PcbLayer)>,
     /// Fan-out / dog-bone stubs that escape a fine-pitch pad to its via, each on
     /// its own copper layer (the pad's layer). Emitted as traces, not on `layer`.
-    stubs: Vec<(Vec2, Vec2, PcbLayer)>,
-    via_pts: Vec<(Vec2, PcbLayer, PcbLayer)>,
-    spans: Vec<SpanId>,
+    pub(super) stubs: Vec<(Vec2, Vec2, PcbLayer)>,
+    pub(super) via_pts: Vec<(Vec2, PcbLayer, PcbLayer)>,
+    pub(super) spans: Vec<SpanId>,
 }
 
 /// Route every unrouted net on `pcb` (optionally restricted to `nets_filter`).
@@ -1003,7 +1004,7 @@ fn try_route(
     net: &str,
     from: Vec2,
     to: Vec2,
-    placed: &[Placed],
+    placed: &mut [Placed],
     cong: &Congestion,
     use_push_shove: bool,
     max_expansions: usize,
@@ -1026,7 +1027,7 @@ fn try_route(
     // Both direct maze attempts (coarse + fine retry) failed. If an endpoint
     // sits inside a dense pin field (BGA / fine-pitch lattice), plan a
     // flow-based escape out of the field and re-search from the egress point.
-    try_route_escape(
+    if let Some(p) = try_route_escape(
         session,
         pcb,
         width,
@@ -1036,6 +1037,22 @@ fn try_route(
         placed,
         cong,
         use_push_shove,
+        max_expansions,
+    ) {
+        return Some(p);
+    }
+    // Last resort — true shove: displace the routed traces blocking the
+    // corridor sideways (bounded, transactional) instead of ripping them,
+    // then re-search. A shoved victim stays routed in its new position.
+    super::shove::try_route_shove(
+        session,
+        pcb,
+        width,
+        net,
+        from,
+        to,
+        placed,
+        cong,
         max_expansions,
     )
 }
@@ -1139,7 +1156,7 @@ fn try_route_escape(
 /// wants to place, valid against the session it was searched on. Committing
 /// re-validates against the *current* session, so candidates can be searched
 /// in parallel against a frozen snapshot and committed sequentially.
-struct Candidate {
+pub(super) struct Candidate {
     net: String,
     from: Vec2,
     to: Vec2,
@@ -1151,7 +1168,7 @@ struct Candidate {
 /// The pure-search half of [`try_route`]: find a clearance-legal route
 /// against `session` without mutating anything.
 #[allow(clippy::too_many_arguments)]
-fn search_route(
+pub(super) fn search_route(
     session: &RouteSession,
     pcb: &Pcb,
     width: f64,
@@ -1292,7 +1309,7 @@ fn search_route(
 /// *current* session (which may have grown since the search) and commit it.
 /// Returns `None` — mutating nothing — if any of its copper is no longer
 /// legal; the caller re-searches or reports the connection unrouted.
-fn validate_and_commit(
+pub(super) fn validate_and_commit(
     session: &mut RouteSession,
     pcb: &Pcb,
     cand: Candidate,
@@ -1810,7 +1827,7 @@ const ESCAPE_RINGS: usize = 10;
 const FINE_PITCH_MM: f64 = 0.65;
 
 /// Commit a trace segment span on `layer`, returning its [`SpanId`].
-fn commit_seg(
+pub(super) fn commit_seg(
     session: &mut RouteSession,
     net: &str,
     a: Vec2,
@@ -1840,7 +1857,7 @@ fn commit_stub(
 }
 
 /// Commit a via as a disc on every copper layer it spans (a through via).
-fn commit_via(
+pub(super) fn commit_via(
     session: &mut RouteSession,
     net: &str,
     p: Vec2,
@@ -1870,7 +1887,7 @@ fn rollback(session: &mut RouteSession, spans: &[SpanId]) {
 }
 
 /// Copper layers present in the stackup, top → bottom (FCu/BCu fallback).
-fn copper_layers(pcb: &Pcb) -> Vec<PcbLayer> {
+pub(super) fn copper_layers(pcb: &Pcb) -> Vec<PcbLayer> {
     let v: Vec<PcbLayer> = pcb
         .stackup
         .layers
@@ -2316,6 +2333,64 @@ fn joint_window_repair(
                 &mut fail_cache,
                 &HashMap::new(),
             ));
+            // Last resort for a small surviving clique: the COMPLETE window
+            // router — either a joint routing the heuristics missed, or a
+            // proof (named bottleneck cut) that none exists at these rules.
+            if !lost.is_empty() && lost.len() <= 6 {
+                let win_w = gw.1[0] - gw.0[0];
+                let win_h = gw.1[1] - gw.0[1];
+                if win_w <= 20.0 && win_h <= 20.0 {
+                    let copper = copper_layers(pcb);
+                    let cl: Vec<PcbLayer> = copper.into_iter().take(4).collect();
+                    match route_window_complete(
+                        session,
+                        (Vec2::new(gw.0[0], gw.0[1]), Vec2::new(gw.1[0], gw.1[1])),
+                        &cl,
+                        &lost,
+                        width,
+                        2_000_000,
+                    ) {
+                        CompleteOutcome::Routed(paths) => {
+                            let mut still_lost = Vec::new();
+                            for (conn, segs) in lost.drain(..).zip(paths) {
+                                // Vias sit at shared endpoints of consecutive
+                                // segments on different layers (adjacent span).
+                                let mut vias = Vec::new();
+                                for w2 in segs.windows(2) {
+                                    if w2[0].2 != w2[1].2 {
+                                        vias.push((w2[0].1, w2[0].2, w2[1].2));
+                                    }
+                                }
+                                let cand = Candidate {
+                                    net: conn.0.clone(),
+                                    from: conn.1,
+                                    to: conn.2,
+                                    width: session.width_for(&conn.0, width),
+                                    segments: segs,
+                                    vias,
+                                };
+                                match validate_and_commit(session, pcb, cand, placed) {
+                                    Some(p) => {
+                                        log::info!("complete window: jointly routed {}", p.net);
+                                        placed.push(p);
+                                    }
+                                    None => still_lost.push(conn),
+                                }
+                            }
+                            lost = still_lost;
+                        }
+                        CompleteOutcome::ProvedInfeasible { reason } => {
+                            log::warn!(
+                                "complete window PROOF: {} connection(s) infeasible at current rules — {reason}",
+                                lost.len()
+                            );
+                        }
+                        CompleteOutcome::BudgetExhausted => {
+                            log::debug!("complete window: budget exhausted, unknown");
+                        }
+                    }
+                }
+            }
             if placed.len() <= placed_before {
                 // Net-negative (or neutral): roll back the entire window.
                 *session = session_snapshot;
@@ -2369,7 +2444,7 @@ fn netlist_from_pads(pcb: &Pcb) -> Netlist {
     }
 }
 
-fn dist(a: Vec2, b: Vec2) -> f64 {
+pub(super) fn dist(a: Vec2, b: Vec2) -> f64 {
     ((a.x - b.x).powi(2) + (a.y - b.y).powi(2)).sqrt()
 }
 
@@ -2574,7 +2649,7 @@ mod tests {
             "S",
             from,
             to,
-            &[],
+            &mut Vec::new(),
             &cong,
             false,
             budget,
@@ -3292,5 +3367,243 @@ mod tests {
         assert_eq!(a.unrouted_nets, b.unrouted_nets);
         assert_eq!(a.traces.len(), b.traces.len());
         assert_eq!(a.vias.len(), b.vias.len());
+    }
+
+    /// The shove fixture: a walled channel with a stuck horizontal net "A"
+    /// and a routed U-shaped victim "B" whose long middle segment seals the
+    /// channel. Returns `(pcb, session, placed_with_victim, from, to)`.
+    ///
+    /// Geometry (single layer, channel between wall rows at y=12 and y=18):
+    /// B runs pad(10,16.8) -> joint(10,MID_Y) -> joint(40,MID_Y) ->
+    /// pad(40,16.8). With MID_Y=13.2 the gap under the middle (to the wall
+    /// copper edge at y=12.5) is too narrow for A's trace, and the pocket
+    /// above is sealed by B's flanks and pads — A is stuck until the middle
+    /// segment moves up.
+    fn shove_fixture(
+        mid_y: f64,
+        victim_pads_at_joints: bool,
+    ) -> (Pcb, RouteSession, Vec<Placed>, Vec2, Vec2) {
+        let mut fps = vec![
+            fp("A1", 5.0, 15.0, vec![pad("1", 0.0, 0.0, "A")]),
+            fp("A2", 45.0, 15.0, vec![pad("1", 0.0, 0.0, "A")]),
+        ];
+        // Solid pad walls across the full board width at y=12 and y=18.
+        for i in 0..50 {
+            let x = 0.5 + i as f64;
+            fps.push(fp(
+                &format!("WT{i}"),
+                x,
+                18.0,
+                vec![pad("1", 0.0, 0.0, "W")],
+            ));
+            fps.push(fp(
+                &format!("WB{i}"),
+                x,
+                12.0,
+                vec![pad("1", 0.0, 0.0, "W")],
+            ));
+        }
+        let (b_from, b_to, segments) = if victim_pads_at_joints {
+            // Negative fixture: B is a single pad-to-pad segment — both
+            // crossing-segment endpoints are anchors. Seal the space above it
+            // with wall-pad columns at x=10 and x=40 so A stays stuck.
+            fps.push(fp("B1", 10.0, mid_y, vec![pad("1", 0.0, 0.0, "B")]));
+            fps.push(fp("B2", 40.0, mid_y, vec![pad("1", 0.0, 0.0, "B")]));
+            for (i, &x) in [10.0f64, 40.0].iter().enumerate() {
+                for (j, &y) in [14.5f64, 15.5, 16.5].iter().enumerate() {
+                    fps.push(fp(
+                        &format!("WC{i}_{j}"),
+                        x,
+                        y,
+                        vec![pad("1", 0.0, 0.0, "W")],
+                    ));
+                }
+            }
+            let a = Vec2::new(10.0, mid_y);
+            let b = Vec2::new(40.0, mid_y);
+            (a, b, vec![(a, b, PcbLayer::FCu)])
+        } else {
+            fps.push(fp("B1", 10.0, 16.8, vec![pad("1", 0.0, 0.0, "B")]));
+            fps.push(fp("B2", 40.0, 16.8, vec![pad("1", 0.0, 0.0, "B")]));
+            let p1 = Vec2::new(10.0, 16.8);
+            let j1 = Vec2::new(10.0, mid_y);
+            let j2 = Vec2::new(40.0, mid_y);
+            let p2 = Vec2::new(40.0, 16.8);
+            (
+                p1,
+                p2,
+                vec![
+                    (p1, j1, PcbLayer::FCu),
+                    (j1, j2, PcbLayer::FCu),
+                    (j2, p2, PcbLayer::FCu),
+                ],
+            )
+        };
+        let pcb = single_layer(board(fps));
+        let mut session = RouteSession::from_pcb(&pcb);
+        // Commit the victim's route as the router would have.
+        let mut spans = Vec::new();
+        for &(a, b, l) in &segments {
+            spans.push(commit_seg(&mut session, "B", a, b, 0.125, l));
+        }
+        let placed = vec![Placed {
+            net: "B".into(),
+            from: b_from,
+            to: b_to,
+            width: 0.25,
+            segments,
+            stubs: Vec::new(),
+            via_pts: Vec::new(),
+            spans,
+        }];
+        (
+            pcb,
+            session,
+            placed,
+            Vec2::new(5.0, 15.0),
+            Vec2::new(45.0, 15.0),
+        )
+    }
+
+    #[test]
+    fn shove_fixture_routes_once_victim_removed() {
+        // Sanity for the fixture itself: with the victim lifted out, the
+        // direct search must succeed.
+        let (pcb, mut session, placed, from, to) = shove_fixture(13.2, false);
+        for &s in &placed[0].spans {
+            session.remove(s);
+        }
+        let cong = Congestion::new(&pcb.outline.vertices);
+        assert!(
+            search_route(&session, &pcb, 0.25, "A", from, to, &cong, false, 50_000, true, None)
+                .is_some(),
+            "fixture broken: A must route on an empty channel"
+        );
+    }
+
+    #[test]
+    fn shove_displaces_blocking_trace_and_routes_stuck_net() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let (pcb, mut session, mut placed, from, to) = shove_fixture(13.2, false);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let budget = 50_000;
+
+        // Without shove, every direct search fails: the channel is sealed.
+        assert!(
+            search_route(&session, &pcb, 0.25, "A", from, to, &cong, false, budget, true, None)
+                .is_none(),
+            "fixture broken: direct search must fail before the shove"
+        );
+
+        let original_segments = placed[0].segments.clone();
+        let p = try_route(
+            &mut session,
+            &pcb,
+            0.25,
+            "A",
+            from,
+            to,
+            &mut placed,
+            &cong,
+            false,
+            budget,
+        )
+        .expect("try_route must succeed via the shove stage");
+        assert!(!p.segments.is_empty());
+        assert_ne!(
+            placed[0].segments, original_segments,
+            "the victim must have been displaced"
+        );
+
+        // The shoved victim's copper must re-probe legal against a session
+        // holding everything EXCEPT the victim itself (fresh board + A's
+        // new route), and the whole applied board must be DRC-clean.
+        let mut check = RouteSession::from_pcb(&pcb);
+        for &(a, b, l) in &p.segments {
+            commit_seg(&mut check, "A", a, b, p.width / 2.0, l);
+        }
+        for &(a, b, l) in &placed[0].segments {
+            let seg = CopperGeom::Segment {
+                a,
+                b,
+                half_w: 0.125,
+            };
+            assert!(
+                check.probe(&seg, l, "B", check.clearance_for("B")).legal,
+                "shoved victim copper is illegal: {a:?}->{b:?}"
+            );
+        }
+        let mut applied = pcb.clone();
+        for (net, segs, w) in [
+            ("B", &placed[0].segments, 0.25),
+            ("A", &p.segments, p.width),
+        ] {
+            for &(a, b, l) in segs.iter() {
+                applied.traces.push(Trace {
+                    start: a,
+                    end: b,
+                    width: w,
+                    layer: l,
+                    net: net.into(),
+                    source: None,
+                });
+            }
+        }
+        let bad: Vec<_> = check_drc(&applied)
+            .into_iter()
+            .filter(|v| {
+                matches!(
+                    v.rule,
+                    crate::drc::DrcRuleType::Short | crate::drc::DrcRuleType::Clearance
+                )
+            })
+            .collect();
+        assert!(
+            bad.is_empty(),
+            "board after shove must be short/clearance clean, got: {:?}",
+            bad.iter().map(|v| &v.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn shove_refuses_pad_anchored_victim() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let (pcb, mut session, mut placed, from, to) = shove_fixture(13.2, true);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let budget = 50_000;
+
+        let original_segments = placed[0].segments.clone();
+        let original_spans = placed[0].spans.clone();
+        assert!(
+            try_route(
+                &mut session,
+                &pcb,
+                0.25,
+                "A",
+                from,
+                to,
+                &mut placed,
+                &cong,
+                false,
+                budget,
+            )
+            .is_none(),
+            "a pad-anchored blocker must refuse the shove and leave A unrouted"
+        );
+        // Victim untouched: same geometry, same live spans.
+        assert_eq!(placed[0].segments, original_segments);
+        assert_eq!(placed[0].spans, original_spans);
+        let seg = CopperGeom::Segment {
+            a: placed[0].segments[0].0,
+            b: placed[0].segments[0].1,
+            half_w: 0.125,
+        };
+        // Its copper is still committed: an other-net probe on it is illegal.
+        assert!(
+            !session
+                .probe(&seg, PcbLayer::FCu, "A", session.clearance_for("A"))
+                .legal,
+            "the victim's original copper must still be in the session"
+        );
     }
 }

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1004,7 +1004,7 @@ fn try_route(
     net: &str,
     from: Vec2,
     to: Vec2,
-    placed: &mut [Placed],
+    placed: &mut Vec<Placed>,
     cong: &Congestion,
     use_push_shove: bool,
     max_expansions: usize,
@@ -1040,6 +1040,27 @@ fn try_route(
         max_expansions,
     ) {
         return Some(p);
+    }
+    // Coupled differential-pair stage: a `_P`/`_N` (or `_C`/`_T`) net whose
+    // lone placement failed is exactly the anti-pattern — route it WITH its
+    // twin as one phantom fat trace realized as two coupled legs, committed
+    // atomically. The partner's Placed lands in `placed` here; the net's own
+    // is returned like any other route.
+    if super::pair::pair_partner(net).is_some() {
+        if let Some((mine, theirs)) = super::pair::try_route_pair(
+            session,
+            pcb,
+            width,
+            net,
+            from,
+            to,
+            placed,
+            cong,
+            max_expansions,
+        ) {
+            placed.push(theirs);
+            return Some(mine);
+        }
     }
     // Last resort — true shove: displace the routed traces blocking the
     // corridor sideways (bounded, transactional) instead of ripping them,
@@ -1157,12 +1178,12 @@ fn try_route_escape(
 /// re-validates against the *current* session, so candidates can be searched
 /// in parallel against a frozen snapshot and committed sequentially.
 pub(super) struct Candidate {
-    net: String,
-    from: Vec2,
-    to: Vec2,
-    width: f64,
-    segments: Vec<(Vec2, Vec2, PcbLayer)>,
-    vias: Vec<(Vec2, PcbLayer, PcbLayer)>,
+    pub(super) net: String,
+    pub(super) from: Vec2,
+    pub(super) to: Vec2,
+    pub(super) width: f64,
+    pub(super) segments: Vec<(Vec2, Vec2, PcbLayer)>,
+    pub(super) vias: Vec<(Vec2, PcbLayer, PcbLayer)>,
 }
 
 /// The pure-search half of [`try_route`]: find a clearance-legal route
@@ -2673,6 +2694,62 @@ mod tests {
                 "escape-assisted route emitted illegal copper: {a:?}->{b:?}"
             );
         }
+    }
+
+    #[test]
+    fn try_route_pairs_p_net_with_partner() {
+        // A `_P` net whose lone maze fails (tiny expansion budget) must be
+        // routed as a coupled pair via the pair stage: try_route returns the
+        // P leg and pushes the N leg into `placed` — both nets end up routed.
+        let small = |num: &str, y: f64, net: &str| Pad {
+            number: num.into(),
+            pad_type: PadType::SMD,
+            shape: PadShape::Circle { diameter: 0.3 },
+            position: Vec2::new(0.0, y),
+            rotation: 0.0,
+            drill: None,
+            net: Some(net.into()),
+            layers: vec![PcbLayer::FCu],
+        };
+        let pcb = board(vec![
+            fp(
+                "J1",
+                5.0,
+                15.0,
+                vec![small("1", 0.325, "LVDS_P"), small("2", -0.325, "LVDS_N")],
+            ),
+            fp(
+                "U1",
+                45.0,
+                15.0,
+                vec![small("1", 0.325, "LVDS_P"), small("2", -0.325, "LVDS_N")],
+            ),
+        ]);
+        let mut session = RouteSession::from_pcb(&pcb);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let mut placed: Vec<Placed> = Vec::new();
+        let from = Vec2::new(5.0, 15.325);
+        let to = Vec2::new(45.0, 15.325);
+        // Budget too small for the ~90-cell direct maze — forces the fallback
+        // ladder down to the pair stage (which uses its own generous floor).
+        let p = try_route(
+            &mut session,
+            &pcb,
+            0.25,
+            "LVDS_P",
+            from,
+            to,
+            &mut placed,
+            &cong,
+            false,
+            20,
+        )
+        .expect("pair stage must route the P net with its partner");
+        assert_eq!(p.net, "LVDS_P");
+        assert!(!p.segments.is_empty());
+        assert_eq!(placed.len(), 1, "partner leg must land in placed");
+        assert_eq!(placed[0].net, "LVDS_N");
+        assert!(!placed[0].segments.is_empty());
     }
 
     #[test]

--- a/crates/vcad-ecad-pcb/src/router/complete.rs
+++ b/crates/vcad-ecad-pcb/src/router/complete.rs
@@ -345,7 +345,6 @@ pub(crate) fn route_window_complete(
         terms: &terms,
         plane,
         nx: grid.nx,
-        nl,
         occ: BitSet::new(n_nodes),
         paths: vec![Vec::new(); conns.len()],
         expansions: 0,
@@ -405,7 +404,6 @@ struct Search<'a> {
     terms: &'a [(usize, usize)],
     plane: usize,
     nx: usize,
-    nl: usize,
     /// Nodes occupied by committed paths of earlier nets AND the current
     /// net's partial path — together the full search state.
     occ: BitSet,

--- a/crates/vcad-ecad-pcb/src/router/complete.rs
+++ b/crates/vcad-ecad-pcb/src/router/complete.rs
@@ -1,0 +1,1053 @@
+//! Complete multi-net window router — an exhaustive, certificate-producing
+//! decision procedure for small joint routing problems.
+//!
+//! Given k connections (k ≤ ~6) inside a rectangular window on ≤ 4 copper
+//! layers, this module either **jointly routes** all of them, **proves** that
+//! no joint routing exists at the current rules and discretization, or
+//! honestly reports that its budget ran out before deciding.
+//!
+//! # Canonical model
+//!
+//! The window is discretized to a coarse uniform grid with pitch
+//! `width + clearance` (coarsened further if the window would exceed
+//! [`MAX_AXIS_CELLS`] cells per axis). Routing happens on the finite graph
+//! whose nodes are `(cell, layer)`:
+//!
+//! - a node is **free** iff a trace centre there clears all fixed copper
+//!   (everything in the [`RouteSession`] that is not on one of the k nets),
+//!   tested with the exact incremental oracle ([`RouteSession::probe`]) —
+//!   the same clearance geometry the DRC pass uses;
+//! - in-plane edges connect 4-adjacent cells on the same layer and are legal
+//!   iff the swept capsule between the two cell centres probes clean;
+//! - via edges connect the same cell on adjacent layers and are legal iff a
+//!   via-sized disc probes clean on both layers;
+//! - every node has **unit capacity**: at most one net's path may occupy a
+//!   `(cell, layer)` node. At pitch = width + clearance, paths through
+//!   distinct cells are clearance-compatible by construction, so node
+//!   disjointness is the canonical inter-net legality rule.
+//!
+//! # Completeness argument
+//!
+//! Over this finite unit-capacity graph, a joint routing is a choice of one
+//! path per net such that the paths are pairwise node-disjoint. Any joint
+//! routing can be reduced to one using only **simple** paths (deleting a
+//! cycle from a path never creates a conflict), so it suffices to enumerate
+//! simple paths. The search routes the nets in a fixed order and, for net
+//! `i`, performs a depth-first enumeration of *all* simple paths from its
+//! source to its target through nodes not occupied by nets `< i`; on each
+//! completed path it recurses to net `i+1`, and on failure it backtracks
+//! through every predecessor choice of net `i` — i.e. the recursion tree
+//! ranges over the entire (finite) set of joint simple-path assignments.
+//! With a fixed net order this is already exhaustive: for any joint routing
+//! `(p_1, …, p_k)` the DFS branch that picks exactly `p_1` for net 1, `p_2`
+//! for net 2, … exists in the tree, so backtracking over net *order* is
+//! unnecessary for completeness (it is purely a speed heuristic and is not
+//! used here — determinism is worth more).
+//!
+//! States are deduplicated at net boundaries by `(net index, occupied-node
+//! bitset)`: whether the remaining nets `i..k` can be routed depends only on
+//! which nodes are occupied, not on which earlier net occupies them or via
+//! which path, so a state that exhausted without a solution can be pruned
+//! when reached again. Memoized failures are only recorded for subtrees that
+//! ran to exhaustion (a budget trip aborts the whole search), so the memo
+//! can never convert "unknown" into "infeasible".
+//!
+//! Hence, when the search returns without finding a routing **and** without
+//! tripping the expansion budget, no node-disjoint joint routing exists on
+//! the canonical grid — [`CompleteOutcome::ProvedInfeasible`]. When the
+//! budget trips first, the result is [`CompleteOutcome::BudgetExhausted`]
+//! ("unknown"), never a feigned proof.
+//!
+//! The proof is relative to the canonical discretization (on-grid paths,
+//! vias at cell centres between adjacent layers, node-disjoint nets). A
+//! finer, off-grid router could in principle still succeed; the certificate
+//! states what was exhausted.
+//!
+//! # Infeasibility certificate
+//!
+//! Before the search, a max-flow necessary-condition check runs: k pairwise
+//! node-disjoint paths require a flow of k through the free-node graph with
+//! unit node capacities (Menger). BFS augmenting-path max flow (Edmonds–
+//! Karp on the node-split graph) from a super-source (unit edge per net's
+//! source terminal) to a super-sink (unit edge per target terminal) is
+//! computed; if it is `f < k`, no assignment of *any* pairing can exist —
+//! joint routing is infeasible outright, and the min-cut nodes (free cells
+//! whose in-half is residual-reachable but whose out-half is not) name the
+//! bottleneck: the certificate reports how many free channels the cut
+//! offers and where they sit. This is a strictly weaker condition than the
+//! search (it ignores which net must pair with which terminal), so it can
+//! only fire on genuinely infeasible instances.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use vcad_ir::ecad::PcbLayer;
+use vcad_ir::Vec2;
+
+use crate::session::RouteSession;
+use crate::spatial::CopperGeom;
+
+/// Hard cap on grid cells per axis; the pitch coarsens to fit. Keeps the
+/// state space honest (≤ 48×48×4 ≈ 9.2k nodes).
+const MAX_AXIS_CELLS: usize = 48;
+
+/// Outcome of the complete window router.
+#[derive(Debug, Clone)]
+pub(crate) enum CompleteOutcome {
+    /// A joint routing was found: per-connection segment lists, in the same
+    /// order as the input `conns`. Layer transitions within a connection are
+    /// vias at the shared segment endpoint (adjacent-layer span).
+    Routed(Vec<Vec<(Vec2, Vec2, PcbLayer)>>),
+    /// No joint routing exists at the current rules on the canonical grid —
+    /// the search space was fully enumerated (or a max-flow cut proves it
+    /// outright). `reason` is a human-readable certificate.
+    ProvedInfeasible {
+        /// Human-readable explanation of why the window is unroutable.
+        reason: String,
+    },
+    /// The expansion budget tripped before the space was exhausted: the
+    /// honest "unknown". Never claimed as infeasibility.
+    BudgetExhausted,
+}
+
+/// Decide joint routability of `conns` inside `window`.
+///
+/// * `window` — `(lo, hi)` corners of the search rectangle (board mm). Must
+///   lie inside the board outline; the router does not consult the outline.
+/// * `layers` — copper stack to route on, front → back (≤ 4 recommended).
+/// * `conns` — the k connections as `(net, from, to)`. Copper on any other
+///   net in `session` is a fixed obstacle.
+/// * `width` — trace width for all k connections (pitch = width + max
+///   clearance across the k nets).
+/// * `budget` — maximum DFS node expansions. A result of
+///   [`CompleteOutcome::ProvedInfeasible`] is only ever returned when the
+///   full space was enumerated within the budget (or the flow cut fired).
+pub(crate) fn route_window_complete(
+    session: &RouteSession,
+    window: (Vec2, Vec2),
+    layers: &[PcbLayer],
+    conns: &[(String, Vec2, Vec2)],
+    width: f64,
+    budget: usize,
+) -> CompleteOutcome {
+    if conns.is_empty() {
+        return CompleteOutcome::Routed(Vec::new());
+    }
+    if layers.is_empty() {
+        return CompleteOutcome::ProvedInfeasible {
+            reason: "no copper layers to route on".into(),
+        };
+    }
+
+    let clearances: Vec<f64> = conns
+        .iter()
+        .map(|(n, _, _)| session.clearance_for(n))
+        .collect();
+    let max_clearance = clearances.iter().cloned().fold(0.0_f64, f64::max);
+    let grid = WinGrid::new(window, width, max_clearance);
+    let plane = grid.nx * grid.ny;
+    let nl = layers.len();
+    let n_nodes = plane * nl;
+    let half_w = width / 2.0;
+    // Via legality is probed as a disc of radius `width` (a conservative
+    // stand-in for the via pad) on both spanned layers.
+    let via_r = width;
+
+    // --- Free-node raster (fixed copper only) ----------------------------
+    // A node is free iff a zero-length capsule (trace centre) at the cell
+    // clears all copper not on this net-set. Copper *on one of the k nets*
+    // is not an obstacle to any of them here: the k nets are being decided
+    // jointly, and same-net copper never blocks. To keep the model simple
+    // and sound we probe against the union net exclusion: a cell is free
+    // for the window iff it is legal for EVERY conn net (the most
+    // conservative choice keeps node-disjointness sufficient).
+    let mut free = vec![true; n_nodes];
+    for (li, &layer) in layers.iter().enumerate() {
+        for cell in 0..plane {
+            let p = grid.world(cell);
+            let ok = conns.iter().zip(&clearances).all(|((net, _, _), &clr)| {
+                session
+                    .probe(&CopperGeom::Segment { a: p, b: p, half_w }, layer, net, clr)
+                    .legal
+            });
+            if !ok {
+                free[li * plane + cell] = false;
+            }
+        }
+    }
+
+    // --- Terminals -------------------------------------------------------
+    // Each terminal snaps to its nearest cell; the endpoint may attach on
+    // any layer whose node is free (pad-side via permitted, as in the 3D
+    // maze router). For the joint model we pick the first free layer for
+    // determinism; the connector from the exact endpoint to the cell centre
+    // must itself probe legal.
+    let mut terms: Vec<(usize, usize)> = Vec::with_capacity(conns.len()); // (src node, dst node)
+    for (ci, (net, from, to)) in conns.iter().enumerate() {
+        let clr = clearances[ci];
+        let attach = |p: Vec2| -> Option<usize> {
+            let cell = grid.snap(p);
+            let c = grid.world(cell);
+            (0..nl).find_map(|li| {
+                let node = li * plane + cell;
+                let conn_ok = session
+                    .probe(
+                        &CopperGeom::Segment { a: p, b: c, half_w },
+                        layers[li],
+                        net,
+                        clr,
+                    )
+                    .legal;
+                (free[node] && conn_ok).then_some(node)
+            })
+        };
+        match (attach(*from), attach(*to)) {
+            (Some(s), Some(t)) => terms.push((s, t)),
+            _ => {
+                return CompleteOutcome::ProvedInfeasible {
+                    reason: format!(
+                        "terminal of net {net} at ({:.2}, {:.2})/({:.2}, {:.2}) has no \
+                         clearance-legal grid attachment on any layer — the pad is walled \
+                         in at the current rules and grid pitch {:.3} mm",
+                        from.x, from.y, to.x, to.y, grid.pitch
+                    ),
+                }
+            }
+        }
+    }
+    // Two connections snapping onto the same node can never be node-disjoint.
+    {
+        let mut seen: HashSet<usize> = HashSet::new();
+        for (ci, &(s, t)) in terms.iter().enumerate() {
+            for node in [s, t] {
+                if !seen.insert(node) {
+                    return CompleteOutcome::ProvedInfeasible {
+                        reason: format!(
+                            "terminals of net {} collide with another connection's terminal \
+                             in the same {:.3} mm grid cell — the window cannot host \
+                             node-disjoint paths",
+                            conns[ci].0, grid.pitch
+                        ),
+                    };
+                }
+            }
+        }
+    }
+
+    // --- Edge legality (lazy, memoized) ----------------------------------
+    let mut edge_memo: HashMap<u64, bool> = HashMap::new();
+    let mut edge_ok = |a: usize, b: usize| -> bool {
+        let key = ((a.min(b) as u64) << 32) | a.max(b) as u64;
+        if let Some(&v) = edge_memo.get(&key) {
+            return v;
+        }
+        let (la, ca) = (a / plane, a % plane);
+        let (lb, cb) = (b / plane, b % plane);
+        let ok = if la == lb {
+            let pa = grid.world(ca);
+            let pb = grid.world(cb);
+            conns.iter().zip(&clearances).all(|((net, _, _), &clr)| {
+                session
+                    .probe(
+                        &CopperGeom::Segment {
+                            a: pa,
+                            b: pb,
+                            half_w,
+                        },
+                        layers[la],
+                        net,
+                        clr,
+                    )
+                    .legal
+            })
+        } else {
+            // Via edge: disc on both spanned (adjacent) layers.
+            debug_assert_eq!(ca, cb);
+            let disc = CopperGeom::Disc {
+                center: grid.world(ca),
+                r: via_r,
+            };
+            conns.iter().zip(&clearances).all(|((net, _, _), &clr)| {
+                session.probe(&disc, layers[la], net, clr).legal
+                    && session.probe(&disc, layers[lb], net, clr).legal
+            })
+        };
+        edge_memo.insert(key, ok);
+        ok
+    };
+
+    // Neighbor generator: 4-adjacent in-plane + adjacent-layer via.
+    let neighbors = |node: usize| -> Vec<usize> {
+        let (li, cell) = (node / plane, node % plane);
+        let (ix, iy) = (cell % grid.nx, cell / grid.nx);
+        let mut out = Vec::with_capacity(6);
+        if ix > 0 {
+            out.push(li * plane + cell - 1);
+        }
+        if ix + 1 < grid.nx {
+            out.push(li * plane + cell + 1);
+        }
+        if iy > 0 {
+            out.push(li * plane + cell - grid.nx);
+        }
+        if iy + 1 < grid.ny {
+            out.push(li * plane + cell + grid.nx);
+        }
+        if li > 0 {
+            out.push((li - 1) * plane + cell);
+        }
+        if li + 1 < nl {
+            out.push((li + 1) * plane + cell);
+        }
+        out
+    };
+
+    // --- Max-flow necessary-condition pre-pass ---------------------------
+    let (flow, cut_cells) = max_node_disjoint_flow(&free, plane, grid.nx, nl, &terms, &neighbors);
+    if flow < conns.len() {
+        let names: Vec<&str> = conns.iter().map(|(n, _, _)| n.as_str()).collect();
+        let mut reason = format!(
+            "nets {} require {} node-disjoint paths, but the free-cell graph admits at \
+             most {} — only {} free channel{} cross the bottleneck",
+            names.join(", "),
+            conns.len(),
+            flow,
+            flow,
+            if flow == 1 { "" } else { "s" },
+        );
+        if !cut_cells.is_empty() {
+            let (mut lo, mut hi) = (
+                Vec2::new(f64::INFINITY, f64::INFINITY),
+                Vec2::new(f64::NEG_INFINITY, f64::NEG_INFINITY),
+            );
+            for &node in &cut_cells {
+                let p = grid.world(node % plane);
+                lo.x = lo.x.min(p.x);
+                lo.y = lo.y.min(p.y);
+                hi.x = hi.x.max(p.x);
+                hi.y = hi.y.max(p.y);
+            }
+            reason.push_str(&format!(
+                " (min cut of {} cell{} near x={:.1}..{:.1}, y={:.1}..{:.1})",
+                cut_cells.len(),
+                if cut_cells.len() == 1 { "" } else { "s" },
+                lo.x - grid.pitch / 2.0,
+                hi.x + grid.pitch / 2.0,
+                lo.y - grid.pitch / 2.0,
+                hi.y + grid.pitch / 2.0,
+            ));
+        }
+        return CompleteOutcome::ProvedInfeasible { reason };
+    }
+
+    // --- Exhaustive backtracking DFS -------------------------------------
+    let mut search = Search {
+        free: &free,
+        terms: &terms,
+        plane,
+        nx: grid.nx,
+        nl,
+        occ: BitSet::new(n_nodes),
+        paths: vec![Vec::new(); conns.len()],
+        expansions: 0,
+        budget,
+        memo: HashSet::new(),
+        edge_ok: &mut edge_ok,
+        neighbors: &neighbors,
+    };
+    match search.solve(0) {
+        Step::Found => {
+            let paths = std::mem::take(&mut search.paths);
+            let mut out = Vec::with_capacity(conns.len());
+            for (ci, path) in paths.iter().enumerate() {
+                out.push(emit_segments(
+                    &grid,
+                    plane,
+                    layers,
+                    conns[ci].1,
+                    conns[ci].2,
+                    path,
+                ));
+            }
+            CompleteOutcome::Routed(out)
+        }
+        Step::Tripped => CompleteOutcome::BudgetExhausted,
+        Step::Exhausted => {
+            let names: Vec<&str> = conns.iter().map(|(n, _, _)| n.as_str()).collect();
+            CompleteOutcome::ProvedInfeasible {
+                reason: format!(
+                    "exhaustive enumeration of all joint simple-path assignments for nets \
+                     {} over the {}x{}x{} window grid (pitch {:.3} mm, {} expansions) found \
+                     no node-disjoint routing — no joint routing exists at the current \
+                     rules and discretization",
+                    names.join(", "),
+                    grid.nx,
+                    grid.ny,
+                    nl,
+                    grid.pitch,
+                    search.expansions,
+                ),
+            }
+        }
+    }
+}
+
+/// DFS step result. `Tripped` aborts the whole search (no memoization of the
+/// interrupted subtree, so a trip can never masquerade as a proof).
+#[derive(PartialEq)]
+enum Step {
+    Found,
+    Exhausted,
+    Tripped,
+}
+
+struct Search<'a> {
+    free: &'a [bool],
+    terms: &'a [(usize, usize)],
+    plane: usize,
+    nx: usize,
+    nl: usize,
+    /// Nodes occupied by committed paths of earlier nets AND the current
+    /// net's partial path — together the full search state.
+    occ: BitSet,
+    paths: Vec<Vec<usize>>,
+    expansions: usize,
+    budget: usize,
+    /// Failed states `(net index, occupied bitset)`, recorded only when the
+    /// subtree exhausted.
+    memo: HashSet<(usize, Box<[u64]>)>,
+    edge_ok: &'a mut dyn FnMut(usize, usize) -> bool,
+    neighbors: &'a dyn Fn(usize) -> Vec<usize>,
+}
+
+impl Search<'_> {
+    /// Route nets `i..` given the occupancy of nets `< i`.
+    fn solve(&mut self, i: usize) -> Step {
+        if i == self.terms.len() {
+            return Step::Found;
+        }
+        let key = (i, self.occ.words.clone().into_boxed_slice());
+        if self.memo.contains(&key) {
+            return Step::Exhausted;
+        }
+        let (s, t) = self.terms[i];
+        if self.occ.get(s) || self.occ.get(t) || !self.free[s] || !self.free[t] {
+            self.memo.insert(key);
+            return Step::Exhausted;
+        }
+        self.occ.set(s);
+        self.paths[i].push(s);
+        let r = self.dfs_path(i, s, t);
+        if r == Step::Found {
+            // Keep the committed path/occupancy intact for reconstruction.
+            return r;
+        }
+        self.paths[i].pop();
+        self.occ.clear(s);
+        if r == Step::Exhausted {
+            self.memo.insert(key);
+        }
+        r
+    }
+
+    /// Enumerate all simple extensions of the current path of net `i` from
+    /// `cur` to `t`, recursing into `solve(i + 1)` at every completion.
+    fn dfs_path(&mut self, i: usize, cur: usize, t: usize) -> Step {
+        self.expansions += 1;
+        if self.expansions > self.budget {
+            return Step::Tripped;
+        }
+        if cur == t {
+            return self.solve(i + 1);
+        }
+        // Order neighbors by goal distance so the first completed path is
+        // near-shortest (shortest-first flavor without a separate k-shortest
+        // machinery; the enumeration is exhaustive either way).
+        let (tx, ty, tl) = self.coords(t);
+        let mut nbs = (self.neighbors)(cur);
+        nbs.sort_by(|&a, &b| {
+            let da = self.dist2(a, tx, ty, tl);
+            let db = self.dist2(b, tx, ty, tl);
+            da.cmp(&db)
+        });
+        for nb in nbs {
+            if !self.free[nb] || self.occ.get(nb) || !(self.edge_ok)(cur, nb) {
+                continue;
+            }
+            self.occ.set(nb);
+            self.paths[i].push(nb);
+            let r = self.dfs_path(i, nb, t);
+            if r == Step::Found {
+                return r;
+            }
+            self.paths[i].pop();
+            self.occ.clear(nb);
+            if r == Step::Tripped {
+                return r;
+            }
+        }
+        Step::Exhausted
+    }
+
+    fn coords(&self, node: usize) -> (i64, i64, i64) {
+        let cell = node % self.plane;
+        (
+            (cell % self.nx) as i64,
+            (cell / self.nx) as i64,
+            (node / self.plane) as i64,
+        )
+    }
+
+    fn dist2(&self, node: usize, tx: i64, ty: i64, tl: i64) -> i64 {
+        let (x, y, l) = self.coords(node);
+        (x - tx) * (x - tx) + (y - ty) * (y - ty) + (l - tl) * (l - tl)
+    }
+}
+
+/// Convert a node path into world segments per layer, with the exact
+/// endpoints attached and collinear runs collapsed.
+fn emit_segments(
+    grid: &WinGrid,
+    plane: usize,
+    layers: &[PcbLayer],
+    from: Vec2,
+    to: Vec2,
+    path: &[usize],
+) -> Vec<(Vec2, Vec2, PcbLayer)> {
+    let mut segs: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
+    if path.is_empty() {
+        return segs;
+    }
+    let mut run: Vec<Vec2> = vec![from];
+    let mut run_layer = path[0] / plane;
+    let flush = |run: &mut Vec<Vec2>, layer: PcbLayer, segs: &mut Vec<(Vec2, Vec2, PcbLayer)>| {
+        let pts = simplify(run);
+        segs.extend(
+            pts.windows(2)
+                .filter(|w| dist(w[0], w[1]) > 1e-9)
+                .map(|w| (w[0], w[1], layer)),
+        );
+        run.clear();
+    };
+    for &node in path {
+        let (li, cell) = (node / plane, node % plane);
+        let w = grid.world(cell);
+        if li != run_layer {
+            // Via at the shared cell centre: end the old-layer run there and
+            // begin the new-layer run there.
+            if run.last().map(|p| dist(*p, w) > 1e-9).unwrap_or(true) {
+                run.push(w);
+            }
+            flush(&mut run, layers[run_layer], &mut segs);
+            run.push(w);
+            run_layer = li;
+        }
+        if run.last().map(|p| dist(*p, w) > 1e-9).unwrap_or(true) {
+            run.push(w);
+        }
+    }
+    if run.last().map(|p| dist(*p, to) > 1e-9).unwrap_or(true) {
+        run.push(to);
+    }
+    flush(&mut run, layers[run_layer], &mut segs);
+    segs
+}
+
+/// Max number of pairwise node-disjoint source→target paths through the free
+/// nodes (unit node capacities via node splitting), together with the cells
+/// of the min vertex cut when the flow is short. Pairing-agnostic: any source
+/// may serve any target, so the value is an upper bound on (i.e. necessary
+/// for) the paired joint routing.
+fn max_node_disjoint_flow(
+    free: &[bool],
+    plane: usize,
+    _nx: usize,
+    nl: usize,
+    terms: &[(usize, usize)],
+    neighbors: &dyn Fn(usize) -> Vec<usize>,
+) -> (usize, Vec<usize>) {
+    let n = plane * nl;
+    // Node split: in(v) = 2v, out(v) = 2v+1; S = 2n, T = 2n+1.
+    let s = 2 * n;
+    let t = 2 * n + 1;
+    let mut g = FlowGraph::new(2 * n + 2);
+    for (v, &f) in free.iter().enumerate().take(n) {
+        if f {
+            g.add_edge(2 * v, 2 * v + 1, 1);
+        }
+    }
+    for (v, &f) in free.iter().enumerate().take(n) {
+        if !f {
+            continue;
+        }
+        for nb in neighbors(v) {
+            if free[nb] {
+                g.add_edge(2 * v + 1, 2 * nb, 1);
+            }
+        }
+    }
+    for &(src, dst) in terms {
+        g.add_edge(s, 2 * src, 1);
+        g.add_edge(2 * dst + 1, t, 1);
+    }
+    let flow = g.max_flow(s, t);
+    if flow >= terms.len() {
+        return (flow, Vec::new());
+    }
+    // Min cut: free nodes whose in-half is residual-reachable but whose
+    // out-half is not — the saturated bottleneck cells.
+    let reach = g.residual_reachable(s);
+    let cut: Vec<usize> = (0..n)
+        .filter(|&v| free[v] && reach[2 * v] && !reach[2 * v + 1])
+        .collect();
+    (flow, cut)
+}
+
+/// Minimal adjacency-list max-flow (Edmonds–Karp: BFS augmenting paths).
+/// Unit capacities keep each augmentation O(E); the graphs here are ≤ ~20k
+/// nodes, so this is instantaneous.
+struct FlowGraph {
+    /// Per-node list of edge indices into `to`/`cap`.
+    adj: Vec<Vec<usize>>,
+    to: Vec<usize>,
+    cap: Vec<i64>,
+}
+
+impl FlowGraph {
+    fn new(n: usize) -> Self {
+        Self {
+            adj: vec![Vec::new(); n],
+            to: Vec::new(),
+            cap: Vec::new(),
+        }
+    }
+
+    fn add_edge(&mut self, u: usize, v: usize, c: i64) {
+        let e = self.to.len();
+        self.to.push(v);
+        self.cap.push(c);
+        self.adj[u].push(e);
+        self.to.push(u);
+        self.cap.push(0);
+        self.adj[v].push(e + 1);
+    }
+
+    fn max_flow(&mut self, s: usize, t: usize) -> usize {
+        let mut flow = 0usize;
+        loop {
+            // BFS for a shortest augmenting path; record the edge used to
+            // reach each node.
+            let mut prev_edge = vec![usize::MAX; self.adj.len()];
+            let mut seen = vec![false; self.adj.len()];
+            seen[s] = true;
+            let mut q = VecDeque::from([s]);
+            'bfs: while let Some(u) = q.pop_front() {
+                for &e in &self.adj[u] {
+                    let v = self.to[e];
+                    if self.cap[e] > 0 && !seen[v] {
+                        seen[v] = true;
+                        prev_edge[v] = e;
+                        if v == t {
+                            break 'bfs;
+                        }
+                        q.push_back(v);
+                    }
+                }
+            }
+            if !seen[t] {
+                return flow;
+            }
+            // Augment by 1 (all capacities are unit).
+            let mut v = t;
+            while v != s {
+                let e = prev_edge[v];
+                self.cap[e] -= 1;
+                self.cap[e ^ 1] += 1;
+                v = self.to[e ^ 1];
+            }
+            flow += 1;
+        }
+    }
+
+    /// Nodes reachable from `s` in the residual graph (call after
+    /// [`Self::max_flow`]).
+    fn residual_reachable(&self, s: usize) -> Vec<bool> {
+        let mut seen = vec![false; self.adj.len()];
+        seen[s] = true;
+        let mut q = VecDeque::from([s]);
+        while let Some(u) = q.pop_front() {
+            for &e in &self.adj[u] {
+                let v = self.to[e];
+                if self.cap[e] > 0 && !seen[v] {
+                    seen[v] = true;
+                    q.push_back(v);
+                }
+            }
+        }
+        seen
+    }
+}
+
+/// Fixed-size bitset over search nodes.
+#[derive(Clone)]
+struct BitSet {
+    words: Vec<u64>,
+}
+
+impl BitSet {
+    fn new(n: usize) -> Self {
+        Self {
+            words: vec![0; n.div_ceil(64)],
+        }
+    }
+    #[inline]
+    fn get(&self, i: usize) -> bool {
+        self.words[i / 64] >> (i % 64) & 1 != 0
+    }
+    #[inline]
+    fn set(&mut self, i: usize) {
+        self.words[i / 64] |= 1 << (i % 64);
+    }
+    #[inline]
+    fn clear(&mut self, i: usize) {
+        self.words[i / 64] &= !(1 << (i % 64));
+    }
+}
+
+/// The window's coarse uniform grid.
+struct WinGrid {
+    origin: Vec2,
+    pitch: f64,
+    nx: usize,
+    ny: usize,
+}
+
+impl WinGrid {
+    fn new(window: (Vec2, Vec2), width: f64, clearance: f64) -> Self {
+        let (lo, hi) = window;
+        let span_x = (hi.x - lo.x).max(1e-3);
+        let span_y = (hi.y - lo.y).max(1e-3);
+        let mut pitch = (width + clearance).max(0.02);
+        let need = (span_x / pitch).max(span_y / pitch);
+        if need > MAX_AXIS_CELLS as f64 {
+            pitch = (span_x / MAX_AXIS_CELLS as f64).max(span_y / MAX_AXIS_CELLS as f64);
+        }
+        let nx = (span_x / pitch).ceil() as usize + 1;
+        let ny = (span_y / pitch).ceil() as usize + 1;
+        Self {
+            origin: lo,
+            pitch,
+            nx,
+            ny,
+        }
+    }
+
+    fn world(&self, cell: usize) -> Vec2 {
+        let (ix, iy) = (cell % self.nx, cell / self.nx);
+        Vec2::new(
+            self.origin.x + ix as f64 * self.pitch,
+            self.origin.y + iy as f64 * self.pitch,
+        )
+    }
+
+    fn snap(&self, p: Vec2) -> usize {
+        let ix = (((p.x - self.origin.x) / self.pitch).round() as i64).clamp(0, self.nx as i64 - 1);
+        let iy = (((p.y - self.origin.y) / self.pitch).round() as i64).clamp(0, self.ny as i64 - 1);
+        iy as usize * self.nx + ix as usize
+    }
+}
+
+/// Drop interior points collinear with their neighbors.
+fn simplify(pts: &[Vec2]) -> Vec<Vec2> {
+    if pts.len() <= 2 {
+        return pts.to_vec();
+    }
+    let mut out = vec![pts[0]];
+    for i in 1..pts.len() - 1 {
+        let a = *out.last().unwrap();
+        let b = pts[i];
+        let c = pts[i + 1];
+        let cross = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+        if cross.abs() > 1e-9 {
+            out.push(b);
+        }
+    }
+    out.push(*pts.last().unwrap());
+    out
+}
+
+fn dist(a: Vec2, b: Vec2) -> f64 {
+    let dx = a.x - b.x;
+    let dy = a.y - b.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::RouteSession;
+    use vcad_ir::ecad::*;
+
+    fn board(traces: Vec<Trace>, layers: &[PcbLayer]) -> Pcb {
+        Pcb {
+            outline: BoardOutline {
+                vertices: vec![
+                    Vec2::new(0.0, 0.0),
+                    Vec2::new(40.0, 0.0),
+                    Vec2::new(40.0, 40.0),
+                    Vec2::new(0.0, 40.0),
+                ],
+                cutouts: vec![],
+                thickness: 1.6,
+            },
+            stackup: LayerStackup {
+                layers: layers
+                    .iter()
+                    .map(|&layer| StackupLayer {
+                        layer,
+                        copper_thickness: Some(0.035),
+                        dielectric_thickness: Some(0.5),
+                        dielectric_er: Some(4.5),
+                        material: Some("FR4".into()),
+                    })
+                    .collect(),
+            },
+            nets: vec![],
+            rules: DesignRules {
+                default_rules: NetClassRules {
+                    name: "Default".into(),
+                    trace_width: 0.25,
+                    clearance: 0.2,
+                    via_diameter: 0.8,
+                    via_drill: 0.4,
+                    diff_pair_gap: None,
+                    diff_pair_width: None,
+                },
+                class_rules: vec![],
+                net_class_assignments: Default::default(),
+                edge_clearance: 0.5,
+                hole_to_hole: 0.5,
+                min_annular_ring: 0.15,
+                min_drill: 0.2,
+            },
+            footprints: vec![],
+            traces,
+            trace_arcs: vec![],
+            vias: vec![],
+            zones: vec![],
+            keepouts: vec![],
+            net_ties: vec![],
+        }
+    }
+
+    fn trace(net: &str, a: Vec2, b: Vec2) -> Trace {
+        Trace {
+            start: a,
+            end: b,
+            width: 0.25,
+            layer: PcbLayer::FCu,
+            net: net.into(),
+            source: None,
+        }
+    }
+
+    const WINDOW: (Vec2, Vec2) = (Vec2 { x: 10.0, y: 10.0 }, Vec2 { x: 30.0, y: 30.0 });
+
+    /// A wall on FCu at x=20 with two ~1.4 mm gaps (y≈14.3..15.7 and
+    /// y≈24.3..25.7): exactly two crossing channels at the coarse pitch.
+    fn two_channel_wall() -> Vec<Trace> {
+        vec![
+            trace("GND", Vec2::new(20.0, 0.0), Vec2::new(20.0, 14.3)),
+            trace("GND", Vec2::new(20.0, 15.7), Vec2::new(20.0, 24.3)),
+            trace("GND", Vec2::new(20.0, 25.7), Vec2::new(20.0, 40.0)),
+        ]
+    }
+
+    fn assert_probe_legal(
+        session: &RouteSession,
+        conns: &[(String, Vec2, Vec2)],
+        routed: &[Vec<(Vec2, Vec2, PcbLayer)>],
+        width: f64,
+    ) {
+        for ((net, _, _), segs) in conns.iter().zip(routed) {
+            let clr = session.clearance_for(net);
+            for (a, b, l) in segs {
+                assert!(
+                    session
+                        .probe(
+                            &CopperGeom::Segment {
+                                a: *a,
+                                b: *b,
+                                half_w: width / 2.0
+                            },
+                            *l,
+                            net,
+                            clr,
+                        )
+                        .legal,
+                    "segment ({:.2},{:.2})->({:.2},{:.2}) on {l:?} of net {net} must be legal",
+                    a.x,
+                    a.y,
+                    b.x,
+                    b.y,
+                );
+            }
+        }
+    }
+
+    /// Endpoints must be reached: first segment starts at `from`, last ends at `to`.
+    fn assert_connected(conns: &[(String, Vec2, Vec2)], routed: &[Vec<(Vec2, Vec2, PcbLayer)>]) {
+        for ((net, from, to), segs) in conns.iter().zip(routed) {
+            assert!(!segs.is_empty(), "net {net} must have copper");
+            assert!(
+                dist(segs[0].0, *from) < 1e-9,
+                "net {net} must start at its from-terminal"
+            );
+            assert!(
+                dist(segs.last().unwrap().1, *to) < 1e-9,
+                "net {net} must end at its to-terminal"
+            );
+            // Contiguity: each segment starts where the previous one ended.
+            for w in segs.windows(2) {
+                assert!(
+                    dist(w[0].1, w[1].0) < 1e-9,
+                    "net {net} path must be contiguous"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn three_crossing_nets_route_on_two_layers() {
+        let pcb = board(vec![], &[PcbLayer::FCu, PcbLayer::BCu]);
+        let session = RouteSession::from_pcb(&pcb);
+        // A and B cross; C runs between them. Jointly routable with vias.
+        let conns = vec![
+            (
+                "A".to_string(),
+                Vec2::new(12.0, 12.0),
+                Vec2::new(28.0, 28.0),
+            ),
+            (
+                "B".to_string(),
+                Vec2::new(12.0, 28.0),
+                Vec2::new(28.0, 12.0),
+            ),
+            (
+                "C".to_string(),
+                Vec2::new(12.0, 20.0),
+                Vec2::new(28.0, 20.0),
+            ),
+        ];
+        let r = route_window_complete(
+            &session,
+            WINDOW,
+            &[PcbLayer::FCu, PcbLayer::BCu],
+            &conns,
+            0.25,
+            2_000_000,
+        );
+        let CompleteOutcome::Routed(routed) = r else {
+            panic!("three crossing nets on two layers must be jointly routable, got {r:?}");
+        };
+        assert_eq!(routed.len(), 3);
+        assert_connected(&conns, &routed);
+        assert_probe_legal(&session, &conns, &routed, 0.25);
+    }
+
+    #[test]
+    fn three_nets_through_two_channels_proved_infeasible() {
+        let pcb = board(two_channel_wall(), &[PcbLayer::FCu]);
+        let session = RouteSession::from_pcb(&pcb);
+        let conns = vec![
+            (
+                "N1".to_string(),
+                Vec2::new(12.0, 14.0),
+                Vec2::new(28.0, 14.0),
+            ),
+            (
+                "N2".to_string(),
+                Vec2::new(12.0, 20.0),
+                Vec2::new(28.0, 20.0),
+            ),
+            (
+                "N3".to_string(),
+                Vec2::new(12.0, 26.0),
+                Vec2::new(28.0, 26.0),
+            ),
+        ];
+        let r = route_window_complete(&session, WINDOW, &[PcbLayer::FCu], &conns, 0.25, 2_000_000);
+        let CompleteOutcome::ProvedInfeasible { reason } = r else {
+            panic!("3 nets through a 2-channel wall must be proved infeasible, got {r:?}");
+        };
+        assert!(
+            reason.contains("channel"),
+            "certificate must name the bottleneck, got: {reason}"
+        );
+        assert!(
+            reason.contains('2'),
+            "certificate must count the free channels: {reason}"
+        );
+    }
+
+    #[test]
+    fn two_nets_through_two_channels_route() {
+        let pcb = board(two_channel_wall(), &[PcbLayer::FCu]);
+        let session = RouteSession::from_pcb(&pcb);
+        let conns = vec![
+            (
+                "N1".to_string(),
+                Vec2::new(12.0, 14.0),
+                Vec2::new(28.0, 14.0),
+            ),
+            (
+                "N2".to_string(),
+                Vec2::new(12.0, 26.0),
+                Vec2::new(28.0, 26.0),
+            ),
+        ];
+        let r = route_window_complete(&session, WINDOW, &[PcbLayer::FCu], &conns, 0.25, 2_000_000);
+        let CompleteOutcome::Routed(routed) = r else {
+            panic!("2 nets through 2 channels must route, got {r:?}");
+        };
+        assert_connected(&conns, &routed);
+        assert_probe_legal(&session, &conns, &routed, 0.25);
+    }
+
+    #[test]
+    fn tiny_budget_reports_unknown_never_infeasible() {
+        // Same (feasible) instance as the crossing test: with budget=1 the
+        // flow pre-pass passes, the DFS trips immediately, and the honest
+        // answer is BudgetExhausted — never a fake infeasibility proof.
+        let pcb = board(vec![], &[PcbLayer::FCu, PcbLayer::BCu]);
+        let session = RouteSession::from_pcb(&pcb);
+        let conns = vec![
+            (
+                "A".to_string(),
+                Vec2::new(12.0, 12.0),
+                Vec2::new(28.0, 28.0),
+            ),
+            (
+                "B".to_string(),
+                Vec2::new(12.0, 28.0),
+                Vec2::new(28.0, 12.0),
+            ),
+            (
+                "C".to_string(),
+                Vec2::new(12.0, 20.0),
+                Vec2::new(28.0, 20.0),
+            ),
+        ];
+        let r = route_window_complete(
+            &session,
+            WINDOW,
+            &[PcbLayer::FCu, PcbLayer::BCu],
+            &conns,
+            0.25,
+            1,
+        );
+        assert!(
+            matches!(r, CompleteOutcome::BudgetExhausted),
+            "budget=1 must yield BudgetExhausted, got {r:?}"
+        );
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/diff_pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/diff_pair.rs
@@ -201,7 +201,7 @@ fn midpoint(a: Vec2, b: Vec2) -> Vec2 {
 /// Positive distance offsets to the left of the travel direction (which is
 /// the `perp()` side), negative to the right. Corners are handled with
 /// mitered joins -- the intersection of adjacent offset edges.
-fn offset_polyline(points: &[Vec2], distance: f64) -> Vec<Vec2> {
+pub(super) fn offset_polyline(points: &[Vec2], distance: f64) -> Vec<Vec2> {
     if points.len() < 2 {
         return points.to_vec();
     }

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -48,6 +48,7 @@ pub mod grid;
 pub mod length_match;
 pub mod length_tune;
 pub mod maze;
+pub(crate) mod pair;
 pub mod push_shove;
 pub(crate) mod shove;
 

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -39,6 +39,7 @@ impl Stopwatch {
     }
 }
 
+pub(crate) mod complete;
 pub mod congestion;
 pub mod diff_pair;
 pub(crate) mod escape;
@@ -48,6 +49,7 @@ pub mod length_match;
 pub mod length_tune;
 pub mod maze;
 pub mod push_shove;
+pub(crate) mod shove;
 
 pub use auto::{
     route_all, route_all_with_opts, RouteAllResult, RouteOptions, RoutedTrace, RoutedVia,

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -1,0 +1,688 @@
+//! Coupled differential-pair routing for the auto-router (the phantom-fat-trace
+//! method).
+//!
+//! The last unrouted connections on dense reference boards are almost all
+//! `_P`/`_N` pairs whose escape plans succeed but whose *lone* placements fail
+//! — a pair leg routed alone blocks the corridor its twin needs. This stage
+//! routes the pair as one unit: search ONE phantom trace of the pair's full
+//! coupled width (`2·w + gap`) between the endpoint midpoints, then realize it
+//! as two offset legs at the declared diff-pair class geometry, connect the
+//! legs to the actual pads, and commit both nets atomically (all-or-nothing)
+//! through [`validate_and_commit`] — so the DRC-clean invariant is untouched.
+
+use vcad_ir::ecad::{Pcb, PcbLayer};
+use vcad_ir::Vec2;
+
+use crate::session::RouteSession;
+
+use super::auto::{copper_layers, dist, validate_and_commit, Candidate, Placed};
+use super::congestion::Congestion;
+use super::diff_pair::offset_polyline;
+use super::maze::route_net_maze3d;
+
+/// The pair partner of `net`, derived from its name. Recognizes:
+/// - trailing `_P` ↔ `_N` (any case): `/PCIe.TX_P` ↔ `/PCIe.TX_N`
+/// - a bare polarity token after a final `.`: `/X.P` ↔ `/X.N`
+/// - DDR true/complement `_C` ↔ `_T` tokens, as a suffix or mid-name
+///   (`DQS1_C_B` ↔ `DQS1_T_B`, `CK_C` ↔ `CK_T`)
+///
+/// Returns `None` for names with no polarity marker (`GND`, `/GPIO4`).
+pub(crate) fn pair_partner(net: &str) -> Option<String> {
+    // Trailing `_P`/`_N` (the overwhelmingly common convention).
+    for (a, b) in [("_P", "_N"), ("_N", "_P"), ("_p", "_n"), ("_n", "_p")] {
+        if let Some(base) = net.strip_suffix(a) {
+            if !base.is_empty() {
+                return Some(format!("{base}{b}"));
+            }
+        }
+    }
+    // A bare `P`/`N` token after the final `.`.
+    for (a, b) in [(".P", ".N"), (".N", ".P")] {
+        if let Some(base) = net.strip_suffix(a) {
+            if !base.is_empty() {
+                return Some(format!("{base}{b}"));
+            }
+        }
+    }
+    // DDR true/complement: swap the last `_C`/`_T` token (suffix or `_C_…`).
+    for (a, b) in [("_C", "_T"), ("_T", "_C")] {
+        if let Some(base) = net.strip_suffix(a) {
+            if !base.is_empty() {
+                return Some(format!("{base}{b}"));
+            }
+        }
+        let mid_a = format!("{a}_");
+        let mid_b = format!("{b}_");
+        if let Some(idx) = net.rfind(&mid_a) {
+            if idx > 0 {
+                let mut s = net.to_string();
+                s.replace_range(idx..idx + mid_a.len(), &mid_b);
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
+/// The pair's leg width and gap: from a declared diff-pair net class containing
+/// `net` when one exists, else the session width and `clearance · 1.5`.
+fn pair_geometry(session: &RouteSession, pcb: &Pcb, net: &str, width: f64) -> (f64, f64) {
+    for class in &pcb.rules.class_rules {
+        let Some(gap) = class.diff_pair_gap else {
+            continue;
+        };
+        let Some(nets) = pcb.rules.net_class_assignments.get(&class.name) else {
+            continue;
+        };
+        if nets.iter().any(|n| n == net) {
+            return (class.diff_pair_width.unwrap_or(class.trace_width), gap);
+        }
+    }
+    (
+        session.width_for(net, width),
+        session.clearance_for(net) * 1.5,
+    )
+}
+
+/// World positions of every pad on `net`.
+fn pads_of_net(pcb: &Pcb, net: &str) -> Vec<Vec2> {
+    let mut out = Vec::new();
+    for fp in &pcb.footprints {
+        for pad in &fp.pads {
+            if pad.net.as_deref() == Some(net) {
+                out.push(crate::geometry::pad_world_position(fp, pad));
+            }
+        }
+    }
+    out
+}
+
+/// The pad of `pads` nearest to `p`.
+fn nearest_pad(pads: &[Vec2], p: Vec2) -> Option<Vec2> {
+    pads.iter()
+        .copied()
+        .min_by(|a, b| dist(*a, p).partial_cmp(&dist(*b, p)).unwrap())
+}
+
+/// One realized leg of the pair: its segments, vias, and endpoints.
+struct Leg {
+    segments: Vec<(Vec2, Vec2, PcbLayer)>,
+    vias: Vec<(Vec2, PcbLayer, PcbLayer)>,
+    first: Vec2,
+    first_layer: PcbLayer,
+    last: Vec2,
+    last_layer: PcbLayer,
+}
+
+/// Route `net` and its pair partner as a coupled differential pair.
+///
+/// Searches one phantom fat trace (`2·w + gap` wide) between the endpoint
+/// midpoints, offsets it into two legs at ±(w+gap)/2, connects the legs to the
+/// four pads, and commits both nets atomically: if either candidate fails
+/// validation, everything is rolled back (including any partner routes that
+/// were ripped to make room) and the session is left exactly as found.
+///
+/// Returns `(placed_for_net, placed_for_partner)` on success.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn try_route_pair(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    width: f64,
+    net: &str,
+    from: Vec2,
+    to: Vec2,
+    placed: &mut Vec<Placed>,
+    cong: &Congestion,
+    max_expansions: usize,
+) -> Option<(Placed, Placed)> {
+    let partner = pair_partner(net)?;
+    let partner_pads = pads_of_net(pcb, &partner);
+    if partner_pads.is_empty() {
+        log::debug!("pair: {net} has partner name {partner} but no pads on board");
+        return None;
+    }
+    // MST-similar partner endpoints: the partner pads nearest to this
+    // connection's own endpoints. They must be two distinct pads.
+    let p_from = nearest_pad(&partner_pads, from)?;
+    let p_to = nearest_pad(&partner_pads, to)?;
+    if dist(p_from, p_to) < 1e-6 {
+        log::debug!("pair: {net}/{partner}: partner endpoints collapse to one pad — bailing");
+        return None;
+    }
+
+    let (w, gap) = pair_geometry(session, pcb, net, width);
+    let half_sep = (w + gap) / 2.0;
+    let fat_w = 2.0 * w + gap;
+    let via_d = pcb.rules.default_rules.via_diameter;
+    let clearance = session.clearance_for(net);
+    let copper = copper_layers(pcb);
+    let first_layer = *copper.first().unwrap_or(&PcbLayer::FCu);
+
+    // Centerline endpoints: the midpoints, pushed toward each other by a lead
+    // so the fat phantom clears the four pads (the pads are other-net copper
+    // from the phantom's perspective at the twin's end of the corridor).
+    let mid_from = Vec2::new((from.x + p_from.x) / 2.0, (from.y + p_from.y) / 2.0);
+    let mid_to = Vec2::new((to.x + p_to.x) / 2.0, (to.y + p_to.y) / 2.0);
+    let span = dist(mid_from, mid_to);
+    let lead = (fat_w + clearance + w).min(span * 0.25);
+    if span < 4.0 * lead.max(0.1) {
+        log::debug!("pair: {net}/{partner}: span {span:.2}mm too short for coupled routing");
+        return None;
+    }
+    let dir = {
+        let d = mid_to - mid_from;
+        d.scale(1.0 / span)
+    };
+    let start = mid_from + dir.scale(lead);
+    let end = mid_to - dir.scale(lead);
+
+    // Rip the partner's committed routes overlapping this span so the phantom
+    // corridor is clean; remember the originals for restore-on-failure. Routes
+    // with fan-out stubs are left in place (stubs can't ride a Candidate).
+    let lo = [
+        mid_from.x.min(mid_to.x) - fat_w - clearance,
+        mid_from.y.min(mid_to.y) - fat_w - clearance,
+    ];
+    let hi = [
+        mid_from.x.max(mid_to.x) + fat_w + clearance,
+        mid_from.y.max(mid_to.y) + fat_w + clearance,
+    ];
+    let overlaps_span = |p: &Placed| {
+        p.segments.iter().any(|(a, b, _)| {
+            let slo = [a.x.min(b.x), a.y.min(b.y)];
+            let shi = [a.x.max(b.x), a.y.max(b.y)];
+            slo[0] <= hi[0] && lo[0] <= shi[0] && slo[1] <= hi[1] && lo[1] <= shi[1]
+        })
+    };
+    let mut ripped: Vec<Placed> = Vec::new();
+    let mut kept: Vec<Placed> = Vec::new();
+    for p in std::mem::take(placed) {
+        if p.net == partner && p.stubs.is_empty() && overlaps_span(&p) {
+            for &s in &p.spans {
+                session.remove(s);
+            }
+            ripped.push(p);
+        } else {
+            kept.push(p);
+        }
+    }
+    *placed = kept;
+
+    // Restore-on-bail: re-commit the ripped partner routes (their space is
+    // still free — nothing was committed since the rip).
+    let restore = |session: &mut RouteSession, placed: &mut Vec<Placed>, ripped: Vec<Placed>| {
+        for orig in ripped {
+            let cand = Candidate {
+                net: orig.net.clone(),
+                from: orig.from,
+                to: orig.to,
+                width: orig.width,
+                segments: orig.segments.clone(),
+                vias: orig.via_pts.clone(),
+            };
+            match validate_and_commit(session, pcb, cand, placed) {
+                Some(p) => placed.push(p),
+                None => log::debug!("pair: could not restore a ripped {} route", orig.net),
+            }
+        }
+    };
+
+    // Centerline search: one phantom fat trace. No tree goals/sources — a
+    // coupled pair needs clean pad-to-pad geometry, not a tap onto a tree.
+    let budget = max_expansions.max(100_000);
+    let r = route_net_maze3d(
+        session,
+        &pcb.outline.vertices,
+        &copper,
+        net,
+        start,
+        &[first_layer],
+        end,
+        &[first_layer],
+        fat_w,
+        via_d,
+        Some(cong),
+        budget,
+        1.0,
+        None,
+        &[],
+        &[],
+        true,
+    );
+    if !r.success || r.segments.is_empty() {
+        log::debug!("pair: {net}/{partner}: phantom centerline search failed");
+        restore(session, placed, ripped);
+        return None;
+    }
+
+    // Realize the two legs from the centerline.
+    let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);
+    let (leg_a, leg_b) = match realize_legs(&r.segments, half_sep, via_off) {
+        Some(l) => l,
+        None => {
+            log::debug!("pair: {net}/{partner}: degenerate centerline — bailing");
+            restore(session, placed, ripped);
+            return None;
+        }
+    };
+
+    // Leg → net assignment: the one whose pad connectors are shortest (the
+    // non-crossing assignment — crossing connectors are strictly longer).
+    let cost = |leg: &Leg, s: Vec2, e: Vec2| dist(s, leg.first) + dist(e, leg.last);
+    let a_mine = cost(&leg_a, from, to) + cost(&leg_b, p_from, p_to)
+        <= cost(&leg_b, from, to) + cost(&leg_a, p_from, p_to);
+    let (mine, theirs) = if a_mine {
+        (leg_a, leg_b)
+    } else {
+        (leg_b, leg_a)
+    };
+
+    let build = |leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Candidate {
+        let mut segments = Vec::with_capacity(leg.segments.len() + 2);
+        if dist(from, leg.first) > 1e-9 {
+            segments.push((from, leg.first, leg.first_layer));
+        }
+        segments.extend(leg.segments.iter().copied());
+        if dist(leg.last, to) > 1e-9 {
+            segments.push((leg.last, to, leg.last_layer));
+        }
+        Candidate {
+            net: net.to_string(),
+            from,
+            to,
+            width: w,
+            segments,
+            vias: leg.vias.clone(),
+        }
+    };
+    let cand_mine = build(&mine, net, from, to);
+    let cand_theirs = build(&theirs, &partner, p_from, p_to);
+
+    // Atomic commit: both legs or neither.
+    let Some(placed_mine) = validate_and_commit(session, pcb, cand_mine, placed) else {
+        log::debug!("pair: {net}/{partner}: leg 1 failed validation");
+        restore(session, placed, ripped);
+        return None;
+    };
+    let Some(placed_theirs) = validate_and_commit(session, pcb, cand_theirs, placed) else {
+        // Leg 2 failed: rip leg 1 back out, restore the partner originals.
+        for &s in &placed_mine.spans {
+            session.remove(s);
+        }
+        log::debug!("pair: {net}/{partner}: leg 2 failed validation — rolled back leg 1");
+        restore(session, placed, ripped);
+        return None;
+    };
+
+    let center_len: f64 = r.segments.iter().map(|(a, b, _)| dist(*a, *b)).sum();
+    log::info!(
+        "pair: routed {net} + {partner} coupled (centerline {:.1}mm, {} via pair(s), w={w} gap={gap})",
+        center_len,
+        placed_mine.via_pts.len(),
+    );
+    Some((placed_mine, placed_theirs))
+}
+
+/// Offset the centerline into two legs at ±`half_sep`, with per-leg vias offset
+/// ±`via_off` perpendicular at each layer transition (two drills per centerline
+/// via, one per leg) and connector jogs where the via offset exceeds the leg
+/// offset. Leg A is the +offset side, leg B the −offset side.
+fn realize_legs(
+    center: &[(Vec2, Vec2, PcbLayer)],
+    half_sep: f64,
+    via_off: f64,
+) -> Option<(Leg, Leg)> {
+    // Group the centerline into contiguous same-layer polyline runs.
+    let mut runs: Vec<(PcbLayer, Vec<Vec2>)> = Vec::new();
+    for &(a, b, l) in center {
+        if dist(a, b) < 1e-9 {
+            continue;
+        }
+        match runs.last_mut() {
+            Some((rl, pts)) if *rl == l && dist(*pts.last().unwrap(), a) < 1e-6 => pts.push(b),
+            _ => runs.push((l, vec![a, b])),
+        }
+    }
+    if runs.is_empty() || runs.iter().any(|(_, pts)| pts.len() < 2) {
+        return None;
+    }
+
+    let leg = |sign: f64| -> Option<Leg> {
+        let mut segments: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
+        let mut vias: Vec<(Vec2, PcbLayer, PcbLayer)> = Vec::new();
+        let mut first: Option<(Vec2, PcbLayer)> = None;
+        let mut prev_end: Option<(Vec2, PcbLayer)> = None;
+        for (layer, pts) in &runs {
+            let off = offset_polyline(pts, sign * half_sep);
+            if off.len() < 2 {
+                return None;
+            }
+            if first.is_none() {
+                first = Some((off[0], *layer));
+            }
+            // Layer transition from the previous run: one via for this leg,
+            // offset perpendicular from the centerline junction, with jog
+            // connectors on both layers when it doesn't sit on the leg line.
+            if let Some((pe, pl)) = prev_end {
+                let junction = pts[0];
+                // Perpendicular at the junction: direction of the new run's
+                // first segment (matches the offset used for the leg points).
+                let d = (pts[1] - pts[0]).normalize();
+                let n = d.perp();
+                let vp = junction + n.scale(sign * via_off);
+                if dist(pe, vp) > 1e-9 {
+                    segments.push((pe, vp, pl));
+                }
+                if dist(vp, off[0]) > 1e-9 {
+                    segments.push((vp, off[0], *layer));
+                }
+                vias.push((vp, pl, *layer));
+            }
+            for wpair in off.windows(2) {
+                if dist(wpair[0], wpair[1]) > 1e-9 {
+                    segments.push((wpair[0], wpair[1], *layer));
+                }
+            }
+            prev_end = Some((*off.last().unwrap(), *layer));
+        }
+        let (first, first_layer) = first?;
+        let (last, last_layer) = prev_end?;
+        Some(Leg {
+            segments,
+            vias,
+            first,
+            first_layer,
+            last,
+            last_layer,
+        })
+    };
+    Some((leg(1.0)?, leg(-1.0)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::RouteSession;
+    use vcad_ir::ecad::*;
+
+    #[test]
+    fn pair_partner_maps_real_names() {
+        assert_eq!(pair_partner("/PCIe.TX_P").as_deref(), Some("/PCIe.TX_N"));
+        assert_eq!(pair_partner("/PCIe.TX_N").as_deref(), Some("/PCIe.TX_P"));
+        assert_eq!(pair_partner("/ETH.2_P").as_deref(), Some("/ETH.2_N"));
+        assert_eq!(
+            pair_partner("/LPDDR4 RAM/DQS1_C_B").as_deref(),
+            Some("/LPDDR4 RAM/DQS1_T_B")
+        );
+        assert_eq!(
+            pair_partner("/LPDDR4 RAM/CK_T_B").as_deref(),
+            Some("/LPDDR4 RAM/CK_C_B")
+        );
+        assert_eq!(pair_partner("USB_D_P").as_deref(), Some("USB_D_N"));
+        assert_eq!(pair_partner("CK_C").as_deref(), Some("CK_T"));
+        // Negatives: no polarity marker.
+        assert_eq!(pair_partner("GND"), None);
+        assert_eq!(pair_partner("/GPIO4"), None);
+        assert_eq!(pair_partner("VCC3V3"), None);
+        assert_eq!(pair_partner("_P"), None);
+    }
+
+    fn pad(num: &str, x: f64, y: f64, net: &str) -> Pad {
+        Pad {
+            number: num.into(),
+            pad_type: PadType::SMD,
+            shape: PadShape::Circle { diameter: 0.3 },
+            position: Vec2::new(x, y),
+            rotation: 0.0,
+            drill: None,
+            net: Some(net.into()),
+            layers: vec![PcbLayer::FCu],
+        }
+    }
+
+    fn fp(reference: &str, x: f64, y: f64, pads: Vec<Pad>) -> Footprint {
+        Footprint {
+            reference: reference.into(),
+            value: "x".into(),
+            footprint_name: "test".into(),
+            position: Vec2::new(x, y),
+            rotation: 0.0,
+            front: true,
+            pads,
+            graphics: vec![],
+            model_3d: None,
+            properties: Default::default(),
+        }
+    }
+
+    /// Open two-layer board with a P/N pad pair at each end (0.65 mm apart,
+    /// perpendicular to the horizontal route) and a diff-pair class declared
+    /// at width 0.2 / gap 0.25.
+    fn pair_board() -> Pcb {
+        let mut pcb = Pcb {
+            outline: BoardOutline {
+                vertices: vec![
+                    Vec2::new(0.0, 0.0),
+                    Vec2::new(50.0, 0.0),
+                    Vec2::new(50.0, 30.0),
+                    Vec2::new(0.0, 30.0),
+                ],
+                cutouts: vec![],
+                thickness: 1.6,
+            },
+            stackup: LayerStackup {
+                layers: vec![
+                    StackupLayer {
+                        layer: PcbLayer::FCu,
+                        copper_thickness: Some(0.035),
+                        dielectric_thickness: Some(1.5),
+                        dielectric_er: Some(4.5),
+                        material: Some("FR4".into()),
+                    },
+                    StackupLayer {
+                        layer: PcbLayer::BCu,
+                        copper_thickness: Some(0.035),
+                        dielectric_thickness: None,
+                        dielectric_er: None,
+                        material: None,
+                    },
+                ],
+            },
+            nets: vec![],
+            rules: DesignRules {
+                default_rules: NetClassRules {
+                    name: "Default".into(),
+                    trace_width: 0.25,
+                    clearance: 0.15,
+                    via_diameter: 0.8,
+                    via_drill: 0.4,
+                    diff_pair_gap: None,
+                    diff_pair_width: None,
+                },
+                class_rules: vec![NetClassRules {
+                    name: "DIFF".into(),
+                    trace_width: 0.2,
+                    clearance: 0.15,
+                    via_diameter: 0.8,
+                    via_drill: 0.4,
+                    diff_pair_gap: Some(0.25),
+                    diff_pair_width: Some(0.2),
+                }],
+                net_class_assignments: Default::default(),
+                edge_clearance: 0.5,
+                hole_to_hole: 0.5,
+                min_annular_ring: 0.15,
+                min_drill: 0.2,
+            },
+            footprints: vec![
+                fp(
+                    "J1",
+                    5.0,
+                    15.0,
+                    vec![
+                        pad("1", 0.0, 0.325, "/ETH.2_P"),
+                        pad("2", 0.0, -0.325, "/ETH.2_N"),
+                    ],
+                ),
+                fp(
+                    "U1",
+                    45.0,
+                    15.0,
+                    vec![
+                        pad("1", 0.0, 0.325, "/ETH.2_P"),
+                        pad("2", 0.0, -0.325, "/ETH.2_N"),
+                    ],
+                ),
+            ],
+            traces: vec![],
+            trace_arcs: vec![],
+            vias: vec![],
+            zones: vec![],
+            keepouts: vec![],
+            net_ties: vec![],
+        };
+        pcb.rules
+            .net_class_assignments
+            .insert("DIFF".into(), vec!["/ETH.2_P".into(), "/ETH.2_N".into()]);
+        pcb
+    }
+
+    #[test]
+    fn routes_open_board_pair_coupled() {
+        let pcb = pair_board();
+        let mut session = RouteSession::from_pcb(&pcb);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let mut placed = Vec::new();
+        let from = Vec2::new(5.0, 15.325);
+        let to = Vec2::new(45.0, 15.325);
+        let result = try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            from,
+            to,
+            &mut placed,
+            &cong,
+            200_000,
+        );
+        let (p, n) = result.expect("open-board pair must route coupled");
+        assert_eq!(p.net, "/ETH.2_P");
+        assert_eq!(n.net, "/ETH.2_N");
+        assert!(!p.segments.is_empty() && !n.segments.is_empty());
+        // Class geometry: legs at width 0.2, centers (w + gap) = 0.45 apart
+        // along the straight coupled run.
+        assert!((p.width - 0.2).abs() < 1e-9);
+        // Sample the coupled mid-span: the horizontal legs' y-separation.
+        let leg_y = |pl: &Placed| -> Option<f64> {
+            pl.segments
+                .iter()
+                .find(|(a, b, _)| (a.y - b.y).abs() < 1e-6 && (a.x - b.x).abs() > 5.0)
+                .map(|(a, _, _)| a.y)
+        };
+        if let (Some(py), Some(ny)) = (leg_y(&p), leg_y(&n)) {
+            let sep = (py - ny).abs();
+            assert!(
+                (sep - 0.45).abs() < 0.02,
+                "leg separation {sep} should be w+gap=0.45"
+            );
+            // No crossing: P stays on the P-pad side (above the centerline).
+            assert!(py > ny, "P leg must stay on the P-pad side");
+        } else {
+            panic!("expected a long horizontal coupled run in both legs");
+        }
+        // Every committed leg segment probes legal on a fresh session.
+        let fresh = RouteSession::from_pcb(&pcb);
+        for pl in [&p, &n] {
+            // The twin leg is same-session copper here, but on a FRESH session
+            // only board copper exists — each leg must clear the pads.
+            for (a, b, l) in &pl.segments {
+                let seg = crate::spatial::CopperGeom::Segment {
+                    a: *a,
+                    b: *b,
+                    half_w: pl.width / 2.0,
+                };
+                assert!(
+                    fresh
+                        .probe(&seg, *l, &pl.net, fresh.clearance_for(&pl.net))
+                        .legal,
+                    "pair leg emitted illegal copper for {}: {a:?}->{b:?}",
+                    pl.net
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn atomicity_blocked_leg_commits_nothing() {
+        let mut pcb = pair_board();
+        // Blocker pad in the N leg's end-connector corridor (between the fat
+        // corridor's end and the N pad at U1), clear of the P connector: the
+        // phantom search cannot see it (it lies past the centerline lead), so
+        // leg validation is what catches it — exercising the rollback path.
+        pcb.footprints
+            .push(fp("R9", 43.6, 14.55, vec![pad("1", 0.0, 0.0, "BLOCK")]));
+        let mut session = RouteSession::from_pcb(&pcb);
+        let baseline = session.len();
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let mut placed = Vec::new();
+        let result = try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            Vec2::new(5.0, 15.325),
+            Vec2::new(45.0, 15.325),
+            &mut placed,
+            &cong,
+            200_000,
+        );
+        // Whether the search bails or a leg fails validation, the contract is
+        // the same: on None, NOTHING was committed.
+        match result {
+            None => {
+                assert_eq!(
+                    session.len(),
+                    baseline,
+                    "failed pair routing must leave the session untouched"
+                );
+                assert!(placed.is_empty());
+            }
+            // If it routed around the blocker, that's fine too — but then both
+            // legs must exist and be legal (covered by validate_and_commit).
+            Some((p, n)) => {
+                assert!(!p.segments.is_empty() && !n.segments.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn bails_when_partner_absent() {
+        let mut pcb = pair_board();
+        // Rename the N pads away: partner name resolves but has no pads.
+        for f in &mut pcb.footprints {
+            for p in &mut f.pads {
+                if p.net.as_deref() == Some("/ETH.2_N") {
+                    p.net = Some("OTHER".into());
+                }
+            }
+        }
+        let mut session = RouteSession::from_pcb(&pcb);
+        let baseline = session.len();
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let mut placed = Vec::new();
+        assert!(try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            Vec2::new(5.0, 15.325),
+            Vec2::new(45.0, 15.325),
+            &mut placed,
+            &cong,
+            200_000,
+        )
+        .is_none());
+        assert_eq!(session.len(), baseline);
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/shove.rs
+++ b/crates/vcad-ecad-pcb/src/router/shove.rs
@@ -1,0 +1,455 @@
+//! True shove: displace blocking routed traces sideways (KiCad PNS-style)
+//! instead of ripping them, as the router's last-resort stage.
+//!
+//! When a connection's search fails and existing *routed* traces block the
+//! corridor, [`try_route_shove`] finds the blocking [`Placed`] routes along
+//! the direct corridor, translates each blocker's offending middle segments
+//! perpendicular to the corridor by the smallest displacement that both stays
+//! clearance-legal and lets the stuck net's fresh maze search succeed — then
+//! commits displaced victim and new route together, transactionally.
+//!
+//! Deliberate bounds (legality safety over completeness):
+//! - Displacement magnitude is capped at [`MAX_SHOVE_MM`].
+//! - Recursion depth is 1: a displaced trace must itself probe legal in its
+//!   new position — it may never displace *other* copper in turn.
+//! - Only MIDDLE segments whose endpoints are trace-trace joints move;
+//!   a crossing segment anchored at a pad, via, or fan-out stub endpoint
+//!   refuses the shove for that victim.
+//! - Victims are shoved one at a time (no joint multi-victim plans).
+
+use vcad_ir::ecad::{Pcb, PcbLayer};
+use vcad_ir::Vec2;
+
+use crate::session::RouteSession;
+use crate::spatial::CopperGeom;
+
+use super::auto::{
+    commit_seg, commit_via, copper_layers, dist, search_route, validate_and_commit, Placed,
+};
+use super::congestion::Congestion;
+
+/// Hard cap (mm) on how far a shove may translate a victim's segments.
+pub(super) const MAX_SHOVE_MM: f64 = 1.2;
+
+/// Displacement step (mm); candidates are tried at `±STEP, ±2·STEP, …` up to
+/// [`MAX_SHOVE_MM`], alternating signs so the smallest workable move wins.
+const SHOVE_STEP_MM: f64 = 0.2;
+
+/// At most this many distinct blocking routes are considered per connection.
+const MAX_SHOVE_VICTIMS: usize = 3;
+
+/// Two points are "the same joint" below this distance (mm).
+const JOINT_EPS: f64 = 1e-6;
+
+/// A point is "anchored" to a pad/via/stub endpoint below this distance (mm).
+const ANCHOR_EPS: f64 = 0.05;
+
+/// The candidate displacement magnitudes, smallest first, alternating signs.
+fn deltas() -> impl Iterator<Item = f64> {
+    let n = (MAX_SHOVE_MM / SHOVE_STEP_MM).round() as usize;
+    (1..=n).flat_map(|k| {
+        let d = k as f64 * SHOVE_STEP_MM;
+        [d, -d]
+    })
+}
+
+/// The plan for one victim: which segment indices move, and the set of joint
+/// points (per layer) that translate with them.
+struct ShovePlan {
+    /// Indices into the victim's `segments` that cross the corridor.
+    offending: Vec<usize>,
+    /// Joints to translate: `(point, layer)`.
+    moved: Vec<(Vec2, PcbLayer)>,
+}
+
+/// A shove translates copper sideways; only segments running roughly ALONG
+/// the corridor can be freed that way (a perpendicular crossing slides along
+/// itself and never clears the channel). Segments at least this aligned with
+/// the corridor direction (|cos|) are shove targets.
+const MIN_ALIGNMENT: f64 = 0.5;
+
+/// Segments of `victim` whose copper lies within `corridor_hw` of the
+/// corridor centerline `from -> to` AND runs roughly parallel to it — the
+/// segments a perpendicular translation could move out of the way.
+fn offending_segments(victim: &Placed, from: Vec2, to: Vec2, corridor_hw: f64) -> Vec<usize> {
+    let corridor = CopperGeom::Segment {
+        a: from,
+        b: to,
+        half_w: 0.0,
+    };
+    let cdir = (to - from).normalize();
+    victim
+        .segments
+        .iter()
+        .enumerate()
+        .filter(|(_, (a, b, _))| {
+            let sdir = (*b - *a).normalize();
+            if cdir.dot(sdir).abs() < MIN_ALIGNMENT {
+                return false;
+            }
+            let seg = CopperGeom::Segment {
+                a: *a,
+                b: *b,
+                half_w: victim.width / 2.0,
+            };
+            seg.distance_to(&corridor) < corridor_hw
+        })
+        .map(|(i, _)| i)
+        .collect()
+}
+
+/// Build the shove plan for `victim`, or `None` when any offending segment is
+/// anchored: an endpoint at the victim's pads (`from`/`to`), at one of its
+/// vias, at a fan-out stub, or dangling (shared with no neighbor segment).
+/// Only interior trace-trace joints may move — that keeps the displaced
+/// polyline connected by construction (neighbors sharing a moved joint are
+/// re-stitched by moving the shared endpoint with it).
+fn plan_shove(victim: &Placed, from: Vec2, to: Vec2, corridor_hw: f64) -> Option<ShovePlan> {
+    let offending = offending_segments(victim, from, to, corridor_hw);
+    if offending.is_empty() {
+        return None;
+    }
+    let anchored = |p: Vec2| -> bool {
+        dist(p, victim.from) < ANCHOR_EPS
+            || dist(p, victim.to) < ANCHOR_EPS
+            || victim
+                .via_pts
+                .iter()
+                .any(|&(vp, _, _)| dist(p, vp) < ANCHOR_EPS)
+            || victim
+                .stubs
+                .iter()
+                .any(|&(a, b, _)| dist(p, a) < ANCHOR_EPS || dist(p, b) < ANCHOR_EPS)
+    };
+    let mut moved: Vec<(Vec2, PcbLayer)> = Vec::new();
+    for &i in &offending {
+        let (a, b, layer) = victim.segments[i];
+        for p in [a, b] {
+            if anchored(p) {
+                return None;
+            }
+            // A movable joint must be shared with at least one other segment
+            // on the same layer — an unshared endpoint that isn't a pad or
+            // via is a dangling end we don't understand; refuse.
+            let shared = victim.segments.iter().enumerate().any(|(j, (sa, sb, sl))| {
+                j != i && *sl == layer && (dist(*sa, p) < JOINT_EPS || dist(*sb, p) < JOINT_EPS)
+            });
+            if !shared {
+                return None;
+            }
+            if !moved
+                .iter()
+                .any(|&(mp, ml)| ml == layer && dist(mp, p) < JOINT_EPS)
+            {
+                moved.push((p, layer));
+            }
+        }
+    }
+    Some(ShovePlan { offending, moved })
+}
+
+/// The victim's segments with every planned joint translated by `offset`.
+/// Neighbors sharing a moved joint stretch to follow it, so the polyline
+/// stays connected. Returns the new segment list plus the indices of every
+/// segment whose geometry changed (the ones that need re-probing).
+fn displaced_segments(
+    victim: &Placed,
+    plan: &ShovePlan,
+    offset: Vec2,
+) -> (Vec<(Vec2, Vec2, PcbLayer)>, Vec<usize>) {
+    let is_moved = |p: Vec2, l: PcbLayer| {
+        plan.moved
+            .iter()
+            .any(|&(mp, ml)| ml == l && dist(mp, p) < JOINT_EPS)
+    };
+    let mut out = Vec::with_capacity(victim.segments.len());
+    let mut changed = Vec::new();
+    for (i, &(a, b, layer)) in victim.segments.iter().enumerate() {
+        let na = if is_moved(a, layer) { a + offset } else { a };
+        let nb = if is_moved(b, layer) { b + offset } else { b };
+        if na != a || nb != b {
+            changed.push(i);
+        }
+        out.push((na, nb, layer));
+    }
+    (out, changed)
+}
+
+/// Commit `segments` and the victim's (unchanged) vias to the session,
+/// returning the new span ids.
+fn commit_victim_copper(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    victim: &Placed,
+    segments: &[(Vec2, Vec2, PcbLayer)],
+) -> Vec<crate::session::SpanId> {
+    let hw = victim.width / 2.0;
+    let via_r = pcb.rules.default_rules.via_diameter / 2.0;
+    let copper = copper_layers(pcb);
+    let mut spans = Vec::new();
+    for &(a, b, l) in segments {
+        spans.push(commit_seg(session, &victim.net, a, b, hw, l));
+    }
+    for &(p, la, lb) in &victim.via_pts {
+        let ia = copper.iter().position(|&l| l == la).unwrap_or(0);
+        let ib = copper
+            .iter()
+            .position(|&l| l == lb)
+            .unwrap_or(copper.len().saturating_sub(1));
+        let slice = &copper[ia.min(ib)..=ia.max(ib)];
+        commit_via(session, &victim.net, p, via_r, slice, &mut spans);
+    }
+    // Fan-out stubs never ride a shove (plan_shove refuses stub-anchored
+    // segments), but a victim may still CARRY stubs elsewhere on its route;
+    // they are part of its committed copper and must come back with it.
+    for &(a, b, l) in &victim.stubs {
+        spans.push(commit_seg(session, &victim.net, a, b, hw, l));
+    }
+    spans
+}
+
+/// Last-resort shove stage for a connection every search stage failed:
+/// displace the routed traces blocking the direct corridor sideways and
+/// re-search. On success the shoved victim's entry in `placed` is updated in
+/// place (new segments + spans) and the stuck connection's new [`Placed`] is
+/// returned; on failure everything is restored exactly as it was and `None`
+/// is returned.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn try_route_shove(
+    session: &mut RouteSession,
+    pcb: &Pcb,
+    width: f64,
+    net: &str,
+    from: Vec2,
+    to: Vec2,
+    placed: &mut [Placed],
+    cong: &Congestion,
+    max_expansions: usize,
+) -> Option<Placed> {
+    if dist(from, to) < JOINT_EPS {
+        return None;
+    }
+    let w = session.width_for(net, width);
+    let clearance = session.clearance_for(net);
+    // Wide enough to catch parallel traces a shove could move out of the way:
+    // the trace's own footprint, a couple of trace pitches of slack, and the
+    // full shove range.
+    let corridor_hw = w / 2.0 + clearance + w * 2.0 + MAX_SHOVE_MM;
+    let corridor = CopperGeom::Segment {
+        a: from,
+        b: to,
+        half_w: corridor_hw,
+    };
+    let copper = copper_layers(pcb);
+
+    // Which placed routes (other nets) block the corridor.
+    let mut blocker_spans = std::collections::HashSet::new();
+    for &layer in &copper {
+        for b in session.probe(&corridor, layer, net, clearance).blockers {
+            blocker_spans.insert(b.span);
+        }
+    }
+    let victims: Vec<usize> = placed
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| p.net != net && p.spans.iter().any(|s| blocker_spans.contains(s)))
+        .map(|(i, _)| i)
+        .take(MAX_SHOVE_VICTIMS)
+        .collect();
+    if victims.is_empty() {
+        return None;
+    }
+
+    // Perpendicular to the corridor: the direction a shove translates along.
+    let d = to - from;
+    let len = dist(from, to);
+    let perp = Vec2::new(-d.y / len, d.x / len);
+
+    for vi in victims {
+        let victim = placed[vi].clone();
+        let Some(plan) = plan_shove(&victim, from, to, corridor_hw) else {
+            log::debug!(
+                "shove: {} blocking {net} has pad/via-anchored crossing segments, skipping",
+                victim.net
+            );
+            continue;
+        };
+        // The victim's CURRENT span ids: a rolled-back attempt re-commits the
+        // original copper under fresh ids, which the next attempt must lift.
+        let mut cur_spans = victim.spans.clone();
+        for delta in deltas() {
+            let offset = Vec2::new(perp.x * delta, perp.y * delta);
+            let (new_segments, changed) = displaced_segments(&victim, &plan, offset);
+
+            // Transaction: lift the victim's copper out, try the displaced
+            // geometry plus the stuck net's fresh search, and restore the
+            // original copper on any failure (the space is free — it was
+            // only just removed).
+            for &s in &cur_spans {
+                session.remove(s);
+            }
+
+            // Depth-1 legality: every changed segment must probe legal as-is
+            // — a displaced trace may never displace others in turn.
+            let vhw = victim.width / 2.0;
+            let vclr = session.clearance_for(&victim.net);
+            let legal = changed.iter().all(|&i| {
+                let (a, b, l) = new_segments[i];
+                session
+                    .probe(
+                        &CopperGeom::Segment { a, b, half_w: vhw },
+                        l,
+                        &victim.net,
+                        vclr,
+                    )
+                    .legal
+            });
+            if !legal {
+                cur_spans = commit_victim_copper(session, pcb, &victim, &victim.segments);
+                placed[vi].spans = cur_spans.clone();
+                log::debug!(
+                    "shove: {} by {delta:+.1}mm for {net} is not clearance-legal",
+                    victim.net
+                );
+                continue;
+            }
+
+            // Commit the displaced victim, then re-search the stuck net in a
+            // corridor window around the connection.
+            let new_spans = commit_victim_copper(session, pcb, &victim, &new_segments);
+            let routed = search_route(
+                session,
+                pcb,
+                width,
+                net,
+                from,
+                to,
+                cong,
+                false,
+                max_expansions,
+                true,
+                Some((from, to)),
+            )
+            .and_then(|cand| validate_and_commit(session, pcb, cand, placed));
+
+            match routed {
+                Some(p) => {
+                    placed[vi].segments = new_segments;
+                    placed[vi].spans = new_spans;
+                    log::info!(
+                        "shove: displaced {} by {delta:+.1}mm to free {net} ({} segment(s) moved)",
+                        victim.net,
+                        plan.offending.len()
+                    );
+                    return Some(p);
+                }
+                None => {
+                    // Roll back: lift the displaced copper, restore the
+                    // original.
+                    for &s in &new_spans {
+                        session.remove(s);
+                    }
+                    cur_spans = commit_victim_copper(session, pcb, &victim, &victim.segments);
+                    placed[vi].spans = cur_spans.clone();
+                    log::debug!(
+                        "shove: {} by {delta:+.1}mm did not free {net}, rolled back",
+                        victim.net
+                    );
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn victim(segments: Vec<(Vec2, Vec2, PcbLayer)>, from: Vec2, to: Vec2) -> Placed {
+        Placed {
+            net: "B".into(),
+            from,
+            to,
+            width: 0.25,
+            segments,
+            stubs: Vec::new(),
+            via_pts: Vec::new(),
+            spans: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn plan_moves_only_interior_joints() {
+        // Three-segment U: pads at the tips, middle segment parallel to and
+        // near the corridor. The plan must move exactly the two interior
+        // joints and refuse nothing.
+        let l = PcbLayer::FCu;
+        let v = victim(
+            vec![
+                (Vec2::new(10.0, 5.0), Vec2::new(10.0, 3.0), l),
+                (Vec2::new(10.0, 3.0), Vec2::new(40.0, 3.0), l),
+                (Vec2::new(40.0, 3.0), Vec2::new(40.0, 5.0), l),
+            ],
+            Vec2::new(10.0, 5.0),
+            Vec2::new(40.0, 5.0),
+        );
+        let plan = plan_shove(&v, Vec2::new(5.0, 3.2), Vec2::new(45.0, 3.2), 1.0)
+            .expect("interior middle segment must be shovable");
+        assert_eq!(plan.offending, vec![1]);
+        assert_eq!(plan.moved.len(), 2);
+
+        let (segs, changed) = displaced_segments(&v, &plan, Vec2::new(0.0, -0.4));
+        // All three segments change: the middle translates, the flanks
+        // stretch to the moved joints.
+        assert_eq!(changed, vec![0, 1, 2]);
+        assert_eq!(segs[1].0, Vec2::new(10.0, 2.6));
+        assert_eq!(segs[1].1, Vec2::new(40.0, 2.6));
+        // Flank pad ends stay put; joint ends follow.
+        assert_eq!(segs[0].0, Vec2::new(10.0, 5.0));
+        assert_eq!(segs[0].1, Vec2::new(10.0, 2.6));
+        assert_eq!(segs[2].1, Vec2::new(40.0, 5.0));
+    }
+
+    #[test]
+    fn plan_refuses_pad_anchored_crossing_segment() {
+        // A single pad-to-pad segment lying in the corridor: both endpoints
+        // are anchors, so the shove must refuse.
+        let l = PcbLayer::FCu;
+        let v = victim(
+            vec![(Vec2::new(10.0, 3.0), Vec2::new(40.0, 3.0), l)],
+            Vec2::new(10.0, 3.0),
+            Vec2::new(40.0, 3.0),
+        );
+        assert!(plan_shove(&v, Vec2::new(5.0, 3.2), Vec2::new(45.0, 3.2), 1.0).is_none());
+    }
+
+    #[test]
+    fn plan_refuses_via_anchored_joint() {
+        let l = PcbLayer::FCu;
+        let mut v = victim(
+            vec![
+                (Vec2::new(10.0, 5.0), Vec2::new(10.0, 3.0), l),
+                (Vec2::new(10.0, 3.0), Vec2::new(40.0, 3.0), l),
+                (Vec2::new(40.0, 3.0), Vec2::new(40.0, 5.0), l),
+            ],
+            Vec2::new(10.0, 5.0),
+            Vec2::new(40.0, 5.0),
+        );
+        // A via sits exactly on one of the joints the shove would move.
+        v.via_pts
+            .push((Vec2::new(10.0, 3.0), PcbLayer::FCu, PcbLayer::BCu));
+        assert!(plan_shove(&v, Vec2::new(5.0, 3.2), Vec2::new(45.0, 3.2), 1.0).is_none());
+    }
+
+    #[test]
+    fn no_offending_segments_means_no_plan() {
+        let l = PcbLayer::FCu;
+        let v = victim(
+            vec![(Vec2::new(10.0, 20.0), Vec2::new(40.0, 20.0), l)],
+            Vec2::new(10.0, 20.0),
+            Vec2::new(40.0, 20.0),
+        );
+        assert!(plan_shove(&v, Vec2::new(5.0, 3.0), Vec2::new(45.0, 3.0), 1.0).is_none());
+    }
+}


### PR DESCRIPTION
The tier-4 endgame weapons, built and battle-tested against the CM5's final structural holdouts.

## New algorithms

- **True shove** (`shove.rs`): KiCad-PNS-style displacement as the search's last resort — blocking mid-route segments translate perpendicular (0.2–1.2mm, smallest first), interior joints only, depth-1, fully transactional with original-copper restore. DRC-verified integration tests.
- **Complete window router** (`complete.rs`, tier-4 item 1): exhaustive backtracking joint search over the exact-oracle-probed grid with bitset-memoized states and an Edmonds–Karp min-cut pre-pass. Three honest outcomes: `Routed` / `ProvedInfeasible` (human-readable bottleneck-cut certificate) / `BudgetExhausted` — a budget trip can never masquerade as a proof. Wired into joint repair. **First blood on the real board: `Net-(U1G-PCIe_TX_N)`, stuck across every heuristic configuration for two days, was jointly routed by the decision procedure.**
- Escape hardening: coincident-pad pitch degeneracy fixed; batch search failures now fall through to the full sequential arsenal (escape/shove included) — previously they bypassed it entirely.

## Where the campaign stands

379 nets carrying copper + contact-satisfied connections ≈ **0.95 cumulative** against what the repo's README reveals is *Raspberry Pi's own production routing* (the reverse-engineering traced the shipping board layer by layer). The project's `.kicad_pro` netclasses vindicate our copper-derived rule calibration to the third decimal (clearance 0.08, microvia 0.21).

The **23 survivors are almost all differential pairs** (`PCIe.TX_P`, `ETH.*_P/N`, RGMII bank) — telemetry shows escape plans succeeding as *plans* and failing as *lone placements*, exactly the signature of nets that must travel coupled at the declared 0.2/0.25 diff-pair class. Coupled diff-pair routing (tier-3 constraints-as-search-costs) is the named final algorithm.

Tests: 220/220 vcad-ecad-pcb; workspace clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)