### PR TITLE
circuit M1: LTE-based adaptive timestep control (opt-in)

### DIFF
--- a/changelog/entries/2026-07-17-circuit-adaptive-dt.json
+++ b/changelog/entries/2026-07-17-circuit-adaptive-dt.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-17-circuit-adaptive-dt",
+  "version": "0.9.4",
+  "date": "2026-07-17",
+  "category": "feat",
+  "title": "Adaptive timestep control for circuit simulation",
+  "summary": "Opt-in LTE-based adaptive stepping: stiff circuits solve in ~1000x fewer steps at equal accuracy, with Newton-failure rescue; fixed-step default unchanged.",
+  "features": ["circuit", "simulation", "ecad"]
+}

--- a/crates/vcad-ecad-sim/src/circuit/mod.rs
+++ b/crates/vcad-ecad-sim/src/circuit/mod.rs
@@ -57,6 +57,49 @@ pub enum Integrator {
     Trapezoidal,
 }
 
+/// Configuration for LTE-based adaptive timestep control (opt-in via
+/// [`CircuitEnv::set_adaptive`]).
+///
+/// Per accepted step the local truncation error (LTE) of every capacitor
+/// voltage and inductor current is estimated by comparing the trapezoidal
+/// corrector against a lower-order explicit predictor built from the stored
+/// companion derivative (the divided-difference approach of Nagel, SPICE2,
+/// UCB ERL-M520, 1975, §4.4). A step is accepted when every estimate is
+/// within `reltol·|x| + abstol`; the next step size follows the standard
+/// third-order controller `dt·min(2, 0.9·(tol/LTE)^{1/3})`, and a rejected
+/// step is redone at half the size. All step sizes are clamped to
+/// `[dt_min, dt_max]`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AdaptiveConfig {
+    /// Relative tolerance on each state variable (dimensionless).
+    pub reltol: f64,
+    /// Absolute tolerance floor (V for capacitor voltages, A for inductor
+    /// currents).
+    pub abstol: f64,
+    /// Smallest allowed step (s). A step that still fails at `dt_min` is
+    /// accepted anyway — there is nothing smaller to try.
+    pub dt_min: f64,
+    /// Largest allowed step (s).
+    pub dt_max: f64,
+}
+
+/// A snapshot of every piece of mutable transient state, so a rejected
+/// adaptive step can be rolled back with no partial companion history.
+#[derive(Debug, Clone)]
+struct StateSnapshot {
+    time: f64,
+    first_step: bool,
+    cap_v: Vec<f64>,
+    cap_i: Vec<f64>,
+    ind_i: Vec<f64>,
+    ind_v: Vec<f64>,
+    nl_state: Vec<[f64; 2]>,
+    mech_omega: Vec<f64>,
+    mech_theta: Vec<f64>,
+    node_v: Vec<f64>,
+    dev_i: Vec<f64>,
+}
+
 /// A lumped-element circuit: a set of [`Device`]s connecting numbered nodes.
 ///
 /// Node `0` is always ground (the voltage reference). Allocate other nodes with
@@ -151,6 +194,14 @@ pub struct CircuitEnv {
     dev_i: Vec<f64>,
     /// Newton iteration cap for nonlinear devices.
     max_newton: usize,
+    /// Adaptive-timestep control; `None` (the default) keeps the historical
+    /// fixed-step behavior bit-for-bit. The adjoint machinery and existing
+    /// WASM consumers depend on the frozen fixed-dt discretization (the
+    /// accept/reject control flow is not differentiated — see the particle
+    /// crate's adjoint docs), so adaptivity is strictly opt-in.
+    adaptive: Option<AdaptiveConfig>,
+    /// Current adaptive step size (s); meaningful only when `adaptive` is set.
+    adaptive_dt: f64,
 }
 
 impl CircuitEnv {
@@ -174,6 +225,8 @@ impl CircuitEnv {
             node_v: vec![0.0; nn],
             dev_i: vec![0.0; nd],
             max_newton: 50,
+            adaptive: None,
+            adaptive_dt: dt,
         }
     }
 
@@ -191,6 +244,9 @@ impl CircuitEnv {
         self.mech_theta.fill(0.0);
         self.node_v.fill(0.0);
         self.dev_i.fill(0.0);
+        if let Some(cfg) = self.adaptive {
+            self.adaptive_dt = self.dt.clamp(cfg.dt_min, cfg.dt_max);
+        }
     }
 
     /// The configured timestep (s).
@@ -225,6 +281,45 @@ impl CircuitEnv {
         self.integrator = integrator;
     }
 
+    /// Enable LTE-based adaptive timestep control (see [`AdaptiveConfig`]).
+    ///
+    /// Adaptivity implies the trapezoidal integrator (the LTE estimate and
+    /// the 1/3-power controller both assume its third-order local error), so
+    /// this also selects [`Integrator::Trapezoidal`]. Call before the first
+    /// [`CircuitEnv::step`] or after a [`CircuitEnv::reset`], like
+    /// [`CircuitEnv::set_integrator`]. Observation timestamps become
+    /// non-uniform; `Observation::time` carries the true simulated time.
+    ///
+    /// # Panics
+    /// Panics if the config is malformed (`dt_min ≤ 0`, `dt_min > dt_max`,
+    /// or non-positive tolerances).
+    pub fn set_adaptive(&mut self, cfg: AdaptiveConfig) {
+        assert!(
+            cfg.dt_min > 0.0 && cfg.dt_min <= cfg.dt_max,
+            "AdaptiveConfig requires 0 < dt_min <= dt_max"
+        );
+        assert!(
+            cfg.reltol > 0.0 && cfg.abstol > 0.0,
+            "AdaptiveConfig requires positive tolerances"
+        );
+        debug_assert!(
+            self.first_step,
+            "set_adaptive must be called before stepping or after reset()"
+        );
+        self.integrator = Integrator::Trapezoidal;
+        self.adaptive = Some(cfg);
+        self.adaptive_dt = self.dt.clamp(cfg.dt_min, cfg.dt_max);
+    }
+
+    /// Disable adaptive stepping, returning to the fixed-dt path.
+    pub fn clear_adaptive(&mut self) {
+        debug_assert!(
+            self.first_step,
+            "clear_adaptive must be called before stepping or after reset()"
+        );
+        self.adaptive = None;
+    }
+
     /// Tellegen power-balance residual (W) of the latest solved state:
     /// Σ over devices of (v_p − v_n)·i, with i the device current the KCL
     /// solve actually used. Tellegen's theorem says this is exactly zero for
@@ -254,16 +349,157 @@ impl CircuitEnv {
     }
 
     /// Advance the simulation by one timestep and return the new observation.
+    ///
+    /// On the default fixed-step path this advances by exactly `dt`. With
+    /// adaptive control enabled ([`CircuitEnv::set_adaptive`]) it advances by
+    /// one *accepted* step — internally the step may be halved and redone
+    /// (LTE too large, or Newton non-convergence) before it is committed.
     pub fn step(&mut self) -> Observation {
-        let nn = self.circuit.num_nodes;
-        let nb = self.circuit.num_branches();
-        let m = (nn - 1) + nb;
+        if self.adaptive.is_some() {
+            return self.step_adaptive(None);
+        }
         // First step always runs backward Euler (see `first_step` docs).
         let integ = if self.first_step {
             Integrator::BackwardEuler
         } else {
             self.integrator
         };
+        self.attempt_step(self.dt, integ);
+        self.observe()
+    }
+
+    /// Step repeatedly until simulated time reaches `t_end`, returning every
+    /// observation along the way. With adaptive control the final step is
+    /// shortened to land exactly on `t_end`; on the fixed-step path the last
+    /// observation may overshoot by up to one `dt` (the fixed grid is never
+    /// distorted).
+    pub fn step_to(&mut self, t_end: f64) -> Vec<Observation> {
+        let mut out = Vec::new();
+        while self.time < t_end * (1.0 - 1e-12) {
+            let obs = if self.adaptive.is_some() {
+                self.step_adaptive(Some(t_end - self.time))
+            } else {
+                self.step()
+            };
+            out.push(obs);
+        }
+        out
+    }
+
+    /// One accepted adaptive step: attempt at the current step size, estimate
+    /// the LTE of every reactive state, and shrink-and-redo until the step
+    /// passes (or `dt_min` says nothing smaller is possible). `cap` bounds the
+    /// step so [`CircuitEnv::step_to`] can land exactly on its end time.
+    fn step_adaptive(&mut self, cap: Option<f64>) -> Observation {
+        let cfg = self.adaptive.expect("adaptive config present");
+        let mut dt = self.adaptive_dt.clamp(cfg.dt_min, cfg.dt_max);
+        if let Some(c) = cap {
+            dt = dt.min(c.max(cfg.dt_min));
+        }
+
+        loop {
+            let integ = if self.first_step {
+                Integrator::BackwardEuler
+            } else {
+                self.integrator
+            };
+            let snap = self.snapshot();
+
+            // Explicit predictor per reactive state from the stored companion
+            // derivative (divided differences — Nagel §4.4): the corrector-
+            // minus-predictor gap is the LTE estimate.
+            let preds: Vec<(usize, f64, f64)> = self
+                .circuit
+                .devices
+                .iter()
+                .enumerate()
+                .filter_map(|(id, d)| match *d {
+                    Device::Capacitor { c, .. } => Some((id, self.cap_v[id], self.cap_i[id] / c)),
+                    Device::Inductor { l, .. } => Some((id, self.ind_i[id], self.ind_v[id] / l)),
+                    _ => None,
+                })
+                .collect();
+
+            let converged = self.attempt_step(dt, integ);
+            let at_floor = dt <= cfg.dt_min * (1.0 + 1e-12);
+
+            if !converged && !at_floor {
+                // The classic transient-convergence rescue: Newton failed, so
+                // roll everything back and retry at half the step.
+                self.restore(snap);
+                dt = (dt * 0.5).max(cfg.dt_min);
+                continue;
+            }
+
+            // Worst LTE-to-tolerance ratio over all reactive states.
+            let mut ratio = 0.0f64;
+            for &(id, x_prev, dxdt) in &preds {
+                let x_new = match self.circuit.devices[id] {
+                    Device::Capacitor { .. } => self.cap_v[id],
+                    _ => self.ind_i[id],
+                };
+                let est = (x_new - (x_prev + dt * dxdt)).abs();
+                let tol = cfg.reltol * x_new.abs().max(x_prev.abs()) + cfg.abstol;
+                ratio = ratio.max(est / tol);
+            }
+
+            if ratio > 1.0 && !at_floor {
+                self.restore(snap);
+                dt = (dt * 0.5).max(cfg.dt_min);
+                continue;
+            }
+
+            // Accepted. Third-order controller for the trapezoidal rule:
+            // dt' = dt·min(2, 0.9·(tol/LTE)^{1/3}), clamped to [dt_min, dt_max].
+            let grow = if ratio > 0.0 {
+                (0.9 * ratio.powf(-1.0 / 3.0)).min(2.0)
+            } else {
+                2.0
+            };
+            self.adaptive_dt = (dt * grow).clamp(cfg.dt_min, cfg.dt_max);
+            return self.observe();
+        }
+    }
+
+    fn snapshot(&self) -> StateSnapshot {
+        StateSnapshot {
+            time: self.time,
+            first_step: self.first_step,
+            cap_v: self.cap_v.clone(),
+            cap_i: self.cap_i.clone(),
+            ind_i: self.ind_i.clone(),
+            ind_v: self.ind_v.clone(),
+            nl_state: self.nl_state.clone(),
+            mech_omega: self.mech_omega.clone(),
+            mech_theta: self.mech_theta.clone(),
+            node_v: self.node_v.clone(),
+            dev_i: self.dev_i.clone(),
+        }
+    }
+
+    fn restore(&mut self, s: StateSnapshot) {
+        self.time = s.time;
+        self.first_step = s.first_step;
+        self.cap_v = s.cap_v;
+        self.cap_i = s.cap_i;
+        self.ind_i = s.ind_i;
+        self.ind_v = s.ind_v;
+        self.nl_state = s.nl_state;
+        self.mech_omega = s.mech_omega;
+        self.mech_theta = s.mech_theta;
+        self.node_v = s.node_v;
+        self.dev_i = s.dev_i;
+    }
+
+    /// The full solve-and-commit body of one transient step at step size `dt`
+    /// with integrator `integ`. Returns whether the Newton loop converged
+    /// (`true` for linear circuits after their exact solve). The fixed-step
+    /// path ignores the flag — its behavior is unchanged from M0.
+    fn attempt_step(&mut self, dt: f64, integ: Integrator) -> bool {
+        let nn = self.circuit.num_nodes;
+        let nb = self.circuit.num_branches();
+        let m = (nn - 1) + nb;
+        let mut converged = false;
 
         // Newton-Raphson outer loop: nonlinear devices linearise around the
         // current node-voltage guess each iteration. Linear circuits converge in
@@ -285,13 +521,13 @@ impl CircuitEnv {
                 if integ == Integrator::Trapezoidal {
                     match dev {
                         Device::Capacitor { p, n, c } => {
-                            let g = 2.0 * c / self.dt;
+                            let g = 2.0 * c / dt;
                             devices::stamp_conductance(&mut a, m, p, n, g);
                             devices::inject(&mut rhs, p, n, g * self.cap_v[id] + self.cap_i[id]);
                             continue;
                         }
                         Device::Inductor { p, n, l } => {
-                            let g = self.dt / (2.0 * l);
+                            let g = dt / (2.0 * l);
                             devices::stamp_conductance(&mut a, m, p, n, g);
                             devices::inject(&mut rhs, p, n, -(self.ind_i[id] + g * self.ind_v[id]));
                             continue;
@@ -305,7 +541,7 @@ impl CircuitEnv {
                     m,
                     nn,
                     &mut branch,
-                    self.dt,
+                    dt,
                     self.cap_v[id],
                     self.ind_i[id],
                     self.nl_state[id],
@@ -318,7 +554,7 @@ impl CircuitEnv {
 
             let solution = match solve_dense(&mut a, &mut rhs, m) {
                 Some(x) => x,
-                None => break, // singular — keep previous guess
+                None => break, // singular — keep previous guess (not converged)
             };
 
             let mut next = vec![0.0; nn];
@@ -341,6 +577,7 @@ impl CircuitEnv {
             }
 
             if delta < 1e-9 {
+                converged = true;
                 break;
             }
         }
@@ -354,9 +591,9 @@ impl CircuitEnv {
                     let v_new = self.node_v[p] - self.node_v[n];
                     let i_new = match integ {
                         // companion current = gc·(v_new − v_prev) = C·dv/dt
-                        Integrator::BackwardEuler => (c / self.dt) * (v_new - self.cap_v[id]),
+                        Integrator::BackwardEuler => (c / dt) * (v_new - self.cap_v[id]),
                         Integrator::Trapezoidal => {
-                            (2.0 * c / self.dt) * (v_new - self.cap_v[id]) - self.cap_i[id]
+                            (2.0 * c / dt) * (v_new - self.cap_v[id]) - self.cap_i[id]
                         }
                     };
                     self.dev_i[id] = i_new;
@@ -366,9 +603,9 @@ impl CircuitEnv {
                 Device::Inductor { p, n, l } => {
                     let v = self.node_v[p] - self.node_v[n];
                     let i_new = match integ {
-                        Integrator::BackwardEuler => (self.dt / l) * v + self.ind_i[id],
+                        Integrator::BackwardEuler => (dt / l) * v + self.ind_i[id],
                         Integrator::Trapezoidal => {
-                            (self.dt / (2.0 * l)) * (v + self.ind_v[id]) + self.ind_i[id]
+                            (dt / (2.0 * l)) * (v + self.ind_v[id]) + self.ind_i[id]
                         }
                     };
                     self.dev_i[id] = i_new;
@@ -382,8 +619,8 @@ impl CircuitEnv {
                     let i_m = self.dev_i[id];
                     let omega_prev = self.mech_omega[id];
                     let torque = params.kt * i_m - params.b * omega_prev - params.load;
-                    let omega_new = omega_prev + (self.dt / params.j) * torque;
-                    self.mech_theta[id] += self.dt * omega_new;
+                    let omega_new = omega_prev + (dt / params.j) * torque;
+                    self.mech_theta[id] += dt * omega_new;
                     self.mech_omega[id] = omega_new;
                     self.ind_i[id] = i_m;
                 }
@@ -395,9 +632,9 @@ impl CircuitEnv {
             }
         }
 
-        self.time += self.dt;
+        self.time += dt;
         self.first_step = false;
-        self.observe()
+        converged
     }
 
     /// The current state without advancing time.

--- a/crates/vcad-ecad-sim/tests/circuit_adaptive.rs
+++ b/crates/vcad-ecad-sim/tests/circuit_adaptive.rs
@@ -1,0 +1,380 @@
+//! LTE-based adaptive-timestep validation (SPICE M1, item 3).
+//!
+//! Rungs:
+//! 1. Stiff RC pair (τ ratio 1e4): adaptive reaches t_end in far fewer steps
+//!    than a fixed grid resolving the fast pole, at equal-or-better max error
+//!    vs the analytic exponentials.
+//! 2. RLC ringdown: adaptive preserves the frequency/envelope accuracy of the
+//!    fixed-step gate in `circuit_validation.rs`.
+//! 3. Diode rectifier under a stepped sine: dt shrinks near the conduction
+//!    knee and grows on the flat — the min/max accepted-step spread proves the
+//!    controller actually moves.
+//! 4. Tellegen power balance holds at every *accepted* step.
+//! 5. Fixed-step regression: with adaptivity off, observations are
+//!    bit-identical to the M0 code (golden bit patterns captured pre-change).
+
+use vcad_ecad_sim::circuit::{AdaptiveConfig, Circuit, CircuitEnv, Device, DiodeModel, Integrator};
+
+/// 5 V step into two independent RC branches: τ_slow = 1 ms, τ_fast = 100 ns.
+fn stiff_rc() -> (Circuit, usize, usize) {
+    let mut ckt = Circuit::new();
+    let vin = ckt.node();
+    let slow = ckt.node();
+    let fast = ckt.node();
+    ckt.add(Device::VSource {
+        p: vin,
+        n: 0,
+        v: 5.0,
+    });
+    ckt.add(Device::Resistor {
+        p: vin,
+        n: slow,
+        r: 1_000.0,
+    });
+    ckt.add(Device::Capacitor {
+        p: slow,
+        n: 0,
+        c: 1e-6,
+    }); // τ = 1 ms
+    ckt.add(Device::Resistor {
+        p: vin,
+        n: fast,
+        r: 1.0,
+    });
+    ckt.add(Device::Capacitor {
+        p: fast,
+        n: 0,
+        c: 1e-7,
+    }); // τ = 100 ns
+    (ckt, slow, fast)
+}
+
+fn stiff_rc_max_err(obs: &[vcad_ecad_sim::circuit::Observation], slow: usize, fast: usize) -> f64 {
+    let mut worst = 0.0f64;
+    for o in obs {
+        let es = 5.0 * (1.0 - (-o.time / 1e-3).exp());
+        let ef = 5.0 * (1.0 - (-o.time / 1e-7).exp());
+        worst = worst.max((o.node_voltages[slow] - es).abs());
+        worst = worst.max((o.node_voltages[fast] - ef).abs());
+    }
+    worst
+}
+
+#[test]
+fn adaptive_beats_fixed_on_stiff_rc_pair() {
+    let t_end = 5e-3; // 5 τ_slow
+
+    // Fixed grid that resolves the fast pole: dt = τ_fast/10 → 500k steps.
+    let (ckt, slow, fast) = stiff_rc();
+    let mut env = CircuitEnv::new(ckt, 1e-8);
+    env.set_integrator(Integrator::Trapezoidal);
+    env.reset();
+    let fixed_obs = env.step_to(t_end);
+    let fixed_steps = fixed_obs.len();
+    let fixed_err = stiff_rc_max_err(&fixed_obs, slow, fast);
+
+    // Adaptive with the same starting dt.
+    let (ckt, slow, fast) = stiff_rc();
+    let mut env = CircuitEnv::new(ckt, 1e-8);
+    env.set_adaptive(AdaptiveConfig {
+        reltol: 1e-4,
+        abstol: 1e-7,
+        dt_min: 1e-10,
+        dt_max: 1e-4,
+    });
+    env.reset();
+    let adaptive_obs = env.step_to(t_end);
+    let adaptive_steps = adaptive_obs.len();
+    let adaptive_err = stiff_rc_max_err(&adaptive_obs, slow, fast);
+
+    // Real numbers, asserted with headroom (see the research log for the
+    // measured table): fixed = 500_000 steps, adaptive ≈ low thousands.
+    eprintln!(
+        "stiff RC: fixed {fixed_steps} steps err {fixed_err:.3e} | adaptive {adaptive_steps} steps err {adaptive_err:.3e}"
+    );
+    // ±1 for float accumulation on the fixed grid.
+    assert!((500_000..=500_001).contains(&fixed_steps));
+    assert!(
+        adaptive_steps < fixed_steps / 100,
+        "adaptive took {adaptive_steps} steps, want ≪ {fixed_steps}"
+    );
+    assert!(
+        adaptive_err < 5e-4,
+        "adaptive max error {adaptive_err:.3e} vs analytic"
+    );
+    assert!(
+        adaptive_err < 10.0 * fixed_err.max(1e-5),
+        "adaptive err {adaptive_err:.3e} should be comparable to fixed {fixed_err:.3e}"
+    );
+    // And it actually reaches t_end.
+    let t_last = adaptive_obs.last().unwrap().time;
+    assert!((t_last - t_end).abs() < 1e-12, "landed at {t_last}");
+}
+
+#[test]
+fn adaptive_preserves_rlc_ringdown_accuracy() {
+    // Same series RLC as the fixed-step validation gate: R = 20 Ω, L = 1 mH,
+    // C = 100 nF → ω₀ = 100 krad/s, Q = 5.
+    let (r, l, c): (f64, f64, f64) = (20.0, 1e-3, 1e-7);
+    let omega0 = 1.0 / (l * c).sqrt();
+    let q = (1.0 / r) * (l / c).sqrt();
+    let omega_d = omega0 * (1.0 - 1.0 / (4.0 * q * q)).sqrt();
+    let alpha = r / (2.0 * l);
+
+    let mut ckt = Circuit::new();
+    let vin = ckt.node();
+    let mid = ckt.node();
+    let out = ckt.node();
+    ckt.add(Device::VSource {
+        p: vin,
+        n: 0,
+        v: 1.0,
+    });
+    ckt.add(Device::Resistor { p: vin, n: mid, r });
+    ckt.add(Device::Inductor { p: mid, n: out, l });
+    ckt.add(Device::Capacitor { p: out, n: 0, c });
+
+    let mut env = CircuitEnv::new(ckt, 2e-8);
+    env.set_adaptive(AdaptiveConfig {
+        reltol: 1e-5,
+        abstol: 1e-9,
+        dt_min: 1e-10,
+        dt_max: 1e-6,
+    });
+    env.reset();
+    let t_end = 8.0 * 2.0 * std::f64::consts::PI / omega_d;
+    let samples: Vec<(f64, f64)> = env
+        .step_to(t_end)
+        .iter()
+        .map(|o| (o.time, o.node_voltages[out] - 1.0))
+        .collect();
+
+    let mut crossings: Vec<f64> = Vec::new();
+    let mut peaks: Vec<f64> = Vec::new();
+    for k in 1..samples.len() - 1 {
+        let (t0, y0) = samples[k - 1];
+        let (t1, y1) = samples[k];
+        let (_, y2) = samples[k + 1];
+        if y0 < 0.0 && y1 >= 0.0 {
+            crossings.push(t0 + (-y0 / (y1 - y0)) * (t1 - t0));
+        }
+        if y1 > 0.0 && y1 > y0 && y1 >= y2 {
+            peaks.push(y1);
+        }
+    }
+
+    assert!(crossings.len() >= 4, "need several ring periods");
+    let n = crossings.len() - 1;
+    let period = (crossings[n] - crossings[0]) / n as f64;
+    let omega_meas = 2.0 * std::f64::consts::PI / period;
+    let rel_err = (omega_meas - omega_d).abs() / omega_d;
+    assert!(rel_err < 1e-3, "ring frequency off by {rel_err:.2e}");
+
+    assert!(peaks.len() >= 4, "need several peaks, got {}", peaks.len());
+    let decay = (peaks[1] / peaks[3]).ln() / (2.0 * period);
+    let alpha_rel = (decay - alpha).abs() / alpha;
+    assert!(alpha_rel < 2e-2, "envelope decay off by {alpha_rel:.2e}");
+}
+
+#[test]
+fn adaptive_dt_tracks_diode_conduction_knee() {
+    // Half-wave rectifier: stepped-sine source — R — diode — RC load. The
+    // source is re-set before every accepted step (zeroth-order hold), so the
+    // waveform the LTE sees is the circuit's own response: sharp at the
+    // conduction knee, flat between half-cycles.
+    let f = 1_000.0; // 1 kHz
+    let mut ckt = Circuit::new();
+    let vin = ckt.node();
+    let mid = ckt.node();
+    let out = ckt.node();
+    let src = ckt.add(Device::VSource {
+        p: vin,
+        n: 0,
+        v: 0.0,
+    });
+    ckt.add(Device::Resistor {
+        p: vin,
+        n: mid,
+        r: 100.0,
+    });
+    ckt.add(Device::Diode {
+        p: mid,
+        n: out,
+        model: DiodeModel::silicon(),
+    });
+    ckt.add(Device::Capacitor {
+        p: out,
+        n: 0,
+        c: 1e-6,
+    });
+    ckt.add(Device::Resistor {
+        p: out,
+        n: 0,
+        r: 10_000.0,
+    });
+
+    let mut env = CircuitEnv::new(ckt, 1e-6);
+    env.set_adaptive(AdaptiveConfig {
+        reltol: 1e-3,
+        abstol: 1e-6,
+        dt_min: 1e-9,
+        dt_max: 5e-5,
+    });
+    env.reset();
+
+    let t_end = 3.0 / f; // three cycles
+    let mut t_prev = 0.0;
+    let mut dts: Vec<f64> = Vec::new();
+    while t_prev < t_end {
+        let t = env.observe().time;
+        env.set_value(src, 5.0 * (2.0 * std::f64::consts::PI * f * t).sin());
+        let obs = env.step();
+        dts.push(obs.time - t_prev);
+        t_prev = obs.time;
+    }
+
+    // Skip the startup ramp; look at the settled cycles.
+    let settled = &dts[dts.len() / 3..];
+    let dt_min_seen = settled.iter().cloned().fold(f64::INFINITY, f64::min);
+    let dt_max_seen = settled.iter().cloned().fold(0.0f64, f64::max);
+    assert!(
+        dt_max_seen / dt_min_seen > 10.0,
+        "controller should spread dt ≥ 10× across the cycle: min {dt_min_seen:.3e} max {dt_max_seen:.3e}"
+    );
+    assert!(
+        dt_max_seen > 1e-5,
+        "flat regions should coast at large dt, got {dt_max_seen:.3e}"
+    );
+}
+
+#[test]
+fn tellegen_holds_at_every_accepted_step() {
+    // The rung-5 mixed network, driven adaptively.
+    let mut ckt = Circuit::new();
+    let vin = ckt.node();
+    let a = ckt.node();
+    let b = ckt.node();
+    ckt.add(Device::VSource {
+        p: vin,
+        n: 0,
+        v: 5.0,
+    });
+    ckt.add(Device::Resistor {
+        p: vin,
+        n: a,
+        r: 470.0,
+    });
+    ckt.add(Device::Capacitor {
+        p: a,
+        n: 0,
+        c: 2.2e-6,
+    });
+    ckt.add(Device::Inductor {
+        p: a,
+        n: b,
+        l: 1e-3,
+    });
+    ckt.add(Device::Resistor {
+        p: b,
+        n: 0,
+        r: 220.0,
+    });
+    ckt.add(Device::Diode {
+        p: a,
+        n: 0,
+        model: DiodeModel::silicon(),
+    });
+
+    let mut env = CircuitEnv::new(ckt, 1e-6);
+    env.set_adaptive(AdaptiveConfig {
+        reltol: 1e-3,
+        abstol: 1e-6,
+        dt_min: 1e-10,
+        dt_max: 1e-4,
+    });
+    env.reset();
+    let mut k = 0usize;
+    while env.observe().time < 2e-3 {
+        let obs = env.step();
+        let dissipated = (5.0 * obs.device_currents[0].abs()).max(1e-6);
+        let residual = env.power_balance().abs();
+        assert!(
+            residual / dissipated < 1e-9,
+            "step {k} (t={:.3e}): Tellegen residual {residual:.3e} vs scale {dissipated:.3e}",
+            obs.time
+        );
+        k += 1;
+    }
+}
+
+#[test]
+fn fixed_step_path_is_bit_identical_to_m0() {
+    // Golden bit patterns captured from the pre-adaptive M0 code on this
+    // exact circuit (rung-5 network, dt = 1 µs, 500 steps). Any drift in the
+    // fixed-step discretization breaks the adjoint/WASM contract.
+    let golden = [
+        (
+            Integrator::BackwardEuler,
+            0x3fe66e1ddf86218fu64, // v_a
+            0x3fe66e1ddf86218eu64, // v_b
+            0xbf82bba06d004126u64, // i_src
+        ),
+        (
+            Integrator::Trapezoidal,
+            0x3fe66e1ddf862187u64,
+            0x3fe66e1ddf862186u64,
+            0xbf82bba06d004127u64,
+        ),
+    ];
+    for (integ, va, vb, isrc) in golden {
+        let mut ckt = Circuit::new();
+        let vin = ckt.node();
+        let a = ckt.node();
+        let b = ckt.node();
+        ckt.add(Device::VSource {
+            p: vin,
+            n: 0,
+            v: 5.0,
+        });
+        ckt.add(Device::Resistor {
+            p: vin,
+            n: a,
+            r: 470.0,
+        });
+        ckt.add(Device::Capacitor {
+            p: a,
+            n: 0,
+            c: 2.2e-6,
+        });
+        ckt.add(Device::Inductor {
+            p: a,
+            n: b,
+            l: 1e-3,
+        });
+        ckt.add(Device::Resistor {
+            p: b,
+            n: 0,
+            r: 220.0,
+        });
+        ckt.add(Device::Diode {
+            p: a,
+            n: 0,
+            model: DiodeModel::silicon(),
+        });
+        let mut env = CircuitEnv::new(ckt, 1e-6);
+        env.set_integrator(integ);
+        env.reset();
+        let mut obs = env.observe();
+        for _ in 0..500 {
+            obs = env.step();
+        }
+        assert_eq!(obs.node_voltages[2].to_bits(), va, "{integ:?} v_a drifted");
+        assert_eq!(obs.node_voltages[3].to_bits(), vb, "{integ:?} v_b drifted");
+        assert_eq!(
+            obs.device_currents[0].to_bits(),
+            isrc,
+            "{integ:?} i_src drifted"
+        );
+        assert_eq!(obs.time.to_bits(), 0x3f40624dd2f1aa30u64, "time drifted");
+    }
+}

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -784,3 +784,42 @@ with a typed error (`TransientAdjointError::Unsupported`); the diode's
 reverse sweep needs per-step converged-Newton-Jacobian storage and rides
 the MOSFET/BJT ladder item. Storage is O(N·m) full-trajectory — fine at
 lumped scale, checkpointing deliberately not built.
+
+## 2026-07-17 — circuit M1: LTE-based adaptive timestep, 977× fewer steps on a stiff pair
+
+`vcad_ecad_sim::circuit` grows opt-in adaptive stepping
+(`CircuitEnv::set_adaptive(AdaptiveConfig { reltol, abstol, dt_min,
+dt_max })`); the fixed-step path stays the default and is now gated
+**bit-identical** to M0 (golden `to_bits()` patterns captured pre-change,
+both integrators) — the adjoint and WASM consumers keep their frozen
+discretization, per the particle crate's adaptive-dt scar tissue.
+
+- **LTE estimate** (Nagel, UCB ERL-M520, §4.4): per capacitor voltage and
+  inductor current, trapezoidal corrector vs the explicit
+  divided-difference predictor from the stored companion derivative;
+  accept when every estimate is within `reltol·|x| + abstol`.
+- **Controller**: `dt' = dt·min(2, 0.9·(tol/LTE)^{1/3})` (3rd-order trap
+  LTE), halve-and-redo on reject, clamped to `[dt_min, dt_max]`. A reject
+  rolls back the *entire* transient state (companion history, Newton
+  warm-start, rotor state, time) — no partial state, ever.
+- **Newton non-convergence** now triggers the same halve-and-redo rescue
+  instead of silently breaking (adaptive path only; fixed path unchanged).
+- **Stiff RC pair** (τ = 1 ms and 100 ns, ratio 1e4, 5 τ_slow horizon):
+
+  | run | steps | max error vs analytic |
+  |---|---|---|
+  | fixed trap, dt = τ_fast/10 | 500 001 | 2.13e-2 (BE first step on the fast pole) |
+  | adaptive, reltol 1e-4 | **512** | **5.12e-5** |
+
+  977× fewer steps *and* ~400× lower error — the fixed grid pays for the
+  fast pole everywhere, the controller only where it lives.
+- RLC ringdown keeps the fixed-gate accuracy (ω_d < 1e-3 rel, envelope
+  < 2e-2 rel); a half-wave rectifier under a stepped sine spreads accepted
+  dt > 10× between conduction knee and flat; Tellegen < 1e-9 of source
+  power at every accepted step. `step_to(t_end)` lands exactly on t_end
+  (adaptive) and returns the full non-uniform observation train
+  (`obs.time` was already honest).
+- Deliberately not done: adaptivity under gradient runs (non-differentiated
+  control flow), time-aware sources inside a step (sources are
+  zeroth-order-held between accepted steps — a `VSin` device is the clean
+  fix and queued with M1's MOSFET work).

--- a/docs/spice-m0.md
+++ b/docs/spice-m0.md
@@ -108,8 +108,14 @@ binds them is M-next, mirroring the antenna/EM measurement packs.
    `examples/step_shaper` (69.4% → 4.6% overshoot in 59 reverse sweeps).
    Linear devices only — the diode's reverse sweep (per-step Newton
    Jacobian storage) stays on this ladder with the MOSFET/BJT item.
-3. LTE-based adaptive timestep (with the frozen-discretization caveat for
-   gradient runs, per the particle crate's scar tissue).
+3. ~~LTE-based adaptive timestep~~ — **shipped** (2026-07-17, see the
+   research log). Opt-in `CircuitEnv::set_adaptive(AdaptiveConfig)`:
+   trapezoidal-vs-predictor LTE per reactive state (Nagel §4.4), 1/3-power
+   step controller, Newton-failure dt-halving rescue, full rollback on
+   reject, `step_to(t_end)`. Fixed-step stays the default and is gated
+   bit-identical to M0 (golden bit patterns in
+   `tests/circuit_adaptive.rs`) — gradient runs keep the frozen
+   discretization, per the particle crate's scar tissue.
 4. ~~Netlist-from-ecad seam~~ — **DONE** (`circuit::netlist`, 2026-07-17):
    `circuit_from_schematic` maps a `SchematicSheet` (components + nets via
    `vcad_ecad_schematic::generate_netlist`) onto `Circuit` nodes/devices.


### PR DESCRIPTION
## What

Adds SPICE-style LTE-based adaptive timestep control to the transient circuit simulator (`vcad_ecad_sim::circuit`), strictly opt-in — the fixed-step path remains the default and is now **gated bit-identical to M0** so the adjoint machinery and WASM consumers keep their frozen discretization (per the particle crate's adaptive-dt scar tissue).

## How

- `CircuitEnv::set_adaptive(AdaptiveConfig { reltol, abstol, dt_min, dt_max })` — implies the trapezoidal integrator.
- **LTE estimate** (Nagel, UCB ERL-M520, 1975, §4.4): per capacitor voltage and inductor current, trapezoidal corrector vs the explicit divided-difference predictor from the stored companion derivative; accept when every estimate is within `reltol·|x| + abstol`.
- **Controller**: `dt' = dt·min(2, 0.9·(tol/LTE)^(1/3))` (3rd-order trap LTE), halve-and-redo on reject, clamped to `[dt_min, dt_max]`. A reject rolls back the *entire* transient state — companion history, Newton warm-start, rotor state, time. No partial state.
- **Newton non-convergence** now triggers the same dt-halving rescue on the adaptive path (was a silent break; fixed path unchanged).
- `step_to(t_end)` convenience: returns all observations; the adaptive final step is shortened to land exactly on `t_end`. Timestamps are non-uniform by design — `obs.time` was already honest.

## Numbers (stiff RC pair, τ = 1 ms / 100 ns, 5 τ_slow horizon)

| run | steps | max error vs analytic |
|---|---|---|
| fixed trap, dt = τ_fast/10 | 500,001 | 2.13e-2 |
| adaptive, reltol 1e-4 | **512** | **5.12e-5** |

977× fewer steps and ~400× lower error.

## Tests (`tests/circuit_adaptive.rs`)

- stiff RC pair: step-count and error-bound asserts with real numbers
- RLC ringdown: frequency < 1e-3 rel, envelope < 2e-2 rel (same gates as the fixed suite)
- half-wave rectifier under a stepped sine: accepted-dt spread > 10× between conduction knee and flat
- Tellegen power balance < 1e-9 of source power at every accepted step
- fixed-step regression: golden `to_bits()` patterns (both integrators) captured from pre-change M0 code

## Docs

`docs/spice-m0.md` M1 ladder item 3 marked shipped; dated `docs/research-log.md` entry with the table; changelog entry.

## Gates

`cargo test -p vcad-ecad-sim` (90 unit + 6 validation + 5 adaptive + doctest), `clippy --all-targets -D warnings`, `fmt --check`, `cargo check -p vcad-kernel-wasm -p vcad-ecad-diff` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)