### PR TITLE
circuit M1.1: transistor models — level-1 MOSFET + Ebers–Moll BJT

### DIFF
--- a/changelog/entries/2026-07-17-circuit-transistors.json
+++ b/changelog/entries/2026-07-17-circuit-transistors.json
@@ -1,0 +1,15 @@
+{
+  "id": "2026-07-17-circuit-transistors",
+  "version": "0.9.4",
+  "date": "2026-07-17",
+  "category": "feat",
+  "title": "Transistors in the circuit simulator",
+  "summary": "Level-1 MOSFET (Shichman-Hodges) and Ebers-Moll BJT models, both polarities, in transient, DC, AC, and adjoint-sensitivity analyses; the AC diode sensitivity placeholder is now computed.",
+  "features": [
+    "circuit-sim",
+    "mosfet",
+    "bjt",
+    "adjoint",
+    "ecad"
+  ]
+}

--- a/crates/vcad-ecad-sim/src/circuit/ac.rs
+++ b/crates/vcad-ecad-sim/src/circuit/ac.rs
@@ -16,7 +16,7 @@
 //! dependency, and the dense complex LU is a line-for-line sibling of the
 //! real one in [`super::linalg`].
 
-use super::dc::{operating_point, DcError};
+use super::dc::{operating_point, DcError, DcSolution};
 use super::devices::VT;
 use super::{Circuit, Device};
 
@@ -183,6 +183,20 @@ pub fn solve_dense_c(a: &mut [Cplx], b: &mut [Cplx], n: usize) -> Option<Vec<Cpl
     Some(x)
 }
 
+/// Complex VCCS stamp: current `g·(v(cp) − v(cn))` drawn out of node `op`
+/// into node `on` (mirrors `devices::stamp_vccs`).
+fn stamp_vccs_c(a: &mut [Cplx], m: usize, op: usize, on: usize, cp: usize, cn: usize, g: Cplx) {
+    let mut add = |row: usize, col: usize, v: Cplx| {
+        if row != 0 && col != 0 {
+            a[(row - 1) * m + (col - 1)] += v;
+        }
+    };
+    add(op, cp, g);
+    add(op, cn, -g);
+    add(on, cp, -g);
+    add(on, cn, g);
+}
+
 /// Why an AC solve failed.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AcError {
@@ -238,6 +252,9 @@ pub(crate) struct AcSystem {
     pub x: Vec<Cplx>,
     /// Branch index (into the branch block) per device id, for branch devices.
     pub branch_of: Vec<Option<usize>>,
+    /// The DC operating point the nonlinear devices were linearized at
+    /// (`None` for an all-linear network, where none was needed).
+    pub op: Option<DcSolution>,
 }
 
 /// Number of AC branch unknowns: voltage sources and inductors.
@@ -268,22 +285,18 @@ pub(crate) fn build_and_solve(
         _ => return Err(AcError::BadSource),
     }
 
-    // Diode small-signal conductances need the DC operating point.
-    let mut diode_g = vec![0.0f64; circuit.devices.len()];
-    if circuit
-        .devices
-        .iter()
-        .any(|d| matches!(d, Device::Diode { .. }))
-    {
-        let dc = operating_point(circuit)?;
-        for (id, dev) in circuit.devices.iter().enumerate() {
-            if let Device::Diode { p, n, model } = *dev {
-                let vte = model.n * VT;
-                let vd = dc.node_voltages[p] - dc.node_voltages[n];
-                diode_g[id] = (model.is / vte) * (vd / vte).min(60.0).exp();
-            }
-        }
-    }
+    // Nonlinear devices linearize about the DC operating point.
+    let op = if circuit.devices.iter().any(|d| {
+        matches!(
+            d,
+            Device::Diode { .. } | Device::Mosfet { .. } | Device::Bjt { .. }
+        )
+    }) {
+        Some(operating_point(circuit)?)
+    } else {
+        None
+    };
+    let opv = |node: usize| op.as_ref().map_or(0.0, |o| o.node_voltages[node]);
 
     let nn = circuit.num_nodes;
     let nb = ac_branches(circuit);
@@ -310,7 +323,25 @@ pub(crate) fn build_and_solve(
         match *dev {
             Device::Resistor { p, n, r } => stamp_g(&mut a, p, n, Cplx::real(1.0 / r)),
             Device::Capacitor { p, n, c } => stamp_g(&mut a, p, n, Cplx::imag(omega * c)),
-            Device::Diode { p, n, .. } => stamp_g(&mut a, p, n, Cplx::real(diode_g[id])),
+            Device::Diode { p, n, model } => {
+                let vte = model.n * VT;
+                let vd = opv(p) - opv(n);
+                let g = (model.is / vte) * (vd / vte).min(60.0).exp();
+                stamp_g(&mut a, p, n, Cplx::real(g));
+            }
+            Device::Mosfet { d, g, s, model } => {
+                // gm / gds linearization at the DC operating point.
+                let (_, gm, gds, _, _) = model.eval(opv(g) - opv(s), opv(d) - opv(s));
+                stamp_g(&mut a, d, s, Cplx::real(gds));
+                stamp_vccs_c(&mut a, m, d, s, g, s, Cplx::real(gm));
+            }
+            Device::Bjt { c, b, e, model } => {
+                let ev = model.eval(opv(b) - opv(e), opv(b) - opv(c));
+                stamp_g(&mut a, b, e, Cplx::real(ev.gpi));
+                stamp_g(&mut a, b, c, Cplx::real(ev.gmu));
+                stamp_vccs_c(&mut a, m, c, e, b, e, Cplx::real(ev.gmf));
+                stamp_vccs_c(&mut a, m, c, e, b, c, Cplx::real(-ev.gmr));
+            }
             Device::Inductor { p, n, l } => {
                 let br = (nn - 1) + branch;
                 branch_of[id] = Some(branch);
@@ -365,6 +396,7 @@ pub(crate) fn build_and_solve(
         a,
         x,
         branch_of,
+        op,
     })
 }
 

--- a/crates/vcad-ecad-sim/src/circuit/adjoint.rs
+++ b/crates/vcad-ecad-sim/src/circuit/adjoint.rs
@@ -32,9 +32,12 @@
 //!
 //! Parameter convention: one slot per device, in device order, differentiating
 //! with respect to that device's **primary scalar** (R in Ω, C in F, L in H,
-//! source values). The diode has no primary scalar; its slot carries
-//! d(output)/d(Is) at DC and 0 at AC (AC sensitivity through the operating-
-//! point shift is an M1 item, noted in `docs/spice-m0.md`).
+//! source values). Devices without a primary scalar use the slot for their
+//! leading parameter — diode/BJT → Is, MOSFET → kp — with the second
+//! parameter (vt0, βF) in [`DcSensitivity::gradient_aux`]. At AC the diode
+//! slot carries the full dH/dIs including the operating-point chain term;
+//! transistor AC slots are deferred placeholders (see
+//! [`AcSensitivity::deferred`]).
 
 use super::ac::{build_and_solve, solve_dense_c, AcError, Cplx};
 use super::dc::{operating_point, DcError, DcSolution};
@@ -48,8 +51,12 @@ pub struct DcSensitivity {
     /// The output: voltage at the requested node (V).
     pub value: f64,
     /// d value / d (device primary), one entry per device in device order.
-    /// The diode slot is d value / d Is.
+    /// Devices without a primary scalar use the slot for their leading
+    /// parameter: diode → d/dIs, MOSFET → d/dkp, BJT → d/dIs.
     pub gradient: Vec<f64>,
+    /// Second-parameter gradient slot, one entry per device in device order:
+    /// MOSFET → d/dvt0, BJT → d/dβF; 0 for every other device kind.
+    pub gradient_aux: Vec<f64>,
     /// The operating point the gradient was evaluated at.
     pub op: DcSolution,
 }
@@ -95,8 +102,9 @@ pub fn dc_sensitivities(circuit: &Circuit, out_node: usize) -> Result<DcSensitiv
     let v = &op.node_voltages;
 
     // dy/dp = −λᵀ·∂F/∂p, with F the KCL/branch residual A(p)x − b(p) (+ the
-    // diode's nonlinear current). Each device touches at most two rows.
+    // nonlinear device currents). Each device touches at most three rows.
     let mut gradient = vec![0.0f64; circuit.devices.len()];
+    let mut gradient_aux = vec![0.0f64; circuit.devices.len()];
     for (id, dev) in circuit.devices.iter().enumerate() {
         gradient[id] = match *dev {
             Device::Resistor { p, n, r } => {
@@ -120,6 +128,22 @@ pub fn dc_sensitivities(circuit: &Circuit, out_node: usize) -> Result<DcSensitiv
                 let ev = ((v[p] - v[n]) / vte).min(60.0).exp();
                 -(lam(p) - lam(n)) * (ev - 1.0)
             }
+            Device::Mosfet { d, g, s, model } => {
+                // F_d += ids, F_s −= ids ⇒ dy/dp = −(λ_d − λ_s)·∂ids/∂p.
+                let (_, _, _, dkp, dvt0) = model.eval(v[g] - v[s], v[d] - v[s]);
+                gradient_aux[id] = -(lam(d) - lam(s)) * dvt0;
+                -(lam(d) - lam(s)) * dkp
+            }
+            Device::Bjt { c, b, e, model } => {
+                // Three branch currents, all ∝ Is: rows (c,e) get iT,
+                // (b,e) get i_be, (b,c) get i_bc.
+                let ev = model.eval(v[b] - v[e], v[b] - v[c]);
+                gradient_aux[id] = (lam(b) - lam(e)) * ev.ibe / model.beta_f;
+                -((lam(c) - lam(e)) * ev.it
+                    + (lam(b) - lam(e)) * ev.ibe
+                    + (lam(b) - lam(c)) * ev.ibc)
+                    / model.is
+            }
             Device::Motor { .. } => unreachable!("rejected by the DC solve"),
         };
     }
@@ -127,6 +151,7 @@ pub fn dc_sensitivities(circuit: &Circuit, out_node: usize) -> Result<DcSensitiv
     Ok(DcSensitivity {
         value: op.node_voltages[out_node],
         gradient,
+        gradient_aux,
         op,
     })
 }
@@ -143,7 +168,7 @@ fn stamp_jacobian_dc(
     _id: usize,
     branch_of: &mut [Option<usize>],
 ) {
-    use super::devices::stamp_conductance;
+    use super::devices::{stamp_conductance, stamp_vccs};
     match *dev {
         Device::Resistor { p, n, r } => stamp_conductance(a, m, p, n, 1.0 / r),
         Device::Capacitor { .. } => {}
@@ -167,6 +192,20 @@ fn stamp_jacobian_dc(
             let geq = (model.is / vte) * (vd / vte).min(60.0).exp();
             stamp_conductance(a, m, p, n, geq);
         }
+        Device::Mosfet { d, g, s, model } => {
+            let v = &op.node_voltages;
+            let (_, gm, gds, _, _) = model.eval(v[g] - v[s], v[d] - v[s]);
+            stamp_conductance(a, m, d, s, gds);
+            stamp_vccs(a, m, d, s, g, s, gm);
+        }
+        Device::Bjt { c, b, e, model } => {
+            let v = &op.node_voltages;
+            let ev = model.eval(v[b] - v[e], v[b] - v[c]);
+            stamp_conductance(a, m, b, e, ev.gpi);
+            stamp_conductance(a, m, b, c, ev.gmu);
+            stamp_vccs(a, m, c, e, b, e, ev.gmf);
+            stamp_vccs(a, m, c, e, b, c, -ev.gmr);
+        }
         Device::Motor { .. } => unreachable!(),
     }
 }
@@ -176,15 +215,19 @@ fn stamp_jacobian_dc(
 pub struct AcSensitivity {
     /// The complex transfer H(jω) = V(out) per unit source amplitude.
     pub h: Cplx,
-    /// dH/dp per device primary, in device order. A slot listed in
-    /// [`AcSensitivity::deferred`] is a **placeholder zero**, not a computed
-    /// value — see [`AcSensitivity::is_deferred`].
+    /// dH/dp per device primary, in device order. Diode slots carry the full
+    /// dH/dIs including the operating-point chain term (the op point shifts
+    /// when a parameter changes, which shifts the small-signal conductance).
+    /// A slot listed in [`AcSensitivity::deferred`] is a **placeholder
+    /// zero**, not a computed value — see [`AcSensitivity::is_deferred`].
     pub gradient: Vec<Cplx>,
     /// Device ids whose gradient slot is a placeholder, not a computed
-    /// sensitivity. At M0 this is exactly the diodes (their AC sensitivity
-    /// runs through the operating-point shift, deferred to M1). Callers that
+    /// sensitivity. As of M1 this is exactly the transistors (MOSFET / BJT):
+    /// their AC sensitivities need d(gm, gds, …)/d(op point) — second
+    /// derivatives of the device models — which are not implemented yet.
+    /// Diode slots were deferred at M0 and are now computed. Callers that
     /// must distinguish "sensitivity is genuinely zero" from "sensitivity was
-    /// not computed" consult this; M1 shrinks the list without an API break.
+    /// not computed" consult this; the list shrinks without an API break.
     pub deferred: Vec<usize>,
 }
 
@@ -291,15 +334,83 @@ pub fn ac_sensitivities(
                     Cplx::ZERO
                 }
             }
-            // Operating-point chain term deferred (M1); see module docs.
-            // Flagged in `deferred` so the placeholder zero is distinguishable
-            // from a genuine zero sensitivity.
-            Device::Diode { .. } => {
+            // A diode's H-dependence on its own Is at a *fixed* op point runs
+            // entirely through g_d; both the explicit ∂g_d/∂Is term and the
+            // op-point chain term are added in the pass below.
+            Device::Diode { .. } => Cplx::ZERO,
+            // Transistor AC sensitivities need d(gm, gds, gπ, gµ)/d(op) —
+            // second derivatives of the models. Deferred honestly.
+            Device::Mosfet { .. } | Device::Bjt { .. } => {
                 deferred.push(id);
                 Cplx::ZERO
             }
             Device::Motor { .. } => unreachable!("rejected by build_and_solve"),
         };
+    }
+
+    // Operating-point chain term (closes the M0 gap): each diode's
+    // small-signal conductance g_d = (Is/vte)·e^{v_d/vte} depends on every
+    // parameter through the DC junction voltage v_d(p). The total derivative
+    //
+    //   dH/dpᵢ = ∂H/∂pᵢ + Σ_diodes (∂H/∂g_d)·[ (g_d/vte)·dv_d/dpᵢ + δ·g_d/Is ]
+    //
+    // with ∂H/∂g_d from the AC adjoint (the conductance stamp pattern) and
+    // dv_d/dpᵢ from the DC adjoint (`dc_sensitivities` at the diode's nodes).
+    // δ = 1 only for the diode's own Is slot (the explicit ∂g_d/∂Is = g_d/Is).
+    let diodes: Vec<(usize, usize, usize, f64, f64)> = circuit
+        .devices
+        .iter()
+        .enumerate()
+        .filter_map(|(id, d)| match *d {
+            Device::Diode { p, n, model } => Some((id, p, n, model.n * VT, model.is)),
+            _ => None,
+        })
+        .collect();
+    if !diodes.is_empty() {
+        let op = sys
+            .op
+            .as_ref()
+            .expect("nonlinear network has an op point")
+            .clone();
+        // DC node-voltage gradients, one adjoint solve per distinct diode node.
+        let ndev = circuit.devices.len();
+        let mut node_grad: Vec<Option<Vec<f64>>> = vec![None; nn];
+        node_grad[0] = Some(vec![0.0; ndev]); // ground never moves
+        for &(_, p, n, _, _) in &diodes {
+            for node in [p, n] {
+                if node_grad[node].is_none() {
+                    node_grad[node] = Some(
+                        dc_sensitivities(circuit, node)
+                            .map_err(AcError::Dc)?
+                            .gradient,
+                    );
+                }
+            }
+        }
+        for &(jid, p, n, vte, is) in &diodes {
+            let vd = op.node_voltages[p] - op.node_voltages[n];
+            let gd = (is / vte) * (vd / vte).min(60.0).exp();
+            // ∂H/∂g_d over the conductance stamp pattern.
+            let dh_dg = -((lam(p) - lam(n)) * (xv(p) - xv(n)));
+            let gp = node_grad[p].as_ref().expect("computed above");
+            let gn = node_grad[n].as_ref().expect("computed above");
+            for i in 0..ndev {
+                if deferred.contains(&i) {
+                    continue; // keep placeholder slots exactly zero
+                }
+                let mut dg = (gd / vte) * (gp[i] - gn[i]);
+                if i == jid {
+                    dg += gd / is;
+                }
+                // The driven source's slot means d/d(AC amplitude), not
+                // d/d(DC value) — the op point does not depend on the AC
+                // amplitude, so no chain term lands there.
+                if i == source {
+                    continue;
+                }
+                gradient[i] += Cplx::real(dg) * dh_dg;
+            }
+        }
     }
 
     Ok(AcSensitivity {
@@ -491,38 +602,255 @@ mod tests {
     }
 
     #[test]
-    fn ac_diode_slot_is_flagged_deferred_not_silently_zero() {
-        // A diode's AC sensitivity slot is a placeholder at M0. It must be
-        // reported as deferred so a caller can tell it apart from a genuine
-        // zero — the linear elements around it are not deferred.
+    fn ac_diode_chain_term_matches_fd() {
+        // DC-biased diode with a bypass cap, driven by the (DC-offset) source:
+        // the small-signal conductance g_d moves when R or Is moves, so the
+        // AC sensitivities of |H| carry the operating-point chain term. The
+        // diode slot must no longer be deferred — M0's placeholder is closed.
+        let (vdc, r, cval) = (5.0, 1_000.0, 1e-7);
+        let build = |r: f64, is: f64| {
+            let mut c = Circuit::new();
+            let vin = c.node();
+            let out = c.node();
+            let src = c.add(Device::VSource {
+                p: vin,
+                n: 0,
+                v: vdc,
+            });
+            c.add(Device::Resistor { p: vin, n: out, r });
+            c.add(Device::Diode {
+                p: out,
+                n: 0,
+                model: DiodeModel { is, n: 1.0 },
+            });
+            c.add(Device::Capacitor {
+                p: out,
+                n: 0,
+                c: cval,
+            });
+            (c, src, out)
+        };
+        let is0 = DiodeModel::silicon().is;
+        let omega = 2.0 * std::f64::consts::PI * 10_000.0;
+        let (ckt, src, out) = build(r, is0);
+        let sens = ac_sensitivities(&ckt, src, omega, out).unwrap();
+        assert!(sens.deferred.is_empty(), "diode slot is computed as of M1");
+
+        let hmag = |r: f64, is: f64| {
+            let (ckt, src, out) = build(r, is);
+            super::super::ac::ac_response(&ckt, src, omega)
+                .unwrap()
+                .node_voltages[out]
+                .abs()
+        };
+        // Resistor slot (id 1): pure chain term — H depends on R directly
+        // *and* through the op-point shift of g_d.
+        let rel = 1e-6;
+        let fd_r = (hmag(r * (1.0 + rel), is0) - hmag(r * (1.0 - rel), is0)) / (2.0 * r * rel);
+        let ad_r = sens.d_magnitude(1);
+        assert!(
+            (fd_r - ad_r).abs() / fd_r.abs().max(ad_r.abs()) < 1e-4,
+            "R slot: adjoint {ad_r} vs FD {fd_r}"
+        );
+        // Diode slot (id 2): explicit ∂g/∂Is + chain through v_d(Is).
+        let fd_is = (hmag(r, is0 * (1.0 + rel)) - hmag(r, is0 * (1.0 - rel))) / (2.0 * is0 * rel);
+        let ad_is = sens.d_magnitude(2);
+        assert!(
+            (fd_is - ad_is).abs() / fd_is.abs().max(ad_is.abs()) < 1e-4,
+            "Is slot: adjoint {ad_is} vs FD {fd_is}"
+        );
+    }
+
+    #[test]
+    fn dc_adjoint_matches_fd_through_the_mosfet() {
+        use crate::circuit::MosfetModel;
+        // Common-source stage: VDD — Rd — drain, gate driven by a divider.
+        let build = |kp: f64, vt0: f64| {
+            let mut c = Circuit::new();
+            let vdd = c.node();
+            let gate = c.node();
+            let drain = c.node();
+            c.add(Device::VSource {
+                p: vdd,
+                n: 0,
+                v: 12.0,
+            });
+            c.add(Device::Resistor {
+                p: vdd,
+                n: gate,
+                r: 10_000.0,
+            });
+            c.add(Device::Resistor {
+                p: gate,
+                n: 0,
+                r: 3_300.0,
+            });
+            c.add(Device::Resistor {
+                p: vdd,
+                n: drain,
+                r: 1_000.0,
+            });
+            c.add(Device::Mosfet {
+                d: drain,
+                g: gate,
+                s: 0,
+                model: MosfetModel {
+                    kp,
+                    vt0,
+                    lambda: 0.02,
+                    polarity: crate::circuit::Polarity::N,
+                },
+            });
+            (c, drain)
+        };
+        let (kp0, vt00) = (0.05, 2.0);
+        let (ckt, out) = build(kp0, vt00);
+        let sens = dc_sensitivities(&ckt, out).unwrap();
+
+        // Linear slots against the generic FD helper.
+        for id in 0..4 {
+            let fd = fd_dc(&ckt, out, id, 1e-6);
+            let ad = sens.gradient[id];
+            let scale = fd.abs().max(ad.abs()).max(1e-12);
+            assert!(
+                (fd - ad).abs() / scale < 1e-4,
+                "device {id}: adjoint {ad} vs FD {fd}"
+            );
+        }
+        // kp (leading slot) and vt0 (aux slot) by direct rebuild.
+        let vout = |kp: f64, vt0: f64| {
+            let (c, out) = build(kp, vt0);
+            operating_point(&c).unwrap().node_voltages[out]
+        };
+        let rel = 1e-6;
+        let fd_kp =
+            (vout(kp0 * (1.0 + rel), vt00) - vout(kp0 * (1.0 - rel), vt00)) / (2.0 * kp0 * rel);
+        let fd_vt =
+            (vout(kp0, vt00 * (1.0 + rel)) - vout(kp0, vt00 * (1.0 - rel))) / (2.0 * vt00 * rel);
+        let (ad_kp, ad_vt) = (sens.gradient[4], sens.gradient_aux[4]);
+        assert!(
+            (fd_kp - ad_kp).abs() / fd_kp.abs().max(ad_kp.abs()) < 1e-4,
+            "kp: adjoint {ad_kp} vs FD {fd_kp}"
+        );
+        assert!(
+            (fd_vt - ad_vt).abs() / fd_vt.abs().max(ad_vt.abs()) < 1e-4,
+            "vt0: adjoint {ad_vt} vs FD {fd_vt}"
+        );
+    }
+
+    #[test]
+    fn dc_adjoint_matches_fd_through_the_bjt() {
+        use crate::circuit::BjtModel;
+        // Classic four-resistor bias: divider on the base, Rc and Re.
+        let build = |is: f64, bf: f64| {
+            let mut c = Circuit::new();
+            let vcc = c.node();
+            let base = c.node();
+            let coll = c.node();
+            let emit = c.node();
+            c.add(Device::VSource {
+                p: vcc,
+                n: 0,
+                v: 12.0,
+            });
+            c.add(Device::Resistor {
+                p: vcc,
+                n: base,
+                r: 47_000.0,
+            });
+            c.add(Device::Resistor {
+                p: base,
+                n: 0,
+                r: 10_000.0,
+            });
+            c.add(Device::Resistor {
+                p: vcc,
+                n: coll,
+                r: 2_200.0,
+            });
+            c.add(Device::Resistor {
+                p: emit,
+                n: 0,
+                r: 1_000.0,
+            });
+            c.add(Device::Bjt {
+                c: coll,
+                b: base,
+                e: emit,
+                model: BjtModel {
+                    is,
+                    beta_f: bf,
+                    beta_r: 1.0,
+                    polarity: crate::circuit::Polarity::N,
+                },
+            });
+            (c, coll)
+        };
+        let (is0, bf0) = (1e-14, 100.0);
+        let (ckt, out) = build(is0, bf0);
+        let sens = dc_sensitivities(&ckt, out).unwrap();
+
+        for id in 0..5 {
+            let fd = fd_dc(&ckt, out, id, 1e-6);
+            let ad = sens.gradient[id];
+            let scale = fd.abs().max(ad.abs()).max(1e-12);
+            assert!(
+                (fd - ad).abs() / scale < 1e-4,
+                "device {id}: adjoint {ad} vs FD {fd}"
+            );
+        }
+        let vout = |is: f64, bf: f64| {
+            let (c, out) = build(is, bf);
+            operating_point(&c).unwrap().node_voltages[out]
+        };
+        let rel = 1e-5;
+        let fd_is =
+            (vout(is0 * (1.0 + rel), bf0) - vout(is0 * (1.0 - rel), bf0)) / (2.0 * is0 * rel);
+        let fd_bf =
+            (vout(is0, bf0 * (1.0 + rel)) - vout(is0, bf0 * (1.0 - rel))) / (2.0 * bf0 * rel);
+        let (ad_is, ad_bf) = (sens.gradient[5], sens.gradient_aux[5]);
+        assert!(
+            (fd_is - ad_is).abs() / fd_is.abs().max(ad_is.abs()) < 1e-4,
+            "Is: adjoint {ad_is} vs FD {fd_is}"
+        );
+        assert!(
+            (fd_bf - ad_bf).abs() / fd_bf.abs().max(ad_bf.abs()) < 1e-4,
+            "betaF: adjoint {ad_bf} vs FD {fd_bf}"
+        );
+    }
+
+    #[test]
+    fn ac_transistor_slots_are_flagged_deferred() {
+        use crate::circuit::MosfetModel;
+        // Transistor AC sensitivities need model second derivatives —
+        // deferred honestly, distinguishable from a genuine zero.
         let mut c = Circuit::new();
-        let vin = c.node();
-        let out = c.node();
-        let src = c.add(Device::VSource {
-            p: vin,
+        let vdd = c.node();
+        let gate = c.node();
+        let drain = c.node();
+        c.add(Device::VSource {
+            p: vdd,
             n: 0,
-            v: 0.0,
+            v: 12.0,
+        });
+        let src = c.add(Device::VSource {
+            p: gate,
+            n: 0,
+            v: 3.0,
         });
         let rid = c.add(Device::Resistor {
-            p: vin,
-            n: out,
+            p: vdd,
+            n: drain,
             r: 1_000.0,
         });
-        let did = c.add(Device::Diode {
-            p: out,
-            n: 0,
-            model: DiodeModel::silicon(),
+        let mid = c.add(Device::Mosfet {
+            d: drain,
+            g: gate,
+            s: 0,
+            model: MosfetModel::nmos(),
         });
-        let sens = ac_sensitivities(&c, src, 2.0 * std::f64::consts::PI * 1_000.0, out).unwrap();
-        assert!(sens.is_deferred(did), "diode slot must be flagged deferred");
-        assert!(
-            !sens.is_deferred(rid),
-            "resistor slot is computed, not deferred"
-        );
-        assert!(
-            !sens.is_deferred(src),
-            "source slot is computed, not deferred"
-        );
-        assert_eq!(sens.deferred, vec![did]);
+        let sens = ac_sensitivities(&c, src, 1e4, drain).unwrap();
+        assert_eq!(sens.deferred, vec![mid]);
+        assert!(!sens.is_deferred(rid));
     }
 }

--- a/crates/vcad-ecad-sim/src/circuit/dc.rs
+++ b/crates/vcad-ecad-sim/src/circuit/dc.rs
@@ -96,7 +96,7 @@ pub fn operating_point(circuit: &Circuit) -> Result<DcSolution, DcError> {
     // gmin ladder: heavy shunt first, then relax, then remove entirely.
     let gmins = [1e-3, 1e-6, 1e-9, 1e-12, 0.0];
     let mut node_v = vec![0.0f64; nn];
-    let mut nl_state = vec![0.0f64; circuit.devices.len()];
+    let mut nl_state = vec![[0.0f64; 2]; circuit.devices.len()];
     let mut branch_i = vec![0.0f64; nb];
     let mut final_iters = 0usize;
 
@@ -156,6 +156,9 @@ pub fn operating_point(circuit: &Circuit) -> Result<DcSolution, DcError> {
             Device::Diode { p, n, model } => {
                 device_currents[id] = model.current(node_v[p] - node_v[n]);
             }
+            Device::Mosfet { .. } | Device::Bjt { .. } => {
+                device_currents[id] = dev.current(&node_v);
+            }
             Device::Motor { .. } => unreachable!("rejected above"),
         }
     }
@@ -164,10 +167,7 @@ pub fn operating_point(circuit: &Circuit) -> Result<DcSolution, DcError> {
         .devices
         .iter()
         .enumerate()
-        .map(|(id, d)| {
-            let (p, n) = d.terminals();
-            (node_v[p] - node_v[n]) * device_currents[id]
-        })
+        .map(|(id, d)| d.power(&node_v, device_currents[id]))
         .sum();
 
     Ok(DcSolution {
@@ -178,8 +178,9 @@ pub fn operating_point(circuit: &Circuit) -> Result<DcSolution, DcError> {
     })
 }
 
-/// Stamp one device into the DC MNA system. `nl_state` carries the diode's
-/// limited junction voltage across Newton iterations.
+/// Stamp one device into the DC MNA system. `nl_state` carries the device's
+/// limited nonlinear voltages across Newton iterations (diode: `[v_d, –]`,
+/// MOSFET: `[vgs, vds]`, BJT: `[vbe, vbc]`).
 #[allow(clippy::too_many_arguments)]
 fn stamp_dc(
     dev: &Device,
@@ -189,7 +190,7 @@ fn stamp_dc(
     nn: usize,
     branch: &mut usize,
     guess: &[f64],
-    nl_state: &mut f64,
+    nl_state: &mut [f64; 2],
 ) {
     let mut stamp_branch = |a: &mut [f64], rhs: &mut [f64], p: usize, n: usize, v: f64| {
         let br = (nn - 1) + *branch;
@@ -216,14 +217,20 @@ fn stamp_dc(
             let vte = model.n * super::devices::VT;
             let vcrit = vte * (vte / (std::f64::consts::SQRT_2 * model.is)).ln();
             let vd_raw = guess[p] - guess[n];
-            let vd = super::devices::pnjlim(vd_raw, *nl_state, vte, vcrit);
-            *nl_state = vd;
+            let vd = super::devices::pnjlim(vd_raw, nl_state[0], vte, vcrit);
+            nl_state[0] = vd;
             let ev = (vd / vte).min(60.0).exp();
             let id = model.is * (ev - 1.0);
             let geq = (model.is / vte) * ev;
             let ieq = id - geq * vd;
             stamp_conductance(a, m, p, n, geq);
             inject(rhs, p, n, -ieq);
+        }
+        Device::Mosfet { d, g, s, model } => {
+            super::devices::stamp_mosfet(a, rhs, m, d, g, s, &model, nl_state, guess);
+        }
+        Device::Bjt { c, b, e, model } => {
+            super::devices::stamp_bjt(a, rhs, m, c, b, e, &model, nl_state, guess);
         }
         Device::Motor { .. } => unreachable!("rejected before stamping"),
     }
@@ -308,6 +315,63 @@ mod tests {
         let sol = operating_point(&c).unwrap();
         assert!((sol.node_voltages[top] - 9.0).abs() < 1e-9);
         assert!(sol.device_currents[r].abs() < 1e-12);
+    }
+
+    #[test]
+    fn cmos_inverter_transfers_and_converges_through_the_gmin_ladder() {
+        // NMOS pull-down + PMOS pull-up, 5 V rail. The strongly nonlinear
+        // switching region is exactly what the gmin ladder exists for.
+        use crate::circuit::MosfetModel;
+        let solve = |vin_v: f64| {
+            let mut c = Circuit::new();
+            let vdd = c.node();
+            let vin = c.node();
+            let out = c.node();
+            c.add(Device::VSource {
+                p: vdd,
+                n: 0,
+                v: 5.0,
+            });
+            c.add(Device::VSource {
+                p: vin,
+                n: 0,
+                v: vin_v,
+            });
+            c.add(Device::Mosfet {
+                d: out,
+                g: vin,
+                s: 0,
+                model: MosfetModel::nmos(),
+            });
+            c.add(Device::Mosfet {
+                d: out,
+                g: vin,
+                s: vdd,
+                model: MosfetModel::pmos(),
+            });
+            // Weak load so the off-state output node is never floating.
+            c.add(Device::Resistor {
+                p: out,
+                n: 0,
+                r: 1e9,
+            });
+            operating_point(&c).unwrap().node_voltages[out]
+        };
+        // Input low → output at the rail; input high → output at ground.
+        assert!(solve(0.0) > 4.9, "low in must pull out to VDD");
+        assert!(solve(5.0) < 0.1, "high in must pull out to ground");
+        // Midpoint: both devices on; with symmetric N/P models the output
+        // sits at the switching point near VDD/2.
+        let mid = solve(2.5);
+        assert!(
+            (1.5..3.5).contains(&mid),
+            "switching-point output {mid} should be near VDD/2"
+        );
+        // The transfer curve is monotonically non-increasing.
+        let vs: Vec<f64> = (0..=10).map(|k| solve(0.5 * k as f64)).collect();
+        for w in vs.windows(2) {
+            assert!(w[1] <= w[0] + 1e-9, "inverter transfer must be monotone");
+        }
     }
 
     #[test]

--- a/crates/vcad-ecad-sim/src/circuit/devices.rs
+++ b/crates/vcad-ecad-sim/src/circuit/devices.rs
@@ -39,6 +39,229 @@ impl DiodeModel {
     }
 }
 
+/// Channel polarity of a MOSFET (or the junction polarity of a BJT).
+///
+/// P-type devices are handled by the standard sign transformation: internal
+/// junction/channel voltages are negated on the way in, currents negated on
+/// the way out, so one set of N-type equations serves both polarities.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Polarity {
+    /// N-channel MOSFET / NPN BJT.
+    N,
+    /// P-channel MOSFET / PNP BJT.
+    P,
+}
+
+impl Polarity {
+    /// +1 for N, −1 for P — the sign of the internal↔external transformation.
+    fn sign(self) -> f64 {
+        match self {
+            Polarity::N => 1.0,
+            Polarity::P => -1.0,
+        }
+    }
+}
+
+/// Shichman–Hodges level-1 MOSFET (SPICE2: Nagel, UCB ERL-M520, 1975, §2):
+/// cutoff / triode / saturation with channel-length modulation.
+///
+/// `kp` is the full transconductance factor β = KP·W/L (A/V²) — W/L is folded
+/// in rather than carried separately. With overdrive `vov = vgs − vt0`:
+///
+/// ```text
+/// cutoff     (vov ≤ 0):        ids = 0
+/// triode     (vds < vov):      ids = kp·(vov·vds − vds²/2)·(1 + λ·vds)
+/// saturation (vds ≥ vov):      ids = (kp/2)·vov²·(1 + λ·vds)
+/// ```
+///
+/// The model is symmetric: for `vds < 0` the source and drain swap roles
+/// internally (standard SPICE practice). For P-channel, pass `vt0` negative
+/// (as in SPICE) and [`Polarity::P`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MosfetModel {
+    /// Transconductance factor β = KP·W/L (A/V²).
+    pub kp: f64,
+    /// Threshold voltage (V). Negative for a P-channel device.
+    pub vt0: f64,
+    /// Channel-length modulation λ (1/V).
+    pub lambda: f64,
+    /// N- or P-channel.
+    pub polarity: Polarity,
+}
+
+impl MosfetModel {
+    /// A small-signal N-channel enhancement FET (2N7000-ish: Vt ≈ 2 V).
+    pub fn nmos() -> Self {
+        MosfetModel {
+            kp: 0.1,
+            vt0: 2.0,
+            lambda: 0.01,
+            polarity: Polarity::N,
+        }
+    }
+
+    /// The P-channel complement of [`MosfetModel::nmos`].
+    pub fn pmos() -> Self {
+        MosfetModel {
+            kp: 0.1,
+            vt0: -2.0,
+            lambda: 0.01,
+            polarity: Polarity::P,
+        }
+    }
+
+    /// Evaluate the model at external `(vgs, vds)`.
+    ///
+    /// Returns `(ids, gm, gds, dids_dkp, dids_dvt0)`: the drain→source channel
+    /// current, its derivatives wrt the external `vgs` / `vds` (the Newton /
+    /// small-signal conductances), and its derivatives wrt the parameters
+    /// `kp` and `vt0`. Polarity and the `vds < 0` source-drain swap are
+    /// handled internally, so all five outputs are in external convention.
+    pub fn eval(&self, vgs: f64, vds: f64) -> (f64, f64, f64, f64, f64) {
+        let s = self.polarity.sign();
+        // Internal N-type frame.
+        let (vgs_i, vds_i, vt0_i) = (s * vgs, s * vds, s * self.vt0);
+        // Source-drain swap for reverse operation: the channel is symmetric,
+        // so evaluate with the roles exchanged and negate the current.
+        let swapped = vds_i < 0.0;
+        let (vgs_e, vds_e) = if swapped {
+            (vgs_i - vds_i, -vds_i)
+        } else {
+            (vgs_i, vds_i)
+        };
+
+        let vov = vgs_e - vt0_i;
+        // (f, df/dvgs_e, df/dvds_e, df/dkp, df/dvt0_i) in the swapped frame.
+        let (f, fg, fd, fkp, fvt) = if vov <= 0.0 {
+            (0.0, 0.0, 0.0, 0.0, 0.0)
+        } else if vds_e < vov {
+            // Triode.
+            let core = self.kp * (vov * vds_e - 0.5 * vds_e * vds_e);
+            let clm = 1.0 + self.lambda * vds_e;
+            let fg = self.kp * vds_e * clm;
+            let fd = self.kp * (vov - vds_e) * clm + core * self.lambda;
+            (core * clm, fg, fd, core * clm / self.kp, -fg)
+        } else {
+            // Saturation.
+            let core = 0.5 * self.kp * vov * vov;
+            let clm = 1.0 + self.lambda * vds_e;
+            let fg = self.kp * vov * clm;
+            (
+                core * clm,
+                fg,
+                core * self.lambda,
+                core * clm / self.kp,
+                -fg,
+            )
+        };
+
+        // Un-swap: ids_i = −f, and vgs_e/vds_e depend on (vgs_i, vds_i) as
+        // vgs_e = vgs_i − vds_i, vds_e = −vds_i.
+        let (ids_i, gg_i, gd_i) = if swapped {
+            (-f, -fg, fg + fd)
+        } else {
+            (f, fg, fd)
+        };
+        let (fkp_i, fvt_i) = if swapped { (-fkp, -fvt) } else { (fkp, fvt) };
+
+        // Un-polarize: ids = s·ids_i; conductances pick up s twice (once from
+        // the current, once from the internal voltage) so they are unchanged.
+        // dids/dvt0 = s·(∂ids_i/∂vt0_i)·(dvt0_i/dvt0 = s) = ∂ids_i/∂vt0_i… ×s·s.
+        (s * ids_i, gg_i, gd_i, s * fkp_i, fvt_i)
+    }
+}
+
+/// Ebers–Moll BJT (transport form): two junction diodes plus the transport
+/// current `iT = Is·(e^{vbe/Vt} − e^{vbc/Vt})` flowing collector→emitter.
+///
+/// ```text
+/// i_be = (Is/βF)·(e^{vbe/Vt} − 1)   (base→emitter)
+/// i_bc = (Is/βR)·(e^{vbc/Vt} − 1)   (base→collector)
+/// iC = iT − i_bc,  iB = i_be + i_bc,  iE = iT + i_be
+/// ```
+///
+/// For PNP the junction voltages and currents are negated internally
+/// ([`Polarity::P`]).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BjtModel {
+    /// Transport saturation current Is (A).
+    pub is: f64,
+    /// Forward current gain βF.
+    pub beta_f: f64,
+    /// Reverse current gain βR.
+    pub beta_r: f64,
+    /// NPN or PNP.
+    pub polarity: Polarity,
+}
+
+impl BjtModel {
+    /// A generic small-signal NPN (2N3904-ish).
+    pub fn npn() -> Self {
+        BjtModel {
+            is: 1e-14,
+            beta_f: 100.0,
+            beta_r: 1.0,
+            polarity: Polarity::N,
+        }
+    }
+
+    /// A generic small-signal PNP.
+    pub fn pnp() -> Self {
+        BjtModel {
+            is: 1e-14,
+            beta_f: 100.0,
+            beta_r: 1.0,
+            polarity: Polarity::P,
+        }
+    }
+}
+
+/// The three Ebers–Moll branch currents and their junction conductances,
+/// all in **external** convention (polarity already applied).
+///
+/// Branches: `it` flows c→e, `ibe` b→e, `ibc` b→c. Each conductance is the
+/// derivative of its branch current wrt the **external** vbe / vbc.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BjtEval {
+    pub it: f64,
+    pub ibe: f64,
+    pub ibc: f64,
+    /// ∂it/∂vbe (the forward transconductance gmf).
+    pub gmf: f64,
+    /// −∂it/∂vbc (the reverse transconductance gmr, positive).
+    pub gmr: f64,
+    /// ∂ibe/∂vbe (gπ).
+    pub gpi: f64,
+    /// ∂ibc/∂vbc (gµ).
+    pub gmu: f64,
+}
+
+impl BjtModel {
+    /// Evaluate at external `(vbe, vbc)`.
+    pub(crate) fn eval(&self, vbe: f64, vbc: f64) -> BjtEval {
+        let s = self.polarity.sign();
+        let ebe = (s * vbe / VT).min(60.0).exp();
+        let ebc = (s * vbc / VT).min(60.0).exp();
+        // Internal currents; external = s·internal. Conductances pick up s
+        // twice (current and controlling voltage) → unchanged.
+        BjtEval {
+            it: s * self.is * (ebe - ebc),
+            ibe: s * (self.is / self.beta_f) * (ebe - 1.0),
+            ibc: s * (self.is / self.beta_r) * (ebc - 1.0),
+            gmf: (self.is / VT) * ebe,
+            gmr: (self.is / VT) * ebc,
+            gpi: (self.is / (self.beta_f * VT)) * ebe,
+            gmu: (self.is / (self.beta_r * VT)) * ebc,
+        }
+    }
+
+    /// Collector current at external `(vbe, vbc)`.
+    pub fn ic(&self, vbe: f64, vbc: f64) -> f64 {
+        let e = self.eval(vbe, vbc);
+        e.it - e.ibc
+    }
+}
+
 /// A brushed DC motor / gyrator: couples an electrical winding to a mechanical
 /// rotor. The winding (R + L) carries the armature current; the back-EMF is
 /// `Ke·ω` and the torque is `Kt·i`. SI units throughout.
@@ -103,6 +326,47 @@ pub enum Device {
         n: usize,
         params: MotorParams,
     },
+    /// Level-1 MOSFET (Shichman–Hodges). `d`/`g`/`s` are the drain, gate, and
+    /// source node ids; the gate draws no current. The device-current slot
+    /// reports the drain current.
+    Mosfet {
+        d: usize,
+        g: usize,
+        s: usize,
+        model: MosfetModel,
+    },
+    /// Ebers–Moll BJT. `c`/`b`/`e` are the collector, base, and emitter node
+    /// ids. The device-current slot reports the collector current.
+    Bjt {
+        c: usize,
+        b: usize,
+        e: usize,
+        model: BjtModel,
+    },
+}
+
+/// Add `v` at MNA position (`row`, `col`) in node-id space (ground skipped).
+pub(crate) fn add_a(a: &mut [f64], m: usize, row: usize, col: usize, v: f64) {
+    if row != 0 && col != 0 {
+        a[(row - 1) * m + (col - 1)] += v;
+    }
+}
+
+/// Stamp a VCCS: current `g·(v(cp) − v(cn))` flowing from `op` to `on`
+/// through the source (i.e. drawn out of node `op`, into node `on`).
+pub(crate) fn stamp_vccs(
+    a: &mut [f64],
+    m: usize,
+    op: usize,
+    on: usize,
+    cp: usize,
+    cn: usize,
+    g: f64,
+) {
+    add_a(a, m, op, cp, g);
+    add_a(a, m, op, cn, -g);
+    add_a(a, m, on, cp, -g);
+    add_a(a, m, on, cn, g);
 }
 
 /// Conductance stamp for a 2-terminal element between `p` and `n`.
@@ -150,8 +414,79 @@ pub(crate) fn pnjlim(vnew: f64, vold: f64, vte: f64, vcrit: f64) -> f64 {
     }
 }
 
+/// Clamp a Newton step in a FET terminal voltage to ±`max_step` — the
+/// square-law analogue of `pnjlim` (the polynomial can't explode, but an
+/// undamped step can oscillate across the triode/saturation boundary).
+pub(crate) fn fetlim(vnew: f64, vold: f64, max_step: f64) -> f64 {
+    vold + (vnew - vold).clamp(-max_step, max_step)
+}
+
+/// Stamp a MOSFET's Newton companion (linearized ids as gds + gm·VCCS + a
+/// Norton current) into `a`/`rhs`. `nl` carries the limited `[vgs, vds]`
+/// across iterations; `guess` is the current node-voltage estimate.
+/// Shared by the transient and DC solvers (and, with a scratch rhs, the
+/// adjoint Jacobian rebuild).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stamp_mosfet(
+    a: &mut [f64],
+    rhs: &mut [f64],
+    m: usize,
+    d: usize,
+    g: usize,
+    s: usize,
+    model: &MosfetModel,
+    nl: &mut [f64; 2],
+    guess: &[f64],
+) {
+    let vgs = fetlim(guess[g] - guess[s], nl[0], 2.0);
+    let vds = fetlim(guess[d] - guess[s], nl[1], 2.0);
+    *nl = [vgs, vds];
+    let (ids, gm, gds, _, _) = model.eval(vgs, vds);
+    stamp_conductance(a, m, d, s, gds);
+    stamp_vccs(a, m, d, s, g, s, gm);
+    let ieq = ids - gm * vgs - gds * vds;
+    inject(rhs, d, s, -ieq);
+}
+
+/// Stamp a BJT's Newton companion: the two junction diodes (b–e, b–c) plus
+/// the transport current c→e controlled by both junctions. `nl` carries the
+/// limited `[vbe, vbc]`. Both junctions get `pnjlim` limiting.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn stamp_bjt(
+    a: &mut [f64],
+    rhs: &mut [f64],
+    m: usize,
+    c: usize,
+    b: usize,
+    e: usize,
+    model: &BjtModel,
+    nl: &mut [f64; 2],
+    guess: &[f64],
+) {
+    let sgn = model.polarity.sign();
+    let vcrit = VT * (VT / (std::f64::consts::SQRT_2 * model.is)).ln();
+    // Limit in the internal (N-type) frame where the exponentials grow.
+    let vbe = sgn * pnjlim(sgn * (guess[b] - guess[e]), sgn * nl[0], VT, vcrit);
+    let vbc = sgn * pnjlim(sgn * (guess[b] - guess[c]), sgn * nl[1], VT, vcrit);
+    *nl = [vbe, vbc];
+    let ev = model.eval(vbe, vbc);
+
+    // b–e junction diode.
+    stamp_conductance(a, m, b, e, ev.gpi);
+    inject(rhs, b, e, -(ev.ibe - ev.gpi * vbe));
+    // b–c junction diode.
+    stamp_conductance(a, m, b, c, ev.gmu);
+    inject(rhs, b, c, -(ev.ibc - ev.gmu * vbc));
+    // Transport current c→e: iT = gmf·vbe − gmr·vbc + const.
+    stamp_vccs(a, m, c, e, b, e, ev.gmf);
+    stamp_vccs(a, m, c, e, b, c, -ev.gmr);
+    inject(rhs, c, e, -(ev.it - ev.gmf * vbe + ev.gmr * vbc));
+}
+
 impl Device {
-    /// The (`p`, `n`) terminal node ids of this device.
+    /// The (`p`, `n`) terminal node ids of this device. For three-terminal
+    /// devices this is the current-carrying pair: (drain, source) for a
+    /// MOSFET, (collector, emitter) for a BJT.
     pub fn terminals(&self) -> (usize, usize) {
         match *self {
             Device::Resistor { p, n, .. }
@@ -161,6 +496,8 @@ impl Device {
             | Device::ISource { p, n, .. }
             | Device::Diode { p, n, .. }
             | Device::Motor { p, n, .. } => (p, n),
+            Device::Mosfet { d, s, .. } => (d, s),
+            Device::Bjt { c, e, .. } => (c, e),
         }
     }
 
@@ -169,16 +506,42 @@ impl Device {
         matches!(self, Device::VSource { .. } | Device::Motor { .. })
     }
 
+    /// Instantaneous power (W) absorbed by this device given the node
+    /// voltages and its reported current `i`. For two-terminal devices this
+    /// is `(v_p − v_n)·i`; three-terminal devices sum over all terminals
+    /// (a BJT's base current carries power that the collector–emitter pair
+    /// alone would miss). This is the quantity Tellegen's theorem sums to
+    /// zero over the network.
+    pub fn power(&self, node_v: &[f64], i: f64) -> f64 {
+        match *self {
+            // Gate draws no current: all channel power is (v_d − v_s)·ids.
+            Device::Mosfet { d, s, .. } => (node_v[d] - node_v[s]) * i,
+            Device::Bjt { c, b, e, model } => {
+                let ev = model.eval(node_v[b] - node_v[e], node_v[b] - node_v[c]);
+                let ic = ev.it - ev.ibc;
+                let ib = ev.ibe + ev.ibc;
+                (node_v[c] - node_v[e]) * ic + (node_v[b] - node_v[e]) * ib
+            }
+            _ => {
+                let (p, n) = self.terminals();
+                (node_v[p] - node_v[n]) * i
+            }
+        }
+    }
+
     /// Stamp this device's contribution into the MNA matrix `a` and RHS `rhs`.
     ///
     /// - `m` is the system dimension, `nn` the node count (incl. ground).
     /// - `branch` is a running branch-index counter; branch devices consume one.
     /// - `cap_v` / `ind_i` are this device's companion history; `nl_prev` is its
-    ///   previous-iteration nonlinear junction voltage (for Newton limiting).
+    ///   previous-iteration nonlinear state (for Newton limiting): the junction
+    ///   voltage in slot 0 for a diode, `[vgs, vds]` for a MOSFET, `[vbe, vbc]`
+    ///   for a BJT.
     /// - `guess` is the current Newton node-voltage estimate.
     ///
-    /// Returns `Some(v)` with the new limited junction voltage for nonlinear
-    /// devices (so the caller can carry it into the next iteration), else `None`.
+    /// Returns `Some(state)` with the new limited nonlinear state for
+    /// nonlinear devices (so the caller can carry it into the next
+    /// iteration), else `None`.
     #[allow(clippy::too_many_arguments)]
     pub fn stamp(
         &self,
@@ -190,10 +553,10 @@ impl Device {
         dt: f64,
         cap_v: f64,
         ind_i: f64,
-        nl_prev: f64,
+        nl_prev: [f64; 2],
         omega: f64,
         guess: &[f64],
-    ) -> Option<f64> {
+    ) -> Option<[f64; 2]> {
         match *self {
             Device::Resistor { p, n, r } => {
                 stamp_conductance(a, m, p, n, 1.0 / r);
@@ -255,32 +618,50 @@ impl Device {
                 let vte = model.vte();
                 let vcrit = vte * (vte / (std::f64::consts::SQRT_2 * model.is)).ln();
                 let vd_raw = guess[p] - guess[n];
-                let vd = pnjlim(vd_raw, nl_prev, vte, vcrit);
+                let vd = pnjlim(vd_raw, nl_prev[0], vte, vcrit);
                 let ev = (vd / vte).min(60.0).exp();
                 let id = model.is * (ev - 1.0);
                 let geq = (model.is / vte) * ev; // di/dv
                 let ieq = id - geq * vd; // companion (Norton) current
                 stamp_conductance(a, m, p, n, geq);
                 inject(rhs, p, n, -ieq);
-                Some(vd)
+                Some([vd, 0.0])
+            }
+            Device::Mosfet { d, g, s, model } => {
+                let mut nl = nl_prev;
+                stamp_mosfet(a, rhs, m, d, g, s, &model, &mut nl, guess);
+                Some(nl)
+            }
+            Device::Bjt { c, b, e, model } => {
+                let mut nl = nl_prev;
+                stamp_bjt(a, rhs, m, c, b, e, &model, &mut nl, guess);
+                Some(nl)
             }
         }
     }
 
-    /// Device current (A, `p`→`n`) computed directly from node voltages. Only
-    /// meaningful for memoryless, non-branch devices (R, I, diode); reactive and
-    /// branch devices report their current through other channels.
+    /// Device current (A) computed directly from node voltages. Only
+    /// meaningful for memoryless, non-branch devices (R, I, diode, MOSFET,
+    /// BJT); reactive and branch devices report their current through other
+    /// channels. For a MOSFET this is the drain current; for a BJT the
+    /// collector current.
     pub fn current(&self, node_v: &[f64]) -> f64 {
         match *self {
             Device::Resistor { p, n, r } => (node_v[p] - node_v[n]) / r,
             Device::ISource { i, .. } => i,
             Device::Diode { p, n, model } => model.current(node_v[p] - node_v[n]),
+            Device::Mosfet { d, g, s, model } => {
+                model.eval(node_v[g] - node_v[s], node_v[d] - node_v[s]).0
+            }
+            Device::Bjt { c, b, e, model } => {
+                model.ic(node_v[b] - node_v[e], node_v[b] - node_v[c])
+            }
             _ => 0.0,
         }
     }
 
-    /// This device's primary scalar (resistance, source value, …). Diodes have
-    /// no single driven scalar, so they report 0.
+    /// This device's primary scalar (resistance, source value, …). Diodes and
+    /// transistors have no single driven scalar, so they report 0.
     pub fn primary(&self) -> f64 {
         match *self {
             Device::Resistor { r, .. } => r,
@@ -288,7 +669,7 @@ impl Device {
             Device::Inductor { l, .. } => l,
             Device::VSource { v, .. } => v,
             Device::ISource { i, .. } => i,
-            Device::Diode { .. } => 0.0,
+            Device::Diode { .. } | Device::Mosfet { .. } | Device::Bjt { .. } => 0.0,
             Device::Motor { params, .. } => params.load,
         }
     }
@@ -301,7 +682,7 @@ impl Device {
             Device::Inductor { l, .. } => *l = value,
             Device::VSource { v, .. } => *v = value,
             Device::ISource { i, .. } => *i = value,
-            Device::Diode { .. } => {}
+            Device::Diode { .. } | Device::Mosfet { .. } | Device::Bjt { .. } => {}
             Device::Motor { params, .. } => params.load = value,
         }
     }

--- a/crates/vcad-ecad-sim/src/circuit/mod.rs
+++ b/crates/vcad-ecad-sim/src/circuit/mod.rs
@@ -30,7 +30,7 @@ mod linalg;
 pub use linalg::solve_dense;
 
 mod devices;
-pub use devices::{Device, DiodeModel, MotorParams};
+pub use devices::{BjtModel, Device, DiodeModel, MosfetModel, MotorParams, Polarity};
 
 pub mod ac;
 pub mod adjoint;
@@ -135,9 +135,10 @@ pub struct CircuitEnv {
     /// Per-device companion history: previous inductor voltage (device id → V).
     /// Used only by the trapezoidal integrator.
     ind_v: Vec<f64>,
-    /// Per-device nonlinear junction voltage (device id → V), warm-started across
-    /// steps and limited across Newton iterations.
-    nl_state: Vec<f64>,
+    /// Per-device nonlinear state (device id → up to two junction/terminal
+    /// voltages), warm-started across steps and limited across Newton
+    /// iterations. Diode: `[v_d, –]`; MOSFET: `[vgs, vds]`; BJT: `[vbe, vbc]`.
+    nl_state: Vec<[f64; 2]>,
     /// Per-device rotor angular velocity (device id → rad/s) for motors.
     mech_omega: Vec<f64>,
     /// Per-device rotor angle (device id → rad) for motors.
@@ -165,7 +166,7 @@ impl CircuitEnv {
             cap_i: vec![0.0; nd],
             ind_i: vec![0.0; nd],
             ind_v: vec![0.0; nd],
-            nl_state: vec![0.0; nd],
+            nl_state: vec![[0.0; 2]; nd],
             mech_omega: vec![0.0; nd],
             mech_theta: vec![0.0; nd],
             node_v: vec![0.0; nn],
@@ -183,7 +184,7 @@ impl CircuitEnv {
         self.cap_i.fill(0.0);
         self.ind_i.fill(0.0);
         self.ind_v.fill(0.0);
-        self.nl_state.fill(0.0);
+        self.nl_state.fill([0.0; 2]);
         self.mech_omega.fill(0.0);
         self.mech_theta.fill(0.0);
         self.node_v.fill(0.0);
@@ -233,10 +234,7 @@ impl CircuitEnv {
             .devices
             .iter()
             .enumerate()
-            .map(|(id, d)| {
-                let (p, n) = d.terminals();
-                (self.node_v[p] - self.node_v[n]) * self.dev_i[id]
-            })
+            .map(|(id, d)| d.power(&self.node_v, self.dev_i[id]))
             .sum()
     }
 

--- a/crates/vcad-ecad-sim/tests/circuit_validation.rs
+++ b/crates/vcad-ecad-sim/tests/circuit_validation.rs
@@ -14,7 +14,9 @@
 //! 5. Tellegen power balance: Σ v·i over all devices stays below 1e-9 of
 //!    dissipated power at **every** timestep — the energy conscience.
 
-use vcad_ecad_sim::circuit::{dc, Circuit, CircuitEnv, Device, DiodeModel, Integrator};
+use vcad_ecad_sim::circuit::{
+    ac, dc, BjtModel, Circuit, CircuitEnv, Device, DiodeModel, Integrator, MosfetModel, Polarity,
+};
 
 /// Lambert W₀ by Halley iteration (Corless et al. 1996, §3). Machine
 /// precision in < 10 iterations for x > 0 (our x is always positive).
@@ -294,6 +296,234 @@ fn rung5_tellegen_power_balance_every_timestep() {
             let obs = env.step();
             // Scale: the source power |V·I| (device 0 is the 5 V source).
             let dissipated = (5.0 * obs.device_currents[0].abs()).max(1e-6);
+            let residual = env.power_balance().abs();
+            assert!(
+                residual / dissipated < 1e-9,
+                "{integ:?} step {step}: Tellegen residual {residual:.3e} vs scale {dissipated:.3e}"
+            );
+        }
+    }
+}
+
+#[test]
+fn rung6_mosfet_saturation_matches_square_law() {
+    // Gate and drain held by ideal sources → the drain current must equal
+    // the Shichman–Hodges closed form (kp/2)·(vgs − vt0)²·(1 + λ·vds)
+    // exactly (SPICE2: Nagel, UCB ERL-M520, 1975, §2).
+    let model = MosfetModel {
+        kp: 0.05,
+        vt0: 1.5,
+        lambda: 0.02,
+        polarity: Polarity::N,
+    };
+    let (vgs, vds) = (3.0, 8.0); // vds > vov = 1.5 → saturation
+    let mut c = Circuit::new();
+    let gate = c.node();
+    let drain = c.node();
+    c.add(Device::VSource {
+        p: gate,
+        n: 0,
+        v: vgs,
+    });
+    c.add(Device::VSource {
+        p: drain,
+        n: 0,
+        v: vds,
+    });
+    let mid = c.add(Device::Mosfet {
+        d: drain,
+        g: gate,
+        s: 0,
+        model,
+    });
+    let sol = dc::operating_point(&c).unwrap();
+
+    let vov = vgs - model.vt0;
+    let i_exact = 0.5 * model.kp * vov * vov * (1.0 + model.lambda * vds);
+    let rel = (sol.device_currents[mid] - i_exact).abs() / i_exact;
+    assert!(
+        rel < 1e-9,
+        "saturation current {} vs square law {i_exact}, rel {rel:.2e}",
+        sol.device_currents[mid]
+    );
+}
+
+#[test]
+fn rung7_common_source_gain_matches_gm_rd_parallel_ro() {
+    // Resistor-loaded common-source amplifier: small-signal gain from the
+    // AC solve must equal −gm·(Rd ∥ ro) with gm and ro from the same op
+    // point — two independent code paths to one closed form.
+    let model = MosfetModel {
+        kp: 2e-3,
+        vt0: 1.5,
+        lambda: 0.02,
+        polarity: Polarity::N,
+    };
+    let (vdd, vbias, rd) = (12.0, 2.5, 1_000.0);
+    let mut c = Circuit::new();
+    let ndd = c.node();
+    let gate = c.node();
+    let drain = c.node();
+    c.add(Device::VSource {
+        p: ndd,
+        n: 0,
+        v: vdd,
+    });
+    let src = c.add(Device::VSource {
+        p: gate,
+        n: 0,
+        v: vbias,
+    });
+    c.add(Device::Resistor {
+        p: ndd,
+        n: drain,
+        r: rd,
+    });
+    c.add(Device::Mosfet {
+        d: drain,
+        g: gate,
+        s: 0,
+        model,
+    });
+
+    let op = dc::operating_point(&c).unwrap();
+    let (vgs, vds) = (vbias, op.node_voltages[drain]);
+    assert!(vds > vgs - model.vt0, "stage must bias into saturation");
+    let vov = vgs - model.vt0;
+    let gm = model.kp * vov * (1.0 + model.lambda * vds);
+    let gds = 0.5 * model.kp * vov * vov * model.lambda;
+    let gain_exact = -gm / (1.0 / rd + gds); // −gm·(Rd ∥ ro)
+
+    // AC at a low frequency (purely resistive network → gain is real).
+    let sol = ac::ac_response(&c, src, 1.0).unwrap();
+    let h = sol.node_voltages[drain];
+    assert!(h.im.abs() < 1e-12, "resistive stage: gain must be real");
+    let rel = (h.re - gain_exact).abs() / gain_exact.abs();
+    assert!(
+        rel < 1e-9,
+        "CS gain {} vs −gm·(Rd∥ro) = {gain_exact}, rel {rel:.2e}",
+        h.re
+    );
+}
+
+#[test]
+fn rung8_bjt_current_mirror_ratio() {
+    // Two matched NPNs, Q1 diode-connected with a reference resistor. The
+    // mirror copies I_ref up to the base-current error: with both bases fed
+    // from Q1's collector, I_out/I_ref = 1/(1 + 2/βF) exactly for matched
+    // devices at equal collector voltage (Ebers–Moll, no Early effect).
+    let model = BjtModel::npn();
+    let (vcc, rref) = (12.0, 10_000.0);
+    let mut c = Circuit::new();
+    let ncc = c.node();
+    let nref = c.node(); // Q1 collector = both bases
+    let nout = c.node(); // Q2 collector
+    c.add(Device::VSource {
+        p: ncc,
+        n: 0,
+        v: vcc,
+    });
+    let rid = c.add(Device::Resistor {
+        p: ncc,
+        n: nref,
+        r: rref,
+    });
+    c.add(Device::Bjt {
+        c: nref,
+        b: nref,
+        e: 0,
+        model,
+    });
+    let q2 = c.add(Device::Bjt {
+        c: nout,
+        b: nref,
+        e: 0,
+        model,
+    });
+    // Hold Q2's collector at Q1's diode voltage scale so vbc matches too
+    // (kills the Early-free reverse-transport mismatch).
+    c.add(Device::VSource {
+        p: nout,
+        n: 0,
+        v: 0.65,
+    });
+    let sol = dc::operating_point(&c).unwrap();
+
+    let i_ref = sol.device_currents[rid];
+    let i_out = sol.device_currents[q2];
+    let ratio = i_out / i_ref;
+    let expected = 1.0 / (1.0 + 2.0 / model.beta_f);
+    assert!(
+        (ratio - expected).abs() < 5e-3,
+        "mirror ratio {ratio} vs {expected} (βF = {})",
+        model.beta_f
+    );
+    assert!(i_ref > 1e-3 / 1.2 && i_ref < 1.2e-3, "I_ref ≈ (Vcc−Vbe)/R");
+}
+
+#[test]
+fn rung9_tellegen_holds_with_transistors_in_the_network() {
+    // The Tellegen gate must keep holding once transistors join: a MOSFET
+    // stage and a BJT stage in one network, stepped through a transient
+    // with both integrators. Σ v·i (all terminals!) < 1e-9 of source power.
+    for integ in [Integrator::BackwardEuler, Integrator::Trapezoidal] {
+        let mut ckt = Circuit::new();
+        let vdd = ckt.node();
+        let gate = ckt.node();
+        let drain = ckt.node();
+        let base = ckt.node();
+        let coll = ckt.node();
+        ckt.add(Device::VSource {
+            p: vdd,
+            n: 0,
+            v: 8.0,
+        });
+        // RC-delayed gate drive → the MOSFET sweeps cutoff → saturation.
+        ckt.add(Device::Resistor {
+            p: vdd,
+            n: gate,
+            r: 10_000.0,
+        });
+        ckt.add(Device::Capacitor {
+            p: gate,
+            n: 0,
+            c: 1e-7,
+        });
+        ckt.add(Device::Resistor {
+            p: vdd,
+            n: drain,
+            r: 2_200.0,
+        });
+        ckt.add(Device::Mosfet {
+            d: drain,
+            g: gate,
+            s: 0,
+            model: MosfetModel::nmos(),
+        });
+        // BJT stage biased from the drain node.
+        ckt.add(Device::Resistor {
+            p: drain,
+            n: base,
+            r: 47_000.0,
+        });
+        ckt.add(Device::Resistor {
+            p: vdd,
+            n: coll,
+            r: 4_700.0,
+        });
+        ckt.add(Device::Bjt {
+            c: coll,
+            b: base,
+            e: 0,
+            model: BjtModel::npn(),
+        });
+        let mut env = CircuitEnv::new(ckt, 1e-6);
+        env.set_integrator(integ);
+        env.reset();
+
+        for step in 0..2000 {
+            let obs = env.step();
+            let dissipated = (8.0 * obs.device_currents[0].abs()).max(1e-6);
             let residual = env.power_balance().abs();
             assert!(
                 residual / dissipated < 1e-9,

--- a/crates/vcad-kernel-wasm/src/circuit_sim.rs
+++ b/crates/vcad-kernel-wasm/src/circuit_sim.rs
@@ -11,21 +11,76 @@
 //! ```
 
 use serde::{Deserialize, Serialize};
-use vcad_ecad_sim::circuit::{Circuit, CircuitEnv, Device, DiodeModel, MotorParams};
+use vcad_ecad_sim::circuit::{
+    BjtModel, Circuit, CircuitEnv, Device, DiodeModel, MosfetModel, MotorParams,
+};
 use wasm_bindgen::prelude::*;
 
 /// One device in a [`CircuitSpec`]. `p`/`n` are node ids (0 = ground).
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 enum DeviceSpec {
-    Resistor { p: usize, n: usize, value: f64 },
-    Capacitor { p: usize, n: usize, value: f64 },
-    Inductor { p: usize, n: usize, value: f64 },
-    Vsource { p: usize, n: usize, value: f64 },
-    Isource { p: usize, n: usize, value: f64 },
-    Diode { p: usize, n: usize },
-    Led { p: usize, n: usize },
-    Motor { p: usize, n: usize },
+    Resistor {
+        p: usize,
+        n: usize,
+        value: f64,
+    },
+    Capacitor {
+        p: usize,
+        n: usize,
+        value: f64,
+    },
+    Inductor {
+        p: usize,
+        n: usize,
+        value: f64,
+    },
+    Vsource {
+        p: usize,
+        n: usize,
+        value: f64,
+    },
+    Isource {
+        p: usize,
+        n: usize,
+        value: f64,
+    },
+    Diode {
+        p: usize,
+        n: usize,
+    },
+    Led {
+        p: usize,
+        n: usize,
+    },
+    Motor {
+        p: usize,
+        n: usize,
+    },
+    /// N-channel level-1 MOSFET (drain / gate / source node ids).
+    Nmos {
+        d: usize,
+        g: usize,
+        s: usize,
+    },
+    /// P-channel level-1 MOSFET.
+    Pmos {
+        d: usize,
+        g: usize,
+        s: usize,
+    },
+    /// NPN BJT (collector / base / emitter node ids).
+    Npn {
+        c: usize,
+        b: usize,
+        e: usize,
+    },
+    /// PNP BJT.
+    Pnp {
+        c: usize,
+        b: usize,
+        e: usize,
+    },
 }
 
 impl DeviceSpec {
@@ -39,6 +94,8 @@ impl DeviceSpec {
             | DeviceSpec::Diode { p, n }
             | DeviceSpec::Led { p, n }
             | DeviceSpec::Motor { p, n } => p.max(n),
+            DeviceSpec::Nmos { d, g, s } | DeviceSpec::Pmos { d, g, s } => d.max(g).max(s),
+            DeviceSpec::Npn { c, b, e } | DeviceSpec::Pnp { c, b, e } => c.max(b).max(e),
         }
     }
 
@@ -63,6 +120,30 @@ impl DeviceSpec {
                 p,
                 n,
                 params: MotorParams::small_dc(),
+            },
+            DeviceSpec::Nmos { d, g, s } => Device::Mosfet {
+                d,
+                g,
+                s,
+                model: MosfetModel::nmos(),
+            },
+            DeviceSpec::Pmos { d, g, s } => Device::Mosfet {
+                d,
+                g,
+                s,
+                model: MosfetModel::pmos(),
+            },
+            DeviceSpec::Npn { c, b, e } => Device::Bjt {
+                c,
+                b,
+                e,
+                model: BjtModel::npn(),
+            },
+            DeviceSpec::Pnp { c, b, e } => Device::Bjt {
+                c,
+                b,
+                e,
+                model: BjtModel::pnp(),
             },
         }
     }

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -494,3 +494,47 @@ New crate (branch `claude/kernel-orbit-m0`), details in
   24 h (max el 75.0° at 08:03 UTC), stated honest to ±minutes.
 - M1 queued: drag + SGP4-compat (or a seam to the `sgp4` crate) +
   TEME↔ICRF, then the differentiable propagator (ΔV optimization).
+
+## 2026-07-17 — circuit M1.1: transistors, and the Tellegen gate learns three terminals
+
+Level-1 MOSFET (Shichman–Hodges, SPICE2 UCB ERL-M520 §2) and Ebers–Moll
+BJT (transport form) land in `vcad-ecad-sim::circuit`, both polarities via
+the sign transformation, wired through all four analyses (transient, DC,
+AC, adjoint) plus the WASM `DeviceSpec`. Branch
+`claude/circuit-m1-transistors`.
+
+| rung | oracle | result |
+|---|---|---|
+| MOSFET saturation | (kp/2)·vov²·(1+λ·vds) square law | < 1e-9 rel |
+| common-source gain | −gm·(Rd ∥ ro) at the op point | < 1e-9 rel, phase exactly real |
+| CMOS inverter transfer | rail-to-rail, monotone, VDD/2 switch point | passes through the gmin ladder |
+| BJT current mirror | I_out/I_ref = 1/(1 + 2/βF) | < 5e-3 abs |
+| DC adjoint vs FD | central differences: kp, vt0, Is, βF + all linear slots | < 1e-4 rel |
+| AC diode chain term vs FD | d\|H\|/dR and d\|H\|/dIs through the op-point shift | < 1e-4 rel |
+| Tellegen with transistors | Σ (all-terminal) v·i, 2000 steps × 2 integrators | < 1e-9 rel |
+
+- **The 3-terminal seam was the real work, not the I–V curves.** `Device`
+  was structurally two-terminal: `terminals() → (p, n)` and power =
+  `(v_p − v_n)·i` everywhere. A MOSFET survives that fiction (the gate
+  draws nothing) but a BJT does not — its base current carries real power,
+  and the Tellegen gate caught the miscount immediately. Fix:
+  `Device::power()` sums over *all* terminals; `terminals()` documents its
+  meaning as the current-carrying pair (drain/source, collector/emitter).
+- **One eval, four consumers**: `MosfetModel::eval` returns
+  (ids, gm, gds, ∂ids/∂kp, ∂ids/∂vt0) in external convention with polarity
+  and the vds < 0 source-drain swap folded in; `BjtModel::eval` likewise
+  returns the three branch currents + four conductances. Transient, DC,
+  AC, and the adjoint all read the same numbers — no per-analysis model
+  drift possible.
+- **M0's flagged gap is closed**: the AC diode sensitivity slot was an
+  honest placeholder; it now carries the full chain term
+  dH/dp = ∂H/∂p + Σ (∂H/∂g_d)·(dg_d/dv_d)·(dv_d/dp), with ∂H/∂g_d from
+  the AC adjoint and dv_d/dp from one DC adjoint solve per diode node.
+  `deferred` now lists exactly the transistors (their version needs model
+  second derivatives — deferred honestly, same pattern).
+- Newton hygiene: BJT junctions get `pnjlim` on both vbe and vbc (in the
+  internal N-frame so PNP limits correctly); FET voltages get a ±2 V step
+  clamp (the square law can't explode, but undamped steps oscillate across
+  the triode/saturation boundary).
+- Next on the M1 ladder: transient adjoint, then the netlist-from-ecad
+  seam so schematics simulate without re-entry.

--- a/docs/spice-m0.md
+++ b/docs/spice-m0.md
@@ -45,14 +45,37 @@ MNA core, companion models, Newton + `pnjlim`, and a live WASM consumer
 | Tellegen | Σ v·i = 0 | < 1e-9 rel at every one of 2000 steps × 2 integrators |
 | adjoint vs FD | central differences, frozen network | < 1e-5 rel on every element kind (DC and AC), < 1e-4 through the diode Newton system |
 
-## Honesty (what M0 does not claim)
+## M1 progress (2026-07-17): transistors
 
-- **Diode is the only nonlinear model.** No BJT, no MOSFET — level-1 MOSFET
-  is the first M1 item. A "nonlinear circuit simulator" claim would be
-  oversold; this is a linear-network simulator with one honest junction.
-- **AC diode sensitivity is zero-filled**: the operating-point chain term
-  (op point moves when R changes, which moves g_d) is deferred to M1 and
-  documented at the definition site.
+M1 item 1 landed. `Device::Mosfet` (Shichman–Hodges level-1: cutoff /
+triode / saturation, kp / vt0 / λ, source-drain swap for vds < 0 — SPICE2,
+UCB ERL-M520, 1975, §2) and `Device::Bjt` (Ebers–Moll transport form:
+Is / βF / βR), both polarities (NMOS/PMOS, NPN/PNP) via the sign
+transformation. Wired everywhere: transient Newton (`pnjlim` on both BJT
+junctions, step-clamped FET voltages), DC (gmin ladder verified on a real
+CMOS inverter transfer curve), AC (gm/gds/gπ/gµ at the DC op point), and
+the DC adjoint (d/dkp + d/dvt0, d/dIs + d/dβF via `gradient_aux`,
+FD-validated to < 1e-4). The Tellegen gate learned multi-terminal power
+(`Device::power`) — a BJT's base current carries power the (c, e) pair
+alone would miss — and holds < 1e-9 with transistors in the network.
+The M0 AC-diode placeholder is closed: `AcSensitivity` diode slots now
+carry the full operating-point chain term (∂H/∂g_d from the AC adjoint ×
+dv_d/dp from the DC adjoint), FD-validated; `deferred` now lists exactly
+the transistors (their AC sensitivities need model second derivatives).
+New validation rungs: MOSFET saturation vs the square law (1e-9),
+common-source gain vs −gm·(Rd ∥ ro) (1e-9), BJT current-mirror ratio vs
+1/(1 + 2/βF).
+
+## Honesty (what is not claimed)
+
+- **Transistor models are level-1 / Ebers–Moll only.** No body effect, no
+  subthreshold, no capacitances (transistors are memoryless here), no
+  Early effect (BJT), no Gummel–Poon. Good for topology-level design and
+  gradients, not for nanometer accuracy.
+- **Transistor AC sensitivities are deferred placeholders** (flagged in
+  `AcSensitivity::deferred`): they need d(gm, gds)/d(op point) — second
+  derivatives of the models. Diode AC sensitivities are now computed,
+  including the operating-point chain term.
 - **No transient adjoint** — DC and AC gradients only. Transient adjoint
   (reverse sweep over companion states) is M1.
 - **Fixed timestep at M0** — LTE-based adaptive stepping flagged for M1.
@@ -73,8 +96,9 @@ binds them is M-next, mirroring the antenna/EM measurement packs.
 
 ## M1 ladder
 
-1. MOSFET level-1 (Shichman–Hodges) + BJT Ebers–Moll, with the same
-   FD-validated adjoint treatment.
+1. ~~MOSFET level-1 (Shichman–Hodges) + BJT Ebers–Moll, with the same
+   FD-validated adjoint treatment.~~ **Done** (see "M1 progress" above);
+   transistor *AC* sensitivities remain deferred.
 2. Transient adjoint (reverse sweep) → time-domain objectives (settling
    time, overshoot) become differentiable.
 3. LTE-based adaptive timestep (with the frozen-discretization caveat for


### PR DESCRIPTION
First transistors in the differentiable circuit simulator (`vcad-ecad-sim::circuit`), M1 item 1 from `docs/spice-m0.md`.

## Models
- **`Device::Mosfet`** — Shichman–Hodges level-1 (cutoff / triode / saturation, `kp`/`vt0`/`lambda`, symmetric vds<0 source-drain swap; SPICE2: Nagel, UCB ERL-M520, 1975, §2). NMOS + PMOS via the standard sign transformation.
- **`Device::Bjt`** — Ebers–Moll transport form (`Is`/`betaF`/`betaR`), NPN + PNP.

One `eval()` per model returns currents + conductances + parameter derivatives in external convention — transient, DC, AC, and the adjoint all consume the same numbers.

## Wiring
- **Transient**: Newton companion stamps with `pnjlim` on both BJT junctions and step-clamped FET voltages; per-device nonlinear state widened to `[f64; 2]`.
- **DC** (`circuit::dc`): gmin ladder verified on a real CMOS inverter (rail-to-rail, monotone transfer, VDD/2 switch point).
- **AC** (`circuit::ac`): gm/gds (MOSFET) and gπ/gµ/gmf/gmr (BJT) linearized at the DC op point.
- **Adjoint** (`circuit::adjoint`): DC sensitivities wrt kp + vt0 and Is + βF (second parameter in the new `gradient_aux`), implicit-function-theorem path, FD-validated < 1e-4.
- **Tellegen**: new `Device::power()` sums over *all* terminals — a BJT's base current carries power the (c, e) pair misses. Gate holds < 1e-9 with transistors in the network, both integrators.
- **WASM**: `DeviceSpec` gains `nmos`/`pmos`/`npn`/`pnp`.

## M0 gap closed
The AC diode sensitivity slot was a flagged placeholder. It now carries the full operating-point chain term — `dH/dp = ∂H/∂p + Σ (∂H/∂g_d)·dg_d/dp`, with `dv_d/dp` from the DC adjoint — FD-validated. `AcSensitivity::deferred` now lists exactly the transistors (their AC sensitivities need model second derivatives; deferred honestly, same pattern).

## Validation ladder additions (`tests/circuit_validation.rs`)
| rung | oracle | result |
|---|---|---|
| MOSFET saturation | (kp/2)·vov²·(1+λ·vds) | < 1e-9 rel |
| common-source gain | −gm·(Rd ∥ ro) | < 1e-9 rel |
| BJT current mirror | 1/(1 + 2/βF) | < 5e-3 |
| Tellegen w/ transistors | Σ all-terminal v·i | < 1e-9, 2000 steps × 2 integrators |

Docs: `spice-m0.md` honesty section updated (diode-only claim retired), dated `research-log.md` entry, changelog entry.

Gates: `cargo test -p vcad-ecad-sim` (105 tests), `clippy --all-targets -D warnings`, `fmt --check`, `cargo check -p vcad-kernel-wasm -p vcad-ecad-diff` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)