### PR TITLE
circuit M1: expose DC/AC/adjoint analyses to agents (WASM + MCP simulate_circuit / tune_circuit)

### DIFF
--- a/changelog/entries/2026-07-17-circuit-mcp-tools.json
+++ b/changelog/entries/2026-07-17-circuit-mcp-tools.json
@@ -1,0 +1,19 @@
+{
+  "id": "2026-07-17-circuit-mcp-tools",
+  "version": "0.9.4",
+  "date": "2026-07-17",
+  "category": "feat",
+  "title": "Circuit simulation and adjoint tuning over MCP",
+  "summary": "Agents can now run SPICE-style DC/AC/transient analyses on netlists-as-data and tune component values toward filter or DC targets with adjoint gradients, with vcad.spice-claims/1 receipts and the power-balance residual as the honesty signal.",
+  "features": [
+    "circuit",
+    "spice",
+    "adjoint",
+    "receipts",
+    "mcp"
+  ],
+  "mcpTools": [
+    "simulate_circuit",
+    "tune_circuit"
+  ]
+}

--- a/crates/vcad-kernel-wasm/src/circuit_sim.rs
+++ b/crates/vcad-kernel-wasm/src/circuit_sim.rs
@@ -12,7 +12,8 @@
 
 use serde::{Deserialize, Serialize};
 use vcad_ecad_sim::circuit::{
-    BjtModel, Circuit, CircuitEnv, Device, DiodeModel, MosfetModel, MotorParams,
+    ac, adjoint, dc, receipt, BjtModel, Circuit, CircuitEnv, Device, DiodeModel, Integrator,
+    MosfetModel, MotorParams,
 };
 use wasm_bindgen::prelude::*;
 
@@ -149,11 +150,31 @@ impl DeviceSpec {
     }
 }
 
-/// JSON description of a circuit to simulate.
+/// JSON description of a circuit to simulate. `dt` is only used by the
+/// transient paths; DC/AC analyses ignore it.
 #[derive(Debug, Deserialize)]
 struct CircuitSpec {
+    #[serde(default)]
     dt: f64,
     devices: Vec<DeviceSpec>,
+}
+
+impl CircuitSpec {
+    fn parse(spec_json: &str) -> Result<CircuitSpec, JsError> {
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad circuit spec: {e}")))
+    }
+
+    fn build(&self) -> Circuit {
+        let max_node = self.devices.iter().map(|d| d.max_node()).max().unwrap_or(0);
+        let mut circuit = Circuit::new();
+        while circuit.num_nodes <= max_node {
+            circuit.node();
+        }
+        for d in &self.devices {
+            circuit.add(d.to_device());
+        }
+        circuit
+    }
 }
 
 /// Serializable observation handed back to JS (camelCase fields).
@@ -190,18 +211,8 @@ impl CircuitSim {
     /// Build a simulation from a JSON `{ dt, devices: [...] }` spec.
     #[wasm_bindgen(constructor)]
     pub fn new(spec_json: &str) -> Result<CircuitSim, JsError> {
-        let spec: CircuitSpec =
-            serde_json::from_str(spec_json).map_err(|e| JsError::new(&e.to_string()))?;
-
-        let max_node = spec.devices.iter().map(|d| d.max_node()).max().unwrap_or(0);
-        let mut circuit = Circuit::new();
-        while circuit.num_nodes <= max_node {
-            circuit.node();
-        }
-        for d in &spec.devices {
-            circuit.add(d.to_device());
-        }
-
+        let spec = CircuitSpec::parse(spec_json)?;
+        let circuit = spec.build();
         let dt = if spec.dt > 0.0 { spec.dt } else { 1e-5 };
         let mut env = CircuitEnv::new(circuit, dt);
         env.reset();
@@ -243,4 +254,671 @@ impl CircuitSim {
     pub fn dt(&self) -> f64 {
         self.env.dt()
     }
+}
+
+// ---------------------------------------------------------------------------
+// Stateless analyses: DC operating point, AC sweep, adjoint sensitivities,
+// batched transient, and adjoint-driven tuning. Each takes the same
+// `{ devices: [...] }` spec JSON as `CircuitSim` and returns camelCase JSON.
+// ---------------------------------------------------------------------------
+
+fn json_out<T: Serialize>(out: &T) -> Result<JsValue, JsError> {
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    out.serialize(&ser)
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+fn check_out_node(circuit: &Circuit, out_node: usize) -> Result<(), JsError> {
+    if out_node == 0 || out_node >= circuit.num_nodes {
+        return Err(JsError::new(&format!(
+            "outNode must be a non-ground node in 1..{} (got {out_node})",
+            circuit.num_nodes
+        )));
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmDcSolution {
+    node_voltages: Vec<f64>,
+    device_currents: Vec<f64>,
+    /// Tellegen residual Σ v·i (W) — the honesty signal: nonzero only
+    /// through solver error.
+    power_balance_w: f64,
+    newton_iterations: usize,
+    claim_set: receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// DC operating point of a `{ devices: [...] }` circuit spec: node voltages,
+/// device currents, the Tellegen power-balance residual, and predicted
+/// `vcad.spice-claims/1` claims (Provisional rollup, never Pass).
+#[wasm_bindgen(js_name = circuitDcOperatingPoint)]
+pub fn circuit_dc_operating_point(spec_json: &str) -> Result<JsValue, JsError> {
+    let circuit = CircuitSpec::parse(spec_json)?.build();
+    let sol = dc::operating_point(&circuit).map_err(|e| JsError::new(&e.to_string()))?;
+    let claim_set = receipt::dc_claims(&sol, circuit.devices.len());
+    let receipt_claims = receipt::design_claims(&claim_set);
+    json_out(&WasmDcSolution {
+        node_voltages: sol.node_voltages.clone(),
+        device_currents: sol.device_currents.clone(),
+        power_balance_w: sol.power_balance_w,
+        newton_iterations: sol.newton_iterations,
+        claim_set,
+        receipt_claims,
+    })
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmAcPoint {
+    omega: f64,
+    /// Real parts of the complex node voltages, indexed by node (0 = ground).
+    node_voltages_re: Vec<f64>,
+    /// Imaginary parts, same indexing.
+    node_voltages_im: Vec<f64>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmAcResponse {
+    source: usize,
+    points: Vec<WasmAcPoint>,
+}
+
+/// Small-signal AC response driven by device `source_id` (a V or I source)
+/// with unit amplitude, solved at each angular frequency in `omegas` (rad/s).
+/// Returns per-omega complex node voltages as re/im arrays.
+#[wasm_bindgen(js_name = circuitAcResponse)]
+pub fn circuit_ac_response(
+    spec_json: &str,
+    source_id: usize,
+    omegas: Vec<f64>,
+) -> Result<JsValue, JsError> {
+    let circuit = CircuitSpec::parse(spec_json)?.build();
+    let mut points = Vec::with_capacity(omegas.len());
+    for &omega in &omegas {
+        let sol = ac::ac_response(&circuit, source_id, omega)
+            .map_err(|e| JsError::new(&format!("AC solve at omega={omega}: {e}")))?;
+        points.push(WasmAcPoint {
+            omega,
+            node_voltages_re: sol.node_voltages.iter().map(|z| z.re).collect(),
+            node_voltages_im: sol.node_voltages.iter().map(|z| z.im).collect(),
+        });
+    }
+    json_out(&WasmAcResponse {
+        source: source_id,
+        points,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcSensSpec {
+    source_id: usize,
+    omega: f64,
+}
+
+/// Analysis selector for [`circuit_sensitivities`]: `{"dc": true}` or
+/// `{"ac": {"sourceId": .., "omega": ..}}`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SensitivitySpec {
+    #[serde(default)]
+    dc: Option<bool>,
+    #[serde(default)]
+    ac: Option<AcSensSpec>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmSensitivities {
+    /// `"dc"` or `"ac"`.
+    analysis: String,
+    /// DC: the out-node voltage (V). AC: |H(jω)|.
+    value: f64,
+    /// DC: d(voltage)/d(primary) per device. AC: d|H|/d(primary) per device.
+    gradient: Vec<f64>,
+    /// AC only: complex dH/dp per device, as re/im arrays.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gradient_re: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gradient_im: Option<Vec<f64>>,
+    /// AC only: complex H(jω).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    h_re: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    h_im: Option<f64>,
+    /// Device ids whose gradient slot is a **placeholder**, not a computed
+    /// value (at M0: diodes at AC). Empty for DC.
+    deferred: Vec<usize>,
+}
+
+/// Adjoint sensitivities of the voltage at `out_node` to every device primary
+/// — one extra transposed solve for the whole gradient. `analysis_json`
+/// selects `{"dc": true}` or `{"ac": {"sourceId", "omega"}}`.
+#[wasm_bindgen(js_name = circuitSensitivities)]
+pub fn circuit_sensitivities(
+    spec_json: &str,
+    out_node: usize,
+    analysis_json: &str,
+) -> Result<JsValue, JsError> {
+    let circuit = CircuitSpec::parse(spec_json)?.build();
+    check_out_node(&circuit, out_node)?;
+    let sel: SensitivitySpec = serde_json::from_str(analysis_json)
+        .map_err(|e| JsError::new(&format!("bad analysis selector: {e}")))?;
+    match (sel.dc, sel.ac) {
+        (Some(true), None) => {
+            let sens = adjoint::dc_sensitivities(&circuit, out_node)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            json_out(&WasmSensitivities {
+                analysis: "dc".into(),
+                value: sens.value,
+                gradient: sens.gradient,
+                gradient_re: None,
+                gradient_im: None,
+                h_re: None,
+                h_im: None,
+                deferred: Vec::new(),
+            })
+        }
+        (None | Some(false), Some(acs)) => {
+            let sens = adjoint::ac_sensitivities(&circuit, acs.source_id, acs.omega, out_node)
+                .map_err(|e| JsError::new(&e.to_string()))?;
+            let d_mag: Vec<f64> = (0..circuit.devices.len())
+                .map(|i| sens.d_magnitude(i))
+                .collect();
+            json_out(&WasmSensitivities {
+                analysis: "ac".into(),
+                value: sens.h.abs(),
+                gradient: d_mag,
+                gradient_re: Some(sens.gradient.iter().map(|z| z.re).collect()),
+                gradient_im: Some(sens.gradient.iter().map(|z| z.im).collect()),
+                h_re: Some(sens.h.re),
+                h_im: Some(sens.h.im),
+                deferred: sens.deferred,
+            })
+        }
+        _ => Err(JsError::new(
+            "analysis selector must be exactly one of {\"dc\": true} or {\"ac\": {\"sourceId\", \"omega\"}}",
+        )),
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmTransient {
+    dt: f64,
+    /// Sampled times (s), every `sample_every` steps (last step always included).
+    times: Vec<f64>,
+    /// Sampled node-voltage vectors, one per time.
+    node_voltages: Vec<Vec<f64>>,
+    /// Device currents at the final step.
+    final_device_currents: Vec<f64>,
+    /// Tellegen residual of the final solved step (W).
+    power_balance_w: f64,
+}
+
+/// Batched transient run (trapezoidal integrator): step `steps` times from
+/// the power-on state, sampling every `sample_every` steps. Sample count is
+/// capped at 5000 — raise `sample_every` for long runs.
+#[wasm_bindgen(js_name = circuitTransient)]
+pub fn circuit_transient(
+    spec_json: &str,
+    steps: usize,
+    sample_every: usize,
+) -> Result<JsValue, JsError> {
+    let spec = CircuitSpec::parse(spec_json)?;
+    if spec.dt <= 0.0 {
+        return Err(JsError::new("transient requires dt > 0 in the spec"));
+    }
+    if steps == 0 || steps > 2_000_000 {
+        return Err(JsError::new("steps must be in 1..=2000000"));
+    }
+    let every = sample_every.max(1);
+    if steps / every > 5000 {
+        return Err(JsError::new(&format!(
+            "{} samples requested (cap 5000) — raise sampleEvery",
+            steps / every
+        )));
+    }
+    let circuit = spec.build();
+    let mut env = CircuitEnv::new(circuit, spec.dt);
+    env.reset();
+    env.set_integrator(Integrator::Trapezoidal);
+    let mut times = Vec::new();
+    let mut node_voltages = Vec::new();
+    let mut obs = env.observe();
+    for k in 1..=steps {
+        obs = env.step();
+        if k % every == 0 || k == steps {
+            times.push(obs.time);
+            node_voltages.push(obs.node_voltages.clone());
+        }
+    }
+    json_out(&WasmTransient {
+        dt: spec.dt,
+        times,
+        node_voltages,
+        final_device_currents: obs.device_currents,
+        power_balance_w: env.power_balance(),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Adjoint-driven tuning — the filter_autotune loop, generalized.
+// ---------------------------------------------------------------------------
+
+/// A Butterworth-style AC magnitude target: cutoff + Q of a 2nd-order
+/// response at `out_node`, driven by `source_id`.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FilterTarget {
+    cutoff_hz: f64,
+    q_factor: f64,
+    source_id: usize,
+    out_node: usize,
+}
+
+/// A DC target: hold `node` at `dc_voltage` volts.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DcTarget {
+    node: usize,
+    dc_voltage: f64,
+}
+
+/// One tunable device: its id plus optional positive bounds on the primary.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FreeDevice {
+    device: usize,
+    #[serde(default)]
+    min: Option<f64>,
+    #[serde(default)]
+    max: Option<f64>,
+}
+
+/// Tune request: exactly one of `filter` / `dc`, plus the devices allowed to
+/// move. Tuning runs in log-parameter space, so every free device's primary
+/// (and its bounds) must be strictly positive.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TuneSpec {
+    #[serde(default)]
+    filter: Option<FilterTarget>,
+    #[serde(default)]
+    dc: Option<DcTarget>,
+    free_devices: Vec<FreeDevice>,
+    #[serde(default)]
+    max_iters: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmTunedValue {
+    device: usize,
+    before: f64,
+    after: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmBodePoint {
+    frequency_hz: f64,
+    magnitude_before: f64,
+    magnitude_after: f64,
+    magnitude_target: f64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WasmTuneResult {
+    tuned_values: Vec<WasmTunedValue>,
+    iterations: usize,
+    objective_before: f64,
+    objective_after: f64,
+    /// Filter tune: Bode points before/after/target at the probe frequencies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    response: Option<Vec<WasmBodePoint>>,
+    /// Filter tune: −3 dB cutoff measured from the tuned response (bisection).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    achieved_cutoff_hz: Option<f64>,
+    /// Filter tune: Q measured as |H| at the −90° phase crossing / |H_dc|.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    achieved_q_factor: Option<f64>,
+    /// DC tune: the achieved node voltage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    achieved_dc_voltage: Option<f64>,
+    claim_set: receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Validate the free-device list and return the initial (positive) values.
+fn free_values(circuit: &Circuit, free: &[FreeDevice]) -> Result<Vec<f64>, JsError> {
+    if free.is_empty() {
+        return Err(JsError::new("freeDevices must not be empty"));
+    }
+    free.iter()
+        .map(|f| {
+            let dev = circuit.devices.get(f.device).ok_or_else(|| {
+                JsError::new(&format!("freeDevices: no device with id {}", f.device))
+            })?;
+            let v = dev.primary();
+            if v <= 0.0 {
+                return Err(JsError::new(&format!(
+                    "free device {} has non-positive primary {v} — log-space tuning needs > 0",
+                    f.device
+                )));
+            }
+            if let (Some(lo), Some(hi)) = (f.min, f.max) {
+                if lo > hi {
+                    return Err(JsError::new(&format!(
+                        "free device {}: min {lo} > max {hi}",
+                        f.device
+                    )));
+                }
+            }
+            if f.min.is_some_and(|lo| lo <= 0.0) {
+                return Err(JsError::new(&format!(
+                    "free device {}: min must be > 0 for log-space tuning",
+                    f.device
+                )));
+            }
+            Ok(v)
+        })
+        .collect()
+}
+
+fn clamp_free(values: &mut [f64], free: &[FreeDevice]) {
+    for (v, f) in values.iter_mut().zip(free) {
+        if let Some(lo) = f.min {
+            *v = v.max(lo);
+        }
+        if let Some(hi) = f.max {
+            *v = v.min(hi);
+        }
+    }
+}
+
+fn with_values(circuit: &Circuit, free: &[FreeDevice], values: &[f64]) -> Circuit {
+    let mut c = circuit.clone();
+    for (f, &v) in free.iter().zip(values) {
+        c.devices[f.device].set_primary(v);
+    }
+    c
+}
+
+/// Analytic 2nd-order low-pass magnitude (the tuning target).
+fn target_mag(f: f64, f0: f64, q: f64) -> f64 {
+    let x = f / f0;
+    1.0 / ((1.0 - x * x).powi(2) + (x / q).powi(2)).sqrt()
+}
+
+/// Generic gradient descent in log-parameter space with backtracking line
+/// search and a scale-invariant stop — the loop from
+/// `vcad-ecad-sim/examples/filter_autotune.rs`, over N free parameters.
+/// `eval` returns (J, dJ/d ln p per free parameter).
+fn descend(
+    mut values: Vec<f64>,
+    free: &[FreeDevice],
+    max_iters: usize,
+    mut eval: impl FnMut(&[f64]) -> Result<(f64, Vec<f64>), JsError>,
+) -> Result<(Vec<f64>, f64, f64, usize), JsError> {
+    let (mut j, mut grad) = eval(&values)?;
+    let j0 = j;
+    let norm = |g: &[f64]| g.iter().map(|x| x * x).sum::<f64>().sqrt();
+    let mut step = 0.25f64;
+    let mut iters = 0usize;
+    for _ in 0..max_iters {
+        iters += 1;
+        let mut accepted = false;
+        for _ in 0..40 {
+            let scale = 1.0 + norm(&grad);
+            let mut trial: Vec<f64> = values
+                .iter()
+                .zip(&grad)
+                .map(|(v, g)| v * (-step * g / scale).exp())
+                .collect();
+            clamp_free(&mut trial, free);
+            let (jt, gt) = eval(&trial)?;
+            if jt < j {
+                let improvement = (j - jt) / j.max(1e-300);
+                values = trial;
+                j = jt;
+                grad = gt;
+                step *= 1.5;
+                accepted = improvement > 1e-12;
+                break;
+            }
+            step *= 0.5;
+        }
+        if !accepted || j < 1e-16 {
+            break;
+        }
+    }
+    Ok((values, j0, j, iters))
+}
+
+/// |H| at frequency `f` (Hz) for the circuit as configured.
+fn mag_at(circuit: &Circuit, source: usize, out: usize, f: f64) -> Result<f64, JsError> {
+    let omega = 2.0 * std::f64::consts::PI * f;
+    Ok(ac::ac_response(circuit, source, omega)
+        .map_err(|e| JsError::new(&format!("AC solve at {f} Hz: {e}")))?
+        .node_voltages[out]
+        .abs())
+}
+
+/// Bisect a scalar monotone-crossing function of log-frequency.
+fn bisect_freq(
+    mut lo: f64,
+    mut hi: f64,
+    mut f: impl FnMut(f64) -> Result<f64, JsError>,
+) -> Result<Option<f64>, JsError> {
+    let (flo, fhi) = (f(lo)?, f(hi)?);
+    if flo.signum() == fhi.signum() {
+        return Ok(None);
+    }
+    let rising = fhi > flo;
+    for _ in 0..80 {
+        let mid = (lo.ln() + hi.ln()).mul_add(0.5, 0.0).exp();
+        let fm = f(mid)?;
+        if (fm > 0.0) == rising {
+            hi = mid;
+        } else {
+            lo = mid;
+        }
+    }
+    Ok(Some((lo * hi).sqrt()))
+}
+
+/// Tune the free devices toward the target by adjoint gradient descent.
+/// Fails closed if any free device's sensitivity slot is deferred
+/// (a placeholder, not a computed gradient — at M0, diodes at AC).
+#[wasm_bindgen(js_name = circuitTune)]
+pub fn circuit_tune(spec_json: &str, tune_json: &str) -> Result<JsValue, JsError> {
+    let circuit = CircuitSpec::parse(spec_json)?.build();
+    let tune: TuneSpec = serde_json::from_str(tune_json)
+        .map_err(|e| JsError::new(&format!("bad tune spec: {e}")))?;
+    let start = free_values(&circuit, &tune.free_devices)?;
+    let max_iters = tune.max_iters.unwrap_or(500).min(5000);
+
+    match (tune.filter, tune.dc) {
+        (Some(t), None) => tune_filter(&circuit, &tune.free_devices, start, max_iters, &t),
+        (None, Some(t)) => tune_dc(&circuit, &tune.free_devices, start, max_iters, &t),
+        _ => Err(JsError::new(
+            "tune spec must carry exactly one of `filter` or `dc`",
+        )),
+    }
+}
+
+fn tune_filter(
+    circuit: &Circuit,
+    free: &[FreeDevice],
+    start: Vec<f64>,
+    max_iters: usize,
+    t: &FilterTarget,
+) -> Result<JsValue, JsError> {
+    check_out_node(circuit, t.out_node)?;
+    if t.cutoff_hz <= 0.0
+        || t.q_factor <= 0.0
+        || !t.cutoff_hz.is_finite()
+        || !t.q_factor.is_finite()
+    {
+        return Err(JsError::new("cutoffHz and qFactor must be > 0"));
+    }
+    // 25 log-spaced probes over two decades centered on the target cutoff.
+    let probes: Vec<f64> = (0..25)
+        .map(|i| (t.cutoff_hz / 10.0) * 10f64.powf(2.0 * i as f64 / 24.0))
+        .collect();
+    let targets: Vec<f64> = probes
+        .iter()
+        .map(|&f| target_mag(f, t.cutoff_hz, t.q_factor))
+        .collect();
+
+    let eval = |values: &[f64]| -> Result<(f64, Vec<f64>), JsError> {
+        let ckt = with_values(circuit, free, values);
+        let mut j = 0.0;
+        let mut grad = vec![0.0f64; free.len()];
+        for (k, &f) in probes.iter().enumerate() {
+            let omega = 2.0 * std::f64::consts::PI * f;
+            let sens = adjoint::ac_sensitivities(&ckt, t.source_id, omega, t.out_node)
+                .map_err(|e| JsError::new(&format!("adjoint solve at {f} Hz: {e}")))?;
+            for fd in free {
+                if sens.is_deferred(fd.device) {
+                    return Err(JsError::new(&format!(
+                        "free device {} has a deferred (placeholder) AC sensitivity — cannot tune it",
+                        fd.device
+                    )));
+                }
+            }
+            let err = sens.h.abs() - targets[k];
+            j += err * err;
+            for (gi, fd) in free.iter().enumerate() {
+                // Chain to log-space: d/d ln p = p · d/dp.
+                grad[gi] += 2.0 * err * sens.d_magnitude(fd.device) * values[gi];
+            }
+        }
+        Ok((j, grad))
+    };
+
+    let (tuned, j0, j, iters) = descend(start.clone(), free, max_iters, eval)?;
+    let before_ckt = with_values(circuit, free, &start);
+    let after_ckt = with_values(circuit, free, &tuned);
+
+    let response: Vec<WasmBodePoint> = probes
+        .iter()
+        .zip(&targets)
+        .map(|(&f, &tm)| {
+            Ok(WasmBodePoint {
+                frequency_hz: f,
+                magnitude_before: mag_at(&before_ckt, t.source_id, t.out_node, f)?,
+                magnitude_after: mag_at(&after_ckt, t.source_id, t.out_node, f)?,
+                magnitude_target: tm,
+            })
+        })
+        .collect::<Result<_, JsError>>()?;
+
+    // Measure the achieved response rather than trusting closed forms:
+    // cutoff = the −3 dB crossing of |H|/|H_low|; Q = |H|/|H_low| at the
+    // −90° phase crossing (exact for a 2nd-order section).
+    let f_lo = t.cutoff_hz / 1000.0;
+    let f_hi = t.cutoff_hz * 1000.0;
+    let h_low = mag_at(&after_ckt, t.source_id, t.out_node, f_lo)?;
+    let achieved_cutoff = bisect_freq(f_lo, f_hi, |f| {
+        Ok(mag_at(&after_ckt, t.source_id, t.out_node, f)? / h_low
+            - std::f64::consts::FRAC_1_SQRT_2)
+    })?;
+    let phase_at = |f: f64| -> Result<f64, JsError> {
+        let omega = 2.0 * std::f64::consts::PI * f;
+        Ok(ac::ac_response(&after_ckt, t.source_id, omega)
+            .map_err(|e| JsError::new(&e.to_string()))?
+            .node_voltages[t.out_node]
+            .arg())
+    };
+    let f_90 = bisect_freq(f_lo, f_hi, |f| {
+        Ok(phase_at(f)? + std::f64::consts::FRAC_PI_2)
+    })?;
+    let achieved_q = match f_90 {
+        Some(f0) => Some(mag_at(&after_ckt, t.source_id, t.out_node, f0)? / h_low),
+        None => None,
+    };
+
+    let claim_set = receipt::filter_claims(
+        achieved_cutoff.unwrap_or(f64::NAN),
+        achieved_q.unwrap_or(f64::NAN),
+        circuit.num_nodes,
+        circuit.devices.len(),
+    );
+    let receipt_claims = receipt::design_claims(&claim_set);
+    json_out(&WasmTuneResult {
+        tuned_values: free
+            .iter()
+            .zip(start.iter().zip(&tuned))
+            .map(|(f, (&b, &a))| WasmTunedValue {
+                device: f.device,
+                before: b,
+                after: a,
+            })
+            .collect(),
+        iterations: iters,
+        objective_before: j0,
+        objective_after: j,
+        response: Some(response),
+        achieved_cutoff_hz: achieved_cutoff,
+        achieved_q_factor: achieved_q,
+        achieved_dc_voltage: None,
+        claim_set,
+        receipt_claims,
+    })
+}
+
+fn tune_dc(
+    circuit: &Circuit,
+    free: &[FreeDevice],
+    start: Vec<f64>,
+    max_iters: usize,
+    t: &DcTarget,
+) -> Result<JsValue, JsError> {
+    check_out_node(circuit, t.node)?;
+    let eval = |values: &[f64]| -> Result<(f64, Vec<f64>), JsError> {
+        let ckt = with_values(circuit, free, values);
+        let sens =
+            adjoint::dc_sensitivities(&ckt, t.node).map_err(|e| JsError::new(&e.to_string()))?;
+        let err = sens.value - t.dc_voltage;
+        let grad = free
+            .iter()
+            .enumerate()
+            .map(|(gi, fd)| 2.0 * err * sens.gradient[fd.device] * values[gi])
+            .collect();
+        Ok((err * err, grad))
+    };
+
+    let (tuned, j0, j, iters) = descend(start.clone(), free, max_iters, eval)?;
+    let after_ckt = with_values(circuit, free, &tuned);
+    let sol = dc::operating_point(&after_ckt).map_err(|e| JsError::new(&e.to_string()))?;
+    let achieved = sol.node_voltages[t.node];
+    let claim_set = receipt::dc_claims(&sol, circuit.devices.len());
+    let receipt_claims = receipt::design_claims(&claim_set);
+    json_out(&WasmTuneResult {
+        tuned_values: free
+            .iter()
+            .zip(start.iter().zip(&tuned))
+            .map(|(f, (&b, &a))| WasmTunedValue {
+                device: f.device,
+                before: b,
+                after: a,
+            })
+            .collect(),
+        iterations: iters,
+        objective_before: j0,
+        objective_after: j,
+        response: None,
+        achieved_cutoff_hz: None,
+        achieved_q_factor: None,
+        achieved_dc_voltage: Some(achieved),
+        claim_set,
+        receipt_claims,
+    })
 }

--- a/docs/research-log.md
+++ b/docs/research-log.md
@@ -874,3 +874,31 @@ C3 ±4.02%, L2 ±20% (its variance share is 0 at f₀), total $0.313 vs $0.418
 proportional baseline; solver-in-the-loop check 0.9886 ±0.0008. Receipts:
 `yield_fraction` + `worst_case_deviation` on `vcad.spice-claims/1`,
 predicted basis, Provisional rollup, MC seed in the note.
+
+## 2026-07-17 — Circuit M1: the differentiable SPICE seam reaches agents
+
+The M0 analyses (PR #577) are now callable end-to-end: WASM bindings
+(`circuitDcOperatingPoint` / `circuitAcResponse` / `circuitSensitivities` /
+`circuitTransient` / `circuitTune`) plus two MCP tools, `simulate_circuit`
+and `tune_circuit`.
+
+- **Netlists as data**: `{devices: [{kind, p, n, value}]}`, node 0 =
+  ground, device id = array index — the same spec the app's `CircuitSim`
+  transient class already took, now shared by every analysis.
+- **The residual rides in public**: every DC and transient result carries
+  the Tellegen power-balance residual; it measures solver error and
+  nothing else, so it ships as the honesty signal next to the claims.
+- **Tuning is the adjoint earning its keep**: `tune_circuit` ports the
+  `filter_autotune` loop (log-space gradient descent, backtracking line
+  search, scale-invariant stop) behind a target-as-data interface —
+  `{cutoffHz, qFactor}` or `{node, dcVoltage}` with optional bounds. The
+  e2e test drives the detuned RLC to 10 kHz / Q = 0.707; the DC case
+  lands the divider resistor at exactly 1500 Ω.
+- **Achieved ≠ assumed**: the tuned cutoff is measured off the response
+  by −3 dB bisection and Q from the −90° phase crossing (exact for a
+  2nd-order section) — no closed forms trusted, so the claims describe
+  the circuit as solved, not the formula we hoped for.
+- **Fail-closed on placeholders**: a free device whose AC sensitivity
+  slot is deferred (diodes at M0) errors instead of silently not moving.
+- Claims land under `vcad.spice-claims/1`, basis predicted, Provisional
+  rollup — the $30-scope measurement pack remains the closing move.

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -466,6 +466,28 @@ export interface KernelModule {
     paramsJson: string,
     optionsJson: string,
   ) => unknown;
+  /** Circuit DC operating point (`{devices:[...]}` spec JSON). */
+  circuitDcOperatingPoint?: (specJson: string) => unknown;
+  /** Circuit small-signal AC sweep at the given angular frequencies. */
+  circuitAcResponse?: (
+    specJson: string,
+    sourceId: number,
+    omegas: Float64Array | number[],
+  ) => unknown;
+  /** Circuit adjoint sensitivities (`{"dc":true}` or `{"ac":{...}}`). */
+  circuitSensitivities?: (
+    specJson: string,
+    outNode: number,
+    analysisJson: string,
+  ) => unknown;
+  /** Batched circuit transient run (trapezoidal). */
+  circuitTransient?: (
+    specJson: string,
+    steps: number,
+    sampleEvery: number,
+  ) => unknown;
+  /** Adjoint gradient-descent circuit tuning (TuneSpec JSON). */
+  circuitTune?: (specJson: string, tuneJson: string) => unknown;
   /** Static structural FEA with convergence gating (FeaSpec/options JSON + mesh). */
   feaAnalyzeMesh?: (
     specJson: string,
@@ -866,6 +888,11 @@ export class Engine {
       particleOptimize: (wasmModule as Record<string, unknown>).particleOptimize as KernelModule["particleOptimize"],
       toleranceAnalyze: (wasmModule as Record<string, unknown>).toleranceAnalyze as KernelModule["toleranceAnalyze"],
       thermalSolve: (wasmModule as Record<string, unknown>).thermalSolve as KernelModule["thermalSolve"],
+      circuitDcOperatingPoint: (wasmModule as Record<string, unknown>).circuitDcOperatingPoint as KernelModule["circuitDcOperatingPoint"],
+      circuitAcResponse: (wasmModule as Record<string, unknown>).circuitAcResponse as KernelModule["circuitAcResponse"],
+      circuitSensitivities: (wasmModule as Record<string, unknown>).circuitSensitivities as KernelModule["circuitSensitivities"],
+      circuitTransient: (wasmModule as Record<string, unknown>).circuitTransient as KernelModule["circuitTransient"],
+      circuitTune: (wasmModule as Record<string, unknown>).circuitTune as KernelModule["circuitTune"],
       feaAnalyzeMesh: (wasmModule as Record<string, unknown>).feaAnalyzeMesh as KernelModule["feaAnalyzeMesh"],
       emSimulate: (wasmModule as Record<string, unknown>).emSimulate as KernelModule["emSimulate"],
       antennaAnalyze: (wasmModule as Record<string, unknown>).antennaAnalyze as KernelModule["antennaAnalyze"],
@@ -1193,6 +1220,62 @@ export class Engine {
       );
     }
     return fn(specJson, paramsJson, optionsJson);
+  }
+
+  private circuitFn<K extends keyof KernelModule>(name: K): NonNullable<KernelModule[K]> {
+    const fn = this.kernel[name];
+    if (typeof fn !== "function") {
+      throw new Error(
+        `${String(name)} is not exported by this kernel WASM build — rebuild packages/kernel-wasm`,
+      );
+    }
+    return fn as NonNullable<KernelModule[K]>;
+  }
+
+  /**
+   * Circuit DC operating point: node voltages, device currents, the Tellegen
+   * power-balance residual, and predicted `vcad.spice-claims/1` claims.
+   * `specJson` is the same `{devices:[{kind,p,n,value}]}` shape `CircuitSim`
+   * takes; see `vcad-ecad-sim::circuit`.
+   */
+  circuitDcOperatingPoint(specJson: string): unknown {
+    return this.circuitFn("circuitDcOperatingPoint")(specJson);
+  }
+
+  /** Small-signal AC sweep: per-omega complex node voltages (re/im arrays). */
+  circuitAcResponse(
+    specJson: string,
+    sourceId: number,
+    omegas: number[],
+  ): unknown {
+    return this.circuitFn("circuitAcResponse")(
+      specJson,
+      sourceId,
+      new Float64Array(omegas),
+    );
+  }
+
+  /** Adjoint sensitivities of the voltage at `outNode` to every device primary. */
+  circuitSensitivities(
+    specJson: string,
+    outNode: number,
+    analysisJson: string,
+  ): unknown {
+    return this.circuitFn("circuitSensitivities")(specJson, outNode, analysisJson);
+  }
+
+  /** Batched circuit transient run (trapezoidal integrator). */
+  circuitTransient(
+    specJson: string,
+    steps: number,
+    sampleEvery: number,
+  ): unknown {
+    return this.circuitFn("circuitTransient")(specJson, steps, sampleEvery);
+  }
+
+  /** Adjoint gradient-descent tuning toward a filter or DC target. */
+  circuitTune(specJson: string, tuneJson: string): unknown {
+    return this.circuitFn("circuitTune")(specJson, tuneJson);
   }
 
   /**

--- a/packages/mcp/src/__tests__/circuit-tools.test.ts
+++ b/packages/mcp/src/__tests__/circuit-tools.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * End-to-end coverage for the circuit tools: the real server, the real WASM
+ * kernel (CI builds it from source).
+ *
+ * Skips (rather than fails) when the loaded kernel WASM predates the circuit
+ * analysis bindings. Locally: `npm run build -w vcad-kernel-wasm`.
+ */
+
+const probeEngine = await Engine.init();
+const wasmHasCircuit =
+  typeof (
+    probeEngine as unknown as {
+      kernel?: { circuitDcOperatingPoint?: unknown };
+    }
+  ).kernel?.circuitDcOperatingPoint === "function";
+
+/** 12 V into a 3k/1k divider: out node sits at exactly 3 V. */
+const DIVIDER = [
+  { kind: "vsource", p: 1, n: 0, value: 12 },
+  { kind: "resistor", p: 1, n: 2, value: 3000 },
+  { kind: "resistor", p: 2, n: 0, value: 1000 },
+];
+
+/** Series RLC low-pass, detuned from the 10 kHz Butterworth target
+ *  (f0 ≈ 15.9 kHz, Q = 0.5) — the filter_autotune example's start point.
+ *  Topology: vin —R— mid —L— out —C— gnd. */
+const RLC = [
+  { kind: "vsource", p: 1, n: 0, value: 0 },
+  { kind: "resistor", p: 1, n: 2, value: 200 },
+  { kind: "inductor", p: 2, n: 3, value: 1e-3 },
+  { kind: "capacitor", p: 3, n: 0, value: 1e-7 },
+];
+
+type ToolText = { content: Array<{ type: string; text: string }> };
+
+describe.skipIf(!wasmHasCircuit)("circuit tools", () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    documents.clear();
+    const engine = await Engine.init();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    client = new Client(
+      { name: "circuit-tools", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  });
+
+  it("simulate_circuit dc: voltage divider hits 3 V with provisional claims", async () => {
+    const res = (await client.callTool({
+      name: "simulate_circuit",
+      arguments: { devices: DIVIDER, analyses: ["dc"] },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.dc.nodeVoltages[2]).toBeCloseTo(3.0, 9);
+    // 12 V across 4k: 3 mA through both resistors.
+    expect(out.dc.deviceCurrents[1]).toBeCloseTo(3e-3, 9);
+    // The honesty signal: Tellegen residual is solver error only.
+    expect(Math.abs(out.dc.powerBalanceW)).toBeLessThan(1e-9);
+
+    expect(out.dc.claimSet.schema).toBe("vcad.spice-claims/1");
+    const names = out.dc.claimSet.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("dc_node_voltage_2");
+    expect(names).toContain("power_balance_residual");
+    expect(out.dc.receiptClaims.length).toBe(out.dc.claimSet.claims.length);
+    for (const c of out.dc.receiptClaims) {
+      expect(c.domain).toBe("circuit");
+      expect(c.id.startsWith("circuit.")).toBe(true);
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("simulate_circuit ac: RC low-pass Bode point at ω = 1/RC is −3 dB / −45°", async () => {
+    const rc = [
+      { kind: "vsource", p: 1, n: 0, value: 0 },
+      { kind: "resistor", p: 1, n: 2, value: 1000 },
+      { kind: "capacitor", p: 2, n: 0, value: 1e-6 },
+    ];
+    const fc = 1 / (2 * Math.PI * 1000 * 1e-6);
+    const res = (await client.callTool({
+      name: "simulate_circuit",
+      arguments: {
+        devices: rc,
+        analyses: ["ac"],
+        ac: { sourceId: 0, outNode: 2, frequenciesHz: [fc] },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+    expect(out.ac.bode.length).toBe(1);
+    expect(out.ac.bode[0].magnitude).toBeCloseTo(Math.SQRT1_2, 9);
+    expect(out.ac.bode[0].phaseDeg).toBeCloseTo(-45, 6);
+    // Raw complex node voltages ride along.
+    expect(out.ac.points[0].nodeVoltagesRe.length).toBe(3);
+  });
+
+  it("simulate_circuit transient: RC charges to the source voltage", async () => {
+    const rc = [
+      { kind: "vsource", p: 1, n: 0, value: 5 },
+      { kind: "resistor", p: 1, n: 2, value: 1000 },
+      { kind: "capacitor", p: 2, n: 0, value: 1e-6 },
+    ];
+    const res = (await client.callTool({
+      name: "simulate_circuit",
+      arguments: {
+        devices: rc,
+        analyses: ["transient"],
+        transient: { dt: 1e-5, steps: 1000, sampleEvery: 100 },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+    const last = out.transient.nodeVoltages.at(-1);
+    expect(last[2]).toBeGreaterThan(4.9); // ~10 τ
+    expect(Math.abs(out.transient.powerBalanceW)).toBeLessThan(1e-9);
+  });
+
+  it("tune_circuit hits the 10 kHz / Q=0.707 Butterworth target from a detuned RLC", async () => {
+    const res = (await client.callTool({
+      name: "tune_circuit",
+      arguments: {
+        devices: RLC,
+        target: {
+          cutoffHz: 10_000,
+          qFactor: Math.SQRT1_2,
+          sourceId: 0,
+          outNode: 3,
+        },
+        freeDevices: [{ device: 1 }, { device: 2 }, { device: 3 }],
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.iterations).toBeGreaterThan(0);
+    expect(out.objectiveAfter).toBeLessThan(out.objectiveBefore);
+    // Achieved values are measured off the tuned response, not closed forms.
+    expect(out.achievedCutoffHz).toBeGreaterThan(9_900);
+    expect(out.achievedCutoffHz).toBeLessThan(10_100);
+    expect(out.achievedQFactor).toBeGreaterThan(0.7);
+    expect(out.achievedQFactor).toBeLessThan(0.715);
+    expect(out.tunedValues.length).toBe(3);
+    expect(out.response.length).toBe(25);
+
+    expect(out.claimSet.schema).toBe("vcad.spice-claims/1");
+    const names = out.claimSet.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("cutoff_hz");
+    expect(names).toContain("q_factor");
+    for (const c of out.receiptClaims) {
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("tune_circuit dc target: divider retuned to 4 V", async () => {
+    const res = (await client.callTool({
+      name: "tune_circuit",
+      arguments: {
+        devices: DIVIDER,
+        target: { node: 2, dcVoltage: 4 },
+        freeDevices: [{ device: 2, min: 100, max: 100_000 }],
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+    expect(out.achievedDcVoltage).toBeCloseTo(4.0, 4);
+    // 12·R2/(3000+R2) = 4 ⇒ R2 = 1500.
+    expect(out.tunedValues[0].after).toBeCloseTo(1500, 0);
+  });
+
+  it("errors surface as typed tool errors, not crashes", async () => {
+    // Floating node (no path to ground) → singular MNA → isError.
+    const res = (await client.callTool({
+      name: "simulate_circuit",
+      arguments: {
+        devices: [{ kind: "resistor", p: 1, n: 2, value: 1000 }],
+        analyses: ["dc"],
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+
+    const res2 = (await client.callTool({
+      name: "tune_circuit",
+      arguments: {
+        devices: RLC,
+        target: { cutoffHz: 10_000, qFactor: 0.707, sourceId: 0, outNode: 3 },
+        freeDevices: [{ device: 99 }],
+      },
+    })) as { isError?: boolean };
+    expect(res2.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -4476,6 +4476,239 @@
     }
   },
   {
+    "name": "simulate_circuit",
+    "title": "Simulate Circuit",
+    "description": "SPICE-style lumped-element circuit simulation (MNA): DC operating point (gmin-stepped Newton, exact at gmin=0), small-signal AC sweep (complex MNA, per-frequency complex node voltages + Bode magnitude/phase for outNode), and transient (trapezoidal, SPICE2's integrator). Netlist is data: {devices:[{kind,p,n,value}]}, node 0 = ground, device id = array index. Returns node voltages/currents and `vcad.spice-claims/1` + unified-receipt claims (basis \"predicted\", rolls up Provisional until measured — a $30 USB scope + signal generator close them). The Tellegen power-balance residual is reported as the honesty signal: it is solver error and nothing else. Limits: diode AC uses the DC-linearized small-signal model; motors are transient-only.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "devices": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "p",
+              "n"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "resistor",
+                  "capacitor",
+                  "inductor",
+                  "vsource",
+                  "isource",
+                  "diode",
+                  "led",
+                  "motor"
+                ],
+                "description": "Device kind. `diode`/`led` use built-in Shockley models; `motor` a small-DC model (transient only)."
+              },
+              "p": {
+                "type": "number",
+                "description": "Positive node id (0 = ground)."
+              },
+              "n": {
+                "type": "number",
+                "description": "Negative node id (0 = ground)."
+              },
+              "value": {
+                "type": "number",
+                "description": "Primary value: R in ohms, C in farads, L in henries, V in volts, I in amps. Ignored for diode/led/motor."
+              }
+            }
+          },
+          "description": "Netlist as data. Node ids are dense integers with 0 = ground; the device's index in this array is its device id (used by sourceId / freeDevices / outNode references)."
+        },
+        "analyses": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "dc",
+              "ac",
+              "transient"
+            ]
+          },
+          "description": "Which analyses to run."
+        },
+        "ac": {
+          "type": "object",
+          "properties": {
+            "sourceId": {
+              "type": "number",
+              "description": "Device id of the driving V/I source (unit amplitude)."
+            },
+            "outNode": {
+              "type": "number",
+              "description": "Node whose transfer magnitude/phase to tabulate (Bode points)."
+            },
+            "frequenciesHz": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Explicit frequency list (Hz). Overrides the sweep."
+            },
+            "startHz": {
+              "type": "number",
+              "description": "Sweep start (default 10)."
+            },
+            "stopHz": {
+              "type": "number",
+              "description": "Sweep stop (default 1e6)."
+            },
+            "points": {
+              "type": "number",
+              "description": "Log-spaced sweep points (default 40, max 500)."
+            }
+          },
+          "description": "Required when analyses includes \"ac\"."
+        },
+        "transient": {
+          "type": "object",
+          "properties": {
+            "dt": {
+              "type": "number",
+              "description": "Timestep (s)."
+            },
+            "steps": {
+              "type": "number",
+              "description": "Step count (max 2e6)."
+            },
+            "sampleEvery": {
+              "type": "number",
+              "description": "Record every Nth step (sample cap 5000). Default 1."
+            }
+          },
+          "description": "Required when analyses includes \"transient\"."
+        }
+      },
+      "required": [
+        "devices",
+        "analyses"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "tune_circuit",
+    "title": "Tune Circuit",
+    "description": "Adjoint-driven circuit tuning: gradient descent in log-parameter space (backtracking line search, scale-invariant stop) moves the freeDevices' values toward a target — either a 2nd-order filter target {cutoffHz, qFactor, sourceId, outNode} or a DC target {node, dcVoltage}. Each gradient costs one transposed MNA solve per probe regardless of component count. Returns tuned values, before/after response points, iteration count, the achieved target (cutoff measured by −3 dB bisection, Q from the −90° phase crossing, or the achieved DC voltage), and `vcad.spice-claims/1` + unified-receipt claims (predicted basis, Provisional rollup). Fails closed if a free device's sensitivity is a deferred placeholder (diodes at AC) or non-positive (log-space needs positive values).",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "devices": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "p",
+              "n"
+            ],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "resistor",
+                  "capacitor",
+                  "inductor",
+                  "vsource",
+                  "isource",
+                  "diode",
+                  "led",
+                  "motor"
+                ],
+                "description": "Device kind. `diode`/`led` use built-in Shockley models; `motor` a small-DC model (transient only)."
+              },
+              "p": {
+                "type": "number",
+                "description": "Positive node id (0 = ground)."
+              },
+              "n": {
+                "type": "number",
+                "description": "Negative node id (0 = ground)."
+              },
+              "value": {
+                "type": "number",
+                "description": "Primary value: R in ohms, C in farads, L in henries, V in volts, I in amps. Ignored for diode/led/motor."
+              }
+            }
+          },
+          "description": "Netlist as data. Node ids are dense integers with 0 = ground; the device's index in this array is its device id (used by sourceId / freeDevices / outNode references)."
+        },
+        "target": {
+          "type": "object",
+          "description": "Either a filter target {cutoffHz, qFactor, sourceId, outNode} (sourceId = driving source device id, outNode = response node) or a DC target {node, dcVoltage}.",
+          "properties": {
+            "cutoffHz": {
+              "type": "number"
+            },
+            "qFactor": {
+              "type": "number"
+            },
+            "sourceId": {
+              "type": "number"
+            },
+            "outNode": {
+              "type": "number"
+            },
+            "node": {
+              "type": "number"
+            },
+            "dcVoltage": {
+              "type": "number"
+            }
+          }
+        },
+        "freeDevices": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": [
+              "device"
+            ],
+            "properties": {
+              "device": {
+                "type": "number",
+                "description": "Device id (index into devices) allowed to move."
+              },
+              "min": {
+                "type": "number",
+                "description": "Lower bound (> 0)."
+              },
+              "max": {
+                "type": "number",
+                "description": "Upper bound."
+              }
+            }
+          }
+        },
+        "maxIters": {
+          "type": "number",
+          "description": "Gradient iteration cap (default 500, max 5000)."
+        }
+      },
+      "required": [
+        "devices",
+        "freeDevices",
+        "target"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
     "name": "predict_physics",
     "title": "Predict Physics",
     "description": "Fast static structural analysis (voxel FEA): max displacement, max von Mises stress, and compliance for a part or box under world-frame loads (N) and supports, in ~100 ms at fidelity=predict. Pass max_displacement_mm / max_von_mises_mpa limits to get receipt claims: predict-tier claims carry basis=predicted and roll up as a PROVISIONAL receipt — use them to iterate on a design cheaply. When the design settles, re-run with fidelity=verify (same solver, fine grid) to upgrade the claims to basis=verified and a certifiable pass. Loads/supports are box regions (mm, Z-up); zero-thickness boxes select a face. Voxel FEA smears stress concentrations — treat stress as an estimate near fillets.",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -132,6 +132,7 @@ import { toolDefs as topoptToolDefs } from "./tools/topopt.js";
 import { toolDefs as particleToolDefs } from "./tools/particle.js";
 import { toolDefs as toleranceToolDefs } from "./tools/tolerance.js";
 import { toolDefs as thermalToolDefs } from "./tools/thermal.js";
+import { toolDefs as circuitToolDefs } from "./tools/circuit.js";
 import { toolDefs as structureToolDefs } from "./tools/structure.js";
 import { toolDefs as emToolDefs } from "./tools/em.js";
 import { toolDefs as antennaToolDefs } from "./tools/antenna.js";
@@ -318,6 +319,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...particleToolDefs,
   ...toleranceToolDefs,
   ...thermalToolDefs,
+  ...circuitToolDefs,
   ...structureToolDefs,
   ...emToolDefs,
   ...antennaToolDefs,
@@ -414,6 +416,8 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "analyze_structure",
   "simulate_neutron_shield",
   "analyze_tolerance_stackup",
+  "simulate_circuit",
+  "tune_circuit",
   // ── Two-tier static physics (predict fast, verify to certify) ──
   "predict_physics",
   // ── Print-then-measure calibration loop (3DP) ──────────────

--- a/packages/mcp/src/tools/circuit.ts
+++ b/packages/mcp/src/tools/circuit.ts
@@ -1,0 +1,299 @@
+/**
+ * Circuit simulation tools — `vcad-ecad-sim::circuit` over MCP.
+ *
+ * `simulate_circuit` runs DC operating point / small-signal AC / transient
+ * analyses of a lumped-element netlist (SPICE-style MNA), returning node
+ * voltages, currents, Bode points, and `vcad.spice-claims/1` claims plus
+ * unified-receipt claims. The Tellegen power-balance residual rides along as
+ * the honesty signal. `tune_circuit` drives free component values toward a
+ * filter (cutoff/Q) or DC-voltage target with adjoint gradients (one
+ * transposed solve per probe — the whole gradient regardless of component
+ * count). Predictions carry `basis: "predicted"` and roll up Provisional —
+ * never verified — until the hardware is measured.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+
+const deviceSchema = {
+  type: "object" as const,
+  required: ["kind", "p", "n"],
+  properties: {
+    kind: {
+      type: "string" as const,
+      enum: [
+        "resistor",
+        "capacitor",
+        "inductor",
+        "vsource",
+        "isource",
+        "diode",
+        "led",
+        "motor",
+      ],
+      description:
+        "Device kind. `diode`/`led` use built-in Shockley models; `motor` a " +
+        "small-DC model (transient only).",
+    },
+    p: { type: "number" as const, description: "Positive node id (0 = ground)." },
+    n: { type: "number" as const, description: "Negative node id (0 = ground)." },
+    value: {
+      type: "number" as const,
+      description:
+        "Primary value: R in ohms, C in farads, L in henries, V in volts, " +
+        "I in amps. Ignored for diode/led/motor.",
+    },
+  },
+};
+
+const devicesSchema = {
+  type: "array" as const,
+  minItems: 1,
+  items: deviceSchema,
+  description:
+    "Netlist as data. Node ids are dense integers with 0 = ground; the " +
+    "device's index in this array is its device id (used by sourceId / " +
+    "freeDevices / outNode references).",
+};
+
+type Json = Record<string, unknown>;
+
+function textResult(payload: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}
+
+/** Frequency grid: explicit list, or a log-spaced start/stop/points sweep. */
+function frequencyGrid(ac: Json): number[] {
+  const list = ac.frequenciesHz as number[] | undefined;
+  if (Array.isArray(list) && list.length > 0) return list;
+  const start = (ac.startHz as number) ?? 10;
+  const stop = (ac.stopHz as number) ?? 1e6;
+  const points = Math.min(Math.max((ac.points as number) ?? 40, 2), 500);
+  if (!(start > 0) || !(stop > start)) {
+    throw new Error("ac sweep needs 0 < startHz < stopHz");
+  }
+  const out: number[] = [];
+  for (let i = 0; i < points; i++) {
+    out.push(start * Math.pow(stop / start, i / (points - 1)));
+  }
+  return out;
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "simulate_circuit",
+    pack: null,
+    description:
+      "SPICE-style lumped-element circuit simulation (MNA): DC operating point " +
+      "(gmin-stepped Newton, exact at gmin=0), small-signal AC sweep (complex MNA, " +
+      "per-frequency complex node voltages + Bode magnitude/phase for outNode), and " +
+      "transient (trapezoidal, SPICE2's integrator). Netlist is data: " +
+      "{devices:[{kind,p,n,value}]}, node 0 = ground, device id = array index. " +
+      "Returns node voltages/currents and `vcad.spice-claims/1` + unified-receipt " +
+      "claims (basis \"predicted\", rolls up Provisional until measured — a $30 USB " +
+      "scope + signal generator close them). The Tellegen power-balance residual is " +
+      "reported as the honesty signal: it is solver error and nothing else. Limits: " +
+      "diode AC uses the DC-linearized small-signal model; motors are transient-only.",
+    inputSchema: {
+      type: "object" as const,
+      required: ["devices", "analyses"],
+      properties: {
+        devices: devicesSchema,
+        analyses: {
+          type: "array" as const,
+          minItems: 1,
+          items: { type: "string" as const, enum: ["dc", "ac", "transient"] },
+          description: "Which analyses to run.",
+        },
+        ac: {
+          type: "object" as const,
+          properties: {
+            sourceId: {
+              type: "number" as const,
+              description: "Device id of the driving V/I source (unit amplitude).",
+            },
+            outNode: {
+              type: "number" as const,
+              description:
+                "Node whose transfer magnitude/phase to tabulate (Bode points).",
+            },
+            frequenciesHz: {
+              type: "array" as const,
+              items: { type: "number" as const },
+              description: "Explicit frequency list (Hz). Overrides the sweep.",
+            },
+            startHz: { type: "number" as const, description: "Sweep start (default 10)." },
+            stopHz: { type: "number" as const, description: "Sweep stop (default 1e6)." },
+            points: {
+              type: "number" as const,
+              description: "Log-spaced sweep points (default 40, max 500).",
+            },
+          },
+          description: "Required when analyses includes \"ac\".",
+        },
+        transient: {
+          type: "object" as const,
+          properties: {
+            dt: { type: "number" as const, description: "Timestep (s)." },
+            steps: { type: "number" as const, description: "Step count (max 2e6)." },
+            sampleEvery: {
+              type: "number" as const,
+              description: "Record every Nth step (sample cap 5000). Default 1.",
+            },
+          },
+          description: "Required when analyses includes \"transient\".",
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const analyses = a.analyses as string[];
+      const specJson = JSON.stringify({
+        dt: (a.transient as Json | undefined)?.dt ?? 0,
+        devices: a.devices,
+      });
+      const out: Json = {};
+      if (analyses.includes("dc")) {
+        out.dc = ctx.engine.circuitDcOperatingPoint(specJson);
+      }
+      if (analyses.includes("ac")) {
+        const ac = (a.ac ?? {}) as Json;
+        if (typeof ac.sourceId !== "number") {
+          throw new Error('analyses includes "ac" but ac.sourceId is missing');
+        }
+        const freqs = frequencyGrid(ac);
+        const omegas = freqs.map((f) => 2 * Math.PI * f);
+        const res = ctx.engine.circuitAcResponse(
+          specJson,
+          ac.sourceId as number,
+          omegas,
+        ) as {
+          points: Array<{
+            omega: number;
+            nodeVoltagesRe: number[];
+            nodeVoltagesIm: number[];
+          }>;
+        };
+        const outNode = ac.outNode as number | undefined;
+        out.ac = {
+          sourceId: ac.sourceId,
+          frequenciesHz: freqs,
+          points: res.points,
+          ...(typeof outNode === "number"
+            ? {
+                bode: res.points.map((p, i) => {
+                  const re = p.nodeVoltagesRe[outNode];
+                  const im = p.nodeVoltagesIm[outNode];
+                  return {
+                    frequencyHz: freqs[i],
+                    magnitude: Math.hypot(re, im),
+                    phaseDeg: (Math.atan2(im, re) * 180) / Math.PI,
+                  };
+                }),
+              }
+            : {}),
+        };
+      }
+      if (analyses.includes("transient")) {
+        const tr = (a.transient ?? {}) as Json;
+        if (typeof tr.dt !== "number" || typeof tr.steps !== "number") {
+          throw new Error(
+            'analyses includes "transient" but transient.dt/steps are missing',
+          );
+        }
+        out.transient = ctx.engine.circuitTransient(
+          specJson,
+          tr.steps as number,
+          (tr.sampleEvery as number) ?? 1,
+        );
+      }
+      return textResult(out);
+    },
+    behavior: behavior({}),
+  },
+  {
+    name: "tune_circuit",
+    pack: null,
+    description:
+      "Adjoint-driven circuit tuning: gradient descent in log-parameter space " +
+      "(backtracking line search, scale-invariant stop) moves the freeDevices' " +
+      "values toward a target — either a 2nd-order filter target {cutoffHz, qFactor, " +
+      "sourceId, outNode} or a DC target {node, dcVoltage}. Each gradient costs one " +
+      "transposed MNA solve per probe regardless of component count. Returns tuned " +
+      "values, before/after response points, iteration count, the achieved target " +
+      "(cutoff measured by −3 dB bisection, Q from the −90° phase crossing, or the " +
+      "achieved DC voltage), and `vcad.spice-claims/1` + unified-receipt claims " +
+      "(predicted basis, Provisional rollup). Fails closed if a free device's " +
+      "sensitivity is a deferred placeholder (diodes at AC) or non-positive " +
+      "(log-space needs positive values).",
+    inputSchema: {
+      type: "object" as const,
+      required: ["devices", "freeDevices", "target"],
+      properties: {
+        devices: devicesSchema,
+        target: {
+          type: "object" as const,
+          description:
+            "Either a filter target {cutoffHz, qFactor, sourceId, outNode} " +
+            "(sourceId = driving source device id, outNode = response node) or a " +
+            "DC target {node, dcVoltage}.",
+          properties: {
+            cutoffHz: { type: "number" as const },
+            qFactor: { type: "number" as const },
+            sourceId: { type: "number" as const },
+            outNode: { type: "number" as const },
+            node: { type: "number" as const },
+            dcVoltage: { type: "number" as const },
+          },
+        },
+        freeDevices: {
+          type: "array" as const,
+          minItems: 1,
+          items: {
+            type: "object" as const,
+            required: ["device"],
+            properties: {
+              device: {
+                type: "number" as const,
+                description: "Device id (index into devices) allowed to move.",
+              },
+              min: { type: "number" as const, description: "Lower bound (> 0)." },
+              max: { type: "number" as const, description: "Upper bound." },
+            },
+          },
+        },
+        maxIters: {
+          type: "number" as const,
+          description: "Gradient iteration cap (default 500, max 5000).",
+        },
+      },
+    },
+    handler: (args, ctx) => {
+      const a = args as Json;
+      const target = a.target as Json;
+      const isFilter =
+        typeof target.cutoffHz === "number" || typeof target.qFactor === "number";
+      const isDc =
+        typeof target.node === "number" || typeof target.dcVoltage === "number";
+      if (isFilter === isDc) {
+        throw new Error(
+          "target must be exactly one of {cutoffHz, qFactor, sourceId, outNode} or {node, dcVoltage}",
+        );
+      }
+      const tune = {
+        ...(isFilter ? { filter: target } : { dc: target }),
+        freeDevices: a.freeDevices,
+        ...(typeof a.maxIters === "number" ? { maxIters: a.maxIters } : {}),
+      };
+      const specJson = JSON.stringify({ devices: a.devices });
+      return textResult(ctx.engine.circuitTune(specJson, JSON.stringify(tune)));
+    },
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -264,6 +264,8 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
     title: "Analyze Tolerance Stackup",
     annotations: RO,
   },
+  simulate_circuit: { title: "Simulate Circuit", annotations: RO },
+  tune_circuit: { title: "Tune Circuit", annotations: RO },
   predict_physics: { title: "Predict Physics", annotations: RO },
   define_loon: { title: "Define Loon Macro", annotations: RW },
   call_loon: { title: "Call Loon Macro", annotations: RW },


### PR DESCRIPTION
## What

Exposes the PR #577 circuit analyses (`dc::operating_point`, `ac::ac_response`, `adjoint::{dc,ac}_sensitivities`, `receipt::*` under `vcad.spice-claims/1`) end-to-end to agents.

### WASM (`crates/vcad-kernel-wasm/src/circuit_sim.rs`)
- `circuitDcOperatingPoint(json)` → `{nodeVoltages, deviceCurrents, powerBalanceW, claimSet, receiptClaims}`
- `circuitAcResponse(json, sourceId, omegas[])` → per-omega complex node voltages (re/im arrays)
- `circuitSensitivities(json, outNode, {dc|ac})` → gradient arrays + `deferred` placeholder ids
- `circuitTransient(json, steps, sampleEvery)` → trapezoidal batch run + final Tellegen residual
- `circuitTune(json, tuneJson)` → the `filter_autotune` loop generalized (log-space gradient descent, backtracking line search, scale-invariant stop), with bounds via clamp-in-trial
- Reuses the existing `CircuitSim` DeviceSpec parsing; all failure paths are typed `JsError`s (out-node / analysis-selector validation runs ahead of the kernel `assert!`s — no panics across the boundary)

### MCP (`packages/mcp/src/tools/circuit.ts`)
- **`simulate_circuit`** — netlist as data (`{devices:[{kind,p,n,value}]}`, node 0 = ground, device id = index), `analyses: ["dc","ac","transient"]`, AC frequency grid (explicit list or log sweep), Bode magnitude/phase for `outNode`. The **power-balance residual is in every DC/transient result** — it measures solver error and nothing else.
- **`tune_circuit`** — targets `{cutoffHz, qFactor, sourceId, outNode}` or `{node, dcVoltage}` plus `freeDevices` with optional bounds. Achieved cutoff is *measured* off the tuned response by −3 dB bisection and Q from the −90° phase crossing (exact for a 2nd-order section) — no closed forms trusted. Fails closed when a free device's AC sensitivity slot is a deferred placeholder (diodes at M0) or its value is non-positive (log-space).
- Both attach `vcad.spice-claims/1` claim sets + unified-receipt claims the same way `simulate_em`/`solve_thermal` do (predicted basis → Provisional rollup, never Pass).

### Tests
6 e2e vitest cases against the real WASM kernel (skip when the loaded WASM predates the bindings, same as the thermal suite): 12 V divider DC at exactly 3 V with claims; RC Bode point −3 dB/−45° at 1/RC; RC transient charge; **detuned RLC tuned to 10 kHz / Q = 0.707** (the Rust example's target, achieved within 1%/1%); DC retune landing R2 = 1500 Ω; typed error paths (floating node, bad free-device id).

## Gates
- `cargo test -p vcad-ecad-sim` ✓, `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` ✓ (desktop pre-existing lints), `cargo fmt --all --check` ✓
- `npm test -w @vcad/mcp` 874 passed (tool-surface fixture regenerated for the 2 new tools), `npm test -w @vcad/engine` ✓
- `packages/kernel-wasm/vcad_kernel_wasm*` artifacts untouched (restored to origin/main; wasm-refresh.yml owns them)

Changelog entry + research-log entry included. kernel-features.mdx unchanged — circuit sim lives in `vcad-ecad-sim`, which isn't in the kernel catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)