### PR TITLE
Strict args, assembly measure/integrity, clearance touching verdict

### DIFF
--- a/changelog/entries/2026-07-18-assembly-measure-integrity.json
+++ b/changelog/entries/2026-07-18-assembly-measure-integrity.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-assembly-measure-integrity",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "fix",
+  "title": "Assemblies are first-class in measure and mutation stats",
+  "summary": "measure, inspect_part, and describe_scene now resolve assembly instances (matching check_clearance), and mutation integrity reports include instance geometry — a 44-instance assembly no longer reports parts: 0, volume: 0.",
+  "features": ["assembly", "measure", "mcp"],
+  "mcpTools": ["measure", "inspect_part", "describe_scene", "create_cad_loon"]
+}

--- a/changelog/entries/2026-07-18-clearance-touching-verdict.json
+++ b/changelog/entries/2026-07-18-clearance-touching-verdict.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-clearance-touching-verdict",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "feat",
+  "title": "check_clearance touching verdict and allowed contact",
+  "summary": "check_clearance reports a clear/touching/intersecting verdict and accepts allow_contact for parts designed to touch (e.g. bolted flush); allowed contact persists on labeled specs and is honored by receipt verification.",
+  "features": ["clearance", "receipts", "mcp"],
+  "mcpTools": ["check_clearance"]
+}

--- a/changelog/entries/2026-07-18-shaded-render-style.json
+++ b/changelog/entries/2026-07-18-shaded-render-style.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-shaded-render-style",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "feat",
+  "title": "Shaded render style with full material colors",
+  "summary": "render_view accepts style: 'shaded' to render parts in their full assigned material colors instead of the navy drafting look; unknown styles and unknown tool arguments now error instead of being silently ignored.",
+  "features": ["render", "materials", "mcp"],
+  "mcpTools": ["render_view"]
+}

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -1850,6 +1850,13 @@ pub struct ClearanceSpec {
     /// Required minimum separation in mm: the assertion holds when the
     /// measured minimum distance between the groups is at least this value.
     pub min_mm: f64,
+    /// Named allowed contact: when true, surfaces touching (measured
+    /// distance within the contact tolerance of zero) satisfy the assertion
+    /// even though it is below `min_mm` — e.g. a stage bolted flush to the
+    /// chamber floor. Penetration beyond the tolerance still fails.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub allow_contact: Option<bool>,
 }
 
 impl Default for Document {

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -298,6 +298,94 @@ pub fn render_svg_camera(
     vcad_render::render_svg_str_opts(vcad_json, scale, &opts).map_err(|e| JsError::new(&e))
 }
 
+/// Render raw `.vcad` document JSON to an SVG with the full [`SvgOptions`]
+/// surface expressed as one JSON options object — the forward-compatible
+/// companion to [`render_svg_camera`] (mirroring [`render_pcb_svg_opts`]),
+/// so new render options never need another positional-arg binding.
+///
+/// `opts_json` (empty string = defaults):
+/// `{"view":"iso","focus":"rotor","axes":false,"labels":false,"dims":false,
+///   "section":"z=10","highlight":["part_3"],"style":"shaded"}`.
+/// `view` accepts everything [`render_svg_view`] does, including
+/// `"orbit:<azimuth>,<elevation>"`. `style` is `"drafting"` (default, navy
+/// tonal family) or `"shaded"` (full material colour). Unknown option keys
+/// and unknown style names are errors, never silently ignored.
+#[wasm_bindgen]
+pub fn render_svg_camera_opts(
+    vcad_json: &str,
+    scale: f64,
+    opts_json: &str,
+) -> Result<String, JsError> {
+    #[derive(serde::Deserialize, Default)]
+    #[serde(deny_unknown_fields)]
+    struct CameraOptsJson {
+        #[serde(default)]
+        view: Option<String>,
+        #[serde(default)]
+        focus: Option<String>,
+        #[serde(default)]
+        axes: bool,
+        #[serde(default)]
+        labels: bool,
+        #[serde(default)]
+        dims: bool,
+        #[serde(default)]
+        section: Option<String>,
+        #[serde(default)]
+        highlight: Vec<String>,
+        #[serde(default)]
+        style: Option<String>,
+        #[serde(default)]
+        transparent: bool,
+    }
+    let o: CameraOptsJson = if opts_json.trim().is_empty() {
+        CameraOptsJson::default()
+    } else {
+        serde_json::from_str(opts_json)
+            .map_err(|e| JsError::new(&format!("invalid render options: {e}")))?
+    };
+    let view = o
+        .view
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or("iso")
+        .parse::<vcad_render::View>()
+        .map_err(|e| JsError::new(&e))?;
+    let section = match o
+        .section
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(s) => Some(
+            s.parse::<vcad_render::SectionPlane>()
+                .map_err(|e| JsError::new(&e))?,
+        ),
+        None => None,
+    };
+    let style = o
+        .style
+        .as_deref()
+        .unwrap_or("")
+        .parse::<vcad_render::RenderStyle>()
+        .map_err(|e| JsError::new(&e))?;
+    let opts = vcad_render::SvgOptions {
+        view,
+        transparent: o.transparent,
+        focus: o.focus.filter(|f| !f.trim().is_empty()),
+        section,
+        highlight: o.highlight,
+        annotations: vcad_render::RenderAnnotations {
+            axes: o.axes,
+            labels: o.labels,
+            dims: o.dims,
+        },
+        style,
+        ..Default::default()
+    };
+    vcad_render::render_svg_str_opts(vcad_json, scale, &opts).map_err(|e| JsError::new(&e))
+}
+
 /// Render a PCB to a flat, top-down, per-layer 2D SVG (the "agent eyes" for
 /// boards — copper, silk, drills, outline).
 ///

--- a/crates/vcad-receipt/src/mechanical.rs
+++ b/crates/vcad-receipt/src/mechanical.rs
@@ -73,7 +73,18 @@ pub struct ClearanceClaim {
     pub measured_mm: f64,
     /// Whether the measured distance satisfies the requirement.
     pub holds: bool,
+    /// Named allowed contact: when true, a measured distance within
+    /// [`CONTACT_EPS_MM`] of zero (surfaces touching, e.g. a part bolted
+    /// flush to another) satisfies the assertion even below `required_mm`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub allow_contact: Option<bool>,
 }
+
+/// Tolerance (mm) around zero within which two parts count as "touching"
+/// rather than clear or intersecting. Absorbs tessellation noise on flush
+/// faces; 1 µm is far below any manufacturable clearance.
+pub const CONTACT_EPS_MM: f64 = 1e-3;
 
 impl ClearanceClaim {
     /// Build a claim, deriving `holds` from the measurement.
@@ -91,7 +102,17 @@ impl ClearanceClaim {
             required_mm,
             measured_mm: if measured_mm == 0.0 { 0.0 } else { measured_mm },
             holds: measured_mm.is_finite() && measured_mm >= required_mm,
+            allow_contact: None,
         }
+    }
+
+    /// Mark contact as allowed and re-derive `holds` accordingly: a
+    /// measurement within [`CONTACT_EPS_MM`] of zero passes.
+    pub fn with_allow_contact(mut self) -> Self {
+        self.allow_contact = Some(true);
+        self.holds = self.measured_mm.is_finite()
+            && (self.measured_mm >= self.required_mm || self.measured_mm.abs() <= CONTACT_EPS_MM);
+        self
     }
 }
 
@@ -122,7 +143,9 @@ pub fn clearance_claims(assertions: &[ClearanceClaim], oracle: &OracleRef) -> Ve
                 )
                 .with_subject(subject);
             }
-            let holds = a.holds && a.measured_mm >= a.required_mm;
+            let contact_ok =
+                a.allow_contact.unwrap_or(false) && a.measured_mm.abs() <= CONTACT_EPS_MM;
+            let holds = a.holds && (a.measured_mm >= a.required_mm || contact_ok);
             let mut c = ReceiptClaim::pass(id, DOMAIN, description, oracle.clone())
                 .with_subject(subject)
                 .with_predicted(ClaimQuantity::new(a.required_mm, "mm"))
@@ -397,6 +420,21 @@ mod tests {
         };
         let claims = mass_properties_claims(&measured, &MassSpec::default(), &oracle());
         assert_eq!(claims[0].verdict, ClaimVerdict::Unverifiable);
+    }
+
+    #[test]
+    fn allow_contact_passes_touching_but_not_penetration() {
+        let touching = ClearanceClaim::new("bolted", vec!["1".into()], vec!["2".into()], 0.5, 0.0)
+            .with_allow_contact();
+        assert!(touching.holds);
+        let claims = clearance_claims(&[touching], &oracle());
+        assert_eq!(claims[0].verdict, crate::ClaimVerdict::Pass);
+
+        let penetrating = ClearanceClaim::new("bad", vec!["1".into()], vec!["2".into()], 0.5, -1.0)
+            .with_allow_contact();
+        assert!(!penetrating.holds);
+        let claims = clearance_claims(&[penetrating], &oracle());
+        assert_eq!(claims[0].verdict, crate::ClaimVerdict::Fail);
     }
 
     #[test]

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -979,6 +979,7 @@ impl EdgeRules {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_artifacts(
     solids: &[Solid],
     tints: &[Option<[f64; 3]>],
@@ -987,6 +988,7 @@ fn build_artifacts(
     segments: u32,
     rules: &EdgeRules,
     section: Option<SectionPlane>,
+    style: RenderStyle,
 ) -> Vec<SolidArtifacts> {
     let highlighting = accents.iter().any(|&a| a);
     let mut out = Vec::new();
@@ -1002,7 +1004,10 @@ fn build_artifacts(
             .get(si)
             .copied()
             .flatten()
-            .map(tint_ramp)
+            .map(match style {
+                RenderStyle::Drafting => tint_ramp,
+                RenderStyle::Shaded => shaded_ramp,
+            })
             .unwrap_or(RAMP);
         if emphasis == Emphasis::Ghost {
             ramp = ghost_ramp(ramp);
@@ -1263,6 +1268,20 @@ fn tint_ramp(color: [f64; 3]) -> [[u8; 3]; 4] {
                               // every preset at ≤20% material contribution, so even fully
                               // saturated red rendered as navy with the faintest pink hint.
     let k = sat.clamp(0.0, 0.85);
+    tint_ramp_k(color, k)
+}
+
+/// Full-material-colour ramp for [`RenderStyle::Shaded`]: the material colour
+/// drives every stop outright (k = 1), rescaled to each stop's luminance so
+/// the lighting ladder is preserved. Achromatic materials (steel, aluminium)
+/// therefore render as true greys instead of staying in the navy family.
+fn shaded_ramp(color: [f64; 3]) -> [[u8; 3]; 4] {
+    tint_ramp_k(color, 1.0)
+}
+
+/// Shared ramp construction: blend the navy [`RAMP`] toward the material
+/// colour (rescaled per-stop to the stop's luminance) by strength `k`.
+fn tint_ramp_k(color: [f64; 3], k: f64) -> [[u8; 3]; 4] {
     let ml = luma(color).max(1e-3);
     let mut out = RAMP;
     for stop in out.iter_mut() {
@@ -1745,6 +1764,36 @@ pub struct SvgOptions {
     /// view. Empty renders normally; a non-empty set matching no part is an
     /// error (never a silently unhighlighted render).
     pub highlight: Vec<String>,
+    /// Shading style: [`RenderStyle::Drafting`] (default) keeps material
+    /// colours in the disciplined navy tonal family;
+    /// [`RenderStyle::Shaded`] renders each part in its full material
+    /// colour (luminance-laddered so lighting is preserved).
+    pub style: RenderStyle,
+}
+
+/// Shading style for the SVG render path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RenderStyle {
+    /// Drafting look: material colours tinted toward the navy tonal family
+    /// in proportion to their saturation (the historical default).
+    #[default]
+    Drafting,
+    /// Full material colour: parts render in their assigned material colour
+    /// with the same Lambertian shading ladder.
+    Shaded,
+}
+
+impl std::str::FromStr for RenderStyle {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "" | "drafting" => Ok(RenderStyle::Drafting),
+            "shaded" => Ok(RenderStyle::Shaded),
+            other => Err(format!(
+                "unknown render style '{other}' — supported: 'drafting', 'shaded'"
+            )),
+        }
+    }
 }
 
 /// Render raw `.vcad` document JSON to a self-contained SVG with full
@@ -1918,6 +1967,7 @@ fn render_svg_impl(
         TESSELLATION_SEGMENTS,
         &EdgeRules::svg(),
         section,
+        opts.style,
     );
 
     // First pass: screen-space bbox + 3D bbox (for the depth-cue bias),
@@ -2827,6 +2877,7 @@ mod raster {
                 keep_occluded: false,
             },
             opts.section,
+            RenderStyle::Drafting,
         );
 
         // Screen-plane (mm) and 3D bounding boxes over all vertices.
@@ -3691,6 +3742,52 @@ mod raytrace {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn render_style_parses_known_names_and_rejects_unknown() {
+        assert_eq!("drafting".parse::<RenderStyle>(), Ok(RenderStyle::Drafting));
+        assert_eq!("".parse::<RenderStyle>(), Ok(RenderStyle::Drafting));
+        assert_eq!("Shaded".parse::<RenderStyle>(), Ok(RenderStyle::Shaded));
+        let err = "raytrace".parse::<RenderStyle>().unwrap_err();
+        assert!(err.contains("unknown render style"), "{err}");
+        assert!(err.contains("shaded"), "{err}");
+    }
+
+    #[test]
+    fn shaded_ramp_uses_full_material_color() {
+        // Achromatic steel grey: drafting keeps navy (blue-dominant stops),
+        // shaded must produce true greys (r ≈ g ≈ b at every stop).
+        let grey = [0.5, 0.5, 0.5];
+        let drafting = tint_ramp(grey);
+        let shaded = shaded_ramp(grey);
+        assert!(
+            drafting.iter().any(|s| s[2] > s[0] + 10),
+            "drafting ramp should stay navy for achromatic materials: {drafting:?}"
+        );
+        for stop in shaded {
+            let (r, g, b) = (stop[0] as i32, stop[1] as i32, stop[2] as i32);
+            assert!(
+                (r - g).abs() <= 2 && (g - b).abs() <= 2,
+                "shaded ramp for grey must be grey: {stop:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn shaded_style_renders_material_color_svg() {
+        let doc = cube_vcad(10.0, 10.0, 10.0);
+        let drafting = render_svg_str_opts(&doc, 2.0, &SvgOptions::default()).unwrap();
+        let shaded = render_svg_str_opts(
+            &doc,
+            2.0,
+            &SvgOptions {
+                style: RenderStyle::Shaded,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_ne!(drafting, shaded, "shaded style must change the output");
+    }
 
     fn cube_vcad(sx: f64, sy: f64, sz: f64) -> String {
         format!(

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -381,7 +381,13 @@ measured_mm: number,
 /**
  * Whether the measured distance satisfies the requirement.
  */
-holds: boolean, };
+holds: boolean, 
+/**
+ * Named allowed contact: when true, a measured distance within
+ * [`CONTACT_EPS_MM`] of zero (surfaces touching, e.g. a part bolted
+ * flush to another) satisfies the assertion even below `required_mm`.
+ */
+allow_contact?: boolean, };
 
 /**
  * A named minimum-clearance assertion between two groups of parts.
@@ -407,7 +413,14 @@ group_b: Array<string>,
  * Required minimum separation in mm: the assertion holds when the
  * measured minimum distance between the groups is at least this value.
  */
-min_mm: number, };
+min_mm: number, 
+/**
+ * Named allowed contact: when true, surfaces touching (measured
+ * distance within the contact tolerance of zero) satisfy the assertion
+ * even though it is below `min_mm` — e.g. a stage bolted flush to the
+ * chamber floor. Penetration beyond the tolerance still fails.
+ */
+allow_contact?: boolean, };
 
 /**
  * Provenance of a piece of copper: who placed it.

--- a/packages/mcp/src/__tests__/feedback-fixes.test.ts
+++ b/packages/mcp/src/__tests__/feedback-fixes.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression tests for the torr-session field-report fixes:
+ *
+ *  1. Unknown tool arguments are rejected at dispatch (never silently
+ *     ignored), and render_view's `style` accepts only known styles.
+ *  2. Assembly-only documents (partDefs + instances, no scene roots) are
+ *     first-class through `measure` and mutation integrity reports —
+ *     previously `measure` answered "Available: none" and create_cad_loon
+ *     reported `parts: 0, volume: 0` for a successful assembly.
+ *  3. `check_clearance` distinguishes touching from intersecting, and
+ *     `allow_contact` lets designed-contact pairs pass.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Document } from "@vcad/ir";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+import { measureResult, MeasureError } from "../tools/measure.js";
+import { computeIntegrity } from "../tools/integrity.js";
+import {
+  clearanceVerdict,
+  clearanceHolds,
+  computeGroupClearance,
+} from "../tools/clearance.js";
+import { unknownArgKeys } from "../tools/validate-args.js";
+import { renderView } from "../tools/render.js";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+const ASSEMBLY_LOON = `
+[let base [cube 40 40 5]]
+[let post [cylinder 5 30]]
+[assembly
+  #[[part "base" base "aluminum"]
+    [part "post" post "steel"]]
+  #[[instance "base1" "base" 0 0 0]
+    [instance "post1" "post" 20 20 5]]
+  #[]
+  "base1"]
+`;
+
+function assemblyDoc(): Document {
+  const doc = engine.evalVcadSource(ASSEMBLY_LOON);
+  if (!doc) throw new Error("loon eval failed");
+  return doc;
+}
+
+describe("strict tool arguments", () => {
+  it("unknownArgKeys flags undeclared keys and honors additionalProperties", () => {
+    const schema = {
+      type: "object",
+      properties: { document_id: { type: "string" } },
+    };
+    expect(unknownArgKeys(schema, { document_id: "d", style: "raytrace" })).toEqual([
+      "style",
+    ]);
+    expect(unknownArgKeys(schema, { document_id: "d" })).toEqual([]);
+    expect(
+      unknownArgKeys(
+        { ...schema, additionalProperties: true },
+        { anything: 1 },
+      ),
+    ).toEqual([]);
+    expect(unknownArgKeys(undefined, { anything: 1 })).toEqual([]);
+  });
+
+  it("dispatch rejects an unknown argument with a structured error", async () => {
+    documents.clear();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    const client = new Client(
+      { name: "strict-args", version: "0.0.0" },
+      { capabilities: {} },
+    );
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+    const result = (await client.callTool({
+      name: "inspect_cad",
+      arguments: { document_id: "nonexistent", raytrace: true },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(result.content[0]!.text!);
+    expect(body.error).toContain("'raytrace'");
+    expect(body.accepted_arguments).toContain("document_id");
+    await client.close();
+  });
+
+  it("render_view rejects an unknown style value loudly", async () => {
+    const result = await renderView({
+      document: { version: "0.1", nodes: {}, roots: [] },
+      style: "raytrace",
+    });
+    expect(result.isError).toBe(true);
+    const body = JSON.parse(
+      (result.content[0] as { type: "text"; text: string }).text,
+    );
+    expect(body.error).toContain("unknown style 'raytrace'");
+    expect(body.error).toContain("shaded");
+  });
+});
+
+describe("assembly-only documents through measure + integrity", () => {
+  it("measure resolves assembly instance ids and names", () => {
+    const doc = assemblyDoc();
+    const pair = measureResult(doc, engine, ["base1", "post1"]);
+    expect(pair.mode).toBe("pair");
+    // The post sits on top of the base plate — contact, not clearance.
+    expect(pair.distance_mm as number).toBeLessThanOrEqual(0.001);
+    const single = measureResult(doc, engine, ["post1"]) as {
+      part: { volume_mm3: number };
+    };
+    // World-placed cylinder r=5 h=30 → ~2356 mm³ (tessellation-bound).
+    expect(single.part.volume_mm3).toBeGreaterThan(2000);
+  });
+
+  it("measure error for a bad id lists instance candidates, not 'none'", () => {
+    const doc = assemblyDoc();
+    try {
+      measureResult(doc, engine, ["nope"]);
+      expect.unreachable("expected MeasureError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MeasureError);
+      expect((e as Error).message).toContain("base1");
+      expect((e as Error).message).not.toContain("Available: none");
+    }
+  });
+
+  it("computeIntegrity reports instance geometry instead of parts:0 volume:0", () => {
+    const doc = assemblyDoc();
+    const report = computeIntegrity(doc, engine);
+    expect(report).not.toBeNull();
+    expect(report!.instances).toBe(2);
+    // base 40*40*5 = 8000 plus the post ≈ 2356.
+    expect(report!.volume_mm3).toBeGreaterThan(8000);
+    expect(report!.bounding_box).not.toBeNull();
+    expect(report!.bounding_box!.max.z).toBeGreaterThan(30);
+  });
+});
+
+describe("check_clearance touching verdict + allow_contact", () => {
+  it("clearanceVerdict classifies clear / touching / intersecting", () => {
+    expect(clearanceVerdict(1.5)).toBe("clear");
+    expect(clearanceVerdict(0)).toBe("touching");
+    expect(clearanceVerdict(0.0005)).toBe("touching");
+    expect(clearanceVerdict(-0.0005)).toBe("touching");
+    expect(clearanceVerdict(-0.5)).toBe("intersecting");
+  });
+
+  it("clearanceHolds passes touching pairs only when contact is allowed", () => {
+    expect(clearanceHolds(0, 0.5, false)).toBe(false);
+    expect(clearanceHolds(0, 0.5, true)).toBe(true);
+    expect(clearanceHolds(-0.5, 0.5, true)).toBe(false);
+    expect(clearanceHolds(1.0, 0.5, false)).toBe(true);
+  });
+
+  it("a bolted-flush assembly pair measures as touching, not intersecting", () => {
+    const doc = assemblyDoc();
+    const { result, error } = computeGroupClearance(
+      doc,
+      engine,
+      ["base1"],
+      ["post1"],
+    );
+    expect(error).toBeUndefined();
+    expect(result).toBeDefined();
+    expect(clearanceVerdict(result!.distance_mm)).toBe("touching");
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -5029,7 +5029,7 @@
   {
     "name": "render_view",
     "title": "Render View",
-    "description": "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Call after mutations to visually confirm the part matches intent before declaring done.",
+    "description": "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Call after mutations to visually confirm the part matches intent before declaring done.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -5094,6 +5094,14 @@
         "highlight_changed": {
           "type": "boolean",
           "description": "Highlight the parts touched by this session's most recent mutation (the last `changed` diff) — the one-flag way to see what your last edit did. Ignored when `highlight` is passed explicitly."
+        },
+        "style": {
+          "type": "string",
+          "enum": [
+            "drafting",
+            "shaded"
+          ],
+          "description": "Shading style: 'drafting' (default) keeps part colors in the navy drafting tonal family; 'shaded' renders each part in its full assigned material color (same Lambertian shading). Any other value is an error."
         }
       }
     },
@@ -7513,7 +7521,7 @@
   {
     "name": "check_clearance",
     "title": "Check Clearance",
-    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), the worst part pair, and pass/fail. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
+    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -7542,6 +7550,10 @@
         "label": {
           "type": "string",
           "description": "Optional assertion name (e.g. 'air-gap'). When given, the spec is persisted on the document and re-verified by build_receipt / verify_receipt whenever geometry changes."
+        },
+        "allow_contact": {
+          "type": "boolean",
+          "description": "Treat exact surface contact (measured distance within 0.001 mm of zero) as passing even though it is below `min_mm` — for parts designed to touch, e.g. a stage bolted flush to the chamber floor. Penetration beyond the tolerance still fails. Persisted with the spec when `label` is given."
         }
       },
       "required": [

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -104,6 +104,7 @@ import {
   type ToolContext,
 } from "./tools/tool-def.js";
 import { TOOL_METADATA } from "./tools/tool-metadata.js";
+import { unknownArgKeys, unknownArgsError } from "./tools/validate-args.js";
 import type { ToolResult } from "./tools/tool-result.js";
 import { buildKernelEventPayload } from "./tools/kernel-event.js";
 
@@ -1364,6 +1365,22 @@ export async function createServer(
         };
         fireToolAlert(name, args, unknownResult);
         return unknownResult;
+      }
+
+      // ── Strict arguments ───────────────────────────────────────────
+      // Any top-level argument key the tool's schema doesn't declare is a
+      // loud error, never a silent no-op — a misspelled or unsupported
+      // option must not vanish into a successful-looking result.
+      const unknown = unknownArgKeys(def.inputSchema, args);
+      if (unknown.length > 0) {
+        const rejection: ToolResult = {
+          content: [
+            { type: "text", text: unknownArgsError(name, unknown, def.inputSchema) },
+          ],
+          isError: true,
+        };
+        fireToolAlert(name, args, rejection);
+        return rejection;
       }
 
       // ── Trust boundary (commerce plane) ────────────────────────────

--- a/packages/mcp/src/tools/clearance.ts
+++ b/packages/mcp/src/tools/clearance.ts
@@ -43,6 +43,33 @@ const CLEARANCE_ORACLE: OracleRef = {
  *  geometry"; beyond it (but still passing) the receipt reads Stale. */
 const STALE_EPS_MM = 1e-6;
 
+/** Tolerance (mm) around zero within which parts count as "touching" rather
+ *  than clear or intersecting. Keep in sync with `CONTACT_EPS_MM` in
+ *  crates/vcad-receipt/src/mechanical.rs. */
+const CONTACT_EPS_MM = 1e-3;
+
+/** Three-way contact verdict derived from the signed minimum distance. */
+export type ClearanceVerdict = "clear" | "touching" | "intersecting";
+
+/** Classify a signed distance into clear / touching / intersecting. */
+export function clearanceVerdict(distanceMm: number): ClearanceVerdict {
+  if (distanceMm < -CONTACT_EPS_MM) return "intersecting";
+  if (distanceMm <= CONTACT_EPS_MM) return "touching";
+  return "clear";
+}
+
+/** Does the measurement satisfy the spec, honoring allowed contact? */
+export function clearanceHolds(
+  distanceMm: number,
+  minMm: number,
+  allowContact: boolean,
+): boolean {
+  return (
+    distanceMm >= minMm ||
+    (allowContact && clearanceVerdict(distanceMm) === "touching")
+  );
+}
+
 /** Round distances so payloads don't carry float noise. */
 const round6 = (v: number) => Math.round(v * 1e6) / 1e6;
 
@@ -71,6 +98,11 @@ export const checkClearanceSchema = {
       type: "string" as const,
       description:
         "Optional assertion name (e.g. 'air-gap'). When given, the spec is persisted on the document and re-verified by build_receipt / verify_receipt whenever geometry changes.",
+    },
+    allow_contact: {
+      type: "boolean" as const,
+      description:
+        "Treat exact surface contact (measured distance within 0.001 mm of zero) as passing even though it is below `min_mm` — for parts designed to touch, e.g. a stage bolted flush to the chamber floor. Penetration beyond the tolerance still fails. Persisted with the spec when `label` is given.",
     },
   },
   required: ["document_id", "group_a", "group_b", "min_mm"],
@@ -253,12 +285,14 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
   const minMm = typeof args.min_mm === "number" ? args.min_mm : NaN;
   if (!Number.isFinite(minMm)) return err("Pass `min_mm`, the required minimum separation in mm.");
   const label = typeof args.label === "string" && args.label.trim() ? args.label.trim() : undefined;
+  const allowContact = args.allow_contact === true;
 
   const doc = getSession(documentId);
   const { result, error } = computeGroupClearance(doc, engine, groupA, groupB);
   if (error || !result) return err(error ?? "Clearance could not be computed.");
 
-  const pass = result.distance_mm >= minMm;
+  const verdict = clearanceVerdict(result.distance_mm);
+  const pass = clearanceHolds(result.distance_mm, minMm, allowContact);
   let specSaved = false;
   if (label) {
     // Persist by resolved part ids so the assertion survives renames.
@@ -267,6 +301,7 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
       group_a: result.group_a.map((p) => p.id),
       group_b: result.group_b.map((p) => p.id),
       min_mm: minMm,
+      ...(allowContact ? { allow_contact: true } : {}),
     });
     specSaved = true;
   }
@@ -278,6 +313,8 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
     required_mm: minMm,
     measured_mm: result.distance_mm,
     pass,
+    verdict,
+    ...(allowContact ? { allow_contact: true } : {}),
     intersecting: result.intersecting,
     worst_pair: result.worst_pair,
     pairs_checked: result.pairs_checked,
@@ -339,13 +376,15 @@ export function clearanceReceiptClaims(doc: Document, engine: Engine | undefined
         subject,
       };
     }
+    const allowContact = spec.allow_contact === true;
     const assertion: ClearanceClaim = {
       label: spec.label,
       group_a: spec.group_a,
       group_b: spec.group_b,
       required_mm: spec.min_mm,
       measured_mm: result.distance_mm,
-      holds: result.distance_mm >= spec.min_mm,
+      holds: clearanceHolds(result.distance_mm, spec.min_mm, allowContact),
+      ...(allowContact ? { allow_contact: true } : {}),
     };
     return {
       id,
@@ -410,7 +449,7 @@ export function verifyClearanceClaims(
       continue;
     }
     const measured = result.distance_mm;
-    if (measured < stored.required_mm) {
+    if (!clearanceHolds(measured, stored.required_mm, stored.allow_contact === true)) {
       checks.push({
         label,
         status: "Violated",
@@ -487,7 +526,7 @@ export const toolDefs: ToolDef[] = [
     name: "check_clearance",
     pack: null,
     description:
-      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), the worst part pair, and pass/fail. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
+      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
     inputSchema: checkClearanceSchema,
     handler: (a, c) => checkClearance(a, c.engine),
     behavior: behavior({ writesDoc: true }),

--- a/packages/mcp/src/tools/integrity.ts
+++ b/packages/mcp/src/tools/integrity.ts
@@ -216,17 +216,10 @@ export function computeIntegrity(
   doc: Document,
   engine: Engine,
 ): IntegrityReport | null {
-  let scene: {
-    parts: Array<{ mesh: TriangleMesh }>;
-    instances?: Array<{
-      mesh: TriangleMesh;
-      transform?: {
-        translation: [number, number, number];
-        rotation: [number, number, number, number];
-        scale: [number, number, number];
-      };
-    }>;
-  };
+  // Infer the scene type from the engine rather than hand-annotating it, so
+  // the instance transform shape (kernel-native {x,y,z}) stays in sync with
+  // @vcad/engine — the same untyped pattern check_clearance uses.
+  let scene: ReturnType<Engine["evaluate"]>;
   try {
     scene = engine.evaluate(doc);
   } catch {

--- a/packages/mcp/src/tools/integrity.ts
+++ b/packages/mcp/src/tools/integrity.ts
@@ -13,6 +13,7 @@
 
 import type { Document } from "@vcad/ir";
 import type { Engine, TriangleMesh } from "@vcad/engine";
+import { transformMesh } from "@vcad/engine";
 
 /** Compact aggregate geometry report attached to mutation results. */
 export interface IntegrityReport {
@@ -28,6 +29,13 @@ export interface IntegrityReport {
   /** Unpaired directed edges across all parts (0 when watertight). */
   open_edges: number;
   parts: number;
+  /**
+   * Assembly instances included in the aggregate (world-posed). Present only
+   * when the document places instances; without it a successful N-instance
+   * assembly reported `parts: 0, volume: 0` — indistinguishable from a
+   * silent failure.
+   */
+  instances?: number;
   triangles: number;
   /**
    * Distance (mm) from the aggregate CoM to each distinct circular-pattern
@@ -208,11 +216,37 @@ export function computeIntegrity(
   doc: Document,
   engine: Engine,
 ): IntegrityReport | null {
-  let scene: { parts: Array<{ mesh: TriangleMesh }> };
+  let scene: {
+    parts: Array<{ mesh: TriangleMesh }>;
+    instances?: Array<{
+      mesh: TriangleMesh;
+      transform?: {
+        translation: [number, number, number];
+        rotation: [number, number, number, number];
+        scale: [number, number, number];
+      };
+    }>;
+  };
   try {
     scene = engine.evaluate(doc);
   } catch {
     return null;
+  }
+
+  // Assembly instances contribute world-posed meshes to the aggregate, the
+  // same way check_clearance's candidate set bakes FK transforms. Without
+  // this, an assembly-only document reported parts: 0, volume: 0.
+  const instanceMeshes: TriangleMesh[] = [];
+  for (const inst of scene.instances ?? []) {
+    const mesh = inst.transform
+      ? transformMesh(inst.mesh, {
+          translate: inst.transform.translation,
+          rotate: inst.transform.rotation,
+          scale: inst.transform.scale,
+        })
+      : inst.mesh;
+    if (!mesh || mesh.positions.length === 0) continue;
+    instanceMeshes.push(mesh);
   }
 
   let volume = 0;
@@ -228,8 +262,12 @@ export function computeIntegrity(
   };
   const warnings: string[] = [];
 
-  for (let partIndex = 0; partIndex < scene.parts.length; partIndex++) {
-    const mesh = scene.parts[partIndex].mesh;
+  const meshes: TriangleMesh[] = [
+    ...scene.parts.map((p) => p.mesh),
+    ...instanceMeshes,
+  ];
+  for (let partIndex = 0; partIndex < meshes.length; partIndex++) {
+    const mesh = meshes[partIndex];
     const tris = mesh.indices.length / 3;
     triangles += tris;
     let partVolume = 0;
@@ -337,6 +375,7 @@ export function computeIntegrity(
     watertight: openEdges === 0,
     open_edges: openEdges,
     parts: scene.parts.length,
+    ...(instanceMeshes.length > 0 ? { instances: instanceMeshes.length } : {}),
     triangles,
     warnings,
   };

--- a/packages/mcp/src/tools/measure.ts
+++ b/packages/mcp/src/tools/measure.ts
@@ -21,6 +21,7 @@
  */
 
 import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
+import { transformMesh } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { computeMeshProperties, type BoundingBox } from "./inspect.js";
 import { getSession } from "./session.js";
@@ -62,6 +63,25 @@ function evaluateParts(doc: Document, engine: Engine): ResolvedPart[] {
       id: rootId,
       name: node?.name ?? undefined,
       material: root.material ?? partMaterials?.[rootId] ?? undefined,
+      mesh,
+    });
+  }
+  // Assembly instances: bake the FK world transform into the part-local mesh
+  // so measurements report poses, not part-local geometry — the same
+  // candidate population check_clearance uses. Without this, assembly-only
+  // documents answered every measure/inspect_part query with "Available: none".
+  for (const inst of scene.instances ?? []) {
+    const mesh = inst.transform
+      ? transformMesh(inst.mesh, {
+          translate: inst.transform.translation,
+          rotate: inst.transform.rotation,
+          scale: inst.transform.scale,
+        })
+      : inst.mesh;
+    if (!mesh || mesh.positions.length === 0) continue;
+    out.push({
+      id: inst.instanceId,
+      name: inst.name ?? undefined,
       mesh,
     });
   }

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -96,6 +96,12 @@ export const renderViewSchema = {
       description:
         "Highlight the parts touched by this session's most recent mutation (the last `changed` diff) — the one-flag way to see what your last edit did. Ignored when `highlight` is passed explicitly.",
     },
+    style: {
+      type: "string" as const,
+      enum: ["drafting", "shaded"],
+      description:
+        "Shading style: 'drafting' (default) keeps part colors in the navy drafting tonal family; 'shaded' renders each part in its full assigned material color (same Lambertian shading). Any other value is an error.",
+    },
   },
 };
 
@@ -302,6 +308,27 @@ export async function renderView(
     highlight = last;
   }
 
+  // Shading style: 'drafting' (default) or 'shaded'. Anything else is a loud
+  // error — a style the server doesn't understand must never silently render
+  // as something else.
+  const styleRaw =
+    typeof args.style === "string" ? args.style.trim().toLowerCase() : "";
+  if (styleRaw && styleRaw !== "drafting" && styleRaw !== "shaded") {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `unknown style '${args.style}' — supported: 'drafting' (navy line-art look), 'shaded' (full material color)`,
+            document_id: documentId,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
+  const style = (styleRaw || "drafting") as "drafting" | "shaded";
+
   const wasm = (await getKernelWasm()) as unknown as {
     render_svg: (vcadJson: string, scale: number) => string;
     render_svg_view?: (vcadJson: string, scale: number, view: string) => string;
@@ -336,6 +363,11 @@ export async function renderView(
       section: string | null,
       highlightJson: string | null,
     ) => string;
+    render_svg_camera_opts?: (
+      vcadJson: string,
+      scale: number,
+      optsJson: string,
+    ) => string;
   };
   if (typeof wasm.render_svg !== "function") {
     return {
@@ -353,6 +385,24 @@ export async function renderView(
   // section + highlight). Prefer it for everything; the narrower bindings are
   // only fallbacks for a single feature on an older WASM build.
   const hasCamera = typeof wasm.render_svg_camera === "function";
+  const hasCameraOpts = typeof wasm.render_svg_camera_opts === "function";
+  // A non-default style has no legacy binding — fail loudly rather than
+  // silently rendering the default look.
+  if (style !== "drafting" && !hasCameraOpts) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error:
+              `style '${style}' unavailable: kernel WASM build predates render_svg_camera_opts — rebuild @vcad/kernel-wasm.`,
+            document_id: documentId,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
   // Orbit and focus have no legacy binding — they require the superset.
   if ((hasOrbit || focus !== undefined) && !hasCamera) {
     return {
@@ -413,7 +463,22 @@ export async function renderView(
     // fall back to the narrowest binding that serves the single requested
     // feature (section → highlight → annotations → named view → plain).
     svg =
-      needsCamera && hasCamera
+      hasCameraOpts && (needsCamera || style !== "drafting")
+        ? wasm.render_svg_camera_opts!(
+            JSON.stringify(doc),
+            SVG_SCALE,
+            JSON.stringify({
+              view: viewStr,
+              ...(focus ? { focus } : {}),
+              axes: annotations.axes,
+              labels: annotations.labels,
+              dims: annotations.dims,
+              ...(sectionRaw ? { section: sectionRaw } : {}),
+              ...(highlight.length > 0 ? { highlight } : {}),
+              style,
+            }),
+          )
+        : needsCamera && hasCamera
         ? wasm.render_svg_camera!(
             JSON.stringify(doc),
             SVG_SCALE,
@@ -511,6 +576,7 @@ export async function renderView(
             view: viewLabel,
             ...(focus ? { focus } : {}),
             ...(sectionRaw ? { section: sectionRaw } : {}),
+            ...(style !== "drafting" ? { style } : {}),
             width_px: widthPx,
             format: "png",
             ...(highlight.length > 0 ? { highlight } : {}),
@@ -1159,7 +1225,7 @@ export const toolDefs: ToolDef[] = [
     name: "render_view",
     pack: null,
     description:
-      "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Call after mutations to visually confirm the part matches intent before declaring done.",
+      "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Call after mutations to visually confirm the part matches intent before declaring done.",
     inputSchema: renderViewSchema,
     handler: async (a) => (await renderView(a)) as unknown as ToolResult,
     behavior: behavior({}),

--- a/packages/mcp/src/tools/validate-args.ts
+++ b/packages/mcp/src/tools/validate-args.ts
@@ -1,0 +1,56 @@
+/**
+ * Strict top-level argument validation for tool dispatch.
+ *
+ * Field report (torr session): a `style: "raytrace"` argument on render_view
+ * was silently accepted and ignored — the caller only discovered it by
+ * byte-comparing outputs. Handlers read args by hand, so an unrecognized key
+ * never surfaces. This module closes that gap at the dispatch layer: any
+ * top-level argument key not declared in the tool's advertised input schema
+ * is a loud, structured error instead of a silent no-op.
+ *
+ * Only object schemas with declared `properties` and without a truthy
+ * `additionalProperties` are enforced — schemas that deliberately accept
+ * free-form maps keep working.
+ */
+
+/** Minimal shape of the JSON schemas the tool defs advertise. */
+interface ObjectishSchema {
+  type?: string;
+  properties?: Record<string, unknown>;
+  additionalProperties?: unknown;
+}
+
+/**
+ * Return the top-level keys of `args` that the schema does not declare, or
+ * an empty array when everything is declared (or the schema opts out of
+ * strictness via `additionalProperties`).
+ */
+export function unknownArgKeys(
+  schema: unknown,
+  args: Record<string, unknown>,
+): string[] {
+  const s = schema as ObjectishSchema | null | undefined;
+  if (!s || s.type !== "object" || !s.properties) return [];
+  if (s.additionalProperties) return [];
+  const declared = new Set(Object.keys(s.properties));
+  return Object.keys(args).filter((k) => !declared.has(k));
+}
+
+/**
+ * Build the rejection error text for unknown argument keys: names the
+ * offenders and lists what the tool actually accepts, so the caller can
+ * self-correct in one step.
+ */
+export function unknownArgsError(
+  toolName: string,
+  unknown: string[],
+  schema: unknown,
+): string {
+  const props = (schema as ObjectishSchema | null | undefined)?.properties ?? {};
+  return JSON.stringify({
+    error: `Unknown argument${unknown.length > 1 ? "s" : ""} for ${toolName}: ${unknown
+      .map((k) => `'${k}'`)
+      .join(", ")}. Unrecognized arguments are rejected rather than silently ignored.`,
+    accepted_arguments: Object.keys(props),
+  });
+}


### PR DESCRIPTION
## Summary

Three field-report fixes addressing silent failures and incomplete assembly support:

1. **Strict tool argument validation**: Unknown arguments are now rejected at dispatch with structured errors instead of being silently ignored. `render_view`'s `style` parameter now validates against known styles.

2. **Assembly-only documents as first-class**: `measure`, `inspect_part`, and `describe_scene` now resolve assembly instances (world-posed) alongside parts. Mutation integrity reports include instance geometry, so a successful 44-instance assembly no longer reports `parts: 0, volume: 0`.

3. **Clearance touching verdict and allowed contact**: `check_clearance` now distinguishes three verdicts (clear/touching/intersecting) and accepts `allow_contact` to pass designed-contact pairs (e.g., bolted flush) that measure within 0.001 mm of zero.

## Key Changes

### Argument Validation
- Added `packages/mcp/src/tools/validate-args.ts` with `unknownArgKeys()` and `unknownArgsError()` to detect undeclared schema properties
- Server dispatch now rejects unknown arguments with a structured error listing accepted parameters
- `render_view` validates `style` against known values ("drafting", "shaded") and errors loudly on unknown styles

### Assembly Instance Support
- `measure.ts`: `evaluateParts()` now bakes FK world transforms into instance meshes, making assembly instances measurable
- `integrity.ts`: `computeIntegrity()` includes instance meshes in aggregate geometry; reports `instances` count when present
- `clearance.ts`: Already supported instances; now exports `clearanceVerdict()` and `clearanceHolds()` helpers for three-way classification

### Shaded Render Style
- Added `RenderStyle` enum (Drafting/Shaded) to `vcad-render/src/lib.rs`
- `shaded_ramp()` uses full material color (k=1.0); `tint_ramp()` uses constrained saturation (k≤0.85) for navy drafting look
- `build_artifacts()` now accepts style parameter and applies appropriate ramp
- WASM binding `render_svg_camera_opts()` exposes style as JSON option alongside view, focus, section, highlight
- TypeScript `renderView()` prefers `render_svg_camera_opts` when style is non-default or other features require it

### Clearance Touching Verdict
- `clearanceVerdict()` classifies signed distance: `< -1e-3` → intersecting, `≤ 1e-3` → touching, `> 1e-3` → clear
- `clearanceHolds()` checks if measurement satisfies spec, honoring `allow_contact` for touching pairs
- `check_clearance` tool accepts `allow_contact` boolean; persists on labeled specs
- Receipt `ClearanceClaim` includes optional `allow_contact` field; `with_allow_contact()` re-derives `holds` logic
- Rust IR and TypeScript generated types updated to include `allow_contact` field

## Testing

- New regression test suite `packages/mcp/src/__tests__/feedback-fixes.test.ts` covers all three fixes:
  - Strict args validation and dispatch rejection
  - Assembly instance resolution in measure and integrity
  - Clearance verdict classification and allowed contact logic
- Render style tests in `vcad-render/src/lib.rs` verify parsing, ramp generation, and SVG output differences
- Receipt tests verify `allow_contact` passes touching but rejects penetration

## Changelog

Three entries added for v0.9.4:
- `2026-07-18-assembly-measure-integrity.json`
- `2026-07-18-clearance-touching-verdict.json`
- `2026-07-18-shaded-render-style.json`

https://claude.ai/code/session_01VXwyNmL2LBQFJgJH8KJHtt