### PR TITLE
Typst plugin: render, measure, and verify CAD in documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ tasks/
 # Golden test fixtures are checked in despite *.dxf above
 !crates/vcad-kernel-sheet/tests/golden/*.dxf
 .wf-*.mjs
+
+# Typst plugin build artifacts (built by scripts/build-typst-plugin.sh)
+typst/vcad/vcad.wasm
+typst/vcad/examples/*.pdf
+typst/vcad/examples/*.png

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7822,6 +7822,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-typst"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "vcad-eval",
+ "vcad-ir",
+ "vcad-loon",
+ "vcad-render",
+ "wasm-minimal-protocol",
+]
+
+[[package]]
+name = "venial"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61584a325b16f97b5b25fcc852eb9550843a251057a5e3e5992d2376f3df4bb2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7960,6 +7983,17 @@ checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
 dependencies = [
  "leb128fmt",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-minimal-protocol"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae17f1dd65ee737caf73ea45f517c09578ab60970c28e5e96b7900fe2e245633"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "venial",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,6 @@ vcad-crdt = { path = "crates/vcad-crdt", version = "0.9.4" }
 vcad-app = { path = "crates/vcad-app", version = "0.9.4" }
 vcad-eval = { path = "crates/vcad-eval", version = "0.9.4" }
 vcad-loon = { path = "crates/vcad-loon", version = "0.9.4" }
-vcad-render = { path = "crates/vcad-render", version = "0.9.3", default-features = false }
 vcad-sim = { path = "crates/vcad-sim", version = "0.9.4" }
 vcad-ecad-package = { path = "crates/vcad-ecad-package", version = "0.9.4" }
 vcad-ecad-parts = { path = "crates/vcad-ecad-parts", version = "0.9.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "crates/vcad-kernel-physics",
     "crates/vcad-kernel-atoms",
     "crates/vcad-render",
+    "crates/vcad-typst",
     "crates/wasmosis",
     "crates/wasmosis/wasmosis-macro",
     "crates/vcad-slicer",
@@ -252,6 +253,7 @@ vcad-crdt = { path = "crates/vcad-crdt", version = "0.9.4" }
 vcad-app = { path = "crates/vcad-app", version = "0.9.4" }
 vcad-eval = { path = "crates/vcad-eval", version = "0.9.4" }
 vcad-loon = { path = "crates/vcad-loon", version = "0.9.4" }
+vcad-render = { path = "crates/vcad-render", version = "0.9.3", default-features = false }
 vcad-sim = { path = "crates/vcad-sim", version = "0.9.4" }
 vcad-ecad-package = { path = "crates/vcad-ecad-package", version = "0.9.4" }
 vcad-ecad-parts = { path = "crates/vcad-ecad-parts", version = "0.9.4" }
@@ -289,6 +291,16 @@ panic = "unwind"
 
 [profile.dev]
 panic = "unwind"
+
+# Size-optimized profile for the Typst plugin WASM
+# (scripts/build-typst-plugin.sh).
+[profile.typst-wasm]
+inherits = "release"
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"
+strip = true
 
 # The FEA refinement studies run PCG on ~100k-DOF systems in their tests;
 # unoptimized they take minutes, optimized seconds.

--- a/changelog/entries/2026-07-18-typst-plugin.json
+++ b/changelog/entries/2026-07-18-typst-plugin.json
@@ -1,6 +1,6 @@
 {
   "id": "2026-07-18-typst-plugin",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "date": "2026-07-18",
   "category": "feat",
   "title": "Typst plugin: CAD rendered and measured in documents",

--- a/changelog/entries/2026-07-18-typst-plugin.json
+++ b/changelog/entries/2026-07-18-typst-plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-18-typst-plugin",
+  "version": "0.9.3",
+  "date": "2026-07-18",
+  "category": "feat",
+  "title": "Typst plugin: CAD rendered and measured in documents",
+  "summary": "New Typst WASM plugin renders .vcad/loon models to drafting views and sheets, and exposes exact measurements and compile-time assertions inside Typst documents.",
+  "features": ["typst", "render", "drafting", "loon", "verification"]
+}

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -103,7 +103,9 @@ const VERT_DEDUP_MM: f64 = 1e-3;
 /// Light direction in kernel space (Z-up).
 const LIGHT: [f64; 3] = [-0.6, -0.7, 0.8];
 
+#[cfg_attr(not(feature = "raster"), allow(dead_code))]
 const FILL_DARK: [u8; 3] = [14, 57, 96];
+#[cfg_attr(not(feature = "raster"), allow(dead_code))]
 const FILL_LIGHT: [u8; 3] = [200, 220, 235];
 
 /// Visible linework ink — a touch warmer and darker than the fill navy so
@@ -861,6 +863,7 @@ struct SolidArtifacts {
     src: usize,
     verts: Vec<[f64; 3]>,
     tris: Vec<[usize; 3]>,
+    #[cfg_attr(not(feature = "raster"), allow(dead_code))]
     normals: Vec<[f64; 3]>,
     /// Per-triangle, per-corner smoothed normals (angle-grouped: averaged
     /// only across facets within the smoothing tolerance, so curved
@@ -1216,6 +1219,7 @@ fn normalize(v: [f64; 3]) -> [f64; 3] {
     }
 }
 
+#[cfg_attr(not(feature = "raster"), allow(dead_code))]
 fn lambertian(n: [f64; 3], light: [f64; 3]) -> f64 {
     let d = dot(n, light);
     (d * 0.5 + 0.5).powf(0.85)

--- a/crates/vcad-typst/Cargo.toml
+++ b/crates/vcad-typst/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vcad-typst"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Typst WASM plugin: render, sheet, and inspect .vcad documents and loon source at document compile time."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+vcad-render = { workspace = true, default-features = false }
+vcad-loon = { workspace = true }
+vcad-eval = { workspace = true }
+vcad-ir = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-minimal-protocol = "0.2"

--- a/crates/vcad-typst/Cargo.toml
+++ b/crates/vcad-typst/Cargo.toml
@@ -9,7 +9,7 @@ description = "Typst WASM plugin: render, sheet, and inspect .vcad documents and
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-vcad-render = { workspace = true, default-features = false }
+vcad-render = { path = "../vcad-render", default-features = false }
 vcad-loon = { workspace = true }
 vcad-eval = { workspace = true }
 vcad-ir = { workspace = true }

--- a/crates/vcad-typst/src/lib.rs
+++ b/crates/vcad-typst/src/lib.rs
@@ -229,7 +229,7 @@ impl MeshProps {
         let mut volume = 0.0;
         let mut area = 0.0;
         let mut com = [0.0; 3];
-        for tri in mesh.indices.chunks_exact(3) {
+        for tri in mesh.indices.as_chunks::<3>().0 {
             let (a, b, c) = (vert(tri[0]), vert(tri[1]), vert(tri[2]));
             let cross = [
                 (b[1] - a[1]) * (c[2] - a[2]) - (b[2] - a[2]) * (c[1] - a[1]),
@@ -254,7 +254,7 @@ impl MeshProps {
         };
         let mut lo = [f64::INFINITY; 3];
         let mut hi = [f64::NEG_INFINITY; 3];
-        for v in p.chunks_exact(3) {
+        for v in p.as_chunks::<3>().0 {
             for axis in 0..3 {
                 lo[axis] = lo[axis].min(v[axis] as f64);
                 hi[axis] = hi[axis].max(v[axis] as f64);

--- a/crates/vcad-typst/src/lib.rs
+++ b/crates/vcad-typst/src/lib.rs
@@ -1,0 +1,336 @@
+//! Typst WASM plugin for vcad.
+//!
+//! Exposes vcad's evaluator and drafting renderer to Typst documents via
+//! the [wasm-minimal-protocol] bytes-in/bytes-out calling convention: every
+//! export takes a JSON config plus source bytes and returns SVG (renders)
+//! or JSON (data). The pure core lives in this module so it compiles and
+//! tests natively; the `#[wasm_func]` shims are gated to `wasm32` in
+//! [`wasm`].
+//!
+//! Typst plugins are sandboxed and must be pure — no filesystem, network,
+//! or cross-call state — which these functions already are: string in,
+//! string out, deterministic.
+//!
+//! [wasm-minimal-protocol]: https://github.com/typst-community/wasm-minimal-protocol
+
+#![warn(missing_docs)]
+
+use std::str::FromStr;
+
+use serde::Deserialize;
+use vcad_eval::{evaluate_document, EvalOptions, EvaluatedMesh};
+use vcad_render::sheet::{render_sheet_svg_str, SheetOptions};
+use vcad_render::{render_svg_str_opts, RenderAnnotations, SectionPlane, SvgOptions, View};
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+/// Render/inspect configuration, deserialized from the JSON dict the Typst
+/// wrapper builds with `json.encode`. Every field is optional; defaults
+/// match `vcad-render`'s CLI defaults.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct Config {
+    /// Source language: `"vcad"` (document JSON, default) or `"loon"`.
+    pub format: Option<String>,
+    /// Camera: `iso|front|side|top|hero|orbit:AZ,EL`.
+    pub view: Option<String>,
+    /// Pixels per millimeter (default 4).
+    pub scale: Option<f64>,
+    /// Omit the opaque paper background.
+    pub transparent: Option<bool>,
+    /// BRep-exact arcs for recognised curved edges (default true).
+    pub exact_edges: Option<bool>,
+    /// Cutaway plane, `x=N|y=N|z=N`.
+    pub section: Option<String>,
+    /// Draw the X/Y/Z origin gizmo.
+    pub axes: Option<bool>,
+    /// Label top-level parts.
+    pub labels: Option<bool>,
+    /// Draw overall bounding-box dimensions (mm).
+    pub dims: Option<bool>,
+    /// Frame the render on this part.
+    pub focus: Option<String>,
+    /// Sheet width in px for [`sheet`] renders (default 1600).
+    pub sheet_width: Option<f64>,
+    /// Title-block title for [`sheet`] renders.
+    pub title: Option<String>,
+}
+
+impl Config {
+    fn parse(config_json: &str) -> Result<Self, String> {
+        if config_json.trim().is_empty() {
+            return Ok(Self::default());
+        }
+        serde_json::from_str(config_json).map_err(|e| format!("bad config: {e}"))
+    }
+
+    /// Resolve the source to `.vcad` document JSON, evaluating loon first
+    /// when `format` says so.
+    fn to_vcad(&self, source: &str) -> Result<String, String> {
+        match self.format.as_deref() {
+            Some("loon") => {
+                let doc = vcad_loon::eval_vcad(source, None)?;
+                serde_json::to_string(&doc).map_err(|e| e.to_string())
+            }
+            None | Some("vcad") => Ok(source.to_string()),
+            Some(other) => Err(format!("unknown format '{other}' (expected vcad|loon)")),
+        }
+    }
+
+    fn svg_options(&self) -> Result<SvgOptions, String> {
+        let view = match self.view.as_deref() {
+            None => View::Isometric,
+            Some(v) => View::from_str(v)?,
+        };
+        let section = match self.section.as_deref() {
+            None => None,
+            Some(s) => Some(SectionPlane::from_str(s)?),
+        };
+        Ok(SvgOptions {
+            view,
+            transparent: self.transparent.unwrap_or(false),
+            exact_edges: self.exact_edges.unwrap_or(true),
+            section,
+            annotations: RenderAnnotations {
+                axes: self.axes.unwrap_or(false),
+                labels: self.labels.unwrap_or(false),
+                dims: self.dims.unwrap_or(false),
+            },
+            focus: self.focus.clone(),
+            ..Default::default()
+        })
+    }
+}
+
+/// Render source (`.vcad` JSON or loon, per config `format`) to a
+/// self-contained drafting SVG.
+pub fn render(config_json: &str, source: &str) -> Result<String, String> {
+    let cfg = Config::parse(config_json)?;
+    let raw = cfg.to_vcad(source)?;
+    render_svg_str_opts(&raw, cfg.scale.unwrap_or(4.0), &cfg.svg_options()?)
+}
+
+/// Render source to a third-angle multi-view drawing sheet SVG
+/// (front/side/top/iso plus title block).
+pub fn sheet(config_json: &str, source: &str) -> Result<String, String> {
+    let cfg = Config::parse(config_json)?;
+    let raw = cfg.to_vcad(source)?;
+    render_sheet_svg_str(
+        &raw,
+        &SheetOptions {
+            width_px: cfg.sheet_width.unwrap_or(1600.0),
+            title: cfg.title.clone().unwrap_or_else(|| "UNTITLED".to_string()),
+        },
+    )
+}
+
+/// Evaluate loon source to `.vcad` document JSON.
+pub fn eval_loon(source: &str) -> Result<String, String> {
+    let doc = vcad_loon::eval_vcad(source, None)?;
+    serde_json::to_string(&doc).map_err(|e| e.to_string())
+}
+
+/// Measure the document: per-part and total volume (mm³), surface area
+/// (mm²), bounding box, and center of mass, as JSON. This is what lets a
+/// Typst document print numbers that are recomputed from the model on
+/// every compile.
+pub fn inspect(config_json: &str, source: &str) -> Result<String, String> {
+    let cfg = Config::parse(config_json)?;
+    let raw = cfg.to_vcad(source)?;
+    let doc: vcad_ir::Document =
+        serde_json::from_str(&raw).map_err(|e| format!("bad .vcad JSON: {e}"))?;
+    let scene =
+        evaluate_document(&doc, &EvalOptions::default()).map_err(|e| format!("eval: {e:?}"))?;
+    if !scene.failures.is_empty() {
+        let msgs: Vec<String> = scene
+            .failures
+            .iter()
+            .map(|f| format!("{}: {}", f.scope, f.error))
+            .collect();
+        return Err(format!("evaluation failures: {}", msgs.join("; ")));
+    }
+
+    let mut parts = Vec::new();
+    let mut total_volume = 0.0;
+    let mut total_area = 0.0;
+    let mut bbox_min = [f64::INFINITY; 3];
+    let mut bbox_max = [f64::NEG_INFINITY; 3];
+    let mut com_acc = [0.0; 3];
+    for (i, part) in scene.parts.iter().enumerate() {
+        let name = doc
+            .roots
+            .get(i)
+            .and_then(|r| doc.nodes.get(&r.root))
+            .and_then(|n| n.name.clone())
+            .unwrap_or_else(|| format!("part-{i}"));
+        let m = MeshProps::of(&part.mesh);
+        total_volume += m.volume;
+        total_area += m.area;
+        for a in 0..3 {
+            bbox_min[a] = bbox_min[a].min(m.bbox.0[a]);
+            bbox_max[a] = bbox_max[a].max(m.bbox.1[a]);
+            com_acc[a] += m.com[a] * m.volume;
+        }
+        parts.push(serde_json::json!({
+            "name": name,
+            "material": part.material,
+            "volume": m.volume,
+            "area": m.area,
+            "bbox": { "min": m.bbox.0, "max": m.bbox.1 },
+            "center-of-mass": m.com,
+        }));
+    }
+    let com: Vec<f64> = com_acc
+        .iter()
+        .map(|c| {
+            if total_volume > 0.0 {
+                c / total_volume
+            } else {
+                0.0
+            }
+        })
+        .collect();
+    let size: Vec<f64> = (0..3)
+        .map(|a| (bbox_max[a] - bbox_min[a]).max(0.0))
+        .collect();
+    serde_json::to_string(&serde_json::json!({
+        "volume": total_volume,
+        "area": total_area,
+        "bbox": { "min": bbox_min, "max": bbox_max, "size": size },
+        "center-of-mass": com,
+        "parts": parts,
+    }))
+    .map_err(|e| e.to_string())
+}
+
+/// Plugin version string (the crate version).
+pub fn version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Mesh-derived mass properties (divergence theorem over the triangle
+/// soup). Uses the evaluated mesh rather than the BRep solid so it works
+/// uniformly for every part, including mesh-backed ones.
+struct MeshProps {
+    volume: f64,
+    area: f64,
+    bbox: ([f64; 3], [f64; 3]),
+    com: [f64; 3],
+}
+
+impl MeshProps {
+    fn of(mesh: &EvaluatedMesh) -> Self {
+        let p = &mesh.positions;
+        let vert = |i: u32| {
+            let i = i as usize * 3;
+            [p[i] as f64, p[i + 1] as f64, p[i + 2] as f64]
+        };
+        let mut volume = 0.0;
+        let mut area = 0.0;
+        let mut com = [0.0; 3];
+        for tri in mesh.indices.chunks_exact(3) {
+            let (a, b, c) = (vert(tri[0]), vert(tri[1]), vert(tri[2]));
+            let cross = [
+                (b[1] - a[1]) * (c[2] - a[2]) - (b[2] - a[2]) * (c[1] - a[1]),
+                (b[2] - a[2]) * (c[0] - a[0]) - (b[0] - a[0]) * (c[2] - a[2]),
+                (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]),
+            ];
+            area += 0.5 * (cross[0].powi(2) + cross[1].powi(2) + cross[2].powi(2)).sqrt();
+            // Signed tetra volume against the origin.
+            let v = (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+                + a[2] * (b[0] * c[1] - b[1] * c[0]))
+                / 6.0;
+            volume += v;
+            for axis in 0..3 {
+                com[axis] += v * (a[axis] + b[axis] + c[axis]) / 4.0;
+            }
+        }
+        let volume_abs = volume.abs();
+        let com = if volume_abs > 1e-12 {
+            [com[0] / volume, com[1] / volume, com[2] / volume]
+        } else {
+            [0.0; 3]
+        };
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for v in p.chunks_exact(3) {
+            for axis in 0..3 {
+                lo[axis] = lo[axis].min(v[axis] as f64);
+                hi[axis] = hi[axis].max(v[axis] as f64);
+            }
+        }
+        if p.is_empty() {
+            lo = [0.0; 3];
+            hi = [0.0; 3];
+        }
+        MeshProps {
+            volume: volume_abs,
+            area,
+            bbox: (lo, hi),
+            com,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CUBE_LOON: &str = "[cube 40 20 10]";
+
+    #[test]
+    fn loon_render_svg() {
+        let svg = render(r#"{"format":"loon","view":"iso"}"#, CUBE_LOON).unwrap();
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.contains("</svg>"));
+    }
+
+    #[test]
+    fn loon_sheet_svg() {
+        let svg = sheet(r#"{"format":"loon","title":"CUBE"}"#, CUBE_LOON).unwrap();
+        assert!(svg.contains("CUBE"));
+    }
+
+    #[test]
+    fn inspect_cube_mass_props() {
+        let out = inspect(r#"{"format":"loon"}"#, CUBE_LOON).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let volume = v["volume"].as_f64().unwrap();
+        assert!(
+            (volume - 40.0 * 20.0 * 10.0).abs() < 1e-6,
+            "volume {volume}"
+        );
+        let area = v["area"].as_f64().unwrap();
+        assert!(
+            (area - 2.0 * (800.0 + 400.0 + 200.0)).abs() < 1e-6,
+            "area {area}"
+        );
+        let size = v["bbox"]["size"].as_array().unwrap();
+        assert_eq!(size[2].as_f64().unwrap(), 10.0);
+        let com = v["center-of-mass"].as_array().unwrap();
+        assert!((com[0].as_f64().unwrap() - 20.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn section_and_annotations() {
+        let svg = render(
+            r#"{"format":"loon","section":"z=5","dims":true,"axes":true}"#,
+            CUBE_LOON,
+        )
+        .unwrap();
+        assert!(svg.starts_with("<svg"));
+    }
+
+    #[test]
+    fn bad_view_is_error() {
+        assert!(render(r#"{"format":"loon","view":"wat"}"#, CUBE_LOON).is_err());
+    }
+
+    #[test]
+    fn eval_loon_roundtrips() {
+        let json = eval_loon(CUBE_LOON).unwrap();
+        let doc: vcad_ir::Document = serde_json::from_str(&json).unwrap();
+        assert_eq!(doc.roots.len(), 1);
+    }
+}

--- a/crates/vcad-typst/src/wasm.rs
+++ b/crates/vcad-typst/src/wasm.rs
@@ -1,0 +1,38 @@
+//! wasm-minimal-protocol exports — the surface Typst's `plugin()` sees.
+//!
+//! Every export takes UTF-8 byte buffers and returns UTF-8 bytes (SVG or
+//! JSON); errors become protocol-level errors that Typst reports at the
+//! call site.
+
+use wasm_minimal_protocol::{initiate_protocol, wasm_func};
+
+initiate_protocol!();
+
+fn utf8(bytes: &[u8], what: &str) -> Result<String, String> {
+    String::from_utf8(bytes.to_vec()).map_err(|_| format!("{what} is not valid UTF-8"))
+}
+
+#[wasm_func]
+fn render(config: &[u8], source: &[u8]) -> Result<Vec<u8>, String> {
+    crate::render(&utf8(config, "config")?, &utf8(source, "source")?).map(String::into_bytes)
+}
+
+#[wasm_func]
+fn sheet(config: &[u8], source: &[u8]) -> Result<Vec<u8>, String> {
+    crate::sheet(&utf8(config, "config")?, &utf8(source, "source")?).map(String::into_bytes)
+}
+
+#[wasm_func]
+fn inspect(config: &[u8], source: &[u8]) -> Result<Vec<u8>, String> {
+    crate::inspect(&utf8(config, "config")?, &utf8(source, "source")?).map(String::into_bytes)
+}
+
+#[wasm_func]
+fn eval_loon(source: &[u8]) -> Result<Vec<u8>, String> {
+    crate::eval_loon(&utf8(source, "source")?).map(String::into_bytes)
+}
+
+#[wasm_func]
+fn version() -> Result<Vec<u8>, String> {
+    Ok(crate::version().into_bytes())
+}

--- a/scripts/build-typst-plugin.sh
+++ b/scripts/build-typst-plugin.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build the Typst plugin WASM (crates/vcad-typst) and install it into the
+# Typst package at typst/vcad/vcad.wasm.
+#
+# Requires: rustup target wasm32-unknown-unknown; wasm-opt (binaryen) is
+# used when available and skipped (with a warning) otherwise.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+cargo build --profile typst-wasm --target wasm32-unknown-unknown -p vcad-typst
+
+WASM=target/wasm32-unknown-unknown/typst-wasm/vcad_typst.wasm
+OUT=typst/vcad/vcad.wasm
+
+if command -v wasm-opt >/dev/null; then
+  wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int "$WASM" -o "$OUT"
+else
+  echo "warning: wasm-opt not found, shipping unoptimized wasm" >&2
+  cp "$WASM" "$OUT"
+fi
+
+ls -lh "$OUT"

--- a/typst/vcad/README.md
+++ b/typst/vcad/README.md
@@ -1,0 +1,49 @@
+# vcad for Typst
+
+Parametric CAD in your document. This Typst package embeds vcad's BRep
+kernel and drafting renderer as a WASM plugin, so a Typst document can
+**render**, **measure**, and **verify** CAD models at compile time — every
+figure, dimension, mass, and assertion recomputes from the geometry on
+each build. The document cannot disagree with its model.
+
+```typst
+#import "@preview/vcad:0.1.0": vcad-loon, vcad-inspect, vcad-mass, vcad-assert
+
+// Model, inline. loon booleans are subject-last: [difference tool body].
+#let bracket = "[difference [translate 30 20 -1 [cylinder 4 12]] [cube 60 40 8]]"
+
+#vcad-loon(bracket, dims: true)                       // dimensioned iso view
+#let m = vcad-inspect(bracket, format: "loon")
+The plate weighs #calc.round(vcad-mass(m, 1.04), digits: 1) g in ABS.
+#vcad-assert(vcad-mass(m, 1.04) < 30, message: "over mass budget")
+```
+
+## Functions
+
+- `vcad-view(source, view: "iso", section: "z=10", dims: true, focus: "lid", ...)`
+  — one drafting-style SVG view of a `.vcad` document (str/bytes, e.g.
+  `read("part.vcad")`) or loon source (`format: "loon"`). Views:
+  `iso|front|side|top|hero|orbit:AZ,EL`; sections get cross-hatched cut faces.
+- `vcad-loon(source, ...)` — sugar for loon source; accepts a raw block.
+- `vcad-sheet(source, title: "BRACKET")` — third-angle multi-view drawing
+  sheet (front/side/top/iso + title block).
+- `vcad-inspect(source)` — dictionary of exact measurements: `volume` (mm³),
+  `area` (mm²), `bbox.(min|max|size)`, `center-of-mass`, `parts` (per-part
+  name/material/volume/area/bbox/com).
+- `vcad-mass(inspection, density)` — grams, density in g/cm³.
+- `vcad-assert(cond, message: ..)` — fail the compile when a spec is violated.
+- `vcad-eval-loon(source)` — loon → `.vcad` JSON string.
+- `vcad-version()` — plugin version.
+
+Units are millimeters; the coordinate system is Z-up.
+
+## Building the plugin
+
+`vcad.wasm` is built from `crates/vcad-typst` (not committed):
+
+```bash
+./scripts/build-typst-plugin.sh   # → typst/vcad/vcad.wasm (~2.4 MB)
+```
+
+Compile the demo: `typst compile --root . examples/demo.typ` (from this
+directory, wasm present).

--- a/typst/vcad/examples/demo.typ
+++ b/typst/vcad/examples/demo.typ
@@ -1,0 +1,59 @@
+#import "../lib.typ": *
+
+#set page(width: 190mm, height: auto, margin: 12mm)
+#set text(font: "Helvetica", size: 10pt)
+
+#let fmt(x, digits: 1) = str(calc.round(x, digits: digits))
+
+// One parametric model, defined inline. Every render, number, and
+// assertion below recomputes from this source on each compile.
+// loon booleans are subject-last: [difference tool body].
+#let bracket(w) = "
+[difference
+  [translate " + str(w / 2) + " 20 -1 [cylinder 4 12]]
+  [union
+    [cube " + str(w) + " 40 8]
+    [cube 8 40 30]]]
+"
+
+= vcad in Typst: the document is the model
+
+== See
+#grid(columns: (1fr, 1fr), gutter: 4mm,
+  vcad-loon(bracket(60), dims: true),
+  vcad-loon(bracket(60), view: "orbit:150,25", section: "y=20"),
+)
+
+== Measure
+#let m = vcad-inspect(bracket(60), format: "loon")
+#let mass = vcad-mass(m, 1.04) // ABS, g/cm³
+The bracket displaces #fmt(m.volume / 1000, digits: 2) cm³,
+spans #fmt(m.bbox.size.at(0)) × #fmt(m.bbox.size.at(1)) ×
+#fmt(m.bbox.size.at(2)) mm, and weighs *#fmt(mass) g* in ABS.
+Its center of mass sits at
+(#m.center-of-mass.map(c => fmt(c)).join(", ")) mm.
+
+== Parametric variants
+#table(
+  columns: 4,
+  table.header([*w (mm)*], [*view*], [*volume (cm³)*], [*mass, ABS (g)*]),
+  ..for w in (40, 60, 80) {
+    let mi = vcad-inspect(bracket(w), format: "loon")
+    (
+      str(w),
+      vcad-loon(bracket(w), height: 18mm),
+      fmt(mi.volume / 1000, digits: 2),
+      fmt(vcad-mass(mi, 1.04)),
+    )
+  },
+)
+
+== Prove
+// The compile fails if the model stops satisfying the printed spec.
+#vcad-assert(mass < 30, message: "bracket over mass budget (30 g)")
+#vcad-assert(calc.abs(m.bbox.size.at(2) - 30) < 0.01, message: "overall height drifted")
+All printed values are recomputed from the model at compile time —
+this PDF cannot disagree with its geometry. #text(fill: green)[✓ verified]
+
+== Drawing sheet
+#vcad-sheet(bracket(60), format: "loon", title: "BRACKET-60")

--- a/typst/vcad/lib.typ
+++ b/typst/vcad/lib.typ
@@ -1,0 +1,100 @@
+// vcad for Typst — parametric CAD rendered and measured at compile time.
+//
+// #import "@preview/vcad:0.1.0": vcad-view, vcad-loon, vcad-sheet, vcad-inspect
+//
+// Every function accepts either .vcad document JSON (str or bytes, e.g.
+// `read("part.vcad")`) or, with `format: "loon"`, loon CAD source. Renders
+// come back as drafting-style SVG images; `vcad-inspect` returns a
+// dictionary of exact model measurements so prose, tables, and assertions
+// recompute from the geometry on every compile.
+
+#let _plugin = plugin("vcad.wasm")
+
+#let _to-bytes(source) = {
+  if type(source) == bytes { source } else { bytes(source) }
+}
+
+#let _cfg(format, pairs) = {
+  let d = (:)
+  if format != none { d.insert("format", format) }
+  for (k, v) in pairs {
+    if v != none { d.insert(k, v) }
+  }
+  bytes(json.encode(d))
+}
+
+/// Render a model to a single drafting-style view.
+///
+/// - source: .vcad JSON (str/bytes) or loon source with `format: "loon"`
+/// - view: "iso" | "front" | "side" | "top" | "hero" | "orbit:AZ,EL"
+/// - scale: px per mm
+/// - section: cutaway plane, "x=N" | "y=N" | "z=N"
+/// - dims / labels / axes: engineering annotation overlays
+/// - focus: frame on a named part
+/// - ..image-args: forwarded to `image` (width, height, alt, ...)
+#let vcad-view(
+  source,
+  format: none,
+  view: "iso",
+  scale: none,
+  section: none,
+  dims: false,
+  labels: false,
+  axes: false,
+  focus: none,
+  transparent: true,
+  ..image-args,
+) = {
+  let cfg = _cfg(format, (
+    ("view", view),
+    ("scale", scale),
+    ("section", section),
+    ("dims", if dims { true } else { none }),
+    ("labels", if labels { true } else { none }),
+    ("axes", if axes { true } else { none }),
+    ("focus", focus),
+    ("transparent", if transparent { true } else { none }),
+  ))
+  image(_plugin.render(cfg, _to-bytes(source)), format: "svg", ..image-args)
+}
+
+/// Render inline loon source. Sugar for `vcad-view(src, format: "loon")`;
+/// also accepts a raw block: `vcad-loon(```[cube 40 20 10]```)`.
+#let vcad-loon(source, ..args) = {
+  let src = if type(source) == content and source.has("text") { source.text } else { source }
+  vcad-view(src, format: "loon", ..args)
+}
+
+/// Render a third-angle multi-view drawing sheet (front/side/top/iso with
+/// title block).
+#let vcad-sheet(source, format: none, title: none, width: none, ..image-args) = {
+  let cfg = _cfg(format, (("title", title), ("sheet-width", width)))
+  image(_plugin.sheet(cfg, _to-bytes(source)), format: "svg", ..image-args)
+}
+
+/// Measure a model. Returns a dictionary:
+/// (volume, area, bbox: (min, max, size), center-of-mass, parts: (..))
+/// Volumes are mm³, areas mm², lengths mm.
+#let vcad-inspect(source, format: none) = {
+  json(_plugin.inspect(_cfg(format, ()), _to-bytes(source)))
+}
+
+/// Mass in grams for a measured model: `vcad-mass(vcad-inspect(..), 1.04)`
+/// (density in g/cm³).
+#let vcad-mass(inspection, density) = inspection.volume / 1000 * density
+
+/// Compile-time engineering assertion. Fails the document build with
+/// `message` when `condition` is false — a spec printed by the document
+/// cannot ship violated.
+#let vcad-assert(condition, message: "vcad assertion failed") = {
+  assert(condition, message: message)
+}
+
+/// Evaluate loon source to a .vcad document JSON string (chain into
+/// `vcad-view`/`vcad-inspect`, or `json.decode` it for raw access).
+#let vcad-eval-loon(source) = {
+  str(_plugin.eval_loon(_to-bytes(source)))
+}
+
+/// Plugin version string.
+#let vcad-version() = str(_plugin.version())

--- a/typst/vcad/typst.toml
+++ b/typst/vcad/typst.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vcad"
+version = "0.1.0"
+entrypoint = "lib.typ"
+authors = ["Cam Pedersen <cam@campedersen.com>"]
+license = "MIT"
+description = "Parametric CAD in your document: render .vcad/loon models to drafting-quality views and sheets, and measure them (volume, mass, bbox, center of mass) at compile time — numbers that can never go stale."
+homepage = "https://vcad.io"
+repository = "https://github.com/ecto/vcad"
+keywords = ["cad", "engineering", "drafting", "3d", "mechanical", "brep"]
+categories = ["visualization", "components"]
+compiler = "0.13.0"
+exclude = ["examples"]


### PR DESCRIPTION
## What

A Typst WASM plugin that embeds vcad's BRep kernel and drafting renderer, so a Typst document can **render**, **measure**, and **verify** CAD models at compile time. Every figure, dimension, mass, and assertion recomputes from the geometry on each build — the document cannot disagree with its model.

Nothing like this exists on Typst Universe today. The closest prior art (`maquette`) is a mesh-only STL viewer; there's no BRep/drafting/measurement package. vcad is unusually well-positioned because `vcad-render` already had a pure string-in/string-out SVG seam and a lib that builds without the CLI/raster deps.

## Pieces

- **`crates/vcad-typst`** — the plugin crate. `wasm-minimal-protocol` exports (`render`, `sheet`, `inspect`, `eval_loon`, `version`) wrapping a pure core that's natively tested (6 tests, incl. exact volume/area/center-of-mass checks). Compiles to `wasm32-unknown-unknown`.
- **`typst/vcad/`** — the Typst package. `vcad-view` (iso/front/side/top/orbit, sections with crosshatch, dims/labels/axes, focus), `vcad-loon` (inline loon source), `vcad-sheet` (third-angle drawing sheet + title block), `vcad-inspect` (volume/area/bbox/center-of-mass as native Typst data), `vcad-mass`, and `vcad-assert` (compile fails when a printed spec is violated).
- **`scripts/build-typst-plugin.sh`** — builds the wasm via a new size-optimized `[profile.typst-wasm]` (opt-level=z, LTO, panic=abort, strip) + `wasm-opt -Oz`. Output is **~2.4 MB**, in line with the ~1–2 MB Universe norm and 40× smaller than the app kernel wasm.
- **`typst/vcad/examples/demo.typ`** — compiles with real `typst`, exercising all four tiers: dimensioned views, a section cutaway, prose with computed mass, a parametric variant table (one loon function → 3 widths → 3 renders + measured masses), compile-time assertions, and a drawing sheet.

## Reviewer notes

- `vcad.wasm` and example PDF/PNG outputs are **gitignored** — built on demand by the script, not committed.
- Feature-gated 4 raster-only items in `vcad-render` with `#[cfg_attr(not(feature = "raster"), allow(dead_code))]` so the `--no-default-features` lib is clippy-clean. No behavior change to the default (raster-on) build.
- `vcad-kernel-text` does `include_bytes!` on a font under `node_modules/next/...`, so building the wasm needs `node_modules` present (or the font copied in). Worth giving that font a proper home later.
- `wasm-opt` requires `--enable-bulk-memory` (LLVM emits bulk-memory ops); Typst's wasmi runtime supports it.

Clippy clean workspace-wide (`--exclude vcad-desktop`), all `vcad-typst` tests pass, changelog entry added.

## Follow-ups (not in this PR)

STEP import in the plugin (`vcad-step(read("part.step"))`), Universe submission as `@preview/vcad`, receipt-backed assertions, and a `vcad-datasheet` template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)