### PR TITLE
MCP: honor boolean args over string-serializing clients; return get_document IR in structuredContent

### DIFF
--- a/changelog/entries/2026-07-18-clearance-boolean-getdoc-ir.json
+++ b/changelog/entries/2026-07-18-clearance-boolean-getdoc-ir.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-clearance-boolean-getdoc-ir",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "fix",
+  "title": "check_clearance allow_contact and get_document IR reliability",
+  "summary": "check_clearance now honors allow_contact (and render_view's axes/labels/dims/highlight_changed) even when a client serializes booleans as strings, and get_document returns the full IR in structuredContent so clients that surface it no longer see only a {document_id} stub.",
+  "features": ["clearance", "render", "mcp"],
+  "mcpTools": ["check_clearance", "render_view", "get_document"]
+}

--- a/packages/mcp/src/__tests__/arg-coerce-and-getdoc.test.ts
+++ b/packages/mcp/src/__tests__/arg-coerce-and-getdoc.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Follow-up fixes after live testing PR #589 on the hosted server:
+ *
+ *  1. Boolean tool args arrived over the hosted transport as strings, so
+ *     `args.allow_contact === true` silently read false and the flag had no
+ *     effect. `asBool` coerces boolean-ish spellings; check_clearance now
+ *     honors allow_contact regardless of how the client serialized it.
+ *  2. get_document's IR was shadowed by the dispatch layer's
+ *     {document_id, document_version} preview handle on clients that surface
+ *     structuredContent. The IR now rides in structuredContent too.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { asBool } from "../tools/arg-coerce.js";
+import { checkClearance } from "../tools/clearance.js";
+import { getDocumentTool, documents } from "../tools/session.js";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+const ASSEMBLY_LOON = `
+[let base [cube 40 40 5]]
+[let post [cylinder 5 30]]
+[assembly
+  #[[part "base" base "aluminum"]
+    [part "post" post "steel"]]
+  #[[instance "base1" "base" 0 0 0]
+    [instance "post1" "post" 20 20 5]]
+  #[]
+  "base1"]
+`;
+
+function assemblyDoc(): Document {
+  const doc = engine.evalVcadSource(ASSEMBLY_LOON);
+  if (!doc) throw new Error("loon eval failed");
+  return doc;
+}
+
+describe("asBool", () => {
+  it("accepts real booleans and boolean-ish strings/numbers", () => {
+    expect(asBool(true)).toBe(true);
+    expect(asBool(false)).toBe(false);
+    expect(asBool("true")).toBe(true);
+    expect(asBool("TRUE")).toBe(true);
+    expect(asBool(" true ")).toBe(true);
+    expect(asBool("false")).toBe(false);
+    expect(asBool("1")).toBe(true);
+    expect(asBool("0")).toBe(false);
+    expect(asBool(1)).toBe(true);
+    expect(asBool(0)).toBe(false);
+  });
+  it("falls back to the default for anything else", () => {
+    expect(asBool(undefined)).toBe(false);
+    expect(asBool(undefined, true)).toBe(true);
+    expect(asBool("yes")).toBe(false);
+    expect(asBool(null)).toBe(false);
+  });
+});
+
+describe("check_clearance honors allow_contact regardless of serialization", () => {
+  it("string 'true' allow_contact passes a touching pair", async () => {
+    documents.clear();
+    const id = "clr_bool";
+    documents.set(id, assemblyDoc());
+    const res = (await checkClearance(
+      {
+        document_id: id,
+        group_a: ["base1"],
+        group_b: ["post1"],
+        min_mm: 0.5,
+        allow_contact: "true", // string, as some clients serialize booleans
+      },
+      engine,
+    )) as { structuredContent?: { clearance?: Record<string, unknown> } };
+    const clr = res.structuredContent!.clearance!;
+    expect(clr.verdict).toBe("touching");
+    expect(clr.pass).toBe(true);
+    expect(clr.allow_contact).toBe(true);
+  });
+
+  it("without allow_contact the same touching pair fails", async () => {
+    documents.clear();
+    const id = "clr_nobool";
+    documents.set(id, assemblyDoc());
+    const res = (await checkClearance(
+      { document_id: id, group_a: ["base1"], group_b: ["post1"], min_mm: 0.5 },
+      engine,
+    )) as { structuredContent?: { clearance?: Record<string, unknown> } };
+    const clr = res.structuredContent!.clearance!;
+    expect(clr.verdict).toBe("touching");
+    expect(clr.pass).toBe(false);
+  });
+});
+
+describe("get_document returns the IR in structuredContent", () => {
+  it("carries the document body so structuredContent-only clients see it", () => {
+    documents.clear();
+    const id = "getdoc_ir";
+    const doc = assemblyDoc();
+    documents.set(id, doc);
+    const res = getDocumentTool({ document_id: id }) as {
+      content: Array<{ type: string; text: string }>;
+      structuredContent?: { document?: Document; document_id?: string };
+    };
+    // Text body still carries the full IR (unchanged contract).
+    const fromText = JSON.parse(res.content[0]!.text) as Document;
+    expect(fromText.instances?.length).toBe(2);
+    // And structuredContent now carries the same document.
+    expect(res.structuredContent?.document_id).toBe(id);
+    expect(res.structuredContent?.document?.instances?.length).toBe(2);
+  });
+});

--- a/packages/mcp/src/tools/arg-coerce.ts
+++ b/packages/mcp/src/tools/arg-coerce.ts
@@ -1,0 +1,34 @@
+/**
+ * Tolerant scalar coercion for tool arguments.
+ *
+ * Field report: `check_clearance {allow_contact: true}` had no effect on the
+ * hosted server — the boolean arrived as something other than a strict `true`
+ * (some MCP clients/transports serialize booleans as the strings "true"/
+ * "false"), so the handler's `args.x === true` check silently read false and
+ * the flag vanished. Numbers survive the same transport, so the failure is
+ * specific to booleans read by identity.
+ *
+ * `asBool` accepts the honest spellings of a boolean flag — the real boolean,
+ * and the case-insensitive strings "true"/"false" / "1"/"0" — and returns the
+ * schema default for anything else. Strict on unknown *keys* (see
+ * validate-args), lenient on the *shape* of a known scalar.
+ */
+
+/** Coerce a boolean-ish argument to a boolean, falling back to `dflt`. */
+export function asBool(v: unknown, dflt = false): boolean {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") return v === 1 ? true : v === 0 ? false : dflt;
+  if (typeof v === "string") {
+    switch (v.trim().toLowerCase()) {
+      case "true":
+      case "1":
+        return true;
+      case "false":
+      case "0":
+        return false;
+      default:
+        return dflt;
+    }
+  }
+  return dflt;
+}

--- a/packages/mcp/src/tools/clearance.ts
+++ b/packages/mcp/src/tools/clearance.ts
@@ -27,6 +27,7 @@ import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
 import { transformMesh } from "@vcad/engine";
 import { unverifiableClaim } from "../receipt-unified.js";
 import { getSession } from "./session.js";
+import { asBool } from "./arg-coerce.js";
 
 /** Claim-id prefix shared with the Rust mech adapter (`vcad-receipt`). */
 export const CLEARANCE_CLAIM_PREFIX = "mech.clearance.";
@@ -285,7 +286,7 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
   const minMm = typeof args.min_mm === "number" ? args.min_mm : NaN;
   if (!Number.isFinite(minMm)) return err("Pass `min_mm`, the required minimum separation in mm.");
   const label = typeof args.label === "string" && args.label.trim() ? args.label.trim() : undefined;
-  const allowContact = args.allow_contact === true;
+  const allowContact = asBool(args.allow_contact);
 
   const doc = getSession(documentId);
   const { result, error } = computeGroupClearance(doc, engine, groupA, groupB);

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -25,6 +25,7 @@ import {
   renderAssetSummary,
   withRenderAssets,
 } from "./render-assets.js";
+import { asBool } from "./arg-coerce.js";
 
 export const renderViewSchema = {
   type: "object" as const,
@@ -272,9 +273,9 @@ export async function renderView(
   }
 
   const annotations = {
-    axes: args.axes === true,
-    labels: args.labels === true,
-    dims: args.dims === true,
+    axes: asBool(args.axes),
+    labels: asBool(args.labels),
+    dims: asBool(args.dims),
   };
   const wantAnnotations =
     annotations.axes || annotations.labels || annotations.dims;
@@ -286,7 +287,7 @@ export async function renderView(
   let highlight: string[] = Array.isArray(args.highlight)
     ? (args.highlight as unknown[]).map(String)
     : [];
-  if (highlight.length === 0 && args.highlight_changed === true) {
+  if (highlight.length === 0 && asBool(args.highlight_changed)) {
     const last = documentId ? getLastChanged(documentId) : null;
     if (!last || last.length === 0) {
       return {

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -355,6 +355,7 @@ export const getDocumentSchema = {
 
 export function getDocumentTool(args: Record<string, unknown>): {
   content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
 } {
   const id = String(args.document_id ?? "");
   const doc = getSession(id);
@@ -367,31 +368,36 @@ export function getDocumentTool(args: Record<string, unknown>): {
   const cap = maxInlineArtifactBytes();
   if (Buffer.byteLength(inline, "utf8") > cap) {
     const handle = storeArtifact([{ name: `${id}.vcad`, content: inline }]);
+    const overflow = {
+      document_id: id,
+      parts: doc.roots?.length ?? 0,
+      nodes: Object.keys(doc.nodes ?? {}).length,
+      bytes: handle.bytes,
+      artifact_id: handle.artifact_id,
+      artifact_url: handle.artifact_url,
+      manifest: handle.manifest,
+      expires_at: handle.expires_at,
+      note:
+        `Document IR is ${handle.bytes} bytes — over the ${cap}-byte inline ` +
+        "limit, so the full IR was written to the artifact store. Download " +
+        "it at artifact_url (sha256 in the manifest verifies the snapshot); " +
+        "the session stays live via document_id.",
+    };
     return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({
-            document_id: id,
-            parts: doc.roots?.length ?? 0,
-            nodes: Object.keys(doc.nodes ?? {}).length,
-            bytes: handle.bytes,
-            artifact_id: handle.artifact_id,
-            artifact_url: handle.artifact_url,
-            manifest: handle.manifest,
-            expires_at: handle.expires_at,
-            note:
-              `Document IR is ${handle.bytes} bytes — over the ${cap}-byte inline ` +
-              "limit, so the full IR was written to the artifact store. Download " +
-              "it at artifact_url (sha256 in the manifest verifies the snapshot); " +
-              "the session stays live via document_id.",
-          }),
-        },
-      ],
+      content: [{ type: "text", text: JSON.stringify(overflow) }],
+      structuredContent: overflow,
     };
   }
+  // Mirror the IR into structuredContent as well as the text body. The
+  // dispatch layer stamps geometry results' structuredContent with a
+  // {document_id, document_version} preview handle; clients that surface
+  // structuredContent instead of the text block would otherwise see only
+  // that stub and never the document the tool exists to return. Carrying
+  // the IR in both places makes get_document return the document on every
+  // client. (Large docs offload above, so this never duplicates megabytes.)
   return {
     content: [{ type: "text", text: inline }],
+    structuredContent: { document: doc, document_id: id },
   };
 }
 


### PR DESCRIPTION
Two follow-up fixes found while live-testing #589 against the hosted `vcad` MCP server.

## 1. Boolean tool args silently dropped over string-serializing clients

`check_clearance {allow_contact: true}` had no effect on the hosted server — `pass` stayed `false` and the flag wasn't echoed — even though the schema accepts it and `verdict`/strict-args prove the #589 handler is running. The boolean arrived as something other than a strict `true` (some MCP clients/transports serialize booleans as the strings `"true"`/`"false"`), so `args.allow_contact === true` read `false` and the flag vanished. Numbers survive the same transport, so the failure is specific to booleans read by identity.

Fix: add `asBool()` — a tolerant coercion accepting the real boolean, `"true"`/`"false"`, `"1"`/`"0"`, and `1`/`0`, falling back to the schema default — and use it at the affected read sites:
- `check_clearance` → `allow_contact`
- `render_view` → `axes`, `labels`, `dims`, `highlight_changed`

Strict on unknown *keys* (the #589 rejection stays), lenient on a known scalar's *shape*.

## 2. get_document IR shadowed by the preview handle

`get_document` returns the full IR in its text content, but the dispatch layer stamps every geometry tool's `structuredContent` with a `{document_id, document_version}` preview handle. Clients that surface `structuredContent` (rather than the text block) therefore saw only that stub — never the document the tool exists to return. Fix: mirror the IR into `structuredContent` on both the inline and artifact-handle paths, so `get_document` returns the document on every client. Large documents still offload to the artifact store, so this never duplicates megabytes.

## Testing
- New unit tests for `asBool`, a `check_clearance` `allow_contact: "true"` handler test (string-serialized boolean now passes a touching pair), and a `get_document` `structuredContent` test.
- Full `@vcad/mcp` suite green (882 passed, 8 skipped); `tsc --noEmit` clean; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXwyNmL2LBQFJgJH8KJHtt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXwyNmL2LBQFJgJH8KJHtt)_