### PR TITLE
Chat sidebar parity with MCP tools + rich in-viewport tool results

### DIFF
--- a/changelog/entries/2026-07-18-chat-mcp-tool-parity.json
+++ b/changelog/entries/2026-07-18-chat-mcp-tool-parity.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-chat-mcp-tool-parity",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "feat",
+  "title": "Chat assistant gains the MCP solver tool surface",
+  "summary": "In-app chat can now run inspect_cad, measure, check_clearance, dfm_check, analyze_structure, topology_optimize and more — with receipt chips, a viewport min-distance line, and undoable results.",
+  "features": ["chat", "mcp", "verification", "topology-optimization"],
+  "mcpTools": ["inspect_cad", "measure", "check_clearance", "dfm_check", "analyze_structure", "topology_optimize", "analyze_tolerance_stackup", "solve_thermal", "predict_print", "predict_physics"]
+}

--- a/packages/app/src/components/ClearanceIndicatorOverlay.tsx
+++ b/packages/app/src/components/ClearanceIndicatorOverlay.tsx
@@ -1,0 +1,60 @@
+import { Line, Html } from "@react-three/drei";
+import { useUiStore } from "@vcad/core";
+
+/**
+ * Min-distance witness line for a chat `check_clearance` result: the segment
+ * between the closest pair of points on the two measured groups, with the
+ * measured distance and pass/fail verdict. Rendered inside the kernel-space
+ * (Z-up) scene group like the other measurement overlays; suppressed during
+ * AI screenshot capture so tool screenshots show geometry, not chrome.
+ */
+export function ClearanceIndicatorOverlay() {
+  const indicator = useUiStore((s) => s.clearanceIndicator);
+  const captureMode = useUiStore((s) => s.captureMode);
+  if (!indicator || captureMode) return null;
+
+  const { pointA, pointB, distanceMm, pass, label } = indicator;
+  const mid: [number, number, number] = [
+    (pointA[0] + pointB[0]) / 2,
+    (pointA[1] + pointB[1]) / 2,
+    (pointA[2] + pointB[2]) / 2,
+  ];
+  const color = pass ? "#22c55e" : "#ef4444";
+
+  return (
+    <group>
+      <Line points={[pointA, pointB]} color={color} lineWidth={2} dashed dashSize={2} gapSize={1.2} />
+      <mesh position={pointA}>
+        <sphereGeometry args={[0.8, 12, 12]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+      <mesh position={pointB}>
+        <sphereGeometry args={[0.8, 12, 12]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+      <Html position={mid} center zIndexRange={[40, 0]}>
+        <div
+          className="pointer-events-auto flex items-center gap-1.5 rounded border px-1.5 py-0.5 text-[10px] font-mono whitespace-nowrap shadow-sm"
+          style={{
+            background: "var(--color-bg, #fff)",
+            borderColor: color,
+            color,
+          }}
+        >
+          <span>
+            {label ? `${label}: ` : ""}
+            {distanceMm.toFixed(2)} mm
+          </span>
+          <span className="font-sans">{pass ? "clear" : "violated"}</span>
+          <button
+            aria-label="Dismiss clearance measurement"
+            className="ml-0.5 opacity-60 hover:opacity-100"
+            onClick={() => useUiStore.getState().setClearanceIndicator(null)}
+          >
+            ×
+          </button>
+        </div>
+      </Html>
+    </group>
+  );
+}

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -33,6 +33,7 @@ import { BoundaryEdgeOverlay } from "./BoundaryEdgeOverlay";
 import { useDebugOverlayStore } from "../stores/debug-overlay-store";
 import { InspectedTriangleMarker } from "./TriangleInspector";
 import { ClashMesh } from "./ClashMesh";
+import { ClearanceIndicatorOverlay } from "./ClearanceIndicatorOverlay";
 import { PreviewMesh } from "./PreviewMesh";
 import { SketchPlane3D } from "./SketchPlane3D";
 import { PlaneGizmo } from "./PlaneGizmo";
@@ -1920,6 +1921,9 @@ export function ViewportContent({
           {scene?.clashes.map((clashMesh, idx) => (
             <ClashMesh key={`clash-${idx}`} mesh={clashMesh} />
           ))}
+
+          {/* Min-distance line from a chat check_clearance call */}
+          <ClearanceIndicatorOverlay />
 
           {/* Extrusion preview (semi-transparent) */}
           {previewMesh && <PreviewMesh mesh={previewMesh} />}

--- a/packages/app/src/components/chat/VcadToolCard.tsx
+++ b/packages/app/src/components/chat/VcadToolCard.tsx
@@ -68,6 +68,110 @@ const extraRenderers: Record<string, ExtraRenderer> = {
 };
 
 // ---------------------------------------------------------------------------
+// Claim chips — honesty as UX. Any solver/verification tool result that
+// carries vcad.receipt/1 claims (or check_clearance's inline pass/verdict)
+// renders each claim as a small status chip: Holds (verified pass),
+// Provisional (predicted/surrogate pass — not yet verified against reality),
+// Violated (fail), Unverifiable (the oracle couldn't check it — never a
+// silent pass). Hover shows the claim's description.
+// ---------------------------------------------------------------------------
+
+type ChipStatus = "holds" | "provisional" | "violated" | "unverifiable";
+
+interface ClaimChipInfo {
+  status: ChipStatus;
+  label: string;
+  title: string;
+}
+
+const CHIP_STYLE: Record<ChipStatus, string> = {
+  holds: "bg-success/10 text-success border-success/30",
+  provisional: "bg-warning/10 text-warning border-warning/30",
+  violated: "bg-error/10 text-error border-error/30",
+  unverifiable: "bg-surface text-text-muted border-border",
+};
+
+const CHIP_TEXT: Record<ChipStatus, string> = {
+  holds: "Holds",
+  provisional: "Provisional",
+  violated: "Violated",
+  unverifiable: "Unverifiable",
+};
+
+function chipStatus(verdict: unknown, basis: unknown): ChipStatus {
+  if (verdict === "fail") return "violated";
+  if (verdict === "unverifiable") return "unverifiable";
+  if (verdict !== "pass") return "unverifiable";
+  return basis === "predicted" || basis === "surrogate" ? "provisional" : "holds";
+}
+
+/** Pull receipt claims out of a tool-result payload: `claim`, `claims`, or
+ *  `receipt.claims`; check_clearance's inline pass/verdict synthesizes one. */
+function extractClaims(call: ToolCallInfo): ClaimChipInfo[] {
+  if (call.status !== "success" || typeof call.result !== "string") return [];
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(call.result) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+  const raw: Array<Record<string, unknown>> = [];
+  const push = (c: unknown) => {
+    if (c && typeof c === "object" && "verdict" in (c as object)) {
+      raw.push(c as Record<string, unknown>);
+    }
+  };
+  push(payload.claim);
+  if (Array.isArray(payload.claims)) payload.claims.forEach(push);
+  const receipt = payload.receipt as Record<string, unknown> | undefined;
+  if (receipt && Array.isArray(receipt.claims)) receipt.claims.forEach(push);
+
+  const chips: ClaimChipInfo[] = raw.map((c) => ({
+    status: chipStatus(c.verdict, c.basis),
+    label: typeof c.id === "string" ? c.id : "claim",
+    title:
+      typeof c.description === "string"
+        ? c.description
+        : typeof c.id === "string"
+          ? c.id
+          : "receipt claim",
+  }));
+
+  // check_clearance carries its verdict inline, not as a claim object.
+  if (chips.length === 0 && call.name === "check_clearance" && "pass" in payload) {
+    const label = typeof payload.label === "string" ? payload.label : "clearance";
+    chips.push({
+      status: payload.pass === true ? "holds" : "violated",
+      label,
+      title: `min distance ${payload.measured_mm} mm (required ${payload.required_mm} mm)`,
+    });
+  }
+  return chips;
+}
+
+function ClaimChips({ call }: { call: ToolCallInfo }) {
+  const chips = extractClaims(call);
+  if (chips.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {chips.map((chip, i) => (
+        <span
+          key={i}
+          title={chip.title}
+          className={cn(
+            "inline-flex items-center gap-1 rounded-full border px-1.5 py-px text-[9px] font-medium",
+            CHIP_STYLE[chip.status],
+          )}
+        >
+          <span className="font-mono opacity-70">{chip.label}</span>
+          {CHIP_TEXT[chip.status]}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Title — the at-rest summary line shown next to the icon
 // ---------------------------------------------------------------------------
 
@@ -139,6 +243,7 @@ export function VcadToolCard({ call }: { call: ToolCallInfo }) {
       )}
       <ToolContent className="space-y-2 border-t border-border p-2 text-text">
         {extra}
+        <ClaimChips call={call} />
 
         {fields.length > 0 && (
           <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5 text-[10px]">

--- a/packages/app/src/hooks/useChatHandler.ts
+++ b/packages/app/src/hooks/useChatHandler.ts
@@ -32,6 +32,12 @@ import {
   SET_DOCUMENT_NAME_TOOL,
   executeAiDocumentTool,
 } from "@/lib/ai-document-tools";
+import {
+  MCP_CHAT_TOOL_NAMES,
+  MCP_TOOLS_SYSTEM_PROMPT_APPENDIX,
+  mcpChatTools,
+  executeMcpChatTool,
+} from "@/lib/mcp-chat-tools";
 
 /**
  * Parse a rate-limit error body emitted by streamChat with LIMIT_ERROR_PREFIX.
@@ -244,6 +250,7 @@ function runTurn(
 
     const tools = [
       ...commandRegistry.toAnthropicTools(),
+      ...mcpChatTools(),
       SCREENSHOT_VIEWPORT_TOOL,
       GET_DOCUMENT_NAME_TOOL,
       SET_DOCUMENT_NAME_TOOL,
@@ -254,6 +261,7 @@ function runTurn(
       SCREENSHOT_SYSTEM_PROMPT_APPENDIX +
       AI_CAMERA_SYSTEM_PROMPT_APPENDIX +
       AI_DOCUMENT_SYSTEM_PROMPT_APPENDIX +
+      MCP_TOOLS_SYSTEM_PROMPT_APPENDIX +
       buildSceneSnapshot();
 
     streamChat(history, context, {
@@ -571,6 +579,16 @@ export function useChatHandler() {
               }
             } else if (AI_CAMERA_TOOL_NAMES.has(tool.name)) {
               const exec = executeAiCamera(tool);
+              toolResults.push({ id: tool.id, content: exec.result, status: exec.status });
+              const entry = accumulatedToolCalls.find((t) => t.id === tool.id);
+              if (entry) {
+                entry.result = exec.result;
+                entry.status = exec.status;
+                entry.display = exec.display;
+                entry.duration = exec.duration;
+              }
+            } else if (MCP_CHAT_TOOL_NAMES.has(tool.name)) {
+              const exec = await executeMcpChatTool(tool);
               toolResults.push({ id: tool.id, content: exec.result, status: exec.status });
               const entry = accumulatedToolCalls.find((t) => t.id === tool.id);
               if (entry) {

--- a/packages/app/src/lib/mcp-chat-tools.ts
+++ b/packages/app/src/lib/mcp-chat-tools.ts
@@ -1,0 +1,256 @@
+/**
+ * Chat ⇄ MCP bridge: exposes the browser-safe MCP tool registry
+ * (`@vcad/mcp/browser-tools`) to the in-app assistant, so the ChatSidebar
+ * gains the long tail of kernel capability (inspect_cad, measure,
+ * check_clearance, dfm_check, analyze_structure, topology_optimize, …)
+ * from the SAME tool-definition source the MCP server advertises — no
+ * hand-mirroring; a new pure-compute MCP tool appears here automatically.
+ *
+ * Execution model: each call registers a deep clone of the live document as
+ * an MCP session, runs the real MCP handler against the app's WASM engine,
+ * then routes any document mutation back through the store so it lands on
+ * the normal CRDT undo/redo stack (`addFromIR` → `import_ir`). The clone
+ * means an MCP handler can never mutate app state behind the store's back.
+ */
+
+import {
+  useDocumentStore,
+  useEngineStore,
+  useUiStore,
+  type ExecutionDisplay,
+  type AnthropicTool,
+} from "@vcad/core";
+import type { Document } from "@vcad/ir";
+import { createDocument } from "@vcad/ir";
+import {
+  browserToolDefs,
+  runBrowserTool,
+  documents as mcpSessions,
+  registerSession,
+} from "@vcad/mcp/browser-tools";
+import type { ToolCall } from "@/lib/chat-api";
+
+/**
+ * MCP tools we do NOT surface in-app. Two reasons a tool lands here:
+ * - It already exists on the app's own command registry under another name
+ *   (the registry version routes through the store natively).
+ * - It mutates the document *in place* in ways the generic add-parts
+ *   write-back below can't translate into store mutations yet
+ *   (dfm_apply_fix rewrites existing nodes; record_measurement and
+ *   set_parameters write session state the app owns elsewhere).
+ */
+const EXCLUDED_IN_APP = new Set([
+  "dfm_apply_fix",
+  "record_measurement",
+  "set_parameters",
+]);
+
+const activeDefs = browserToolDefs.filter((d) => !EXCLUDED_IN_APP.has(d.name));
+
+/** Names of MCP tools callable from the in-app assistant. */
+export const MCP_CHAT_TOOL_NAMES = new Set(activeDefs.map((d) => d.name));
+
+export const MCP_TOOLS_SYSTEM_PROMPT_APPENDIX = `
+
+## Analysis & verification tools
+
+You also have the vcad solver/verification tools (inspect_cad, measure, check_clearance, dfm_check, analyze_structure, analyze_tolerance_stackup, solve_thermal, topology_optimize, predict_print, predict_physics, list_parameters, parameter_gradient). They operate on the current document automatically — never pass document_id or document arguments. Quantitative results from these tools are measured by the kernel; quote them with their verdicts (a claim can be pass, fail, or unverifiable — never present an unverifiable or predicted value as verified). topology_optimize adds its result to the document as a new part (undoable like any other edit).`;
+
+/** Strip the session-plumbing arguments from an MCP inputSchema — the app
+ *  injects the live document's session itself, the model never sees ids. */
+function stripDocArgs(
+  schema: Record<string, unknown>,
+): Record<string, unknown> {
+  const props = { ...((schema.properties as Record<string, unknown>) ?? {}) };
+  delete props.document_id;
+  delete props.document;
+  const required = Array.isArray(schema.required)
+    ? (schema.required as string[]).filter(
+        (r) => r !== "document_id" && r !== "document",
+      )
+    : undefined;
+  return {
+    ...schema,
+    properties: props,
+    ...(required ? { required } : {}),
+  };
+}
+
+/** The MCP tool surface as Anthropic tool descriptors for the chat turn. */
+export function mcpChatTools(): AnthropicTool[] {
+  return activeDefs.map((def) => ({
+    name: def.name,
+    description: def.description,
+    input_schema: stripDocArgs(def.inputSchema),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Result → display projection
+// ---------------------------------------------------------------------------
+
+/** Human labels for the compact field grid — everything else falls back to
+ *  the raw JSON view in the tool card. */
+function fieldsFromPayload(
+  payload: Record<string, unknown>,
+): Array<{ label: string; value: string }> {
+  const fields: Array<{ label: string; value: string }> = [];
+  for (const [key, value] of Object.entries(payload)) {
+    if (fields.length >= 10) break;
+    if (key === "success" || key === "document_id") continue;
+    if (
+      typeof value === "number" ||
+      typeof value === "string" ||
+      typeof value === "boolean"
+    ) {
+      fields.push({
+        label: key.replace(/_/g, " "),
+        value:
+          typeof value === "number"
+            ? Number.isInteger(value)
+              ? String(value)
+              : value.toFixed(3)
+            : String(value),
+      });
+    }
+  }
+  return fields;
+}
+
+function displayFor(
+  def: { name: string; title?: string },
+  payload: Record<string, unknown>,
+): ExecutionDisplay {
+  return {
+    summary: [{ type: "text", text: def.title ?? def.name }],
+    fields: fieldsFromPayload(payload),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Write-back: land parts an MCP handler added on the store's undo stack
+// ---------------------------------------------------------------------------
+
+/**
+ * Diff the session clone against the pre-call document and import any parts
+ * the handler added (topology_optimize's frozen result mesh, for example)
+ * via `addFromIR`, which routes through the CRDT engine's `import_ir` — a
+ * tracked mutation, so ⌘Z undoes it exactly like a manual edit.
+ */
+function importAddedParts(before: Document, after: Document): number {
+  const beforeNodes = new Set(Object.keys(before.nodes));
+  const beforeRoots = new Set(before.roots.map((r) => String(r.root)));
+  const newRoots = after.roots.filter((r) => !beforeRoots.has(String(r.root)));
+  if (newRoots.length === 0) return 0;
+
+  const mini = createDocument();
+  for (const [id, node] of Object.entries(after.nodes)) {
+    if (!beforeNodes.has(id)) mini.nodes[id] = node;
+  }
+  mini.roots = newRoots;
+  useDocumentStore.getState().addFromIR(mini);
+  return newRoots.length;
+}
+
+// ---------------------------------------------------------------------------
+// Execution
+// ---------------------------------------------------------------------------
+
+export interface McpToolExecution {
+  result: string;
+  status: "success" | "error";
+  display?: ExecutionDisplay;
+  duration?: number;
+}
+
+/** Execute one MCP browser tool against the live document + engine. */
+export async function executeMcpChatTool(
+  tool: ToolCall,
+): Promise<McpToolExecution> {
+  const started = performance.now();
+  const engine = useEngineStore.getState().engine;
+  if (!engine) {
+    return {
+      result: "Engine not ready yet — try again in a moment.",
+      status: "error",
+      duration: performance.now() - started,
+    };
+  }
+  const def = activeDefs.find((d) => d.name === tool.name);
+  if (!def) {
+    return {
+      result: `Unknown tool: ${tool.name}`,
+      status: "error",
+      duration: performance.now() - started,
+    };
+  }
+
+  // Register a deep clone of the live doc as a throwaway MCP session. The
+  // handler mutates the clone freely; anything it added flows back through
+  // the store (undo-tracked) in importAddedParts below.
+  const liveDoc = useDocumentStore.getState().document as unknown as Document;
+  const before = JSON.parse(JSON.stringify(liveDoc)) as Document;
+  const sessionDoc = JSON.parse(JSON.stringify(liveDoc)) as Document;
+  const sessionId = registerSession(sessionDoc);
+
+  try {
+    const res = await runBrowserTool(
+      tool.name,
+      { ...tool.args, document_id: sessionId },
+      engine,
+    );
+    const text = res.content?.[0]?.text ?? "";
+    const duration = performance.now() - started;
+    if (res.isError) {
+      let message = text;
+      try {
+        const parsed = JSON.parse(text) as { error?: string };
+        if (parsed.error) message = parsed.error;
+      } catch {
+        /* raw text error */
+      }
+      return { result: message, status: "error", duration };
+    }
+
+    let payload: Record<string, unknown> = {};
+    try {
+      payload = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+      /* non-JSON success body — leave payload empty */
+    }
+
+    // Land added parts on the store's undo stack (topology_optimize et al.).
+    if (def.behavior.writesDoc) {
+      importAddedParts(before, sessionDoc);
+    }
+
+    // check_clearance: draw the min-distance witness line in the viewport.
+    if (tool.name === "check_clearance") {
+      const wp = (payload.worst_pair ?? null) as {
+        point_a?: [number, number, number];
+        point_b?: [number, number, number];
+      } | null;
+      if (wp?.point_a && wp?.point_b) {
+        useUiStore.getState().setClearanceIndicator({
+          pointA: wp.point_a,
+          pointB: wp.point_b,
+          distanceMm:
+            typeof payload.measured_mm === "number" ? payload.measured_mm : 0,
+          pass: payload.pass === true,
+          ...(typeof payload.label === "string"
+            ? { label: payload.label }
+            : {}),
+        });
+      }
+    }
+
+    return {
+      result: text,
+      status: "success",
+      display: displayFor(def, payload),
+      duration,
+    };
+  } finally {
+    mcpSessions.delete(sessionId);
+  }
+}

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -64,6 +64,18 @@ export type FollowMode = "free" | "follow" | "lock";
  */
 export type InspectorTarget = { kind: "scene" } | null;
 
+/** A min-distance witness segment measured by `check_clearance`, drawn as a
+ *  viewport overlay (kernel Z-up coordinates, mm). */
+export interface ClearanceIndicator {
+  pointA: [number, number, number];
+  pointB: [number, number, number];
+  distanceMm: number;
+  /** Whether the measured distance met the required minimum. */
+  pass: boolean;
+  /** Optional persisted-spec label. */
+  label?: string;
+}
+
 export interface UiState {
   /** Tagged-union selection — parts, faces, edges, vertices, segments,
    *  constraints. Source of truth for everything selected. */
@@ -92,6 +104,12 @@ export interface UiState {
    *  rendered in this mode so the AI can orient itself without guessing
    *  which direction is "right" or "front". Always false in normal use. */
   captureMode: boolean;
+  /** Min-distance measurement drawn in the viewport after a chat
+   *  `check_clearance` tool call — the witness segment between the closest
+   *  pair of points, with the measured distance and pass/fail. Null when no
+   *  measurement is being shown. Cleared on the next document mutation is the
+   *  caller's concern; the overlay itself just renders whatever is set. */
+  clearanceIndicator: ClearanceIndicator | null;
   showWireframe: boolean;
   gridSnap: boolean;
   pointSnap: boolean;
@@ -184,6 +202,7 @@ export interface UiState {
   setDraggingGizmo: (dragging: boolean) => void;
   setOrbiting: (orbiting: boolean) => void;
   setCaptureMode: (on: boolean) => void;
+  setClearanceIndicator: (indicator: ClearanceIndicator | null) => void;
   copyToClipboard: (partIds: string[]) => void;
   showDeleteConfirm: (partIds: string[]) => void;
   hideDeleteConfirm: () => void;
@@ -296,6 +315,7 @@ export const useUiStore = create<UiState>((set) => ({
   isDraggingGizmo: false,
   isOrbiting: false,
   captureMode: false,
+  clearanceIndicator: null,
   showWireframe: false,
   gridSnap: true,
   pointSnap: true,
@@ -436,6 +456,8 @@ export const useUiStore = create<UiState>((set) => ({
   setOrbiting: (orbiting) => set({ isOrbiting: orbiting }),
 
   setCaptureMode: (on) => set({ captureMode: on }),
+
+  setClearanceIndicator: (indicator) => set({ clearanceIndicator: indicator }),
 
   copyToClipboard: (partIds) => set({ clipboard: partIds }),
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,6 +12,7 @@
     ".": "./dist/index.js",
     "./server": "./dist/server.js",
     "./viewer": "./dist/viewer.js",
+    "./browser-tools": "./dist/browser-tools.js",
     "./oauth": "./dist/oauth.js"
   },
   "files": [

--- a/packages/mcp/src/browser-tools.ts
+++ b/packages/mcp/src/browser-tools.ts
@@ -1,0 +1,134 @@
+/**
+ * Browser-safe MCP tool registry — the shared tool-definition source the web
+ * app's ChatSidebar consumes so in-app chat gains the MCP tool surface
+ * without hand-mirroring (issue #594).
+ *
+ * Every module imported here must be free of Node builtins all the way down:
+ * the only session dependency allowed is `session-core.ts` (the browser-safe
+ * split of `session.ts`). Server-only tools (export/import/order/share/verify,
+ * anything touching fs or network) stay out; they remain reachable only via
+ * the real MCP server.
+ *
+ * A new pure-compute tool appears in-app automatically once its module is
+ * added to `BROWSER_TOOL_MODULES` — one line, no schema mirroring.
+ */
+
+import type { Engine } from "@vcad/engine";
+import type { ToolDef, ToolContext } from "./tools/tool-def.js";
+import type { ToolResult } from "./tools/tool-result.js";
+import { TOOL_METADATA } from "./tools/tool-metadata.js";
+
+import { toolDefs as inspectTools } from "./tools/inspect.js";
+import { toolDefs as measureTools } from "./tools/measure.js";
+import { toolDefs as clearanceTools } from "./tools/clearance.js";
+import { toolDefs as dfmTools } from "./tools/dfm.js";
+import { toolDefs as toleranceTools } from "./tools/tolerance.js";
+import { toolDefs as thermalTools } from "./tools/thermal.js";
+import { toolDefs as structureTools } from "./tools/structure.js";
+import { toolDefs as topoptTools } from "./tools/topopt.js";
+import { toolDefs as parameterTools } from "./tools/parameters.js";
+import { toolDefs as printCheckTools } from "./tools/print-check.js";
+import { toolDefs as physicsTools } from "./tools/physics.js";
+
+export {
+  documents,
+  registerSession,
+  getSession,
+  recordHistorySnapshot,
+  undoLastSnapshot,
+  getLastChanged,
+} from "./tools/session-core.js";
+export type { ToolDef, ToolContext } from "./tools/tool-def.js";
+export type { ToolResult } from "./tools/tool-result.js";
+
+/** Pure-compute tool modules whose defs are safe to run in the browser
+ *  against the app's own WASM engine. Add a module here and every tool it
+ *  defines appears in the in-app assistant automatically. */
+const BROWSER_TOOL_MODULES: ToolDef[][] = [
+  inspectTools,
+  measureTools,
+  clearanceTools,
+  dfmTools,
+  toleranceTools,
+  thermalTools,
+  structureTools,
+  topoptTools,
+  parameterTools,
+  printCheckTools,
+  physicsTools,
+];
+
+/** All browser-runnable MCP tool defs, with display titles merged from the
+ *  central metadata table (same source the MCP server advertises). */
+export const browserToolDefs: ToolDef[] = BROWSER_TOOL_MODULES.flat().map(
+  (def) => {
+    const meta = TOOL_METADATA[def.name];
+    return meta
+      ? { ...def, title: meta.title, annotations: meta.annotations }
+      : def;
+  },
+);
+
+const byName = new Map(browserToolDefs.map((d) => [d.name, d]));
+
+/** Look up a browser tool def by name, or undefined. */
+export function getBrowserTool(name: string): ToolDef | undefined {
+  return byName.get(name);
+}
+
+/** An Anthropic Messages-API tool descriptor (the shape the app's /api/chat
+ *  proxy forwards). */
+export interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+/** The browser tool surface as Anthropic tool descriptors, ready to merge
+ *  with the app's commandRegistry tools. */
+export function browserToolsToAnthropic(): AnthropicTool[] {
+  return browserToolDefs.map((def) => ({
+    name: def.name,
+    description: def.description,
+    input_schema: def.inputSchema,
+  }));
+}
+
+/**
+ * Run a browser tool by name against the given engine. The caller (the app's
+ * chat bridge) is responsible for registering its live document as a session
+ * first and passing the resulting `document_id` in `args`. Only `ctx.engine`
+ * is populated — the pure-compute tools never touch the server-side stores,
+ * which don't exist in the browser.
+ */
+export async function runBrowserTool(
+  name: string,
+  args: Record<string, unknown>,
+  engine: Engine,
+): Promise<ToolResult> {
+  const def = byName.get(name);
+  if (!def) {
+    return {
+      isError: true,
+      content: [
+        { type: "text", text: JSON.stringify({ error: `Unknown tool: ${name}` }) },
+      ],
+    };
+  }
+  // Pure-compute handlers read only ctx.engine; the store fields are
+  // server-side services that have no browser counterpart.
+  const ctx = { engine, user: null } as unknown as ToolContext;
+  try {
+    return await def.handler(args, ctx);
+  } catch (e) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ error: e instanceof Error ? e.message : String(e) }),
+        },
+      ],
+    };
+  }
+}

--- a/packages/mcp/src/tools/clearance.ts
+++ b/packages/mcp/src/tools/clearance.ts
@@ -26,7 +26,7 @@ import type {
 import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
 import { transformMesh } from "@vcad/engine";
 import { unverifiableClaim } from "../receipt-unified.js";
-import { getSession } from "./session.js";
+import { getSession } from "./session-core.js";
 
 /** Claim-id prefix shared with the Rust mech adapter (`vcad-receipt`). */
 export const CLEARANCE_CLAIM_PREFIX = "mech.clearance.";

--- a/packages/mcp/src/tools/dfm.ts
+++ b/packages/mcp/src/tools/dfm.ts
@@ -23,7 +23,7 @@ import type {
 import { runDfm, runPcbDfm } from "@vcad/engine";
 import type { Document, Node, Pcb } from "@vcad/ir";
 import { getNodePcb, getPcbNodeIds } from "@vcad/core";
-import { documents, resolveDocInput } from "./session.js";
+import { documents, resolveDocInput } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
 /** Most-recent report per session, used by explain / suggest / apply.

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -11,7 +11,7 @@
 import { transformMesh, type Engine, type TriangleMesh } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { isoperimetricViolation } from "./integrity.js";
-import { resolveDocInput } from "./session.js";
+import { resolveDocInput } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
 export const inspectCadSchema = {

--- a/packages/mcp/src/tools/measure.ts
+++ b/packages/mcp/src/tools/measure.ts
@@ -24,7 +24,7 @@ import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
 import { transformMesh } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { computeMeshProperties, type BoundingBox } from "./inspect.js";
-import { getSession } from "./session.js";
+import { getSession } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
 /** Round to micron precision so payloads don't carry float noise. */

--- a/packages/mcp/src/tools/parameters.ts
+++ b/packages/mcp/src/tools/parameters.ts
@@ -22,7 +22,7 @@ import { behavior, type ToolDef } from "./tool-def.js";
 import { resolveParameters } from "@vcad/engine";
 import type { Document, Expr, Parameter } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
-import { getSession, resolveDocInput } from "./session.js";
+import { getSession, resolveDocInput } from "./session-core.js";
 
 /** MCP result shape used across these tools. */
 type ToolResult = {

--- a/packages/mcp/src/tools/physics.ts
+++ b/packages/mcp/src/tools/physics.ts
@@ -12,7 +12,7 @@
 
 import type { Engine, StaticAnalysisSpec, StaticAnalysisResult } from "@vcad/engine";
 import type { DesignReceipt, ReceiptClaim, OracleRef } from "@vcad/ir";
-import { getSession } from "./session.js";
+import { getSession } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import { resolvePartMesh } from "./topopt.js";
 import { RECEIPT_SCHEMA, summarize, unverifiableClaim } from "../receipt-unified.js";

--- a/packages/mcp/src/tools/print-check.ts
+++ b/packages/mcp/src/tools/print-check.ts
@@ -30,7 +30,7 @@ import {
   type MeasurementContext,
   type PrintPrediction,
 } from "@vcad/core";
-import { getSession } from "./session.js";
+import { getSession } from "./session-core.js";
 import { computeInspection } from "./inspect.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 

--- a/packages/mcp/src/tools/session-core.ts
+++ b/packages/mcp/src/tools/session-core.ts
@@ -1,0 +1,242 @@
+/**
+ * Browser-safe core of the MCP session layer: the document cache, session
+ * ids, undo snapshots, and the dual-mode document-input resolver. Split out
+ * of `session.ts` so pure-compute tool modules (inspect, measure, clearance,
+ * dfm, …) can bundle into the web app — this module imports no Node
+ * builtins. `session.ts` re-exports everything here and layers the
+ * Node-only parts on top (AsyncLocalStorage connection scoping, file-backed
+ * save/load, the session tool defs).
+ */
+
+import { type Document } from "@vcad/ir";
+
+// ─── Session cache (per-connection isolated, or process-wide fallback) ────────
+//
+// The cache used to be a single process-global Map keyed by bare document_id,
+// shared across every connection on a warm serverless instance. Once sessions
+// became user-owned that was a cross-tenant leak: user B passing user A's id
+// would read A's warm-cached doc straight from the shared Map (getSession does
+// no ownership check). The fix: a signed-in connection runs inside an
+// AsyncLocalStorage scope with its OWN per-request Map — installed by
+// `session.ts` via `setSessionScopeProvider` (AsyncLocalStorage is Node-only,
+// so the indirection keeps this module browser-safe). Anonymous / stdio /
+// in-browser callers have no tenant boundary and use the process-wide
+// fallback.
+
+/** Process-wide fallback cache: anonymous hosted calls, stdio, in-browser,
+ *  and any access outside a per-connection scope. */
+const fallbackDocuments = new Map<string, Document>();
+
+/** Returns the current connection's isolated cache, or null to use the
+ *  fallback. Installed by the Node layer (`session.ts`). */
+let scopeProvider: () => Map<string, Document> | null = () => null;
+
+/** Install the per-connection cache provider (Node's AsyncLocalStorage
+ *  bridge). Browser bundles never call this. */
+export function setSessionScopeProvider(
+  provider: () => Map<string, Document> | null,
+): void {
+  scopeProvider = provider;
+}
+
+/** The cache for the current connection: a signed-in user's isolated
+ *  per-request Map, or the process-wide fallback. */
+function activeDocuments(): Map<string, Document> {
+  return scopeProvider() ?? fallbackDocuments;
+}
+
+/**
+ * Session cache facade. Every read/write routes to the active cache
+ * (`activeDocuments`), so all existing `documents.has/get/set/delete/clear`
+ * call sites — here, in server.ts, in dfm.ts, and in tests — are transparently
+ * scope-aware with no change. Exported (in place of the raw Map) so tests can
+ * still clear/inspect it; outside any scope it is exactly the fallback Map. */
+export const documents = {
+  has: (id: string): boolean => activeDocuments().has(id),
+  get: (id: string): Document | undefined => activeDocuments().get(id),
+  set: (id: string, doc: Document): Map<string, Document> =>
+    activeDocuments().set(id, doc),
+  delete: (id: string): boolean => activeDocuments().delete(id),
+  clear: (): void => activeDocuments().clear(),
+  get size(): number {
+    return activeDocuments().size;
+  },
+};
+
+let nextId = 1;
+
+/** 9 random bytes as base64url, via WebCrypto so it works in both Node and
+ *  the browser (node:crypto is unavailable in app bundles). */
+function randomSuffix(): string {
+  const bytes = new Uint8Array(9);
+  globalThis.crypto.getRandomValues(bytes);
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export function nextSessionId(): string {
+  // The counter keeps intra-process uniqueness; the random suffix makes the id
+  // unguessable. Once a session persists to a user's account the id is a
+  // capability — sequential ids would let one caller enumerate another's
+  // warm-cache sessions.
+  return `doc_${nextId++}_${randomSuffix()}`;
+}
+
+/** Register a freshly-built document as a session and return its id.
+ *  Lets other tools (e.g. `sheet_metal_create`) hand back a
+ *  `document_id` that `inspect_cad` / `export_cad` / `open_in_browser`
+ *  can then operate on, without duplicating the id scheme. */
+export function registerSession(doc: Document): string {
+  const id = nextSessionId();
+  documents.set(id, doc);
+  return id;
+}
+
+/** Get a session document by id, or throw a helpful error. Synchronous and
+ *  cache-only by design — the dispatch layer runs `hydrateSession` first, so a
+ *  durably-stored session is already resident here by the time a tool reads
+ *  it, and a genuine miss still throws the pinned error. */
+export function getSession(documentId: string): Document {
+  const doc = documents.get(documentId);
+  if (!doc) {
+    throw new Error(
+      `Unknown document_id "${documentId}". Open one with open_document first, or list active sessions with the documents map.`,
+    );
+  }
+  return doc;
+}
+
+// ─── Dual-mode document input (session id OR inline document) ─────────────────
+//
+// The primary path is always a live `document_id` session. But a warm session
+// is process-local: after a cold start or a serverless instance flip the id no
+// longer resolves. An inline `document` object is the stateless escape hatch —
+// the caller pastes the IR it already holds and the tool runs without a
+// resident session. Generalized here (it began as ecad's private helper) so the
+// core read-only tools share one contract and one error string.
+
+/** A resolved document input: session-backed (preferred) or inline (the
+ *  stateless escape hatch for cold serverless instances). */
+export interface DocInputCtx {
+  doc: Document;
+  /** Set when the doc came from a live server session. */
+  documentId?: string;
+}
+
+/**
+ * Resolve a tool's document argument. `document_id` (a live session) is the
+ * primary path; an inline document object is the stateless fallback that still
+ * works when no session is resident (cold instance / instance flip). By default
+ * the inline field is `document`; pass `inlineKeys` to accept aliases (e.g.
+ * export_cad's legacy `ir`), tried in order.
+ */
+export function resolveDocInput(
+  args: Record<string, unknown>,
+  inlineKeys: readonly string[] = ["document"],
+): DocInputCtx {
+  const id = args.document_id ? String(args.document_id) : "";
+  if (id) return { doc: getSession(id), documentId: id };
+  for (const key of inlineKeys) {
+    const inline = args[key];
+    if (inline && typeof inline === "object") return { doc: inline as Document };
+  }
+  const names = inlineKeys.map((k) => `\`${k}\``).join(" or ");
+  throw new Error(
+    `Pass \`document_id\` (from open_document) — or an inline ${names} object for the stateless flow.`,
+  );
+}
+
+// ─── Per-session undo history (in-memory snapshot stack) ──────────────────────
+//
+// The event spine (session_events) is an append-only telemetry/realtime log,
+// not a reconstruction fold: it records {tool, args, changed} — never enough to
+// rebuild geometry — and is a no-op without Supabase env (stdio/local). So undo
+// can't be "fold all-but-last event". Instead the dispatch layer snapshots the
+// document *before* each mutation onto this stack, and `undo` pops the last
+// snapshot back into the live session. Restoring a full snapshot is exact and
+// works identically on stdio, anonymous, and signed-in deployments.
+//
+// The stack is process-global (NOT per-request-scoped) so it survives across
+// the per-connection session scopes a signed-in user gets — a snapshot pushed
+// on call N must still be poppable on call N+1. It's keyed by the unguessable
+// document_id (the session capability), and a pop only ever writes back into a
+// session the caller already resolved via getSession, so it leaks nothing
+// cross-tenant. Depth is capped so a long editing session can't grow unbounded.
+
+/** Max snapshots retained per session — older edits drop off the bottom. */
+const MAX_HISTORY = 50;
+
+/** document_id → stack of pre-mutation Document snapshots (oldest first). */
+const sessionHistory = new Map<string, Document[]>();
+
+/** Deep clone a document — the same JSON round-trip openDocument uses, so a
+ *  later in-place mutation can never corrupt a retained snapshot. */
+function cloneDoc(doc: Document): Document {
+  return JSON.parse(JSON.stringify(doc)) as Document;
+}
+
+/**
+ * Push the current state of a session onto its undo stack, to be called by the
+ * dispatch layer right before a mutating tool runs. No-op when the session
+ * isn't resident (nothing to snapshot). Caps the stack at MAX_HISTORY by
+ * dropping the oldest entry.
+ */
+export function recordHistorySnapshot(documentId: string): void {
+  const doc = documents.get(documentId);
+  if (!doc) return;
+  const stack = sessionHistory.get(documentId) ?? [];
+  stack.push(cloneDoc(doc));
+  if (stack.length > MAX_HISTORY) stack.shift();
+  sessionHistory.set(documentId, stack);
+}
+
+/** Number of undo steps available for a session. */
+export function historyDepth(documentId: string): number {
+  return sessionHistory.get(documentId)?.length ?? 0;
+}
+
+/**
+ * Pop the last snapshot and restore it as the live session document. Returns
+ * the restored Document, or null when there's nothing to undo. The caller is
+ * expected to have already resolved the session (getSession) so ownership is
+ * enforced before any state is rewound.
+ */
+export function undoLastSnapshot(documentId: string): Document | null {
+  const stack = sessionHistory.get(documentId);
+  if (!stack || stack.length === 0) return null;
+  const snapshot = stack.pop()!;
+  if (stack.length === 0) sessionHistory.delete(documentId);
+  documents.set(documentId, snapshot);
+  return snapshot;
+}
+
+/** Drop a session's undo history (on close/drop) so it can't outlive the doc. */
+export function clearHistory(documentId: string): void {
+  sessionHistory.delete(documentId);
+  lastChangedParts.delete(documentId);
+}
+
+// ─── Last mutation diff (per session) ─────────────────────────────────────────
+//
+// Every mutation result carries a `changed` diff of the parts it touched; this
+// map remembers the most recent one so `render_view {highlight_changed: true}`
+// can spotlight exactly those parts without the agent re-plumbing ids. Process-
+// local, like the undo stack: after an instance flip there is no "last
+// mutation", and render_view reports that instead of guessing.
+
+/** document_id → part ids from the most recent mutation's `changed` diff
+ *  (added + modified; removed parts no longer exist to highlight). */
+const lastChangedParts = new Map<string, string[]>();
+
+/** Record the part ids a mutation just touched (added + modified). */
+export function recordLastChanged(documentId: string, partIds: string[]): void {
+  if (!documentId) return;
+  lastChangedParts.set(documentId, partIds);
+}
+
+/** Part ids from the session's most recent mutation diff, or null when no
+ *  mutation has been recorded on this instance. */
+export function getLastChanged(documentId: string): string[] | null {
+  return lastChangedParts.get(documentId) ?? null;
+}

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -19,34 +19,49 @@ import { maxInlineArtifactBytes } from "./remote.js";
 import type { SessionStore } from "../session-store.js";
 import type { AuthUser } from "../oauth.js";
 import { behavior, type ToolDef } from "./tool-def.js";
+import {
+  documents,
+  nextSessionId,
+  registerSession,
+  getSession,
+  clearHistory,
+  setSessionScopeProvider,
+} from "./session-core.js";
 
-// ─── Session cache (per-connection isolated, or process-wide fallback) ────────
+// The browser-safe core of the session layer (document cache, ids, undo
+// snapshots, resolveDocInput) lives in session-core.ts so pure-compute tool
+// modules can bundle into the web app. This module re-exports it and adds the
+// Node-only pieces: AsyncLocalStorage connection scoping, file-backed
+// save/load, and the session tool defs.
+export {
+  documents,
+  nextSessionId,
+  registerSession,
+  getSession,
+  resolveDocInput,
+  recordHistorySnapshot,
+  historyDepth,
+  undoLastSnapshot,
+  clearHistory,
+  recordLastChanged,
+  getLastChanged,
+  type DocInputCtx,
+} from "./session-core.js";
+
+// ─── Per-connection scoping (Node-only: AsyncLocalStorage) ────────────────────
 //
-// The cache used to be a single process-global Map keyed by bare document_id,
-// shared across every connection on a warm serverless instance. Once sessions
-// became user-owned that was a cross-tenant leak: user B passing user A's id
-// would read A's warm-cached doc straight from the shared Map (getSession does
-// no ownership check). The fix: a signed-in connection runs inside an
-// AsyncLocalStorage scope with its OWN per-request Map, populated only from
-// that user's (user-scoped) durable store — so a cache hit can never serve
-// another tenant's document, and the per-request Map is GC'd after the request
-// (no unbounded growth). Anonymous / stdio callers have no tenant boundary and
-// keep the process-wide fallback (cross-request warm cache, today's behavior).
-
-/** Process-wide fallback cache: anonymous hosted calls, stdio, and any access
- *  outside a per-connection scope (e.g. direct test calls). */
-const fallbackDocuments = new Map<string, Document>();
+// A signed-in connection runs inside an AsyncLocalStorage scope with its OWN
+// per-request document Map, populated only from that user's (user-scoped)
+// durable store — so a cache hit can never serve another tenant's document.
+// The scope is installed into session-core via setSessionScopeProvider;
+// browser bundles never import this module, so they keep the fallback Map.
 
 const sessionScope = new AsyncLocalStorage<{
   documents: Map<string, Document>;
   user: AuthUser | null;
 }>();
 
-/** The cache for the current connection: a signed-in user's isolated
- *  per-request Map, or the process-wide fallback. */
-function activeDocuments(): Map<string, Document> {
-  return sessionScope.getStore()?.documents ?? fallbackDocuments;
-}
+setSessionScopeProvider(() => sessionScope.getStore()?.documents ?? null);
 
 /**
  * Run `fn` with an isolated per-connection session cache when `user` is signed
@@ -65,192 +80,6 @@ export function runInSessionScope<T>(user: AuthUser | null, fn: () => T): T {
  *  Read by telemetry to attribute events; outside any scope returns null. */
 export function currentUser(): AuthUser | null {
   return sessionScope.getStore()?.user ?? null;
-}
-
-/**
- * Session cache facade. Every read/write routes to the active cache
- * (`activeDocuments`), so all existing `documents.has/get/set/delete/clear`
- * call sites — here, in server.ts, in dfm.ts, and in tests — are transparently
- * scope-aware with no change. Exported (in place of the raw Map) so tests can
- * still clear/inspect it; outside any scope it is exactly the fallback Map. */
-export const documents = {
-  has: (id: string): boolean => activeDocuments().has(id),
-  get: (id: string): Document | undefined => activeDocuments().get(id),
-  set: (id: string, doc: Document): Map<string, Document> =>
-    activeDocuments().set(id, doc),
-  delete: (id: string): boolean => activeDocuments().delete(id),
-  clear: (): void => activeDocuments().clear(),
-  get size(): number {
-    return activeDocuments().size;
-  },
-};
-
-let nextId = 1;
-
-function nextSessionId(): string {
-  // The counter keeps intra-process uniqueness; the random suffix makes the id
-  // unguessable. Once a session persists to a user's account the id is a
-  // capability — sequential ids would let one caller enumerate another's
-  // warm-cache sessions.
-  return `doc_${nextId++}_${randomBytes(9).toString("base64url")}`;
-}
-
-/** Register a freshly-built document as a session and return its id.
- *  Lets other tools (e.g. `sheet_metal_create`) hand back a
- *  `document_id` that `inspect_cad` / `export_cad` / `open_in_browser`
- *  can then operate on, without duplicating the id scheme. */
-export function registerSession(doc: Document): string {
-  const id = nextSessionId();
-  documents.set(id, doc);
-  return id;
-}
-
-/** Get a session document by id, or throw a helpful error. Synchronous and
- *  cache-only by design — the dispatch layer runs `hydrateSession` first, so a
- *  durably-stored session is already resident here by the time a tool reads
- *  it, and a genuine miss still throws the pinned error. */
-export function getSession(documentId: string): Document {
-  const doc = documents.get(documentId);
-  if (!doc) {
-    throw new Error(
-      `Unknown document_id "${documentId}". Open one with open_document first, or list active sessions with the documents map.`,
-    );
-  }
-  return doc;
-}
-
-// ─── Dual-mode document input (session id OR inline document) ─────────────────
-//
-// The primary path is always a live `document_id` session. But a warm session
-// is process-local: after a cold start or a serverless instance flip the id no
-// longer resolves. An inline `document` object is the stateless escape hatch —
-// the caller pastes the IR it already holds and the tool runs without a
-// resident session. Generalized here (it began as ecad's private helper) so the
-// core read-only tools share one contract and one error string.
-
-/** A resolved document input: session-backed (preferred) or inline (the
- *  stateless escape hatch for cold serverless instances). */
-export interface DocInputCtx {
-  doc: Document;
-  /** Set when the doc came from a live server session. */
-  documentId?: string;
-}
-
-/**
- * Resolve a tool's document argument. `document_id` (a live session) is the
- * primary path; an inline document object is the stateless fallback that still
- * works when no session is resident (cold instance / instance flip). By default
- * the inline field is `document`; pass `inlineKeys` to accept aliases (e.g.
- * export_cad's legacy `ir`), tried in order.
- */
-export function resolveDocInput(
-  args: Record<string, unknown>,
-  inlineKeys: readonly string[] = ["document"],
-): DocInputCtx {
-  const id = args.document_id ? String(args.document_id) : "";
-  if (id) return { doc: getSession(id), documentId: id };
-  for (const key of inlineKeys) {
-    const inline = args[key];
-    if (inline && typeof inline === "object") return { doc: inline as Document };
-  }
-  const names = inlineKeys.map((k) => `\`${k}\``).join(" or ");
-  throw new Error(
-    `Pass \`document_id\` (from open_document) — or an inline ${names} object for the stateless flow.`,
-  );
-}
-
-// ─── Per-session undo history (in-memory snapshot stack) ──────────────────────
-//
-// The event spine (session_events) is an append-only telemetry/realtime log,
-// not a reconstruction fold: it records {tool, args, changed} — never enough to
-// rebuild geometry — and is a no-op without Supabase env (stdio/local). So undo
-// can't be "fold all-but-last event". Instead the dispatch layer snapshots the
-// document *before* each mutation onto this stack, and `undo` pops the last
-// snapshot back into the live session. Restoring a full snapshot is exact and
-// works identically on stdio, anonymous, and signed-in deployments.
-//
-// The stack is process-global (NOT per-request-scoped) so it survives across
-// the per-connection session scopes a signed-in user gets — a snapshot pushed
-// on call N must still be poppable on call N+1. It's keyed by the unguessable
-// document_id (the session capability), and a pop only ever writes back into a
-// session the caller already resolved via getSession, so it leaks nothing
-// cross-tenant. Depth is capped so a long editing session can't grow unbounded.
-
-/** Max snapshots retained per session — older edits drop off the bottom. */
-const MAX_HISTORY = 50;
-
-/** document_id → stack of pre-mutation Document snapshots (oldest first). */
-const sessionHistory = new Map<string, Document[]>();
-
-/** Deep clone a document — the same JSON round-trip openDocument uses, so a
- *  later in-place mutation can never corrupt a retained snapshot. */
-function cloneDoc(doc: Document): Document {
-  return JSON.parse(JSON.stringify(doc)) as Document;
-}
-
-/**
- * Push the current state of a session onto its undo stack, to be called by the
- * dispatch layer right before a mutating tool runs. No-op when the session
- * isn't resident (nothing to snapshot). Caps the stack at MAX_HISTORY by
- * dropping the oldest entry.
- */
-export function recordHistorySnapshot(documentId: string): void {
-  const doc = documents.get(documentId);
-  if (!doc) return;
-  const stack = sessionHistory.get(documentId) ?? [];
-  stack.push(cloneDoc(doc));
-  if (stack.length > MAX_HISTORY) stack.shift();
-  sessionHistory.set(documentId, stack);
-}
-
-/** Number of undo steps available for a session. */
-export function historyDepth(documentId: string): number {
-  return sessionHistory.get(documentId)?.length ?? 0;
-}
-
-/**
- * Pop the last snapshot and restore it as the live session document. Returns
- * the restored Document, or null when there's nothing to undo. The caller is
- * expected to have already resolved the session (getSession) so ownership is
- * enforced before any state is rewound.
- */
-export function undoLastSnapshot(documentId: string): Document | null {
-  const stack = sessionHistory.get(documentId);
-  if (!stack || stack.length === 0) return null;
-  const snapshot = stack.pop()!;
-  if (stack.length === 0) sessionHistory.delete(documentId);
-  documents.set(documentId, snapshot);
-  return snapshot;
-}
-
-/** Drop a session's undo history (on close/drop) so it can't outlive the doc. */
-export function clearHistory(documentId: string): void {
-  sessionHistory.delete(documentId);
-  lastChangedParts.delete(documentId);
-}
-
-// ─── Last mutation diff (per session) ─────────────────────────────────────────
-//
-// Every mutation result carries a `changed` diff of the parts it touched; this
-// map remembers the most recent one so `render_view {highlight_changed: true}`
-// can spotlight exactly those parts without the agent re-plumbing ids. Process-
-// local, like the undo stack: after an instance flip there is no "last
-// mutation", and render_view reports that instead of guessing.
-
-/** document_id → part ids from the most recent mutation's `changed` diff
- *  (added + modified; removed parts no longer exist to highlight). */
-const lastChangedParts = new Map<string, string[]>();
-
-/** Record the part ids a mutation just touched (added + modified). */
-export function recordLastChanged(documentId: string, partIds: string[]): void {
-  if (!documentId) return;
-  lastChangedParts.set(documentId, partIds);
-}
-
-/** Part ids from the session's most recent mutation diff, or null when no
- *  mutation has been recorded on this instance. */
-export function getLastChanged(documentId: string): string[] | null {
-  return lastChangedParts.get(documentId) ?? null;
 }
 
 // ─── Durable cache ⇄ store bridge ─────────────────────────────────────────────

--- a/packages/mcp/src/tools/structure.ts
+++ b/packages/mcp/src/tools/structure.ts
@@ -17,7 +17,7 @@
  * attached (safety factor included when a yield strength is given).
  */
 
-import { getSession } from "./session.js";
+import { getSession } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import { resolvePartMesh } from "./topopt.js";
 

--- a/packages/mcp/src/tools/topopt.ts
+++ b/packages/mcp/src/tools/topopt.ts
@@ -21,7 +21,7 @@ import type {
   TopoOptSpec,
   TriangleMesh,
 } from "@vcad/engine";
-import { getSession, registerSession } from "./session.js";
+import { getSession, registerSession } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
 const regionSchema = {


### PR DESCRIPTION
Closes #594.

## What

The in-app ChatSidebar assistant now consumes the **same tool-definition source** as the MCP server — the solver/verification surface (`inspect_cad`, `measure`, `check_clearance`, `dfm_check`, `analyze_structure`, `topology_optimize`, `analyze_tolerance_stackup`, `solve_thermal`, `predict_print`, `predict_physics`, `list_parameters`, `parameter_gradient`, …) is callable in-app, with rich viewport rendering and receipt chips.

## How

- **`@vcad/mcp` browser-safe split**: `tools/session.ts` → new `tools/session-core.ts` (document cache, session ids, undo snapshots, `resolveDocInput`; WebCrypto ids, injectable AsyncLocalStorage scope — zero Node builtins). The Node layer re-exports it unchanged, so the server surface and tests are untouched (883 mcp tests pass).
- **New `@vcad/mcp/browser-tools` export**: 17 pure-compute `ToolDef`s + Anthropic-tool conversion + a runner. Adding a pure-compute tool module there is one line — it appears in-app automatically, no schema mirroring. Verified browser-clean via an esbuild `--platform=browser` bundle.
- **App bridge** (`packages/app/src/lib/mcp-chat-tools.ts`): each call registers a deep clone of the live document as an MCP session and runs the real MCP handler against the app's WASM engine. Session-plumbing args (`document_id`/`document`) are stripped from the advertised schemas and injected by the bridge.
- **Undo/redo**: parts a handler adds (e.g. `topology_optimize`'s frozen result mesh) are diffed out of the session clone and landed via `addFromIR` → CRDT `import_ir`, a tracked mutation — ⌘Z works and the part shows in the FeatureTree. In-place mutators without a store translation yet (`dfm_apply_fix`, `set_parameters`, `record_measurement`) are excluded in-app.
- **Rich results**: `check_clearance` draws the min-distance witness segment in the viewport (green/red by verdict, distance label, dismissible). Tool cards render **receipt claim chips** — Holds / Provisional / Violated / Unverifiable — parsed from `vcad.receipt/1` claims in any tool payload, so quantitative claims carry their verdicts.

## Testing

- `@vcad/mcp`: 883 passed / 2 skipped
- `@vcad/core`: 127 passed; `@vcad/app` tests: 55 passed
- `tsc --noEmit` clean in mcp and app; app Vite build clean
- No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)