### PR TITLE
Wire shop-ready drawings + PDF export into DrawingView

### DIFF
--- a/changelog/entries/2026-07-18-shop-ready-drawings.json
+++ b/changelog/entries/2026-07-18-shop-ready-drawings.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-18-shop-ready-drawings",
+  "version": "0.9.4",
+  "date": "2026-07-18",
+  "category": "feat",
+  "title": "Shop-ready drawings: sections, title block, BOM, PDF",
+  "summary": "Drawing mode gains offset section views, a title block editor, BOM table placement, and kernel-rendered PDF export from the toolbar, File menu, and command palette.",
+  "features": ["drafting", "drawing", "pdf", "sections", "bom"],
+  "mcpTools": []
+}

--- a/crates/vcad-app/src/feature.rs
+++ b/crates/vcad-app/src/feature.rs
@@ -331,6 +331,18 @@ pub enum FeatureInput {
         #[serde(skip_serializing_if = "Option::is_none")]
         sheet: Option<String>,
     },
+    /// Drawing sheet settings (title block, section lines, BOM visibility).
+    DrawingSettings {
+        /// Title block fields (JSON-serialized `DrawingTitleBlock`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title_block: Option<String>,
+        /// Section lines (JSON-serialized `Vec<DrawingSectionLine>`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sections: Option<String>,
+        /// BOM table visibility (JSON bool).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        show_bom: Option<String>,
+    },
     /// Atomic / molecular system (the `molecule` document domain).
     Molecule {
         /// System data (JSON-serialized `MoleculeSystem`).
@@ -367,6 +379,7 @@ impl FeatureInput {
             Self::Instance { .. } => "instance",
             Self::Joint { .. } => "joint",
             Self::SceneSettings { .. } => "scene-settings",
+            Self::DrawingSettings { .. } => "drawing-settings",
             Self::Schematic { .. } => "schematic",
             Self::Molecule { .. } => "molecule",
         }
@@ -669,6 +682,21 @@ impl FeatureInput {
                     p.insert("camera_presets".into(), Value::String(v.clone()));
                 }
             }
+            Self::DrawingSettings {
+                title_block,
+                sections,
+                show_bom,
+            } => {
+                if let Some(v) = title_block {
+                    p.insert("title_block".into(), Value::String(v.clone()));
+                }
+                if let Some(v) = sections {
+                    p.insert("sections".into(), Value::String(v.clone()));
+                }
+                if let Some(v) = show_bom {
+                    p.insert("show_bom".into(), Value::String(v.clone()));
+                }
+            }
             Self::Schematic { title, sheet } => {
                 if let Some(v) = title {
                     p.insert("title".into(), Value::String(v.clone()));
@@ -824,6 +852,11 @@ impl FeatureInput {
                 axis: get_vec3(params, "axis"),
                 name: get_str(params, "name"),
                 limits: get_str(params, "limits"),
+            },
+            "drawing-settings" => Self::DrawingSettings {
+                title_block: get_str(params, "title_block"),
+                sections: get_str(params, "sections"),
+                show_bom: get_str(params, "show_bom"),
             },
             "scene-settings" => Self::SceneSettings {
                 environment: get_str(params, "environment"),

--- a/crates/vcad-app/src/materializer.rs
+++ b/crates/vcad-app/src/materializer.rs
@@ -133,6 +133,10 @@ pub fn materialize(crdt: &CrdtDocument) -> MaterializeResult {
                 materialize_scene_settings(&mut doc, feature);
                 continue;
             }
+            "drawing-settings" => {
+                materialize_drawing_settings(&mut doc, feature);
+                continue;
+            }
             "schematic" => {
                 materialize_schematic(&mut doc, feature);
                 continue;
@@ -190,6 +194,7 @@ fn materialize_feature(
         | FeatureInput::Instance { .. }
         | FeatureInput::Joint { .. }
         | FeatureInput::SceneSettings { .. }
+        | FeatureInput::DrawingSettings { .. }
         | FeatureInput::Schematic { .. }
         | FeatureInput::Molecule { .. } => return None,
         _ => {}
@@ -1287,6 +1292,29 @@ fn materialize_molecule(doc: &mut Document, feature: &FeatureState) {
     {
         doc.molecule = serde_json::from_str(&json).ok();
     }
+}
+
+fn materialize_drawing_settings(doc: &mut Document, feature: &FeatureState) {
+    let Some(FeatureInput::DrawingSettings {
+        title_block,
+        sections,
+        show_bom,
+    }) = FeatureInput::from_crdt_params(&feature.kind, &feature.params)
+    else {
+        return;
+    };
+
+    let mut drawing = vcad_ir::DrawingSettings::default();
+    if let Some(json) = title_block {
+        drawing.title_block = serde_json::from_str(&json).ok();
+    }
+    if let Some(json) = sections {
+        drawing.sections = serde_json::from_str(&json).ok();
+    }
+    if let Some(json) = show_bom {
+        drawing.show_bom = serde_json::from_str(&json).ok();
+    }
+    doc.drawing = Some(drawing);
 }
 
 fn materialize_scene_settings(doc: &mut Document, feature: &FeatureState) {

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -1747,6 +1747,71 @@ pub struct SceneSettings {
     pub camera_presets: Option<Vec<CameraPreset>>,
 }
 
+/// Title block fields for a technical drawing sheet.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct DrawingTitleBlock {
+    /// Part or assembly name.
+    #[serde(default)]
+    pub part_name: String,
+    /// Author (drawn by).
+    #[serde(default)]
+    pub author: String,
+    /// Date string (caller-formatted, e.g. "2026-07-18").
+    #[serde(default)]
+    pub date: String,
+    /// Drawing scale note (e.g. "1:1").
+    #[serde(default)]
+    pub scale: String,
+    /// Material specification (e.g. "6061-T6 AL").
+    #[serde(default)]
+    pub material: String,
+    /// Revision letter (e.g. "A").
+    #[serde(default)]
+    pub revision: String,
+}
+
+/// A section cut line drawn on an orthographic drawing view. The polyline
+/// runs vertically in view coordinates; horizontal jogs produce an offset
+/// (stepped) section.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct DrawingSectionLine {
+    /// Unique id within the drawing.
+    pub id: String,
+    /// View direction the line was drawn on ("front", "top", "right", …).
+    pub view: String,
+    /// Section label letter (e.g. "A" → "SECTION A-A").
+    pub label: String,
+    /// Polyline points in 2D view coordinates (mm).
+    pub points: Vec<[f64; 2]>,
+}
+
+/// Drawing (drafting) settings persisted on the document: title block,
+/// section lines, and BOM table visibility for the 2D drawing sheet.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct DrawingSettings {
+    /// Title block fields shown on the sheet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub title_block: Option<DrawingTitleBlock>,
+    /// Section cut lines defined on drawing views.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub sections: Option<Vec<DrawingSectionLine>>,
+    /// Whether the BOM table is placed on the sheet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub show_bom: Option<bool>,
+}
+
 /// A vcad document — the `.vcad` file format.
 ///
 /// Contains the full IR DAG, material definitions, and scene assembly.
@@ -1824,6 +1889,12 @@ pub struct Document {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub clearance_specs: Vec<ClearanceSpec>,
 
+    // Drafting (optional, zero-cost when absent)
+    /// Drawing sheet settings: title block, section lines, BOM visibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub drawing: Option<DrawingSettings>,
+
     // Animation (optional, zero-cost when absent)
     /// Animation timeline: keyframed parameters/joints/visibility plus
     /// camera shots. Absent for static models.
@@ -1878,6 +1949,7 @@ impl Default for Document {
             parameters: HashMap::new(),
             bindings: Bindings::new(),
             clearance_specs: Vec::new(),
+            drawing: None,
             timeline: None,
         }
     }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -2564,6 +2564,228 @@ impl Default for WasmAnnotationLayer {
 }
 
 // =========================================================================
+// Shop-ready drawing sheet: offset sections, title block, BOM, PDF
+// =========================================================================
+
+/// Generate an offset (stepped) section view from a triangle mesh.
+///
+/// # Arguments
+/// * `mesh_js` - Mesh data as JS object with `positions` (Float32Array) and `indices` (Uint32Array)
+/// * `plane_json` - JSON `OffsetSectionPlane`: `{"base": {"origin": [x,y,z], "normal": [x,y,z], "up": [x,y,z]}, "steps": [{"u_start": f64, "u_end": f64, "offset": f64}]}`
+/// * `hatch_json` - Optional JSON hatch pattern: `{"spacing": f64, "angle": f64}`
+///
+/// # Returns
+/// A JS object containing the section view with curves, hatch lines, and bounds.
+#[module("drafting")]
+#[wasm_bindgen(js_name = offsetSectionMesh)]
+pub fn offset_section_mesh_wasm(
+    mesh_js: JsValue,
+    plane_json: &str,
+    hatch_json: Option<String>,
+) -> JsValue {
+    use vcad_kernel_drafting::{offset_section_mesh, HatchPattern, OffsetSectionPlane};
+    use vcad_kernel_tessellate::TriangleMesh;
+
+    let mesh_data: WasmMesh = match serde_wasm_bindgen::from_value(mesh_js) {
+        Ok(m) => m,
+        Err(_) => return JsValue::NULL,
+    };
+
+    let mesh = TriangleMesh {
+        vertices: mesh_data.positions,
+        indices: mesh_data.indices,
+        normals: Vec::new(),
+        face_kinds: Vec::new(),
+    };
+
+    let plane: OffsetSectionPlane = match serde_json::from_str(plane_json) {
+        Ok(p) => p,
+        Err(_) => return JsValue::NULL,
+    };
+
+    let hatch: Option<HatchPattern> = hatch_json.and_then(|h| serde_json::from_str(&h).ok());
+
+    let view = offset_section_mesh(&mesh, &plane, hatch.as_ref());
+    serde_wasm_bindgen::to_value(&view).unwrap_or(JsValue::NULL)
+}
+
+/// Render a title block as drawing primitives, bottom-left corner at (0, 0).
+///
+/// # Arguments
+/// * `fields_json` - JSON `TitleBlockFields`: `{"part_name": "...", "material": "...", "finish": "...", "scale": "...", "drawn_by": "...", "date": "...", "revision": "...", "units": "...", "tolerance_note": "..."}`
+///
+/// # Returns
+/// `{ rendered: RenderedDimension, width: f64, height: f64 }`, or null on
+/// parse failure.
+#[module("drafting")]
+#[wasm_bindgen(js_name = renderTitleBlock)]
+pub fn render_title_block_wasm(fields_json: &str) -> JsValue {
+    use vcad_kernel_drafting::{Point2D, TitleBlock, TitleBlockFields};
+
+    let fields: TitleBlockFields = match serde_json::from_str(fields_json) {
+        Ok(f) => f,
+        Err(_) => return JsValue::NULL,
+    };
+
+    let block = TitleBlock::new(fields);
+    let out = RenderedBlock {
+        rendered: block.render(Point2D::new(0.0, 0.0)),
+        width: block.width,
+        height: block.height,
+    };
+    serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+}
+
+/// A rendered drawing entity plus its footprint, for sheet placement.
+#[derive(serde::Serialize)]
+struct RenderedBlock {
+    rendered: vcad_kernel_drafting::RenderedDimension,
+    width: f64,
+    height: f64,
+}
+
+/// Render a BOM table as drawing primitives, bottom-left corner at (0, 0).
+///
+/// # Arguments
+/// * `rows_json` - JSON array of `BomRow`: `[{"item": 1, "name": "...", "qty": 2, "material": "..."}]`
+///
+/// # Returns
+/// `{ rendered: RenderedDimension, width: f64, height: f64 }`, or null on
+/// parse failure.
+#[module("drafting")]
+#[wasm_bindgen(js_name = renderBomTable)]
+pub fn render_bom_table_wasm(rows_json: &str) -> JsValue {
+    use vcad_kernel_drafting::{BomRow, BomTable, Point2D};
+
+    let rows: Vec<BomRow> = match serde_json::from_str(rows_json) {
+        Ok(r) => r,
+        Err(_) => return JsValue::NULL,
+    };
+
+    let table = BomTable { rows };
+    let out = RenderedBlock {
+        rendered: table.render(Point2D::new(0.0, 0.0)),
+        width: table.width(),
+        height: table.height(),
+    };
+    serde_wasm_bindgen::to_value(&out).unwrap_or(JsValue::NULL)
+}
+
+/// Specification for composing a drawing sheet (see [`drawing_sheet_to_pdf`]).
+#[derive(serde::Deserialize)]
+struct SheetSpec {
+    /// Sheet size ("a4", "a3", "letter", or {"custom": {...}}). Default A4.
+    #[serde(default)]
+    size: Option<vcad_kernel_drafting::SheetSize>,
+    /// Projected views placed on the sheet.
+    #[serde(default)]
+    views: Vec<PlacedProjectedView>,
+    /// Section views placed on the sheet.
+    #[serde(default)]
+    sections: Vec<PlacedSectionView>,
+    /// Pre-rendered annotations (dimensions, cut lines) in sheet coordinates.
+    #[serde(default)]
+    annotations: Vec<vcad_kernel_drafting::RenderedDimension>,
+    /// Title block fields; omitted → no title block.
+    #[serde(default)]
+    title_block: Option<vcad_kernel_drafting::TitleBlockFields>,
+    /// BOM rows; omitted or empty → no BOM table.
+    #[serde(default)]
+    bom: Option<Vec<vcad_kernel_drafting::BomRow>>,
+}
+
+/// A projected view with sheet placement.
+#[derive(serde::Deserialize)]
+struct PlacedProjectedView {
+    view: vcad_kernel_drafting::ProjectedView,
+    /// Sheet position of the view's bounds center, mm from bottom-left.
+    center: [f64; 2],
+    scale: f64,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+/// A section view with sheet placement.
+#[derive(serde::Deserialize)]
+struct PlacedSectionView {
+    view: vcad_kernel_drafting::SectionView,
+    center: [f64; 2],
+    scale: f64,
+    #[serde(default)]
+    label: Option<String>,
+}
+
+/// Compose a drawing sheet from projected views, sections, annotations,
+/// title block, and BOM table, and export it as a PDF.
+///
+/// # Arguments
+/// * `spec_json` - JSON `SheetSpec` (see the struct docs above).
+///
+/// # Returns
+/// PDF file bytes (deterministic PDF 1.4 from the kernel's drafting crate).
+#[module("drafting")]
+#[wasm_bindgen(js_name = drawingSheetToPdf)]
+pub fn drawing_sheet_to_pdf(spec_json: &str) -> Result<Vec<u8>, JsError> {
+    use vcad_kernel_drafting::{
+        sheet_to_pdf, BomTable, DrawingSheet, LineClass, Point2D, RenderedText, SheetSize,
+        TitleBlock,
+    };
+
+    let spec: SheetSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&e.to_string()))?;
+
+    let mut sheet = DrawingSheet::new(spec.size.unwrap_or(SheetSize::A4));
+
+    for placed in &spec.views {
+        let center = Point2D::new(placed.center[0], placed.center[1]);
+        sheet.add_projected_view(&placed.view, center, placed.scale);
+        if let Some(label) = &placed.label {
+            let half_h = (placed.view.bounds.max_y - placed.view.bounds.min_y) / 2.0 * placed.scale;
+            sheet.texts.push(RenderedText::new(
+                Point2D::new(center.x, center.y - half_h - 8.0),
+                label,
+                3.5,
+            ));
+        }
+    }
+
+    for placed in &spec.sections {
+        let center = Point2D::new(placed.center[0], placed.center[1]);
+        sheet.add_section_view(&placed.view, center, placed.scale);
+        if let Some(label) = &placed.label {
+            let bounds = &placed.view.bounds;
+            let half_h = (bounds.max_y - bounds.min_y) / 2.0 * placed.scale;
+            sheet.texts.push(RenderedText::new(
+                Point2D::new(center.x, center.y - half_h - 8.0),
+                label,
+                3.5,
+            ));
+        }
+    }
+
+    for rd in &spec.annotations {
+        sheet.add_annotation(rd, LineClass::Dimension, Point2D::new(0.0, 0.0));
+    }
+
+    let title_block_height = if let Some(fields) = spec.title_block {
+        let block = TitleBlock::new(fields);
+        sheet.add_title_block(&block);
+        block.height
+    } else {
+        0.0
+    };
+
+    if let Some(rows) = spec.bom {
+        if !rows.is_empty() {
+            let table = BomTable { rows };
+            sheet.add_bom_table(&table, title_block_height);
+        }
+    }
+
+    Ok(sheet_to_pdf(&sheet))
+}
+
+// =========================================================================
 // DXF Export
 // =========================================================================
 

--- a/packages/app/src/components/DrawingToolbar.tsx
+++ b/packages/app/src/components/DrawingToolbar.tsx
@@ -5,6 +5,10 @@ import { MagnifyingGlassPlus } from "@phosphor-icons/react/dist/ssr/MagnifyingGl
 import { X } from "@phosphor-icons/react/dist/ssr/X";
 import { Download } from "@phosphor-icons/react/dist/ssr/Download";
 import { CaretDown } from "@phosphor-icons/react/dist/ssr/CaretDown";
+import { Scissors } from "@phosphor-icons/react/dist/ssr/Scissors";
+import { Table } from "@phosphor-icons/react/dist/ssr/Table";
+import { Article } from "@phosphor-icons/react/dist/ssr/Article";
+import { FilePdf } from "@phosphor-icons/react/dist/ssr/FilePdf";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
@@ -12,8 +16,11 @@ import { cn } from "@/lib/utils";
 import { useEngineStore } from "@vcad/core";
 import { useDrawingStore, type ViewDirection } from "@/stores/drawing-store";
 import { useNotificationStore } from "@/stores/notification-store";
-import { useUiStore } from "@vcad/core";
+import { useUiStore, useDocumentStore } from "@vcad/core";
 import { downloadDxf } from "@/lib/save-load";
+import { exportDrawingPdf } from "@/lib/drawing-sheet";
+import { TitleBlockEditor } from "./TitleBlockEditor";
+import { useState } from "react";
 
 const VIEW_DIRECTIONS: { value: ViewDirection; label: string }[] = [
   { value: "front", label: "Front" },
@@ -39,8 +46,15 @@ export function DrawingToolbar() {
   const engine = useEngineStore((s) => s.engine);
   const scene = useEngineStore((s) => s.scene);
   const isOrbiting = useUiStore((s) => s.isOrbiting);
+  const drawing = useDocumentStore((s) => s.document.drawing);
+  const setDrawingSettings = useDocumentStore((s) => s.setDrawingSettings);
+  const [titleBlockOpen, setTitleBlockOpen] = useState(false);
 
   if (viewMode !== "2d") return null;
+
+  const sections = drawing?.sections ?? [];
+  const showBom = drawing?.showBom ?? false;
+  const canSection = viewDirection !== "isometric";
 
   const hasParts = scene?.parts?.length ?? 0 > 0;
 
@@ -64,6 +78,27 @@ export function DrawingToolbar() {
 
   function handleStartDetailView() {
     window.dispatchEvent(new CustomEvent("vcad:start-detail-view"));
+  }
+
+  function handleStartSection() {
+    window.dispatchEvent(new CustomEvent("vcad:start-section-view"));
+  }
+
+  function handleClearSections() {
+    setDrawingSettings({ sections: [] });
+  }
+
+  function handleToggleBom() {
+    setDrawingSettings({ showBom: !showBom });
+  }
+
+  function handleExportPdf() {
+    const error = exportDrawingPdf();
+    if (error) {
+      useNotificationStore.getState().addToast(error, "error");
+    } else {
+      useNotificationStore.getState().addToast("PDF exported", "success");
+    }
   }
 
   return (
@@ -157,6 +192,58 @@ export function DrawingToolbar() {
 
           <Separator orientation="vertical" className="mx-1 h-5" />
 
+          {/* Section views */}
+          <Tooltip
+            content={
+              canSection
+                ? "Add Section (click points, Enter to finish)"
+                : "Sections need an orthographic view"
+            }
+          >
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleStartSection}
+              disabled={!hasParts || !canSection}
+            >
+              <Scissors size={16} />
+            </Button>
+          </Tooltip>
+
+          {sections.length > 0 && (
+            <Tooltip content="Clear Sections">
+              <Button variant="ghost" size="icon-sm" onClick={handleClearSections}>
+                <X size={16} />
+              </Button>
+            </Tooltip>
+          )}
+
+          <Separator orientation="vertical" className="mx-1 h-5" />
+
+          {/* Sheet furniture */}
+          <Tooltip content="Edit Title Block">
+            <Button
+              variant={titleBlockOpen ? "default" : "ghost"}
+              size="icon-sm"
+              onClick={() => setTitleBlockOpen((v) => !v)}
+            >
+              <Article size={16} />
+            </Button>
+          </Tooltip>
+
+          <Tooltip content={showBom ? "Hide BOM Table" : "Show BOM Table"}>
+            <Button
+              variant={showBom ? "default" : "ghost"}
+              size="icon-sm"
+              onClick={handleToggleBom}
+              disabled={!hasParts}
+            >
+              <Table size={16} />
+            </Button>
+          </Tooltip>
+
+          <Separator orientation="vertical" className="mx-1 h-5" />
+
           {/* Export */}
           <Tooltip content="Export DXF">
             <Button
@@ -168,8 +255,21 @@ export function DrawingToolbar() {
               <Download size={16} />
             </Button>
           </Tooltip>
+
+          <Tooltip content="Export PDF Drawing">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleExportPdf}
+              disabled={!hasParts || !engine}
+            >
+              <FilePdf size={16} />
+            </Button>
+          </Tooltip>
         </div>
       </div>
+
+      {titleBlockOpen && <TitleBlockEditor onClose={() => setTitleBlockOpen(false)} />}
     </>
   );
 }

--- a/packages/app/src/components/DrawingView.tsx
+++ b/packages/app/src/components/DrawingView.tsx
@@ -6,8 +6,17 @@ import {
   type ProjectedView,
   type RenderedDimension,
   type DetailView,
+  type SectionView,
+  type RenderedBlock,
 } from "@vcad/core";
-import { useDrawingStore, type DetailViewDef } from "../stores/drawing-store";
+import type { DrawingSectionLine } from "@vcad/ir";
+import { useDrawingStore, type DetailViewDef, type ViewDirection } from "../stores/drawing-store";
+import {
+  sectionPlaneFromLine,
+  combineSceneMeshes,
+  toKernelTitleBlock,
+  buildBomRows,
+} from "@/lib/drawing-sheet";
 import { useTheme } from "@/hooks/useTheme";
 
 // Color schemes for light and dark modes
@@ -22,6 +31,8 @@ const COLORS = {
     selectionFill: "rgba(59, 130, 246, 0.1)",
     detailRegion: "#e11d48",
     detailRegionFill: "rgba(225, 29, 72, 0.05)",
+    section: "#d97706",
+    sheet: "#444444",
   },
   dark: {
     background: "#0a0a0a",
@@ -33,8 +44,67 @@ const COLORS = {
     selectionFill: "rgba(0, 212, 170, 0.1)",
     detailRegion: "#f43f5e",
     detailRegionFill: "rgba(244, 63, 94, 0.08)",
+    section: "#fbbf24",
+    sheet: "#aaaaaa",
   },
 };
+
+/** Render a kernel-drawn block (title block / BOM table) anchored with its
+ * bottom-left corner at (`ax`, `aySvg`) in SVG coordinates, scaled by `sb`. */
+function renderBlock(
+  block: RenderedBlock,
+  ax: number,
+  aySvg: number,
+  sb: number,
+  color: string,
+  strokeWidth: number,
+  keyPrefix: string,
+) {
+  const mx = (x: number) => ax + x * sb;
+  const my = (y: number) => aySvg - y * sb;
+  return (
+    <g key={keyPrefix} pointerEvents="none">
+      {block.rendered.lines.map(([a, b], i) => (
+        <line
+          key={`${keyPrefix}-l-${i}`}
+          x1={mx(a.x)}
+          y1={my(a.y)}
+          x2={mx(b.x)}
+          y2={my(b.y)}
+          stroke={color}
+          strokeWidth={strokeWidth}
+        />
+      ))}
+      {block.rendered.texts.map((t, i) => {
+        const alignment = String(t.alignment);
+        const anchor = alignment.includes("Left")
+          ? "start"
+          : alignment.includes("Right")
+            ? "end"
+            : "middle";
+        const baseline = alignment.startsWith("Top")
+          ? "hanging"
+          : alignment.startsWith("Bottom")
+            ? "auto"
+            : "middle";
+        return (
+          <text
+            key={`${keyPrefix}-t-${i}`}
+            x={mx(t.position.x)}
+            y={my(t.position.y)}
+            fontSize={t.height * sb}
+            fill={color}
+            textAnchor={anchor}
+            dominantBaseline={baseline}
+            fontFamily="monospace"
+          >
+            {t.text}
+          </text>
+        );
+      })}
+    </g>
+  );
+}
 
 /**
  * SVG-based 2D technical drawing view.
@@ -64,6 +134,8 @@ export function DrawingView() {
   const scene = useEngineStore((s) => s.scene);
   const engine = useEngineStore((s) => s.engine);
   const parts = useDocumentStore((s) => s.parts);
+  const drawing = useDocumentStore((s) => s.document.drawing);
+  const setDrawingSettings = useDocumentStore((s) => s.setDrawingSettings);
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const select = useUiStore((s) => s.select);
   const clearSelection = useUiStore((s) => s.clearSelection);
@@ -81,6 +153,11 @@ export function DrawingView() {
   const [isCreatingDetail, setIsCreatingDetail] = useState(false);
   const [detailStart, setDetailStart] = useState<{ x: number; y: number } | null>(null);
   const [detailEnd, setDetailEnd] = useState<{ x: number; y: number } | null>(null);
+
+  // Section line creation state
+  const [isCreatingSection, setIsCreatingSection] = useState(false);
+  const [sectionPoints, setSectionPoints] = useState<Array<[number, number]>>([]);
+  const [sectionCursor, setSectionCursor] = useState<{ x: number; y: number } | null>(null);
 
   const colors = isDark ? COLORS.dark : COLORS.light;
 
@@ -153,6 +230,53 @@ export function DrawingView() {
       })
       .filter((v): v is { def: DetailViewDef; view: DetailView } => v !== null);
   }, [combinedView, engine, detailViews]);
+
+  // Section cut lines for the current view + their computed section views
+  const computedSections = useMemo<
+    Array<{ def: DrawingSectionLine; view: SectionView }>
+  >(() => {
+    if (!engine || !scene?.parts?.length) return [];
+    const defs = (drawing?.sections ?? []).filter((s) => s.view === viewDirection);
+    if (defs.length === 0) return [];
+    const mesh = combineSceneMeshes();
+    if (!mesh) return [];
+
+    return defs
+      .map((def) => {
+        const plane = sectionPlaneFromLine(
+          def.view as ViewDirection,
+          def.points as Array<[number, number]>,
+        );
+        if (!plane) return null;
+        const view = engine.offsetSectionMesh(mesh, plane, {
+          spacing: 3,
+          angle: Math.PI / 4,
+        });
+        return view ? { def, view } : null;
+      })
+      .filter((v): v is { def: DrawingSectionLine; view: SectionView } => v !== null);
+  }, [engine, scene, drawing, viewDirection]);
+
+  // Kernel-rendered title block (matches the exported PDF)
+  const titleBlock = useMemo<RenderedBlock | null>(() => {
+    if (!engine || !drawing?.titleBlock) return null;
+    try {
+      return engine.renderTitleBlock(toKernelTitleBlock(drawing.titleBlock, ""));
+    } catch {
+      return null;
+    }
+  }, [engine, drawing]);
+
+  // Kernel-rendered BOM table for assembly drawings
+  const bomBlock = useMemo<RenderedBlock | null>(() => {
+    if (!engine || !drawing?.showBom || parts.length === 0) return null;
+    try {
+      const rows = buildBomRows();
+      return rows.length > 0 ? engine.renderBomTable(rows) : null;
+    } catch {
+      return null;
+    }
+  }, [engine, drawing, parts]);
 
   // Generate dimension annotations from combined bounding box
   const dimensions = useMemo<RenderedDimension[]>(() => {
@@ -478,6 +602,71 @@ export function DrawingView() {
     return () => window.removeEventListener("vcad:start-detail-view", handleStartDetailView);
   }, [startDetailCreation]);
 
+  // Listen for start-section-view event from toolbar
+  useEffect(() => {
+    const handleStartSection = () => {
+      setIsCreatingSection(true);
+      setSectionPoints([]);
+      setSectionCursor(null);
+    };
+    window.addEventListener("vcad:start-section-view", handleStartSection);
+    return () => window.removeEventListener("vcad:start-section-view", handleStartSection);
+  }, []);
+
+  // Commit the in-progress section line to the document
+  const commitSection = useCallback(() => {
+    if (sectionPoints.length >= 2) {
+      const existing = drawing?.sections ?? [];
+      const label = String.fromCharCode(65 + (existing.length % 26));
+      setDrawingSettings({
+        sections: [
+          ...existing,
+          {
+            id: `section-${label}-${Date.now()}`,
+            view: viewDirection,
+            label,
+            points: sectionPoints,
+          },
+        ],
+      });
+    }
+    setIsCreatingSection(false);
+    setSectionPoints([]);
+    setSectionCursor(null);
+  }, [sectionPoints, drawing, setDrawingSettings, viewDirection]);
+
+  // Section creation: click adds a point, Enter commits, Escape cancels
+  const handleSectionClick = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = screenToSvg(e.clientX, e.clientY);
+      if (pos) setSectionPoints((pts) => [...pts, [pos.x, pos.y]]);
+    },
+    [screenToSvg],
+  );
+
+  const handleSectionMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      const pos = screenToSvg(e.clientX, e.clientY);
+      if (pos) setSectionCursor(pos);
+    },
+    [screenToSvg],
+  );
+
+  useEffect(() => {
+    if (!isCreatingSection) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsCreatingSection(false);
+        setSectionPoints([]);
+        setSectionCursor(null);
+      } else if (e.key === "Enter") {
+        commitSection();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isCreatingSection, commitSection]);
+
   if (!combinedBounds || projectedViews.length === 0) {
     return (
       <div
@@ -507,6 +696,13 @@ export function DrawingView() {
   const hiddenStrokeWidth = strokeWidth * 0.6;
   const dimStrokeWidth = strokeWidth * 0.4;
 
+  // Sheet furniture layout (title block bottom-right, BOM above it)
+  const sheetPad = viewWidth * 0.015;
+  const tbScale = titleBlock ? (viewWidth * 0.3) / titleBlock.width : 0;
+  const tbHeightSvg = titleBlock ? titleBlock.height * tbScale : 0;
+  const tbClearance = titleBlock ? tbHeightSvg + sheetPad : 0;
+  const bomScale = bomBlock ? (viewWidth * 0.3) / bomBlock.width : 0;
+
   return (
     <svg
       ref={svgRef}
@@ -515,17 +711,34 @@ export function DrawingView() {
       preserveAspectRatio="xMidYMid meet"
       style={{
         backgroundColor: colors.background,
-        cursor: isCreatingDetail ? "crosshair" : isPanning ? "grabbing" : "default",
+        cursor:
+          isCreatingDetail || isCreatingSection
+            ? "crosshair"
+            : isPanning
+              ? "grabbing"
+              : "default",
       }}
-      onPointerDown={isCreatingDetail ? undefined : handlePointerDown}
-      onPointerMove={isCreatingDetail ? undefined : handlePointerMove}
-      onPointerUp={isCreatingDetail ? undefined : handlePointerUp}
-      onPointerLeave={isCreatingDetail ? undefined : handlePointerUp}
+      onPointerDown={isCreatingDetail || isCreatingSection ? undefined : handlePointerDown}
+      onPointerMove={isCreatingDetail || isCreatingSection ? undefined : handlePointerMove}
+      onPointerUp={isCreatingDetail || isCreatingSection ? undefined : handlePointerUp}
+      onPointerLeave={isCreatingDetail || isCreatingSection ? undefined : handlePointerUp}
       onMouseDown={isCreatingDetail ? handleDetailMouseDown : undefined}
-      onMouseMove={isCreatingDetail ? handleDetailMouseMove : undefined}
+      onMouseMove={
+        isCreatingDetail
+          ? handleDetailMouseMove
+          : isCreatingSection
+            ? handleSectionMouseMove
+            : undefined
+      }
       onMouseUp={isCreatingDetail ? handleDetailMouseUp : undefined}
-      onClick={isCreatingDetail ? undefined : handleBackgroundClick}
-      onDoubleClick={handleDoubleClick}
+      onClick={
+        isCreatingDetail
+          ? undefined
+          : isCreatingSection
+            ? handleSectionClick
+            : handleBackgroundClick
+      }
+      onDoubleClick={isCreatingSection ? commitSection : handleDoubleClick}
     >
       {/* Grid pattern for dark mode */}
       {isDark && (
@@ -733,6 +946,57 @@ export function DrawingView() {
         );
       })}
 
+      {/* Section cut lines on the main view */}
+      {computedSections.map(({ def }) => {
+        const pts = def.points as Array<[number, number]>;
+        if (pts.length < 2) return null;
+        const first = pts[0]!;
+        const last = pts[pts.length - 1]!;
+        return (
+          <g key={`cut-${def.id}`} pointerEvents="none">
+            <polyline
+              points={pts.map(([x, y]) => `${x},${-y}`).join(" ")}
+              fill="none"
+              stroke={colors.section}
+              strokeWidth={strokeWidth}
+              strokeDasharray={`${strokeWidth * 6},${strokeWidth * 2},${strokeWidth * 2},${strokeWidth * 2}`}
+            />
+            {[first, last].map(([x, y], i) => (
+              <text
+                key={`cut-${def.id}-t-${i}`}
+                x={x}
+                y={-y - strokeWidth * 4}
+                fontSize={strokeWidth * 6}
+                fill={colors.section}
+                textAnchor="middle"
+                fontFamily="monospace"
+                fontWeight="600"
+              >
+                {def.label}
+              </text>
+            ))}
+          </g>
+        );
+      })}
+
+      {/* In-progress section polyline */}
+      {isCreatingSection && sectionPoints.length > 0 && (
+        <g pointerEvents="none">
+          <polyline
+            points={[...sectionPoints, ...(sectionCursor ? [[sectionCursor.x, sectionCursor.y]] : [])]
+              .map(([x, y]) => `${x},${-(y as number)}`)
+              .join(" ")}
+            fill="none"
+            stroke={colors.section}
+            strokeWidth={strokeWidth}
+            strokeDasharray={`${strokeWidth * 3},${strokeWidth * 2}`}
+          />
+          {sectionPoints.map(([x, y], i) => (
+            <circle key={`sp-${i}`} cx={x} cy={-y} r={strokeWidth * 2} fill={colors.section} />
+          ))}
+        </g>
+      )}
+
       {/* Selection rectangle while creating detail view */}
       {isCreatingDetail && detailStart && detailEnd && (
         <rect
@@ -783,7 +1047,8 @@ export function DrawingView() {
         const detailSize = Math.min(viewWidth, viewHeight) * 0.25;
         const padding = detailSize * 0.1;
         const detailX = viewX + viewWidth - detailSize - padding;
-        const detailY = viewY + viewHeight - detailSize * (idx + 1) - padding * (idx + 1);
+        const detailY =
+          viewY + viewHeight - detailSize * (idx + 1) - padding * (idx + 1) - tbClearance;
 
         // Scale to fit in the detail box
         const detailWidth = view.bounds.max_x - view.bounds.min_x;
@@ -858,6 +1123,103 @@ export function DrawingView() {
           </g>
         );
       })}
+
+      {/* Section view insets, stacked bottom-left */}
+      {computedSections.map(({ def, view }, idx) => {
+        const boxSize = Math.min(viewWidth, viewHeight) * 0.28;
+        const pad = boxSize * 0.1;
+        const boxX = viewX + pad;
+        const boxY = viewY + viewHeight - boxSize * (idx + 1) - pad * (idx + 1);
+
+        const secW = view.bounds.max_x - view.bounds.min_x;
+        const secH = view.bounds.max_y - view.bounds.min_y;
+        const fitScale = Math.min(
+          (boxSize * 0.8) / (secW || 1),
+          (boxSize * 0.8) / (secH || 1),
+        );
+        const cx = (view.bounds.min_x + view.bounds.max_x) / 2;
+        const cy = (view.bounds.min_y + view.bounds.max_y) / 2;
+        const boxCx = boxX + boxSize / 2;
+        const boxCy = boxY + boxSize / 2;
+
+        return (
+          <g key={`sec-${def.id}`} pointerEvents="none">
+            <rect
+              x={boxX}
+              y={boxY}
+              width={boxSize}
+              height={boxSize}
+              fill={colors.background}
+              stroke={colors.section}
+              strokeWidth={strokeWidth}
+            />
+            <text
+              x={boxX + strokeWidth * 2}
+              y={boxY + strokeWidth * 5}
+              fontSize={strokeWidth * 5}
+              fill={colors.section}
+              fontFamily="monospace"
+              fontWeight="600"
+            >
+              SECTION {def.label}-{def.label}
+            </text>
+            <g
+              transform={`translate(${boxCx - cx * fitScale}, ${boxCy + cy * fitScale}) scale(${fitScale})`}
+            >
+              {view.curves.map((curve, ci) => (
+                <polyline
+                  key={`sec-${def.id}-c-${ci}`}
+                  points={[
+                    ...curve.points,
+                    ...(curve.is_closed && curve.points.length > 0 ? [curve.points[0]!] : []),
+                  ]
+                    .map((p) => `${p.x},${-p.y}`)
+                    .join(" ")}
+                  fill="none"
+                  stroke={colors.edge}
+                  strokeWidth={(strokeWidth * 1.2) / fitScale}
+                  strokeLinecap="round"
+                />
+              ))}
+              {view.hatch_lines.map(([a, b], hi) => (
+                <line
+                  key={`sec-${def.id}-h-${hi}`}
+                  x1={a.x}
+                  y1={-a.y}
+                  x2={b.x}
+                  y2={-b.y}
+                  stroke={colors.section}
+                  strokeWidth={(strokeWidth * 0.5) / fitScale}
+                />
+              ))}
+            </g>
+          </g>
+        );
+      })}
+
+      {/* Title block, bottom-right (kernel-rendered, matches the PDF) */}
+      {titleBlock &&
+        renderBlock(
+          titleBlock,
+          viewX + viewWidth - titleBlock.width * tbScale - sheetPad,
+          viewY + viewHeight - sheetPad,
+          tbScale,
+          colors.sheet,
+          strokeWidth * 0.5,
+          "titleblock",
+        )}
+
+      {/* BOM table, above the title block */}
+      {bomBlock &&
+        renderBlock(
+          bomBlock,
+          viewX + viewWidth - bomBlock.width * bomScale - sheetPad,
+          viewY + viewHeight - tbClearance - sheetPad * 2,
+          bomScale,
+          colors.sheet,
+          strokeWidth * 0.5,
+          "bom",
+        )}
     </svg>
   );
 }

--- a/packages/app/src/components/Header.tsx
+++ b/packages/app/src/components/Header.tsx
@@ -30,6 +30,7 @@ import { openCustomerPortal } from "@/lib/billing-api";
 import { UpgradeModal } from "@/components/UpgradeModal";
 import { cn } from "@/lib/utils";
 import { downloadBlob } from "@/lib/download";
+import { exportDrawingPdf } from "@/lib/drawing-sheet";
 import { examples } from "@/data/examples";
 import { analytics } from "@/lib/analytics";
 import { SignInButton, UserMenu, triggerSync, useAuthStore } from "@vcad/auth";
@@ -455,6 +456,15 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
     }
   };
 
+  const handleExportDrawingPdf = () => {
+    const error = exportDrawingPdf();
+    if (error) {
+      useNotificationStore.getState().addToast(error, "error");
+    } else {
+      useNotificationStore.getState().addToast("Drawing PDF exported", "success");
+    }
+  };
+
   // Examples live in /src/data and their file loader still goes through a
   // dispatched event — not in the command registry because each entry is
   // unique, not a shared command. Detail carries either an inline
@@ -565,6 +575,9 @@ export function Header({ onAboutOpen, onProductOpen, onSave, onOpen, onShareOpen
                   <MenuItem onSelect={() => handleExport("stl")}>STL</MenuItem>
                   <MenuItem onSelect={() => handleExport("glb")}>GLB</MenuItem>
                   <MenuItem onSelect={() => handleExport("step")}>STEP</MenuItem>
+                  <MenuItem onSelect={handleExportDrawingPdf}>
+                    {t("cmd.export_drawing_pdf.label")}
+                  </MenuItem>
                 </Submenu>
                 <MenuSeparator />
                 <Submenu

--- a/packages/app/src/components/TitleBlockEditor.tsx
+++ b/packages/app/src/components/TitleBlockEditor.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { X } from "@phosphor-icons/react/dist/ssr/X";
+import { Button } from "@/components/ui/button";
+import { useDocumentStore } from "@vcad/core";
+import type { DrawingTitleBlock } from "@vcad/ir";
+
+const FIELDS: Array<{ key: keyof DrawingTitleBlock; label: string; placeholder: string }> = [
+  { key: "partName", label: "Part name", placeholder: "Bracket, rev A" },
+  { key: "author", label: "Drawn by", placeholder: "Your name" },
+  { key: "date", label: "Date", placeholder: "2026-07-18" },
+  { key: "scale", label: "Scale", placeholder: "1:1" },
+  { key: "material", label: "Material", placeholder: "6061-T6 AL" },
+  { key: "revision", label: "Revision", placeholder: "A" },
+];
+
+/**
+ * Title block editor for the 2D drawing sheet. Fields persist on the
+ * document (`document.drawing.titleBlock`) and render on both the on-screen
+ * sheet and the exported PDF.
+ */
+export function TitleBlockEditor({ onClose }: { onClose: () => void }) {
+  const persisted = useDocumentStore((s) => s.document.drawing?.titleBlock);
+  const setDrawingSettings = useDocumentStore((s) => s.setDrawingSettings);
+
+  const [fields, setFields] = useState<DrawingTitleBlock>({
+    partName: persisted?.partName ?? "",
+    author: persisted?.author ?? "",
+    date: persisted?.date ?? new Date().toISOString().slice(0, 10),
+    scale: persisted?.scale ?? "",
+    material: persisted?.material ?? "",
+    revision: persisted?.revision ?? "A",
+  });
+
+  function handleApply() {
+    setDrawingSettings({ titleBlock: fields });
+    onClose();
+  }
+
+  return (
+    <div className="fixed right-4 bottom-20 z-40 w-64 border border-border bg-card p-3 shadow-lg">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-medium text-text">Title Block</span>
+        <Button variant="ghost" size="icon-sm" onClick={onClose}>
+          <X size={14} />
+        </Button>
+      </div>
+      <div className="flex flex-col gap-2">
+        {FIELDS.map(({ key, label, placeholder }) => (
+          <label key={key} className="flex flex-col gap-1 text-xs text-text-muted">
+            {label}
+            <input
+              value={fields[key] ?? ""}
+              placeholder={placeholder}
+              onChange={(e) => setFields((f) => ({ ...f, [key]: e.target.value }))}
+              className="h-7 border border-border bg-surface px-2 text-xs text-text"
+            />
+          </label>
+        ))}
+      </div>
+      <div className="mt-3 flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button variant="default" size="sm" onClick={handleApply}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/hooks/useAppCommands.ts
+++ b/packages/app/src/hooks/useAppCommands.ts
@@ -21,6 +21,7 @@ import { useCamStore } from "@/stores/cam-store";
 import { useNotificationStore } from "@/stores/notification-store";
 import { downloadBlob } from "@/lib/download";
 import { newDocId } from "@/lib/doc-id";
+import { exportDrawingPdf } from "@/lib/drawing-sheet";
 import { analytics } from "@/lib/analytics";
 
 export type CommandSurface = "palette" | "mobile-menu" | "desktop-menu";
@@ -137,6 +138,15 @@ export function useAppCommands({
         onDismiss();
       },
       exportStep: () => doExport("step"),
+      exportDrawingPdf: () => {
+        const error = exportDrawingPdf();
+        if (error) {
+          useNotificationStore.getState().addToast(error, "error");
+        } else {
+          useNotificationStore.getState().addToast("Drawing PDF exported", "success");
+        }
+        onDismiss();
+      },
 
       // Edit extras
       copy: () => {

--- a/packages/app/src/lib/drawing-sheet.ts
+++ b/packages/app/src/lib/drawing-sheet.ts
@@ -1,0 +1,337 @@
+import {
+  useEngineStore,
+  useDocumentStore,
+  type RenderedDimension,
+  type SectionView,
+  type OffsetSectionPlane,
+  type TitleBlockFields,
+  type BomRow,
+  type DrawingSheetSpec,
+} from "@vcad/core";
+import type { DrawingSectionLine, DrawingTitleBlock } from "@vcad/ir";
+import { useDrawingStore, type ViewDirection } from "@/stores/drawing-store";
+import { downloadBlob } from "./download";
+
+type Vec3 = [number, number, number];
+
+const cross = (a: Vec3, b: Vec3): Vec3 => [
+  a[1] * b[2] - a[2] * b[1],
+  a[2] * b[0] - a[0] * b[2],
+  a[0] * b[1] - a[1] * b[0],
+];
+const scale3 = (a: Vec3, s: number): Vec3 => [a[0] * s, a[1] * s, a[2] * s];
+const normalize = (a: Vec3): Vec3 => {
+  const n = Math.hypot(a[0], a[1], a[2]);
+  return n > 1e-12 ? scale3(a, 1 / n) : a;
+};
+
+/** Orthographic view basis, mirroring the kernel's `ViewMatrix` construction
+ * (`crates/vcad-kernel-drafting/src/projection.rs`): view x = p·right,
+ * view y = p·up. Isometric views have no axis-aligned section semantics. */
+export function viewBasis(
+  dir: ViewDirection,
+): { right: Vec3; up: Vec3; forward: Vec3 } | null {
+  const table: Record<string, { forward: Vec3; worldUp: Vec3 }> = {
+    front: { forward: [0, 1, 0], worldUp: [0, 0, 1] },
+    back: { forward: [0, -1, 0], worldUp: [0, 0, 1] },
+    top: { forward: [0, 0, -1], worldUp: [0, 1, 0] },
+    bottom: { forward: [0, 0, 1], worldUp: [0, -1, 0] },
+    right: { forward: [1, 0, 0], worldUp: [0, 0, 1] },
+    left: { forward: [-1, 0, 0], worldUp: [0, 0, 1] },
+  };
+  const entry = table[dir];
+  if (!entry) return null;
+  const right = normalize(cross(entry.worldUp, entry.forward));
+  const up = normalize(cross(entry.forward, right));
+  return { right, up, forward: entry.forward };
+}
+
+/**
+ * Derive an offset (stepped) section plane from a cut polyline drawn on an
+ * orthographic view. The line runs vertically in view coordinates; each
+ * roughly-vertical segment becomes one step, its horizontal position the
+ * step's jog offset.
+ */
+export function sectionPlaneFromLine(
+  dir: ViewDirection,
+  points: Array<[number, number]>,
+): OffsetSectionPlane | null {
+  const basis = viewBasis(dir);
+  if (!basis || points.length < 2) return null;
+
+  const steps: Array<{ u_start: number; u_end: number; offset: number }> = [];
+  let baseX: number | null = null;
+  for (let i = 0; i < points.length - 1; i++) {
+    const [x1, y1] = points[i]!;
+    const [x2, y2] = points[i + 1]!;
+    if (Math.abs(y2 - y1) <= Math.abs(x2 - x1)) continue; // jog segment
+    const x = (x1 + x2) / 2;
+    if (baseX === null) baseX = x;
+    steps.push({
+      u_start: Math.min(y1, y2),
+      u_end: Math.max(y1, y2),
+      offset: x - baseX,
+    });
+  }
+  if (baseX === null) return null;
+
+  // Cutting planes are perpendicular to the view's right axis; the section's
+  // U axis (up × normal) must equal the view's up so step spans line up with
+  // the drawn polyline's vertical extents.
+  return {
+    base: {
+      origin: scale3(basis.right, baseX),
+      normal: basis.right,
+      up: basis.forward,
+    },
+    steps: steps.every((s) => s.offset === 0) ? [] : steps,
+  };
+}
+
+/** Concatenate all scene part meshes into a single mesh for sectioning. */
+export function combineSceneMeshes(): {
+  positions: Float32Array;
+  indices: Uint32Array;
+} | null {
+  const scene = useEngineStore.getState().scene;
+  if (!scene?.parts?.length) return null;
+
+  let vertCount = 0;
+  let idxCount = 0;
+  for (const part of scene.parts) {
+    vertCount += part.mesh.positions.length;
+    idxCount += part.mesh.indices.length;
+  }
+  const positions = new Float32Array(vertCount);
+  const indices = new Uint32Array(idxCount);
+  let vOff = 0;
+  let iOff = 0;
+  for (const part of scene.parts) {
+    positions.set(part.mesh.positions, vOff);
+    const base = vOff / 3;
+    for (let i = 0; i < part.mesh.indices.length; i++) {
+      indices[iOff + i] = part.mesh.indices[i]! + base;
+    }
+    vOff += part.mesh.positions.length;
+    iOff += part.mesh.indices.length;
+  }
+  return { positions, indices };
+}
+
+/** Compute the section view for a persisted section line. */
+export function computeSectionView(section: DrawingSectionLine): SectionView | null {
+  const engine = useEngineStore.getState().engine;
+  if (!engine) return null;
+  const mesh = combineSceneMeshes();
+  if (!mesh) return null;
+  const plane = sectionPlaneFromLine(
+    section.view as ViewDirection,
+    section.points as Array<[number, number]>,
+  );
+  if (!plane) return null;
+  return engine.offsetSectionMesh(mesh, plane, { spacing: 3, angle: Math.PI / 4 });
+}
+
+/** Kernel-shaped title block fields from the persisted (camelCase) IR shape. */
+export function toKernelTitleBlock(tb: DrawingTitleBlock, scaleNote: string): TitleBlockFields {
+  return {
+    part_name: tb.partName || "UNTITLED",
+    material: tb.material || "",
+    finish: "",
+    scale: tb.scale || scaleNote,
+    drawn_by: tb.author || "",
+    date: tb.date || "",
+    revision: tb.revision || "A",
+    units: "MM",
+    tolerance_note: "±0.1 UNLESS NOTED",
+  };
+}
+
+/** BOM rows from the document's part list. */
+export function buildBomRows(): BomRow[] {
+  const state = useDocumentStore.getState();
+  const materials = state.document.part_materials ?? {};
+  return state.parts.map((part, i) => ({
+    item: i + 1,
+    name: part.name || part.id,
+    qty: 1,
+    material: materials[part.name] ?? materials[part.id] ?? "",
+  }));
+}
+
+/** Map a rendered dimension from view coordinates to sheet coordinates:
+ * scale about `viewCenter`, translate so it lands at `sheetCenter`. Text and
+ * arrow sizes stay in sheet mm (readable at any view scale). */
+function dimensionToSheet(
+  rd: RenderedDimension,
+  viewCenter: [number, number],
+  sheetCenter: [number, number],
+  s: number,
+): RenderedDimension {
+  const map = (p: { x: number; y: number }) => ({
+    x: sheetCenter[0] + (p.x - viewCenter[0]) * s,
+    y: sheetCenter[1] + (p.y - viewCenter[1]) * s,
+  });
+  return {
+    lines: rd.lines.map(([a, b]) => [map(a), map(b)]),
+    arcs: rd.arcs.map((a) => ({ ...a, center: map(a.center), radius: a.radius * s })),
+    arrows: rd.arrows.map((a) => ({ ...a, tip: map(a.tip) })),
+    texts: rd.texts.map((t) => ({ ...t, position: map(t.position) })),
+    is_basic: rd.is_basic,
+  };
+}
+
+/** A cut-line annotation (polyline + end labels) in view coordinates. */
+function cutLineDimension(section: DrawingSectionLine): RenderedDimension {
+  const pts = section.points as Array<[number, number]>;
+  const lines: RenderedDimension["lines"] = [];
+  for (let i = 0; i < pts.length - 1; i++) {
+    lines.push([
+      { x: pts[i]![0], y: pts[i]![1] },
+      { x: pts[i + 1]![0], y: pts[i + 1]![1] },
+    ]);
+  }
+  const mkText = (p: [number, number]) => ({
+    position: { x: p[0], y: p[1] },
+    text: section.label,
+    height: 4,
+    rotation: 0,
+    alignment: "MiddleCenter",
+  });
+  return {
+    lines,
+    arcs: [],
+    arrows: [],
+    texts: pts.length ? [mkText(pts[0]!), mkText(pts[pts.length - 1]!)] : [],
+    is_basic: false,
+  };
+}
+
+/** Round a drawing scale to a conventional value (1:1, 1:2, 2:1, …). */
+function niceScale(s: number): { value: number; note: string } {
+  const standards = [100, 50, 20, 10, 5, 2, 1, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01];
+  const value = standards.find((v) => v <= s) ?? standards[standards.length - 1]!;
+  const note = value >= 1 ? `${value}:1` : `1:${Math.round(1 / value)}`;
+  return { value, note };
+}
+
+/**
+ * Compose the shop-drawing sheet spec from current app state: the active
+ * orthographic view, its dimensions, section views for this view's cut
+ * lines, the persisted title block, and the BOM when enabled.
+ */
+export function buildDrawingSheetSpec(): DrawingSheetSpec | null {
+  const engine = useEngineStore.getState().engine;
+  const scene = useEngineStore.getState().scene;
+  if (!engine || !scene?.parts?.length) return null;
+
+  const { viewDirection } = useDrawingStore.getState();
+  const doc = useDocumentStore.getState().document;
+  const drawing = doc.drawing;
+
+  const mesh = combineSceneMeshes();
+  if (!mesh) return null;
+  const view = engine.projectMesh(mesh, viewDirection);
+  if (!view) return null;
+
+  const sections = (drawing?.sections ?? []).filter((s) => s.view === viewDirection);
+  const showBom = drawing?.showBom ?? false;
+
+  // Sheet layout: A4 landscape (297×210), 10 mm margin. Reserve the right
+  // strip for sections and the bottom-right for title block + BOM.
+  const hasSections = sections.length > 0;
+  const mainBoxW = hasSections ? 140 : 200;
+  const mainBoxH = 130;
+  const mainCenter: [number, number] = hasSections ? [85, 120] : [120, 120];
+
+  const vw = view.bounds.max_x - view.bounds.min_x || 1;
+  const vh = view.bounds.max_y - view.bounds.min_y || 1;
+  const { value: s, note: scaleNote } = niceScale(
+    Math.min(mainBoxW / vw, mainBoxH / vh),
+  );
+  const viewCenter: [number, number] = [
+    (view.bounds.min_x + view.bounds.max_x) / 2,
+    (view.bounds.min_y + view.bounds.max_y) / 2,
+  ];
+
+  const spec: DrawingSheetSpec = {
+    size: "a4",
+    views: [
+      {
+        view,
+        center: mainCenter,
+        scale: s,
+        label: `${viewDirection.toUpperCase()} VIEW  (${scaleNote})`,
+      },
+    ],
+    sections: [],
+    annotations: [],
+  };
+
+  // Overall dimensions, transformed into sheet coordinates.
+  const AnnotationLayer = engine.WasmAnnotationLayer;
+  try {
+    const layer = new AnnotationLayer();
+    layer.addHorizontalDimension(
+      view.bounds.min_x, view.bounds.min_y, view.bounds.max_x, view.bounds.min_y, -10 / s,
+    );
+    layer.addVerticalDimension(
+      view.bounds.max_x, view.bounds.min_y, view.bounds.max_x, view.bounds.max_y, 10 / s,
+    );
+    const rendered = layer.renderAll() as RenderedDimension[];
+    layer.free();
+    for (const rd of rendered) {
+      spec.annotations!.push(dimensionToSheet(rd, viewCenter, mainCenter, s));
+    }
+  } catch {
+    // Dimensions are best-effort; the sheet is still valid without them.
+  }
+
+  // Section views stacked in the right strip, plus cut lines on the main view.
+  const sectionCenterX = 225;
+  let sectionY = 160;
+  for (const section of sections) {
+    const sv = computeSectionView(section);
+    if (!sv) continue;
+    spec.sections!.push({
+      view: sv,
+      center: [sectionCenterX, sectionY],
+      scale: s,
+      label: `SECTION ${section.label}-${section.label}  (${scaleNote})`,
+    });
+    sectionY -= 65;
+    spec.annotations!.push(
+      dimensionToSheet(cutLineDimension(section), viewCenter, mainCenter, s),
+    );
+  }
+
+  if (drawing?.titleBlock) {
+    spec.title_block = toKernelTitleBlock(drawing.titleBlock, scaleNote);
+  }
+  if (showBom) {
+    const rows = buildBomRows();
+    if (rows.length > 0) spec.bom = rows;
+  }
+
+  return spec;
+}
+
+/** Export the current drawing as a kernel-rendered PDF. Returns an error
+ * message on failure, null on success. */
+export function exportDrawingPdf(): string | null {
+  const engine = useEngineStore.getState().engine;
+  if (!engine) return "Engine not ready";
+  const spec = buildDrawingSheetSpec();
+  if (!spec) return "Nothing to export";
+  let bytes: Uint8Array | null;
+  try {
+    bytes = engine.drawingSheetToPdf(spec);
+  } catch (err) {
+    return `PDF export failed: ${(err as Error).message}`;
+  }
+  if (!bytes) return "Kernel build does not support PDF export";
+  const { viewDirection } = useDrawingStore.getState();
+  const blob = new Blob([new Uint8Array(bytes)], { type: "application/pdf" });
+  downloadBlob(blob, `drawing-${viewDirection}.pdf`);
+  return null;
+}

--- a/packages/core/src/commands.ts
+++ b/packages/core/src/commands.ts
@@ -120,6 +120,8 @@ export interface CommandActions {
   // File — optional extras
   openFromCloud?: () => void;
   exportStep?: () => void;
+  /** Export the current 2D drawing sheet as a kernel-rendered PDF. */
+  exportDrawingPdf?: () => void;
   newDocument?: () => void;
   // Edit — optional extras
   copy?: () => void;
@@ -414,6 +416,17 @@ export function createCommandRegistry(actions: CommandActions): CommandRegistry 
       keywords: ["open", "cloud", "load", "sync", "remote"],
       shortcut: "Ctrl+Shift+O",
       action: actions.openFromCloud,
+      category: "file",
+    });
+  }
+  if (actions.exportDrawingPdf) {
+    cmds.push({
+      id: "export-drawing-pdf",
+      label: t("cmd.export_drawing_pdf.label"),
+      icon: "Export",
+      keywords: ["export", "pdf", "drawing", "sheet", "print", "drafting"],
+      action: actions.exportDrawingPdf,
+      enabled: actions.hasParts,
       category: "file",
     });
   }

--- a/packages/core/src/i18n/translations.ts
+++ b/packages/core/src/i18n/translations.ts
@@ -734,6 +734,7 @@ export const translations = {
     "cmd.export_stl.label": "Export STL",
     "cmd.export_glb.label": "Export GLB",
     "cmd.export_step.label": "Export STEP",
+    "cmd.export_drawing_pdf.label": "Export Drawing PDF",
     "cmd.quit.label": "Quit",
     "cmd.toggle_sidebar.label": "Toggle Sidebar",
     "cmd.toggle_feature_tree.label": "Toggle Feature Tree",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,6 +334,15 @@ export type {
   RenderedArc,
   DetailView,
   DetailViewParams,
+  SectionView,
+  SectionCurve,
+  SectionPlane,
+  OffsetSectionPlane,
+  OffsetSectionStep,
+  TitleBlockFields,
+  BomRow,
+  RenderedBlock,
+  DrawingSheetSpec,
 } from "@vcad/engine";
 
 // Logger

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -12,6 +12,7 @@ import type {
   SweepOp,
   JointKind,
   SceneSettings,
+  DrawingSettings,
   Environment,
   Light,
   Background,
@@ -415,6 +416,8 @@ export interface DocumentState {
   reorderPart: (partId: string, newIndex: number) => void;
   // Scene settings actions
   setSceneSettings: (settings: SceneSettings) => void;
+  /** Persist drawing sheet settings (title block, sections, BOM) on the document. */
+  setDrawingSettings: (settings: DrawingSettings) => void;
   updateEnvironment: (environment: Environment) => void;
   updateLights: (lights: Light[]) => void;
   addLight: (light: Light) => void;
@@ -734,6 +737,28 @@ function getOrCreateSceneFeature(state: DocumentState): string {
   return "";
 }
 
+let _drawingSettingsFeatureId: string | null = null;
+
+function getOrCreateDrawingFeature(state: DocumentState): string {
+  const engine = state._crdtEngine!;
+  if (_drawingSettingsFeatureId) return _drawingSettingsFeatureId;
+
+  const featuresJson = engine.get_ordered_features_json();
+  const features: { id: string; kind: string }[] = JSON.parse(featuresJson);
+  const existing = features.find((f) => f.kind === "drawing-settings");
+  if (existing) {
+    _drawingSettingsFeatureId = existing.id;
+    return existing.id;
+  }
+
+  const result = engine.create_feature("drawing-settings", "{}");
+  if (result.createdFeatureId) {
+    _drawingSettingsFeatureId = result.createdFeatureId;
+    return result.createdFeatureId;
+  }
+  return "";
+}
+
 function getOrCreateSchematicFeature(state: DocumentState): string {
   const engine = state._crdtEngine!;
   if (_schematicFeatureId) return _schematicFeatureId;
@@ -842,6 +867,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     }
     _sceneSettingsFeatureId = null;
     _schematicFeatureId = null;
+    _drawingSettingsFeatureId = null;
     const engine = new EngineClass();
     set({ _crdtEngine: engine, _crdtEngineClass: EngineClass });
   },
@@ -1782,6 +1808,7 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     if (state._crdtEngineClass) {
       _sceneSettingsFeatureId = null;
       _schematicFeatureId = null;
+      _drawingSettingsFeatureId = null;
       const engine = new state._crdtEngineClass();
       set({
         document: createDocument(),
@@ -1866,6 +1893,17 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
     if (settings.background) engine.set_param(fid, "background", JSON.stringify(crdtStr(JSON.stringify(settings.background))));
     if (settings.postProcessing) engine.set_param(fid, "post_processing", JSON.stringify(crdtStr(JSON.stringify(settings.postProcessing))));
     if (settings.cameraPresets) engine.set_param(fid, "camera_presets", JSON.stringify(crdtStr(JSON.stringify(settings.cameraPresets))));
+    const doc: Document = JSON.parse(engine.get_document_json());
+    set({ document: doc, isDirty: true });
+  },
+
+  setDrawingSettings: (settings) => {
+    const state = get();
+    const engine = state._crdtEngine!;
+    const fid = getOrCreateDrawingFeature(state);
+    if (settings.titleBlock) engine.set_param(fid, "title_block", JSON.stringify(crdtStr(JSON.stringify(settings.titleBlock))));
+    if (settings.sections) engine.set_param(fid, "sections", JSON.stringify(crdtStr(JSON.stringify(settings.sections))));
+    if (settings.showBom !== undefined) engine.set_param(fid, "show_bom", JSON.stringify(crdtStr(JSON.stringify(settings.showBom))));
     const doc: Document = JSON.parse(engine.get_document_json());
     set({ document: doc, isDirty: true });
   },

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -357,6 +357,77 @@ export interface DetailView {
   params: DetailViewParams;
 }
 
+/** A 2D section cut curve (from sectioning a mesh with a plane) */
+export interface SectionCurve {
+  points: Array<{ x: number; y: number }>;
+  is_closed: boolean;
+}
+
+/** Result of sectioning a mesh: cut curves, hatch lines, bounds */
+export interface SectionView {
+  curves: SectionCurve[];
+  hatch_lines: Array<[{ x: number; y: number }, { x: number; y: number }]>;
+  bounds: BoundingBox2D;
+}
+
+/** A cutting plane for section views */
+export interface SectionPlane {
+  origin: [number, number, number];
+  normal: [number, number, number];
+  up: [number, number, number];
+}
+
+/** One step (jog span) of an offset section */
+export interface OffsetSectionStep {
+  u_start: number;
+  u_end: number;
+  offset: number;
+}
+
+/** An offset (stepped) section plane: base plane + jogs */
+export interface OffsetSectionPlane {
+  base: SectionPlane;
+  steps: OffsetSectionStep[];
+}
+
+/** Title block field values for a drawing sheet (kernel snake_case shape) */
+export interface TitleBlockFields {
+  part_name: string;
+  material: string;
+  finish: string;
+  scale: string;
+  drawn_by: string;
+  date: string;
+  revision: string;
+  units: string;
+  tolerance_note: string;
+}
+
+/** One row of a drawing BOM table */
+export interface BomRow {
+  item: number;
+  name: string;
+  qty: number;
+  material: string;
+}
+
+/** A rendered drawing block (title block / BOM table) plus its footprint */
+export interface RenderedBlock {
+  rendered: RenderedDimension;
+  width: number;
+  height: number;
+}
+
+/** Spec for composing a drawing sheet for PDF export */
+export interface DrawingSheetSpec {
+  size?: "a4" | "a3" | "letter" | { custom: { width: number; height: number } };
+  views?: Array<{ view: ProjectedView; center: [number, number]; scale: number; label?: string }>;
+  sections?: Array<{ view: SectionView; center: [number, number]; scale: number; label?: string }>;
+  annotations?: RenderedDimension[];
+  title_block?: TitleBlockFields;
+  bom?: BomRow[];
+}
+
 /** Type for the initialized kernel module */
 export interface KernelModule {
   Solid: typeof Solid;
@@ -377,6 +448,18 @@ export interface KernelModule {
    */
   importUrdfBuffer: (data: Uint8Array) => string;
   exportProjectedViewToDxf: (view_json: string) => Uint8Array;
+  /** Offset (stepped) section of a mesh; null on parse failure. */
+  offsetSectionMesh?: (
+    mesh: { positions: Float32Array; indices: Uint32Array },
+    plane_json: string,
+    hatch_json?: string,
+  ) => SectionView | null;
+  /** Render a title block at origin (0,0). */
+  renderTitleBlock?: (fields_json: string) => RenderedBlock | null;
+  /** Render a BOM table at origin (0,0). */
+  renderBomTable?: (rows_json: string) => RenderedBlock | null;
+  /** Compose a drawing sheet and export it as PDF bytes. */
+  drawingSheetToPdf?: (spec_json: string) => Uint8Array;
   createDetailView: (
     parent_json: string,
     center_x: number,
@@ -866,6 +949,10 @@ export class Engine {
       importStepBuffer: wasmModule.importStepBuffer,
       importUrdfBuffer: (wasmModule as Record<string, unknown>).importUrdfBuffer as KernelModule["importUrdfBuffer"],
       exportProjectedViewToDxf: wasmModule.exportProjectedViewToDxf,
+      offsetSectionMesh: (wasmModule as Record<string, unknown>).offsetSectionMesh as KernelModule["offsetSectionMesh"],
+      renderTitleBlock: (wasmModule as Record<string, unknown>).renderTitleBlock as KernelModule["renderTitleBlock"],
+      renderBomTable: (wasmModule as Record<string, unknown>).renderBomTable as KernelModule["renderBomTable"],
+      drawingSheetToPdf: (wasmModule as Record<string, unknown>).drawingSheetToPdf as KernelModule["drawingSheetToPdf"],
       createDetailView: wasmModule.createDetailView,
       evaluateDocument: (wasmModule as Record<string, unknown>).evaluateDocument as KernelModule["evaluateDocument"],
       evalVcadSource: (wasmModule as Record<string, unknown>).evalVcadSource as KernelModule["evalVcadSource"],
@@ -1498,6 +1585,40 @@ export class Engine {
   exportDrawingToDxf(view: ProjectedView): Uint8Array {
     const json = JSON.stringify(view);
     return this.kernel.exportProjectedViewToDxf(json);
+  }
+
+  /** Offset (stepped) section of a mesh. Returns null when the kernel lacks
+   * the binding or the inputs fail to parse. */
+  offsetSectionMesh(
+    mesh: { positions: Float32Array; indices: Uint32Array },
+    plane: OffsetSectionPlane,
+    hatch?: { spacing: number; angle: number },
+  ): SectionView | null {
+    if (!this.kernel.offsetSectionMesh) return null;
+    return this.kernel.offsetSectionMesh(
+      mesh,
+      JSON.stringify(plane),
+      hatch ? JSON.stringify(hatch) : undefined,
+    );
+  }
+
+  /** Render a title block (kernel-drawn, matches the PDF output). */
+  renderTitleBlock(fields: TitleBlockFields): RenderedBlock | null {
+    if (!this.kernel.renderTitleBlock) return null;
+    return this.kernel.renderTitleBlock(JSON.stringify(fields));
+  }
+
+  /** Render a BOM table (kernel-drawn, matches the PDF output). */
+  renderBomTable(rows: BomRow[]): RenderedBlock | null {
+    if (!this.kernel.renderBomTable) return null;
+    return this.kernel.renderBomTable(JSON.stringify(rows));
+  }
+
+  /** Compose a drawing sheet and export it as PDF bytes. Returns null when
+   * the kernel lacks the binding. */
+  drawingSheetToPdf(spec: DrawingSheetSpec): Uint8Array | null {
+    if (!this.kernel.drawingSheetToPdf) return null;
+    return this.kernel.drawingSheetToPdf(JSON.stringify(spec));
   }
 
   /**

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -1148,10 +1148,84 @@ bindings?: Bindings,
  */
 clearance_specs?: Array<ClearanceSpec>, 
 /**
+ * Drawing sheet settings: title block, section lines, BOM visibility.
+ */
+drawing?: DrawingSettings, 
+/**
  * Animation timeline: keyframed parameters/joints/visibility plus
  * camera shots. Absent for static models.
  */
 timeline?: Timeline, };
+
+/**
+ * A section cut line drawn on an orthographic drawing view. The polyline
+ * runs vertically in view coordinates; horizontal jogs produce an offset
+ * (stepped) section.
+ */
+export type DrawingSectionLine = { 
+/**
+ * Unique id within the drawing.
+ */
+id: string, 
+/**
+ * View direction the line was drawn on ("front", "top", "right", …).
+ */
+view: string, 
+/**
+ * Section label letter (e.g. "A" → "SECTION A-A").
+ */
+label: string, 
+/**
+ * Polyline points in 2D view coordinates (mm).
+ */
+points: Array<[number, number]>, };
+
+/**
+ * Drawing (drafting) settings persisted on the document: title block,
+ * section lines, and BOM table visibility for the 2D drawing sheet.
+ */
+export type DrawingSettings = { 
+/**
+ * Title block fields shown on the sheet.
+ */
+titleBlock?: DrawingTitleBlock, 
+/**
+ * Section cut lines defined on drawing views.
+ */
+sections?: Array<DrawingSectionLine>, 
+/**
+ * Whether the BOM table is placed on the sheet.
+ */
+showBom?: boolean, };
+
+/**
+ * Title block fields for a technical drawing sheet.
+ */
+export type DrawingTitleBlock = { 
+/**
+ * Part or assembly name.
+ */
+partName: string, 
+/**
+ * Author (drawn by).
+ */
+author: string, 
+/**
+ * Date string (caller-formatted, e.g. "2026-07-18").
+ */
+date: string, 
+/**
+ * Drawing scale note (e.g. "1:1").
+ */
+scale: string, 
+/**
+ * Material specification (e.g. "6061-T6 AL").
+ */
+material: string, 
+/**
+ * Revision letter (e.g. "A").
+ */
+revision: string, };
 
 /**
  * A canonicalized DRC summary: total, per-rule counts (sorted), and the


### PR DESCRIPTION
Closes #593.

The kernel's shop-drawing toolkit (#571 — offset sections, title block, BOM table, deterministic PDF) is now reachable from the app's drawing mode.

## What's new

- **Offset section views** — pick the scissors tool, click points on an orthographic view (vertical cut line, horizontal jogs = offset steps), Enter to commit. The kernel computes the section (`offset_section_mesh`) and it renders as a `SECTION A-A` inset with hatching, plus the cut line on the parent view.
- **Title block editor** — part name, author, date, scale, material, revision. Persisted on the `.vcad` document (`document.drawing.titleBlock`) via a new `drawing-settings` CRDT feature kind, and rendered on-sheet by the kernel (`TitleBlock::render`) so screen and PDF match.
- **BOM table** — one toggle places the kernel-rendered BOM (item / part name / qty / material from the document's part list) above the title block.
- **Export Drawing PDF** — in the drawing toolbar, **File → Export**, and the **command palette**. Composes a `DrawingSheet` (A4, main view + dimensions + sections + cut lines + title block + BOM) in the kernel and emits its dependency-free PDF 1.4 — no client-side canvas printing.

## Plumbing

- `vcad-ir`: `DrawingSettings` / `DrawingTitleBlock` / `DrawingSectionLine` on `Document` (+ `ir:gen`)
- `vcad-app` (Rust): `drawing-settings` feature kind + materializer
- `vcad-kernel-wasm`: `offsetSectionMesh`, `renderTitleBlock`, `renderBomTable`, `drawingSheetToPdf`
- `@vcad/engine` / `@vcad/core`: typed wrappers, `setDrawingSettings` store action, `export-drawing-pdf` command
- WASM artifacts intentionally not committed (wasm-refresh maintains them on main)

## Verified

- `cargo test` (ir/app/drafting/wasm), `cargo clippy --workspace -D warnings`, `cargo fmt --check`, `ir:check`, all TS package builds + tests
- Manually in the browser: section creation on the bracket example, title block + BOM rendering, "PDF exported" from toolbar, File menu entry, ⌘K entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)