### PR TITLE
Kinematic joint playback: time-major keyframes without physics

### DIFF
--- a/changelog/entries/2026-07-19-kinematic-joint-playback.json
+++ b/changelog/entries/2026-07-19-kinematic-joint-playback.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-19-kinematic-joint-playback",
+  "version": "0.9.4",
+  "date": "2026-07-19",
+  "category": "feat",
+  "title": "Kinematic joint playback: keyframes without physics",
+  "summary": "animate/render_sequence/export_video accept time-major joint keyframes — servo-style commanded motion posed exactly, no gravity; export_video gains render_view's azimuth/elevation camera.",
+  "features": ["animation", "assembly", "joints"],
+  "mcpTools": ["animate", "render_sequence", "export_video"]
+}

--- a/packages/mcp/src/__tests__/animate.test.ts
+++ b/packages/mcp/src/__tests__/animate.test.ts
@@ -16,10 +16,15 @@ import {
   verifySequenceClearance,
   injectHud,
   compileRolloutTimeline,
+  compileJointKeyframes,
   startMp4Encoder,
 } from "../tools/animate.js";
 import { documents, openDocument } from "../tools/session.js";
-import { sampleSequence } from "@vcad/engine";
+import {
+  sampleSequence,
+  poseDocument,
+  solveForwardKinematics,
+} from "@vcad/engine";
 
 let engine: Engine;
 
@@ -465,5 +470,236 @@ describe("injectHud", () => {
     });
     expect(failing).toContain("#ef4444");
     expect(failing).toContain("✗");
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/* Kinematic keyframe playback                                         */
+/* ------------------------------------------------------------------ */
+
+/** Three-link machine: base → revolute arm → prismatic slider riding the
+ *  arm. The acceptance fixture for kinematic playback: a mid-tree joint
+ *  move (shoulder) must carry the slider with it. */
+function machineDocument(): Document {
+  return {
+    version: "0.1",
+    nodes: {
+      "1": {
+        id: 1,
+        name: "base",
+        op: { type: "Cube", size: { x: 80, y: 80, z: 10 } },
+      },
+      "2": {
+        id: 2,
+        name: "arm",
+        op: { type: "Cube", size: { x: 60, y: 10, z: 10 } },
+      },
+      "3": {
+        id: 3,
+        name: "slider",
+        op: { type: "Cube", size: { x: 15, y: 8, z: 8 } },
+      },
+    },
+    materials: {},
+    part_materials: {},
+    roots: [],
+    partDefs: {
+      base: { id: "base", name: "Base", root: 1, defaultMaterial: null },
+      arm: { id: "arm", name: "Arm", root: 2, defaultMaterial: null },
+      slider: { id: "slider", name: "Slider", root: 3, defaultMaterial: null },
+    },
+    instances: [
+      { id: "base_inst", partDefId: "base", name: "Base", transform: null, material: null },
+      { id: "arm_inst", partDefId: "arm", name: "Arm", transform: null, material: null },
+      { id: "slider_inst", partDefId: "slider", name: "Slider", transform: null, material: null },
+    ],
+    joints: [
+      {
+        id: "shoulder",
+        name: "Shoulder",
+        parentInstanceId: "base_inst",
+        childInstanceId: "arm_inst",
+        parentAnchor: { x: 40, y: 40, z: 10 },
+        childAnchor: { x: 0, y: 5, z: 0 },
+        kind: { type: "Revolute", axis: { x: 0, y: 0, z: 1 }, limits: null },
+        state: 0,
+      },
+      {
+        id: "slide",
+        name: "Slide",
+        parentInstanceId: "arm_inst",
+        childInstanceId: "slider_inst",
+        parentAnchor: { x: 10, y: 5, z: 10 },
+        childAnchor: { x: 0, y: 4, z: 0 },
+        kind: { type: "Slider", axis: { x: 1, y: 0, z: 0 }, limits: null },
+        state: 0,
+      },
+    ],
+    groundInstanceId: "base_inst",
+  } as unknown as Document;
+}
+
+const machineKeyframes = [
+  { t: 0, joints: { shoulder: 0, slide: 0 } },
+  { t: 1, joints: { shoulder: 90, slide: 30 } },
+];
+
+describe("compileJointKeyframes", () => {
+  it("compiles time-major keyframes into per-joint linear tracks", () => {
+    const compiled = compileJointKeyframes(machineKeyframes);
+    if ("error" in compiled) throw new Error(compiled.error);
+    const tl = compiled.timeline;
+    expect(tl.durationS).toBe(1);
+    expect(tl.fps).toBe(24);
+    expect(tl.tracks).toHaveLength(2);
+    const shoulder = tl.tracks.find(
+      (t) => (t.target as { jointId?: string }).jointId === "shoulder",
+    )!;
+    expect(shoulder.keys).toEqual([
+      { t: 0, value: 0, ease: "linear" },
+      { t: 1, value: 90, ease: "linear" },
+    ]);
+  });
+
+  it("rejects malformed keyframes loudly", () => {
+    expect(compileJointKeyframes([])).toHaveProperty("error");
+    expect(
+      compileJointKeyframes([
+        { t: 1, joints: { a: 0 } },
+        { t: 0.5, joints: { a: 1 } },
+      ]),
+    ).toHaveProperty("error");
+    expect(
+      compileJointKeyframes([
+        { t: 0, joints: { a: NaN } },
+        { t: 1, joints: { a: 1 } },
+      ]),
+    ).toHaveProperty("error");
+    expect(
+      compileJointKeyframes([
+        { t: 0, joints: {} },
+        { t: 1, joints: { a: 1 } },
+      ]),
+    ).toHaveProperty("error");
+  });
+});
+
+describe("kinematic playback (keyframes)", () => {
+  it("animate accepts keyframes and refuses timeline+keyframes together", async () => {
+    const opened = out(openDocument({ initial: machineDocument() }));
+    const docId = opened.document_id as string;
+    const both = await animate({
+      document_id: docId,
+      timeline: spinTimeline,
+      keyframes: machineKeyframes,
+    });
+    expect(both.isError).toBe(true);
+
+    const res = await animate({
+      document_id: docId,
+      keyframes: machineKeyframes,
+      fps: 12,
+    });
+    const body = out(res);
+    if (res.isError) throw new Error(body.error);
+    expect(body.duration_s).toBe(1);
+    expect(body.fps).toBe(12);
+    expect(body.tracks).toHaveLength(2);
+  });
+
+  it("rejects keyframes referencing unknown joints", async () => {
+    const opened = out(openDocument({ initial: machineDocument() }));
+    const docId = opened.document_id as string;
+    const res = await animate({
+      document_id: docId,
+      keyframes: [
+        { t: 0, joints: { elbow: 0 } },
+        { t: 1, joints: { elbow: 45 } },
+      ],
+    });
+    expect(res.isError).toBe(true);
+    expect(out(res).error).toContain('unknown joint "elbow"');
+  });
+
+  it("a mid-tree joint move carries children: the slider rides the arm", async () => {
+    const doc = machineDocument();
+    const compiled = compileJointKeyframes(machineKeyframes, { fps: 4 });
+    if ("error" in compiled) throw new Error(compiled.error);
+    const frames = sampleSequence(doc, compiled.timeline);
+    const first = frames[0]!;
+    const last = frames[frames.length - 1]!;
+    expect(last.joints.shoulder).toBeCloseTo(90);
+    expect(last.joints.slide).toBeCloseTo(30);
+
+    const world0 = solveForwardKinematics(poseDocument(doc, first));
+    const world1 = solveForwardKinematics(poseDocument(doc, last));
+    const s0 = world0.get("slider_inst")!.translation;
+    const s1 = world1.get("slider_inst")!.translation;
+    // With shoulder at 90° the whole slide axis has rotated: the slider's
+    // world position must move in BOTH x and y, not just along its own axis.
+    expect(Math.abs(s1.x - s0.x)).toBeGreaterThan(1);
+    expect(Math.abs(s1.y - s0.y)).toBeGreaterThan(1);
+
+    // And with the shoulder pinned, the slide joint alone must translate
+    // the slider along the (rotated) arm — pure kinematics, no sag.
+    const pinned = { ...last, joints: { shoulder: 90, slide: 0 } };
+    const worldPinned = solveForwardKinematics(poseDocument(doc, pinned));
+    const sp = worldPinned.get("slider_inst")!.translation;
+    const slideDist = Math.hypot(s1.x - sp.x, s1.y - sp.y, s1.z - sp.z);
+    expect(slideDist).toBeCloseTo(30, 1);
+  });
+
+  it("export_video renders keyframes to a GIF (arm sweep + slider travel)", async () => {
+    const opened = out(openDocument({ initial: machineDocument() }));
+    const docId = opened.document_id as string;
+    const res = await exportVideo(
+      {
+        document_id: docId,
+        keyframes: machineKeyframes,
+        fps: 6,
+        format: "gif",
+        width_px: 240,
+      },
+      { engine } as never,
+    );
+    const content = res.content as Array<{
+      type: string;
+      text?: string;
+      data?: string;
+      mimeType?: string;
+    }>;
+    const text = content.find((c) => c.type === "text")!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const summary: any = JSON.parse(text.text!);
+    if (res.isError) throw new Error(summary.error);
+    expect(summary.format).toBe("gif");
+    expect(summary.frames).toBe(7); // 1s at 6fps inclusive
+    const image = content.find((c) => c.type === "image");
+    expect(image?.mimeType).toBe("image/gif");
+    const gif = Buffer.from(image!.data!, "base64");
+    expect(gif.subarray(0, 6).toString("latin1")).toBe("GIF89a");
+  });
+
+  it("export_video accepts render_view-style azimuth/elevation", async () => {
+    const opened = out(openDocument({ initial: machineDocument() }));
+    const docId = opened.document_id as string;
+    const res = await exportVideo(
+      {
+        document_id: docId,
+        keyframes: machineKeyframes,
+        fps: 2,
+        format: "gif",
+        width_px: 160,
+        azimuth: 45,
+        elevation: 20,
+      },
+      { engine } as never,
+    );
+    const content = res.content as Array<{ type: string; text?: string }>;
+    const text = content.find((c) => c.type === "text")!;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const summary: any = JSON.parse(text.text!);
+    if (res.isError) throw new Error(summary.error);
+    expect(summary.view).toBe("orbit(azimuth=45, elevation=20)");
   });
 });

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -5112,7 +5112,7 @@
   {
     "name": "animate",
     "title": "Animate",
-    "description": "Set (or clear) the document's animation timeline: keyframe named parameters, joint states, instance visibility, or a global explode factor, plus declarative camera shots (turntable/orbit/focus). Preview with render_sequence; ship with export_video.",
+    "description": "Set (or clear) the document's animation timeline: keyframe named parameters, joint states, instance visibility, or a global explode factor, plus declarative camera shots (turntable/orbit/focus). For kinematic joint playback (servo-style commanded motion, no physics) pass `keyframes:[{t, joints:{jointId: value}}]` instead of a full timeline. Preview with render_sequence; ship with export_video.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -5123,11 +5123,21 @@
         "timeline": {
           "type": "object",
           "description": "Full timeline to set on the document: {durationS, fps?, tracks?, camera?}. Tracks keyframe targets: {target:{type:\"Parameter\",name}|{type:\"Joint\",jointId}|{type:\"Visibility\",instanceId}|{type:\"Explode\"}, keys:[{t,value,ease?:\"linear\"|\"step\"|\"ease-in-out\"}]}. Camera shots: {startS,endS,kind:{type:\"Turntable\",degrees,elevationDeg?}|{type:\"Orbit\",from:[az,el],to:[az,el]}|{type:\"Focus\",target,dolly?}|{type:\"Static\"}}. Pass null to clear the timeline."
+        },
+        "keyframes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Kinematic playback shorthand: time-major joint keyframes [{t, joints:{jointId: value}}] with linear interpolation between keys — no physics, no gravity; joints are posed exactly at the commanded values (degrees for revolute, mm for prismatic) and children ride their parents through the joint tree. Compiled to per-joint linear tracks. Mutually exclusive with `timeline`."
+        },
+        "fps": {
+          "type": "number",
+          "description": "Playback frame rate when compiling `keyframes` (1-60, default 24). Ignored when `timeline` is passed."
         }
       },
       "required": [
-        "document_id",
-        "timeline"
+        "document_id"
       ]
     },
     "annotations": {
@@ -5174,7 +5184,7 @@
   {
     "name": "render_sequence",
     "title": "Render Sequence",
-    "description": "Compile the document's timeline into an animated GLB (glTF animation channels) — the cheap preview loop for motion. Joint/visibility/explode tracks animate instance nodes; parameter tracks re-evaluate geometry at sampled times. When the document has clearance_specs, they are re-measured across frames and reported (the sequence as evidence).",
+    "description": "Compile the document's timeline into an animated GLB (glTF animation channels) — the cheap preview loop for motion. Accepts one-shot `keyframes:[{t, joints:{jointId: value}}]` for kinematic joint playback (posed exactly, no physics). Joint/visibility/explode tracks animate instance nodes; parameter tracks re-evaluate geometry at sampled times. When the document has clearance_specs, they are re-measured across frames and reported (the sequence as evidence).",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -5185,6 +5195,17 @@
         "timeline": {
           "type": "object",
           "description": "Optional one-shot timeline override (same shape as `animate`). When omitted, the document's stored timeline is used."
+        },
+        "keyframes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Kinematic playback shorthand: time-major joint keyframes [{t, joints:{jointId: value}}] with linear interpolation between keys — no physics, no gravity; joints are posed exactly at the commanded values (degrees for revolute, mm for prismatic) and children ride their parents through the joint tree. Compiled to per-joint linear tracks. Mutually exclusive with `timeline`."
+        },
+        "fps": {
+          "type": "number",
+          "description": "Playback frame rate when compiling `keyframes` (1-60, default 24)."
         },
         "verify": {
           "type": "boolean",
@@ -5211,7 +5232,7 @@
   {
     "name": "export_video",
     "title": "Export Video",
-    "description": "Render the timeline to an animated GIF or MP4 through the kernel renderer, with the verification HUD (time, animated values, clearance status) burned into every frame. MP4 requires ffmpeg on the server; GIF always works. Large outputs offload to an artifact URL.",
+    "description": "Render the timeline to an animated GIF or MP4 through the kernel renderer, with the verification HUD (time, animated values, clearance status) burned into every frame. Accepts one-shot `keyframes:[{t, joints:{jointId: value}}]` for kinematic joint playback (posed exactly, no physics) — children ride their parents through the joint tree. Camera matches render_view: named `view` or azimuth/elevation orbit. MP4 requires ffmpeg on the server; GIF always works. Large outputs offload to an artifact URL.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -5222,6 +5243,17 @@
         "timeline": {
           "type": "object",
           "description": "Optional one-shot timeline override (same shape as `animate`)."
+        },
+        "keyframes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          },
+          "description": "Kinematic playback shorthand: time-major joint keyframes [{t, joints:{jointId: value}}] with linear interpolation between keys — no physics, no gravity; joints are posed exactly at the commanded values (degrees for revolute, mm for prismatic) and children ride their parents through the joint tree. Compiled to per-joint linear tracks. Mutually exclusive with `timeline`."
+        },
+        "fps": {
+          "type": "number",
+          "description": "Playback frame rate when compiling `keyframes` (1-60, default 24)."
         },
         "format": {
           "type": "string",
@@ -5241,7 +5273,15 @@
             "front",
             "side"
           ],
-          "description": "Camera view for the kernel renderer; defaults to 'iso'."
+          "description": "Camera view for the kernel renderer; defaults to 'iso'. Ignored when azimuth/elevation are given."
+        },
+        "azimuth": {
+          "type": "number",
+          "description": "Orbit camera azimuth in degrees, CCW from +X in the XY plane (Z-up), matching render_view. Providing azimuth and/or elevation selects an arbitrary orbit view (missing angle defaults to 0) and overrides `view`."
+        },
+        "elevation": {
+          "type": "number",
+          "description": "Orbit camera elevation in degrees above the XY plane, clamped to [-90, 90]. See `azimuth`."
         },
         "width_px": {
           "type": "number",

--- a/packages/mcp/src/tools/animate.ts
+++ b/packages/mcp/src/tools/animate.ts
@@ -201,6 +201,114 @@ export function verifySequenceClearance(
 }
 
 /* ------------------------------------------------------------------ */
+/* Kinematic keyframes → timeline                                      */
+/* ------------------------------------------------------------------ */
+
+/** One time-major kinematic keyframe: every listed joint is posed at `t`. */
+export interface JointKeyframe {
+  /** Time in seconds (ascending across the list). */
+  t: number;
+  /** Joint id → commanded state (degrees for revolute, mm for prismatic). */
+  joints: Record<string, number>;
+}
+
+export const KEYFRAMES_DESCRIPTION =
+  "Kinematic playback shorthand: time-major joint keyframes " +
+  '[{t, joints:{jointId: value}}] with linear interpolation between keys — ' +
+  "no physics, no gravity; joints are posed exactly at the commanded values " +
+  "(degrees for revolute, mm for prismatic) and children ride their parents " +
+  "through the joint tree. Compiled to per-joint linear tracks. " +
+  "Mutually exclusive with `timeline`.";
+
+/**
+ * Compile time-major joint keyframes into a track-major {@link Timeline}
+ * (one linear track per joint id). Pure; exported for tests.
+ *
+ * A joint absent from some keyframes simply has fewer keys — the sampler's
+ * clamp-outside/interpolate-between semantics give the natural behavior
+ * (hold before its first key, hold after its last).
+ */
+export function compileJointKeyframes(
+  keyframes: JointKeyframe[],
+  opts: { fps?: number } = {},
+): { timeline: Timeline } | { error: string } {
+  if (!Array.isArray(keyframes) || keyframes.length < 2) {
+    return { error: "`keyframes` needs at least 2 entries" };
+  }
+  const perJoint = new Map<string, { t: number; value: number; ease: "linear" }[]>();
+  let prevT = -Infinity;
+  for (let i = 0; i < keyframes.length; i++) {
+    const kf = keyframes[i]!;
+    const t = Number(kf?.t);
+    if (!Number.isFinite(t) || t < 0) {
+      return { error: `keyframes[${i}].t must be a finite number >= 0` };
+    }
+    if (t < prevT) {
+      return { error: `keyframes[${i}].t=${t} is not ascending (previous was ${prevT})` };
+    }
+    prevT = t;
+    const joints = kf?.joints;
+    if (!joints || typeof joints !== "object" || Object.keys(joints).length === 0) {
+      return { error: `keyframes[${i}].joints must map at least one joint id to a value` };
+    }
+    for (const [id, raw] of Object.entries(joints)) {
+      const value = Number(raw);
+      if (!Number.isFinite(value)) {
+        return { error: `keyframes[${i}].joints["${id}"] must be a finite number` };
+      }
+      let keys = perJoint.get(id);
+      if (!keys) {
+        keys = [];
+        perJoint.set(id, keys);
+      }
+      keys.push({ t, value, ease: "linear" });
+    }
+  }
+  const durationS = prevT;
+  if (!(durationS > 0)) {
+    return { error: "keyframes must span a positive duration (last t must be > 0)" };
+  }
+  const fps =
+    opts.fps !== undefined && Number.isFinite(opts.fps)
+      ? Math.min(60, Math.max(1, Math.round(opts.fps)))
+      : 24;
+  const tracks: AnimTrack[] = [...perJoint.entries()].map(
+    ([jointId, keys]) =>
+      ({ target: { type: "Joint", jointId }, keys }) as unknown as AnimTrack,
+  );
+  return { timeline: { durationS, fps, tracks, camera: [] } as unknown as Timeline };
+}
+
+/**
+ * Resolve the timeline for a render tool call: an explicit one-shot
+ * `timeline`, compiled `keyframes`, or the document's stored timeline —
+ * in that priority, with `timeline`+`keyframes` together refused.
+ */
+function resolveTimelineInput(
+  args: Record<string, unknown>,
+  doc: Document,
+): { timeline: Timeline } | { error: string } {
+  if (args.timeline !== undefined && args.keyframes !== undefined) {
+    return { error: "Pass either `timeline` or `keyframes`, not both." };
+  }
+  if (args.keyframes !== undefined) {
+    const compiled = compileJointKeyframes(args.keyframes as JointKeyframe[], {
+      fps: args.fps === undefined ? undefined : Number(args.fps),
+    });
+    if ("error" in compiled) return compiled;
+    return { timeline: compiled.timeline };
+  }
+  const timeline = (args.timeline as Timeline | undefined) ?? doc.timeline;
+  if (!timeline) {
+    return {
+      error:
+        "No timeline: set one with `animate`, or pass one-shot `timeline` or `keyframes` here.",
+    };
+  }
+  return { timeline };
+}
+
+/* ------------------------------------------------------------------ */
 /* animate — author the timeline                                       */
 /* ------------------------------------------------------------------ */
 
@@ -216,8 +324,18 @@ export const animateSchema = {
       description:
         'Full timeline to set on the document: {durationS, fps?, tracks?, camera?}. Tracks keyframe targets: {target:{type:"Parameter",name}|{type:"Joint",jointId}|{type:"Visibility",instanceId}|{type:"Explode"}, keys:[{t,value,ease?:"linear"|"step"|"ease-in-out"}]}. Camera shots: {startS,endS,kind:{type:"Turntable",degrees,elevationDeg?}|{type:"Orbit",from:[az,el],to:[az,el]}|{type:"Focus",target,dolly?}|{type:"Static"}}. Pass null to clear the timeline.',
     },
+    keyframes: {
+      type: "array" as const,
+      items: { type: "object" as const },
+      description: KEYFRAMES_DESCRIPTION,
+    },
+    fps: {
+      type: "number" as const,
+      description:
+        "Playback frame rate when compiling `keyframes` (1-60, default 24). Ignored when `timeline` is passed.",
+    },
   },
-  required: ["document_id", "timeline"],
+  required: ["document_id"],
 };
 
 export async function animate(
@@ -229,7 +347,22 @@ export async function animate(
     doc.timeline = undefined;
     return ok({ timeline: null, note: "timeline cleared" });
   }
-  const timeline = raw as Timeline;
+  if (raw !== undefined && args.keyframes !== undefined) {
+    return err("Pass either `timeline` or `keyframes`, not both.");
+  }
+  let timeline: Timeline;
+  if (raw === undefined) {
+    if (args.keyframes === undefined) {
+      return err("Pass `timeline` (or `keyframes`, or null to clear).");
+    }
+    const compiled = compileJointKeyframes(args.keyframes as JointKeyframe[], {
+      fps: args.fps === undefined ? undefined : Number(args.fps),
+    });
+    if ("error" in compiled) return err(`keyframes rejected: ${compiled.error}`);
+    timeline = compiled.timeline;
+  } else {
+    timeline = raw as Timeline;
+  }
   const issues = validateTimeline(doc, timeline);
   if (issues.length > 0) {
     return err(
@@ -265,6 +398,16 @@ export const renderSequenceSchema = {
       type: "object" as const,
       description:
         "Optional one-shot timeline override (same shape as `animate`). When omitted, the document's stored timeline is used.",
+    },
+    keyframes: {
+      type: "array" as const,
+      items: { type: "object" as const },
+      description: KEYFRAMES_DESCRIPTION,
+    },
+    fps: {
+      type: "number" as const,
+      description:
+        "Playback frame rate when compiling `keyframes` (1-60, default 24).",
     },
     verify: {
       type: "boolean" as const,
@@ -584,12 +727,9 @@ export async function renderSequence(
     return err(e instanceof Error ? e.message : String(e));
   }
 
-  const timeline = (args.timeline as Timeline | undefined) ?? doc.timeline;
-  if (!timeline) {
-    return err(
-      "No timeline: set one with `animate` (or pass a one-shot `timeline` here).",
-    );
-  }
+  const resolved = resolveTimelineInput(args, doc);
+  if ("error" in resolved) return err(resolved.error);
+  const timeline = resolved.timeline;
   const issues = validateTimeline(doc, timeline);
   if (issues.length > 0) {
     return err(
@@ -660,6 +800,16 @@ export const exportVideoSchema = {
       type: "object" as const,
       description: "Optional one-shot timeline override (same shape as `animate`).",
     },
+    keyframes: {
+      type: "array" as const,
+      items: { type: "object" as const },
+      description: KEYFRAMES_DESCRIPTION,
+    },
+    fps: {
+      type: "number" as const,
+      description:
+        "Playback frame rate when compiling `keyframes` (1-60, default 24).",
+    },
     format: {
       type: "string" as const,
       enum: ["gif", "mp4", "auto"],
@@ -669,7 +819,18 @@ export const exportVideoSchema = {
     view: {
       type: "string" as const,
       enum: ["iso", "isometric", "top", "front", "side"],
-      description: "Camera view for the kernel renderer; defaults to 'iso'.",
+      description:
+        "Camera view for the kernel renderer; defaults to 'iso'. Ignored when azimuth/elevation are given.",
+    },
+    azimuth: {
+      type: "number" as const,
+      description:
+        "Orbit camera azimuth in degrees, CCW from +X in the XY plane (Z-up), matching render_view. Providing azimuth and/or elevation selects an arbitrary orbit view (missing angle defaults to 0) and overrides `view`.",
+    },
+    elevation: {
+      type: "number" as const,
+      description:
+        "Orbit camera elevation in degrees above the XY plane, clamped to [-90, 90]. See `azimuth`.",
     },
     width_px: {
       type: "number" as const,
@@ -870,10 +1031,9 @@ export async function exportVideo(
   ctx: ToolContext,
 ): Promise<ToolResult> {
   const doc = getSession(String(args.document_id));
-  const timeline = (args.timeline as Timeline | undefined) ?? doc.timeline;
-  if (!timeline) {
-    return err("No timeline: set one with `animate` first.");
-  }
+  const resolvedTimeline = resolveTimelineInput(args, doc);
+  if ("error" in resolvedTimeline) return err(resolvedTimeline.error);
+  const timeline = resolvedTimeline.timeline;
   const issues = validateTimeline(doc, timeline);
   if (issues.length > 0) {
     return err(`timeline invalid:\n${issues.map((i) => i.problem).join("\n")}`);
@@ -891,6 +1051,15 @@ export async function exportVideo(
     Math.max(MIN_WIDTH_PX, Number(args.width_px) || DEFAULT_WIDTH_PX),
   );
   const view = String(args.view ?? "iso");
+  // Arbitrary orbit camera, matching render_view: azimuth/elevation
+  // (degrees, Z-up) override the named view; a missing angle defaults to 0.
+  const azRaw = args.azimuth === undefined ? undefined : Number(args.azimuth);
+  const elRaw = args.elevation === undefined ? undefined : Number(args.elevation);
+  const hasOrbit =
+    (azRaw !== undefined && Number.isFinite(azRaw)) ||
+    (elRaw !== undefined && Number.isFinite(elRaw));
+  const azimuth = azRaw !== undefined && Number.isFinite(azRaw) ? azRaw : 0;
+  const elevation = elRaw !== undefined && Number.isFinite(elRaw) ? elRaw : 0;
   const wantHud = args.hud !== false;
   const wantVerify = args.verify !== false;
 
@@ -905,12 +1074,29 @@ export async function exportVideo(
   const wasm = (await getKernelWasm()) as unknown as {
     render_svg: (vcadJson: string, scale: number) => string;
     render_svg_view?: (vcadJson: string, scale: number, view: string) => string;
+    render_svg_camera?: (
+      vcadJson: string,
+      scale: number,
+      view: string,
+      focus: string | null,
+      axes: boolean,
+      labels: boolean,
+      dims: boolean,
+      section: string | null,
+      highlightJson: string | null,
+    ) => string;
   };
   if (typeof wasm.render_svg !== "function") {
     return err(
       "export_video unavailable: kernel WASM build predates render_svg.",
     );
   }
+  if (hasOrbit && typeof wasm.render_svg_camera !== "function") {
+    return err(
+      "azimuth/elevation unavailable: kernel WASM build predates render_svg_camera — rebuild @vcad/kernel-wasm.",
+    );
+  }
+  const orbitView = hasOrbit ? `orbit:${azimuth},${elevation}` : null;
 
   // Verification first, so the HUD can show per-spec status while frames render.
   const verification = wantVerify
@@ -960,8 +1146,19 @@ export async function exportVideo(
     const posed = poseDocument(doc, frame);
     let svg: string;
     try {
-      svg =
-        view !== "iso" && typeof wasm.render_svg_view === "function"
+      svg = orbitView
+        ? wasm.render_svg_camera!(
+            JSON.stringify(posed),
+            SVG_SCALE,
+            orbitView,
+            null,
+            false,
+            false,
+            false,
+            null,
+            null,
+          )
+        : view !== "iso" && typeof wasm.render_svg_view === "function"
           ? wasm.render_svg_view(JSON.stringify(posed), SVG_SCALE, view)
           : wasm.render_svg(JSON.stringify(posed), SVG_SCALE);
     } catch (e) {
@@ -1041,6 +1238,7 @@ export async function exportVideo(
     width: size.width,
     height: size.height,
     bytes: bytes.byteLength,
+    view: hasOrbit ? `orbit(azimuth=${azimuth}, elevation=${elevation})` : view,
     hud: wantHud,
     ...(verification ? { verification } : {}),
   };
@@ -1226,7 +1424,7 @@ export const toolDefs: ToolDef[] = [
     name: "animate",
     pack: null,
     description:
-      "Set (or clear) the document's animation timeline: keyframe named parameters, joint states, instance visibility, or a global explode factor, plus declarative camera shots (turntable/orbit/focus). Preview with render_sequence; ship with export_video.",
+      "Set (or clear) the document's animation timeline: keyframe named parameters, joint states, instance visibility, or a global explode factor, plus declarative camera shots (turntable/orbit/focus). For kinematic joint playback (servo-style commanded motion, no physics) pass `keyframes:[{t, joints:{jointId: value}}]` instead of a full timeline. Preview with render_sequence; ship with export_video.",
     inputSchema: animateSchema,
     handler: async (a) => animate(a),
     behavior: behavior({ writesDoc: true }),
@@ -1235,7 +1433,7 @@ export const toolDefs: ToolDef[] = [
     name: "render_sequence",
     pack: null,
     description:
-      "Compile the document's timeline into an animated GLB (glTF animation channels) — the cheap preview loop for motion. Joint/visibility/explode tracks animate instance nodes; parameter tracks re-evaluate geometry at sampled times. When the document has clearance_specs, they are re-measured across frames and reported (the sequence as evidence).",
+      "Compile the document's timeline into an animated GLB (glTF animation channels) — the cheap preview loop for motion. Accepts one-shot `keyframes:[{t, joints:{jointId: value}}]` for kinematic joint playback (posed exactly, no physics). Joint/visibility/explode tracks animate instance nodes; parameter tracks re-evaluate geometry at sampled times. When the document has clearance_specs, they are re-measured across frames and reported (the sequence as evidence).",
     inputSchema: renderSequenceSchema,
     handler: async (a, ctx) => renderSequence(a, ctx),
     // Mounts the viewer: the animated GLB rides in _meta and autoplays —
@@ -1255,7 +1453,7 @@ export const toolDefs: ToolDef[] = [
     name: "export_video",
     pack: null,
     description:
-      "Render the timeline to an animated GIF or MP4 through the kernel renderer, with the verification HUD (time, animated values, clearance status) burned into every frame. MP4 requires ffmpeg on the server; GIF always works. Large outputs offload to an artifact URL.",
+      "Render the timeline to an animated GIF or MP4 through the kernel renderer, with the verification HUD (time, animated values, clearance status) burned into every frame. Accepts one-shot `keyframes:[{t, joints:{jointId: value}}]` for kinematic joint playback (posed exactly, no physics) — children ride their parents through the joint tree. Camera matches render_view: named `view` or azimuth/elevation orbit. MP4 requires ffmpeg on the server; GIF always works. Large outputs offload to an artifact URL.",
     inputSchema: exportVideoSchema,
     handler: async (a, ctx) => exportVideo(a, ctx),
     behavior: behavior({}),


### PR DESCRIPTION
## What

Adds a kinematic playback mode for machine documents whose motion is servo-commanded, not dynamic. `render_sequence` / `export_video` already had the right bones (the timeline's per-joint keyframe tracks + kernel SVG → GIF pipeline), so this extends them rather than adding a new tool or a physics-env mode:

- **`keyframes: [{t, joints: {jointId: value}}]`** accepted by `animate`, `render_sequence`, and `export_video` (mutually exclusive with `timeline`; optional `fps`, default 24). Compiled to per-joint linear tracks — joints are posed *exactly* at the commanded values (degrees for revolute, mm for prismatic/Slider), linear interpolation between keys, clamp outside. No gravity, no integrator, no env — nothing sags.
- **Mid-tree posing**: children ride their parents through the joint tree via the existing FK solve (`vcad_eval::solve_forward_kinematics`), which the renderer already uses per frame. Covered by a new test: with the shoulder at 90° the slider's world position moves in both X and Y, and with the shoulder pinned the slide joint alone translates it exactly 30 mm along the rotated arm axis.
- **Camera parity with `render_view`**: `export_video` now takes `azimuth`/`elevation` (orbit via `render_svg_camera`, overrides the named `view`); `view`/`width_px`/`fps` already matched.

## Acceptance

Test assembly = base + revolute arm + prismatic slider (child of the arm). New tests in `animate.test.ts` (23 pass, full MCP suite 895 pass): keyframe compilation + validation (non-ascending t, NaN, unknown joint → loud errors), the mid-tree ride proof above, and an end-to-end `export_video` GIF (GIF89a header, 7 frames at 6 fps, arm sweep 90° + slider travel 30 mm). Also rendered a real 21-frame GIF locally and eyeballed first/mid/last frames from two azimuths — poses match FK.

No Rust changes (clippy state unchanged from main); tool-surface fixture regenerated; changelog entry added.

## What the rune omni document needs to declare

The document just needs a joint tree — `joints` entries linking instances parent→child, with `groundInstanceId` set. E.g. for the turret + XY stage (`.vcad` JSON; loon emits the same via its assembly/joint forms):

```jsonc
"groundInstanceId": "frame",
"joints": [
  { "id": "turret_index", "parentInstanceId": "frame",  "childInstanceId": "turret",
    "parentAnchor": {"x": 0, "y": 0, "z": 40}, "childAnchor": {"x": 0, "y": 0, "z": 0},
    "kind": {"type": "Revolute", "axis": {"x": 0, "y": 0, "z": 1}}, "state": 0 },
  { "id": "stage_x", "parentInstanceId": "frame", "childInstanceId": "x_carriage",
    "parentAnchor": {"x": 0, "y": 0, "z": 10}, "childAnchor": {"x": 0, "y": 0, "z": 0},
    "kind": {"type": "Slider", "axis": {"x": 1, "y": 0, "z": 0}}, "state": 0 },
  { "id": "stage_y", "parentInstanceId": "x_carriage", "childInstanceId": "y_carriage",
    "parentAnchor": {"x": 0, "y": 0, "z": 10}, "childAnchor": {"x": 0, "y": 0, "z": 0},
    "kind": {"type": "Slider", "axis": {"x": 0, "y": 1, "z": 0}}, "state": 0 }
]
```

Notes for their manual: prismatic = `"Slider"` in the IR; revolute values are degrees, slider values mm; joints **fully place** their children (a jointed child's static instance transform is ignored — anchors define the mating). Then a 60° turret index + serpentine pass is one call:

```jsonc
export_video({ document_id, fps: 24, keyframes: [
  { "t": 0.0, "joints": { "turret_index": 0,  "stage_x": 0,  "stage_y": 0 } },
  { "t": 0.5, "joints": { "turret_index": 60 } },
  { "t": 1.5, "joints": { "stage_x": 80 } },
  { "t": 2.0, "joints": { "stage_y": 20 } },
  { "t": 3.0, "joints": { "stage_x": 0 } }
]})
```

Heads-up: main currently lacks the joint-FK double-offset fix (9eb03daa, on the stirling-engine branch) — anchors on their machine doc should be authored against the fully-place contract above once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)