### PR TITLE
fix(raytrace): clamp cylinder/cone wall height when trim loop is degenerate

### DIFF
--- a/changelog/entries/2026-07-19-raytrace-cylinder-wall-clamp.json
+++ b/changelog/entries/2026-07-19-raytrace-cylinder-wall-clamp.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-19-raytrace-cylinder-wall-clamp",
+  "version": "0.9.4",
+  "date": "2026-07-19",
+  "category": "fix",
+  "title": "Ray-traced cylinder walls no longer render elongated",
+  "summary": "Full cylinder/cone walls (e.g. rotated discs like a flywheel) traced as infinite tubes in raytrace mode; their height is now clamped correctly on both GPU and CPU paths.",
+  "features": ["raytrace", "kernel"]
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -723,8 +723,26 @@ impl GpuScene {
             let trim_start = trim_verts.len() as u32;
             let mut trim_count = 0u32;
 
-            // Extract UV coordinates for the outer loop
-            let uvs = trim::extract_face_uv_loop(brep, face_id);
+            // Extract UV coordinates for the outer loop.
+            //
+            // A full cylinder/cone wall's outer loop projects to a zero-area
+            // UV polygon (only seam vertices survive; the rim circles
+            // collapse). The shader treats a degenerate outer loop as
+            // untrimmed — correct for spheres/tori whose v is bounded, but
+            // on a cylinder v is an unbounded length and the wall would
+            // trace as an infinite tube. Collapse such loops to the
+            // 2-vertex (v_min, v_max) form the shader's trim_count==2 path
+            // already clamps against.
+            let mut uvs = trim::extract_face_uv_loop(brep, face_id);
+            let surface = &brep.geometry.surfaces[face.surface_index];
+            if trim::polygon_area(&uvs).abs() < 1e-9 {
+                if let Some((v_min, v_max)) = trim::unbounded_v_range(surface.as_ref(), &uvs) {
+                    uvs = vec![
+                        vcad_kernel_math::Point2::new(0.0, v_min),
+                        vcad_kernel_math::Point2::new(0.0, v_max),
+                    ];
+                }
+            }
             #[cfg(target_arch = "wasm32")]
             {
                 web_sys::console::log_1(

--- a/crates/vcad-kernel-raytrace/src/trim.rs
+++ b/crates/vcad-kernel-raytrace/src/trim.rs
@@ -27,8 +27,18 @@ pub fn point_in_face(brep: &BRepSolid, face_id: FaceId, uv: Point2) -> bool {
     // surface — and still honour inner loops (holes) below.
     let untrimmed = polygon_area(&outer_uvs).abs() < 1e-9;
 
-    // Check if point is inside outer loop
-    if !untrimmed && !point_in_polygon(&uv, &outer_uvs) {
+    if untrimmed {
+        // On a cylinder or cone, v is an unbounded length parameter, so a
+        // seam-degenerate loop (e.g. a full cylinder wall: only seam
+        // vertices survive projection, the rim circles collapse) must still
+        // clamp v to the loop's extent — otherwise the wall traces as an
+        // infinite cylinder. u legitimately wraps the full turn.
+        if let Some((v_min, v_max)) = unbounded_v_range(surface.as_ref(), &outer_uvs) {
+            if uv.y < v_min || uv.y > v_max {
+                return false;
+            }
+        }
+    } else if !point_in_polygon(&uv, &outer_uvs) {
         return false;
     }
 
@@ -45,7 +55,7 @@ pub fn point_in_face(brep: &BRepSolid, face_id: FaceId, uv: Point2) -> bool {
 
 /// Signed area of a UV polygon (shoelace). Near-zero means the loop is
 /// degenerate in parameter space — e.g. a closed surface's seam-only loop.
-fn polygon_area(polygon: &[Point2]) -> f64 {
+pub(crate) fn polygon_area(polygon: &[Point2]) -> f64 {
     if polygon.len() < 3 {
         return 0.0;
     }
@@ -56,6 +66,27 @@ fn polygon_area(polygon: &[Point2]) -> f64 {
         area += a.x * b.y - b.x * a.y;
     }
     area / 2.0
+}
+
+/// For surfaces whose v parameter is an unbounded length (cylinder, cone),
+/// return the v-range spanned by a degenerate outer loop's vertices. Returns
+/// `None` for surfaces with intrinsically bounded v (sphere, torus, plane…),
+/// where the untrimmed fallback is safe as-is, or when the loop is empty.
+pub(crate) fn unbounded_v_range(surface: &dyn Surface, outer_uvs: &[Point2]) -> Option<(f64, f64)> {
+    use vcad_kernel_geom::SurfaceKind;
+    match surface.surface_type() {
+        SurfaceKind::Cylinder | SurfaceKind::Cone => {
+            let mut it = outer_uvs.iter();
+            let first = it.next()?;
+            let (mut v_min, mut v_max) = (first.y, first.y);
+            for uv in it {
+                v_min = v_min.min(uv.y);
+                v_max = v_max.max(uv.y);
+            }
+            Some((v_min, v_max))
+        }
+        _ => None,
+    }
 }
 
 /// Get the UV coordinates of vertices in a loop by projecting 3D positions onto the surface.

--- a/crates/vcad-kernel-raytrace/tests/rotated_disc.rs
+++ b/crates/vcad-kernel-raytrace/tests/rotated_disc.rs
@@ -1,0 +1,97 @@
+//! Regression: a rotated disc's cylindrical wall must not trace as an
+//! infinite tube.
+//!
+//! A full cylinder wall's outer loop projects to a zero-area UV polygon
+//! (only seam vertices survive projection — the rim circles collapse), and
+//! the degenerate-loop "untrimmed" fallback (added for full spheres) left v
+//! unbounded. On screen this rendered e.g. the Stirling-engine flywheel
+//! (cylinder r40 h8 rotated 90° about X) elongated ~10x along its axis.
+
+use vcad_kernel_math::{Point3, Transform, Vec3};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_raytrace::{Bvh, Ray};
+
+/// Cylinder r40 h8, rotated 90° about X: axis ends up along -Y, wall spans
+/// y in [-8, 0].
+fn rotated_disc() -> BRepSolid {
+    let mut brep = make_cylinder(40.0, 8.0, 32);
+    let t = Transform::rotation_x(90f64.to_radians());
+    for (_id, v) in &mut brep.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    for s in &mut brep.geometry.surfaces {
+        *s = s.transform(&t);
+    }
+    brep
+}
+
+#[test]
+fn cpu_wall_bounded_along_axis() {
+    let bvh = Bvh::build(&rotated_disc());
+
+    // Ray aimed at the wall surface but 40mm beyond the disc along its
+    // axis — must miss.
+    let beyond = Ray::new(Point3::new(0.0, 40.0, 100.0), Vec3::new(0.0, 0.0, -1.0));
+    assert!(
+        bvh.trace_closest(&beyond).is_none(),
+        "wall must not extend past the disc height"
+    );
+    let far_side = Ray::new(Point3::new(0.0, -48.0, 100.0), Vec3::new(0.0, 0.0, -1.0));
+    assert!(
+        bvh.trace_closest(&far_side).is_none(),
+        "wall must not extend past the disc on the -axis side"
+    );
+
+    // Ray through the disc itself — must hit the wall at z = 40 (t = 60).
+    let at_disc = Ray::new(Point3::new(0.0, -4.0, 100.0), Vec3::new(0.0, 0.0, -1.0));
+    let hit = bvh.trace_closest(&at_disc).expect("must hit the disc wall");
+    assert!(
+        (hit.t - 60.0).abs() < 1e-9,
+        "wall front at t=60, got {}",
+        hit.t
+    );
+}
+
+#[test]
+fn cpu_unrotated_wall_bounded_along_axis() {
+    // Same defect exists unrotated (axis +Z, wall z in [0, 8]).
+    let bvh = Bvh::build(&make_cylinder(40.0, 8.0, 32));
+    let beyond = Ray::new(Point3::new(0.0, -100.0, 48.0), Vec3::new(0.0, 1.0, 0.0));
+    assert!(bvh.trace_closest(&beyond).is_none());
+    let at_disc = Ray::new(Point3::new(0.0, -100.0, 4.0), Vec3::new(0.0, 1.0, 0.0));
+    assert!(bvh.trace_closest(&at_disc).is_some());
+}
+
+#[cfg(feature = "gpu")]
+#[test]
+fn gpu_scene_packs_wall_v_range() {
+    use vcad_kernel_raytrace::gpu::GpuScene;
+    // The GPU scene must not upload the wall as an untrimmed (zero-area)
+    // loop — it collapses to the 2-vertex v-range form that the shader's
+    // trim_count==2 path clamps against.
+    let scene = GpuScene::from_brep(&rotated_disc()).expect("scene builds");
+
+    let wall_faces: Vec<_> = scene
+        .faces
+        .iter()
+        .filter(|f| scene.surfaces[f.surface_idx as usize].surface_type == 1)
+        .collect();
+    assert!(
+        !wall_faces.is_empty(),
+        "disc must have a cylindrical wall face"
+    );
+
+    for face in wall_faces {
+        assert_eq!(
+            face.trim_count, 2,
+            "degenerate wall loop must collapse to a 2-vertex v-range"
+        );
+        let a = scene.trim_verts[face.trim_start as usize];
+        let b = scene.trim_verts[face.trim_start as usize + 1];
+        let (v_min, v_max) = (a.y.min(b.y), a.y.max(b.y));
+        assert!(
+            (v_max - v_min - 8.0).abs() < 1e-4,
+            "wall v-range must equal the 8mm height, got [{v_min}, {v_max}]"
+        );
+    }
+}


### PR DESCRIPTION
## What

Fixes the GPU-raytrace mis-render where rotated cylinder walls (e.g. the Stirling-engine flywheel, r40 h8 rotated 90° about X) drew ~10x elongated along their axis.

## Why

A full cylinder wall's outer trim loop projects to a zero-area UV polygon — only seam vertices survive projection; the rim circles collapse to points. The degenerate-loop "untrimmed" fallback (added so full spheres would trace) then left **v unbounded**, so the wall traced as an infinite tube, clipped only by BVH AABBs. The CPU path had the identical defect (a probe ray 40mm past the disc still hit the "wall"); rotation isn't causal — it just orients the flywheel so the ~10x elongation (80mm diameter vs 8mm height) is glaring.

## How

- **CPU** (`trim.rs`): when the outer loop is degenerate on a surface whose v is an unbounded length (cylinder, cone), `point_in_face` clamps `uv.y` to the loop's v-range. Spheres/tori keep the untrimmed fallback — their v is intrinsically bounded.
- **GPU** (`gpu/buffers.rs`): degenerate cylinder/cone outer loops collapse to the 2-vertex `(v_min, v_max)` form the shader's existing `trim_count == 2` path already bounds — no WGSL change.

## Tests

New `tests/rotated_disc.rs`: rays beyond the rotated wall on both sides must miss and through the disc must hit at the exact t; same unrotated; GPU packing asserts the wall face carries a 2-vertex trim spanning exactly 8mm (feature-gated on `gpu`). Also green: `vcad-kernel-raytrace --all-features`, clippy `-D warnings`, vcad-render golden suite (61 tests), vcad-cli, vcad-kernel-dfm.

Verified via CPU tracer + GPU buffer packing, not a live browser render — worth a visual check on the stirling-engine doc in raytrace mode after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)