### PR TITLE
Transient thermal solves with piecewise-constant drive schedules

### DIFF
--- a/changelog/entries/2026-07-19-transient-thermal.json
+++ b/changelog/entries/2026-07-19-transient-thermal.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-19-transient-thermal",
+  "version": "0.9.4",
+  "date": "2026-07-19",
+  "category": "feat",
+  "title": "Transient thermal solves with drive schedules",
+  "summary": "solve_thermal gains a transient mode: backward-Euler time stepping over piecewise-constant schedules (RTP ramp/soak/cool, ambient steps), returning T_max time series and a run-integrated energy audit.",
+  "features": ["thermal", "simulation", "receipts"],
+  "mcpTools": ["solve_thermal"]
+}

--- a/crates/vcad-kernel-thermal/examples/rune_stage_stack.rs
+++ b/crates/vcad-kernel-thermal/examples/rune_stage_stack.rs
@@ -1,0 +1,198 @@
+//! The rune stepper's stage stack — the transient solver's flagship case.
+//!
+//! Reconstruction of the R0 stack from the rune project's manual
+//! (Z stage → crossed rails → XY stage → chuck → wafer, chamber floor as
+//! the thermal anchor), the same stack whose steady solves produced the
+//! "first solved physics" numbers (θ ≈ 0.25 K/W wafer-to-floor in chuck
+//! contact). This example asks the two questions steady state can't:
+//!
+//! 1. **Overlay drift**: the chamber floor steps +2 °C mid-job. How long
+//!    until the wafer has moved through most of that step? A lithography
+//!    layer takes ~2 h; if the stack's thermal time constant is a large
+//!    fraction of that, ambient control (or mid-job re-registration)
+//!    is mandatory, not optional.
+//! 2. **RTP heat/soak/cool**: the lamp dumps power into the wafer for a
+//!    soak, then shuts off. How hot does the stack under it get, and how
+//!    long until the wafer is back near baseline?
+//!
+//! Run with `--release`; the full grid is 100×100×75 = 750k voxels.
+//!
+//! ```sh
+//! cargo run --release -p vcad-kernel-thermal --example rune_stage_stack
+//! ```
+
+use vcad_kernel_thermal::model::{
+    Axis, FixedTemperature, MaterialRegion, PowerSource, Shape, ThermalModel,
+};
+use vcad_kernel_thermal::solve::{solve_steady, SolveOptions};
+use vcad_kernel_thermal::transient::{solve_transient_schedule, ScheduleSegment};
+
+// Handbook values, volumetric heat capacity ρc_p in J/(m³·K).
+const AL: (f64, f64) = (167.0, 2.42e6); // 6061 aluminum
+const STEEL: (f64, f64) = (45.0, 3.90e6); // rail steel
+const SI: (f64, f64) = (148.0, 1.66e6); // silicon wafer
+
+fn stack() -> ThermalModel {
+    // Domain: 220 × 220 mm around the stack, 100 mm tall, 100×100×75
+    // voxels (2.2 × 2.2 × 1.33 mm cells) — the grid of the steady runs.
+    let mut m = ThermalModel::new([0.0, 0.0, 0.0], [220.0, 220.0, 100.0], [100, 100, 75]);
+    let al = |shape| MaterialRegion::isotropic(shape, AL.0).with_heat_capacity(AL.1);
+
+    // Z stage, 200 × 200 × 40, bolted to the chamber floor.
+    m.materials.push(al(Shape::Box {
+        min_mm: [10.0, 10.0, 0.0],
+        size_mm: [200.0, 200.0, 40.0],
+    }));
+    // Crossed rails: two 180 × 12 × 10 steel rails.
+    for y in [40.0, 168.0] {
+        m.materials.push(
+            MaterialRegion::isotropic(
+                Shape::Box {
+                    min_mm: [20.0, y, 40.0],
+                    size_mm: [180.0, 12.0, 10.0],
+                },
+                STEEL.0,
+            )
+            .with_heat_capacity(STEEL.1),
+        );
+    }
+    // XY stage, 170 × 170 × 30.
+    m.materials.push(al(Shape::Box {
+        min_mm: [25.0, 25.0, 50.0],
+        size_mm: [170.0, 170.0, 30.0],
+    }));
+    // Chuck, Ø120 × 15, centered.
+    m.materials.push(
+        MaterialRegion::isotropic(
+            Shape::Tube {
+                axis: Axis::Z,
+                center_mm: [110.0, 110.0],
+                span_mm: [80.0, 95.0],
+                outer_radius_mm: 60.0,
+                inner_radius_mm: 0.0,
+            },
+            AL.0,
+        )
+        .with_heat_capacity(AL.1),
+    );
+    // Wafer, Ø100 × 2, in full chuck contact.
+    m.materials.push(
+        MaterialRegion::isotropic(
+            Shape::Tube {
+                axis: Axis::Z,
+                center_mm: [110.0, 110.0],
+                span_mm: [95.0, 97.0],
+                outer_radius_mm: 50.0,
+                inner_radius_mm: 0.0,
+            },
+            SI.0,
+        )
+        .with_heat_capacity(SI.1),
+    );
+
+    // The chamber floor is the anchor: the Z stage's bottom layer is
+    // pinned at 20 °C (a fixed *region*, so the schedule can step it).
+    m.fixed.push(FixedTemperature {
+        shape: Shape::Box {
+            min_mm: [10.0, 10.0, 0.0],
+            size_mm: [200.0, 200.0, 1.5],
+        },
+        temperature_c: 20.0,
+    });
+    // Vacuum everywhere else: all other surfaces adiabatic (default).
+    m.reference_c = Some(20.0);
+    m
+}
+
+fn beam(power_w: f64) -> PowerSource {
+    // Ø16 beam spot into the wafer top surface.
+    PowerSource {
+        name: "beam".into(),
+        shape: Shape::Tube {
+            axis: Axis::Z,
+            center_mm: [110.0, 110.0],
+            span_mm: [95.5, 97.0],
+            outer_radius_mm: 8.0,
+            inner_radius_mm: 0.0,
+        },
+        power_w,
+    }
+}
+
+fn main() {
+    let opts = SolveOptions::default();
+
+    // --- Steady baseline: 30 W beam, chuck contact -------------------
+    let mut m = stack();
+    m.sources.push(beam(30.0));
+    let steady = solve_steady(&m, &opts).expect("steady solve");
+    let theta = steady.sources[0].theta_c_per_w.unwrap();
+    println!("steady, 30 W beam, chuck contact:");
+    println!(
+        "  wafer T_max = {:.2} C  (theta = {:.3} K/W; energy residual {:.1e})",
+        steady.sources[0].t_max_c, theta, steady.energy.residual_rel
+    );
+
+    // --- Overlay drift: chamber floor steps +2 C ---------------------
+    // Wafer at thermal equilibrium (no beam), floor steps 20 -> 22 C.
+    // A 100 mm silicon wafer at 2.6 ppm/K moves ~0.26 µm across its
+    // radius per K, so "most of 2 K" is the overlay budget gone.
+    let mut m = stack();
+    m.sources.push(beam(0.0)); // 0 W: a pure wafer temperature probe
+    let mut step = ScheduleSegment::plain(60.0, 120); // 2 h at 1-min steps
+    step.fixed_temperature_c.insert(0, 22.0);
+    let drift = solve_transient_schedule(&m, &opts, 20.0, 0, &[step]).expect("drift solve");
+    let wafer = &drift.source_t_max_c[0];
+    println!("\nambient step +2 C at the chamber floor (2 h at 1-min steps):");
+    for frac in [0.5, 0.9, 0.99] {
+        let target = 20.0 + 2.0 * frac;
+        match wafer.iter().position(|&t| t >= target) {
+            Some(i) => println!(
+                "  wafer through {:.0}% of the step after {:>6.0} s ({:.1} min)",
+                frac * 100.0,
+                drift.times_s[i],
+                drift.times_s[i] / 60.0
+            ),
+            None => println!(
+                "  wafer NOT through {:.0}% of the step in 2 h (T_end = {:.3} C)",
+                frac * 100.0,
+                wafer.last().unwrap()
+            ),
+        }
+    }
+    println!(
+        "  energy audit residual {:.1e}",
+        drift.energy_audit_residual_rel
+    );
+
+    // --- RTP-shaped soak: lamp on / soak / off -----------------------
+    // 200 W into the wafer for 60 s, then off for 10 min: how hot does
+    // the wafer get in chuck contact, and how fast does it recover?
+    let mut m = stack();
+    m.sources.push(beam(0.0));
+    let mut heat = ScheduleSegment::plain(1.0, 60);
+    heat.source_power_w.insert("beam".into(), 200.0);
+    let mut cool = ScheduleSegment::plain(5.0, 120);
+    cool.source_power_w.insert("beam".into(), 0.0);
+    let rtp = solve_transient_schedule(&m, &opts, 20.0, 0, &[heat, cool]).expect("rtp solve");
+    let peak = rtp
+        .t_max_c
+        .iter()
+        .cloned()
+        .fold(f64::NEG_INFINITY, f64::max);
+    println!("\nRTP-shaped: 200 W x 60 s into the wafer, then off (chuck contact):");
+    println!(
+        "  peak wafer T = {:.1} C at t = 60 s; T after 10 min cool = {:.2} C",
+        peak,
+        rtp.t_max_c.last().unwrap()
+    );
+    println!(
+        "  stored {:.1} J vs injected {:.1} J (audit {:.1e}, {} CG iters total)",
+        rtp.stored_delta_j, rtp.injected_j, rtp.energy_audit_residual_rel, rtp.cg_iterations_total
+    );
+    println!(
+        "\n(The chuck-contact theta = {theta:.3} K/W is why RTP at 1000 C needs lift \
+         pins: the soak would drain kilowatts into the stack. Conduction only; \
+         radiation not modeled.)"
+    );
+}

--- a/crates/vcad-kernel-thermal/src/receipt.rs
+++ b/crates/vcad-kernel-thermal/src/receipt.rs
@@ -373,6 +373,103 @@ pub fn compare(
     })
 }
 
+/// Build the predicted claim set for one transient run.
+///
+/// Same fail-closed contract as [`predicted_claims`]: `opts` must be what
+/// the run used, the model is the **base** (pre-schedule) model, and every
+/// claim carries `basis: "predicted"`. Series data stays on the
+/// [`TransientSolution`]; the claims capture the quantities a recipe is
+/// judged by — the peak, the endpoint, how far the endpoint sits from
+/// steady, and the integrated energy audit.
+pub fn transient_claims(
+    model: &ThermalModel,
+    tsol: &crate::transient::TransientSolution,
+    opts: &SolveOptions,
+) -> ClaimSet {
+    let caveat = conduction_caveat(model);
+    let steady = predicted_claims(model, &tsol.final_state, opts);
+    let total_time_s = tsol.times_s.last().copied().unwrap_or(0.0);
+    let steps = tsol.times_s.len();
+    let run = format!("{steps} backward-Euler steps to t = {total_time_s} s");
+
+    let (peak_i, peak) =
+        tsol.t_max_c
+            .iter()
+            .enumerate()
+            .fold(
+                (0, f64::NEG_INFINITY),
+                |acc, (i, &t)| {
+                    if t > acc.1 {
+                        (i, t)
+                    } else {
+                        acc
+                    }
+                },
+            );
+    let final_t = tsol.t_max_c.last().copied().unwrap_or(f64::NAN);
+
+    let mut claims = vec![
+        claim(
+            "t_max_peak_c".into(),
+            peak,
+            "C",
+            format!(
+                "hottest solid voxel over the run, at t = {} s; {run}; {caveat}",
+                tsol.times_s[peak_i]
+            ),
+        ),
+        claim(
+            "t_max_final_c".into(),
+            final_t,
+            "C",
+            format!("hottest solid voxel at the end of the run; {run}; {caveat}"),
+        ),
+    ];
+    let single = tsol.final_state.sources.len() == 1;
+    for (s, series) in tsol.final_state.sources.iter().zip(&tsol.source_t_max_c) {
+        let name = if single {
+            "t_source_final_c".to_string()
+        } else {
+            format!("t_source_final_c:{}", s.name)
+        };
+        claims.push(claim(
+            name,
+            series.last().copied().unwrap_or(f64::NAN),
+            "C",
+            format!(
+                "hottest voxel of source {:?} at the end of the run; {caveat}",
+                s.name
+            ),
+        ));
+    }
+    claims.push(claim(
+        "transient_energy_audit_residual".into(),
+        tsol.energy_audit_residual_rel,
+        "1",
+        "|stored-energy change - integrated net injection| over the run, normalized by \
+         gross energy traffic; a discrete identity of backward Euler, closes to CG \
+         tolerance or the trajectory is wrong"
+            .into(),
+    ));
+    claims.push(claim(
+        "distance_from_steady_residual".into(),
+        tsol.final_state.energy.residual_rel,
+        "1",
+        "steady energy-balance residual of the final field: ~solver tolerance means the \
+         run has relaxed to steady state; O(1) means the endpoint is still moving"
+            .into(),
+    ));
+
+    ClaimSet {
+        schema: CLAIM_SCHEMA.to_string(),
+        provenance: SolverProvenance {
+            cg_iterations: tsol.cg_iterations_total,
+            ..steady.provenance
+        },
+        claims,
+    }
+}
+
 /// Domain tag for thermal claims in the unified [`vcad_receipt`] schema.
 pub const RECEIPT_DOMAIN: &str = "thermal";
 
@@ -434,6 +531,52 @@ mod tests {
     use super::*;
     use crate::model::{Boundary, MaterialRegion, PowerSource, Shape, ThermalModel};
     use crate::solve::solve_steady;
+
+    #[test]
+    fn transient_claims_capture_peak_endpoint_and_audits() {
+        let mut m = chip_model();
+        m.materials[0].heat_capacity_j_m3k = Some(1.8e6);
+        let opts = crate::solve::SolveOptions::default();
+        let tsol = crate::transient::solve_transient(
+            &m,
+            &opts,
+            &crate::transient::TransientOptions {
+                dt_s: 5.0,
+                steps: 20,
+                initial_c: 25.0,
+                snapshot_every: 0,
+            },
+        )
+        .unwrap();
+        let set = transient_claims(&m, &tsol, &opts);
+        assert_eq!(set.schema, CLAIM_SCHEMA);
+        let names: Vec<&str> = set.claims.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"t_max_peak_c"));
+        assert!(names.contains(&"t_max_final_c"));
+        assert!(names.contains(&"t_source_final_c"));
+        assert!(names.contains(&"transient_energy_audit_residual"));
+        assert!(names.contains(&"distance_from_steady_residual"));
+        assert!(set.claims.iter().all(|c| c.basis == "predicted"));
+        assert_eq!(set.provenance.cg_iterations, tsol.cg_iterations_total);
+        // Heating run: the peak is the endpoint.
+        let peak = set
+            .claims
+            .iter()
+            .find(|c| c.name == "t_max_peak_c")
+            .unwrap();
+        let fin = set
+            .claims
+            .iter()
+            .find(|c| c.name == "t_max_final_c")
+            .unwrap();
+        assert!((peak.value - fin.value).abs() < 1e-12);
+        // And it rides the unified receipt as Provisional like the rest.
+        let rc = design_claims(&set);
+        assert_eq!(rc.len(), set.claims.len());
+        assert!(rc
+            .iter()
+            .all(|c| c.basis == Some(vcad_receipt::ClaimBasis::Predicted)));
+    }
 
     fn chip_model() -> ThermalModel {
         let mut m = ThermalModel::new([0.0, 0.0, 0.0], [60.0, 60.0, 2.0], [30, 30, 2]);

--- a/crates/vcad-kernel-thermal/src/solve.rs
+++ b/crates/vcad-kernel-thermal/src/solve.rs
@@ -89,6 +89,10 @@ pub enum SolveError {
     /// A transient solve was asked for a non-positive time step or zero
     /// steps.
     InvalidTimeStep,
+    /// A transient schedule segment named a source, face, or fixed region
+    /// it cannot override (unknown name, out-of-range slot, or an
+    /// adiabatic face with no temperature to move).
+    BadScheduleOverride(String),
     /// The smooth-max exponent must be finite and > 1.
     InvalidSmoothingExponent,
 }
@@ -116,6 +120,9 @@ impl std::fmt::Display for SolveError {
             ),
             SolveError::InvalidTimeStep => {
                 write!(f, "transient solve requires dt > 0 and at least one step")
+            }
+            SolveError::BadScheduleOverride(why) => {
+                write!(f, "invalid schedule override: {why}")
             }
             SolveError::InvalidSmoothingExponent => {
                 write!(f, "smooth-max exponent p must be finite and > 1")

--- a/crates/vcad-kernel-thermal/src/spec.rs
+++ b/crates/vcad-kernel-thermal/src/spec.rs
@@ -42,6 +42,7 @@ use crate::model::{
     Axis, Boundary, FixedTemperature, MaterialRegion, PowerSource, Shape, ThermalModel,
     VoxelMaterials,
 };
+use crate::transient::ScheduleSegment;
 
 /// A literal value or the name of a document parameter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -94,6 +95,12 @@ pub enum ParamRole {
 pub enum SpecError {
     /// A named parameter had no binding.
     UnknownParameter(String),
+    /// A schedule segment referenced a face by an unknown label.
+    UnknownFaceLabel(String),
+    /// A schedule segment keyed a fixed-region override by a non-integer.
+    BadFixedIndex(String),
+    /// A schedule segment's duration or time step is not positive-finite.
+    InvalidSegmentTiming(String),
 }
 
 impl std::fmt::Display for SpecError {
@@ -101,6 +108,17 @@ impl std::fmt::Display for SpecError {
         match self {
             SpecError::UnknownParameter(name) => {
                 write!(f, "unbound thermal parameter: {name:?}")
+            }
+            SpecError::UnknownFaceLabel(label) => write!(
+                f,
+                "unknown face label {label:?} (expected -x, +x, -y, +y, -z, +z, or exposed)"
+            ),
+            SpecError::BadFixedIndex(key) => write!(
+                f,
+                "fixed-region override key {key:?} is not an integer index"
+            ),
+            SpecError::InvalidSegmentTiming(why) => {
+                write!(f, "invalid schedule segment timing: {why}")
             }
         }
     }
@@ -509,6 +527,99 @@ impl ThermalSpec {
     }
 }
 
+/// One schedule segment of a [`TransientSpec`]: a duration of
+/// piecewise-constant drives, with number-only overrides.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SegmentSpec {
+    /// Segment duration, s (> 0).
+    pub duration_s: ParamValue,
+    /// Target time step, s (> 0). The realized step is
+    /// `duration_s / ceil(duration_s / dt_s)` — the segment is covered
+    /// exactly by an integer number of steps no larger than the target.
+    pub dt_s: ParamValue,
+    /// Source-power overrides by source name, W.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub source_power_w: BTreeMap<String, ParamValue>,
+    /// Boundary-temperature overrides by face label (`-x`, `+x`, `-y`,
+    /// `+y`, `-z`, `+z`, `exposed`): retunes a fixed face's temperature
+    /// or a convection face's ambient.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub face_temperature_c: BTreeMap<String, ParamValue>,
+    /// Fixed-region temperature overrides keyed by the region's index in
+    /// `fixed` (as a string, JSON maps being string-keyed).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fixed_temperature_c: BTreeMap<String, ParamValue>,
+}
+
+/// Serializable transient run: an initial condition and a schedule of
+/// piecewise-constant segments (an RTP recipe, an ambient step, a duty
+/// cycle). Every physical number is a [`ParamValue`]; resolution is
+/// fail-closed like the steady spec.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TransientSpec {
+    /// Uniform initial temperature of the free field, °C.
+    pub initial_c: ParamValue,
+    /// The schedule, in order (at least one segment).
+    pub segments: Vec<SegmentSpec>,
+}
+
+fn face_slot(label: &str) -> Result<usize, SpecError> {
+    match label {
+        "-x" => Ok(0),
+        "+x" => Ok(1),
+        "-y" => Ok(2),
+        "+y" => Ok(3),
+        "-z" => Ok(4),
+        "+z" => Ok(5),
+        "exposed" => Ok(6),
+        other => Err(SpecError::UnknownFaceLabel(other.to_string())),
+    }
+}
+
+impl TransientSpec {
+    /// Resolve to the initial temperature and model-level schedule,
+    /// fail-closed on unbound names, bad face labels, bad fixed-region
+    /// keys, and non-positive durations/steps.
+    pub fn resolve(
+        &self,
+        params: &BTreeMap<String, f64>,
+    ) -> Result<(f64, Vec<ScheduleSegment>), SpecError> {
+        let initial_c = self.initial_c.resolve(params)?;
+        let mut segments = Vec::with_capacity(self.segments.len());
+        for (i, seg) in self.segments.iter().enumerate() {
+            let duration_s = seg.duration_s.resolve(params)?;
+            let dt_target_s = seg.dt_s.resolve(params)?;
+            if !(duration_s.is_finite() && duration_s > 0.0) {
+                return Err(SpecError::InvalidSegmentTiming(format!(
+                    "segment {i}: duration_s = {duration_s} (must be > 0)"
+                )));
+            }
+            if !(dt_target_s.is_finite() && dt_target_s > 0.0) {
+                return Err(SpecError::InvalidSegmentTiming(format!(
+                    "segment {i}: dt_s = {dt_target_s} (must be > 0)"
+                )));
+            }
+            let steps = (duration_s / dt_target_s - 1e-9).ceil().max(1.0) as usize;
+            let mut out = ScheduleSegment::plain(duration_s / steps as f64, steps);
+            for (name, v) in &seg.source_power_w {
+                out.source_power_w.insert(name.clone(), v.resolve(params)?);
+            }
+            for (label, v) in &seg.face_temperature_c {
+                out.face_temperature_c
+                    .insert(face_slot(label)?, v.resolve(params)?);
+            }
+            for (key, v) in &seg.fixed_temperature_c {
+                let index: usize = key
+                    .parse()
+                    .map_err(|_| SpecError::BadFixedIndex(key.clone()))?;
+                out.fixed_temperature_c.insert(index, v.resolve(params)?);
+            }
+            segments.push(out);
+        }
+        Ok((initial_c, segments))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -653,6 +764,123 @@ mod tests {
             size_mm[1] = ParamValue::Named("k_cu".into());
         }
         assert_eq!(mixed.parameter_roles()["k_cu"], ParamRole::FiniteDifference);
+    }
+
+    #[test]
+    fn transient_spec_resolves_and_runs_a_schedule() {
+        let json = r#"{
+            "initial_c": "t_start",
+            "segments": [
+                {"duration_s": 20.0, "dt_s": "dt",
+                 "source_power_w": {"lamp": "p_soak"}},
+                {"duration_s": 30.0, "dt_s": 3.0,
+                 "source_power_w": {"lamp": 0.0},
+                 "face_temperature_c": {"-z": 30.0},
+                 "fixed_temperature_c": {"0": 22.0}}
+            ]
+        }"#;
+        let tspec: TransientSpec = serde_json::from_str(json).expect("parse");
+        let (initial_c, segments) = tspec
+            .resolve(&params(&[("t_start", 25.0), ("dt", 2.0), ("p_soak", 3.0)]))
+            .expect("resolve");
+        assert_eq!(initial_c, 25.0);
+        assert_eq!(segments[0].steps, 10);
+        assert_eq!(segments[0].dt_s, 2.0);
+        assert_eq!(segments[0].source_power_w["lamp"], 3.0);
+        assert_eq!(segments[1].face_temperature_c[&4], 30.0);
+        assert_eq!(segments[1].fixed_temperature_c[&0], 22.0);
+
+        // Round-trips through serde.
+        let round = serde_json::to_string(&tspec).expect("serialize");
+        let back: TransientSpec = serde_json::from_str(&round).expect("reparse");
+        assert_eq!(tspec, back);
+
+        // And drives a real solve end to end.
+        let mut m = ThermalModel::new([0.0, 0.0, 0.0], [20.0, 20.0, 4.0], [8, 8, 2]);
+        m.materials.push(
+            MaterialRegion::isotropic(
+                Shape::Box {
+                    min_mm: [0.0, 0.0, 0.0],
+                    size_mm: [20.0, 20.0, 4.0],
+                },
+                150.0,
+            )
+            .with_heat_capacity(1.7e6),
+        );
+        m.sources.push(PowerSource {
+            name: "lamp".into(),
+            shape: Shape::Box {
+                min_mm: [5.0, 5.0, 2.0],
+                size_mm: [10.0, 10.0, 2.0],
+            },
+            power_w: 1.0,
+        });
+        m.fixed.push(FixedTemperature {
+            shape: Shape::Box {
+                min_mm: [0.0, 0.0, 0.0],
+                size_mm: [20.0, 20.0, 2.0],
+            },
+            temperature_c: 25.0,
+        });
+        m.domain_faces[4] = Boundary::FixedTemperature {
+            temperature_c: 25.0,
+        };
+        m.reference_c = Some(25.0);
+        let sol = crate::transient::solve_transient_schedule(
+            &m,
+            &SolveOptions::default(),
+            initial_c,
+            0,
+            &segments,
+        )
+        .expect("transient solve");
+        assert_eq!(sol.times_s.len(), 20);
+        assert!((sol.times_s.last().unwrap() - 50.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn transient_spec_fails_closed() {
+        let bad_face: TransientSpec = serde_json::from_str(
+            r#"{"initial_c": 25.0, "segments": [
+                {"duration_s": 1.0, "dt_s": 1.0,
+                 "face_temperature_c": {"top": 30.0}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            bad_face.resolve(&BTreeMap::new()).unwrap_err(),
+            SpecError::UnknownFaceLabel("top".into())
+        );
+
+        let bad_key: TransientSpec = serde_json::from_str(
+            r#"{"initial_c": 25.0, "segments": [
+                {"duration_s": 1.0, "dt_s": 1.0,
+                 "fixed_temperature_c": {"chuck": 30.0}}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            bad_key.resolve(&BTreeMap::new()).unwrap_err(),
+            SpecError::BadFixedIndex("chuck".into())
+        );
+
+        let bad_dt: TransientSpec = serde_json::from_str(
+            r#"{"initial_c": 25.0, "segments": [
+                {"duration_s": 1.0, "dt_s": 0.0}]}"#,
+        )
+        .unwrap();
+        assert!(matches!(
+            bad_dt.resolve(&BTreeMap::new()).unwrap_err(),
+            SpecError::InvalidSegmentTiming(_)
+        ));
+
+        let unbound: TransientSpec = serde_json::from_str(
+            r#"{"initial_c": "t0", "segments": [
+                {"duration_s": 1.0, "dt_s": 1.0}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            unbound.resolve(&BTreeMap::new()).unwrap_err(),
+            SpecError::UnknownParameter("t0".into())
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-thermal/src/transient.rs
+++ b/crates/vcad-kernel-thermal/src/transient.rs
@@ -31,11 +31,12 @@
 //! [`TransientSolution::energy_audit_residual_rel`] reports how well the
 //! computed trajectory honors it over the whole run.
 
-use crate::model::{ModelError, ThermalModel};
+use crate::model::{Boundary, ModelError, ThermalModel};
 use crate::solve::{
     assemble_solution, build, pcg, resolve_reference, Solution, SolveError, SolveOptions,
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// Options for [`solve_transient`].
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -72,7 +73,9 @@ pub struct TransientSolution {
     /// Hottest solid-voxel temperature after each step, °C.
     pub t_max_c: Vec<f64>,
     /// Per-source hottest temperature after each step, °C
-    /// (`[source][step]`, sources in model order).
+    /// (`[source][step]`, sources in model order). A zero-power source
+    /// doubles as a temperature probe: it injects nothing but its
+    /// region's hottest temperature is tracked here every step.
     pub source_t_max_c: Vec<Vec<f64>>,
     /// Full report at the final time. Its `energy.residual_rel` is the
     /// steady-state balance residual of the *final field* — i.e. the
@@ -83,8 +86,12 @@ pub struct TransientSolution {
     pub stored_delta_j: f64,
     /// Net injected energy ∫(P_source − P_out) dt over the run, J.
     pub injected_j: f64,
-    /// |stored − injected| / max(|stored|, |injected|): the conservation
-    /// identity of the scheme, honored to CG tolerance.
+    /// |stored − injected| normalized by the gross energy traffic of the
+    /// run (Σ|per-step stored change|, Σ|per-step net injection|, and the
+    /// net totals — whichever is largest): the conservation identity of
+    /// the scheme, honored to CG tolerance. Gross normalization keeps the
+    /// audit meaningful for round-trip schedules (heat then cool back)
+    /// where the *net* totals both approach zero.
     pub energy_audit_residual_rel: f64,
     /// Total CG iterations across all steps.
     pub cg_iterations_total: usize,
@@ -92,111 +99,262 @@ pub struct TransientSolution {
     pub snapshots: Vec<Snapshot>,
 }
 
-/// Solve the transient conduction problem by backward Euler.
+/// One piecewise-constant interval of a transient run's drive schedule.
+///
+/// Within a segment every source power and boundary temperature is held
+/// constant; between segments the named overrides switch step-wise. This
+/// is exactly the shape of the problems transient conduction gets asked
+/// in practice: an RTP recipe is ramp/soak/cool segments of lamp power,
+/// an overlay-drift study is an ambient step. Overrides are **numbers
+/// only** — a segment may retune a source's watts or a boundary's
+/// temperature, never add/remove regions or change which faces convect
+/// (structure is provenance; changing it mid-run would silently change
+/// the mesh's free set).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ScheduleSegment {
+    /// Time step within this segment, s (> 0).
+    pub dt_s: f64,
+    /// Number of steps in this segment (≥ 1).
+    pub steps: usize,
+    /// Source-power overrides by source name, W (fail-closed: an unknown
+    /// name is an error). Sources not named keep the model's power.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub source_power_w: BTreeMap<String, f64>,
+    /// Domain-face temperature overrides by BC slot (0..=5 in
+    /// `[-x,+x,-y,+y,-z,+z]` order, 6 = the exposed BC). Retunes a
+    /// `FixedTemperature`'s temperature or a `Convection`'s ambient;
+    /// overriding an `Adiabatic` face is an error (fail-closed — there
+    /// is no temperature there to move).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub face_temperature_c: BTreeMap<usize, f64>,
+    /// Fixed-region temperature overrides by index into
+    /// `ThermalModel::fixed` (fail-closed on out-of-range).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fixed_temperature_c: BTreeMap<usize, f64>,
+}
+
+impl ScheduleSegment {
+    /// A plain segment with no overrides.
+    pub fn plain(dt_s: f64, steps: usize) -> Self {
+        Self {
+            dt_s,
+            steps,
+            source_power_w: BTreeMap::new(),
+            face_temperature_c: BTreeMap::new(),
+            fixed_temperature_c: BTreeMap::new(),
+        }
+    }
+
+    /// The base model with this segment's overrides applied (fail-closed).
+    fn apply(&self, base: &ThermalModel) -> Result<ThermalModel, SolveError> {
+        let mut m = base.clone();
+        for (name, &power_w) in &self.source_power_w {
+            let src = m
+                .sources
+                .iter_mut()
+                .find(|s| &s.name == name)
+                .ok_or_else(|| {
+                    SolveError::BadScheduleOverride(format!("unknown source {name:?}"))
+                })?;
+            src.power_w = power_w;
+        }
+        for (&slot, &temp) in &self.face_temperature_c {
+            let bc = if slot < 6 {
+                &mut m.domain_faces[slot]
+            } else if slot == 6 {
+                &mut m.exposed
+            } else {
+                return Err(SolveError::BadScheduleOverride(format!(
+                    "face slot {slot} out of range (0..=5 domain faces, 6 exposed)"
+                )));
+            };
+            match bc {
+                Boundary::FixedTemperature { temperature_c } => *temperature_c = temp,
+                Boundary::Convection { ambient_c, .. } => *ambient_c = temp,
+                Boundary::Adiabatic => {
+                    return Err(SolveError::BadScheduleOverride(format!(
+                        "face slot {slot} is adiabatic; it has no temperature to schedule"
+                    )));
+                }
+            }
+        }
+        for (&index, &temp) in &self.fixed_temperature_c {
+            let fx = m.fixed.get_mut(index).ok_or_else(|| {
+                SolveError::BadScheduleOverride(format!(
+                    "fixed region {index} out of range ({} regions)",
+                    base.fixed.len()
+                ))
+            })?;
+            fx.temperature_c = temp;
+        }
+        Ok(m)
+    }
+}
+
+/// Solve the transient conduction problem by backward Euler with constant
+/// drives — the single-segment special case of
+/// [`solve_transient_schedule`].
 pub fn solve_transient(
     model: &ThermalModel,
     opts: &SolveOptions,
     topts: &TransientOptions,
 ) -> Result<TransientSolution, SolveError> {
-    if topts.dt_s <= 0.0 || !topts.dt_s.is_finite() || topts.steps == 0 {
+    solve_transient_schedule(
+        model,
+        opts,
+        topts.initial_c,
+        topts.snapshot_every,
+        &[ScheduleSegment::plain(topts.dt_s, topts.steps)],
+    )
+}
+
+/// Solve a transient run driven by a piecewise-constant schedule.
+///
+/// The temperature field is continuous across segment boundaries; the
+/// drives (source powers, boundary temperatures) switch step-wise at
+/// them. Each segment's operator is reassembled from the overridden
+/// model — number-only overrides guarantee the voxel structure (solid,
+/// free, pinned sets) is identical across segments, so the field carries
+/// over index-for-index. The energy audit integrates over the whole run,
+/// segment switches included.
+pub fn solve_transient_schedule(
+    model: &ThermalModel,
+    opts: &SolveOptions,
+    initial_c: f64,
+    snapshot_every: usize,
+    segments: &[ScheduleSegment],
+) -> Result<TransientSolution, SolveError> {
+    if segments.is_empty()
+        || segments
+            .iter()
+            .any(|s| s.dt_s <= 0.0 || !s.dt_s.is_finite() || s.steps == 0)
+    {
         return Err(SolveError::InvalidTimeStep);
     }
-    let sys = build(model)?;
-    let reference_c = resolve_reference(&sys, model)?;
-    let nvox = sys.b.len();
+    let total_steps: usize = segments.iter().map(|s| s.steps).sum();
+
+    // θ reference comes from the base model (the schedule may move
+    // ambients; the reference is the stated baseline, not a moving one).
+    let base_sys = build(model)?;
+    let reference_c = resolve_reference(&base_sys, model)?;
+    let nvox = base_sys.b.len();
 
     // Thermal mass per voxel; every solid voxel must have one (fail
     // closed, naming the offending material region).
     let mut cap = vec![0.0_f64; nvox];
     for (p, c) in cap.iter_mut().enumerate() {
-        if sys.solid[p] {
-            if sys.rc[p] <= 0.0 {
+        if base_sys.solid[p] {
+            if base_sys.rc[p] <= 0.0 {
                 return Err(ModelError::MissingHeatCapacity {
-                    index: sys.mat_id[p],
+                    index: base_sys.mat_id[p],
                 }
                 .into());
             }
-            *c = sys.rc[p] * sys.cell_volume_m3;
+            *c = base_sys.rc[p] * base_sys.cell_volume_m3;
         }
     }
-    let cdt: Vec<f64> = cap.iter().map(|c| c / topts.dt_s).collect();
-    let diag_t: Vec<f64> = sys.diag.iter().zip(&cdt).map(|(d, c)| d + c).collect();
 
     let mut t: Vec<f64> = (0..nvox)
-        .map(|p| if sys.free[p] { topts.initial_c } else { 0.0 })
+        .map(|p| if base_sys.free[p] { initial_c } else { 0.0 })
         .collect();
-    let fixed_t_max = (0..nvox)
-        .filter(|&p| sys.solid[p] && !sys.free[p])
-        .map(|p| sys.tfix[p])
-        .fold(f64::NEG_INFINITY, f64::max);
 
-    let mut times_s = Vec::with_capacity(topts.steps);
-    let mut t_max_series = Vec::with_capacity(topts.steps);
-    let mut source_series: Vec<Vec<f64>> = sys
+    let mut times_s = Vec::with_capacity(total_steps);
+    let mut t_max_series = Vec::with_capacity(total_steps);
+    let mut source_series: Vec<Vec<f64>> = base_sys
         .sources
         .iter()
-        .map(|_| Vec::with_capacity(topts.steps))
+        .map(|_| Vec::with_capacity(total_steps))
         .collect();
     let mut snapshots = Vec::new();
     let mut rhs = vec![0.0_f64; nvox];
     let mut stored_delta_j = 0.0;
     let mut injected_j = 0.0;
+    let mut stored_gross_j = 0.0;
+    let mut injected_gross_j = 0.0;
     let mut cg_iterations_total = 0usize;
     let mut last_iters = 0usize;
     let mut last_resid = 0.0_f64;
+    let mut time = 0.0_f64;
+    let mut global_step = 0usize;
 
-    for step in 1..=topts.steps {
-        for p in 0..nvox {
-            rhs[p] = if sys.free[p] {
-                sys.b[p] + cdt[p] * t[p]
-            } else {
-                0.0
-            };
+    // Reused for the final report: the last segment's system and model.
+    let mut seg_model = model.clone();
+    let mut sys = base_sys;
+
+    for (si, seg) in segments.iter().enumerate() {
+        if si > 0 || !seg_is_plain(seg) {
+            seg_model = seg.apply(model)?;
+            sys = build(&seg_model)?;
         }
-        let (x, iters, resid) = pcg(&sys, &diag_t, &rhs, &t, opts)?;
-        cg_iterations_total += iters;
-        last_iters = iters;
-        last_resid = resid;
+        let cdt: Vec<f64> = cap.iter().map(|c| c / seg.dt_s).collect();
+        let diag_t: Vec<f64> = sys.diag.iter().zip(&cdt).map(|(d, c)| d + c).collect();
+        let fixed_t_max = (0..nvox)
+            .filter(|&p| sys.solid[p] && !sys.free[p])
+            .map(|p| sys.tfix[p])
+            .fold(f64::NEG_INFINITY, f64::max);
 
-        // Conservation audit of this step (an identity of the scheme).
-        let mut de = 0.0;
-        for p in 0..nvox {
-            if sys.free[p] {
-                de += cap[p] * (x[p] - t[p]);
+        for _ in 0..seg.steps {
+            for p in 0..nvox {
+                rhs[p] = if sys.free[p] {
+                    sys.b[p] + cdt[p] * t[p]
+                } else {
+                    0.0
+                };
             }
-        }
-        stored_delta_j += de;
-        injected_j += topts.dt_s * (sys.source_w_total - sys.boundary_outflow_w(&x));
+            let (x, iters, resid) = pcg(&sys, &diag_t, &rhs, &t, opts)?;
+            cg_iterations_total += iters;
+            last_iters = iters;
+            last_resid = resid;
 
-        t = x;
-        let time = step as f64 * topts.dt_s;
-        times_s.push(time);
-        let mut tmax = fixed_t_max;
-        for (p, &tv) in t.iter().enumerate() {
-            if sys.free[p] && tv > tmax {
-                tmax = tv;
-            }
-        }
-        t_max_series.push(tmax);
-        for (series, (_, _, ids)) in source_series.iter_mut().zip(&sys.sources) {
-            let mut m = f64::NEG_INFINITY;
-            for &p in ids {
-                if t[p] > m {
-                    m = t[p];
+            // Conservation audit of this step (an identity of the scheme).
+            let mut de = 0.0;
+            for p in 0..nvox {
+                if sys.free[p] {
+                    de += cap[p] * (x[p] - t[p]);
                 }
             }
-            series.push(m);
-        }
-        if topts.snapshot_every > 0 && step % topts.snapshot_every == 0 {
-            snapshots.push(Snapshot {
-                time_s: time,
-                t_c: full_field(&sys, &t),
-            });
+            stored_delta_j += de;
+            stored_gross_j += de.abs();
+            let net_in = seg.dt_s * (sys.source_w_total - sys.boundary_outflow_w(&x));
+            injected_j += net_in;
+            injected_gross_j += net_in.abs();
+
+            t = x;
+            time += seg.dt_s;
+            global_step += 1;
+            times_s.push(time);
+            let mut tmax = fixed_t_max;
+            for (p, &tv) in t.iter().enumerate() {
+                if sys.free[p] && tv > tmax {
+                    tmax = tv;
+                }
+            }
+            t_max_series.push(tmax);
+            for (series, (_, _, ids)) in source_series.iter_mut().zip(&sys.sources) {
+                let mut m = f64::NEG_INFINITY;
+                for &p in ids {
+                    if t[p] > m {
+                        m = t[p];
+                    }
+                }
+                series.push(m);
+            }
+            if snapshot_every > 0 && global_step.is_multiple_of(snapshot_every) {
+                snapshots.push(Snapshot {
+                    time_s: time,
+                    t_c: full_field(&sys, &t),
+                });
+            }
         }
     }
 
-    let audit_scale = stored_delta_j.abs().max(injected_j.abs()).max(1e-30);
-    let final_state = assemble_solution(&sys, model, &t, last_iters, last_resid, reference_c);
+    let audit_scale = stored_delta_j
+        .abs()
+        .max(injected_j.abs())
+        .max(stored_gross_j)
+        .max(injected_gross_j)
+        .max(1e-30);
+    let final_state = assemble_solution(&sys, &seg_model, &t, last_iters, last_resid, reference_c);
     Ok(TransientSolution {
         times_s,
         t_max_c: t_max_series,
@@ -208,6 +366,12 @@ pub fn solve_transient(
         cg_iterations_total,
         snapshots,
     })
+}
+
+fn seg_is_plain(seg: &ScheduleSegment) -> bool {
+    seg.source_power_w.is_empty()
+        && seg.face_temperature_c.is_empty()
+        && seg.fixed_temperature_c.is_empty()
 }
 
 fn full_field(sys: &crate::solve::System, x: &[f64]) -> Vec<f64> {
@@ -447,6 +611,165 @@ mod tests {
             .unwrap_err();
             assert!(matches!(err, SolveError::InvalidTimeStep));
         }
+    }
+
+    /// Lumped cube (Biot ≪ 1) equilibrated at ambient, then the ambient
+    /// steps +2 °C — the overlay-drift question. The response after the
+    /// switch is the same single exponential toward the *new* ambient:
+    /// T(t') = 27 − 2·exp(−t'/τ).
+    #[test]
+    fn ambient_step_schedule_relaxes_toward_the_new_ambient() {
+        let mut m = ThermalModel::new([0.0, 0.0, 0.0], [10.0, 10.0, 10.0], [4, 4, 4]);
+        m.materials.push(
+            MaterialRegion::isotropic(
+                Shape::Box {
+                    min_mm: [0.0, 0.0, 0.0],
+                    size_mm: [10.0, 10.0, 10.0],
+                },
+                300.0,
+            )
+            .with_heat_capacity(2.43e6),
+        );
+        m.domain_faces = [Boundary::Convection {
+            h_w_m2k: 20.0,
+            ambient_c: 25.0,
+        }; 6];
+
+        let tau = 2.43e6 * 1e-6 / (20.0 * 6.0e-4); // ≈ 202.6 s
+        let hold = ScheduleSegment::plain(1.0, 50);
+        let mut step = ScheduleSegment::plain(1.0, 400);
+        for slot in 0..6 {
+            step.face_temperature_c.insert(slot, 27.0);
+        }
+        let sol =
+            solve_transient_schedule(&m, &SolveOptions::default(), 25.0, 0, &[hold, step.clone()])
+                .unwrap();
+
+        // Held segment stays put at ambient.
+        assert!((sol.t_max_c[49] - 25.0).abs() < 1e-9);
+        // After the step, exponential approach to 27 °C.
+        for &after in &[100usize, 200, 400] {
+            let got = sol.t_max_c[50 + after - 1];
+            let exact = 27.0 - 2.0 * (-(after as f64) / tau).exp();
+            assert!(
+                (got - exact).abs() < 0.005 * 2.0,
+                "t' = {after} s: computed {got:.4}, exact {exact:.4}"
+            );
+        }
+        assert!(sol.energy_audit_residual_rel < 1e-6);
+    }
+
+    /// RTP-shaped source schedule: heat / soak / lamp-off. T_max peaks at
+    /// the end of the soak, then decays back toward the reservoir; the
+    /// energy audit integrates cleanly across the power switches.
+    #[test]
+    fn source_schedule_heats_soaks_and_cools() {
+        let mut m = ThermalModel::new([0.0, 0.0, 0.0], [20.0, 20.0, 4.0], [10, 10, 2]);
+        m.materials.push(
+            MaterialRegion::isotropic(
+                Shape::Box {
+                    min_mm: [0.0, 0.0, 0.0],
+                    size_mm: [20.0, 20.0, 4.0],
+                },
+                150.0,
+            )
+            .with_heat_capacity(1.7e6),
+        );
+        m.sources.push(PowerSource {
+            name: "lamp".into(),
+            shape: Shape::Box {
+                min_mm: [5.0, 5.0, 2.0],
+                size_mm: [10.0, 10.0, 2.0],
+            },
+            power_w: 5.0,
+        });
+        m.domain_faces[4] = Boundary::FixedTemperature {
+            temperature_c: 25.0,
+        };
+        m.reference_c = Some(25.0);
+
+        let mut soak = ScheduleSegment::plain(0.5, 40);
+        soak.source_power_w.insert("lamp".into(), 5.0);
+        let mut off = ScheduleSegment::plain(0.5, 80);
+        off.source_power_w.insert("lamp".into(), 0.0);
+        let sol =
+            solve_transient_schedule(&m, &SolveOptions::default(), 25.0, 0, &[soak, off]).unwrap();
+
+        let peak = sol
+            .t_max_c
+            .iter()
+            .cloned()
+            .fold(f64::NEG_INFINITY, f64::max);
+        // Peak is at the end of the powered segment...
+        assert!((sol.t_max_c[39] - peak).abs() < 1e-9);
+        assert!(peak > 25.5);
+        // ...and the lamp-off tail decays monotonically toward the chuck.
+        for w in sol.t_max_c[40..].windows(2) {
+            assert!(w[1] <= w[0] + 1e-9);
+        }
+        assert!(sol.t_max_c.last().unwrap() - 25.0 < 0.5 * (peak - 25.0));
+        // Gross-normalized audit: the net totals both round-trip toward
+        // zero here, so the bound reflects per-step CG noise against the
+        // gross traffic (‖rhs‖ carries the 25 °C offset).
+        assert!(
+            sol.energy_audit_residual_rel < 1e-3,
+            "audit residual {}",
+            sol.energy_audit_residual_rel
+        );
+        // The source series follows the schedule too (its own probe).
+        assert_eq!(sol.source_t_max_c[0].len(), 120);
+    }
+
+    #[test]
+    fn schedule_overrides_fail_closed() {
+        let mut m = ThermalModel::new([0.0, 0.0, 0.0], [10.0, 5.0, 5.0], [4, 1, 1]);
+        m.materials.push(
+            MaterialRegion::isotropic(
+                Shape::Box {
+                    min_mm: [0.0, 0.0, 0.0],
+                    size_mm: [10.0, 5.0, 5.0],
+                },
+                50.0,
+            )
+            .with_heat_capacity(2.0e6),
+        );
+        m.domain_faces[0] = Boundary::FixedTemperature { temperature_c: 0.0 };
+
+        let run = |seg: ScheduleSegment| {
+            solve_transient_schedule(&m, &SolveOptions::default(), 0.0, 0, &[seg]).unwrap_err()
+        };
+
+        let mut bad_source = ScheduleSegment::plain(1.0, 1);
+        bad_source.source_power_w.insert("ghost".into(), 1.0);
+        assert!(
+            matches!(run(bad_source), SolveError::BadScheduleOverride(w) if w.contains("ghost"))
+        );
+
+        let mut adiabatic_face = ScheduleSegment::plain(1.0, 1);
+        adiabatic_face.face_temperature_c.insert(3, 40.0);
+        assert!(matches!(
+            run(adiabatic_face),
+            SolveError::BadScheduleOverride(w) if w.contains("adiabatic")
+        ));
+
+        let mut bad_slot = ScheduleSegment::plain(1.0, 1);
+        bad_slot.face_temperature_c.insert(7, 40.0);
+        assert!(matches!(
+            run(bad_slot),
+            SolveError::BadScheduleOverride(w) if w.contains("out of range")
+        ));
+
+        let mut bad_fixed = ScheduleSegment::plain(1.0, 1);
+        bad_fixed.fixed_temperature_c.insert(0, 40.0);
+        assert!(matches!(
+            run(bad_fixed),
+            SolveError::BadScheduleOverride(w) if w.contains("out of range")
+        ));
+
+        assert!(matches!(
+            solve_transient_schedule(&m, &SolveOptions::default(), 0.0, 0, &[]),
+            Err(SolveError::InvalidTimeStep)
+        ));
     }
 
     /// Abramowitz & Stegun 7.1.26 rational approximation (|ε| ≤ 1.5e-7),

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -8206,6 +8206,140 @@ pub fn thermal_solve(
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
 }
 
+#[derive(serde::Serialize)]
+struct WasmThermalTransient {
+    divisions: [usize; 3],
+    voxel_mm: [f64; 3],
+    /// Time after each step, s.
+    times_s: Vec<f64>,
+    /// Hottest solid-voxel temperature after each step, °C.
+    t_max_c: Vec<f64>,
+    /// Per-source hottest temperature after each step, °C, keyed by
+    /// source name (model order preserved by the parallel `sources` list).
+    source_names: Vec<String>,
+    source_t_max_c: Vec<Vec<f64>>,
+    /// Final-state summary (same shape as the steady solve's report).
+    final_t_max_c: f64,
+    final_t_max_at_mm: [f64; 3],
+    reference_c: Option<f64>,
+    final_sources: Vec<WasmThermalSource>,
+    final_energy: WasmThermalEnergy,
+    /// Whole-run energy audit: stored-energy change vs integrated net
+    /// injection (the transient conservation identity).
+    stored_delta_j: f64,
+    injected_j: f64,
+    energy_audit_residual_rel: f64,
+    cg_iterations_total: usize,
+    claim_set: vcad_kernel::vcad_kernel_thermal::receipt::ClaimSet,
+    receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Transient heat-conduction solve: backward-Euler time stepping over a
+/// piecewise-constant drive schedule (RTP ramp/soak/cool, ambient steps,
+/// duty cycles). Returns the T_max and per-source time series plus the
+/// final-state summary and the integrated energy audit — full field
+/// snapshots are not returned over this seam.
+///
+/// `spec_json` is a `ThermalSpec` (every material needs
+/// `heat_capacity_j_m3k`), `transient_json` a
+/// `vcad_kernel_thermal::spec::TransientSpec`, `params_json` a
+/// `{name: value}` map, `options_json` a [`ThermalOptions`].
+#[wasm_bindgen(js_name = thermalSolveTransient)]
+pub fn thermal_solve_transient(
+    spec_json: &str,
+    transient_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_thermal as th;
+    let spec: th::spec::ThermalSpec =
+        serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+    let tspec: th::spec::TransientSpec = serde_json::from_str(transient_json)
+        .map_err(|e| JsError::new(&format!("bad transient spec: {e}")))?;
+    let params: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&format!("bad params: {e}")))?
+    };
+    let opts: ThermalOptions = if options_json.trim().is_empty() {
+        Default::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+    };
+    let model = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let (initial_c, segments) = tspec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let n_voxels: usize = model.divisions.iter().product();
+    if n_voxels > 2_000_000 {
+        return Err(JsError::new(&format!(
+            "grid too large for the MCP tier: {n_voxels} voxels (cap 2,000,000) — lower `divisions`"
+        )));
+    }
+    let total_steps: usize = segments.iter().map(|s| s.steps).sum();
+    if total_steps > 20_000 {
+        return Err(JsError::new(&format!(
+            "schedule too long for the MCP tier: {total_steps} steps (cap 20,000) — raise `dt_s`"
+        )));
+    }
+    if n_voxels.saturating_mul(total_steps) > 1_000_000_000 {
+        return Err(JsError::new(&format!(
+            "run too large for the MCP tier: {n_voxels} voxels x {total_steps} steps exceeds 1e9 \
+             voxel-steps — coarsen the grid or raise `dt_s`"
+        )));
+    }
+    let sopts = th::solve::SolveOptions {
+        tol: opts.tol,
+        max_iters: opts.max_iters,
+    };
+    let tsol = th::transient::solve_transient_schedule(&model, &sopts, initial_c, 0, &segments)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    let claim_set = th::receipt::transient_claims(&model, &tsol, &sopts);
+    let receipt_claims = th::receipt::design_claims(&claim_set);
+    let fs = &tsol.final_state;
+    let out = WasmThermalTransient {
+        divisions: fs.divisions,
+        voxel_mm: fs.voxel_mm,
+        times_s: tsol.times_s.clone(),
+        t_max_c: tsol.t_max_c.clone(),
+        source_names: fs.sources.iter().map(|s| s.name.clone()).collect(),
+        source_t_max_c: tsol.source_t_max_c.clone(),
+        final_t_max_c: fs.t_max_c,
+        final_t_max_at_mm: fs.t_max_at_mm,
+        reference_c: fs.reference_c,
+        final_sources: fs
+            .sources
+            .iter()
+            .map(|s| WasmThermalSource {
+                name: s.name.clone(),
+                power_w: s.power_w,
+                t_max_c: s.t_max_c,
+                t_max_at_mm: s.t_max_at_mm,
+                theta_c_per_w: s.theta_c_per_w,
+            })
+            .collect(),
+        final_energy: WasmThermalEnergy {
+            source_w: fs.energy.source_w,
+            fixed_face_out_w: fs.energy.fixed_face_out_w,
+            convection_out_w: fs.energy.convection_out_w,
+            fixed_region_out_w: fs.energy.fixed_region_out_w,
+            net_out_w: fs.energy.net_out_w,
+            residual_rel: fs.energy.residual_rel,
+        },
+        stored_delta_j: tsol.stored_delta_j,
+        injected_j: tsol.injected_j,
+        energy_audit_residual_rel: tsol.energy_audit_residual_rel,
+        cg_iterations_total: tsol.cg_iterations_total,
+        claim_set,
+        receipt_claims,
+    };
+    let ser = serde_wasm_bindgen::Serializer::json_compatible();
+    serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
 // ---------------------------------------------------------------------------
 // Static structural FEA (vcad-kernel-fea)
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -583,6 +583,13 @@ export interface KernelModule {
     paramsJson: string,
     optionsJson: string,
   ) => unknown;
+  /** Transient heat-conduction solve (adds a TransientSpec schedule). */
+  thermalSolveTransient?: (
+    specJson: string,
+    transientJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => unknown;
   /** Semantic entity-level diff of two `.vcad` documents (JSON strings). */
   documentDiff?: (oldJson: string, newJson: string) => unknown;
   /** Apply a `DocumentDiff` to a document, returning the patched document. */
@@ -1022,6 +1029,7 @@ export class Engine {
       particleOptimize: (wasmModule as Record<string, unknown>).particleOptimize as KernelModule["particleOptimize"],
       toleranceAnalyze: (wasmModule as Record<string, unknown>).toleranceAnalyze as KernelModule["toleranceAnalyze"],
       thermalSolve: (wasmModule as Record<string, unknown>).thermalSolve as KernelModule["thermalSolve"],
+      thermalSolveTransient: (wasmModule as Record<string, unknown>).thermalSolveTransient as KernelModule["thermalSolveTransient"],
       documentDiff: (wasmModule as Record<string, unknown>).documentDiff as KernelModule["documentDiff"],
       documentDiffApply: (wasmModule as Record<string, unknown>).documentDiffApply as KernelModule["documentDiffApply"],
       documentMerge: (wasmModule as Record<string, unknown>).documentMerge as KernelModule["documentMerge"],
@@ -1358,6 +1366,27 @@ export class Engine {
       );
     }
     return fn(specJson, paramsJson, optionsJson);
+  }
+
+  /**
+   * Transient heat-conduction solve: backward-Euler stepping over a
+   * piecewise-constant drive schedule (TransientSpec JSON), returning
+   * T_max/per-source time series, the final-state summary, and the
+   * integrated energy audit with predicted receipt claims.
+   */
+  thermalSolveTransient(
+    specJson: string,
+    transientJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ): unknown {
+    const fn = this.kernel.thermalSolveTransient;
+    if (typeof fn !== "function") {
+      throw new Error(
+        "thermalSolveTransient is not exported by this kernel WASM build — rebuild packages/kernel-wasm",
+      );
+    }
+    return fn(specJson, transientJson, paramsJson, optionsJson);
   }
 
   private circuitFn<K extends keyof KernelModule>(name: K): NonNullable<KernelModule[K]> {

--- a/packages/mcp/src/__tests__/thermal-tools.test.ts
+++ b/packages/mcp/src/__tests__/thermal-tools.test.ts
@@ -97,6 +97,79 @@ describe.skipIf(!wasmHasThermal)("thermal solve tool", () => {
     }
   });
 
+  it("transient mode returns time series, schedule switching + audit", async () => {
+    const wasmHasTransient =
+      typeof (
+        probeEngine as unknown as {
+          kernel?: { thermalSolveTransient?: unknown };
+        }
+      ).kernel?.thermalSolveTransient === "function";
+    if (!wasmHasTransient) return; // WASM predates the transient binding
+
+    const spec = {
+      ...SPEC,
+      materials: [
+        { ...SPEC.materials[0], heat_capacity_j_m3k: 1.8e6 },
+      ],
+    };
+    const res = (await client.callTool({
+      name: "solve_thermal",
+      arguments: {
+        spec,
+        parameters: { p_die: 2.0 },
+        transient: {
+          initial_c: 25.0,
+          segments: [
+            { duration_s: 60, dt_s: 3, source_power_w: { die: 2.0 } },
+            { duration_s: 60, dt_s: 3, source_power_w: { die: 0.0 } },
+          ],
+        },
+      },
+    })) as ToolText;
+    const out = JSON.parse(res.content[0].text);
+
+    expect(out.times_s.length).toBe(40);
+    expect(out.t_max_c.length).toBe(40);
+    expect(out.source_names).toEqual(["die"]);
+    // Heats while powered, cools after the switch.
+    expect(out.t_max_c[19]).toBeGreaterThan(25.5);
+    expect(out.t_max_c[39]).toBeLessThan(out.t_max_c[19]);
+    expect(out.energy_audit_residual_rel).toBeLessThan(1e-3);
+
+    expect(out.claim_set.schema).toBe("vcad.thermal-claims/1");
+    const names = out.claim_set.claims.map((c: { name: string }) => c.name);
+    expect(names).toContain("t_max_peak_c");
+    expect(names).toContain("t_max_final_c");
+    expect(names).toContain("transient_energy_audit_residual");
+    for (const c of out.receipt_claims) {
+      expect(c.basis).toBe("predicted");
+    }
+  });
+
+  it("transient without heat capacity fails closed", async () => {
+    const wasmHasTransient =
+      typeof (
+        probeEngine as unknown as {
+          kernel?: { thermalSolveTransient?: unknown };
+        }
+      ).kernel?.thermalSolveTransient === "function";
+    if (!wasmHasTransient) return;
+
+    const res = (await client.callTool({
+      name: "solve_thermal",
+      arguments: {
+        spec: SPEC,
+        parameters: { p_die: 2.0 },
+        transient: {
+          initial_c: 25.0,
+          segments: [{ duration_s: 10, dt_s: 1 }],
+        },
+      },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("heat capacity");
+  });
+
   it("an all-adiabatic (ungrounded) domain fails closed", async () => {
     const res = (await client.callTool({
       name: "solve_thermal",

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -3295,7 +3295,7 @@
   {
     "name": "solve_thermal",
     "title": "Solve Thermal",
-    "description": "Steady heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, returning T_max and its location, per-source theta_ja (K/W, junction-to-ambient), reservoir loads, and an energy-balance audit — as data plus `vcad.thermal-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until hardware is measured. Conduction only: convection enters as film coefficients you supply (h values are the dominant uncertainty), no radiation, no fluid flow, steady state only. The full temperature field is not returned (summaries + claims are). Cost scales with voxel count (capped at 2M); a 20x20x2 board solves instantly, 100x100x13 in seconds.",
+    "description": "Heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, returning T_max and its location, per-source theta_ja (K/W, junction-to-ambient), reservoir loads, and an energy-balance audit — as data plus `vcad.thermal-claims/1` and unified-receipt claims. Predictions carry basis \"predicted\" and roll up Provisional until hardware is measured. Steady state by default; pass `transient` for backward-Euler time stepping over a piecewise-constant drive schedule (RTP ramp/soak/cool, ambient steps, duty cycles — needs per-material `heat_capacity_j_m3k`), which returns T_max/per-source time series and the run-integrated energy audit. Conduction only: convection enters as film coefficients you supply (h values are the dominant uncertainty), no radiation, no fluid flow. Full temperature fields are not returned (summaries + claims are). Cost scales with voxel count (capped at 2M; transient runs also capped at 20k steps and 1e9 voxel-steps); a 20x20x2 board solves instantly, 100x100x13 in seconds.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -3876,6 +3876,107 @@
                   "type": "string"
                 }
               ]
+            }
+          }
+        },
+        "transient": {
+          "type": "object",
+          "required": [
+            "initial_c",
+            "segments"
+          ],
+          "description": "Transient mode: backward-Euler time stepping from a uniform initial temperature over a schedule of piecewise-constant segments (an RTP ramp/soak/cool recipe, an ambient step, a duty cycle). Every material must declare `heat_capacity_j_m3k` (rho*c_p, J/(m^3*K)). Returns T_max and per-source time series instead of a single steady state, plus the energy audit integrated over the run.",
+          "properties": {
+            "initial_c": {
+              "description": "Uniform initial temperature of the free field, degC.",
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "segments": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "object",
+                "required": [
+                  "duration_s",
+                  "dt_s"
+                ],
+                "properties": {
+                  "duration_s": {
+                    "description": "Segment duration, s.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "dt_s": {
+                    "description": "Target time step, s. Implicit stepping is stable at any dt; pick it to resolve the fastest time constant you care about. The realized step divides the duration exactly.",
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "source_power_w": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "Source-power overrides for this segment by source name, W (fail-closed on unknown names). Unnamed sources keep the spec's power."
+                  },
+                  "face_temperature_c": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "Boundary-temperature overrides by face label (\"-x\",\"+x\",\"-y\",\"+y\",\"-z\",\"+z\",\"exposed\"): retunes a FixedTemperature face's temperature or a Convection face's ambient. Overriding an adiabatic face errors (fail-closed)."
+                  },
+                  "fixed_temperature_c": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "description": "A number, or the name of a named parameter bound via `parameters`.",
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "description": "Fixed-region temperature overrides keyed by the region's index in `fixed` (as a string)."
+                  }
+                }
+              }
             }
           }
         },

--- a/packages/mcp/src/tools/thermal.ts
+++ b/packages/mcp/src/tools/thermal.ts
@@ -154,6 +154,69 @@ const thermalSpecSchema = {
   },
 };
 
+const transientSchema = {
+  type: "object" as const,
+  required: ["initial_c", "segments"],
+  description:
+    "Transient mode: backward-Euler time stepping from a uniform initial " +
+    "temperature over a schedule of piecewise-constant segments (an RTP " +
+    "ramp/soak/cool recipe, an ambient step, a duty cycle). Every " +
+    "material must declare `heat_capacity_j_m3k` (rho*c_p, J/(m^3*K)). " +
+    "Returns T_max and per-source time series instead of a single steady " +
+    "state, plus the energy audit integrated over the run.",
+  properties: {
+    initial_c: {
+      ...paramValue,
+      description: "Uniform initial temperature of the free field, degC.",
+    },
+    segments: {
+      type: "array" as const,
+      minItems: 1,
+      items: {
+        type: "object" as const,
+        required: ["duration_s", "dt_s"],
+        properties: {
+          duration_s: {
+            ...paramValue,
+            description: "Segment duration, s.",
+          },
+          dt_s: {
+            ...paramValue,
+            description:
+              "Target time step, s. Implicit stepping is stable at any " +
+              "dt; pick it to resolve the fastest time constant you care " +
+              "about. The realized step divides the duration exactly.",
+          },
+          source_power_w: {
+            type: "object" as const,
+            additionalProperties: paramValue,
+            description:
+              "Source-power overrides for this segment by source name, W " +
+              "(fail-closed on unknown names). Unnamed sources keep the " +
+              "spec's power.",
+          },
+          face_temperature_c: {
+            type: "object" as const,
+            additionalProperties: paramValue,
+            description:
+              'Boundary-temperature overrides by face label ("-x","+x",' +
+              '"-y","+y","-z","+z","exposed"): retunes a FixedTemperature ' +
+              "face's temperature or a Convection face's ambient. " +
+              "Overriding an adiabatic face errors (fail-closed).",
+          },
+          fixed_temperature_c: {
+            type: "object" as const,
+            additionalProperties: paramValue,
+            description:
+              "Fixed-region temperature overrides keyed by the region's " +
+              "index in `fixed` (as a string).",
+          },
+        },
+      },
+    },
+  },
+};
+
 type Json = Record<string, unknown>;
 
 function textResult(payload: unknown) {
@@ -172,20 +235,26 @@ export const toolDefs: ToolDef[] = [
     name: "solve_thermal",
     pack: null,
     description:
-      "Steady heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, " +
+      "Heat-conduction FEA on a voxel grid: harmonic-mean finite volumes + PCG, " +
       "returning T_max and its location, per-source theta_ja (K/W, junction-to-ambient), " +
       "reservoir loads, and an energy-balance audit — as data plus " +
       "`vcad.thermal-claims/1` and unified-receipt claims. Predictions carry basis " +
-      "\"predicted\" and roll up Provisional until hardware is measured. Conduction only: " +
-      "convection enters as film coefficients you supply (h values are the dominant " +
-      "uncertainty), no radiation, no fluid flow, steady state only. The full temperature " +
-      "field is not returned (summaries + claims are). Cost scales with voxel count " +
-      "(capped at 2M); a 20x20x2 board solves instantly, 100x100x13 in seconds.",
+      "\"predicted\" and roll up Provisional until hardware is measured. Steady state by " +
+      "default; pass `transient` for backward-Euler time stepping over a piecewise-" +
+      "constant drive schedule (RTP ramp/soak/cool, ambient steps, duty cycles — needs " +
+      "per-material `heat_capacity_j_m3k`), which returns T_max/per-source time series " +
+      "and the run-integrated energy audit. Conduction only: convection enters as film " +
+      "coefficients you supply (h values are the dominant uncertainty), no radiation, " +
+      "no fluid flow. Full temperature fields are not returned (summaries + claims are). " +
+      "Cost scales with voxel count (capped at 2M; transient runs also capped at 20k " +
+      "steps and 1e9 voxel-steps); a 20x20x2 board solves instantly, 100x100x13 in " +
+      "seconds.",
     inputSchema: {
       type: "object" as const,
       required: ["spec"],
       properties: {
         spec: thermalSpecSchema,
+        transient: transientSchema,
         parameters: {
           type: "object" as const,
           additionalProperties: { type: "number" as const },
@@ -208,11 +277,18 @@ export const toolDefs: ToolDef[] = [
     },
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.thermalSolve(
-        JSON.stringify(a.spec),
-        JSON.stringify(a.parameters ?? {}),
-        JSON.stringify(a.options ?? {}),
-      );
+      const out = a.transient
+        ? ctx.engine.thermalSolveTransient(
+            JSON.stringify(a.spec),
+            JSON.stringify(a.transient),
+            JSON.stringify(a.parameters ?? {}),
+            JSON.stringify(a.options ?? {}),
+          )
+        : ctx.engine.thermalSolve(
+            JSON.stringify(a.spec),
+            JSON.stringify(a.parameters ?? {}),
+            JSON.stringify(a.options ?? {}),
+          );
       return textResult(out);
     },
     behavior: behavior({}),


### PR DESCRIPTION
## What

The voxel conduction FEA behind `solve_thermal` was steady-state only. This adds a **transient mode** end to end, driven by the rune stepper's two live questions: overlay drift after an ambient step, and RTP ramp/soak/cool recipes.

- **Kernel** (`vcad-kernel-thermal`): `solve_transient_schedule` — backward-Euler stepping (implicit, unconditionally stable, one warm-started PCG solve per step) over piecewise-constant segments that retune source powers, boundary temperatures (fixed faces / convection ambients), and fixed-region temperatures. Overrides are numbers-only and fail-closed (unknown source name, adiabatic face, out-of-range slot/index all error). `solve_transient` becomes the single-segment case.
- **Energy audit** (the product's signature) integrates over the whole run, and is now normalized by **gross energy traffic** so round-trip schedules (heat then cool back, where net stored ≈ net injected ≈ 0) stay auditable instead of dividing by zero.
- **Spec seam**: `TransientSpec`/`SegmentSpec` with `ParamValue`-named numbers, `duration_s` + target `dt_s` per segment (realized step divides the duration exactly), face labels `-x…+z`/`exposed`, fail-closed resolution.
- **Receipts**: `transient_claims` — `t_max_peak_c`, `t_max_final_c`, per-source endpoint temps, `transient_energy_audit_residual`, `distance_from_steady_residual` — `basis: "predicted"`, rolling up Provisional on the unified receipt like the steady family.
- **WASM + engine + MCP**: `thermalSolveTransient` binding; `solve_thermal` gains an optional `transient` argument returning T_max/per-source time series plus the integrated audit. MCP-tier caps: 2M voxels, 20k steps, 1e9 voxel-steps. Zero-power sources double as temperature probes.

## Benchmark: the rune stage stack

`examples/rune_stage_stack.rs` reconstructs the R0 stack (Z stage → rails → XY stage → chuck → wafer, chamber floor anchored, 100×100×75 — the grid of the "first solved physics" steady runs; θ ≈ 0.29 K/W vs their 0.25):

- **Overlay drift**: a +2 °C chamber-floor step reaches 50% at the wafer in ~4 min, 90% in ~10 min — well inside a 2 h litho layer, so ambient swings do reach the stage stack within a job.
- **RTP-shaped**: 200 W × 60 s into the wafer in chuck contact peaks at ~65 °C and recovers to +0.2 °C in 10 min; audit closes to 5.6e-6 across the power switches.

## Validation

- Analytic: lumped-capacitance exponential decay (0.5%), semi-infinite-slab erfc response (pre-existing); **new**: ambient-step schedule tracks the exponential toward the new ambient to 0.5%; heat/soak/cool peaks at the switch and decays monotonically.
- Fail-closed: missing heat capacity, bad dt/steps, unknown override targets, bad face labels/fixed keys — all error with named causes.
- `cargo test --workspace` ✅, `cargo clippy --workspace -- -D warnings` ✅ (excl. pre-existing vcad-desktop lints), `cargo fmt --check` ✅, engine 119 ✅, MCP 890 ✅ (incl. new end-to-end transient tool tests against WASM built from source).
- WASM artifacts untouched per the single-writer policy; tool-surface fixture regenerated.

Changelog entry included. (`packages/docs` kernel-features catalog doesn't exist in this tree — no catalog update.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)