### PR TITLE
perf(apple): pattern roots render as shared-mesh instances in the native app

### DIFF
--- a/apple/VcadApp/Sources/VcadApp/Document.swift
+++ b/apple/VcadApp/Sources/VcadApp/Document.swift
@@ -1,4 +1,5 @@
 import Foundation
+import simd
 
 // Parses a `.vcad` parametric document (JSON: a node DAG + scene roots) into a
 // navigable feature tree — the native counterpart of the web app's FeatureTree.
@@ -409,6 +410,18 @@ struct DocumentGraph {
     }
 }
 
+/// Viewport instancing for a pattern root: the seed subtree is tessellated
+/// once and rendered as N rigid copies (one shared MeshResource, N entities)
+/// instead of N independently tessellated + unioned meshes.
+struct PatternInstancing {
+    /// The LinearPattern/CircularPattern node at the root.
+    let patternNodeId: Int
+    /// The pattern's child — the seed the kernel tessellates once.
+    let seedNodeId: Int
+    /// Kernel-space (Z-up, mm) rigid transforms, one per copy; first = identity.
+    let transforms: [simd_float4x4]
+}
+
 // MARK: in-place JSON edits
 // The kernel is a pure `JSON → meshes` evaluator, so editing a document is just
 // mutating its JSON dict and re-evaluating — no editable-doc FFI needed. These
@@ -534,6 +547,67 @@ enum DocEdit {
             }
             vis += 1
         }
+    }
+
+    /// Instancing plan for a visible root whose node is a Linear/CircularPattern.
+    /// Because the pattern IS the root, nothing downstream consumes its result,
+    /// so the copies are pure rigid transforms of the seed — safe to instance.
+    /// Returns nil (→ fall back to the baked kernel mesh) when the op isn't a
+    /// pattern, the parameters are degenerate, or a document binding targets
+    /// this node (bindings rewrite fields inside the kernel at eval time, so
+    /// the raw JSON values here could be stale).
+    static func patternInstancing(_ json: [String: Any], rootNodeId: Int) -> PatternInstancing? {
+        guard let nodes = json["nodes"] as? [String: Any],
+              let node = nodes[String(rootNodeId)] as? [String: Any],
+              let op = node["op"] as? [String: Any],
+              let type = op["type"] as? String,
+              type == "LinearPattern" || type == "CircularPattern",
+              let seed = (op["child"] as? NSNumber)?.intValue,
+              nodes[String(seed)] != nil,
+              let count = (op["count"] as? NSNumber)?.intValue, count >= 2
+        else { return nil }
+        if let bindings = json["bindings"] as? [String: Any],
+           bindings.keys.contains(where: { $0.hasPrefix("\(rootNodeId):") }) { return nil }
+        func vec(_ k: String) -> SIMD3<Double>? {
+            guard let v = op[k] as? [String: Any],
+                  let x = (v["x"] as? NSNumber)?.doubleValue,
+                  let y = (v["y"] as? NSNumber)?.doubleValue,
+                  let z = (v["z"] as? NSNumber)?.doubleValue else { return nil }
+            return SIMD3(x, y, z)
+        }
+        var transforms: [simd_float4x4] = []
+        transforms.reserveCapacity(count)
+        if type == "LinearPattern" {
+            // Kernel: copies at i·spacing along the normalized direction.
+            guard let d = vec("direction"),
+                  let spacing = (op["spacing"] as? NSNumber)?.doubleValue else { return nil }
+            let n = simd_length(d)
+            guard n > 1e-12 else { return nil }
+            let dir = d / n
+            for i in 0..<count {
+                var m = matrix_identity_float4x4
+                let o = dir * (spacing * Double(i))
+                m.columns.3 = SIMD4(Float(o.x), Float(o.y), Float(o.z), 1)
+                transforms.append(m)
+            }
+        } else {
+            // Kernel: step = angle_deg/count about the axis through axis_origin.
+            guard let o = vec("axis_origin"), let a = vec("axis_dir"),
+                  let angle = (op["angle_deg"] as? NSNumber)?.doubleValue else { return nil }
+            let n = simd_length(a)
+            guard n > 1e-12 else { return nil }
+            let axis = SIMD3<Float>(a / n)
+            let origin = SIMD3<Float>(o)
+            let step = angle * .pi / 180 / Double(count)
+            for i in 0..<count {
+                let q = simd_quatf(angle: Float(step * Double(i)), axis: axis)
+                var m = simd_float4x4(q)
+                m.columns.3 = SIMD4(origin - q.act(origin), 1)
+                transforms.append(m)
+            }
+        }
+        return PatternInstancing(patternNodeId: rootNodeId, seedNodeId: seed,
+                                 transforms: transforms)
     }
 
     /// Current op dict for a node (for populating the inspector's editors).

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -250,6 +250,12 @@ final class EditorModel {
     var pickDirty = false
     var displayScale: Float = 0.02
     var displayCenter: SIMD3<Float> = .zero
+    /// Native RealityKit picking: the live `centering` entity (weak) provides
+    /// the scene for collision raycasts and world↔kernel conversion.
+    @ObservationIgnored weak var centeringEntity: Entity?
+    /// Per-entity collider build tokens — an async static-mesh collider only
+    /// lands if it is still the newest request for that entity name.
+    @ObservationIgnored var colliderTokens: [String: Int] = [:]
 
     var geometryDirty = true
     var parameterDirty = false
@@ -280,6 +286,10 @@ final class EditorModel {
     /// Part under the cursor (documents) — drives a subtle hover highlight.
     var hoveredPartIndex: Int?
     var hoverDirty = false
+    /// Zebra surface analysis: striped environment reflected off chromed parts,
+    /// so stripe continuity reveals curvature/tangency defects.
+    var zebraMode = false { didSet { if zebraMode != oldValue { zebraDirty = true } } }
+    var zebraDirty = false
     /// Per-part kernel-space triangle meshes (+ AABB), index-aligned with the
     /// rendered parts — the basis for precise ray-triangle hover/pick. The AABB
     /// is a broadphase cull before the triangle test.
@@ -293,6 +303,12 @@ final class EditorModel {
     /// Feature-edge segments per part (index-aligned with docPartMeshes),
     /// refreshed on every evaluate/re-evaluate for the CAD edge overlay.
     @ObservationIgnored var docPartEdges: [[SIMD3<Float>]] = []
+    /// Per-part instancing (index-aligned with docPartMeshes): non-nil when the
+    /// part is a pattern root rendered as one shared mesh + N instance entities.
+    /// The in-place re-eval path reads this to sync instance entities without a
+    /// full rebuild; pick/edge data is pre-aggregated so everything downstream
+    /// (hover, pick, gizmo, auto-fit) is instancing-agnostic.
+    @ObservationIgnored var docPartInstancing: [PatternInstancing?] = []
     /// Crease threshold for the edge overlay: creases sharper than this many
     /// degrees draw; cylinder facets (~6°) stay invisible.
     static let edgeAngleDeg: Float = 25.0
@@ -648,67 +664,8 @@ final class EditorModel {
     /// never repaint a part's material; it only adds a subtle emissive lift.
     static let brandOrange = NSColor(srgbRed: 1.0, green: 0.45, blue: 0.10, alpha: 1.0)
 
-    /// Ray-pick a document part by its actual triangles (kernel coords) — the
-    /// nearest surface hit wins. An AABB test culls parts the ray misses, and
-    /// skips parts whose box is already farther than the best surface hit.
-    func pickDocumentPart(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Int? {
-        var best: (i: Int, t: Float)?
-        for (i, pm) in docPartMeshes.enumerated() where isPartVisible(i) {
-            guard let tBox = Self.rayAABB(o: o, d: d, lo: pm.lo, hi: pm.hi) else { continue }
-            if let b = best, tBox > b.t { continue }      // whole box is behind a closer hit
-            var localBest: Float?
-            let pos = pm.positions, ind = pm.indices
-            var k = 0
-            while k + 2 < ind.count {
-                let a = pos[Int(ind[k])], b2 = pos[Int(ind[k + 1])], c = pos[Int(ind[k + 2])]
-                if let t = Self.rayTriangle(o: o, d: d, a: a, b: b2, c: c),
-                   localBest == nil || t < localBest! { localBest = t }
-                k += 3
-            }
-            if let lt = localBest, best == nil || lt < best!.t { best = (i, lt) }
-        }
-        return best?.i
-    }
-
-    /// Möller–Trumbore ray-triangle intersection → hit distance, or nil.
-    private static func rayTriangle(o: SIMD3<Float>, d: SIMD3<Float>,
-                                    a: SIMD3<Float>, b: SIMD3<Float>, c: SIMD3<Float>) -> Float? {
-        let e1 = b - a, e2 = c - a
-        let p = cross(d, e2)
-        let det = simd_dot(e1, p)
-        if abs(det) < 1e-7 { return nil }
-        let inv = 1 / det
-        let tv = o - a
-        let u = simd_dot(tv, p) * inv
-        if u < -1e-5 || u > 1 + 1e-5 { return nil }
-        let q = cross(tv, e1)
-        let v = simd_dot(d, q) * inv
-        if v < -1e-5 || u + v > 1 + 1e-5 { return nil }
-        let t = simd_dot(e2, q) * inv
-        return t > 1e-5 ? t : nil
-    }
-
-    /// Slab test → entry distance along the ray, or nil if it misses.
-    private static func rayAABB(o: SIMD3<Float>, d: SIMD3<Float>,
-                                lo: SIMD3<Float>, hi: SIMD3<Float>) -> Float? {
-        var tmin: Float = -.greatestFiniteMagnitude
-        var tmax: Float = .greatestFiniteMagnitude
-        for a in 0..<3 {
-            let di = d[a]
-            if abs(di) < 1e-9 {
-                if o[a] < lo[a] || o[a] > hi[a] { return nil }
-            } else {
-                let inv = 1 / di
-                var t1 = (lo[a] - o[a]) * inv
-                var t2 = (hi[a] - o[a]) * inv
-                if t1 > t2 { swap(&t1, &t2) }
-                tmin = max(tmin, t1)
-                tmax = min(tmax, t2)
-                if tmin > tmax { return nil }
-            }
-        }
-        return tmax < 0 ? nil : max(tmin, 0)
-    }
+    // Part picking is native RealityKit now: part entities carry generated
+    // static-mesh colliders and scene raycasts do the hit testing (Shell.swift).
 
     // MARK: document editing
     // The kernel is a pure JSON→meshes evaluator, so editing = mutate the live
@@ -1051,41 +1008,8 @@ final class EditorModel {
         gizmoDirty = true
     }
 
-    /// Nearest gizmo handle the ray hits, or nil — drives hover + tap-protection.
-    func hitGizmoHandle(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> String? {
-        guard showsGizmo, let c = gizmoCenterKernel() else { return nil }
-        let len = gizmoArmLength()
-        let pad = max(0.6, len * 0.045)
-        var best: (name: String, t: Float)?
-        func consider(_ name: String, _ lo: SIMD3<Float>, _ hi: SIMD3<Float>) {
-            if let t = Self.rayAABB(o: o, d: d, lo: lo, hi: hi), best == nil || t < best!.t { best = (name, t) }
-        }
-        for a in Self.gizmoAxisDefs {
-            consider(a.name, simd_min(c, c + a.dir * len) - SIMD3(repeating: pad),
-                     simd_max(c, c + a.dir * len) + SIMD3(repeating: pad))
-        }
-        let off = gizmoPlaneOffset, hs = gizmoPlaneSize / 2 + pad
-        for p in Self.gizmoPlaneDefs {
-            let pc = c + (p.a + p.b) * off
-            consider(p.name, pc - SIMD3(repeating: hs), pc + SIMD3(repeating: hs))
-        }
-        // Rotate rings: ray ∩ ring plane, then distance ≈ ring radius.
-        let ringR = gizmoRingRadius, ringPad = max(0.8, len * 0.06)
-        for rd in Self.gizmoRotDefs {
-            let denom = simd_dot(d, rd.axis)
-            if abs(denom) < 1e-6 { continue }
-            let t = simd_dot(c - o, rd.axis) / denom
-            if t <= 0 { continue }
-            if abs(simd_length((o + d * t) - c) - ringR) < ringPad, best == nil || t < best!.t {
-                best = (rd.name, t)
-            }
-        }
-        return best?.name
-    }
-    /// Whether a ray hits the gizmo (so a tap on it doesn't deselect).
-    func rayHitsGizmo(originKernel o: SIMD3<Float>, dirKernel d: SIMD3<Float>) -> Bool {
-        hitGizmoHandle(originKernel: o, dirKernel: d) != nil
-    }
+    // Gizmo hover/tap hit testing is native now: the gizmo's invisible grab
+    // proxies carry CollisionComponents, so scene raycasts find them directly.
 
     /// Param `t` along the axis line (center + t·axis) closest to the ray — the
     /// standard closest-point-between-two-lines solution (axis is a unit vector).
@@ -1246,7 +1170,9 @@ final class EditorModel {
     /// fixed so the part doesn't jump mid-edit; updates the live readouts +
     /// pick bounds. Returns nil if the edit produced no geometry.
     func reevalDocumentMeshes() -> [MeshResource]? {
-        guard let json = documentJSON, let data = DocEdit.serialize(json) else { return nil }
+        guard documentJSON != nil else { return nil }
+        let plan = documentInstancingPlan()
+        guard let data = evalData(applying: plan) else { return nil }
         let start = Date()
         let scene: OpaquePointer? = data.withUnsafeBytes {
             vcad_scene_from_json($0.bindMemory(to: UInt8.self).baseAddress, data.count)
@@ -1255,6 +1181,7 @@ final class EditorModel {
         defer { vcad_scene_free(scene) }
         let count = vcad_scene_part_count(scene)
         var meshes: [MeshResource] = []
+        var instancing: [PatternInstancing?] = []
         var picks: [PickMesh] = []
         var edges: [[SIMD3<Float>]] = []
         var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
@@ -1263,21 +1190,33 @@ final class EditorModel {
         for i in 0..<count {
             let km = KernelMesh.fromView(vcad_scene_part_mesh(scene, i))
             if km.isEmpty { continue }
-            lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
-            tris += km.triangleCount
-            meshes.append(km.resource(name: "part\(i)"))
-            picks.append(PickMesh(positions: km.positions, indices: km.indices,
-                                  lo: km.minBound, hi: km.maxBound))
+            var segs: [SIMD3<Float>] = []
             if let eh = vcad_scene_part_edges(scene, i, Self.edgeAngleDeg) {
-                edges.append(EdgeOverlay.segments(fromView: vcad_edges_view(eh)))
+                segs = EdgeOverlay.segments(fromView: vcad_edges_view(eh))
                 vcad_edges_free(eh)
+            }
+            meshes.append(km.resource(name: "part\(i)"))
+            if let inst = plan[i] {
+                let agg = Self.aggregateInstances(km, edgeSegments: segs,
+                                                  transforms: inst.transforms)
+                lo = simd_min(lo, agg.lo); hi = simd_max(hi, agg.hi)
+                tris += km.triangleCount * inst.transforms.count
+                instancing.append(inst)
+                picks.append(agg.pick)
+                edges.append(agg.edges)
             } else {
-                edges.append([])
+                lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
+                tris += km.triangleCount
+                instancing.append(nil)
+                picks.append(PickMesh(positions: km.positions, indices: km.indices,
+                                      lo: km.minBound, hi: km.maxBound))
+                edges.append(segs)
             }
         }
         guard !meshes.isEmpty else { return nil }
         docPartMeshes = picks
         docPartEdges = edges
+        docPartInstancing = instancing
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = tris
         partCount = meshes.count
@@ -1352,11 +1291,9 @@ final class EditorModel {
     }
 
     // Hover affordance for the draggable handles (cursor + a subtle scale pop).
-    // The handles' live world positions are projected to screen to hit-test the
-    // pointer; `hoveredHandle` drives the highlight + cursor.
+    // Scene raycasts against the handles' colliders hit-test the pointer;
+    // `hoveredHandle` drives the highlight + cursor.
     var hoveredHandle: String?
-    @ObservationIgnored var connectorHandleWorld: SIMD3<Float> = .zero
-    @ObservationIgnored var filletHandleWorld: SIMD3<Float> = .zero
 
     /// Frame the geometry at a clean 3/4 view. Parts auto-fit to a constant
     /// display size, so fixed camera params frame any part well.
@@ -1917,6 +1854,7 @@ final class EditorModel {
         } else {
             docPartEdges = []
         }
+        docPartInstancing = []
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = km.triangleCount
         partCount = 1
@@ -1945,36 +1883,77 @@ final class EditorModel {
 
     struct PickHit { var point: SIMD3<Float>; var normal: SIMD3<Float> }
 
-    /// Cast a ray (kernel coords) against the current sandbox solid.
-    func raycastSandbox(originKernel: SIMD3<Float>, dirKernel: SIMD3<Float>) -> PickHit? {
-        guard source.isSandbox, let base = makeBase() else { return nil }
-        defer { vcad_solid_free(base) }
-        var target = base
-        var owned: OpaquePointer?
-        if modifierApplies {
-            switch modifier {
-            case .fillet: if let f = vcad_solid_fillet(base, modifierValue) { target = f; owned = f }
-            case .chamfer: if let c = vcad_solid_chamfer(base, modifierValue) { target = c; owned = c }
-            case .none: break
+    // MARK: pattern instancing (shared seed mesh + N transformed entities)
+
+    /// Kernel part index → instancing plan, for visible roots whose node is a
+    /// Linear/CircularPattern. Only the editable-JSON path instances (legacy
+    /// docs the parser couldn't load fall back to baked kernel meshes).
+    private func documentInstancingPlan() -> [Int: PatternInstancing] {
+        guard let json = documentJSON, let g = documentGraph else { return [:] }
+        var plan: [Int: PatternInstancing] = [:]
+        for (i, root) in g.visibleRoots.enumerated() {
+            if let inst = DocEdit.patternInstancing(json, rootNodeId: root.nodeId),
+               inst.transforms.count > 1 {
+                plan[i] = inst
             }
         }
-        defer { if let o = owned { vcad_solid_free(o) } }
-        let o: [Double] = [Double(originKernel.x), Double(originKernel.y), Double(originKernel.z)]
-        let d: [Double] = [Double(dirKernel.x), Double(dirKernel.y), Double(dirKernel.z)]
-        let hit = vcad_solid_raycast(target, o, d)
-        guard hit.hit != 0 else { return nil }
-        return PickHit(
-            point: SIMD3(Float(hit.point.0), Float(hit.point.1), Float(hit.point.2)),
-            normal: SIMD3(Float(hit.normal.0), Float(hit.normal.1), Float(hit.normal.2))
-        )
+        return plan
+    }
+
+    /// Serialize the live doc for kernel eval with each instanced pattern root
+    /// re-pointed at its seed child — the kernel then tessellates the seed ONCE
+    /// (no N-way boolean union); the viewport places the N copies.
+    private func evalData(applying plan: [Int: PatternInstancing]) -> Data? {
+        guard var json = documentJSON else { return nil }
+        if !plan.isEmpty, var roots = json["roots"] as? [[String: Any]] {
+            var vis = 0
+            for idx in roots.indices where (roots[idx]["visible"] as? Bool) ?? true {
+                if let inst = plan[vis] { roots[idx]["root"] = inst.seedNodeId }
+                vis += 1
+            }
+            json["roots"] = roots
+        }
+        return DocEdit.serialize(json)
+    }
+
+    /// Aggregate a seed mesh + edge segments over instance transforms into one
+    /// kernel-space pick mesh / edge list, so ray pick, hover, the gizmo, and
+    /// the edge overlay see exactly the geometry the instanced entities show.
+    private static func aggregateInstances(
+        _ km: KernelMesh, edgeSegments: [SIMD3<Float>], transforms: [simd_float4x4]
+    ) -> (pick: PickMesh, edges: [SIMD3<Float>], lo: SIMD3<Float>, hi: SIMD3<Float>) {
+        var positions: [SIMD3<Float>] = []
+        var indices: [UInt32] = []
+        var segs: [SIMD3<Float>] = []
+        positions.reserveCapacity(km.positions.count * transforms.count)
+        indices.reserveCapacity(km.indices.count * transforms.count)
+        segs.reserveCapacity(edgeSegments.count * transforms.count)
+        var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
+        var hi = SIMD3<Float>(repeating: -.greatestFiniteMagnitude)
+        for t in transforms {
+            let base = UInt32(positions.count)
+            for p in km.positions {
+                let w = t * SIMD4(p, 1)
+                let v = SIMD3(w.x, w.y, w.z)
+                positions.append(v)
+                lo = simd_min(lo, v); hi = simd_max(hi, v)
+            }
+            for idx in km.indices { indices.append(base + idx) }
+            for s in edgeSegments {
+                let w = t * SIMD4(s, 1)
+                segs.append(SIMD3(w.x, w.y, w.z))
+            }
+        }
+        return (PickMesh(positions: positions, indices: indices, lo: lo, hi: hi), segs, lo, hi)
     }
 
     private func documentScene(path: String) -> RenderScene {
         let start = Date()
         // Prefer the live (possibly edited) doc; fall back to the file on disk
         // for formats the JSON parser couldn't load (legacy terse `.vcad`).
+        let plan = documentInstancingPlan()
         let data: Data?
-        if let json = documentJSON { data = DocEdit.serialize(json) }
+        if documentJSON != nil { data = evalData(applying: plan) }
         else { data = try? Data(contentsOf: URL(fileURLWithPath: path)) }
         guard let data, !data.isEmpty else { return .empty }
         let scene: OpaquePointer? = data.withUnsafeBytes { raw in
@@ -1985,7 +1964,7 @@ final class EditorModel {
             return assemblyScene(adopting: scene, start: start)
         }
         defer { vcad_scene_free(scene) }
-        return sceneFromHandle(scene, start: start)
+        return sceneFromHandle(scene, start: start, plan: plan)
     }
 
     /// Render the AI-generated loon program. Same evaluator + part-gather as a
@@ -2099,10 +2078,12 @@ final class EditorModel {
     /// Gather every part mesh out of an evaluated scene handle into a centered,
     /// auto-fit `RenderScene`, updating the live readouts. Shared by the
     /// document and AI-generated paths.
-    private func sceneFromHandle(_ scene: OpaquePointer, start: Date) -> RenderScene {
+    private func sceneFromHandle(_ scene: OpaquePointer, start: Date,
+                                 plan: [Int: PatternInstancing] = [:]) -> RenderScene {
         clearAssembly()                      // part-mode scene: drop any resident assembly
         let count = vcad_scene_part_count(scene)
         var meshes: [(MeshResource, NSColor)] = []
+        var instancing: [PatternInstancing?] = []
         var picks: [PickMesh] = []
         var edges: [[SIMD3<Float>]] = []
         var lo = SIMD3<Float>(repeating: .greatestFiniteMagnitude)
@@ -2111,24 +2092,38 @@ final class EditorModel {
         for i in 0..<count {
             let km = KernelMesh.fromView(vcad_scene_part_mesh(scene, i))
             if km.isEmpty { continue }
-            lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
-            tris += km.triangleCount
-            meshes.append((km.resource(name: "part\(i)"), Self.partColors[i % Self.partColors.count]))
-            // Index-aligned with `meshes` (and thus the rendered part entities),
-            // so a viewport ray maps back to the right feature-tree row.
-            picks.append(PickMesh(positions: km.positions, indices: km.indices,
-                                  lo: km.minBound, hi: km.maxBound))
             // Feature edges for the CAD edge overlay (same index alignment).
+            var segs: [SIMD3<Float>] = []
             if let eh = vcad_scene_part_edges(scene, i, Self.edgeAngleDeg) {
-                edges.append(EdgeOverlay.segments(fromView: vcad_edges_view(eh)))
+                segs = EdgeOverlay.segments(fromView: vcad_edges_view(eh))
                 vcad_edges_free(eh)
+            }
+            meshes.append((km.resource(name: "part\(i)"), Self.partColors[i % Self.partColors.count]))
+            if let inst = plan[i] {
+                // Pattern root: the kernel returned the SEED (the eval doc was
+                // re-pointed) — aggregate picks/edges/bounds over the instances.
+                let agg = Self.aggregateInstances(km, edgeSegments: segs,
+                                                  transforms: inst.transforms)
+                lo = simd_min(lo, agg.lo); hi = simd_max(hi, agg.hi)
+                tris += km.triangleCount * inst.transforms.count
+                instancing.append(inst)
+                picks.append(agg.pick)
+                edges.append(agg.edges)
             } else {
-                edges.append([])
+                lo = simd_min(lo, km.minBound); hi = simd_max(hi, km.maxBound)
+                tris += km.triangleCount
+                instancing.append(nil)
+                // Index-aligned with `meshes` (and thus the rendered part
+                // entities), so a viewport ray maps back to the right tree row.
+                picks.append(PickMesh(positions: km.positions, indices: km.indices,
+                                      lo: km.minBound, hi: km.maxBound))
+                edges.append(segs)
             }
         }
         guard !meshes.isEmpty else { return .empty }
         docPartMeshes = picks
         docPartEdges = edges
+        docPartInstancing = instancing
 
         solveMillis = Date().timeIntervalSince(start) * 1000
         triangleCount = tris
@@ -2139,7 +2134,8 @@ final class EditorModel {
         displayCenter = center
         displayScale = 0.6 / max(size, 0.0001)
         return RenderScene(meshes: meshes, center: center, size: size,
-                           triangleCount: tris, partCount: meshes.count, edges: edges)
+                           triangleCount: tris, partCount: meshes.count, edges: edges,
+                           instancing: instancing)
     }
 
     static func extent(_ lo: SIMD3<Float>, _ hi: SIMD3<Float>) -> Float {

--- a/apple/VcadApp/Sources/VcadApp/Kernel.swift
+++ b/apple/VcadApp/Sources/VcadApp/Kernel.swift
@@ -166,6 +166,9 @@ struct RenderScene {
     /// its kernel-frame world transform, so playback can re-pose the entity
     /// per frame without touching the mesh.
     var instances: [RenderInstance] = []
+    /// Index-aligned with `meshes`: non-nil when part i is a pattern rendered
+    /// as one shared MeshResource + N per-instance transforms (else one entity).
+    var instancing: [PatternInstancing?] = []
 
     static let empty = RenderScene(meshes: [], center: .zero, size: 1, triangleCount: 0, partCount: 0)
 }

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -180,6 +180,8 @@ struct DocumentMenu: View {
                 ForEach(ToolPlacement.allCases) { p in Text(p.label).tag(p) }
             }
             Button("Toggle Tool Palette") { model.cycleToolPlacement() }.keyboardShortcut("t")
+            Button(model.zebraMode ? "Zebra Analysis ✓" : "Zebra Analysis") { model.zebraMode.toggle() }
+                .keyboardShortcut("z", modifiers: [])
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: model.source.isSandbox ? "cube" : "doc").font(.system(size: 12))
@@ -1226,11 +1228,13 @@ struct ViewportView: View {
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
              model.docParamDirty, model.sketchDirty, model.hoverDirty, model.gizmoDirty,
-             model.playbackTime, model.playbackDirty)
+             model.playbackTime, model.playbackDirty, model.zebraDirty)
 
         return GeometryReader { geo in
           RealityView { content in
-            if let env = makeStudioEnvironment() { content.environment = .skybox(env) }
+            if let env = model.zebraMode ? Self.zebraEnvironment : Self.studioEnvironment {
+                content.environment = .skybox(env)
+            }
             setupScene(content)
             rebuildGeometry(content)
             model.geometryDirty = false
@@ -1244,6 +1248,11 @@ struct ViewportView: View {
             if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                let gizmo = root.findEntity(named: "gizmoRoot") {
                 gizmo.scale = SIMD3<Float>(repeating: gizmoScreenScale())
+            }
+            if model.zebraDirty {
+                var mutableContent = content
+                applyZebra(&mutableContent, on: model.zebraMode)
+                model.zebraDirty = false
             }
             if model.geometryDirty {
                 rebuildGeometry(content)
@@ -1260,7 +1269,10 @@ struct ViewportView: View {
                     if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                        let centering = root.findEntity(named: "centering") {
                         for (i, item) in scene.meshes.enumerated() {
-                            (centering.findEntity(named: "part\(i)") as? ModelEntity)?.model?.mesh = item.mesh
+                            if let pe = centering.findEntity(named: "part\(i)") as? ModelEntity {
+                                pe.model?.mesh = item.mesh
+                                Self.applyPartPicking(pe, mesh: item.mesh, model: model)
+                            }
                         }
                         centering.findEntity(named: "connectorHandle")?.position =
                             model.connectorHandlePosition()
@@ -1270,9 +1282,12 @@ struct ViewportView: View {
                 } else {
                     let recreated = model.streamSandbox()
                     if let root = content.entities.first(where: { $0.name == "geomRoot" }) {
-                        if recreated, let res = model.streaming.resource,
+                        if let res = model.streaming.resource,
                            let entity = root.findEntity(named: "part0") as? ModelEntity {
-                            entity.model?.mesh = res
+                            if recreated { entity.model?.mesh = res }
+                            // Streaming mutates the buffers in place — refresh
+                            // the collider either way so picks track the solve.
+                            Self.applyPartPicking(entity, mesh: res, model: model)
                         }
                         if model.showsHandle {
                             root.findEntity(named: "filletHandle")?.position =
@@ -1319,7 +1334,9 @@ struct ViewportView: View {
                    let root = content.entities.first(where: { $0.name == "geomRoot" }),
                    let centering = root.findEntity(named: "centering") {
                     for (i, m) in meshes.enumerated() {
-                        (centering.findEntity(named: "part\(i)") as? ModelEntity)?.model?.mesh = m
+                        if let pe = centering.findEntity(named: "part\(i)") as? ModelEntity {
+                            syncPartEntity(pe, index: i, mesh: m)
+                        }
                         if i < model.docPartEdges.count,
                            let ribbon = EdgeOverlay.ribbonResource(
                                segments: model.docPartEdges[i],
@@ -1377,7 +1394,10 @@ struct ViewportView: View {
                     if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                        let centering = root.findEntity(named: "centering") {
                         for (i, mesh) in solve.meshes.enumerated() {
-                            (centering.findEntity(named: "part\(i)") as? ModelEntity)?.model?.mesh = mesh
+                            if let pe = centering.findEntity(named: "part\(i)") as? ModelEntity {
+                                pe.model?.mesh = mesh
+                                Self.applyPartPicking(pe, mesh: mesh, model: model)
+                            }
                         }
                     }
                     redrawCopper(content, solve.copper)
@@ -1385,15 +1405,13 @@ struct ViewportView: View {
                 model.copperDirty = false
             }
 
-            // Keep the handles' world positions current + apply the hover pop.
+            // Apply the hover pop on the draggable handles.
             if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                let centering = root.findEntity(named: "centering") {
                 if let h = centering.findEntity(named: "connectorHandle") {
-                    model.connectorHandleWorld = h.position(relativeTo: nil)
                     applyHover(h, hovered: model.hoveredHandle == "connectorHandle")
                 }
                 if let h = centering.findEntity(named: "filletHandle") {
-                    model.filletHandleWorld = h.position(relativeTo: nil)
                     applyHover(h, hovered: model.hoveredHandle == "filletHandle")
                 }
             }
@@ -1503,7 +1521,32 @@ struct ViewportView: View {
     /// both the skybox backdrop and image-based reflections on the geometry.
     /// A soft ceiling, a horizon band, and three softbox highlights at varied
     /// azimuths give metals real reflection structure as the camera orbits.
-    private func makeStudioEnvironment() -> EnvironmentResource? {
+    static let studioEnvironment: EnvironmentResource? = makeStudioEnvironment()
+    static let zebraEnvironment: EnvironmentResource? = makeZebraEnvironment()
+
+    /// Equirect of bold horizontal bands: the classic zebra-analysis light box.
+    /// Reflected off a chromed surface, stripe kinks expose G1/G2 breaks.
+    private static func makeZebraEnvironment() -> EnvironmentResource? {
+        let w = 2048, h = 1024
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
+                                  bytesPerRow: 0, space: cs,
+                                  bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else { return nil }
+        ctx.setFillColor(CGColor(gray: 0.03, alpha: 1))
+        ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+        // Latitude bands: even count, mirrored about the horizon so stripes stay
+        // readable at any camera elevation. 16 white bands ≈ classic light-tube rig.
+        let bands = 32
+        let bandH = CGFloat(h) / CGFloat(bands)
+        ctx.setFillColor(CGColor(gray: 0.98, alpha: 1))
+        for i in stride(from: 0, to: bands, by: 2) {
+            ctx.fill(CGRect(x: 0, y: CGFloat(i) * bandH, width: CGFloat(w), height: bandH))
+        }
+        guard let img = ctx.makeImage() else { return nil }
+        return try? EnvironmentResource(equirectangular: img)
+    }
+
+    private static func makeStudioEnvironment() -> EnvironmentResource? {
         let w = 2048, h = 1024
         let cs = CGColorSpaceCreateDeviceRGB()
         guard let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
@@ -1634,16 +1677,32 @@ struct ViewportView: View {
         let centering = Entity()
         centering.name = "centering"
         centering.position = -scene.center
+        model.centeringEntity = centering        // scene handle for native raycasts
         for (i, item) in scene.meshes.enumerated() {
             // The gripper's parts get intentional materials (glass enclosure,
             // green FR4 board, brushed-metal bracket) so each domain reads as what
             // it is; everything else falls back to the index palette.
             let mat: PhysicallyBasedMaterial =
-                model.source.isGripper ? gripperMaterial(i)
+                model.zebraMode ? Self.zebraChrome
+                : model.source.isGripper ? gripperMaterial(i)
                 : model.usesDocumentTree ? pbrMaterial(model.resolvedMaterial(forPart: i))
                 : material(item.color)
-            let entity = ModelEntity(mesh: item.mesh, materials: [mat])
+            let entity = ModelEntity()
             entity.name = "part\(i)"
+            if let inst = i < scene.instancing.count ? scene.instancing[i] : nil {
+                // Pattern root: one shared MeshResource, N instance entities
+                // with per-copy rigid transforms (kernel-space, under centering).
+                for (j, t) in inst.transforms.enumerated() {
+                    let child = ModelEntity(mesh: item.mesh, materials: [mat])
+                    child.name = "part\(i)_inst\(j)"
+                    child.transform = Transform(matrix: t)
+                    Self.applyPartPicking(child, mesh: item.mesh, model: model)
+                    entity.addChild(child)
+                }
+            } else {
+                entity.model = ModelComponent(mesh: item.mesh, materials: [mat])
+                Self.applyPartPicking(entity, mesh: item.mesh, model: model)
+            }
             centering.addChild(entity)
             // CAD edge overlay: crisp feature edges over the shading. Width is
             // proportional to the scene so it stays visually constant across
@@ -1655,6 +1714,7 @@ struct ViewportView: View {
                    name: "edges\(i)") {
                 let edgeEntity = ModelEntity(mesh: ribbon, materials: [Self.edgeMaterial])
                 edgeEntity.name = "edges\(i)"
+                edgeEntity.isEnabled = !model.zebraMode
                 centering.addChild(edgeEntity)
             }
         }
@@ -1757,6 +1817,37 @@ struct ViewportView: View {
         m.roughness = 0.34
         m.metallic = 0.55
         return m
+    }
+
+    /// Mirror-chrome for zebra analysis: near-zero roughness so the striped
+    /// environment reflects as sharp bands.
+    static let zebraChrome: PhysicallyBasedMaterial = {
+        var m = PhysicallyBasedMaterial()
+        m.baseColor = .init(tint: .white)
+        m.metallic = 1.0
+        m.roughness = 0.02
+        return m
+    }()
+
+    /// Toggle zebra analysis: swap the environment and chrome/restore the part
+    /// materials in place. Restore goes through a (pop-suppressed) rebuild so
+    /// gripper/document/palette materials come back exactly as built.
+    private func applyZebra(_ content: inout RealityViewCameraContent, on: Bool) {
+        if on {
+            if let env = Self.zebraEnvironment { content.environment = .skybox(env) }
+            guard let root = content.entities.first(where: { $0.name == "geomRoot" }),
+                  let centering = root.findEntity(named: "centering") else { return }
+            var i = 0
+            while let e = centering.findEntity(named: "part\(i)") as? ModelEntity {
+                for h in Self.partModelEntities(e) { h.model?.materials = [Self.zebraChrome] }
+                centering.findEntity(named: "edges\(i)")?.isEnabled = false
+                i += 1
+            }
+        } else {
+            if let env = Self.studioEnvironment { content.environment = .skybox(env) }
+            model.suppressMaterializePop = true
+            rebuildGeometry(content)
+        }
     }
 
     /// Build a PBR material from a resolved document material (color + metallic +
@@ -2094,6 +2185,71 @@ struct ViewportView: View {
         if model.showsGizmo { centering.addChild(buildGizmo()) }
     }
 
+    // MARK: pattern instancing helpers
+
+    /// The ModelEntities that carry a part's geometry: the part entity itself,
+    /// or its per-instance children when the part is a pattern rendered as
+    /// shared-mesh instances.
+    private static func partModelEntities(_ e: ModelEntity) -> [ModelEntity] {
+        if e.model != nil { return [e] }
+        return e.children.compactMap { $0 as? ModelEntity }
+            .filter { $0.name.hasPrefix("\(e.name)_inst") }
+    }
+
+    /// In-place scrub update for one part: swap the mesh (and, for instanced
+    /// patterns, sync the instance count + transforms) without rebuilding
+    /// entities — materials, outlines, and colliders ride along. Handles the
+    /// part flipping between plain and instanced mid-scrub (count 1 ↔ N).
+    private func syncPartEntity(_ pe: ModelEntity, index i: Int, mesh m: MeshResource) {
+        let inst = i < model.docPartInstancing.count ? model.docPartInstancing[i] : nil
+        if let inst {
+            var children = pe.children.compactMap { $0 as? ModelEntity }
+                .filter { $0.name.hasPrefix("part\(i)_inst") }
+            if pe.model != nil {          // was plain last frame → become container
+                pe.model = nil
+                pe.components.remove(CollisionComponent.self)
+                pe.components.remove(InputTargetComponent.self)
+            }
+            let mat: any RealityKit.Material = children.first?.model?.materials.first
+                ?? pbrMaterial(model.resolvedMaterial(forPart: i))
+            while children.count > inst.transforms.count {
+                children.removeLast().removeFromParent()
+            }
+            for (j, t) in inst.transforms.enumerated() {
+                if j < children.count {
+                    children[j].model?.mesh = m
+                    children[j].transform = Transform(matrix: t)
+                    Self.applyPartPicking(children[j], mesh: m, model: model)
+                } else {
+                    let child = ModelEntity(mesh: m, materials: [mat])
+                    child.name = "part\(i)_inst\(j)"
+                    child.transform = Transform(matrix: t)
+                    Self.applyPartPicking(child, mesh: m, model: model)
+                    pe.addChild(child)
+                }
+            }
+        } else {
+            for c in pe.children.filter({ $0.name.hasPrefix("part\(i)_inst") }) {
+                c.removeFromParent()
+            }
+            if pe.model == nil {          // was instanced last frame → plain again
+                pe.model = ModelComponent(
+                    mesh: m, materials: [pbrMaterial(model.resolvedMaterial(forPart: i))])
+            } else {
+                pe.model?.mesh = m
+            }
+            Self.applyPartPicking(pe, mesh: m, model: model)
+        }
+        // Ride the selection outline along the scrub (per instance when patterned).
+        let selected = model.highlightedParts.contains(i)
+        for host in Self.partModelEntities(pe) {
+            if let o = host.findEntity(named: "outline\(i)") as? ModelEntity {
+                o.model?.mesh = m
+                Self.fitOutline(o, to: m, thickness: outlineThickness(selected: selected))
+            }
+        }
+    }
+
     // MARK: feature-tree sync (visibility + selection highlight)
 
     /// Enable/disable part entities to honor the tree's eye toggles + isolate.
@@ -2105,10 +2261,12 @@ struct ViewportView: View {
         }
     }
 
-    /// Give the selected part a subtle brand-orange emissive lift so the tree
-    /// selection reads in the viewport without masking the document material
-    /// (the plate must still look like alu, not the accent color). Non-selected
-    /// parts are restored exactly to their base material.
+    /// Selection reads as a screen-space outline via an inverted hull: a
+    /// slightly inflated copy of the part's mesh rendered with front faces
+    /// culled, so only its back faces peek past the silhouette — a crisp
+    /// brand-orange rim that tracks camera orbit for free. Selection = thick +
+    /// bright, hover = thinner + dimmer. Part materials are never touched, so
+    /// the plate still looks like alu, not the accent color.
     private func applySelectionHighlight(_ content: RealityViewCameraContent) {
         guard model.usesDocumentTree,
               let root = content.entities.first(where: { $0.name == "geomRoot" }),
@@ -2117,16 +2275,54 @@ struct ViewportView: View {
         let hov = model.hoveredPartIndex
         for i in 0..<model.partCount {
             guard let e = centering.findEntity(named: "part\(i)") as? ModelEntity else { continue }
-            var m = pbrMaterial(model.resolvedMaterial(forPart: i))
-            if sel.contains(i) {
-                m.emissiveColor = .init(color: EditorModel.brandOrange)
-                m.emissiveIntensity = 0.18     // subtle — base color stays legible
-            } else if i == hov {
-                m.emissiveColor = .init(color: EditorModel.brandOrange)
-                m.emissiveIntensity = 0.06     // faint hover glow
+            // For instanced patterns each copy hosts its own outline (it rides
+            // the instance transform for free as a child).
+            let hosts = Self.partModelEntities(e)
+            for h in hosts { h.findEntity(named: "outline\(i)")?.removeFromParent() }
+            let selected = sel.contains(i)
+            guard selected || i == hov else { continue }
+            for h in hosts {
+                guard let mesh = h.model?.mesh else { continue }
+                h.addChild(Self.outlineEntity(
+                    index: i, mesh: mesh,
+                    thickness: outlineThickness(selected: selected),
+                    brightness: selected ? 1.0 : 0.35))
             }
-            e.model?.materials = [m]
         }
+    }
+
+    /// Outline rim width in kernel mm, proportional to the scene (like the
+    /// edge ribbons) so it stays visually constant across part sizes.
+    private func outlineThickness(selected: Bool) -> Double {
+        max(Double(model.displayedSceneSize) * (selected ? 0.008 : 0.004), selected ? 0.08 : 0.04)
+    }
+
+    /// Build the inverted-hull outline entity for one part.
+    private static func outlineEntity(index: Int, mesh: MeshResource,
+                                      thickness: Double, brightness: Float) -> ModelEntity {
+        var m = PhysicallyBasedMaterial()
+        m.baseColor = .init(tint: .black)
+        m.emissiveColor = .init(color: EditorModel.brandOrange)
+        m.emissiveIntensity = 2.0 * brightness   // reads unlit — pure rim color
+        m.roughness = 1.0
+        m.metallic = 0.0
+        m.faceCulling = .front                   // back faces only → silhouette
+        let outline = ModelEntity(mesh: mesh, materials: [m])
+        outline.name = "outline\(index)"
+        fitOutline(outline, to: mesh, thickness: thickness)
+        return outline
+    }
+
+    /// Inflate the hull ~`thickness` mm on every axis by scaling around the
+    /// mesh-bounds center — per-axis, so thin plates get the same rim as cubes.
+    private static func fitOutline(_ outline: ModelEntity, to mesh: MeshResource, thickness: Double) {
+        let b = mesh.bounds
+        let t = Float(thickness)
+        let s = SIMD3<Float>(1 + 2 * t / max(b.extents.x, 1e-4),
+                             1 + 2 * t / max(b.extents.y, 1e-4),
+                             1 + 2 * t / max(b.extents.z, 1e-4))
+        outline.scale = s
+        outline.position = b.center * (SIMD3<Float>(repeating: 1) - s)
     }
 
     // MARK: gestures
@@ -2161,44 +2357,58 @@ struct ViewportView: View {
                     model.setConnectorX(model.connectorDragBaseline + delta)
                     return
                 }
-                guard value.entity.name == "filletHandle" else { return }
-                if !model.draggingHandle {
-                    model.draggingHandle = true
-                    model.handleBaseline = model.modifierValue
+                if value.entity.name == "filletHandle" {
+                    if !model.draggingHandle {
+                        model.draggingHandle = true
+                        model.handleBaseline = model.modifierValue
+                    }
+                    let delta = Double(-value.translation.height) * 0.03
+                    model.modifierValue = max(0, min(12, model.handleBaseline + delta))
+                    return
                 }
-                let delta = Double(-value.translation.height) * 0.03
-                model.modifierValue = max(0, min(12, model.handleBaseline + delta))
+                // Parts are input targets too (for native picking) — a drag
+                // that starts on one is still an orbit/pan, same as empty space.
+                orbitChanged(value.translation)
             }
             .onEnded { _ in
-                if model.draggingHandle { NSCursor.arrow.set() }
-                model.draggingHandle = false
-                model.endGizmoDrag()
-                // Connector settled → re-route the copper once (gripper only).
-                if model.source.isGripper { model.copperDirty = true }
+                if model.draggingHandle {
+                    NSCursor.arrow.set()
+                    model.draggingHandle = false
+                    model.endGizmoDrag()
+                    // Connector settled → re-route the copper once (gripper only).
+                    if model.source.isGripper { model.copperDirty = true }
+                } else {
+                    orbitEnded()
+                }
             }
     }
 
+    // Drag orbits (with flick-to-spin momentum); ⇧-drag pans the look-at.
+    // Shared by the plain background gesture and entity drags on parts.
+    private func orbitChanged(_ translation: CGSize) {
+        guard !model.draggingHandle else { return }
+        if model.lastDrag == .zero { model.beginOrbit() }   // grab → stop coasting
+        let dx = Float(translation.width - model.lastDrag.width)
+        let dy = Float(translation.height - model.lastDrag.height)
+        if NSEvent.modifierFlags.contains(.shift) {
+            model.panBy(dx: dx, dy: dy)
+        } else {
+            model.orbitDrag(dx: dx, dy: dy)
+        }
+        model.lastDrag = translation
+        NSCursor.closedHand.set()        // grabbing to orbit/pan
+    }
+
+    private func orbitEnded() {
+        model.lastDrag = .zero
+        model.endOrbit()                 // coast if the flick was fast
+        if !model.draggingHandle { NSCursor.arrow.set() }
+    }
+
     private var orbitGesture: some Gesture {
-        // Drag orbits (with flick-to-spin momentum); ⇧-drag pans the look-at.
         DragGesture()
-            .onChanged { value in
-                guard !model.draggingHandle else { return }
-                if model.lastDrag == .zero { model.beginOrbit() }   // grab → stop coasting
-                let dx = Float(value.translation.width - model.lastDrag.width)
-                let dy = Float(value.translation.height - model.lastDrag.height)
-                if NSEvent.modifierFlags.contains(.shift) {
-                    model.panBy(dx: dx, dy: dy)
-                } else {
-                    model.orbitDrag(dx: dx, dy: dy)
-                }
-                model.lastDrag = value.translation
-                NSCursor.closedHand.set()        // grabbing to orbit/pan
-            }
-            .onEnded { _ in
-                model.lastDrag = .zero
-                model.endOrbit()                 // coast if the flick was fast
-                if !model.draggingHandle { NSCursor.arrow.set() }
-            }
+            .onChanged { orbitChanged($0.translation) }
+            .onEnded { _ in orbitEnded() }
     }
 
     private var zoomGesture: some Gesture {
@@ -2212,9 +2422,10 @@ struct ViewportView: View {
 
     // MARK: picking (#7)
 
-    /// Screen point → ray in kernel space (origin, normalized dir). Inverse of
-    /// the pinhole projection; shared by face-pick, part-pick, and sketch-pick.
-    private func kernelRay(at p: CGPoint, viewSize: CGSize) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
+    /// Screen point → ray in RealityKit world space (origin, normalized dir).
+    /// Inverse of the pinhole projection; the basis for both native raycasts
+    /// and the kernel-space conversion below.
+    private func worldRay(at p: CGPoint, viewSize: CGSize) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
         guard viewSize.width > 1, viewSize.height > 1 else { return nil }
         let cam = model.cameraPosition
         let forward = normalize(model.panOffset - cam)
@@ -2224,7 +2435,13 @@ struct ViewportView: View {
         let aspect = Float(viewSize.width / viewSize.height)
         let ndcX = Float(2 * p.x / viewSize.width - 1)
         let ndcY = Float(1 - 2 * p.y / viewSize.height)
-        let dirWorld = normalize(forward + ndcX * tanHalf * aspect * right + ndcY * tanHalf * up)
+        return (cam, normalize(forward + ndcX * tanHalf * aspect * right + ndcY * tanHalf * up))
+    }
+
+    /// Screen point → ray in kernel space — still needed for sketch-plane taps
+    /// and the gizmo's closest-point drag math.
+    private func kernelRay(at p: CGPoint, viewSize: CGSize) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
+        guard let (cam, dirWorld) = worldRay(at: p, viewSize: viewSize) else { return nil }
         let s = model.displayScale
         return (rxPlus90(cam / s) + model.displayCenter, normalize(rxPlus90(dirWorld)))
     }
@@ -2232,33 +2449,42 @@ struct ViewportView: View {
     private func pick(at p: CGPoint, viewSize: CGSize) {
         model.viewSize = viewSize                 // keep fresh for gizmo drags
         model.stopSpin()                          // a tap settles the camera
-        guard let (camKernel, dirKernel) = kernelRay(at: p, viewSize: viewSize) else { return }
 
         // Sketch mode: a tap drops a point on the sketch plane.
         if model.sketching {
-            if let pt = model.sketchPlanePoint(originKernel: camKernel, dirKernel: dirKernel) {
+            if let (o, d) = kernelRay(at: p, viewSize: viewSize),
+               let pt = model.sketchPlanePoint(originKernel: o, dirKernel: d) {
                 model.sketchTap(pt)
             }
             return
         }
 
+        let hits = raycastHits(at: p, viewSize: viewSize)
+
         // Documents: tap a part → select its row (⌘-tap toggles multi-select, for
-        // booleans); tap empty space → deselect. Kernel-space AABBs make it cheap.
+        // booleans); tap empty space → deselect. Native collision raycast.
         if model.usesDocumentTree {
             let cmd = NSEvent.modifierFlags.contains(.command)
-            if let pi = model.pickDocumentPart(originKernel: camKernel, dirKernel: dirKernel),
+            if let pi = hits.compactMap({ Self.partIndex($0.entity) }).first,
                pi < model.featureNodes.count {
                 if cmd { model.toggleMultiSelect(part: pi, featureID: model.featureNodes[pi].id) }
                 else { model.selectFeature(model.featureNodes[pi].id) }
-            } else if !cmd, !model.rayHitsGizmo(originKernel: camKernel, dirKernel: dirKernel) {
+            } else if !cmd,
+                      !hits.contains(where: { model.gizmoHandle(for: $0.entity.name) != nil }) {
                 model.deselectAll()        // empty space (but not a tap on the gizmo)
             }
             return
         }
 
-        if let hit = model.raycastSandbox(originKernel: camKernel, dirKernel: dirKernel) {
-            model.pickPoint = hit.point
-            model.pickInfo = describe(hit)
+        // Sandbox: surface probe — nearest part hit, converted world → kernel
+        // through the live centering entity (handles Z-up rotation + scale).
+        if model.source.isSandbox,
+           let hit = hits.first(where: { Self.partIndex($0.entity) != nil }),
+           let centering = model.centeringEntity {
+            let pt = centering.convert(position: hit.position, from: nil)
+            let n = normalize(centering.convert(direction: hit.normal, from: nil))
+            model.pickPoint = pt
+            model.pickInfo = describe(EditorModel.PickHit(point: pt, normal: n))
         } else {
             model.pickPoint = nil
             model.pickInfo = nil
@@ -2292,24 +2518,24 @@ struct ViewportView: View {
             }
             return
         }
-        // Documents: hover-highlight the part under the cursor (ray-AABB pick),
-        // and show a pointing cursor to signal it's clickable.
+        // Documents: hover-highlight the part under the cursor (native collision
+        // raycast), and show a pointing cursor to signal it's clickable.
         if model.usesDocumentTree {
             switch phase {
             case .active(let point):
-                let ray = kernelRay(at: point, viewSize: viewSize)
+                let hits = raycastHits(at: point, viewSize: viewSize)
                 // Gizmo handles win over part hover (they sit on top). Never
                 // re-highlight mid-drag — that would rebuild the grabbed arm.
-                let gh = (model.showsGizmo && !model.draggingHandle) ? ray.flatMap {
-                    model.hitGizmoHandle(originKernel: $0.o, dirKernel: $0.d)
-                } : nil
+                let gh = (model.showsGizmo && !model.draggingHandle)
+                    ? hits.first(where: { model.gizmoHandle(for: $0.entity.name) != nil })?.entity.name
+                    : nil
                 if gh != model.hoveredGizmoHandle { model.hoveredGizmoHandle = gh; model.gizmoDirty = true }
                 if gh != nil {
                     if model.hoveredPartIndex != nil { model.hoveredPartIndex = nil; model.hoverDirty = true }
                     NSCursor.openHand.set()
                     return
                 }
-                let pi = ray.flatMap { model.pickDocumentPart(originKernel: $0.o, dirKernel: $0.d) }
+                let pi = hits.compactMap { Self.partIndex($0.entity) }.first
                 if pi != model.hoveredPartIndex { model.hoveredPartIndex = pi; model.hoverDirty = true }
                 (pi != nil ? NSCursor.pointingHand : NSCursor.arrow).set()
             case .ended:
@@ -2322,7 +2548,12 @@ struct ViewportView: View {
 
         switch phase {
         case .active(let point):
-            let hit = hitHandle(at: point, viewSize: viewSize)
+            // The draggable handles' colliders answer hover directly; handle
+            // hits win over any part in front (the glass enclosure encloses
+            // the gripper's connector handle).
+            let hit = raycastHits(at: point, viewSize: viewSize)
+                .first(where: { $0.entity.name == "connectorHandle" || $0.entity.name == "filletHandle" })?
+                .entity.name
             if hit != nil, !model.draggingHandle {
                 NSCursor.openHand.set()
             } else if hit == nil, model.hoveredHandle != nil {
@@ -2337,42 +2568,45 @@ struct ViewportView: View {
         }
     }
 
-    /// Nearest visible handle whose projected screen position is within reach of
-    /// the pointer, or nil.
-    private func hitHandle(at p: CGPoint, viewSize: CGSize) -> String? {
-        var best: (name: String, dist: CGFloat)?
-        func consider(_ name: String, _ world: SIMD3<Float>) {
-            guard let s = worldToScreen(world, viewSize) else { return }
-            let d = hypot(s.x - p.x, s.y - p.y)
-            if d < 24, best == nil || d < best!.dist { best = (name, d) }
-        }
-        if model.showsConnectorHandle { consider("connectorHandle", model.connectorHandleWorld) }
-        if model.showsHandle { consider("filletHandle", model.filletHandleWorld) }
-        return best?.name
-    }
-
-    /// Forward pinhole projection — the inverse of `pick`'s ray build: world → screen.
-    private func worldToScreen(_ p: SIMD3<Float>, _ viewSize: CGSize) -> CGPoint? {
-        guard viewSize.width > 1, viewSize.height > 1 else { return nil }
-        let cam = model.cameraPosition
-        let forward = normalize(model.panOffset - cam)
-        let right = normalize(cross(forward, SIMD3<Float>(0, 1, 0)))
-        let up = cross(right, forward)
-        let rel = p - cam
-        let z = dot(rel, forward)
-        guard z > 0.0001 else { return nil }
-        let tanHalf = Float(tan(Double.pi / 6.0))
-        let aspect = Float(viewSize.width / viewSize.height)
-        let ndcX = (dot(rel, right) / z) / (tanHalf * aspect)
-        let ndcY = (dot(rel, up) / z) / tanHalf
-        return CGPoint(x: Double((ndcX + 1) / 2) * viewSize.width,
-                       y: Double((1 - ndcY) / 2) * viewSize.height)
-    }
-
     private func applyHover(_ e: Entity, hovered: Bool) {
         let target: Float = hovered ? 1.4 : 1.0
         if abs(e.scale.x - target) > 0.001 {
             e.scale = SIMD3<Float>(repeating: target)
         }
+    }
+
+    // MARK: native picking (collision raycasts)
+
+    /// Make a part entity natively pickable: an input target plus a static-mesh
+    /// collider generated from the render mesh, so scene raycasts hit exactly
+    /// what is drawn. Collider generation is async; the token guards against an
+    /// older build landing after a newer mesh swap.
+    static func applyPartPicking(_ entity: ModelEntity, mesh: MeshResource, model: EditorModel) {
+        entity.components.set(InputTargetComponent())
+        let key = entity.name
+        let token = (model.colliderTokens[key] ?? 0) + 1
+        model.colliderTokens[key] = token
+        Task { @MainActor in
+            guard let shape = try? await ShapeResource.generateStaticMesh(from: mesh),
+                  model.colliderTokens[key] == token else { return }
+            entity.components.set(CollisionComponent(shapes: [shape]))
+        }
+    }
+
+    /// All collision hits under a screen point, nearest first — parts, gizmo
+    /// grab proxies, and drag handles all carry colliders.
+    private func raycastHits(at p: CGPoint, viewSize: CGSize) -> [CollisionCastHit] {
+        guard let scene = model.centeringEntity?.scene,
+              let (o, d) = worldRay(at: p, viewSize: viewSize) else { return [] }
+        return scene.raycast(origin: o, direction: d, length: 100,
+                             query: .all, mask: .all, relativeTo: nil)
+            .sorted { $0.distance < $1.distance }
+    }
+
+    /// "part7" → 7 (instance children "part7_inst2" also → 7); else nil.
+    private static func partIndex(_ e: Entity) -> Int? {
+        guard e.name.hasPrefix("part") else { return nil }
+        let digits = e.name.dropFirst(4).prefix(while: \.isNumber)
+        return digits.isEmpty ? nil : Int(digits)
     }
 }

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import AppKit
 import simd
+import CVcadFFI
 
 @main
 struct VcadApp: App {
@@ -28,6 +29,10 @@ struct VcadApp: App {
         }
         if let path = ProcessInfo.processInfo.environment["VCAD_MAT_SMOKE"] {
             MainActor.assumeIsolated { matSmoke(path: path) }
+            exit(0)
+        }
+        if let path = ProcessInfo.processInfo.environment["VCAD_PATTERN_SMOKE"] {
+            MainActor.assumeIsolated { patternSmoke(path: path) }
             exit(0)
         }
         if let path = ProcessInfo.processInfo.environment["VCAD_GIZMO_SMOKE"] {
@@ -128,6 +133,46 @@ private func fmt3(_ v: SIMD3<Float>) -> String {
 private func rgb(_ c: NSColor) -> String {
     let s = c.usingColorSpace(.sRGB) ?? c
     return String(format: "(%.2f, %.2f, %.2f)", s.redComponent, s.greenComponent, s.blueComponent)
+}
+
+/// Pattern instancing: load a doc with pattern roots through the instanced
+/// eval path, then cross-check each instanced part's aggregated bounds and
+/// triangle count against a full BAKED kernel eval of the untouched document.
+/// Agreement proves the Swift-side transforms reproduce the kernel's pattern
+/// placement exactly.
+@MainActor private func patternSmoke(path: String) {
+    func emit(_ s: String) { FileHandle.standardError.write(Data((s + "\n").utf8)) }
+    let m = EditorModel()
+    m.source = .document(path: path, label: "pattern")
+    guard m.usesDocumentTree, m.reevalDocumentMeshes() != nil else {
+        emit("[VCAD_PATTERN] load failed"); return
+    }
+    let instanced = m.docPartInstancing.enumerated().compactMap { i, p in p.map { (i, $0) } }
+    emit("[VCAD_PATTERN] \(m.partCount) part(s), \(instanced.count) instanced · tris \(m.triangleCount) · bbox \(fmt3(m.sizeMM))")
+    for (i, p) in instanced {
+        emit("[VCAD_PATTERN] part\(i): node \(p.patternNodeId) seed \(p.seedNodeId) × \(p.transforms.count) copies")
+    }
+
+    // Baked reference: evaluate the ORIGINAL doc (patterns unioned in-kernel).
+    guard let json = m.documentJSON, let data = DocEdit.serialize(json) else { return }
+    let scene: OpaquePointer? = data.withUnsafeBytes {
+        vcad_scene_from_json($0.bindMemory(to: UInt8.self).baseAddress, data.count)
+    }
+    guard let scene else { emit("[VCAD_PATTERN] baked eval failed"); return }
+    defer { vcad_scene_free(scene) }
+    var ok = true
+    for i in 0..<vcad_scene_part_count(scene) {
+        let km = KernelMesh.fromView(vcad_scene_part_mesh(scene, i))
+        guard i < m.docPartMeshes.count else { continue }
+        let pick = m.docPartMeshes[i]
+        let dLo = simd_length(km.minBound - pick.lo), dHi = simd_length(km.maxBound - pick.hi)
+        let match = dLo < 1e-3 && dHi < 1e-3
+        // Baked pattern tris can differ slightly (the union sews coincident
+        // faces); bounds are the placement invariant.
+        emit("[VCAD_PATTERN] part\(i) bounds baked vs instanced: Δlo \(String(format: "%.5f", dLo)) Δhi \(String(format: "%.5f", dHi)) → \(match ? "MATCH" : "MISMATCH")")
+        if !match { ok = false }
+    }
+    emit("[VCAD_PATTERN] \(ok ? "PASS" : "FAIL")")
 }
 
 /// Gizmo translate: move part 0 by +50 in X via the root Translate, confirm the

--- a/apple/VcadApp/pattern-test.vcad
+++ b/apple/VcadApp/pattern-test.vcad
@@ -1,0 +1,148 @@
+{
+ "version": "0.1",
+ "nodes": {
+  "1": {
+   "id": 1,
+   "name": "Plate",
+   "op": {
+    "type": "Cube",
+    "size": {
+     "x": 80.0,
+     "y": 6.0,
+     "z": 60.0
+    }
+   }
+  },
+  "2": {
+   "id": 2,
+   "name": "Hole",
+   "op": {
+    "type": "Cylinder",
+    "radius": 5.0,
+    "height": 10.0,
+    "segments": 32
+   }
+  },
+  "3": {
+   "id": 3,
+   "name": "Hole Positioned",
+   "op": {
+    "type": "Translate",
+    "child": 2,
+    "offset": {
+     "x": 40.0,
+     "y": 3.0,
+     "z": 30.0
+    }
+   }
+  },
+  "4": {
+   "id": 4,
+   "name": "Plate with Hole",
+   "op": {
+    "type": "Difference",
+    "left": 1,
+    "right": 3
+   }
+  },
+  "10": {
+   "id": 10,
+   "name": "Post",
+   "op": {
+    "type": "Cylinder",
+    "radius": 3.0,
+    "height": 20.0,
+    "segments": 48
+   }
+  },
+  "11": {
+   "id": 11,
+   "name": "Post row",
+   "op": {
+    "type": "LinearPattern",
+    "child": 10,
+    "direction": {
+     "x": 1.0,
+     "y": 0.0,
+     "z": 0.0
+    },
+    "count": 6,
+    "spacing": 12.0
+   }
+  },
+  "12": {
+   "id": 12,
+   "name": "Tooth",
+   "op": {
+    "type": "Cube",
+    "size": {
+     "x": 6.0,
+     "y": 4.0,
+     "z": 8.0
+    }
+   }
+  },
+  "13": {
+   "id": 13,
+   "name": "Tooth offset",
+   "op": {
+    "type": "Translate",
+    "child": 12,
+    "offset": {
+     "x": 30.0,
+     "y": -2.0,
+     "z": 0.0
+    }
+   }
+  },
+  "14": {
+   "id": 14,
+   "name": "Tooth ring",
+   "op": {
+    "type": "CircularPattern",
+    "child": 13,
+    "axis_origin": {
+     "x": 30.0,
+     "y": 40.0,
+     "z": 0.0
+    },
+    "axis_dir": {
+     "x": 0.0,
+     "y": 0.0,
+     "z": 1.0
+    },
+    "count": 8,
+    "angle_deg": 360.0
+   }
+  }
+ },
+ "materials": {
+  "aluminum": {
+   "name": "aluminum",
+   "color": [
+    0.91,
+    0.92,
+    0.93
+   ],
+   "metallic": 1.0,
+   "roughness": 0.4,
+   "density": 2700.0,
+   "friction": 0.6
+  }
+ },
+ "part_materials": {},
+ "roots": [
+  {
+   "root": 4,
+   "material": "aluminum"
+  },
+  {
+   "root": 11,
+   "material": "aluminum"
+  },
+  {
+   "root": 14,
+   "material": "aluminum"
+  }
+ ]
+}

--- a/changelog/entries/2026-07-19-native-pattern-instancing.json
+++ b/changelog/entries/2026-07-19-native-pattern-instancing.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-19-native-pattern-instancing",
+  "version": "0.9.4",
+  "date": "2026-07-19",
+  "category": "perf",
+  "title": "Native app renders patterns as shared-mesh instances",
+  "summary": "Linear/circular pattern parts in the macOS app now tessellate the seed once and render N transformed instances, instead of N unioned tessellations.",
+  "features": ["native-app", "patterns", "viewport"]
+}


### PR DESCRIPTION
## What

Linear/circular **pattern roots** in the native macOS app now render as **one shared `MeshResource` + N `ModelEntity` instances** with per-copy rigid transforms, instead of N independently tessellated + boolean-unioned meshes.

- The eval JSON sent to the kernel is re-pointed at the pattern's **seed child**, so the kernel tessellates the seed **once** — no N-way union.
- Swift reproduces the kernel's placement exactly: linear = `i·spacing` along the normalized direction; circular = `angle_deg/count` steps about the axis through `axis_origin` (both matched to `vcad-kernel`'s `linear_pattern`/`circular_pattern`).
- Pick meshes, feature-edge segments, and bounds are **aggregated over the instance transforms**, so ray pick, hover, selection outlines, the transform gizmo, and auto-fit are instancing-agnostic.
- Per-instance selection/visibility semantics preserved: instance children are `part<i>_inst<j>` under a `part<i>` container; `partIndex` parsing, collider tokens, outline hosting, zebra mode, and the in-place scrub path (`syncPartEntity`, including a part flipping plain ↔ instanced when `count` is scrubbed) all handle both shapes.

**Fallbacks to baked kernel meshes** (correctness first): pattern not at a root (consumed by a downstream boolean/modifier), `count < 2`, degenerate direction/axis, or a document **binding targeting the pattern node** (bindings rewrite fields inside the kernel at eval time, so raw-JSON transforms would be stale). Export, ray-traced stills, and legacy docs keep evaluating the untouched document.

Also rides on (and includes) the uncommitted viewport groundwork it depends on: inverted-hull selection outlines, native collision-raycast picking, and zebra analysis mode. USDZ export was deliberately left out of this PR.

## Verification

New `VCAD_PATTERN_SMOKE=<doc>` headless hook loads a doc through the instanced path and cross-checks every part's aggregated bounds against a full **baked** kernel eval of the untouched document, on the bundled `apple/VcadApp/pattern-test.vcad` (6-copy linear row + 8-copy circular ring + a plain boolean part):

```
[VCAD_PATTERN] 3 part(s), 2 instanced · tris 1048 · bbox 92.0×85.0×60.0
[VCAD_PATTERN] part1: node 11 seed 10 × 6 copies
[VCAD_PATTERN] part2: node 14 seed 13 × 8 copies
[VCAD_PATTERN] part0/1/2 bounds baked vs instanced: Δlo 0.00000 Δhi 0.00000 → MATCH
[VCAD_PATTERN] PASS
```

Edit/undo/export and gizmo smokes pass; the gizmo drag on a pattern root wraps it in a Translate and falls back to baked cleanly. Merged against #608 (kinematic playback) with its `inst<i>` assembly entities — no naming collision (`part<i>_inst<j>` prefix differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)