### PR TITLE
fix(apple): point Examples menu at the main repo, not a deleted worktree

### DIFF
--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -19,7 +19,7 @@ enum Motion {
     static let pop = Animation.spring(response: 0.32, dampingFraction: 0.7)
 }
 
-private let kSamplesDir = "/Users/cam/Developer/vcad/.claude/worktrees/great-bohr-4c355d"
+private let kSamplesDir = "/Users/cam/Developer/vcad"
 
 enum GeometrySource: Hashable, Identifiable {
     case sandbox


### PR DESCRIPTION
## Summary
- `kSamplesDir` in the native macOS app pointed at `.claude/worktrees/great-bohr-4c355d`, a worktree that no longer exists — every Examples menu item silently loaded an empty document (feature tree unpopulated, no geometry, stale measurements).
- Point it at the main checkout so Pulley / Counterbore / Ribbed plate / Robot arm / Sensor mast resolve again.

## Verification
- Launched `dist/vcad.app`, loaded Examples → Pulley: geometry renders, native picking (hover outline, click-select, deselect, orbit-from-part) all work.
- `VCAD_EDIT_SMOKE` on the pulley + counterbore docs evaluates clean.
- Note: robot-arm-2dof / sensor-mast still render empty — pre-existing (assembly docs aren't handled by the scene-eval path), unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)