### PR TITLE
fix(app): viewport picking parity with the native macOS app

### DIFF
--- a/changelog/entries/2026-07-19-viewport-picking-parity.json
+++ b/changelog/entries/2026-07-19-viewport-picking-parity.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-19-viewport-picking-parity",
+  "version": "0.9.4",
+  "date": "2026-07-19",
+  "category": "fix",
+  "title": "Viewport picking parity with the native app",
+  "summary": "Brand-orange hover/selection accents, ⌘-click part multi-select, gizmo-protected clicks, pointer cursor, and correct picking when parts are hidden.",
+  "features": ["viewport", "selection", "picking"]
+}

--- a/packages/app/src/components/PropertyPanel.tsx
+++ b/packages/app/src/components/PropertyPanel.tsx
@@ -1332,7 +1332,20 @@ function SubFeatureInspector({
 
   const part = parts.find((p) => p.id === item.partId);
   const partIdx = parts.findIndex((p) => p.id === item.partId);
-  const mesh = partIdx >= 0 ? scene?.parts[partIdx]?.mesh : null;
+  // scene.parts indexes visible roots only (hidden parts are skipped during
+  // evaluation) — translate the full-roots index before the mesh lookup.
+  const docRoots = useDocumentStore((s) => s.document.roots);
+  const sceneIdx = useMemo(() => {
+    if (partIdx < 0) return -1;
+    let visIdx = 0;
+    for (let i = 0; i < docRoots.length; i++) {
+      if (docRoots[i]?.visible === false) continue;
+      if (i === partIdx) return visIdx;
+      visIdx++;
+    }
+    return -1;
+  }, [docRoots, partIdx]);
+  const mesh = sceneIdx >= 0 ? scene?.parts[sceneIdx]?.mesh : null;
 
   const stats = useMemo(() => {
     if (!mesh) return null;

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -19,7 +19,12 @@ import { inspectTriangleFromMesh as runInspectTriangle } from "./TriangleInspect
 import { pickSubFeature } from "@/lib/sub-feature-picking";
 import { useAnalyzeStore } from "@/stores/analyze-store";
 
-const HOVER_EMISSIVE = new THREE.Color(0xffb800); // neon amber
+// Brand-orange accent, sRGB (1.0, 0.45, 0.10) — matches the native macOS
+// app's picking accent. Hover and selection only *add* emissive at different
+// intensities; the base material color is never repainted.
+const ACCENT_EMISSIVE = new THREE.Color(1.0, 0.45, 0.1);
+const HOVER_EMISSIVE_INTENSITY = 0.06;
+const SELECT_EMISSIVE_INTENSITY = 0.18;
 const FACE_HIGHLIGHT_COLOR = new THREE.Color(0x00d4ff); // cyan for face selection
 
 const DEG2RAD = Math.PI / 180;
@@ -503,7 +508,6 @@ export const SceneMesh = memo(function SceneMesh({
   const select = useUiStore((s) => s.select);
   const toggleSelect = useUiStore((s) => s.toggleSelect);
   const selectItem = useUiStore((s) => s.selectItem);
-  const toggleItem = useUiStore((s) => s.toggleItem);
   const setHoveredItem = useUiStore((s) => s.setHoveredItem);
   const selectionFilter = useUiStore((s) => s.selectionFilter);
   const showWireframe = useUiStore((s) => s.showWireframe);
@@ -528,6 +532,10 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Disable raycasting during orbit for performance
   const isOrbiting = useUiStore((s) => s.isOrbiting);
+  // Gizmo handles win over part hover, and hover must never re-highlight
+  // mid-drag — matches the native app's picking semantics.
+  const isDraggingGizmo = useUiStore((s) => s.isDraggingGizmo);
+  const isGizmoHovered = useUiStore((s) => s.isGizmoHovered);
   // During AI screenshot capture, suppress emissive tint so user-selected
   // parts don't glow in the shot — the AI is verifying geometry/materials,
   // not watching the user's cursor.
@@ -536,7 +544,17 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Use selectionId if provided, otherwise fall back to partInfo.id
   const effectiveSelectionId = selectionId ?? partInfo.id;
-  const isHovered = hoveredPartId === effectiveSelectionId;
+  // The part under the cursor gets the faint accent lift whether the picker
+  // resolved a whole-part hover or a sub-feature (face/edge/vertex) on it —
+  // the sub-feature overlay draws on top of the lift.
+  const hoveredItem = useUiStore((s) => s.hoveredItem);
+  const isHovered =
+    hoveredPartId === effectiveSelectionId ||
+    (hoveredItem != null &&
+      (hoveredItem.kind === "face" ||
+        hoveredItem.kind === "edge" ||
+        hoveredItem.kind === "vertex") &&
+      hoveredItem.partId === partInfo.id);
   const isHoveredFace =
     faceSelectionMode && hoveredFace?.partId === partInfo.id;
 
@@ -645,15 +663,15 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Compute emissive state: selected > hovered > none (face highlight uses overlay)
   const emissiveColor = useMemo(() => {
-    if (effectiveSelected) return materialColor.clone().multiplyScalar(0.3);
-    if (isHovered && !faceSelectionMode && !captureMode) return HOVER_EMISSIVE;
+    if (effectiveSelected) return ACCENT_EMISSIVE;
+    if (isHovered && !faceSelectionMode && !captureMode) return ACCENT_EMISSIVE;
     return undefined;
-  }, [effectiveSelected, isHovered, faceSelectionMode, captureMode, materialColor]);
+  }, [effectiveSelected, isHovered, faceSelectionMode, captureMode]);
 
   const emissiveIntensity = effectiveSelected
-    ? 0.2
+    ? SELECT_EMISSIVE_INTENSITY
     : isHovered && !faceSelectionMode && !captureMode
-    ? 0.08
+    ? HOVER_EMISSIVE_INTENSITY
     : 0;
 
   // Update shader material uniforms for emissive state
@@ -663,16 +681,16 @@ export const SceneMesh = memo(function SceneMesh({
     if (!uniforms["uEmissive"] || !uniforms["uEmissiveIntensity"]) return;
 
     if (effectiveSelected) {
-      uniforms["uEmissive"].value = materialColor.clone().multiplyScalar(0.3);
-      uniforms["uEmissiveIntensity"].value = 0.2;
+      uniforms["uEmissive"].value = ACCENT_EMISSIVE;
+      uniforms["uEmissiveIntensity"].value = SELECT_EMISSIVE_INTENSITY;
     } else if (isHovered && !faceSelectionMode && !captureMode) {
-      uniforms["uEmissive"].value = HOVER_EMISSIVE;
-      uniforms["uEmissiveIntensity"].value = 0.08;
+      uniforms["uEmissive"].value = ACCENT_EMISSIVE;
+      uniforms["uEmissiveIntensity"].value = HOVER_EMISSIVE_INTENSITY;
     } else {
       uniforms["uEmissive"].value = new THREE.Color(0, 0, 0);
       uniforms["uEmissiveIntensity"].value = 0;
     }
-  }, [shaderMaterial, effectiveSelected, isHovered, faceSelectionMode, captureMode, materialColor]);
+  }, [shaderMaterial, effectiveSelected, isHovered, faceSelectionMode, captureMode]);
 
   useEffect(() => {
     setDraftName(partInfo.name);
@@ -809,6 +827,9 @@ export const SceneMesh = memo(function SceneMesh({
     (e: ThreeEvent<MouseEvent>) => {
       // Ignore the click that fires after a camera rotate/pan gesture.
       if (viewportWasDrag()) return;
+      // A click that lands on a transform-gizmo handle belongs to the gizmo,
+      // even when a part mesh sits behind it.
+      if (isDraggingGizmo || isGizmoHovered) return;
       e.stopPropagation();
 
       // Debug triangle inspector: when enabled, show triangle info.
@@ -833,6 +854,19 @@ export const SceneMesh = memo(function SceneMesh({
       // current selectionFilter. Falls through to body-only behavior when
       // the filter is "auto" and there's no candidate within threshold,
       // or when the filter is explicitly "body".
+      // ⌘-click (metaKey) toggles multi-select for boolean workflows —
+      // selection order is preserved (first selected = base), matching the
+      // native app. Shift-click keeps working as the historical alias.
+      const isToggle = e.nativeEvent.shiftKey || e.nativeEvent.metaKey;
+
+      // Toggle-clicks work at the part level (skip the sub-feature picker):
+      // boolean workflows consume ordered part selections, and this matches
+      // the native app's ⌘-click semantics.
+      if (isToggle) {
+        toggleSelect(effectiveSelectionId);
+        return;
+      }
+
       if (e.faceIndex != null) {
         const item = pickSubFeature({
           triIndex: e.faceIndex,
@@ -844,23 +878,18 @@ export const SceneMesh = memo(function SceneMesh({
           viewport: viewportSize,
         });
         if (item) {
-          if (e.nativeEvent.shiftKey) {
-            toggleItem(item);
-          } else {
-            selectItem(item);
-          }
+          selectItem(item);
           return;
         }
       }
 
       // Filter narrowed too far / fallback to part-level select.
-      if (e.nativeEvent.shiftKey) {
-        toggleSelect(partInfo.id);
-      } else {
-        select(partInfo.id);
-      }
+      select(effectiveSelectionId);
     },
     [
+      effectiveSelectionId,
+      isDraggingGizmo,
+      isGizmoHovered,
       faceSelectionMode,
       mesh,
       partInfo.id,
@@ -868,7 +897,6 @@ export const SceneMesh = memo(function SceneMesh({
       toggleSelect,
       select,
       selectItem,
-      toggleItem,
       selectionFilter,
       camera,
       viewportSize,
@@ -879,8 +907,8 @@ export const SceneMesh = memo(function SceneMesh({
 
   const handlePointerMove = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
-      // Skip during orbit for performance
-      if (isOrbiting) return;
+      // Skip during orbit for performance; gizmo interactions win over hover.
+      if (isOrbiting || isDraggingGizmo || isGizmoHovered) return;
       if (faceSelectionMode && e.faceIndex != null) {
         e.stopPropagation();
         const faceInfo = computeFaceInfo(mesh, e.faceIndex, partInfo.id);
@@ -910,6 +938,8 @@ export const SceneMesh = memo(function SceneMesh({
     },
     [
       isOrbiting,
+      isDraggingGizmo,
+      isGizmoHovered,
       faceSelectionMode,
       mesh,
       partInfo.id,
@@ -923,14 +953,14 @@ export const SceneMesh = memo(function SceneMesh({
 
   const handlePointerOver = useCallback(
     (e: ThreeEvent<PointerEvent>) => {
-      // Skip during orbit for performance
-      if (isOrbiting) return;
+      // Skip during orbit for performance; gizmo interactions win over hover.
+      if (isOrbiting || isDraggingGizmo || isGizmoHovered) return;
       e.stopPropagation();
       if (!faceSelectionMode) {
         setHoveredPartId(partInfo.id);
       }
     },
-    [isOrbiting, faceSelectionMode, partInfo.id, setHoveredPartId],
+    [isOrbiting, isDraggingGizmo, isGizmoHovered, faceSelectionMode, partInfo.id, setHoveredPartId],
   );
 
   const handlePointerOut = useCallback(() => {

--- a/packages/app/src/components/TransformGizmo.tsx
+++ b/packages/app/src/components/TransformGizmo.tsx
@@ -68,6 +68,7 @@ export function TransformGizmo({
   const selectedPartIds = useUiStore((s) => s.selectedPartIds);
   const transformMode = useUiStore((s) => s.transformMode);
   const setDraggingGizmo = useUiStore((s) => s.setDraggingGizmo);
+  const setGizmoHovered = useUiStore((s) => s.setGizmoHovered);
   const gridSnap = useUiStore((s) => s.gridSnap);
   const snapIncrement = useUiStore((s) => s.snapIncrement);
 
@@ -159,11 +160,24 @@ export function TransformGizmo({
       }
     };
 
+    // Pointer is over a gizmo handle when `axis` is non-null. Gizmo hover
+    // wins over part hover, and a click on a handle must not deselect —
+    // consumers (SceneMesh, Viewport onPointerMissed) read this flag.
+    const onAxisChanged = (event: { value: string | null }) => {
+      const hovered = event.value != null;
+      setGizmoHovered(hovered);
+      // Gizmo wins: drop any part hover the moment a handle is under the cursor.
+      if (hovered) useUiStore.getState().setHoveredItem(null);
+    };
+
     controls.addEventListener("dragging-changed", onDraggingChanged);
+    controls.addEventListener("axis-changed", onAxisChanged);
     return () => {
       controls.removeEventListener("dragging-changed", onDraggingChanged);
+      controls.removeEventListener("axis-changed", onAxisChanged);
+      setGizmoHovered(false);
     };
-  }, [proxy, orbitControls, setDraggingGizmo]);
+  }, [proxy, orbitControls, setDraggingGizmo, setGizmoHovered]);
 
   // Handle transform changes during drag
   useEffect(() => {

--- a/packages/app/src/components/Viewport.tsx
+++ b/packages/app/src/components/Viewport.tsx
@@ -233,6 +233,9 @@ export function Viewport() {
   const containerRef = useRef<HTMLDivElement>(null);
   const clearSelection = useUiStore((s) => s.clearSelection);
   const clearDfmSelection = useDfmStore((s) => s.selectIssue);
+  const hoveredItem = useUiStore((s) => s.hoveredItem);
+  const isGizmoHovered = useUiStore((s) => s.isGizmoHovered);
+  const isDraggingGizmo = useUiStore((s) => s.isDraggingGizmo);
   const renderMode = useUiStore((s) => s.renderMode);
   const raytraceAvailable = useUiStore((s) => s.raytraceAvailable);
   const { isDark } = useTheme();
@@ -345,6 +348,15 @@ export function Viewport() {
     };
   }, []);
 
+  // Pointer cursor over a pickable part, matching the native app. Gizmo
+  // hover/drag suppresses it — the gizmo shows its own affordance.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.style.cursor =
+      hoveredItem && !isGizmoHovered && !isDraggingGizmo ? "pointer" : "";
+  }, [hoveredItem, isGizmoHovered, isDraggingGizmo]);
+
   // Render 2D Drawing View
   if (viewMode === "2d") {
     return (
@@ -371,9 +383,17 @@ export function Viewport() {
         key={glEpoch}
         frameloop={xrPresenting ? "always" : "demand"}
         camera={{ position: [50, 50, 50], fov: 50, near: 0.1, far: 10000 }}
-        onPointerMissed={() => {
+        onPointerMissed={(e) => {
           // Ignore the click that follows a drag/rotate gesture.
           if (viewportWasDrag()) return;
+          // A tap on a transform-gizmo handle must never deselect — the
+          // gizmo's pickers sit outside the R3F event graph, so a handle
+          // click looks like a miss here.
+          const ui = useUiStore.getState();
+          if (ui.isDraggingGizmo || ui.isGizmoHovered) return;
+          // Only a plain click deselects; ⌘/shift-clicks are multi-select
+          // gestures and shouldn't nuke the selection on a narrow miss.
+          if (e.metaKey || e.shiftKey) return;
           if (!electronicsActive) clearSelection();
           clearDfmSelection(null);
         }}

--- a/packages/app/src/components/ViewportContent.tsx
+++ b/packages/app/src/components/ViewportContent.tsx
@@ -501,6 +501,19 @@ export function ViewportContent({
     return mapping;
   }, [docInstances, docPartDefs, docRoots]);
 
+  // Scene evaluation filters out hidden roots (`visible === false`), so
+  // `scene.parts[idx]` indexes *visible* roots while `parts`/`docRoots` index
+  // all of them. Map each scene index back to its original root index so a
+  // click on a part still selects the right feature-tree row when an earlier
+  // part is hidden.
+  const visibleRootIndices = useMemo(
+    () =>
+      docRoots
+        .map((entry, idx) => (entry.visible !== false ? idx : -1))
+        .filter((idx) => idx >= 0),
+    [docRoots],
+  );
+
   // Check if a part at given index is selected (handles both part IDs and instance IDs)
   const isPartSelected = useCallback(
     (partId: string, partIndex: number): boolean => {
@@ -588,7 +601,11 @@ export function ViewportContent({
     const meshFor = (partId: string) => {
       const idx = parts.findIndex((p) => p.id === partId);
       if (idx < 0) return null;
-      return scene.parts[idx]?.mesh ?? null;
+      // scene.parts indexes visible roots only — translate the full-roots
+      // index before looking up the evaluated mesh.
+      const sceneIdx = visibleRootIndices.indexOf(idx);
+      if (sceneIdx < 0) return null;
+      return scene.parts[sceneIdx]?.mesh ?? null;
     };
 
     for (const item of selection) {
@@ -619,10 +636,12 @@ export function ViewportContent({
           // Legacy path: full part mesh. Also covers instances exposed as
           // parts via isPartSelected — keep the existing index-based walk
           // so the same id can match either path.
-          parts.forEach((part, index) => {
-            if (!isPartSelected(part.id, index)) return;
+          visibleRootIndices.forEach((rootIdx, sceneIdx) => {
+            const part = parts[rootIdx];
+            if (!part) return;
+            if (!isPartSelected(part.id, rootIdx)) return;
             if (part.id !== item.id) return;
-            const evalPart = scene.parts[index];
+            const evalPart = scene.parts[sceneIdx];
             if (!evalPart) return;
             const positions = evalPart.mesh.positions;
             for (let i = 0; i < positions.length; i += 3) {
@@ -688,7 +707,7 @@ export function ViewportContent({
     const center = new Vector3(kernelCenter.x, kernelCenter.z, -kernelCenter.y);
     const mode: "fit" | "pan-only" = hasSubFeature ? "pan-only" : "fit";
     return { center, radius, mode };
-  }, [selection, scene, parts, isPartSelected]);
+  }, [selection, scene, parts, isPartSelected, visibleRootIndices]);
 
   // Animate orbit target to selection center. For part selections we also
   // tighten distance to fit the bounding sphere; for sub-features we keep
@@ -1994,7 +2013,11 @@ export function ViewportContent({
               {(!scene?.instances || scene.instances.length === 0) &&
                 parts.length > 0 &&
                 scene?.parts.map((evalPart, idx) => {
-                  const partInfo = parts[idx];
+                  // scene.parts indexes visible roots only — map back to the
+                  // full-roots index so partInfo/selection stay aligned when
+                  // some parts are hidden.
+                  const rootIdx = visibleRootIndices[idx] ?? idx;
+                  const partInfo = parts[rootIdx];
                   if (!partInfo) return null;
                   // The focused board renders via PcbScene's unified kernel
                   // meshes instead of its merged solid.
@@ -2005,7 +2028,7 @@ export function ViewportContent({
                       partInfo={partInfo}
                       mesh={evalPart.mesh}
                       materialKey={evalPart.material}
-                      selected={isPartSelected(partInfo.id, idx)}
+                      selected={isPartSelected(partInfo.id, rootIdx)}
                       ghosted={pcbEditFocus && !isPcbBoardPart(partInfo)}
                     />
                   );

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -96,6 +96,9 @@ export interface UiState {
   featureTreeOpen: boolean;
   theme: Theme;
   isDraggingGizmo: boolean;
+  /** True while the pointer is over a transform-gizmo handle. Gizmo handles
+   *  win over part hover, and a click on a handle must not deselect. */
+  isGizmoHovered: boolean;
   isOrbiting: boolean;
   /** True while ai-screenshot.ts is capturing an off-screen frame from the
    *  AI's camera. Overlays (selection highlights, participant attention
@@ -200,6 +203,7 @@ export interface UiState {
   togglePointSnap: () => void;
   setSnapIncrement: (value: number) => void;
   setDraggingGizmo: (dragging: boolean) => void;
+  setGizmoHovered: (hovered: boolean) => void;
   setOrbiting: (orbiting: boolean) => void;
   setCaptureMode: (on: boolean) => void;
   setClearanceIndicator: (indicator: ClearanceIndicator | null) => void;
@@ -313,6 +317,7 @@ export const useUiStore = create<UiState>((set) => ({
   featureTreeOpen: true,
   theme: "system",
   isDraggingGizmo: false,
+  isGizmoHovered: false,
   isOrbiting: false,
   captureMode: false,
   clearanceIndicator: null,
@@ -452,6 +457,7 @@ export const useUiStore = create<UiState>((set) => ({
     set({ snapIncrement: value, gridSnap: true }),
 
   setDraggingGizmo: (dragging) => set({ isDraggingGizmo: dragging }),
+  setGizmoHovered: (hovered) => set({ isGizmoHovered: hovered }),
 
   setOrbiting: (orbiting) => set({ isOrbiting: orbiting }),
 


### PR DESCRIPTION
## What

Brings the web viewport's picking semantics in line with the native macOS app (RealityKit picking, PRs #608–#612):

- **Brand-orange accents** — hover and selection use sRGB (1.0, 0.45, 0.10) as an emissive-only lift (intensity 0.06 hover / 0.18 selection); the base material color is never repainted. Applied to both the PBR and procedural-shader paths. A part also gets the faint hover lift when one of its faces/edges/vertices is the hovered sub-feature (the overlay draws on top).
- **⌘-click multi-select** — metaKey (and shift, the historical alias) toggles the part in/out of the selection at the *part* level, bypassing the sub-feature picker, so boolean workflows get ordered part selections (first selected = base).
- **Gizmo-aware picking** — new `isGizmoHovered` flag in the core ui-store, driven by TransformControls' `axis-changed` event. Gizmo handles win over part hover, part clicks behind a handle are ignored, hover never re-highlights mid-drag, and a tap on a gizmo handle never deselects (`onPointerMissed` guard). Plain-click-only deselect: ⌘/shift clicks on empty space keep the selection.
- **Pointer cursor** over pickable geometry, keyed off `hoveredItem` (sub-feature hovers derive a null `hoveredPartId`, so the old key would miss them).

## Bug found along the way

Scene evaluation filters hidden roots, so `scene.parts` indexes **visible** roots while `document.roots`/`parts` index all of them. Four call sites indexed `scene.parts` with the full-roots index, so hiding an earlier part made clicks select the **wrong feature-tree row** and broke the sub-feature inspector ("Mesh not available"): SceneMesh rendering in ViewportContent, `meshFor`, the selection-bbox walk, and PropertyPanel's `SubFeatureInspector`. All now translate through a visible-roots index mapping.

## Already at parity (verified, unchanged)

Triangle-precise nearest-first raycasting (three.js Raycaster via R3F), hidden parts unhittable (not rendered), and drag-vs-click suppression (`viewportWasDrag`) so orbits starting on a part never select.

## Verification

- `npm run build -w @vcad/app` clean; core (128) and app (55) tests pass.
- Manually verified in the browser with a cube + cylinder: hover lift + pointer cursor, click-select syncs the tree, ⌘-click multi-selects both rows, empty-space deselect, drag-on-part doesn't select, and with the cube hidden the cylinder click selects the correct row with working edge stats.

## Reviewer notes

- Modifier-clicks previously toggled *sub-feature* items; they now toggle the owning part. Plain clicks keep the full sub-feature picking behavior. No consumer of multi-sub-feature selections was found (AnalyzePanel uses `selection.find`).
- Selection accent changes from a material-color tint to the brand orange — intentional, per the native spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)