### PR TITLE
feat: orange feature-edge selection highlighting (native + web)

### DIFF
--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -1354,6 +1354,14 @@ struct ViewportView: View {
                                name: "edges\(i)") {
                             (centering.findEntity(named: "edges\(i)") as? ModelEntity)?.model?.mesh = ribbon
                         }
+                        // Ride the selection highlight ribbon along the scrub.
+                        if let o = centering.findEntity(named: "outline\(i)") as? ModelEntity,
+                           let ribbon = EdgeOverlay.ribbonResource(
+                               segments: i < model.docPartEdges.count ? model.docPartEdges[i] : [],
+                               width: outlineWidth(selected: model.highlightedParts.contains(i)),
+                               name: "outline\(i)") {
+                            o.model?.mesh = ribbon
+                        }
                     }
                     // Slide the gizmo with the part (don't rebuild — that would
                     // destroy the arm the drag is holding).
@@ -2250,14 +2258,6 @@ struct ViewportView: View {
             }
             Self.applyPartPicking(pe, mesh: m, model: model)
         }
-        // Ride the selection outline along the scrub (per instance when patterned).
-        let selected = model.highlightedParts.contains(i)
-        for host in Self.partModelEntities(pe) {
-            if let o = host.findEntity(named: "outline\(i)") as? ModelEntity {
-                o.model?.mesh = m
-                Self.fitOutline(o, to: m, thickness: outlineThickness(selected: selected))
-            }
-        }
     }
 
     // MARK: feature-tree sync (visibility + selection highlight)
@@ -2271,12 +2271,13 @@ struct ViewportView: View {
         }
     }
 
-    /// Selection reads as a screen-space outline via an inverted hull: a
-    /// slightly inflated copy of the part's mesh rendered with front faces
-    /// culled, so only its back faces peek past the silhouette — a crisp
-    /// brand-orange rim that tracks camera orbit for free. Selection = thick +
-    /// bright, hover = thinner + dimmer. Part materials are never touched, so
-    /// the plate still looks like alu, not the accent color.
+    /// Selection reads as brand-orange feature-edge ribbons: the same crisp
+    /// edge polylines the CAD overlay already draws, rebuilt a touch wider in
+    /// accent orange for the selected part (hover = thinner + dimmer). This is
+    /// the classic CAD idiom — every silhouette, hole rim, and rib edge lights
+    /// up exactly where the geometry is, with none of the inflated-hull
+    /// artifacts. The part's dark edge ribbon is hidden while highlighted so
+    /// the two coplanar ribbons don't z-fight.
     private func applySelectionHighlight(_ content: RealityViewCameraContent) {
         guard model.usesDocumentTree,
               let root = content.entities.first(where: { $0.name == "geomRoot" }),
@@ -2284,55 +2285,37 @@ struct ViewportView: View {
         let sel = model.highlightedParts
         let hov = model.hoveredPartIndex
         for i in 0..<model.partCount {
-            guard let e = centering.findEntity(named: "part\(i)") as? ModelEntity else { continue }
-            // For instanced patterns each copy hosts its own outline (it rides
-            // the instance transform for free as a child).
-            let hosts = Self.partModelEntities(e)
-            for h in hosts { h.findEntity(named: "outline\(i)")?.removeFromParent() }
+            centering.findEntity(named: "outline\(i)")?.removeFromParent()
+            let edges = centering.findEntity(named: "edges\(i)")
             let selected = sel.contains(i)
-            guard selected || i == hov else { continue }
-            for h in hosts {
-                guard let mesh = h.model?.mesh else { continue }
-                h.addChild(Self.outlineEntity(
-                    index: i, mesh: mesh,
-                    thickness: outlineThickness(selected: selected),
-                    brightness: selected ? 1.0 : 0.35))
-            }
+            guard selected || i == hov else { edges?.isEnabled = true; continue }
+            guard let outline = outlineRibbon(index: i, selected: selected) else { continue }
+            centering.addChild(outline)
+            edges?.isEnabled = false
         }
     }
 
-    /// Outline rim width in kernel mm, proportional to the scene (like the
-    /// edge ribbons) so it stays visually constant across part sizes.
-    private func outlineThickness(selected: Bool) -> Double {
-        max(Double(model.displayedSceneSize) * (selected ? 0.008 : 0.004), selected ? 0.08 : 0.04)
+    /// Build the highlight ribbon for one part from its feature-edge segments
+    /// (already aggregated across pattern instances). Nil if there are none.
+    private func outlineRibbon(index i: Int, selected: Bool) -> ModelEntity? {
+        guard i < model.docPartEdges.count,
+              let ribbon = EdgeOverlay.ribbonResource(
+                  segments: model.docPartEdges[i],
+                  width: outlineWidth(selected: selected),
+                  name: "outline\(i)") else { return nil }
+        let color = selected
+            ? EditorModel.brandOrange
+            : NSColor(srgbRed: 0.62, green: 0.32, blue: 0.10, alpha: 1.0)   // dim hover
+        let e = ModelEntity(mesh: ribbon, materials: [UnlitMaterial(color: color)])
+        e.name = "outline\(i)"
+        return e
     }
 
-    /// Build the inverted-hull outline entity for one part.
-    private static func outlineEntity(index: Int, mesh: MeshResource,
-                                      thickness: Double, brightness: Float) -> ModelEntity {
-        var m = PhysicallyBasedMaterial()
-        m.baseColor = .init(tint: .black)
-        m.emissiveColor = .init(color: EditorModel.brandOrange)
-        m.emissiveIntensity = 2.0 * brightness   // reads unlit — pure rim color
-        m.roughness = 1.0
-        m.metallic = 0.0
-        m.faceCulling = .front                   // back faces only → silhouette
-        let outline = ModelEntity(mesh: mesh, materials: [m])
-        outline.name = "outline\(index)"
-        fitOutline(outline, to: mesh, thickness: thickness)
-        return outline
-    }
-
-    /// Inflate the hull ~`thickness` mm on every axis by scaling around the
-    /// mesh-bounds center — per-axis, so thin plates get the same rim as cubes.
-    private static func fitOutline(_ outline: ModelEntity, to mesh: MeshResource, thickness: Double) {
-        let b = mesh.bounds
-        let t = Float(thickness)
-        let s = SIMD3<Float>(1 + 2 * t / max(b.extents.x, 1e-4),
-                             1 + 2 * t / max(b.extents.y, 1e-4),
-                             1 + 2 * t / max(b.extents.z, 1e-4))
-        outline.scale = s
-        outline.position = b.center * (SIMD3<Float>(repeating: 1) - s)
+    /// Highlight ribbon width in kernel mm — a bit heavier than the standard
+    /// edge overlay (0.0016×scene) so the accent reads, scaled with the scene
+    /// so it stays visually constant across part sizes.
+    private func outlineWidth(selected: Bool) -> Float {
+        max(model.displayedSceneSize * (selected ? 0.0042 : 0.0026), selected ? 0.05 : 0.03)
     }
 
     // MARK: gestures

--- a/changelog/entries/2026-07-20-edge-selection-highlight.json
+++ b/changelog/entries/2026-07-20-edge-selection-highlight.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-20-edge-selection-highlight",
+  "version": "0.9.4",
+  "date": "2026-07-20",
+  "category": "feat",
+  "title": "Selection reads as orange feature-edge highlighting",
+  "summary": "Selected and hovered parts now light up with brand-orange feature-edge lines (silhouettes, hole rims, ribs) instead of a material tint, in both the web viewport and the native macOS app.",
+  "features": ["viewport", "selection", "native"]
+}

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -1024,14 +1024,14 @@ export const SceneMesh = memo(function SceneMesh({
         <Edges
           threshold={15}
           color={effectiveSelected ? SELECTION_EDGE_COLOR : HOVER_EDGE_COLOR}
-          lineWidth={effectiveSelected ? 2 : 1.25}
+          lineWidth={effectiveSelected ? 3 : 2}
           renderOrder={1}
         />
       )}
       {showSelectionEdges && geoReady && isSmoothBody && (
         <Outlines
           color={effectiveSelected ? SELECTION_EDGE_COLOR : HOVER_EDGE_COLOR}
-          thickness={effectiveSelected ? 2 : 1.25}
+          thickness={effectiveSelected ? 3 : 2}
           angle={Math.PI}
           renderOrder={1}
         />

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useMemo, useCallback, useState } from "react";
 import * as THREE from "three";
-import { Edges, Html } from "@react-three/drei";
+import { Edges, Html, Outlines } from "@react-three/drei";
 import { useThree } from "@react-three/fiber";
 import type { TriangleMesh, PartInfo, FaceInfo } from "@vcad/core";
 import { useUiStore, useDocumentStore, useSketchStore, isPcbBoardPart, isStitchPart, isEmbroideryPatternPart } from "@vcad/core";
@@ -669,6 +669,19 @@ export const SceneMesh = memo(function SceneMesh({
     !captureMode &&
     (effectiveSelected || (isHovered && !faceSelectionMode));
 
+  // Smooth bodies (spheres, blends) have no dihedral > 15° — the edge
+  // highlight would draw nothing. Fall back to a screen-space silhouette
+  // outline for those. Recomputed only when the mesh changes.
+  const isSmoothBody = useMemo(() => {
+    if (!geoReady) return false;
+    const geo = geoRef.current;
+    if (!geo) return false;
+    const eg = new THREE.EdgesGeometry(geo, 15);
+    const segments = eg.attributes["position"]?.count ?? 0;
+    eg.dispose();
+    return segments === 0;
+  }, [geoReady, mesh]);
+
   useEffect(() => {
     setDraftName(partInfo.name);
   }, [partInfo.name, selected]);
@@ -1007,11 +1020,19 @@ export const SceneMesh = memo(function SceneMesh({
       {/* Selection/hover highlight: brand-orange feature-edge lines (ported
           from the native app). Fat screen-space lines, so the width stays
           visually constant at any zoom. */}
-      {showSelectionEdges && geoReady && (
+      {showSelectionEdges && geoReady && !isSmoothBody && (
         <Edges
           threshold={15}
           color={effectiveSelected ? SELECTION_EDGE_COLOR : HOVER_EDGE_COLOR}
           lineWidth={effectiveSelected ? 2 : 1.25}
+          renderOrder={1}
+        />
+      )}
+      {showSelectionEdges && geoReady && isSmoothBody && (
+        <Outlines
+          color={effectiveSelected ? SELECTION_EDGE_COLOR : HOVER_EDGE_COLOR}
+          thickness={effectiveSelected ? 2 : 1.25}
+          angle={Math.PI}
           renderOrder={1}
         />
       )}

--- a/packages/app/src/components/SceneMesh.tsx
+++ b/packages/app/src/components/SceneMesh.tsx
@@ -19,12 +19,12 @@ import { inspectTriangleFromMesh as runInspectTriangle } from "./TriangleInspect
 import { pickSubFeature } from "@/lib/sub-feature-picking";
 import { useAnalyzeStore } from "@/stores/analyze-store";
 
-// Brand-orange accent, sRGB (1.0, 0.45, 0.10) — matches the native macOS
-// app's picking accent. Hover and selection only *add* emissive at different
-// intensities; the base material color is never repainted.
-const ACCENT_EMISSIVE = new THREE.Color(1.0, 0.45, 0.1);
-const HOVER_EMISSIVE_INTENSITY = 0.06;
-const SELECT_EMISSIVE_INTENSITY = 0.18;
+// Selection reads as brand-orange feature-edge lines (same design as the
+// native app): every silhouette, hole rim, and rib edge lights up exactly on
+// the geometry, and the part material is never touched. Hover = thinner +
+// dimmer burnt orange.
+const SELECTION_EDGE_COLOR = new THREE.Color(1.0, 0.45, 0.1); // brand orange
+const HOVER_EDGE_COLOR = new THREE.Color(0.62, 0.32, 0.1); // dim hover
 const FACE_HIGHLIGHT_COLOR = new THREE.Color(0x00d4ff); // cyan for face selection
 
 const DEG2RAD = Math.PI / 180;
@@ -544,17 +544,18 @@ export const SceneMesh = memo(function SceneMesh({
 
   // Use selectionId if provided, otherwise fall back to partInfo.id
   const effectiveSelectionId = selectionId ?? partInfo.id;
-  // The part under the cursor gets the faint accent lift whether the picker
-  // resolved a whole-part hover or a sub-feature (face/edge/vertex) on it —
-  // the sub-feature overlay draws on top of the lift.
+  // Part reads as hovered when the cursor is anywhere on it — including when
+  // the sub-feature picker is reporting a vertex/edge/face of this part (that
+  // path clears `hoveredPartId`, so check the hovered item's owner too).
   const hoveredItem = useUiStore((s) => s.hoveredItem);
   const isHovered =
     hoveredPartId === effectiveSelectionId ||
     (hoveredItem != null &&
-      (hoveredItem.kind === "face" ||
-        hoveredItem.kind === "edge" ||
-        hoveredItem.kind === "vertex") &&
-      hoveredItem.partId === partInfo.id);
+      hoveredItem.kind !== "segment" &&
+      hoveredItem.kind !== "constraint" &&
+      (hoveredItem.kind === "part"
+        ? hoveredItem.id === effectiveSelectionId
+        : hoveredItem.partId === partInfo.id));
   const isHoveredFace =
     faceSelectionMode && hoveredFace?.partId === partInfo.id;
 
@@ -661,36 +662,12 @@ export const SceneMesh = memo(function SceneMesh({
     return new THREE.Color(0.55, 0.55, 0.55);
   }, [materialDef]);
 
-  // Compute emissive state: selected > hovered > none (face highlight uses overlay)
-  const emissiveColor = useMemo(() => {
-    if (effectiveSelected) return ACCENT_EMISSIVE;
-    if (isHovered && !faceSelectionMode && !captureMode) return ACCENT_EMISSIVE;
-    return undefined;
-  }, [effectiveSelected, isHovered, faceSelectionMode, captureMode]);
-
-  const emissiveIntensity = effectiveSelected
-    ? SELECT_EMISSIVE_INTENSITY
-    : isHovered && !faceSelectionMode && !captureMode
-    ? HOVER_EMISSIVE_INTENSITY
-    : 0;
-
-  // Update shader material uniforms for emissive state
-  useEffect(() => {
-    if (!shaderMaterial) return;
-    const uniforms = shaderMaterial.uniforms;
-    if (!uniforms["uEmissive"] || !uniforms["uEmissiveIntensity"]) return;
-
-    if (effectiveSelected) {
-      uniforms["uEmissive"].value = ACCENT_EMISSIVE;
-      uniforms["uEmissiveIntensity"].value = SELECT_EMISSIVE_INTENSITY;
-    } else if (isHovered && !faceSelectionMode && !captureMode) {
-      uniforms["uEmissive"].value = ACCENT_EMISSIVE;
-      uniforms["uEmissiveIntensity"].value = HOVER_EMISSIVE_INTENSITY;
-    } else {
-      uniforms["uEmissive"].value = new THREE.Color(0, 0, 0);
-      uniforms["uEmissiveIntensity"].value = 0;
-    }
-  }, [shaderMaterial, effectiveSelected, isHovered, faceSelectionMode, captureMode]);
+  // Selection/hover reads as edge highlighting, not a material tint — the
+  // part must still look like its material (see the edge overlay below).
+  const showSelectionEdges =
+    !ghosted &&
+    !captureMode &&
+    (effectiveSelected || (isHovered && !faceSelectionMode));
 
   useEffect(() => {
     setDraftName(partInfo.name);
@@ -1012,8 +989,6 @@ export const SceneMesh = memo(function SceneMesh({
         <PbrMaterial
           color={mesh.colors || analyzeColors ? undefined : materialColor}
           vertexColors={!!mesh.colors || !!analyzeColors}
-          emissive={emissiveColor}
-          emissiveIntensity={emissiveIntensity}
           metalness={materialDef?.metallic ?? 0.0}
           roughness={materialDef?.roughness ?? 0.7}
           transmission={materialDef?.transmission}
@@ -1029,6 +1004,17 @@ export const SceneMesh = memo(function SceneMesh({
         />
       )}
       {showWireframe && geoReady && <Edges threshold={15} color="#666" />}
+      {/* Selection/hover highlight: brand-orange feature-edge lines (ported
+          from the native app). Fat screen-space lines, so the width stays
+          visually constant at any zoom. */}
+      {showSelectionEdges && geoReady && (
+        <Edges
+          threshold={15}
+          color={effectiveSelected ? SELECTION_EDGE_COLOR : HOVER_EDGE_COLOR}
+          lineWidth={effectiveSelected ? 2 : 1.25}
+          renderOrder={1}
+        />
+      )}
       {/* Face highlight overlay for individual face selection */}
       {faceHighlightGeo && (
         <mesh geometry={faceHighlightGeo} renderOrder={1}>


### PR DESCRIPTION
## Summary

Selection and hover now read as **brand-orange feature-edge highlighting** in both viewports, replacing the emissive material tints. Every silhouette, hole rim, and rib edge lights up exactly on the geometry while the part material stays untouched — the plate still looks like alu, not the accent color.

### Native macOS app
- `applySelectionHighlight` rebuilds the part's existing feature-edge polylines as unlit brand-orange ribbons (selection = bright + wider, hover = dimmer + thinner)
- The part's dark edge ribbon hides while highlighted so the coplanar ribbons don't z-fight; the highlight rides along parameter scrubs
- (An earlier inverted-hull approach was dropped: fold-over slivers and misaligned hole crescents on CAD tessellations)

### Web app
- Same design via drei's fat-line `Edges` (15° threshold, constant pixel width: 3px selected / 2px hover)
- Smooth bodies (spheres, blends) have no dihedral edge above threshold, so they fall back to drei's `Outlines` screen-space silhouette ring
- Fixed a latent hover bug: the sub-feature picker's `setHoveredItem` cleared the part-level hover id, so part hover almost never fired; hover now also reads the hovered item's owning part

## Test plan
- [x] Native: ribbed-plate example — selection/hover verified in the running app, holes concentric, tracks orbit and mesh scrubs
- [x] Web: mounting-plate example — body-select shows orange edges; sphere shows silhouette ring; hover dims correctly
- [x] `npm run build -w @vcad/app` clean; Swift app builds + bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)