### PR TITLE
feat(native): Release to Desktop mode for the macOS app

### DIFF
--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -290,6 +290,10 @@ final class EditorModel {
     /// so stripe continuity reveals curvature/tangency defects.
     var zebraMode = false { didSet { if zebraMode != oldValue { zebraDirty = true } } }
     var zebraDirty = false
+    /// Release-to-desktop: the window goes transparent + chromeless and the
+    /// parts float over the desktop (environment kept for lighting only).
+    var releaseMode = false { didSet { if releaseMode != oldValue { releaseDirty = true } } }
+    var releaseDirty = false
     /// Per-part kernel-space triangle meshes (+ AABB), index-aligned with the
     /// rendered parts — the basis for precise ray-triangle hover/pick. The AABB
     /// is a broadphase cull before the triangle test.

--- a/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
+++ b/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
@@ -1,0 +1,478 @@
+import AppKit
+import RealityKit
+import SwiftUI
+
+// Release-to-desktop: RealityView's drawable on macOS always clears opaque, so
+// the released experience lives in its OWN borderless transparent window
+// hosting an ARView (which supports `environment.background = .color(.clear)`).
+// The parts composite straight over the desktop; the main window hides while
+// released and comes back on return.
+//
+// Around the floating parts we open Borland C++ Builder-style tool windows —
+// a Component Palette and an Object Inspector — as separate floating panels,
+// the way the classic multi-window IDEs scattered themselves over the desktop.
+
+/// Borderless windows refuse key status by default, which starves SwiftUI
+/// gestures inside them — opt back in.
+final class KeyableWindow: NSWindow {
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { true }
+}
+
+@MainActor
+final class ReleaseWindowController {
+    static let shared = ReleaseWindowController()
+    private var window: NSWindow?
+    private var mainWindow: NSWindow?
+    private var mouseMonitors: [Any] = []
+    /// Set by ReleasedARView so the pass-through hit test can raycast the scene.
+    weak var arView: ARView?
+    /// Chrome regions (tool windows, pill) in overlay view coords (top-left
+    /// origin), reported by SwiftUI — the overlay owns the mouse over these.
+    var chromeRects: [String: CGRect] = [:]
+
+    func show(model: EditorModel) {
+        guard window == nil else { return }
+        mainWindow = NSApp.keyWindow ?? NSApp.mainWindow
+
+        let frame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
+        let w = KeyableWindow(contentRect: frame, styleMask: [.borderless],
+                              backing: .buffered, defer: false)
+        w.isOpaque = false
+        w.backgroundColor = .clear
+        w.hasShadow = false
+        w.level = .normal                       // stacks like any window, not always-on-top
+        w.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        w.contentView = NSHostingView(rootView: ReleasedOverlayView(model: model))
+        w.makeKeyAndOrderFront(nil)
+        window = w
+        mainWindow?.orderOut(nil)
+
+        let update: () -> Void = { [weak self] in self?.updatePassThrough() }
+        if let m = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { _ in
+            Task { @MainActor in update() }
+        } { mouseMonitors.append(m) }
+        mouseMonitors.append(NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved]) { e in
+            Task { @MainActor in update() }
+            return e
+        } as Any)
+        updatePassThrough()
+    }
+
+    /// Own the mouse over geometry or chrome; pass everything else through.
+    /// Never flips mid-drag (the orbit would be dropped half-way).
+    private func updatePassThrough() {
+        guard let w = window else { return }
+        guard NSEvent.pressedMouseButtons == 0 else { return }
+        let winPoint = w.convertPoint(fromScreen: NSEvent.mouseLocation)
+        let topLeft = CGPoint(x: winPoint.x, y: w.frame.height - winPoint.y)
+        if chromeRects.values.contains(where: { $0.insetBy(dx: -8, dy: -8).contains(topLeft) }) {
+            w.ignoresMouseEvents = false
+            return
+        }
+        guard let ar = arView else { return }
+        var viewPoint = ar.convert(winPoint, from: nil)
+        if !ar.isFlipped { viewPoint.y = ar.bounds.height - viewPoint.y }
+        w.ignoresMouseEvents = ar.hitTest(viewPoint).isEmpty
+    }
+
+    func hide() {
+        mouseMonitors.forEach { NSEvent.removeMonitor($0) }
+        mouseMonitors = []
+        arView = nil
+        chromeRects = [:]
+        window?.orderOut(nil)
+        window = nil
+        mainWindow?.makeKeyAndOrderFront(nil)
+        mainWindow = nil
+    }
+}
+
+/// Reports a chrome element's frame (overlay view coords) to the controller
+/// so the pass-through hit test knows the mouse belongs to us there.
+struct ChromeRegion: ViewModifier {
+    let key: String
+    func body(content: Content) -> some View {
+        content.onGeometryChange(for: CGRect.self) { $0.frame(in: .global) } action: {
+            ReleaseWindowController.shared.chromeRects[key] = $0
+        }
+    }
+}
+
+/// Full-screen overlay content: transparent ARView + orbit/zoom gestures +
+/// the return pill. Reading the model's orbit state here keeps the ARView's
+/// camera live (flick momentum included — endOrbit's coast mutates azimuth,
+/// which re-renders this view).
+struct ReleasedOverlayView: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            ReleasedARView(model: model,
+                           cameraPosition: model.cameraPosition,
+                           lookAt: model.panOffset,
+                           geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)")
+                .ignoresSafeArea()
+            // ARView consumes mouse events — capture orbit/zoom on a clear
+            // layer above it instead.
+            Color.clear
+                .contentShape(Rectangle())
+                .ignoresSafeArea()
+                .gesture(orbitGesture)
+                .simultaneousGesture(zoomGesture)
+            // BCB-style tool windows, hosted in the overlay itself (separate
+            // NSPanels break SwiftUI hit testing after auto-resize).
+            VStack(alignment: .leading, spacing: 12) {
+                ComponentPaletteWindow(model: model)
+                    .modifier(ChromeRegion(key: "palette"))
+                ObjectInspectorWindow(model: model)
+                    .modifier(ChromeRegion(key: "inspector"))
+            }
+            .padding(16)
+        }
+        .overlay(alignment: .topTrailing) {
+            ReleaseReturnPill(model: model)
+                .padding(16)
+                .modifier(ChromeRegion(key: "pill"))
+        }
+    }
+
+    private var orbitGesture: some Gesture {
+        DragGesture(minimumDistance: 2)
+            .onChanged { value in
+                if model.lastDrag == .zero { model.beginOrbit() }
+                let dx = Float(value.translation.width - model.lastDrag.width)
+                let dy = Float(value.translation.height - model.lastDrag.height)
+                if NSEvent.modifierFlags.contains(.shift) {
+                    model.panBy(dx: dx, dy: dy)
+                } else {
+                    model.orbitDrag(dx: dx, dy: dy)
+                }
+                model.lastDrag = value.translation
+            }
+            .onEnded { _ in
+                model.lastDrag = .zero
+                model.endOrbit()
+            }
+    }
+
+    private var zoomGesture: some Gesture {
+        MagnifyGesture()
+            .onChanged { value in
+                model.stopSpin()
+                model.distance = max(0.45, min(8.0, model.pinchBaseline / Float(value.magnification)))
+            }
+            .onEnded { _ in model.pinchBaseline = model.distance }
+    }
+}
+
+/// An ARView with a clear background showing the document's parts, camera and
+/// geometry kept in sync with the editor model.
+struct ReleasedARView: NSViewRepresentable {
+    let model: EditorModel
+    let cameraPosition: SIMD3<Float>
+    let lookAt: SIMD3<Float>
+    let geometryKey: String
+
+    final class Coordinator {
+        var camera: PerspectiveCamera?
+        var anchor: AnchorEntity?
+        var builtKey = ""
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> ARView {
+        let ar = ARView(frame: .zero)
+        ar.environment.background = .color(.clear)
+        ReleaseWindowController.shared.arView = ar
+        let anchor = AnchorEntity(world: .zero)
+        let camera = PerspectiveCamera()
+        anchor.addChild(camera)
+        ar.scene.addAnchor(anchor)
+        context.coordinator.anchor = anchor
+        context.coordinator.camera = camera
+        rebuild(in: anchor, coordinator: context.coordinator)
+        syncCamera(context.coordinator)
+        return ar
+    }
+
+    func updateNSView(_ ar: ARView, context: Context) {
+        if context.coordinator.builtKey != geometryKey {
+            rebuild(in: context.coordinator.anchor, coordinator: context.coordinator)
+            // Zebra in released mode: striped IBL on chrome parts, desktop
+            // still visible behind (lighting only — never a skybox).
+            ar.environment.lighting.resource =
+                model.zebraMode ? ViewportView.zebraEnvironment : nil
+        }
+        syncCamera(context.coordinator)
+    }
+
+    private func syncCamera(_ c: Coordinator) {
+        guard let camera = c.camera else { return }
+        camera.position = cameraPosition
+        camera.look(at: lookAt, from: cameraPosition, relativeTo: nil)
+    }
+
+    private func rebuild(in anchor: AnchorEntity?, coordinator: Coordinator) {
+        guard let anchor else { return }
+        coordinator.builtKey = geometryKey
+        anchor.children.filter { $0.name == "geomRoot" }.forEach { $0.removeFromParent() }
+
+        let scene = model.buildScene()
+        let sceneScale = 0.6 / max(scene.size, 0.0001)
+
+        let centering = Entity()
+        centering.position = -scene.center
+        for (i, item) in scene.meshes.enumerated() {
+            var m = PhysicallyBasedMaterial()
+            if model.zebraMode {
+                m = ViewportView.zebraChrome
+            } else if model.usesDocumentTree {
+                let r = model.resolvedMaterial(forPart: i)
+                m.baseColor = .init(tint: r.color)
+                m.roughness = .init(floatLiteral: r.roughness)
+                m.metallic = .init(floatLiteral: r.metallic)
+            } else {
+                m.baseColor = .init(tint: item.color)
+                m.roughness = 0.34
+                m.metallic = 0.55
+            }
+            let e = ModelEntity(mesh: item.mesh, materials: [m])
+            e.name = "part\(i)"
+            e.generateCollisionShapes(recursive: false)   // pass-through hit test
+            centering.addChild(e)
+        }
+
+        let zUp = Entity()
+        zUp.addChild(centering)
+        zUp.orientation = simd_quatf(angle: -.pi / 2, axis: [1, 0, 0])
+
+        let geomRoot = Entity()
+        geomRoot.name = "geomRoot"
+        geomRoot.addChild(zUp)
+        geomRoot.scale = SIMD3<Float>(repeating: sceneScale)
+        anchor.addChild(geomRoot)
+    }
+}
+
+// MARK: - Floating tool windows (BCB-style UX, Apple HIG styling)
+//
+// The C++ Builder idea — the IDE as a constellation of small floating tool
+// windows around your work — implemented as native macOS panels: material
+// backgrounds, SF Symbols, standard controls.
+
+/// A floating tool window: compact title row (drags the panel) over a
+/// material body, rounded and stroked like a native HUD panel.
+struct ToolWindow<Content: View>: View {
+    let title: String
+    let onClose: () -> Void
+    @ViewBuilder var content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 24)
+            }
+            .overlay(alignment: .trailing) {
+                Button(action: onClose) {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                        .padding(4)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .help("Close")
+            }
+            content
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.separator, lineWidth: 1))
+        .fixedSize()
+    }
+}
+
+/// The Component Palette: create + modify sections and a document-action
+/// cluster (undo/redo, zebra analysis, export) — the BCB palette, HIG-ified.
+struct ComponentPaletteWindow: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        ToolWindow(title: "Components", onClose: { model.releaseMode = false }) {
+            HStack(spacing: 10) {
+                HStack(spacing: 2) {
+                    ForEach(BaseShape.allCases, id: \.self) { s in
+                        paletteButton(s.label, s.symbol, active: model.baseShape == s) {
+                            model.baseShape = s
+                        }
+                    }
+                }
+                Divider().frame(height: 22)
+                HStack(spacing: 2) {
+                    ForEach(Modifier.allCases, id: \.self) { m in
+                        paletteButton(m.label, m.symbol, active: model.modifier == m) {
+                            model.modifier = m
+                        }
+                    }
+                }
+                Divider().frame(height: 22)
+                HStack(spacing: 2) {
+                    paletteButton("Zebra", "line.3.horizontal", active: model.zebraMode) {
+                        model.zebraMode.toggle()
+                    }
+                    iconButton("Undo", "arrow.uturn.backward", enabled: model.canUndo) { model.undo() }
+                    iconButton("Redo", "arrow.uturn.forward", enabled: model.canRedo) { model.redo() }
+                    iconButton("STL", "square.and.arrow.up", enabled: model.canExport) {
+                        exportPanel(ext: "stl") { model.exportSTL(to: $0) }
+                    }
+                    iconButton("USDZ", "arkit", enabled: model.canExport) {
+                        exportPanel(ext: "usdz") { model.exportUSDZ(to: $0) }
+                    }
+                }
+            }
+        }
+    }
+
+    private func exportPanel(ext: String, _ export: @escaping (URL) -> Bool) {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "\(model.documentName).\(ext)"
+        panel.begin { resp in
+            guard resp == .OK, let url = panel.url else { return }
+            _ = export(url)
+        }
+    }
+
+    private func paletteButton(_ label: String, _ symbol: String,
+                               active: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: symbol).font(.system(size: 14))
+                Text(label).font(.system(size: 9))
+            }
+            .frame(width: 52, height: 40)
+            .foregroundStyle(active ? Color.accentColor : Color.primary)
+            .background(active ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
+                        in: RoundedRectangle(cornerRadius: 7))
+            // .plain buttons only hit-test opaque pixels; without this, clicks
+            // in the transparent padding between glyph and label do nothing.
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func iconButton(_ label: String, _ symbol: String, enabled: Bool,
+                            action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 3) {
+                Image(systemName: symbol).font(.system(size: 14))
+                Text(label).font(.system(size: 9))
+            }
+            .frame(width: 52, height: 40)
+            .foregroundStyle(enabled ? Color.primary : Color.secondary.opacity(0.4))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!enabled)
+    }
+}
+
+/// The Object Inspector: parameters, camera, material, and measurements.
+struct ObjectInspectorWindow: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        ToolWindow(title: "Object Inspector", onClose: { model.releaseMode = false }) {
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                row("Shape", model.baseShape.label)
+                row("Modifier", model.modifier.label)
+                GridRow {
+                    Text(model.modifier.paramLabel)
+                        .font(.system(size: 11)).foregroundStyle(.secondary)
+                    HStack(spacing: 6) {
+                        Slider(value: $model.modifierValue, in: 0...12)
+                            .controlSize(.mini)
+                            .frame(width: 108)
+                        Text(String(format: "%.1f mm", model.modifierValue))
+                            .font(.system(size: 11).monospacedDigit())
+                    }
+                }
+                if model.usesDocumentTree {
+                    GridRow {
+                        Text("Material").font(.system(size: 11)).foregroundStyle(.secondary)
+                        Picker("", selection: materialBinding) {
+                            ForEach(MaterialPreset.grouped, id: \.category) { group in
+                                Section(group.category.capitalized) {
+                                    ForEach(group.items) { m in Text(m.name).tag(m.key) }
+                                }
+                            }
+                        }
+                        .labelsHidden()
+                        .controlSize(.small)
+                        .frame(width: 150)
+                    }
+                }
+                Divider().gridCellUnsizedAxes(.horizontal)
+                GridRow {
+                    Text("Camera").font(.system(size: 11)).foregroundStyle(.secondary)
+                    HStack(spacing: 2) {
+                        camButton("Iso", az: .pi / 5, el: .pi / 7)
+                        camButton("Front", az: 0, el: 0)
+                        camButton("Right", az: .pi / 2, el: 0)
+                        camButton("Top", az: 0, el: 1.45)
+                    }
+                }
+                GridRow {
+                    Text("Zoom").font(.system(size: 11)).foregroundStyle(.secondary)
+                    Slider(value: zoomBinding, in: 0...1)
+                        .controlSize(.mini)
+                        .frame(width: 150)
+                }
+                Divider().gridCellUnsizedAxes(.horizontal)
+                row("Triangles", "\(model.triangleCount)")
+                row("Bounds", String(format: "%.0f × %.0f × %.0f mm",
+                                     model.sizeMM.x, model.sizeMM.y, model.sizeMM.z))
+            }
+        }
+    }
+
+    /// Zoom slider ∈ [0,1] mapped onto the orbit distance (inverted: right = closer).
+    private var zoomBinding: Binding<Double> {
+        Binding(
+            get: { Double(1 - (model.distance - 0.45) / (8.0 - 0.45)) },
+            set: {
+                model.stopSpin()
+                model.distance = 0.45 + Float(1 - $0) * (8.0 - 0.45)
+                model.pinchBaseline = model.distance
+            })
+    }
+
+    private var materialBinding: Binding<String> {
+        Binding(
+            get: { model.materialName(forPart: 0) ?? "aluminum" },
+            set: { model.setPartMaterial(0, $0) })
+    }
+
+    private func camButton(_ label: String, az: Float, el: Float) -> some View {
+        Button(label) {
+            model.stopSpin()
+            withAnimation(.smooth(duration: 0.25)) {
+                model.azimuth = az
+                model.elevation = el
+            }
+        }
+        .buttonStyle(.bordered)
+        .controlSize(.mini)
+    }
+
+    private func row(_ k: String, _ v: String) -> some View {
+        GridRow {
+            Text(k).font(.system(size: 11)).foregroundStyle(.secondary)
+            Text(v).font(.system(size: 11).monospacedDigit())
+        }
+    }
+}

--- a/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
+++ b/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
@@ -111,7 +111,7 @@ struct ReleasedOverlayView: View {
             ReleasedARView(model: model,
                            cameraPosition: model.cameraPosition,
                            lookAt: model.panOffset,
-                           geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)")
+                           geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)|\(model.highlightedParts.sorted())|\(model.hiddenParts.sorted())|\(String(describing: model.isolatedPart))")
                 .ignoresSafeArea()
             // ARView consumes mouse events — capture orbit/zoom on a clear
             // layer above it instead.
@@ -120,6 +120,10 @@ struct ReleasedOverlayView: View {
                 .ignoresSafeArea()
                 .gesture(orbitGesture)
                 .simultaneousGesture(zoomGesture)
+                .gesture(SpatialTapGesture(coordinateSpace: .local).modifiers(.command)
+                    .onEnded { value in tapSelect(at: value.location, additive: true) })
+                .gesture(SpatialTapGesture(coordinateSpace: .local)
+                    .onEnded { value in tapSelect(at: value.location, additive: false) })
             // BCB-style tool windows, hosted in the overlay itself (separate
             // NSPanels break SwiftUI hit testing after auto-resize).
             VStack(alignment: .leading, spacing: 12) {
@@ -127,6 +131,13 @@ struct ReleasedOverlayView: View {
                     .modifier(ChromeRegion(key: "palette"))
                 ObjectInspectorWindow(model: model)
                     .modifier(ChromeRegion(key: "inspector"))
+                ScrollView {
+                    FeatureTreeView(model: model)
+                }
+                .frame(width: 230)
+                .frame(maxHeight: 380)
+                .fixedSize(horizontal: false, vertical: true)
+                .modifier(ChromeRegion(key: "tree"))
             }
             .padding(16)
         }
@@ -135,6 +146,28 @@ struct ReleasedOverlayView: View {
                 .padding(16)
                 .modifier(ChromeRegion(key: "pill"))
         }
+    }
+
+    /// Click a part to select it (⌘-click for the boolean multi-selection,
+    /// empty space to deselect) — the released twin of the studio's pick.
+    private func tapSelect(at p: CGPoint, additive: Bool) {
+        guard model.usesDocumentTree,
+              let ar = ReleaseWindowController.shared.arView else { return }
+        if let e = ar.hitTest(p).first?.entity, e.name.hasPrefix("part"),
+           let pi = Int(e.name.dropFirst(4)),
+           let fid = model.featureNodes.first(where: { $0.partIndex == pi })?.id {
+            // Modifiers come from the gesture (.modifiers(.command)), not
+            // NSEvent.modifierFlags — that reads hardware key state and misses
+            // synthetic events (and some tap orderings).
+            if additive {
+                model.toggleMultiSelect(part: pi, featureID: fid)
+            } else {
+                model.selectFeature(fid)
+            }
+        } else if !additive {
+            model.deselectAll()
+        }
+        model.selectionDirty = false   // released view rebuilds via geometryKey
     }
 
     private var orbitGesture: some Gesture {
@@ -238,8 +271,15 @@ struct ReleasedARView: NSViewRepresentable {
                 m.roughness = 0.34
                 m.metallic = 0.55
             }
+            if model.usesDocumentTree, !model.zebraMode, model.highlightedParts.contains(i) {
+                // Brand orange = action: a subtle emissive lift marks selection
+                // without repainting the material (mirrors the studio rule).
+                m.emissiveColor = .init(color: NSColor(red: 1.0, green: 0.62, blue: 0.12, alpha: 1.0))
+                m.emissiveIntensity = 0.35
+            }
             let e = ModelEntity(mesh: item.mesh, materials: [m])
             e.name = "part\(i)"
+            e.isEnabled = model.isPartVisible(i)
             e.generateCollisionShapes(recursive: false)   // pass-through hit test
             centering.addChild(e)
         }
@@ -304,38 +344,67 @@ struct ComponentPaletteWindow: View {
 
     var body: some View {
         ToolWindow(title: "Components", onClose: { model.releaseMode = false }) {
-            HStack(spacing: 10) {
-                HStack(spacing: 2) {
-                    ForEach(BaseShape.allCases, id: \.self) { s in
-                        paletteButton(s.label, s.symbol, active: model.baseShape == s) {
-                            model.baseShape = s
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 10) {
+                    // Same tabs, same tools, same enable/hint logic as the
+                    // in-studio palette: one source of truth (model.tools(for:)).
+                    Picker("", selection: $model.toolTab) {
+                        ForEach(availableTabs) { t in Text(t.label).tag(t) }
+                    }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                    .controlSize(.small)
+                    .fixedSize()
+                    Divider().frame(height: 22)
+                    HStack(spacing: 2) {
+                        iconButton("Zebra", "line.3.horizontal", enabled: true,
+                                   active: model.zebraMode) { model.zebraMode.toggle() }
+                        iconButton("Undo", "arrow.uturn.backward", enabled: model.canUndo) { model.undo() }
+                        iconButton("Redo", "arrow.uturn.forward", enabled: model.canRedo) { model.redo() }
+                        iconButton("STL", "square.and.arrow.up", enabled: model.canExport) {
+                            exportPanel(ext: "stl") { model.exportSTL(to: $0) }
+                        }
+                        iconButton("USDZ", "arkit", enabled: model.canExport) {
+                            exportPanel(ext: "usdz") { model.exportUSDZ(to: $0) }
                         }
                     }
                 }
-                Divider().frame(height: 22)
                 HStack(spacing: 2) {
-                    ForEach(Modifier.allCases, id: \.self) { m in
-                        paletteButton(m.label, m.symbol, active: model.modifier == m) {
-                            model.modifier = m
-                        }
-                    }
-                }
-                Divider().frame(height: 22)
-                HStack(spacing: 2) {
-                    paletteButton("Zebra", "line.3.horizontal", active: model.zebraMode) {
-                        model.zebraMode.toggle()
-                    }
-                    iconButton("Undo", "arrow.uturn.backward", enabled: model.canUndo) { model.undo() }
-                    iconButton("Redo", "arrow.uturn.forward", enabled: model.canRedo) { model.redo() }
-                    iconButton("STL", "square.and.arrow.up", enabled: model.canExport) {
-                        exportPanel(ext: "stl") { model.exportSTL(to: $0) }
-                    }
-                    iconButton("USDZ", "arkit", enabled: model.canExport) {
-                        exportPanel(ext: "usdz") { model.exportUSDZ(to: $0) }
+                    ForEach(model.tools(for: activeTab)) { tool in
+                        toolButton(tool)
                     }
                 }
             }
         }
+    }
+
+    /// Combine only exists for documents (needs two selected parts).
+    private var availableTabs: [ToolTab] {
+        model.usesDocumentTree ? ToolTab.allCases : [.create, .modify]
+    }
+    private var activeTab: ToolTab {
+        availableTabs.contains(model.toolTab) ? model.toolTab : .create
+    }
+
+    private func toolButton(_ tool: Tool) -> some View {
+        Button(action: tool.action) {
+            VStack(spacing: 3) {
+                Image(systemName: tool.symbol).font(.system(size: 14))
+                Text(tool.label).font(.system(size: 9)).lineLimit(1)
+            }
+            .frame(minWidth: 52, minHeight: 40)
+            .padding(.horizontal, 4)
+            .foregroundStyle(tool.isActive ? Color.accentColor
+                             : tool.enabled ? Color.primary : Color.secondary.opacity(0.4))
+            .background(tool.isActive ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
+                        in: RoundedRectangle(cornerRadius: 7))
+            // .plain buttons only hit-test opaque pixels; without this, clicks
+            // in the transparent padding between glyph and label do nothing.
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!tool.enabled)
+        .help(tool.hint.isEmpty ? tool.label : tool.hint)
     }
 
     private func exportPanel(ext: String, _ export: @escaping (URL) -> Bool) {
@@ -347,25 +416,8 @@ struct ComponentPaletteWindow: View {
         }
     }
 
-    private func paletteButton(_ label: String, _ symbol: String,
-                               active: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 3) {
-                Image(systemName: symbol).font(.system(size: 14))
-                Text(label).font(.system(size: 9))
-            }
-            .frame(width: 52, height: 40)
-            .foregroundStyle(active ? Color.accentColor : Color.primary)
-            .background(active ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
-                        in: RoundedRectangle(cornerRadius: 7))
-            // .plain buttons only hit-test opaque pixels; without this, clicks
-            // in the transparent padding between glyph and label do nothing.
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-
     private func iconButton(_ label: String, _ symbol: String, enabled: Bool,
+                            active: Bool = false,
                             action: @escaping () -> Void) -> some View {
         Button(action: action) {
             VStack(spacing: 3) {
@@ -373,7 +425,10 @@ struct ComponentPaletteWindow: View {
                 Text(label).font(.system(size: 9))
             }
             .frame(width: 52, height: 40)
-            .foregroundStyle(enabled ? Color.primary : Color.secondary.opacity(0.4))
+            .foregroundStyle(active ? Color.accentColor
+                             : enabled ? Color.primary : Color.secondary.opacity(0.4))
+            .background(active ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
+                        in: RoundedRectangle(cornerRadius: 7))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -452,9 +507,10 @@ struct ObjectInspectorWindow: View {
     }
 
     private var materialBinding: Binding<String> {
-        Binding(
-            get: { model.materialName(forPart: 0) ?? "aluminum" },
-            set: { model.setPartMaterial(0, $0) })
+        let pi = model.selectedPartIndex ?? 0
+        return Binding(
+            get: { model.materialName(forPart: pi) ?? "aluminum" },
+            set: { model.setPartMaterial(pi, $0) })
     }
 
     private func camButton(_ label: String, az: Float, el: Float) -> some View {

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -37,8 +37,12 @@ struct EditorView: View {
             let compact = geo.size.width < 760
             ViewportView(model: model)
                 .ignoresSafeArea()
+                .background(ReleaseWindowConfigurator(release: model.releaseMode))
+                .containerBackground(
+                    model.releaseMode ? AnyShapeStyle(.clear) : AnyShapeStyle(.background),
+                    for: .window)
                 .overlay(alignment: .topLeading) {
-                    if !compact {
+                    if !compact && !model.releaseMode {
                         FeatureTreeView(model: model)
                             .frame(width: 206)
                             .padding(14)
@@ -46,18 +50,20 @@ struct EditorView: View {
                     }
                 }
                 .overlay(alignment: .top) {
-                    if showsTools && model.toolPlacement == .header {
+                    if showsTools && !model.releaseMode && model.toolPlacement == .header {
                         toolStrip(header: true)
                             .transition(.move(edge: .top).combined(with: .opacity))
                     }
                 }
                 .overlay(alignment: .top) {
-                    if model.source.isGripper {
+                    if model.source.isGripper && !model.releaseMode {
                         GripperReceiptPill(model: model).padding(.top, 14)
                     }
                 }
                 .overlay(alignment: .topTrailing) {
-                    if model.source.isGripper {
+                    if model.releaseMode {
+                        ReleaseReturnPill(model: model).padding(14)
+                    } else if model.source.isGripper {
                         // The cross-domain Receipt takes the inspector slot — the
                         // adaptive inspector adapting to a multi-domain part.
                         ReceiptLedger(model: model)
@@ -71,6 +77,7 @@ struct EditorView: View {
                     }
                 }
                 .overlay(alignment: .bottom) {
+                  if !model.releaseMode {
                     VStack(spacing: 10) {
                         if model.sketching {
                             SketchHintBar(model: model)
@@ -90,6 +97,7 @@ struct EditorView: View {
                     .animation(Motion.smooth, value: intent.draft.isEmpty)
                     .animation(Motion.panel, value: model.sketching)
                     .animation(Motion.panel, value: model.toolPlacement)
+                  }
                 }
                 .toolbar {
                     ToolbarItem(placement: .navigation) { BrandMark() }
@@ -97,6 +105,13 @@ struct EditorView: View {
                     ToolbarItem(placement: .primaryAction) { CollabAvatars() }
                 }
                 .navigationTitle(model.documentName)
+                .onChange(of: model.releaseMode) { _, released in
+                    if released {
+                        ReleaseWindowController.shared.show(model: model)
+                    } else {
+                        ReleaseWindowController.shared.hide()
+                    }
+                }
                 .animation(.smooth(duration: 0.3), value: compact)
                 .task {
                     // Dev hook: VCAD_GRIPPER=1 [VCAD_CONNECTOR_X=n] launches into
@@ -106,6 +121,12 @@ struct EditorView: View {
                     // for verifying the feature tree against a real document).
                     if let path = env["VCAD_OPEN"], !path.isEmpty {
                         model.openDocument(URL(fileURLWithPath: path))
+                    }
+                    // Dev hook: VCAD_RELEASE=1 enters release-to-desktop on launch
+                    // (headless hit-test debugging without driving the menu).
+                    if env["VCAD_RELEASE"] == "1" {
+                        try? await Task.sleep(for: .seconds(1))
+                        model.releaseMode = true
                     }
                     guard env["VCAD_GRIPPER"] == "1" else { return }
                     model.openGripper()
@@ -184,6 +205,10 @@ struct DocumentMenu: View {
             Button("Toggle Tool Palette") { model.cycleToolPlacement() }.keyboardShortcut("t")
             Button(model.zebraMode ? "Zebra Analysis ✓" : "Zebra Analysis") { model.zebraMode.toggle() }
                 .keyboardShortcut("z", modifiers: [])
+            Button(model.releaseMode ? "Return to Studio" : "Release to Desktop") {
+                withAnimation(Motion.panel) { model.releaseMode.toggle() }
+            }
+            .keyboardShortcut(.space, modifiers: [.command, .shift])
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: model.source.isSandbox ? "cube" : "doc").font(.system(size: 12))
@@ -1229,6 +1254,72 @@ struct PlaybackBar: View {
     }
 }
 
+/// Applies/reverts the transparent-window styling for release-to-desktop mode.
+/// Lives as an invisible background NSView so it can reach the hosting NSWindow.
+struct ReleaseWindowConfigurator: NSViewRepresentable {
+    var release: Bool
+
+    func makeNSView(context: Context) -> NSView { NSView() }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        let release = release
+        DispatchQueue.main.async {
+            guard let w = view.window else { return }
+            w.isOpaque = !release
+            w.backgroundColor = release ? .clear : .windowBackgroundColor
+            w.hasShadow = !release
+            w.titlebarAppearsTransparent = release
+            w.titleVisibility = release ? .hidden : .visible
+            w.toolbar?.isVisible = !release
+            if release {
+                w.styleMask.insert(.fullSizeContentView)
+                w.level = .floating
+            } else {
+                w.styleMask.remove(.fullSizeContentView)
+                w.level = .normal
+            }
+            // RealityKit's drawable clears opaque — punch through every metal
+            // layer in the hierarchy so the desktop shows behind the parts.
+            if let content = w.contentView { Self.setMetalLayersOpaque(!release, in: content) }
+        }
+    }
+
+    private static func setMetalLayersOpaque(_ opaque: Bool, in view: NSView) {
+        if let layer = view.layer { walkLayers(layer, opaque: opaque) }
+        for sub in view.subviews { setMetalLayersOpaque(opaque, in: sub) }
+    }
+
+    private static func walkLayers(_ layer: CALayer, opaque: Bool) {
+        if layer is CAMetalLayer {
+            layer.isOpaque = opaque
+            layer.backgroundColor = opaque ? nil : NSColor.clear.cgColor
+        }
+        for sub in layer.sublayers ?? [] { walkLayers(sub, opaque: opaque) }
+    }
+}
+
+/// The only chrome left in release mode: a small pill to come back inside.
+struct ReleaseReturnPill: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        Button {
+            withAnimation(Motion.panel) { model.releaseMode = false }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.down.forward.and.arrow.up.backward")
+                    .font(.system(size: 11, weight: .semibold))
+                Text("Return to Studio").font(.system(size: 12, weight: .medium))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(.ultraThinMaterial, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("Bring vcad back into its window (⌘⇧Space)")
+    }
+}
+
 struct ViewportView: View {
     let model: EditorModel
 
@@ -1238,11 +1329,13 @@ struct ViewportView: View {
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
              model.docParamDirty, model.sketchDirty, model.hoverDirty, model.gizmoDirty,
-             model.playbackTime, model.playbackDirty, model.zebraDirty)
+             model.playbackTime, model.playbackDirty, model.zebraDirty, model.releaseDirty)
 
         return GeometryReader { geo in
           RealityView { content in
-            if let env = model.zebraMode ? Self.zebraEnvironment : Self.studioEnvironment {
+            if model.releaseMode {
+                content.environment = .default
+            } else if let env = model.zebraMode ? Self.zebraEnvironment : Self.studioEnvironment {
                 content.environment = .skybox(env)
             }
             setupScene(content)
@@ -1263,6 +1356,11 @@ struct ViewportView: View {
                 var mutableContent = content
                 applyZebra(&mutableContent, on: model.zebraMode)
                 model.zebraDirty = false
+            }
+            if model.releaseDirty {
+                var mutableContent = content
+                applyRelease(&mutableContent, on: model.releaseMode)
+                model.releaseDirty = false
             }
             if model.geometryDirty {
                 rebuildGeometry(content)
@@ -1780,6 +1878,7 @@ struct ViewportView: View {
         let floor = ModelEntity(mesh: .generatePlane(width: 8, depth: 8), materials: [floorMat])
         floor.name = "floor"
         floor.position = [0, floorY, 0]
+        floor.isEnabled = !model.releaseMode
         content.add(floor)
 
         // Adaptive reference grid: minor cells snap to a 1/2/5-decade of the
@@ -1803,6 +1902,7 @@ struct ViewportView: View {
                 let grid = ModelEntity(mesh: gmesh, materials: [gm])
                 grid.name = "grid"
                 grid.position = [0, floorY + 0.0008, 0]
+                grid.isEnabled = !model.releaseMode
                 content.add(grid)
             }
         }
@@ -1817,6 +1917,7 @@ struct ViewportView: View {
             let blob = ModelEntity(mesh: .generatePlane(width: fwd, depth: dpt), materials: [sm])
             blob.name = "contactShadow"
             blob.position = [0, floorY + 0.0015, 0]
+            blob.isEnabled = !model.releaseMode
             content.add(blob)
         }
     }
@@ -1842,6 +1943,21 @@ struct ViewportView: View {
     /// Toggle zebra analysis: swap the environment and chrome/restore the part
     /// materials in place. Restore goes through a (pop-suppressed) rebuild so
     /// gripper/document/palette materials come back exactly as built.
+    /// Release-to-desktop: keep the studio environment for LIGHTING only (no
+    /// skybox → the view composites transparent over the desktop) and hide the
+    /// grounding set (floor, grid, contact shadow). Window transparency is
+    /// handled by ReleaseWindowConfigurator.
+    private func applyRelease(_ content: inout RealityViewCameraContent, on: Bool) {
+        if on {
+            content.environment = .default
+        } else if let env = model.zebraMode ? Self.zebraEnvironment : Self.studioEnvironment {
+            content.environment = .skybox(env)
+        }
+        for name in ["floor", "grid", "contactShadow"] {
+            content.entities.filter { $0.name == name }.forEach { $0.isEnabled = !on }
+        }
+    }
+
     private func applyZebra(_ content: inout RealityViewCameraContent, on: Bool) {
         if on {
             if let env = Self.zebraEnvironment { content.environment = .skybox(env) }

--- a/changelog/entries/2026-07-20-release-to-desktop.json
+++ b/changelog/entries/2026-07-20-release-to-desktop.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-20-release-to-desktop",
+  "version": "0.9.4",
+  "date": "2026-07-20",
+  "category": "feat",
+  "title": "Release to Desktop mode in the macOS app",
+  "summary": "Parts float directly over the desktop with studio-parity floating tool windows: palette, object inspector, feature tree, click-to-select, zebra analysis.",
+  "features": ["native", "macos", "viewport"]
+}


### PR DESCRIPTION
## What

Adds a chromeless **Release to Desktop** mode to the native macOS app. The editor window goes transparent and the document's parts composite straight over the desktop through a borderless `ARView` overlay, ringed by Borland-C++-Builder-style floating tool windows styled to the Apple HIG. Toggle from the Document menu (*Release to Desktop* / *Return to Studio*), ⌘⇧Space, or the return pill.

## Studio parity (second commit)

The floating chrome is no longer a hand-rolled subset — it reaches feature parity with the in-studio editor:

- **Components palette driven by `model.tools(for:)`** — the same source of truth as the studio palette: Create / Modify / Combine tabs, document-aware tools (Add primitives, Sketch, modifier-on-selection, booleans), enable states and hints, plus an action cluster (Zebra, Undo/Redo, STL/USDZ export).
- **Click-to-select on desktop parts** — raycast tap selects, ⌘-tap toggles the boolean multi-selection (read from the SwiftUI gesture's `.modifiers(.command)`, not `NSEvent.modifierFlags`, which reads hardware state and misses synthetic events), empty space deselects. Selection renders as the brand-orange emissive lift.
- **Feature tree** — the studio's `FeatureTreeView` joins the chrome as a third tool window with full selection sync, visibility eyes, isolate, and context menus; the released render honors hidden/isolated parts.
- **Object Inspector** — parameter scrub, camera presets, zoom, material picker following the selected part, live measurements.
- **Zebra analysis on the desktop** — striped IBL on chromed parts with the wallpaper still visible (lighting-only environment, never a skybox).

Also: click-through (`ignoresMouseEvents` driven by scene raycast + chrome rects, so empty pixels pass to windows behind), normal window level (not always-on-top).

## The hit-test fix

The palette is a **single row**. Earlier it had been split into two rows as a workaround for a symptom that looked like "buttons past x≈360 don't respond." The real cause was not positional:

- `Button { … }.buttonStyle(.plain)` over a `.clear` background only hit-tests the **opaque pixels of its label**. Clicks in the transparent padding — especially the gap between icon and text, right where you aim — fell straight through.
- The *active* button carries a `.selection` background, making its whole frame clickable. Since the model defaults were always the active ones, exactly those buttons "worked everywhere," disguising the failure as an x-coordinate band.

Fix: `.contentShape(Rectangle())` on the label inside every plain-style button.

## Verification

Reproduced and verified headlessly via the `VCAD_RELEASE=1` + `VCAD_OPEN=<doc>` launch hooks plus synthetic clicks: sandbox and document palettes, add-primitive, tap-select highlight, tree↔viewport selection sync, eye-toggle hiding a part from the desktop render, zebra IBL, and the return round-trip. The app bundles clean (`./build-ffi.sh` → `./bundle.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)