### PR TITLE
feat(native): make Release to Desktop the default, port the studio editor into it

### DIFF
--- a/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
+++ b/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
@@ -1,5 +1,6 @@
 import AppKit
 import RealityKit
+import ScreenCaptureKit
 import SwiftUI
 
 // Release-to-desktop: RealityView's drawable on macOS always clears opaque, so
@@ -27,11 +28,22 @@ final class ReleaseWindowController {
     private var mouseMonitors: [Any] = []
     /// Set by ReleasedARView so the pass-through hit test can raycast the scene.
     weak var arView: ARView?
+    /// The kernel-space frame entity (scale + Z-up + centering applied), set by
+    /// ReleasedARView on rebuild — sketch taps convert world rays through it,
+    /// and the live sketch ink parents under it.
+    weak var centeringEntity: Entity?
+    /// Sketch mode is modal: the overlay owns the mouse everywhere, so clicks
+    /// land on the sketch plane instead of falling through to the desktop.
+    var sketchModal = false
+    /// Image-based lighting built from a snapshot of the desktop *behind* this
+    /// window, so the chrome parts reflect the actual desktop rather than an
+    /// invisible studio skybox. Rebuilt on show and whenever geometry rebuilds.
+    var desktopEnvironment: EnvironmentResource?
     /// Chrome regions (tool windows, pill) in overlay view coords (top-left
     /// origin), reported by SwiftUI — the overlay owns the mouse over these.
     var chromeRects: [String: CGRect] = [:]
 
-    func show(model: EditorModel) {
+    func show(model: EditorModel, intent: IntentEngine) {
         guard window == nil else { return }
         mainWindow = NSApp.keyWindow ?? NSApp.mainWindow
 
@@ -43,10 +55,11 @@ final class ReleaseWindowController {
         w.hasShadow = false
         w.level = .normal                       // stacks like any window, not always-on-top
         w.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
-        w.contentView = NSHostingView(rootView: ReleasedOverlayView(model: model))
+        w.contentView = NSHostingView(rootView: ReleasedOverlayView(model: model, intent: intent))
         w.makeKeyAndOrderFront(nil)
         window = w
         mainWindow?.orderOut(nil)
+        refreshDesktopEnvironment()
 
         let update: () -> Void = { [weak self] in self?.updatePassThrough() }
         if let m = NSEvent.addGlobalMonitorForEvents(matching: [.mouseMoved]) { _ in
@@ -64,6 +77,7 @@ final class ReleaseWindowController {
     private func updatePassThrough() {
         guard let w = window else { return }
         guard NSEvent.pressedMouseButtons == 0 else { return }
+        if sketchModal { w.ignoresMouseEvents = false; return }
         let winPoint = w.convertPoint(fromScreen: NSEvent.mouseLocation)
         let topLeft = CGPoint(x: winPoint.x, y: w.frame.height - winPoint.y)
         if chromeRects.values.contains(where: { $0.insetBy(dx: -8, dy: -8).contains(topLeft) }) {
@@ -80,11 +94,96 @@ final class ReleaseWindowController {
         mouseMonitors.forEach { NSEvent.removeMonitor($0) }
         mouseMonitors = []
         arView = nil
+        centeringEntity = nil
+        sketchModal = false
         chromeRects = [:]
+        desktopEnvironment = nil
         window?.orderOut(nil)
         window = nil
         mainWindow?.makeKeyAndOrderFront(nil)
         mainWindow = nil
+    }
+
+    /// Snapshot the screen *excluding* our transparent window (so the parts
+    /// aren't fed back into their own reflection) and bake it into an
+    /// equirectangular IBL. ScreenCaptureKit is async and needs Screen
+    /// Recording permission — the first release prompts for it; until granted
+    /// the capture returns nil and the chrome just falls back to default
+    /// lighting. Once the bake lands it's applied to the live ARView directly.
+    func refreshDesktopEnvironment() {
+        guard let w = window else { return }
+        let id = CGWindowID(w.windowNumber)
+        Task { @MainActor in
+            guard let shot = await Self.captureDesktop(excludingWindowID: id),
+                  let env = Self.equirectEnvironment(from: shot) else { return }
+            desktopEnvironment = env
+            if let ar = arView, !(arView?.scene.anchors.isEmpty ?? true) {
+                ar.environment.lighting.resource = env
+            }
+        }
+    }
+
+    private static func captureDesktop(excludingWindowID id: CGWindowID) async -> CGImage? {
+        guard let content = try? await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: true),
+              let display = content.displays.first else { return nil }
+        let excluded = content.windows.filter { $0.windowID == id }
+        let filter = SCContentFilter(display: display, excludingWindows: excluded)
+        let cfg = SCStreamConfiguration()
+        cfg.width = display.width
+        cfg.height = display.height
+        cfg.showsCursor = false
+        return try? await SCScreenshotManager.captureImage(
+            contentFilter: filter, configuration: cfg)
+    }
+
+    /// Wrap a flat desktop snapshot into a 2:1 equirectangular environment.
+    /// The desktop is drawn full-bleed (it's the whole visible surround) and a
+    /// vertical tonal gradient is multiplied over it — bright at the horizon,
+    /// falling off toward zenith/nadir — so reflective edges still catch a
+    /// readable highlight line instead of a flat wash, and the overall level is
+    /// pulled down so bright wallpapers don't blow out the chrome.
+    private static func equirectEnvironment(from desktop: CGImage) -> EnvironmentResource? {
+        let w = 2048, h = 1024
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
+                                  bytesPerRow: 0, space: cs,
+                                  bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else { return nil }
+        let fw = CGFloat(w), fh = CGFloat(h)
+        ctx.draw(desktop, in: CGRect(x: 0, y: 0, width: fw, height: fh))
+
+        // Pull the level down and shape it: a soft horizon-bright band keeps the
+        // metal from reading as a mirror of a too-bright screen.
+        ctx.setBlendMode(.multiply)
+        let tone = CGGradient(colorsSpace: cs, colors: [
+            CGColor(gray: 0.25, alpha: 1),   // nadir
+            CGColor(gray: 0.72, alpha: 1),
+            CGColor(gray: 0.85, alpha: 1),   // horizon — brightest
+            CGColor(gray: 0.72, alpha: 1),
+            CGColor(gray: 0.30, alpha: 1),   // zenith
+        ] as CFArray, locations: [0, 0.34, 0.5, 0.66, 1])!
+        ctx.drawLinearGradient(tone, start: CGPoint(x: 0, y: 0), end: CGPoint(x: 0, y: fh), options: [])
+
+        guard let img = ctx.makeImage() else { return nil }
+        return try? EnvironmentResource(equirectangular: img)
+    }
+}
+
+extension ReleaseWindowController {
+    /// In-place re-eval → mesh swap for the released scene (the twin of the
+    /// studio's docParamDirty path): parameter scrubs and gizmo drags update
+    /// the floating parts without a rebuild pop. Plain (non-instanced) part
+    /// entities only — instanced docs settle on the next full rebuild.
+    func refreshGeometry(model: EditorModel, collisions: Bool = true) {
+        guard let centering = centeringEntity,
+              let meshes = model.reevalDocumentMeshes() else { return }
+        for (i, m) in meshes.enumerated() {
+            if let pe = centering.findEntity(named: "part\(i)") as? ModelEntity, pe.model != nil {
+                pe.model?.mesh = m
+                if collisions { pe.generateCollisionShapes(recursive: false) }
+            }
+        }
+        model.docParamDirty = false      // consumed here; the studio view is hidden
     }
 }
 
@@ -105,13 +204,14 @@ struct ChromeRegion: ViewModifier {
 /// which re-renders this view).
 struct ReleasedOverlayView: View {
     @Bindable var model: EditorModel
+    @Bindable var intent: IntentEngine
 
     var body: some View {
         ZStack(alignment: .topLeading) {
             ReleasedARView(model: model,
                            cameraPosition: model.cameraPosition,
                            lookAt: model.panOffset,
-                           geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)|\(model.highlightedParts.sorted())|\(model.hiddenParts.sorted())|\(String(describing: model.isolatedPart))")
+                           geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)|\(model.highlightedParts.sorted())|\(model.hiddenParts.sorted())|\(String(describing: model.isolatedPart))|\(model.sketching)")
                 .ignoresSafeArea()
             // ARView consumes mouse events — capture orbit/zoom on a clear
             // layer above it instead.
@@ -123,7 +223,20 @@ struct ReleasedOverlayView: View {
                 .gesture(SpatialTapGesture(coordinateSpace: .local).modifiers(.command)
                     .onEnded { value in tapSelect(at: value.location, additive: true) })
                 .gesture(SpatialTapGesture(coordinateSpace: .local)
-                    .onEnded { value in tapSelect(at: value.location, additive: false) })
+                    .onEnded { value in
+                        if model.sketching { sketchTap(at: value.location) }
+                        else { tapSelect(at: value.location, additive: false) }
+                    })
+                .onContinuousHover(coordinateSpace: .local) { phase in
+                    guard model.sketching else { return }
+                    switch phase {
+                    case .active(let p):
+                        model.sketchCursor = sketchPlanePoint(at: p)
+                    case .ended:
+                        model.sketchCursor = nil
+                    }
+                    refreshSketchInk()
+                }
             // BCB-style tool windows, hosted in the overlay itself (separate
             // NSPanels break SwiftUI hit testing after auto-resize).
             VStack(alignment: .leading, spacing: 12) {
@@ -146,6 +259,90 @@ struct ReleasedOverlayView: View {
                 .padding(16)
                 .modifier(ChromeRegion(key: "pill"))
         }
+        .overlay(alignment: .top) {
+            // Cross-domain gripper receipt — the released twin of the studio's
+            // top-center verification pill.
+            if model.source.isGripper {
+                GripperReceiptPill(model: model)
+                    .padding(.top, 16)
+                    .modifier(ChromeRegion(key: "gripper"))
+            }
+        }
+        .overlay(alignment: .bottom) {
+            // Bottom cluster: the AI command bar (the app's spine) plus the
+            // kinematic transport when a timeline is loaded. Same views, same
+            // model/engine bindings as the studio — just floated over the desktop.
+            VStack(spacing: 10) {
+                if model.sketching {
+                    SketchHintBar(model: model)
+                        .modifier(ChromeRegion(key: "sketchHint"))
+                    SketchPaletteView(model: model)
+                        .modifier(ChromeRegion(key: "sketchPalette"))
+                } else {
+                    if model.timeline != nil {
+                        PlaybackBar(model: model)
+                            .modifier(ChromeRegion(key: "playback"))
+                    }
+                    if model.source.isSandbox && intent.draft.isEmpty && !intent.isThinking {
+                        ExampleChips(intent: intent)
+                            .modifier(ChromeRegion(key: "examples"))
+                    }
+                    ComposerBar(engine: intent, model: model)
+                        .modifier(ChromeRegion(key: "composer"))
+                }
+            }
+            .padding(.bottom, 16)
+            .animation(Motion.smooth, value: intent.draft.isEmpty)
+            .animation(Motion.smooth, value: model.timeline == nil)
+            .animation(Motion.panel, value: model.sketching)
+        }
+        .onChange(of: model.sketching) { _, on in
+            // Sketch is modal over the desktop: own the mouse everywhere while
+            // drawing, hand non-chrome/non-part mouse back when done.
+            ReleaseWindowController.shared.sketchModal = on
+            refreshSketchInk(force: true)
+        }
+        .onChange(of: model.sketchDirty) { _, dirty in
+            if dirty { refreshSketchInk() }
+        }
+    }
+
+    /// Screen point → kernel-space ray, through the ARView's native ray and
+    /// the kernel-frame (centering) entity — no hand-rolled camera math.
+    private func kernelRay(at p: CGPoint) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
+        guard let ar = ReleaseWindowController.shared.arView,
+              let centering = ReleaseWindowController.shared.centeringEntity else { return nil }
+        // SwiftUI hands us top-left-origin points; ray(through:) expects the
+        // ARView's native (unflipped AppKit, bottom-left) space — same flip the
+        // pass-through hit test does.
+        var vp = p
+        if !ar.isFlipped { vp.y = ar.bounds.height - vp.y }
+        guard let ray = ar.ray(through: vp) else { return nil }
+        let o = centering.convert(position: ray.origin, from: nil)
+        let d = normalize(centering.convert(direction: ray.direction, from: nil))
+        return (o, d)
+    }
+
+    /// Screen point → 2D sketch-plane coords.
+    private func sketchPlanePoint(at p: CGPoint) -> SIMD2<Float>? {
+        guard let ray = kernelRay(at: p) else { return nil }
+        return model.sketchPlanePoint(originKernel: ray.o, dirKernel: ray.d)
+    }
+
+    private func sketchTap(at p: CGPoint) {
+        guard let pt = sketchPlanePoint(at: p) else { return }
+        model.sketchTap(pt)
+        refreshSketchInk()
+    }
+
+    /// Rebuild the sketch ink under the kernel frame. Imperative (not keyed
+    /// through geometryKey) so a cursor move never re-tessellates the parts.
+    private func refreshSketchInk(force: Bool = false) {
+        guard force || model.sketchDirty || model.sketching else { return }
+        guard let centering = ReleaseWindowController.shared.centeringEntity else { return }
+        centering.findEntity(named: "sketchRoot")?.removeFromParent()
+        if model.sketching { centering.addChild(buildSketchRoot(model: model)) }
+        model.sketchDirty = false
     }
 
     /// Click a part to select it (⌘-click for the boolean multi-selection,
@@ -173,6 +370,27 @@ struct ReleasedOverlayView: View {
     private var orbitGesture: some Gesture {
         DragGesture(minimumDistance: 2)
             .onChanged { value in
+                if model.lastDrag == .zero && !model.draggingHandle {
+                    // A drag that starts on a gizmo handle is a part transform,
+                    // not an orbit — same split the studio's targeted gesture
+                    // makes, done here via hitTest (the clear layer owns events).
+                    if let ar = ReleaseWindowController.shared.arView,
+                       let name = ar.hitTest(value.startLocation)
+                           .first(where: { model.gizmoHandle(for: $0.entity.name) != nil })?.entity.name,
+                       let ray = kernelRay(at: value.startLocation) {
+                        model.draggingHandle = true
+                        NSCursor.closedHand.set()
+                        model.beginGizmoDrag(handle: name, ray: ray)
+                        model.lastDrag = value.translation
+                        return
+                    }
+                }
+                if model.draggingHandle {
+                    if let ray = kernelRay(at: value.location) { model.gizmoDragTo(ray: ray) }
+                    refreshDraggedGeometry(final: false)
+                    model.lastDrag = value.translation
+                    return
+                }
                 if model.lastDrag == .zero { model.beginOrbit() }
                 let dx = Float(value.translation.width - model.lastDrag.width)
                 let dy = Float(value.translation.height - model.lastDrag.height)
@@ -185,8 +403,30 @@ struct ReleasedOverlayView: View {
             }
             .onEnded { _ in
                 model.lastDrag = .zero
-                model.endOrbit()
+                if model.draggingHandle {
+                    NSCursor.arrow.set()
+                    model.draggingHandle = false
+                    model.endGizmoDrag()
+                    refreshDraggedGeometry(final: true)
+                } else {
+                    model.endOrbit()
+                }
             }
+    }
+
+    /// Live-sync the dragged part: re-evaluate the document meshes in place and
+    /// swap them into the existing entities (plain parts only), then slide the
+    /// gizmo with the part. On `final`, also regenerate collision shapes and
+    /// rebuild the gizmo at its settled center.
+    private func refreshDraggedGeometry(final: Bool) {
+        guard let centering = ReleaseWindowController.shared.centeringEntity else { return }
+        ReleaseWindowController.shared.refreshGeometry(model: model, collisions: final)
+        if final {
+            centering.findEntity(named: "gizmoRoot")?.removeFromParent()
+            if model.showsGizmo { centering.addChild(buildGizmo(model: model)) }
+        } else if let c = model.gizmoCenterKernel() {
+            centering.findEntity(named: "gizmoRoot")?.position = c + model.gizmoLiveOffset
+        }
     }
 
     private var zoomGesture: some Gesture {
@@ -226,17 +466,30 @@ struct ReleasedARView: NSViewRepresentable {
         context.coordinator.anchor = anchor
         context.coordinator.camera = camera
         rebuild(in: anchor, coordinator: context.coordinator)
+        applyLighting(ar)
         syncCamera(context.coordinator)
         return ar
+    }
+
+    /// Reflect the real desktop: use the snapshot-derived IBL as the scene
+    /// lighting (zebra still wins when curvature analysis is on). The desktop
+    /// bake is built once on show and reused — re-baking the cubemap on every
+    /// geometry edit would stutter, and the desktop is static while you model.
+    /// Re-entering release mode re-snapshots (hide() clears the bake).
+    private func applyLighting(_ ar: ARView) {
+        if model.zebraMode {
+            ar.environment.lighting.resource = ViewportView.zebraEnvironment
+        } else {
+            let ctl = ReleaseWindowController.shared
+            if ctl.desktopEnvironment == nil { ctl.refreshDesktopEnvironment() }
+            ar.environment.lighting.resource = ctl.desktopEnvironment
+        }
     }
 
     func updateNSView(_ ar: ARView, context: Context) {
         if context.coordinator.builtKey != geometryKey {
             rebuild(in: context.coordinator.anchor, coordinator: context.coordinator)
-            // Zebra in released mode: striped IBL on chrome parts, desktop
-            // still visible behind (lighting only — never a skybox).
-            ar.environment.lighting.resource =
-                model.zebraMode ? ViewportView.zebraEnvironment : nil
+            applyLighting(ar)
         }
         syncCamera(context.coordinator)
     }
@@ -256,7 +509,15 @@ struct ReleasedARView: NSViewRepresentable {
         let sceneScale = 0.6 / max(scene.size, 0.0001)
 
         let centering = Entity()
+        centering.name = "centering"
         centering.position = -scene.center
+        ReleaseWindowController.shared.centeringEntity = centering
+        // Keep the in-progress sketch ink alive across geometry rebuilds.
+        if model.sketching { centering.addChild(buildSketchRoot(model: model)) }
+        // Transform gizmo on the selected part — same shared builder as the
+        // studio; its handle proxies carry collision shapes, so the ARView
+        // hitTest (drag start + pass-through) sees them like parts.
+        if model.showsGizmo { centering.addChild(buildGizmo(model: model)) }
         for (i, item) in scene.meshes.enumerated() {
             var m = PhysicallyBasedMaterial()
             if model.zebraMode {
@@ -469,6 +730,32 @@ struct ObjectInspectorWindow: View {
                         .labelsHidden()
                         .controlSize(.small)
                         .frame(width: 150)
+                    }
+                }
+                if !model.docParameters.isEmpty {
+                    Divider().gridCellUnsizedAxes(.horizontal)
+                    // Document-level named parameters — the web app's property
+                    // panel scrub, floating over the desktop. Edits re-solve
+                    // every bound node and mesh-swap in place (no rebuild pop).
+                    ForEach(model.docParameters) { p in
+                        GridRow {
+                            Text(p.name).font(.system(size: 11)).foregroundStyle(.secondary)
+                                .help(p.description ?? p.name)
+                            if let v = p.value {
+                                ScrubField(label: "", value: v, unit: p.unit ?? "mm",
+                                           sensitivity: InspectorView.paramSensitivity(p),
+                                           minValue: p.min ?? -.greatestFiniteMagnitude) { v, s in
+                                    model.editParameter(p.name, value: v, snapshot: s)
+                                    // Collisions on typed commits / scrub start
+                                    // only — per-tick regen would stutter big docs.
+                                    ReleaseWindowController.shared.refreshGeometry(model: model, collisions: s)
+                                }
+                                .frame(width: 150)
+                            } else if let f = p.formula {
+                                Text("= \(f)").font(.system(size: 11).monospacedDigit())
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
                     }
                 }
                 Divider().gridCellUnsizedAxes(.horizontal)

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -107,7 +107,7 @@ struct EditorView: View {
                 .navigationTitle(model.documentName)
                 .onChange(of: model.releaseMode) { _, released in
                     if released {
-                        ReleaseWindowController.shared.show(model: model)
+                        ReleaseWindowController.shared.show(model: model, intent: intent)
                     } else {
                         ReleaseWindowController.shared.hide()
                     }
@@ -122,9 +122,11 @@ struct EditorView: View {
                     if let path = env["VCAD_OPEN"], !path.isEmpty {
                         model.openDocument(URL(fileURLWithPath: path))
                     }
-                    // Dev hook: VCAD_RELEASE=1 enters release-to-desktop on launch
-                    // (headless hit-test debugging without driving the menu).
-                    if env["VCAD_RELEASE"] == "1" {
+                    // Release-to-desktop is the default launch mode; VCAD_RELEASE=0
+                    // opts out (studio window on launch, handy for dev/debugging).
+                    // The 1s delay lets the window exist before the release
+                    // controller reparents it.
+                    if env["VCAD_RELEASE"] != "0" {
                         try? await Task.sleep(for: .seconds(1))
                         model.releaseMode = true
                     }
@@ -1350,7 +1352,7 @@ struct ViewportView: View {
             // way every desktop CAD tool does (zooming never balloons it).
             if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                let gizmo = root.findEntity(named: "gizmoRoot") {
-                gizmo.scale = SIMD3<Float>(repeating: gizmoScreenScale())
+                gizmo.scale = SIMD3<Float>(repeating: gizmoScreenScale(model: model))
             }
             if model.zebraDirty {
                 var mutableContent = content
@@ -1493,7 +1495,7 @@ struct ViewportView: View {
                 if let root = content.entities.first(where: { $0.name == "geomRoot" }),
                    let centering = root.findEntity(named: "centering") {
                     centering.findEntity(named: "sketchRoot")?.removeFromParent()
-                    if model.sketching { centering.addChild(buildSketchRoot()) }
+                    if model.sketching { centering.addChild(buildSketchRoot(model: model)) }
                 }
                 model.sketchDirty = false
             }
@@ -1852,7 +1854,7 @@ struct ViewportView: View {
             centering.addChild(buildCopperRoot(model.routeGripperCopper()))
         }
         if model.showsGizmo {
-            centering.addChild(buildGizmo())
+            centering.addChild(buildGizmo(model: model))
         }
 
         let zUp = Entity()
@@ -2110,15 +2112,27 @@ struct ViewportView: View {
         copperRoot.components.set(OpacityComponent(opacity: dim ? 0.3 : 1.0))
     }
 
-    // MARK: sketch preview overlay
+    // MARK: transform gizmo overlay
 
-    /// Build the in-progress sketch: committed segments + vertex dots in brand
-    /// pink, plus a cyan rubber-band from the last point / anchor to the cursor.
-    private func buildSketchRoot() -> Entity {
-        let root = Entity(); root.name = "sketchRoot"
-        let ink = NSColor(srgbRed: 0.98, green: 0.15, blue: 0.45, alpha: 1.0)   // brand pink
-        let live = NSColor(srgbRed: 0.55, green: 0.92, blue: 1.0, alpha: 1.0)   // cyan
-        let verts = model.sketchVerts
+    /// Near-black unlit material for the feature-edge overlay — reads as ink
+    /// lines over the shaded surfaces, the classic CAD look.
+    private static let edgeMaterial: UnlitMaterial = {
+        UnlitMaterial(color: NSColor(white: 0.09, alpha: 1.0))
+    }()
+}
+
+// MARK: sketch preview overlay (shared: studio viewport + released desktop)
+
+/// Build the in-progress sketch: committed segments + vertex dots in brand
+/// pink, plus a cyan rubber-band from the last point / anchor to the cursor.
+/// Shared between the studio viewport and the released-desktop ARView — both
+/// parent it under their `centering` entity, so kernel coords line up.
+@MainActor
+func buildSketchRoot(model: EditorModel) -> Entity {
+    let root = Entity(); root.name = "sketchRoot"
+    let ink = NSColor(srgbRed: 0.98, green: 0.15, blue: 0.45, alpha: 1.0)   // brand pink
+    let live = NSColor(srgbRed: 0.55, green: 0.92, blue: 1.0, alpha: 1.0)   // cyan
+    let verts = model.sketchVerts
 
         func seg(_ a2: SIMD2<Float>, _ b2: SIMD2<Float>, _ color: NSColor) {
             let a = model.sketchWorld(a2), b = model.sketchWorld(b2)
@@ -2177,47 +2191,49 @@ struct ViewportView: View {
             }
         }
         return root
-    }
+}
 
-    // MARK: transform gizmo overlay
+// MARK: transform gizmo overlay (shared: studio viewport + released desktop)
 
-    /// Near-black unlit material for the feature-edge overlay — reads as ink
-    /// lines over the shaded surfaces, the classic CAD look.
-    private static let edgeMaterial: UnlitMaterial = {
-        UnlitMaterial(color: NSColor(white: 0.09, alpha: 1.0))
-    }()
+/// Gizmo handle ink: X red / Y green / Z blue.
+enum GizmoInk {
+    static let x = NSColor(srgbRed: 0.95, green: 0.30, blue: 0.34, alpha: 1)
+    static let y = NSColor(srgbRed: 0.42, green: 0.80, blue: 0.44, alpha: 1)
+    static let z = NSColor(srgbRed: 0.32, green: 0.58, blue: 0.98, alpha: 1)
 
-    private static let gizmoX = NSColor(srgbRed: 0.95, green: 0.30, blue: 0.34, alpha: 1)
-    private static let gizmoY = NSColor(srgbRed: 0.42, green: 0.80, blue: 0.44, alpha: 1)
-    private static let gizmoZ = NSColor(srgbRed: 0.32, green: 0.58, blue: 0.98, alpha: 1)
-
-    private func brighten(_ c: NSColor) -> NSColor {
+    static func brighten(_ c: NSColor) -> NSColor {
         let s = c.usingColorSpace(.sRGB) ?? c
         return NSColor(srgbRed: min(1, s.redComponent * 1.2 + 0.18),
                        green: min(1, s.greenComponent * 1.2 + 0.18),
                        blue: min(1, s.blueComponent * 1.2 + 0.18), alpha: 1)
     }
+}
 
-    /// Scale factor that keeps the gizmo a constant fraction of the view
-    /// height: target world arm length is proportional to orbit distance, so
-    /// zooming in/out never changes its apparent size.
-    private func gizmoScreenScale() -> Float {
-        let armKernel = model.gizmoArmLength()
-        let armWorld = armKernel * model.displayScale
-        guard armWorld > 1e-6 else { return 1 }
-        return (0.14 * model.distance) / armWorld
-    }
+/// Scale factor that keeps the gizmo a constant fraction of the view
+/// height: target world arm length is proportional to orbit distance, so
+/// zooming in/out never changes its apparent size.
+@MainActor
+func gizmoScreenScale(model: EditorModel) -> Float {
+    let armKernel = model.gizmoArmLength()
+    let armWorld = armKernel * model.displayScale
+    guard armWorld > 1e-6 else { return 1 }
+    return (0.14 * model.distance) / armWorld
+}
 
-    /// A refined translate gizmo: cylinder shafts + cone arrowheads (axis drag),
-    /// corner squares (plane drag), a pearl hub, and invisible full-length grab
-    /// proxies. The hovered handle brightens + thickens. X red / Y green / Z blue.
-    private func buildGizmo() -> Entity {
-        let root = Entity(); root.name = "gizmoRoot"
-        guard let c = model.gizmoCenterKernel() else { return root }
+/// A refined translate gizmo: cylinder shafts + cone arrowheads (axis drag),
+/// corner squares (plane drag), a pearl hub, and invisible full-length grab
+/// proxies. The hovered handle brightens + thickens. X red / Y green / Z blue.
+/// Shared between the studio viewport and the released desktop — both parent
+/// it under their `centering` entity (kernel coords).
+@MainActor
+func buildGizmo(model: EditorModel) -> Entity {
+    func brighten(_ c: NSColor) -> NSColor { GizmoInk.brighten(c) }
+    let root = Entity(); root.name = "gizmoRoot"
+    guard let c = model.gizmoCenterKernel() else { return root }
         // Children live in gizmo-local coords; the root carries the center so
         // the whole gizmo can be scaled per-frame for constant screen size.
         root.position = c
-        root.scale = SIMD3<Float>(repeating: gizmoScreenScale())
+        root.scale = SIMD3<Float>(repeating: gizmoScreenScale(model: model))
         let len = model.gizmoArmLength()
         let shaftR = max(0.3, len * 0.013)
         let headLen = len * 0.2
@@ -2226,9 +2242,9 @@ struct ViewportView: View {
         let hov = model.hoveredGizmoHandle
 
         let axes: [(name: String, dir: SIMD3<Float>, color: NSColor)] = [
-            ("gizmoX", SIMD3(1, 0, 0), Self.gizmoX),
-            ("gizmoY", SIMD3(0, 1, 0), Self.gizmoY),
-            ("gizmoZ", SIMD3(0, 0, 1), Self.gizmoZ),
+            ("gizmoX", SIMD3(1, 0, 0), GizmoInk.x),
+            ("gizmoY", SIMD3(0, 1, 0), GizmoInk.y),
+            ("gizmoZ", SIMD3(0, 0, 1), GizmoInk.z),
         ]
         for a in axes {
             let on = hov == a.name
@@ -2253,9 +2269,9 @@ struct ViewportView: View {
         // Plane handles — a square in the corner of each axis pair (normal colored).
         let pOff = model.gizmoPlaneOffset, pSize = model.gizmoPlaneSize
         let planes: [(name: String, a: SIMD3<Float>, b: SIMD3<Float>, color: NSColor)] = [
-            ("planeXY", SIMD3(1, 0, 0), SIMD3(0, 1, 0), Self.gizmoZ),
-            ("planeYZ", SIMD3(0, 1, 0), SIMD3(0, 0, 1), Self.gizmoX),
-            ("planeXZ", SIMD3(1, 0, 0), SIMD3(0, 0, 1), Self.gizmoY),
+            ("planeXY", SIMD3(1, 0, 0), SIMD3(0, 1, 0), GizmoInk.z),
+            ("planeYZ", SIMD3(0, 1, 0), SIMD3(0, 0, 1), GizmoInk.x),
+            ("planeXZ", SIMD3(1, 0, 0), SIMD3(0, 0, 1), GizmoInk.y),
         ]
         for p in planes {
             let on = hov == p.name
@@ -2278,9 +2294,9 @@ struct ViewportView: View {
         let tube = max(0.25, len * 0.013)
         let segN = 40
         let rings: [(name: String, axis: SIMD3<Float>, color: NSColor)] = [
-            ("rotX", SIMD3(1, 0, 0), Self.gizmoX),
-            ("rotY", SIMD3(0, 1, 0), Self.gizmoY),
-            ("rotZ", SIMD3(0, 0, 1), Self.gizmoZ),
+            ("rotX", SIMD3(1, 0, 0), GizmoInk.x),
+            ("rotY", SIMD3(0, 1, 0), GizmoInk.y),
+            ("rotZ", SIMD3(0, 0, 1), GizmoInk.z),
         ]
         for r in rings {
             let on = hov == r.name
@@ -2308,15 +2324,16 @@ struct ViewportView: View {
 
         let hub = ModelEntity(mesh: .generateSphere(radius: shaftR * 2.4),
                               materials: [UnlitMaterial(color: NSColor(white: 0.95, alpha: 1))])
-        root.addChild(hub)
-        return root
-    }
+    root.addChild(hub)
+    return root
+}
 
+extension ViewportView {
     private func rebuildGizmo(_ content: RealityViewCameraContent) {
         guard let root = content.entities.first(where: { $0.name == "geomRoot" }),
               let centering = root.findEntity(named: "centering") else { return }
         centering.findEntity(named: "gizmoRoot")?.removeFromParent()
-        if model.showsGizmo { centering.addChild(buildGizmo()) }
+        if model.showsGizmo { centering.addChild(buildGizmo(model: model)) }
     }
 
     // MARK: pattern instancing helpers


### PR DESCRIPTION
## What

Release-to-desktop was a mode you had to opt into. It's now how the macOS app launches — and since it's the default, the released overlay had to become a *whole* editor rather than a viewer with two tool windows. This ports the rest of the studio surface into it.

**Default launch.** `VCAD_RELEASE=1` (opt in) becomes `VCAD_RELEASE=0` (opt out — studio window on launch, for dev/debugging).

**Panels ported into the floating overlay,** reusing the studio views and model bindings verbatim. Each is registered as a `ChromeRegion` so the transparent window's pass-through hit test hands it the mouse:

- AI command bar (`ComposerBar` + New/Open/Examples menu) and `ExampleChips`
- kinematic transport (`PlaybackBar`), when a timeline is loaded
- cross-domain gripper receipt pill
- sketch palette (plane · tool · depth · Extrude/Cancel) + hint bar
- document parameters in the Object Inspector

**Sketch mode** needed real interaction, not just chrome. Taps and the live cursor raycast through `ARView.ray(through:)` and convert world → kernel via the centering entity, then feed the same `sketchPlanePoint`/`sketchTap` model code the studio uses. While sketching, the overlay is modal (owns the whole screen) so clicks land on the sketch plane instead of falling through to the desktop.

**Transform gizmo** comes across the same way: a drag starting on a handle hit-tests as a transform and runs the existing `beginGizmoDrag`/`gizmoDragTo` closest-point math; anything else stays orbit/pan.

**Document parameters** scrub with the same `ScrubField` as the studio (drag to scrub, double-click to type) — edits re-solve every bound node together, formulas render read-only as `= expr`.

## Notes for review

- `buildSketchRoot` and `buildGizmo` were private to `ViewportView`; they're now shared file-scope functions taking the model, so the studio and the released desktop render identical ink/handles instead of drifting. This is the bulk of the `Shell.swift` diff — it's a move, not a rewrite.
- Live geometry updates during a scrub or gizmo drag go through a new `ReleaseWindowController.refreshGeometry`, the released twin of the studio's `docParamDirty` mesh-swap path (no rebuild pop). Collision shapes regenerate on settle, not per tick.
- `refreshGeometry` swaps meshes on plain part entities only; instanced (pattern) docs settle on the next full rebuild.
- Y-flip gotcha worth knowing about: SwiftUI hands top-left-origin points, `ar.ray(through:)` wants AppKit bottom-left. First cut of the sketch raycast was mirrored vertically until it did the same `bounds.height - y` flip the pass-through hit test does.

## Testing

Built clean (`swift build`) and verified by hand in the running app: released mode launches by default, the command bar and chips render over the desktop, an example doc loads with the gizmo on the selected part, and the parametric plate shows live `bore_d` / `depth` / `thickness` / `width` scrubs with `bore_r = bore_d / 2` following along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)