### PR TITLE
SI campaign: net-class inference, coupled diff pairs, skew tuning, vcad.si-claims receipt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6997,6 +6997,7 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.8.23",
  "vcad-ecad-package",
+ "vcad-ecad-sim",
  "vcad-ecad-symbols",
  "vcad-ir",
  "vcad-kernel-math",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7002,6 +7002,7 @@ dependencies = [
  "vcad-ir",
  "vcad-kernel-math",
  "vcad-kernel-sheet",
+ "vcad-receipt",
 ]
 
 [[package]]

--- a/crates/vcad-ecad-pcb/Cargo.toml
+++ b/crates/vcad-ecad-pcb/Cargo.toml
@@ -21,5 +21,6 @@ rayon = "1.10"
 log = "0.4"
 
 [dev-dependencies]
+vcad-ecad-sim = { path = "../vcad-ecad-sim" }
 vcad-ecad-symbols = { workspace = true }
 env_logger = "0.11"

--- a/crates/vcad-ecad-pcb/Cargo.toml
+++ b/crates/vcad-ecad-pcb/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
+vcad-receipt = { workspace = true }
 vcad-ir = { workspace = true }
 vcad-ecad-package = { workspace = true }
 vcad-kernel-math = { workspace = true }

--- a/crates/vcad-ecad-pcb/examples/cm5_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_bench.rs
@@ -17,6 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
 use vcad_ecad_pcb::router::classes::{apply_classes, classify_nets};
+use vcad_ecad_pcb::router::length_match::net_routed_length;
 use vcad_ecad_pcb::router::{route_all_with_opts, RouteOptions};
 use vcad_ecad_symbols::parse_kicad_pcb;
 use vcad_ir::ecad::{Trace, Via};
@@ -181,6 +182,54 @@ fn main() {
     );
     for d in r.diagnostics.iter().take(10) {
         eprintln!("unrouted {}: {}", d.net, d.reason);
+    }
+
+    // SI scoreboard: skew per length-match group and per differential pair,
+    // measured on the routed copper. This is the gap the meander tuner must
+    // close — and the number the human board is matched to within microns.
+    {
+        let mut with_routes = pcb.clone();
+        for t in &r.traces {
+            with_routes.traces.push(Trace {
+                start: t.start,
+                end: t.end,
+                width: t.width,
+                layer: t.layer,
+                net: t.net.clone(),
+                source: None,
+            });
+        }
+        for (gname, members) in &classifier.match_groups {
+            let lens: Vec<(f64, &str)> = members
+                .iter()
+                .map(|n| (net_routed_length(&with_routes, n), n.as_str()))
+                .filter(|(l, _)| *l > 0.0)
+                .collect();
+            if lens.len() > 1 {
+                let max = lens.iter().map(|(l, _)| *l).fold(f64::MIN, f64::max);
+                let min = lens.iter().map(|(l, _)| *l).fold(f64::MAX, f64::min);
+                println!(
+                    "si-skew group {gname}: {} nets, {:.2}..{:.2} mm, skew {:.2} mm",
+                    lens.len(),
+                    min,
+                    max,
+                    max - min
+                );
+            }
+        }
+        let mut pair_worst: f64 = 0.0;
+        let mut pair_measured = 0usize;
+        for (p, n) in &classifier.pairs {
+            let (lp, ln) = (
+                net_routed_length(&with_routes, p),
+                net_routed_length(&with_routes, n),
+            );
+            if lp > 0.0 && ln > 0.0 {
+                pair_measured += 1;
+                pair_worst = pair_worst.max((lp - ln).abs());
+            }
+        }
+        println!("si-skew pairs: {pair_measured} measured, worst intra-pair {pair_worst:.3} mm");
     }
 
     // Save the routed board for rendering / inspection without re-routing.

--- a/crates/vcad-ecad-pcb/examples/cm5_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_bench.rs
@@ -16,6 +16,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Instant;
 
+use vcad_ecad_pcb::router::classes::{apply_classes, classify_nets};
 use vcad_ecad_pcb::router::{route_all_with_opts, RouteOptions};
 use vcad_ecad_symbols::parse_kicad_pcb;
 use vcad_ir::ecad::{Trace, Via};
@@ -115,6 +116,29 @@ fn main() {
             .map(|(n, _)| n.to_string())
             .collect()
     };
+
+    // Recover electrical intent from net names (diff pairs, match groups)
+    // and realize it as class rules — the SI constraint foundation.
+    let all_nets: Vec<String> = {
+        let mut v: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for f in &pcb.footprints {
+            for pad in &f.pads {
+                if let Some(n) = &pad.net {
+                    if !n.is_empty() {
+                        v.insert(n.clone());
+                    }
+                }
+            }
+        }
+        v.into_iter().collect()
+    };
+    let classifier = classify_nets(&all_nets);
+    apply_classes(&mut pcb, &classifier);
+    println!(
+        "classes: {} diff pairs, {} match groups",
+        classifier.pairs.len(),
+        classifier.match_groups.len()
+    );
 
     let width = pcb.rules.default_rules.trace_width;
     let t0 = Instant::now();

--- a/crates/vcad-ecad-pcb/examples/si_polish.rs
+++ b/crates/vcad-ecad-pcb/examples/si_polish.rs
@@ -1,0 +1,46 @@
+//! Pair polish: rip each still-uncoupled differential pair off a finished
+//! board and re-route it coupled against the settled copper. Strictly
+//! non-regressive per pair (failure restores the original copper).
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example si_polish -- in.pcb.json out.pcb.json [expansions]
+//! ```
+
+use vcad_ecad_pcb::router::classes::{apply_classes, classify_nets};
+use vcad_ecad_pcb::router::polish_pairs;
+use vcad_ir::ecad::Pcb;
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format_timestamp_millis()
+        .init();
+    let mut args = std::env::args().skip(1);
+    let input = args.next().expect("usage: si_polish <in> <out> [exp]");
+    let output = args.next().expect("usage: si_polish <in> <out> [exp]");
+    let expansions: usize = args
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2_000_000);
+
+    let mut pcb: Pcb =
+        serde_json::from_str(&std::fs::read_to_string(&input).expect("read")).expect("parse");
+    let nets: Vec<String> = {
+        let mut v: std::collections::BTreeSet<String> = Default::default();
+        for f in &pcb.footprints {
+            for pad in &f.pads {
+                if let Some(n) = &pad.net {
+                    if !n.is_empty() {
+                        v.insert(n.clone());
+                    }
+                }
+            }
+        }
+        v.into_iter().collect()
+    };
+    let classifier = classify_nets(&nets);
+    apply_classes(&mut pcb, &classifier);
+    let (polished, attempted) = polish_pairs(&mut pcb, expansions);
+    println!("pair-polish: {polished}/{attempted} uncoupled pairs re-routed coupled");
+    std::fs::write(&output, serde_json::to_string(&pcb).expect("serialize")).expect("write");
+    eprintln!("wrote {output}");
+}

--- a/crates/vcad-ecad-pcb/examples/si_report.rs
+++ b/crates/vcad-ecad-pcb/examples/si_report.rs
@@ -9,6 +9,7 @@
 
 use vcad_ecad_pcb::router::classes::classify_nets;
 use vcad_ecad_pcb::router::length_match::net_routed_length;
+use vcad_ecad_pcb::router::si_claims::{si_claims, SiBounds};
 use vcad_ecad_symbols::parse_kicad_pcb;
 use vcad_ir::ecad::Pcb;
 
@@ -175,5 +176,29 @@ fn main() {
     println!(
         "pairs: {measured} measured, worst intra-pair skew {:.3} mm ({})",
         worst.0, worst.1
+    );
+
+    // The claim set: the machine-checkable verdict this whole report exists
+    // to feed. Bounds = the human CM5 envelope.
+    let set = si_claims(&pcb, &c, &SiBounds::default());
+    println!("\nvcad.si-claims/1 (bounds = human CM5 envelope):");
+    for cl in &set.claims {
+        println!(
+            "  {} {}: {:.3} {} (bound {:.3}) — {}",
+            if cl.holds { "HOLDS " } else { "BROKEN" },
+            cl.name,
+            cl.value,
+            cl.unit,
+            cl.bound,
+            cl.note
+        );
+    }
+    println!(
+        "verdict: {}",
+        if set.all_hold {
+            "ALL HOLD"
+        } else {
+            "NOT ALL HOLD"
+        }
     );
 }

--- a/crates/vcad-ecad-pcb/examples/si_report.rs
+++ b/crates/vcad-ecad-pcb/examples/si_report.rs
@@ -1,0 +1,76 @@
+//! SI report: classify a board's nets (pairs + match groups) and print the
+//! routed-length skew tables — for any board, imported `.kicad_pcb` or saved
+//! `.pcb.json`. Run it on the human-routed CM5 to get the ground-truth skew
+//! discipline our tuner must reach; run it on an autorouted board to score.
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example si_report -- board.kicad_pcb
+//! ```
+
+use vcad_ecad_pcb::router::classes::classify_nets;
+use vcad_ecad_pcb::router::length_match::net_routed_length;
+use vcad_ecad_symbols::parse_kicad_pcb;
+use vcad_ir::ecad::Pcb;
+
+fn main() {
+    let path = std::env::args().nth(1).expect("usage: si_report <board>");
+    let text = std::fs::read_to_string(&path).expect("read board");
+    let pcb: Pcb = if path.ends_with(".json") {
+        serde_json::from_str(&text).expect("parse pcb json")
+    } else {
+        parse_kicad_pcb(&text).expect("parse kicad_pcb")
+    };
+
+    let nets: Vec<String> = {
+        let mut v: std::collections::BTreeSet<String> = Default::default();
+        for f in &pcb.footprints {
+            for pad in &f.pads {
+                if let Some(n) = &pad.net {
+                    if !n.is_empty() {
+                        v.insert(n.clone());
+                    }
+                }
+            }
+        }
+        v.into_iter().collect()
+    };
+    let c = classify_nets(&nets);
+    println!(
+        "classes: {} pairs, {} groups",
+        c.pairs.len(),
+        c.match_groups.len()
+    );
+
+    for (gname, members) in &c.match_groups {
+        let lens: Vec<(f64, &str)> = members
+            .iter()
+            .map(|n| (net_routed_length(&pcb, n), n.as_str()))
+            .filter(|(l, _)| *l > 0.0)
+            .collect();
+        if lens.len() > 1 {
+            let max = lens.iter().map(|(l, _)| *l).fold(f64::MIN, f64::max);
+            let min = lens.iter().map(|(l, _)| *l).fold(f64::MAX, f64::min);
+            println!(
+                "group {gname}: {} nets, {min:.2}..{max:.2} mm, skew {:.2} mm",
+                lens.len(),
+                max - min
+            );
+        }
+    }
+    let mut worst: (f64, String) = (0.0, String::new());
+    let mut measured = 0usize;
+    for (p, n) in &c.pairs {
+        let (lp, ln) = (net_routed_length(&pcb, p), net_routed_length(&pcb, n));
+        if lp > 0.0 && ln > 0.0 {
+            measured += 1;
+            let skew = (lp - ln).abs();
+            if skew > worst.0 {
+                worst = (skew, p.clone());
+            }
+        }
+    }
+    println!(
+        "pairs: {measured} measured, worst intra-pair skew {:.3} mm ({})",
+        worst.0, worst.1
+    );
+}

--- a/crates/vcad-ecad-pcb/examples/si_report.rs
+++ b/crates/vcad-ecad-pcb/examples/si_report.rs
@@ -117,6 +117,49 @@ fn main() {
         }
     }
 
+    // Impedance geometry: differential Z of the declared pair class (w, gap)
+    // on each copper layer, from the imported physical stackup. Outer layers
+    // model as microstrip (reference = first inner plane), inner layers as
+    // stripline. This is the task-24 seam: the numbers that decide per-layer
+    // width/gap overrides for a 90/100 ohm target.
+    {
+        use vcad_ecad_sim::impedance::{diff_microstrip_impedance, diff_stripline_impedance};
+        let dp_w = pcb.rules.default_rules.diff_pair_width.unwrap_or(0.2);
+        let dp_gap = pcb.rules.default_rules.diff_pair_gap.unwrap_or(0.25);
+        let coppers: Vec<&vcad_ir::ecad::StackupLayer> = pcb
+            .stackup
+            .layers
+            .iter()
+            .filter(|l| l.layer.is_copper())
+            .collect();
+        let n = coppers.len();
+        for (i, sl) in coppers.iter().enumerate() {
+            let t = sl.copper_thickness.unwrap_or(0.035);
+            let er = sl.dielectric_er.unwrap_or(4.5);
+            // Height to the adjacent copper (the reference in a dense stack).
+            let h = if i + 1 < n {
+                coppers[i + 1]
+                    .dielectric_thickness
+                    .or(sl.dielectric_thickness)
+            } else {
+                sl.dielectric_thickness
+            }
+            .unwrap_or(0.1);
+            let outer = i == 0 || i + 1 == n;
+            let zdiff = if outer {
+                diff_microstrip_impedance(dp_w, dp_gap, t, h, er)
+            } else {
+                diff_stripline_impedance(dp_w, dp_gap, t, 2.0 * h, er)
+            };
+            println!(
+                "impedance {:?}: pair w={dp_w} gap={dp_gap} -> Zdiff {:.0} ohm ({})",
+                sl.layer,
+                zdiff,
+                if outer { "microstrip" } else { "stripline" }
+            );
+        }
+    }
+
     let mut worst: (f64, String) = (0.0, String::new());
     let mut measured = 0usize;
     for (p, n) in &c.pairs {

--- a/crates/vcad-ecad-pcb/examples/si_report.rs
+++ b/crates/vcad-ecad-pcb/examples/si_report.rs
@@ -9,7 +9,7 @@
 
 use vcad_ecad_pcb::router::classes::classify_nets;
 use vcad_ecad_pcb::router::length_match::net_routed_length;
-use vcad_ecad_pcb::router::si_claims::{si_claims, SiBounds};
+use vcad_ecad_pcb::router::si_claims::{si_claims, to_receipt_claims, SiBounds};
 use vcad_ecad_symbols::parse_kicad_pcb;
 use vcad_ir::ecad::Pcb;
 
@@ -201,4 +201,15 @@ fn main() {
             "NOT ALL HOLD"
         }
     );
+
+    // Optional second arg: write the unified DesignReceipt JSON.
+    if let Some(out) = std::env::args().nth(2) {
+        let receipt = vcad_receipt::DesignReceipt::with_claims(to_receipt_claims(&set));
+        std::fs::write(
+            &out,
+            serde_json::to_string_pretty(&receipt).expect("serialize"),
+        )
+        .expect("write receipt");
+        eprintln!("wrote {out} (verdict: {:?})", receipt.verdict());
+    }
 }

--- a/crates/vcad-ecad-pcb/examples/si_report.rs
+++ b/crates/vcad-ecad-pcb/examples/si_report.rs
@@ -57,6 +57,66 @@ fn main() {
             );
         }
     }
+    // Reference-plane discipline: which copper layers hold a large zone
+    // (plane), and for each SI-class net, how much of its length rides a
+    // layer ADJACENT (stackup-neighbouring) to a plane — the return-path
+    // metric — plus its via count (each via is a reference change).
+    {
+        let mut plane_pos: std::collections::BTreeSet<u8> = Default::default();
+        for z in &pcb.zones {
+            let area = {
+                let v = &z.outline;
+                let mut a = 0.0;
+                for i in 0..v.len() {
+                    let j = (i + 1) % v.len();
+                    a += v[i].x * v[j].y - v[j].x * v[i].y;
+                }
+                (a / 2.0).abs()
+            };
+            if area > 100.0 {
+                if let Some(pz) = z.layer.copper_position() {
+                    plane_pos.insert(pz);
+                }
+            }
+        }
+        let referenced = |pos: u8| {
+            plane_pos.contains(&pos)
+                || (pos > 0 && plane_pos.contains(&(pos - 1)))
+                || plane_pos.contains(&(pos + 1))
+        };
+        let si_nets: Vec<&String> = c.pairs.iter().flat_map(|(p, n)| [p, n]).collect();
+        let (mut ref_len, mut tot_len) = (0.0f64, 0.0f64);
+        let mut vias = 0usize;
+        let mut worst_net = (1.0f64, String::new());
+        for net in &si_nets {
+            let (mut r, mut t) = (0.0f64, 0.0f64);
+            for tr in pcb.traces.iter().filter(|t| &t.net == *net) {
+                let l = (tr.end - tr.start).length();
+                t += l;
+                if tr.layer.copper_position().map(referenced).unwrap_or(false) {
+                    r += l;
+                }
+            }
+            vias += pcb.vias.iter().filter(|v| &v.net == *net).count();
+            ref_len += r;
+            tot_len += t;
+            if t > 0.0 && r / t < worst_net.0 {
+                worst_net = (r / t, (*net).clone());
+            }
+        }
+        if tot_len > 0.0 {
+            println!(
+                "plane-discipline: {} plane layers; SI nets {:.1}% plane-referenced, {} vias across {} nets, worst {:.0}% ({})",
+                plane_pos.len(),
+                100.0 * ref_len / tot_len,
+                vias,
+                si_nets.len(),
+                100.0 * worst_net.0,
+                worst_net.1
+            );
+        }
+    }
+
     let mut worst: (f64, String) = (0.0, String::new());
     let mut measured = 0usize;
     for (p, n) in &c.pairs {

--- a/crates/vcad-ecad-pcb/examples/si_tune.rs
+++ b/crates/vcad-ecad-pcb/examples/si_tune.rs
@@ -1,0 +1,81 @@
+//! SI tuner: close length-match skew on a routed board. Classifies nets
+//! (pairs + match groups), grows short members with clearance-checked
+//! meanders on their longest single-layer run, and saves the tuned board.
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example si_tune -- in.pcb.json out.pcb.json
+//! ```
+
+use vcad_ecad_pcb::router::classes::classify_nets;
+use vcad_ecad_pcb::router::length_match::{match_lengths_runs, LengthMatchOptions};
+use vcad_ir::ecad::Pcb;
+
+fn tune_group(pcb: &mut Pcb, label: &str, nets: &[String], tolerance: f64) {
+    let opts = LengthMatchOptions {
+        tolerance,
+        ..Default::default()
+    };
+    let r = match_lengths_runs(pcb, nets, &opts);
+    let (mut tuned, mut skipped) = (0usize, 0usize);
+    for n in &r.nets {
+        if n.tuned {
+            tuned += 1;
+            pcb.traces.retain(|t| t.net != n.net);
+            pcb.traces.extend(n.new_traces.iter().cloned());
+        } else if n.skip_reason.is_some() {
+            skipped += 1;
+        }
+    }
+    println!(
+        "tune {label}: target {:.2} mm, tuned {tuned}, skipped {skipped}, all_matched={}",
+        r.target_length, r.all_matched
+    );
+    for n in r.nets.iter().filter(|n| !n.matched) {
+        println!(
+            "  unmatched {}: {:.2} -> {:.2} mm ({})",
+            n.net,
+            n.length_before,
+            n.length_after,
+            n.skip_reason.as_deref().unwrap_or("meander fell short")
+        );
+    }
+}
+
+fn main() {
+    env_logger::init();
+    let mut args = std::env::args().skip(1);
+    let (Some(input), Some(output)) = (args.next(), args.next()) else {
+        eprintln!("usage: si_tune <in.pcb.json> <out.pcb.json>");
+        std::process::exit(2);
+    };
+    let mut pcb: Pcb =
+        serde_json::from_str(&std::fs::read_to_string(&input).expect("read")).expect("parse");
+
+    let nets: Vec<String> = {
+        let mut v: std::collections::BTreeSet<String> = Default::default();
+        for f in &pcb.footprints {
+            for pad in &f.pads {
+                if let Some(n) = &pad.net {
+                    if !n.is_empty() {
+                        v.insert(n.clone());
+                    }
+                }
+            }
+        }
+        v.into_iter().collect()
+    };
+    let c = classify_nets(&nets);
+
+    // Bus groups first (coarser tolerance — the human board's own raw-skew
+    // discipline), then pairs at tight intra-pair tolerance: pair legs also
+    // sit in no bus group, so the two passes never fight.
+    for (gname, members) in &c.match_groups {
+        tune_group(&mut pcb, gname, members, 1.0);
+    }
+    for (p, n) in &c.pairs {
+        tune_group(&mut pcb, &format!("pair {p}"), &[p.clone(), n.clone()], 0.1);
+    }
+
+    std::fs::write(&output, serde_json::to_string(&pcb).expect("serialize")).expect("write");
+    eprintln!("wrote {output}");
+}

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -748,11 +748,25 @@ fn route_pass(
             // corridor slack route on the emptiest board; flexible nets
             // route around them. Priority nets stay in front; constraint
             // degree breaks residual ties; length breaks the rest.
+            // Pair legs rank ahead of singles: a coupled phantom needs a
+            // corridor 4-6 tracks wide, which only exists on an empty board —
+            // singles thread around committed pairs far better than pairs
+            // thread around committed singles (si4: 27/49 coupled, every
+            // failure a phantom-search bail against single-net congestion).
+            let pair_nets: std::collections::BTreeSet<&str> = pcb
+                .rules
+                .net_class_assignments
+                .get(super::classes::DIFF_PAIR_CLASS)
+                .map(|v| v.iter().map(|s| s.as_str()).collect())
+                .unwrap_or_default();
             let mut order: Vec<usize> = (0..conns.len()).collect();
             order.sort_by(|&a, &b| {
                 let pa = opts_priority.contains(&conns[a].0);
                 let pb = opts_priority.contains(&conns[b].0);
+                let qa = pair_nets.contains(conns[a].0.as_str());
+                let qb = pair_nets.contains(conns[b].0.as_str());
                 pb.cmp(&pa)
+                    .then_with(|| qb.cmp(&qa))
                     .then_with(|| {
                         scarcity[a]
                             .min_residual

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1490,13 +1490,16 @@ pub(super) fn validate_and_commit(
             b: *b,
             half_w: hw,
         };
-        if !session.probe(&seg, *l, net, clearance).legal {
+        let pr = session.probe(&seg, *l, net, clearance);
+        if !pr.legal {
             log::debug!(
-                "validate: {net} segment ({:.2},{:.2})->({:.2},{:.2}) {l:?} w={w} illegal",
+                "validate: {net} segment ({:.2},{:.2})->({:.2},{:.2}) {l:?} w={w} illegal — blocker {} at {:.3}mm",
                 a.x,
                 a.y,
                 b.x,
-                b.y
+                b.y,
+                pr.blockers.first().map(|b| b.net.as_str()).unwrap_or("?"),
+                pr.min_clearance
             );
             return None;
         }

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -780,14 +780,18 @@ fn route_pass(
         .get(super::classes::DIFF_PAIR_CLASS)
         .map(|v| v.iter().map(|s| s.as_str()).collect())
         .unwrap_or_default();
-    let mut conns = conns;
     if !pair_nets.is_empty() {
         let mut routed_pairs: std::collections::BTreeSet<String> = Default::default();
         let mut deferred = Vec::with_capacity(conns.len());
         let mut coupled = 0usize;
         for (net, from, to) in std::mem::take(&mut conns) {
-            let base = super::pair::pair_partner(&net)
-                .map(|p| if p < net { format!("{p}|{net}") } else { format!("{net}|{p}") });
+            let base = super::pair::pair_partner(&net).map(|p| {
+                if p < net {
+                    format!("{p}|{net}")
+                } else {
+                    format!("{net}|{p}")
+                }
+            });
             let done = base.as_ref().is_some_and(|b| routed_pairs.contains(b));
             if !done && pair_nets.contains(net.as_str()) {
                 if let Some((mine, theirs)) = super::pair::try_route_pair(

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1491,6 +1491,13 @@ pub(super) fn validate_and_commit(
             half_w: hw,
         };
         if !session.probe(&seg, *l, net, clearance).legal {
+            log::debug!(
+                "validate: {net} segment ({:.2},{:.2})->({:.2},{:.2}) {l:?} w={w} illegal",
+                a.x,
+                a.y,
+                b.x,
+                b.y
+            );
             return None;
         }
     }
@@ -1541,6 +1548,11 @@ pub(super) fn validate_and_commit(
             .iter()
             .all(|&l| session.probe(&disc, l, net, clearance).legal);
         if !legal {
+            log::debug!(
+                "validate: {net} via ({:.2},{:.2}) {la:?}..{lb:?} illegal",
+                p.x,
+                p.y
+            );
             return None;
         }
         new_vias.push((p, la, lb));

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1512,6 +1512,7 @@ pub(super) fn validate_and_commit(
             half_w: thin_hw,
         };
         if !session.probe(&seg, *l, net, clearance).legal {
+            log::debug!("validate: {net} THIN segment illegal");
             return None;
         }
     }
@@ -1547,14 +1548,25 @@ pub(super) fn validate_and_commit(
             center: p,
             r: via_r,
         };
-        let legal = span_slice(la, lb)
-            .iter()
-            .all(|&l| session.probe(&disc, l, net, clearance).legal);
-        if !legal {
+        let mut bad: Option<(PcbLayer, String, f64)> = None;
+        for &l in span_slice(la, lb) {
+            let pr = session.probe(&disc, l, net, clearance);
+            if !pr.legal {
+                bad = Some((
+                    l,
+                    pr.blockers
+                        .first()
+                        .map(|b| b.net.clone())
+                        .unwrap_or_default(),
+                    pr.min_clearance,
+                ));
+                break;
+            }
+        }
+        if let Some((l, bnet, d)) = bad {
             log::debug!(
-                "validate: {net} via ({:.2},{:.2}) {la:?}..{lb:?} illegal",
-                p.x,
-                p.y
+                "validate: {net} via ({:.3},{:.3}) {la:?}..{lb:?} illegal on {l:?} — blocker {bnet} at {d:.3}mm",
+                p.x, p.y
             );
             return None;
         }

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -768,6 +768,56 @@ fn route_pass(
         }
     };
 
+    // Pair-first stage: differential-pair legs route FIRST and COUPLED, on
+    // the emptiest board — the anti-pattern proven by the CM5 campaign was
+    // pairs entering the batch as independent singles and the pair stage
+    // firing only as a rescue. Membership comes from the declared diff-pair
+    // class (see router::classes). A pair that fails coupled routing falls
+    // back into the batch as singles, so routability can never regress.
+    let pair_nets: std::collections::BTreeSet<&str> = pcb
+        .rules
+        .net_class_assignments
+        .get(super::classes::DIFF_PAIR_CLASS)
+        .map(|v| v.iter().map(|s| s.as_str()).collect())
+        .unwrap_or_default();
+    let mut conns = conns;
+    if !pair_nets.is_empty() {
+        let mut routed_pairs: std::collections::BTreeSet<String> = Default::default();
+        let mut deferred = Vec::with_capacity(conns.len());
+        let mut coupled = 0usize;
+        for (net, from, to) in std::mem::take(&mut conns) {
+            let base = super::pair::pair_partner(&net)
+                .map(|p| if p < net { format!("{p}|{net}") } else { format!("{net}|{p}") });
+            let done = base.as_ref().is_some_and(|b| routed_pairs.contains(b));
+            if !done && pair_nets.contains(net.as_str()) {
+                if let Some((mine, theirs)) = super::pair::try_route_pair(
+                    &mut session,
+                    pcb,
+                    width,
+                    &net,
+                    from,
+                    to,
+                    &mut placed,
+                    cong,
+                    max_expansions,
+                ) {
+                    placed.push(mine);
+                    placed.push(theirs);
+                    coupled += 1;
+                    if let Some(b) = base {
+                        routed_pairs.insert(b);
+                    }
+                    continue;
+                }
+            }
+            deferred.push((net, from, to));
+        }
+        conns = deferred;
+        if coupled > 0 {
+            log::info!("pair-first: {coupled} pairs routed coupled");
+        }
+    }
+
     let unrouted_conns = route_batch(
         &mut session,
         pcb,

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -2403,14 +2403,18 @@ fn reroute_victims_with_restore(
     ) {
         let restored = originals
             .remove(&conn_key(&net, from, to))
-            .filter(|orig| orig.stubs.is_empty())
             .and_then(|orig| {
+                // Stub-carrying routes (fan-out dog-bones, pair connectors)
+                // restore through the thin channel — before it existed they
+                // were dropped as unrouted, and once pair routes made stubs
+                // common the rip-up loop bled routes every round (si3: round
+                // 0 record 509, then pending exploded 56→124).
                 validate_and_commit(
                     session,
                     pcb,
                     Candidate {
-                        thin_segments: vec![],
-                        thin_width: orig.width,
+                        thin_segments: orig.stubs.clone(),
+                        thin_width: orig.stub_width,
                         net: orig.net.clone(),
                         from: orig.from,
                         to: orig.to,

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -917,7 +917,10 @@ fn incremental_round(
     // Search-only (no rescue arsenal) and hard-budgeted: this round is
     // speculative — keep-best discards it unless it beats the snapshot, so
     // it must be cheap. The arsenal fires where results stick.
-    let budget_ms = 1_200_000.0 * (max_expansions as f64 / 200_000.0).max(1.0);
+    // Flat 20-minute budget regardless of effort: scaling by expansion
+    // budget multiplied speculative-round cost right back up at high effort
+    // (effort 10 → 3.3h/round), exactly what the budget exists to prevent.
+    let budget_ms = 1_200_000.0;
     let pending = ripup_pass(
         &mut session,
         pcb,

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -248,6 +248,9 @@ pub(super) struct Placed {
     /// Fan-out / dog-bone stubs that escape a fine-pitch pad to its via, each on
     /// its own copper layer (the pad's layer). Emitted as traces, not on `layer`.
     pub(super) stubs: Vec<(Vec2, Vec2, PcbLayer)>,
+    /// Width the stubs were committed at (fan-out: the net width; pair
+    /// connectors: the board default — the neck-down width).
+    pub(super) stub_width: f64,
     pub(super) via_pts: Vec<(Vec2, PcbLayer, PcbLayer)>,
     pub(super) spans: Vec<SpanId>,
 }
@@ -471,7 +474,7 @@ pub fn route_all_with_opts(
             traces.push(RoutedTrace {
                 start: *a,
                 end: *b,
-                width: p.width,
+                width: p.stub_width,
                 layer: *l,
                 net: p.net.clone(),
             });
@@ -1310,6 +1313,12 @@ pub(super) struct Candidate {
     pub(super) width: f64,
     pub(super) segments: Vec<(Vec2, Vec2, PcbLayer)>,
     pub(super) vias: Vec<(Vec2, PcbLayer, PcbLayer)>,
+    /// Segments probed and committed at [`Candidate::thin_width`] instead of
+    /// `width` — the neck-down channel (pair connectors through pin fields).
+    /// They land in [`Placed::stubs`].
+    pub(super) thin_segments: Vec<(Vec2, Vec2, PcbLayer)>,
+    /// Width for `thin_segments` (defaults to `width` when unused).
+    pub(super) thin_width: f64,
 }
 
 /// The pure-search half of [`try_route`]: find a clearance-legal route
@@ -1404,6 +1413,8 @@ pub(super) fn search_route(
         // every resume because the ratsnest keys completion off traces).
         log::debug!("{net}: connection already satisfied by existing copper contact");
         return Some(Candidate {
+            thin_segments: vec![],
+            thin_width: width,
             net: net.to_string(),
             from,
             to,
@@ -1443,6 +1454,8 @@ pub(super) fn search_route(
     };
 
     Some(Candidate {
+        thin_segments: vec![],
+        thin_width: width,
         net: net.to_string(),
         from,
         to,
@@ -1476,6 +1489,17 @@ pub(super) fn validate_and_commit(
             a: *a,
             b: *b,
             half_w: hw,
+        };
+        if !session.probe(&seg, *l, net, clearance).legal {
+            return None;
+        }
+    }
+    let thin_hw = cand.thin_width / 2.0;
+    for (a, b, l) in &cand.thin_segments {
+        let seg = CopperGeom::Segment {
+            a: *a,
+            b: *b,
+            half_w: thin_hw,
         };
         if !session.probe(&seg, *l, net, clearance).legal {
             return None;
@@ -1526,6 +1550,9 @@ pub(super) fn validate_and_commit(
     for (a, b, l) in &segments {
         spans.push(commit_seg(session, net, *a, *b, hw, *l));
     }
+    for (a, b, l) in &cand.thin_segments {
+        spans.push(commit_seg(session, net, *a, *b, thin_hw, *l));
+    }
     for &(p, la, lb) in &new_vias {
         commit_via(session, net, p, via_r, span_slice(la, lb), &mut spans);
     }
@@ -1535,7 +1562,8 @@ pub(super) fn validate_and_commit(
         to: cand.to,
         width: w,
         segments,
-        stubs: Vec::new(),
+        stubs: cand.thin_segments,
+        stub_width: cand.thin_width,
         via_pts: new_vias,
         spans,
     })
@@ -1822,6 +1850,7 @@ fn try_route_fanout(
         width: w,
         segments: rb.segments.into_iter().map(|(a, b)| (a, b, back)).collect(),
         stubs,
+        stub_width: w,
         via_pts: via_pts.into_iter().map(|v| (v, front, back)).collect(),
         spans,
     })
@@ -2353,6 +2382,8 @@ fn reroute_victims_with_restore(
                     session,
                     pcb,
                     Candidate {
+                        thin_segments: vec![],
+                        thin_width: orig.width,
                         net: orig.net.clone(),
                         from: orig.from,
                         to: orig.to,
@@ -2543,6 +2574,8 @@ fn joint_window_repair(
                                     }
                                 }
                                 let cand = Candidate {
+                                    thin_segments: vec![],
+                                    thin_width: session.width_for(&conn.0, width),
                                     net: conn.0.clone(),
                                     from: conn.1,
                                     to: conn.2,
@@ -3703,6 +3736,7 @@ mod tests {
             width: 0.25,
             segments,
             stubs: Vec::new(),
+            stub_width: 0.25,
             via_pts: Vec::new(),
             spans,
         }];

--- a/crates/vcad-ecad-pcb/src/router/classes.rs
+++ b/crates/vcad-ecad-pcb/src/router/classes.rs
@@ -131,7 +131,14 @@ pub fn apply_classes(pcb: &mut Pcb, classifier: &NetClassifier) {
         return;
     }
     let d = &pcb.rules.default_rules;
-    let dp_width = d.diff_pair_width.unwrap_or(d.trace_width);
+    // Boards imported without net-class geometry (calibrated .kicad_pcb —
+    // classes live in the .kicad_pro that never ships with it) get the
+    // CM5-class defaults: 0.2 mm legs, 0.25 mm gap — the values the CM5's
+    // own project file declares, and a typical 90-100 ohm pair on this
+    // stackup family. Without this, pair_geometry silently fell back to
+    // single-ended width and 1.5x clearance for EVERY pair.
+    let dp_width = d.diff_pair_width.unwrap_or(0.2);
+    let dp_gap = d.diff_pair_gap.unwrap_or(0.25);
     let rule = NetClassRules {
         name: DIFF_PAIR_CLASS.to_string(),
         trace_width: dp_width,
@@ -141,8 +148,8 @@ pub fn apply_classes(pcb: &mut Pcb, classifier: &NetClassifier) {
         // the modal microvia).
         via_diameter: d.via_diameter,
         via_drill: d.via_drill,
-        diff_pair_gap: d.diff_pair_gap,
-        diff_pair_width: d.diff_pair_width,
+        diff_pair_gap: Some(dp_gap),
+        diff_pair_width: Some(dp_width),
     };
     match pcb
         .rules

--- a/crates/vcad-ecad-pcb/src/router/classes.rs
+++ b/crates/vcad-ecad-pcb/src/router/classes.rs
@@ -1,0 +1,244 @@
+//! Net-class inference and application — the constraint foundation for
+//! signal-integrity routing.
+//!
+//! Production boards imported from traced references (the CM5 fixture) carry
+//! a single `Default` net class: the electrical intent — which nets are
+//! differential pairs, which belong to a matched bus — lives only in the net
+//! *names*. This module recovers that intent:
+//!
+//! * [`classify_nets`] scans net names and produces a [`NetClassifier`]:
+//!   pair membership (via [`super::pair::pair_partner`] plus the USB
+//!   `DP`/`DM` convention) and length-match groups (LPDDR4 CA/DQ buses per
+//!   channel, RGMII, and every pair intra-matched).
+//! * [`apply_classes`] realizes the classification as IR design rules — a
+//!   `diff-pair` class carrying the board's differential geometry — so the
+//!   existing per-net width/clearance plumbing (session maps, DRC) simply
+//!   picks it up.
+//!
+//! The classifier is deliberately name-driven and conservative: a net it
+//! cannot place stays in the default class, which is always legal — just not
+//! yet signal-integrity-aware.
+
+use std::collections::BTreeMap;
+
+use vcad_ir::ecad::{NetClassRules, Pcb};
+
+use super::pair::pair_partner;
+
+/// The class name applied to differential-pair nets.
+pub const DIFF_PAIR_CLASS: &str = "diff-pair";
+
+/// Recovered electrical intent for a board's nets.
+#[derive(Debug, Clone, Default)]
+pub struct NetClassifier {
+    /// Differential pairs as `(positive, negative)` net names. Each net
+    /// appears in at most one pair.
+    pub pairs: Vec<(String, String)>,
+    /// Length-match groups: group name → member nets. Pairs are implicitly
+    /// intra-matched and do not need a group here unless they also belong to
+    /// a bus (e.g. DDR DQS within a byte lane).
+    pub match_groups: BTreeMap<String, Vec<String>>,
+}
+
+impl NetClassifier {
+    /// True when `net` is one leg of a recognized differential pair.
+    pub fn is_pair_member(&self, net: &str) -> bool {
+        self.pairs.iter().any(|(p, n)| p == net || n == net)
+    }
+}
+
+/// USB 2.0 `DP`/`DM` partner (D+/D−) — a convention
+/// [`pair_partner`] does not cover because it is not symmetric-suffix.
+fn usb_dp_dm_partner(net: &str) -> Option<String> {
+    for (a, b) in [("DP", "DM"), ("DM", "DP"), ("D+", "D-"), ("D-", "D+")] {
+        if let Some(base) = net.strip_suffix(a) {
+            // Require a separator before the token so e.g. "LDP" doesn't match.
+            if base.ends_with('.') || base.ends_with('_') || base.ends_with('-') {
+                return Some(format!("{base}{b}"));
+            }
+        }
+    }
+    None
+}
+
+/// Scan `nets` and recover pairs and match groups from their names.
+pub fn classify_nets(nets: &[String]) -> NetClassifier {
+    let set: std::collections::BTreeSet<&str> = nets.iter().map(|s| s.as_str()).collect();
+    let mut c = NetClassifier::default();
+    let mut paired: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for net in nets {
+        if paired.contains(net.as_str()) {
+            continue;
+        }
+        let partner = pair_partner(net)
+            .or_else(|| usb_dp_dm_partner(net))
+            .filter(|p| set.contains(p.as_str()));
+        if let Some(p) = partner {
+            // Canonical order: positive leg first when identifiable.
+            let (pos, neg) = if net.ends_with('N') || net.ends_with('M') || net.ends_with('-') {
+                (p.clone(), net.clone())
+            } else {
+                (net.clone(), p.clone())
+            };
+            if !paired.contains(&pos) && !paired.contains(&neg) {
+                paired.insert(pos.clone());
+                paired.insert(neg.clone());
+                c.pairs.push((pos, neg));
+            }
+        }
+    }
+
+    // Match groups. LPDDR4: CA bus per channel (the `_A`/`_B` suffix on the
+    // CM5 is the die/channel, not a pair); DQ bus per byte lane; RGMII as one
+    // source-synchronous group.
+    for net in nets {
+        let group = if let Some(rest) = net.strip_prefix("/LPDDR4 RAM/") {
+            if rest.starts_with("CA") || rest.starts_with("CKE") || rest.starts_with("CS") {
+                let chan = rest.chars().last().unwrap_or('A');
+                Some(format!("lpddr4-ca-{chan}"))
+            } else if let Some(dq) = rest.strip_prefix("DQ") {
+                // Byte lane = DQ index / 8; DQS/DM riders join their lane.
+                dq.chars()
+                    .take_while(|ch| ch.is_ascii_digit())
+                    .collect::<String>()
+                    .parse::<usize>()
+                    .ok()
+                    .map(|i| format!("lpddr4-dq-lane{}", i / 8))
+            } else {
+                None
+            }
+        } else if net.starts_with("/RGMII.") {
+            Some("rgmii".to_string())
+        } else {
+            None
+        };
+        if let Some(g) = group {
+            c.match_groups.entry(g).or_default().push(net.clone());
+        }
+    }
+    // A "group" of one constrains nothing.
+    c.match_groups.retain(|_, v| v.len() > 1);
+    c
+}
+
+/// Realize `classifier` on the board's design rules: create (or update) the
+/// [`DIFF_PAIR_CLASS`] with the board's differential geometry and assign
+/// every pair leg to it. The existing session/DRC per-net maps pick the
+/// class up with no further wiring.
+pub fn apply_classes(pcb: &mut Pcb, classifier: &NetClassifier) {
+    if classifier.pairs.is_empty() {
+        return;
+    }
+    let d = &pcb.rules.default_rules;
+    let dp_width = d.diff_pair_width.unwrap_or(d.trace_width);
+    let rule = NetClassRules {
+        name: DIFF_PAIR_CLASS.to_string(),
+        trace_width: dp_width,
+        clearance: d.clearance,
+        // Pairs transition on the smallest legal via: the microvia class the
+        // board's rules carry (via_diameter on calibrated imports is already
+        // the modal microvia).
+        via_diameter: d.via_diameter,
+        via_drill: d.via_drill,
+        diff_pair_gap: d.diff_pair_gap,
+        diff_pair_width: d.diff_pair_width,
+    };
+    match pcb
+        .rules
+        .class_rules
+        .iter_mut()
+        .find(|r| r.name == DIFF_PAIR_CLASS)
+    {
+        Some(existing) => *existing = rule,
+        None => pcb.rules.class_rules.push(rule),
+    }
+    let members: Vec<String> = classifier
+        .pairs
+        .iter()
+        .flat_map(|(p, n)| [p.clone(), n.clone()])
+        .collect();
+    pcb.rules
+        .net_class_assignments
+        .insert(DIFF_PAIR_CLASS.to_string(), members);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn pairs_found_by_suffix_and_usb_convention() {
+        let nets = names(&[
+            "/PCIe.TX_P",
+            "/PCIe.TX_N",
+            "/USB3-0.DP",
+            "/USB3-0.DM",
+            "/MDIO.MDC",
+            "/LPDDR4 RAM/CK0_T",
+            "/LPDDR4 RAM/CK0_C",
+        ]);
+        let c = classify_nets(&nets);
+        assert_eq!(c.pairs.len(), 3);
+        assert!(c.is_pair_member("/PCIe.TX_N"));
+        assert!(c.is_pair_member("/USB3-0.DM"));
+        assert!(c.is_pair_member("/LPDDR4 RAM/CK0_C"));
+        assert!(!c.is_pair_member("/MDIO.MDC"));
+    }
+
+    #[test]
+    fn ddr_and_rgmii_match_groups() {
+        let nets = names(&[
+            "/LPDDR4 RAM/CA0_A",
+            "/LPDDR4 RAM/CA1_A",
+            "/LPDDR4 RAM/CA0_B",
+            "/LPDDR4 RAM/CA1_B",
+            "/LPDDR4 RAM/DQ0",
+            "/LPDDR4 RAM/DQ7",
+            "/LPDDR4 RAM/DQ8",
+            "/RGMII.TXD0",
+            "/RGMII.TXC",
+        ]);
+        let c = classify_nets(&nets);
+        assert_eq!(c.match_groups["lpddr4-ca-A"].len(), 2);
+        assert_eq!(c.match_groups["lpddr4-ca-B"].len(), 2);
+        assert_eq!(c.match_groups["lpddr4-dq-lane0"].len(), 2);
+        assert!(!c.match_groups.contains_key("lpddr4-dq-lane1"));
+        assert_eq!(c.match_groups["rgmii"].len(), 2);
+    }
+
+    #[test]
+    fn apply_creates_diff_pair_class_with_board_geometry() {
+        let mut pcb: Pcb = serde_json::from_value(serde_json::json!({
+            "outline": {"vertices": [], "cutouts": [], "thickness": 1.6},
+            "stackup": {"layers": []},
+            "nets": [],
+            "rules": {
+                "defaultRules": {"name": "Default", "traceWidth": 0.08, "clearance": 0.08,
+                                  "viaDiameter": 0.21, "viaDrill": 0.12},
+                "edgeClearance": 0.2, "holeToHole": 0.2, "minAnnularRing": 0.05, "minDrill": 0.1
+            },
+            "footprints": [], "traces": [], "traceArcs": [], "vias": [], "zones": []
+        }))
+        .expect("test board");
+        pcb.rules.default_rules.trace_width = 0.08;
+        pcb.rules.default_rules.diff_pair_width = Some(0.2);
+        pcb.rules.default_rules.diff_pair_gap = Some(0.25);
+        let c = classify_nets(&names(&["/PCIe.TX_P", "/PCIe.TX_N"]));
+        apply_classes(&mut pcb, &c);
+        let rule = pcb
+            .rules
+            .class_rules
+            .iter()
+            .find(|r| r.name == DIFF_PAIR_CLASS)
+            .expect("class created");
+        assert_eq!(rule.trace_width, 0.2);
+        assert_eq!(rule.diff_pair_gap, Some(0.25));
+        let members = &pcb.rules.net_class_assignments[DIFF_PAIR_CLASS];
+        assert!(members.contains(&"/PCIe.TX_N".to_string()));
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/length_match.rs
+++ b/crates/vcad-ecad-pcb/src/router/length_match.rs
@@ -584,3 +584,314 @@ mod tests {
         assert!((r.nets[1].length_before - 30.0).abs() < 1e-9);
     }
 }
+
+// ============================================================================
+// Multi-layer tuning: meander the longest single-layer run
+// ============================================================================
+
+/// Chain `segs` (all one net, one layer) into open unbranched chains and
+/// return the longest one as ordered points. `None` when the layer branches
+/// (T-junction) or holds no open chain — the conservative refusal inherited
+/// from [`net_polyline`], scoped to one layer instead of the whole net.
+fn longest_chain(segs: &[&Trace]) -> Option<Vec<Vec2>> {
+    if segs.is_empty() {
+        return None;
+    }
+    let key = |p: Vec2| {
+        (
+            (p.x / CHAIN_EPS).round() as i64,
+            (p.y / CHAIN_EPS).round() as i64,
+        )
+    };
+    let mut adj: HashMap<(i64, i64), Vec<usize>> = HashMap::new();
+    for (i, t) in segs.iter().enumerate() {
+        adj.entry(key(t.start)).or_default().push(i);
+        adj.entry(key(t.end)).or_default().push(i);
+    }
+    if adj.values().any(|v| v.len() > 2) {
+        return None;
+    }
+    // Walk each open chain from an endpoint; keep the longest by length.
+    let mut used: std::collections::HashSet<usize> = Default::default();
+    let mut best: Option<(f64, Vec<Vec2>)> = None;
+    let endpoints: Vec<(i64, i64)> = adj
+        .iter()
+        .filter(|(_, v)| v.len() == 1)
+        .map(|(k, _)| *k)
+        .collect();
+    for start in endpoints {
+        let first = adj[&start][0];
+        if used.contains(&first) {
+            continue;
+        }
+        let mut points = Vec::new();
+        let mut current = start;
+        let mut prev_seg: Option<usize> = None;
+        let mut len = 0.0;
+        while let Some(next_seg) = adj[&current]
+            .iter()
+            .copied()
+            .find(|s| Some(*s) != prev_seg && !used.contains(s))
+        {
+            let t = segs[next_seg];
+            used.insert(next_seg);
+            let (from, to) = if key(t.start) == current {
+                (t.start, t.end)
+            } else {
+                (t.end, t.start)
+            };
+            if points.is_empty() {
+                points.push(from);
+            }
+            len += (to - from).length();
+            points.push(to);
+            current = key(to);
+            prev_seg = Some(next_seg);
+        }
+        if points.len() >= 2 && best.as_ref().map(|(l, _)| len > *l).unwrap_or(true) {
+            best = Some((len, points));
+        }
+    }
+    best.map(|(_, p)| p)
+}
+
+/// Group length matching for nets whose routing spans layers and vias — the
+/// production case [`match_lengths`]'s whole-net-polyline contract refuses.
+///
+/// Strategy: the net's total routed length is measured across all layers, but
+/// the *meander is inserted into the longest single-layer run* (the longest
+/// unbranched chain of same-layer segments). Clearance is checked against
+/// other-net traces on that layer only. `new_traces` in each tuned report is
+/// a full-net replacement (untouched runs pass through verbatim), preserving
+/// the existing consumer contract: delete the net's traces, insert
+/// `new_traces`.
+pub fn match_lengths_runs(
+    pcb: &Pcb,
+    nets: &[String],
+    opts: &LengthMatchOptions,
+) -> LengthMatchResult {
+    let lengths: Vec<f64> = nets.iter().map(|n| net_routed_length(pcb, n)).collect();
+    let longest = lengths.iter().cloned().fold(0.0_f64, f64::max);
+    let target = opts.target_length.unwrap_or(longest);
+    let session = RouteSession::from_pcb(pcb);
+
+    let mut reports = Vec::with_capacity(nets.len());
+    for (net, &before) in nets.iter().zip(&lengths) {
+        let deficit = target - before;
+        if deficit <= opts.tolerance {
+            reports.push(NetLengthReport {
+                net: net.clone(),
+                length_before: before,
+                length_after: before,
+                matched: deficit >= -opts.tolerance,
+                tuned: false,
+                skip_reason: if deficit < -opts.tolerance {
+                    Some("net is longer than the target (shortening unsupported)".into())
+                } else {
+                    None
+                },
+                new_traces: vec![],
+            });
+            continue;
+        }
+
+        // Longest single-layer run across the net's layers.
+        let mut layers: Vec<vcad_ir::ecad::PcbLayer> = pcb
+            .traces
+            .iter()
+            .filter(|t| t.net == *net)
+            .map(|t| t.layer)
+            .collect();
+        layers.sort();
+        layers.dedup();
+        let mut run: Option<(f64, Vec<Vec2>, vcad_ir::ecad::PcbLayer)> = None;
+        for layer in layers {
+            let segs: Vec<&Trace> = pcb
+                .traces
+                .iter()
+                .filter(|t| t.net == *net && t.layer == layer)
+                .collect();
+            if let Some(points) = longest_chain(&segs) {
+                let len: f64 = points.windows(2).map(|w| (w[1] - w[0]).length()).sum();
+                if run.as_ref().map(|(l, _, _)| len > *l).unwrap_or(true) {
+                    run = Some((len, points, layer));
+                }
+            }
+        }
+        let Some((run_len, points, layer)) = run else {
+            reports.push(NetLengthReport {
+                net: net.clone(),
+                length_before: before,
+                length_after: before,
+                matched: false,
+                tuned: false,
+                skip_reason: Some("no unbranched single-layer run to tune".into()),
+                new_traces: vec![],
+            });
+            continue;
+        };
+
+        let template = pcb
+            .traces
+            .iter()
+            .find(|t| t.net == *net && t.layer == layer)
+            .expect("run implies at least one trace on the layer")
+            .clone();
+        let params = LengthTuneParams {
+            // The tuner grows THIS run by the whole-net deficit.
+            target_length: run_len + deficit,
+            max_amplitude: opts.max_amplitude,
+            spacing: opts.spacing,
+            style: opts.style,
+        };
+        let min_clearance = session.clearance_for(net) + template.width;
+        let obstacles: Vec<(Vec2, Vec2)> = pcb
+            .traces
+            .iter()
+            .filter(|t| t.net != *net && t.layer == layer)
+            .map(|t| (t.start, t.end))
+            .collect();
+
+        match generate_meanders_checked(&points, &params, min_clearance, &obstacles) {
+            Some(meanders) if !meanders.is_empty() => {
+                let tuned_run = polyline_to_traces(&points, &meanders, &template);
+                // Full-net replacement: untouched segments (other layers and
+                // other chains on this layer) pass through verbatim.
+                let key = |p: Vec2| {
+                    (
+                        (p.x / CHAIN_EPS).round() as i64,
+                        (p.y / CHAIN_EPS).round() as i64,
+                    )
+                };
+                let run_keys: std::collections::HashSet<((i64, i64), (i64, i64))> = points
+                    .windows(2)
+                    .flat_map(|w| [(key(w[0]), key(w[1])), (key(w[1]), key(w[0]))])
+                    .collect();
+                let mut new_traces: Vec<Trace> = pcb
+                    .traces
+                    .iter()
+                    .filter(|t| {
+                        t.net == *net
+                            && !(t.layer == layer && run_keys.contains(&(key(t.start), key(t.end))))
+                    })
+                    .cloned()
+                    .collect();
+                new_traces.extend(tuned_run);
+                let after: f64 = new_traces.iter().map(|t| (t.end - t.start).length()).sum();
+                reports.push(NetLengthReport {
+                    net: net.clone(),
+                    length_before: before,
+                    length_after: after,
+                    matched: (target - after).abs() <= opts.tolerance,
+                    tuned: true,
+                    skip_reason: None,
+                    new_traces,
+                });
+            }
+            _ => {
+                reports.push(NetLengthReport {
+                    net: net.clone(),
+                    length_before: before,
+                    length_after: before,
+                    matched: false,
+                    tuned: false,
+                    skip_reason: Some(
+                        "meanders do not fit on the longest run: amplitude/clearance \
+                         constraints or run shorter than the meander spacing"
+                            .into(),
+                    ),
+                    new_traces: vec![],
+                });
+            }
+        }
+    }
+
+    let all_matched = reports.iter().all(|r| r.matched);
+    LengthMatchResult {
+        target_length: target,
+        tolerance: opts.tolerance,
+        all_matched,
+        nets: reports,
+    }
+}
+
+#[cfg(test)]
+mod run_tests {
+    use super::*;
+    use vcad_ir::ecad::PcbLayer;
+
+    fn seg(net: &str, layer: PcbLayer, a: (f64, f64), b: (f64, f64)) -> Trace {
+        Trace {
+            start: Vec2::new(a.0, a.1),
+            end: Vec2::new(b.0, b.1),
+            width: 0.2,
+            layer,
+            net: net.into(),
+            source: None,
+        }
+    }
+
+    fn board(traces: Vec<Trace>) -> Pcb {
+        let mut pcb: Pcb = serde_json::from_value(serde_json::json!({
+            "outline": {"vertices": [
+                {"x": -5.0, "y": -5.0}, {"x": 60.0, "y": -5.0},
+                {"x": 60.0, "y": 20.0}, {"x": -5.0, "y": 20.0}
+            ], "cutouts": [], "thickness": 1.6},
+            "stackup": {"layers": []},
+            "nets": [],
+            "rules": {
+                "defaultRules": {"name": "Default", "traceWidth": 0.2, "clearance": 0.15,
+                                  "viaDiameter": 0.6, "viaDrill": 0.3},
+                "edgeClearance": 0.2, "holeToHole": 0.2, "minAnnularRing": 0.05, "minDrill": 0.1
+            },
+            "footprints": [], "traces": [], "traceArcs": [], "vias": [], "zones": []
+        }))
+        .expect("test board");
+        pcb.traces = traces;
+        pcb
+    }
+
+    #[test]
+    fn multilayer_net_tunes_its_longest_run() {
+        // "A": 30mm front run + 10mm back run (via-joined in spirit).
+        // "B": 50mm front run. Target = 50; A needs +10, grown on the front run.
+        let pcb = board(vec![
+            seg("A", PcbLayer::FCu, (0.0, 0.0), (30.0, 0.0)),
+            seg("A", PcbLayer::BCu, (30.0, 0.0), (40.0, 0.0)),
+            seg("B", PcbLayer::FCu, (0.0, 10.0), (50.0, 10.0)),
+        ]);
+        let r = match_lengths_runs(
+            &pcb,
+            &["A".into(), "B".into()],
+            &LengthMatchOptions::default(),
+        );
+        let a = &r.nets[0];
+        assert!(a.tuned, "A must tune: {:?}", a.skip_reason);
+        assert!(
+            (a.length_after - 50.0).abs() <= r.tolerance,
+            "A grew to target: {}",
+            a.length_after
+        );
+        // The BCu run passes through untouched.
+        assert!(a.new_traces.iter().any(|t| t.layer == PcbLayer::BCu));
+        assert!(r.nets[1].matched && !r.nets[1].tuned);
+    }
+
+    #[test]
+    fn branched_layer_reports_skip() {
+        // T-junction on the only layer: no tunable run.
+        let pcb = board(vec![
+            seg("A", PcbLayer::FCu, (0.0, 0.0), (10.0, 0.0)),
+            seg("A", PcbLayer::FCu, (10.0, 0.0), (20.0, 0.0)),
+            seg("A", PcbLayer::FCu, (10.0, 0.0), (10.0, 5.0)),
+            seg("B", PcbLayer::FCu, (0.0, 10.0), (50.0, 10.0)),
+        ]);
+        let r = match_lengths_runs(
+            &pcb,
+            &["A".into(), "B".into()],
+            &LengthMatchOptions::default(),
+        );
+        assert!(!r.nets[0].tuned);
+        assert!(r.nets[0].skip_reason.is_some());
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod auto;
 pub mod classes;
+pub mod si_claims;
 
 /// Wall-clock timer that is a no-op on wasm32 (where `Instant::now` traps).
 /// Elapsed milliseconds, or 0.0 when timing is unavailable.

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -11,6 +11,7 @@
 //! - [`congestion`] -- PathFinder-style negotiated-congestion history-cost field
 
 pub mod auto;
+pub mod classes;
 
 /// Wall-clock timer that is a no-op on wasm32 (where `Instant::now` traps).
 /// Elapsed milliseconds, or 0.0 when timing is unavailable.

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -64,6 +64,7 @@ pub use length_match::{
     check_length_match, match_lengths, LengthMatchOptions, LengthMatchResult, NetLengthReport,
 };
 pub use maze::route_net_maze;
+pub use pair::polish_pairs;
 
 use vcad_ir::ecad::{Pcb, PcbLayer};
 use vcad_ir::Vec2;

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -153,9 +153,14 @@ pub(super) fn try_route_pair(
 
     let (w, gap) = pair_geometry(session, pcb, net, width);
     let half_sep = (w + gap) / 2.0;
-    let fat_w = 2.0 * w + gap;
     let via_d = pcb.rules.default_rules.via_diameter;
     let clearance = session.clearance_for(net);
+    // The phantom corridor must cover everything realize_legs emits: the two
+    // legs AND the via dog-bones, which sit at ±via_off with via_d discs
+    // (census 11: leg segments/jogs stepped outside a 2w+gap corridor onto
+    // unprobed copper whenever the search dropped a layer change).
+    let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);
+    let fat_w = (2.0 * w + gap).max(2.0 * via_off + via_d);
     let copper = copper_layers(pcb);
     let first_layer = *copper.first().unwrap_or(&PcbLayer::FCu);
 
@@ -299,7 +304,6 @@ pub(super) fn try_route_pair(
     };
 
     // Realize the two legs from the centerline.
-    let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);
     let (leg_a, leg_b) = match realize_legs(&r.segments, half_sep, via_off) {
         Some(l) => l,
         None => {

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -400,30 +400,6 @@ pub(super) fn try_route_pair(
             None
         }
     };
-    let build =
-        |session: &RouteSession, leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
-            let (head_segs, head_vias) =
-                connect(session, net, from, leg.first, leg.first_layer, leg)?;
-            let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer, leg)?;
-            // Connectors are the neck-down: they commit at `nw` via the thin
-            // channel, while the coupled leg stays at the class width.
-            let mut thin = head_segs;
-            // Tail connector was searched pad→leg; reverse into leg→pad order.
-            thin.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
-            let mut vias = leg.vias.clone();
-            vias.extend(head_vias);
-            vias.extend(tail_vias);
-            Some(Candidate {
-                net: net.to_string(),
-                from,
-                to,
-                width: w,
-                segments: leg.segments.clone(),
-                vias,
-                thin_segments: thin,
-                thin_width: nw,
-            })
-        };
     // Ordering (census 9's lesson): commit BOTH legs first — they are
     // parallel and disjoint by construction — then route the four pad
     // connectors against the complete picture, so no connector can cut the

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -160,7 +160,7 @@ pub(super) fn try_route_pair(
     // (census 11: leg segments/jogs stepped outside a 2w+gap corridor onto
     // unprobed copper whenever the search dropped a layer change).
     let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);
-    let voff_max = via_off.max(via_d / 2.0 + clearance + w / 2.0 + 0.02 - half_sep);
+    let voff_max = via_off.max(via_d / 2.0 + 1.5 * clearance + w / 2.0 - half_sep);
     let fat_w = (2.0 * w + gap).max(2.0 * (voff_max + via_d / 2.0));
     let copper = copper_layers(pcb);
     let first_layer = *copper.first().unwrap_or(&PcbLayer::FCu);
@@ -528,7 +528,7 @@ pub(super) fn try_route_pair(
 fn realize_legs(
     center: &[(Vec2, Vec2, PcbLayer)],
     half_sep: f64,
-    via_off: f64,
+    _via_off: f64,
     via_r: f64,
     clearance: f64,
     w: f64,
@@ -586,112 +586,132 @@ fn realize_legs(
         return None;
     }
 
+    // One combined centerline: runs concatenated with junction vertices kept
+    // (a junction is an interior vertex of the whole polyline, so both its
+    // sides offset with ONE mitered normal — per-run offsetting gave each
+    // side a different normal and shaved the pair gap at every junction).
+    let mut pts: Vec<Vec2> = Vec::new();
+    let mut seg_layers: Vec<PcbLayer> = Vec::new();
+    for (layer, rp) in &runs {
+        for (k, p) in rp.iter().enumerate() {
+            match pts.last() {
+                Some(last) if dist(*last, *p) < 1e-6 => {
+                    if k > 0 {
+                        // interior duplicate — skip
+                    }
+                }
+                _ => pts.push(*p),
+            }
+            if pts.len() >= 2 && seg_layers.len() < pts.len() - 1 {
+                seg_layers.push(*layer);
+            }
+        }
+    }
+    // Trim terminal reversals (maze end-approach overshoot-and-return):
+    // offsetting a cusp hurls one leg across the other's lane. Interior
+    // cusps (rare) make the pair bail rather than emit crossing copper.
+    let rev = |a: Vec2, b: Vec2, c: Vec2| -> bool {
+        let d0 = (b - a).normalize();
+        let d1 = (c - b).normalize();
+        d0.dot(d1) < -0.5
+    };
+    while pts.len() >= 3 && rev(pts[pts.len() - 3], pts[pts.len() - 2], pts[pts.len() - 1]) {
+        pts.pop();
+        seg_layers.pop();
+    }
+    while pts.len() >= 3 && rev(pts[0], pts[1], pts[2]) {
+        pts.remove(0);
+        seg_layers.remove(0);
+    }
+    for k in 1..pts.len().saturating_sub(1) {
+        if rev(pts[k - 1], pts[k], pts[k + 1]) {
+            log::debug!("pair: interior centerline cusp — bailing");
+            return None;
+        }
+    }
+    if pts.len() < 2 || seg_layers.len() != pts.len() - 1 {
+        log::debug!(
+            "pair: combined centerline malformed: {} pts {} seg layers",
+            pts.len(),
+            seg_layers.len()
+        );
+        return None;
+    }
+    // In-line vias demand the disc clears the other leg's line — but only
+    // when the centerline actually changes layers.
+    let has_transition = seg_layers.windows(2).any(|w2| w2[0] != w2[1]);
+    if has_transition && 2.0 * half_sep < via_r + clearance + w / 2.0 + 0.01 {
+        log::debug!(
+            "pair: in-line via gate: 2*half_sep {} too small",
+            2.0 * half_sep
+        );
+        return None;
+    }
+    let need = 2.0 * via_r + clearance + 0.04;
+    let lat = 2.0 * half_sep;
+    let stagger = if lat >= need {
+        0.0
+    } else {
+        (need * need - lat * lat).sqrt()
+    };
+
     let leg = |sign: f64| -> Option<Leg> {
+        let off = offset_polyline(&pts, sign * half_sep);
+        let other = offset_polyline(&pts, -sign * half_sep);
+        if off.len() != pts.len() || other.len() != pts.len() {
+            return None;
+        }
         let mut segments: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
         let mut vias: Vec<(Vec2, PcbLayer, PcbLayer)> = Vec::new();
-        let mut first: Option<(Vec2, PcbLayer)> = None;
-        let mut prev_end: Option<(Vec2, PcbLayer)> = None;
-        let mut prev_dir: Option<Vec2> = None;
-        // Side consistency (census 15's twin-crossing bug): when a run's
-        // direction reverses relative to the previous run, its left-hand
-        // normal flips — a fixed sign would swap which physical side this
-        // leg occupies, and the via jog would cut straight through the twin.
-        // The per-run sign flips cumulatively to keep the leg on one side.
-        let mut run_sign = sign;
-        for (layer, pts) in &runs {
-            let d_first = (pts[1] - pts[0]).normalize();
-            if let Some(pd) = prev_dir {
-                if pd.dot(d_first) < 0.0 {
-                    run_sign = -run_sign;
-                }
-            }
-            let off = offset_polyline(pts, run_sign * half_sep);
-            if off.len() < 2 {
-                return None;
-            }
-            if first.is_none() {
-                first = Some((off[0], *layer));
-            }
-            // Layer transition: STAGGERED pair vias on the track axis (the
-            // human DDR pattern) — the perpendicular dog-bone interleaved
-            // the two legs' discs and jogs below clearance at corners
-            // (censuses 11–16). The `sign>0` leg vias BEFORE the junction on
-            // the incoming axis, the other AFTER on the outgoing axis; each
-            // jog swerves around the other leg's via when it passes close.
-            if let Some((pe, pl)) = prev_end {
-                let j = pts[0];
-                let d0 = prev_dir.unwrap_or(d_first);
-                let d1 = d_first;
-                let delta = {
-                    let chord = (d0 + d1).length().max(0.5);
-                    ((2.0 * via_r + clearance + 0.04) / chord).max(via_off)
-                };
-                // Perpendicular clearance: the via must clear the OTHER
-                // leg's line (at half_sep on the far side), so its center
-                // sits at least via_r + clearance + w/2 past the centerline
-                // on its OWN side — a centerline via clobbers both legs
-                // whenever via_r exceeds the gap (the unit repro's finding).
-                let voff = via_off.max(via_r + clearance + w / 2.0 + 0.02 - half_sep);
-                let before = j - d0.scale(delta) + d0.perp().scale(run_sign * voff);
-                let after = j + d1.scale(delta) + d1.perp().scale(run_sign * voff);
-                let (own, other) = if sign > 0.0 {
-                    (before, after)
+        for k in 0..off.len() - 1 {
+            let (a, b, l) = (off[k], off[k + 1], seg_layers[k]);
+            // Layer change at vertex k (k>0): via on this leg's own line at
+            // the mitered junction vertex; the `sign<0` leg pulls its via
+            // back along its previous segment so the two discs clear.
+            if k > 0 && seg_layers[k - 1] != l {
+                let pl = seg_layers[k - 1];
+                let vp = if sign > 0.0 {
+                    off[k]
                 } else {
-                    (after, before)
-                };
-                let s_off = via_r + clearance + w / 2.0 + 0.02;
-                let dodge = |from: Vec2, to: Vec2, obst: Vec2| -> Vec<Vec2> {
-                    let ab = to - from;
-                    let l2 = ab.x * ab.x + ab.y * ab.y;
-                    if l2 < 1e-18 {
-                        return vec![from, to];
+                    // Pull back along this leg's own segment until the disc
+                    // truly clears the twin's via at ITS mitered vertex —
+                    // the nominal stagger under-counts when the miter shifts
+                    // the twin's vertex along the corner.
+                    let (pa, pb) = (off[k - 1], off[k]);
+                    let seg_len = dist(pa, pb);
+                    let d = (pb - pa).normalize();
+                    let need_d = 2.0 * via_r + clearance + 0.04;
+                    let mut t = stagger.min(seg_len - 1e-6).max(0.0);
+                    let mut vp = pb - d.scale(t);
+                    while dist(vp, other[k]) < need_d && t + 0.05 < seg_len {
+                        t += 0.05;
+                        vp = pb - d.scale(t);
                     }
-                    let t = (((obst.x - from.x) * ab.x + (obst.y - from.y) * ab.y) / l2)
-                        .clamp(0.0, 1.0);
-                    let proj = from + ab.scale(t);
-                    if dist(proj, obst) >= s_off || t <= 1e-6 || t >= 1.0 - 1e-6 {
-                        return vec![from, to];
+                    if dist(vp, other[k]) < need_d {
+                        return None;
                     }
-                    let away = {
-                        let v = proj - obst;
-                        let vl = v.length();
-                        if vl < 1e-9 {
-                            ab.normalize().perp()
-                        } else {
-                            v.scale(1.0 / vl)
-                        }
-                    };
-                    vec![from, obst + away.scale(s_off), to]
+                    vp
                 };
-                let mut emit = |path: Vec<Vec2>, layer: PcbLayer| {
-                    for wp in path.windows(2) {
-                        if dist(wp[0], wp[1]) > 1e-9 {
-                            segments.push((wp[0], wp[1], layer));
-                        }
-                    }
-                };
-                emit(dodge(pe, own, other), pl);
-                emit(dodge(own, off[0], other), *layer);
-                vias.push((own, pl, *layer));
-            }
-            for wpair in off.windows(2) {
-                if dist(wpair[0], wpair[1]) > 1e-9 {
-                    segments.push((wpair[0], wpair[1], *layer));
+                // Retrace from the (possibly pulled-back) via to the mitered
+                // vertex on the NEW layer, staying on this leg's line.
+                if dist(vp, off[k]) > 1e-9 {
+                    segments.push((vp, off[k], l));
                 }
+                vias.push((vp, pl, l));
             }
-            prev_end = Some((*off.last().unwrap(), *layer));
-            let np = pts.len();
-            prev_dir = Some((pts[np - 1] - pts[np - 2]).normalize());
+            if dist(a, b) > 1e-9 {
+                segments.push((a, b, l));
+            }
         }
-        let (first, first_layer) = first?;
-        let (last, last_layer) = prev_end?;
+        let first = *off.first().unwrap();
+        let last = *off.last().unwrap();
         Some(Leg {
             segments,
             vias,
             first,
-            first_layer,
+            first_layer: seg_layers[0],
             last,
-            last_layer,
+            last_layer: *seg_layers.last().unwrap(),
         })
     };
     Some((leg(1.0)?, leg(-1.0)?))
@@ -793,8 +813,8 @@ mod tests {
                     name: "Default".into(),
                     trace_width: 0.25,
                     clearance: 0.15,
-                    via_diameter: 0.8,
-                    via_drill: 0.4,
+                    via_diameter: 0.35,
+                    via_drill: 0.2,
                     diff_pair_gap: None,
                     diff_pair_width: None,
                 },
@@ -802,8 +822,8 @@ mod tests {
                     name: "DIFF".into(),
                     trace_width: 0.2,
                     clearance: 0.15,
-                    via_diameter: 0.8,
-                    via_drill: 0.4,
+                    via_diameter: 0.35,
+                    via_drill: 0.2,
                     diff_pair_gap: Some(0.25),
                     diff_pair_width: Some(0.2),
                 }],
@@ -1062,5 +1082,84 @@ mod tests {
             worst >= clearance - 1e-9,
             "twin edge clearance {worst:.3}mm < {clearance}"
         );
+    }
+
+    /// Twin-clearance check shared by the transition repros.
+    fn assert_twin_clear(mine: &Placed, theirs: &Placed, clearance: f64) {
+        let seg_seg = |a1: Vec2, b1: Vec2, a2: Vec2, b2: Vec2| -> f64 {
+            let pt_seg = |p: Vec2, a: Vec2, b: Vec2| -> f64 {
+                let ab = b - a;
+                let l2 = ab.x * ab.x + ab.y * ab.y;
+                if l2 < 1e-18 {
+                    return dist(p, a);
+                }
+                let t = (((p.x - a.x) * ab.x + (p.y - a.y) * ab.y) / l2).clamp(0.0, 1.0);
+                dist(p, a + ab.scale(t))
+            };
+            pt_seg(a1, a2, b2)
+                .min(pt_seg(b1, a2, b2))
+                .min(pt_seg(a2, a1, b1))
+                .min(pt_seg(b2, a1, b1))
+        };
+        let all = |p: &Placed| -> Vec<(Vec2, Vec2, PcbLayer, f64)> {
+            let mut v: Vec<(Vec2, Vec2, PcbLayer, f64)> = p
+                .segments
+                .iter()
+                .map(|&(a, b, l)| (a, b, l, p.width))
+                .collect();
+            v.extend(p.stubs.iter().map(|&(a, b, l)| (a, b, l, p.stub_width)));
+            v
+        };
+        let mut worst = f64::INFINITY;
+        for &(a1, b1, l1, w1) in &all(mine) {
+            for &(a2, b2, l2, w2) in &all(theirs) {
+                if l1 == l2 {
+                    worst = worst.min(seg_seg(a1, b1, a2, b2) - w1 / 2.0 - w2 / 2.0);
+                }
+            }
+        }
+        assert!(
+            worst >= clearance - 1e-9,
+            "twin edge clearance {worst:.3}mm < {clearance}"
+        );
+    }
+
+    /// Corner transition: walls force the pair through a via field at an
+    /// L-turn — the corner-normal rotation case the straight-wall repro
+    /// cannot exercise.
+    #[test]
+    fn pair_corner_transition_keeps_twin_clearance() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let mut pcb = pair_board();
+        // Move the destination pads to force an L (right then up).
+        pcb.footprints[1].position = Vec2::new(45.0, 15.0);
+        for pad in &mut pcb.footprints[1].pads {
+            pad.position = Vec2::new(pad.position.y, pad.position.x + 10.0);
+        }
+        // Wall on FCu with a vertical jog channel only reachable on BCu.
+        pcb.traces.push(Trace {
+            start: Vec2::new(30.0, 0.0),
+            end: Vec2::new(30.0, 30.0),
+            width: 0.4,
+            layer: PcbLayer::FCu,
+            net: "WALL".into(),
+            source: None,
+        });
+        let mut session = RouteSession::from_pcb(&pcb);
+        let mut placed: Vec<Placed> = Vec::new();
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let r = try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            Vec2::new(5.0, 15.325),
+            Vec2::new(45.325, 25.0),
+            &mut placed,
+            &cong,
+            400_000,
+        );
+        let (mine, theirs) = r.expect("pair must route the L across the wall");
+        assert_twin_clear(&mine, &theirs, 0.15);
     }
 }

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -229,31 +229,54 @@ pub(super) fn try_route_pair(
 
     // Centerline search: one phantom fat trace. No tree goals/sources — a
     // coupled pair needs clean pad-to-pad geometry, not a tap onto a tree.
+    //
+    // Neck-down retreat (the CM5 bail census: 96/110 failures were this
+    // search): near pin fields no fat capsule exists, so on failure the
+    // coupling endpoints retreat toward the span middle in escalating steps
+    // and the single-width connector stubs cover the necked ends — exactly
+    // how a human escapes a BGA with a pair: singles in the field, coupled
+    // in the open.
     let budget = max_expansions.max(100_000);
-    let r = route_net_maze3d(
-        session,
-        &pcb.outline.vertices,
-        &copper,
-        net,
-        start,
-        &[first_layer],
-        end,
-        &[first_layer],
-        fat_w,
-        via_d,
-        Some(cong),
-        budget,
-        1.0,
-        None,
-        &[],
-        &[],
-        true,
-    );
-    if !r.success || r.segments.is_empty() {
+    let mut found = None;
+    for retreat in [0.0, 1.0, 2.0, 4.0, 8.0] {
+        let usable = span - 2.0 * lead;
+        if 2.0 * retreat >= usable - 1.0 {
+            break;
+        }
+        let s_pt = start + dir.scale(retreat);
+        let e_pt = end - dir.scale(retreat);
+        let r = route_net_maze3d(
+            session,
+            &pcb.outline.vertices,
+            &copper,
+            net,
+            s_pt,
+            &[first_layer],
+            e_pt,
+            &[first_layer],
+            fat_w,
+            via_d,
+            Some(cong),
+            budget,
+            1.0,
+            None,
+            &[],
+            &[],
+            true,
+        );
+        if r.success && !r.segments.is_empty() {
+            if retreat > 0.0 {
+                log::debug!("pair: {net}/{partner}: coupled after {retreat}mm neck-down retreat");
+            }
+            found = Some(r);
+            break;
+        }
+    }
+    let Some(r) = found else {
         log::debug!("pair: {net}/{partner}: phantom centerline search failed");
         restore(session, placed, ripped);
         return None;
-    }
+    };
 
     // Realize the two legs from the centerline.
     let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -787,12 +787,21 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
             .filter(|z| !z.net.is_empty())
             .map(|z| z.net.as_str())
             .collect();
-        let in_band = |a: Vec2, b: Vec2| {
-            a.x.max(b.x) >= lo.x
-                && a.x.min(b.x) <= hi.x
-                && a.y.max(b.y) >= lo.y
-                && a.y.min(b.y) <= hi.y
+        // Corridor test: distance from the segment ends to the from→to LINE
+        // — a bbox test on a long diagonal span sweeps half the board into
+        // the rip set and the all-must-reroute bar becomes unmeetable.
+        let span_dir = {
+            let d = to - from;
+            let l = dist(from, to).max(1e-9);
+            d.scale(1.0 / l)
         };
+        let span_len = dist(from, to);
+        let to_line = |p: Vec2| -> f64 {
+            let v = p - from;
+            let t = (v.x * span_dir.x + v.y * span_dir.y).clamp(0.0, span_len);
+            dist(p, from + span_dir.scale(t))
+        };
+        let in_band = |a: Vec2, b: Vec2| to_line(a) <= band || to_line(b) <= band;
         let mut ripped_nets: std::collections::BTreeSet<String> = Default::default();
         for t in &work.traces {
             if !classifier.is_pair_member(&t.net)

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -334,7 +334,7 @@ pub(super) fn try_route_pair(
         if dist(from, to) <= w * 2.0 {
             return Some((vec![(from, to, to_layer)], vec![]));
         }
-        let margin = 2.0 + w;
+        let margin = 4.0 + w;
         let window = (
             Vec2::new(from.x.min(to.x) - margin, from.y.min(to.y) - margin),
             Vec2::new(from.x.max(to.x) + margin, from.y.max(to.y) + margin),
@@ -351,7 +351,7 @@ pub(super) fn try_route_pair(
             w,
             via_d,
             Some(cong),
-            50_000,
+            120_000,
             0.5,
             Some(window),
             &[],

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -586,8 +586,21 @@ fn realize_legs(
         let mut vias: Vec<(Vec2, PcbLayer, PcbLayer)> = Vec::new();
         let mut first: Option<(Vec2, PcbLayer)> = None;
         let mut prev_end: Option<(Vec2, PcbLayer)> = None;
+        let mut prev_dir: Option<Vec2> = None;
+        // Side consistency (census 15's twin-crossing bug): when a run's
+        // direction reverses relative to the previous run, its left-hand
+        // normal flips — a fixed sign would swap which physical side this
+        // leg occupies, and the via jog would cut straight through the twin.
+        // The per-run sign flips cumulatively to keep the leg on one side.
+        let mut run_sign = sign;
         for (layer, pts) in &runs {
-            let off = offset_polyline(pts, sign * half_sep);
+            let d_first = (pts[1] - pts[0]).normalize();
+            if let Some(pd) = prev_dir {
+                if pd.dot(d_first) < 0.0 {
+                    run_sign = -run_sign;
+                }
+            }
+            let off = offset_polyline(pts, run_sign * half_sep);
             if off.len() < 2 {
                 return None;
             }
@@ -601,9 +614,8 @@ fn realize_legs(
                 let junction = pts[0];
                 // Perpendicular at the junction: direction of the new run's
                 // first segment (matches the offset used for the leg points).
-                let d = (pts[1] - pts[0]).normalize();
-                let n = d.perp();
-                let vp = junction + n.scale(sign * via_off);
+                let n = d_first.perp();
+                let vp = junction + n.scale(run_sign * via_off);
                 if dist(pe, vp) > 1e-9 {
                     segments.push((pe, vp, pl));
                 }
@@ -618,6 +630,8 @@ fn realize_legs(
                 }
             }
             prev_end = Some((*off.last().unwrap(), *layer));
+            let np = pts.len();
+            prev_dir = Some((pts[np - 1] - pts[np - 2]).normalize());
         }
         let (first, first_layer) = first?;
         let (last, last_layer) = prev_end?;

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -781,10 +781,6 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
         // pair commits; any that fail restore verbatim only if the pair
         // failed (the pair outranks a flexible single).
         let band = 2.0 * (w + gap) + 1.0;
-        let (lo, hi) = (
-            Vec2::new(from.x.min(to.x) - band, from.y.min(to.y) - band),
-            Vec2::new(from.x.max(to.x) + band, from.y.max(to.y) + band),
-        );
         let plane_nets: std::collections::BTreeSet<&str> = pcb
             .zones
             .iter()
@@ -820,6 +816,10 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
             .collect();
         work.traces.retain(|t| !ripped_nets.contains(&t.net));
         work.vias.retain(|v| !ripped_nets.contains(&v.net));
+        log::debug!(
+            "pair-polish: {pn}: ripping {} corridor singles",
+            ripped_nets.len()
+        );
 
         let mut session = RouteSession::from_pcb(&work);
         let mut placed: Vec<Placed> = Vec::new();

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -347,41 +347,47 @@ pub(super) fn try_route_pair(
             None
         }
     };
-    let build = |leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
-        let (head_segs, head_vias) = connect(session, net, from, leg.first, leg.first_layer)?;
-        let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer)?;
-        let mut segments =
-            Vec::with_capacity(leg.segments.len() + head_segs.len() + tail_segs.len());
-        segments.extend(head_segs);
-        segments.extend(leg.segments.iter().copied());
-        // Tail connector was searched pad→leg; reverse into leg→pad order.
-        segments.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
-        let mut vias = leg.vias.clone();
-        vias.extend(head_vias);
-        vias.extend(tail_vias);
-        Some(Candidate {
-            net: net.to_string(),
-            from,
-            to,
-            width: w,
-            segments,
-            vias,
-        })
-    };
-    let Some(cand_mine) = build(&mine, net, from, to) else {
+    let build =
+        |session: &RouteSession, leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
+            let (head_segs, head_vias) = connect(session, net, from, leg.first, leg.first_layer)?;
+            let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer)?;
+            let mut segments =
+                Vec::with_capacity(leg.segments.len() + head_segs.len() + tail_segs.len());
+            segments.extend(head_segs);
+            segments.extend(leg.segments.iter().copied());
+            // Tail connector was searched pad→leg; reverse into leg→pad order.
+            segments.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
+            let mut vias = leg.vias.clone();
+            vias.extend(head_vias);
+            vias.extend(tail_vias);
+            Some(Candidate {
+                net: net.to_string(),
+                from,
+                to,
+                width: w,
+                segments,
+                vias,
+            })
+        };
+    // Build-and-commit SEQUENTIALLY: leg 2's connectors are searched against
+    // the session that already holds leg 1's copper, so they route around it
+    // instead of colliding in the necked corridor (69 of the census-3 bails).
+    // Atomicity is preserved by the rollback below.
+    let Some(cand_mine) = build(session, &mine, net, from, to) else {
         log::debug!("pair: {net}/{partner}: connector routing failed (mine)");
         restore(session, placed, ripped);
         return None;
     };
-    let Some(cand_theirs) = build(&theirs, &partner, p_from, p_to) else {
-        log::debug!("pair: {net}/{partner}: connector routing failed (partner)");
+    let Some(placed_mine) = validate_and_commit(session, pcb, cand_mine, placed) else {
+        log::debug!("pair: {net}/{partner}: leg 1 failed validation");
         restore(session, placed, ripped);
         return None;
     };
-
-    // Atomic commit: both legs or neither.
-    let Some(placed_mine) = validate_and_commit(session, pcb, cand_mine, placed) else {
-        log::debug!("pair: {net}/{partner}: leg 1 failed validation");
+    let Some(cand_theirs) = build(session, &theirs, &partner, p_from, p_to) else {
+        log::debug!("pair: {net}/{partner}: connector routing failed (partner)");
+        for &sp in &placed_mine.spans {
+            session.remove(sp);
+        }
         restore(session, placed, ripped);
         return None;
     };

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -238,13 +238,28 @@ pub(super) fn try_route_pair(
     // in the open.
     let budget = max_expansions.max(100_000);
     let mut found = None;
-    for retreat in [0.0, 1.0, 2.0, 4.0, 8.0] {
+    // Asymmetric ladder: most pairs have only ONE end in a pin field, so
+    // necking both ends symmetrically wastes coupled length and misses the
+    // cases where only one side needs the retreat.
+    for (r_from, r_to) in [
+        (0.0, 0.0),
+        (1.0, 0.0),
+        (0.0, 1.0),
+        (1.0, 1.0),
+        (2.0, 0.0),
+        (0.0, 2.0),
+        (2.0, 2.0),
+        (4.0, 0.0),
+        (0.0, 4.0),
+        (4.0, 4.0),
+        (8.0, 8.0),
+    ] {
         let usable = span - 2.0 * lead;
-        if 2.0 * retreat >= usable - 1.0 {
-            break;
+        if r_from + r_to >= usable - 1.0 {
+            continue;
         }
-        let s_pt = start + dir.scale(retreat);
-        let e_pt = end - dir.scale(retreat);
+        let s_pt = start + dir.scale(r_from);
+        let e_pt = end - dir.scale(r_to);
         let r = route_net_maze3d(
             session,
             &pcb.outline.vertices,
@@ -265,8 +280,10 @@ pub(super) fn try_route_pair(
             true,
         );
         if r.success && !r.segments.is_empty() {
-            if retreat > 0.0 {
-                log::debug!("pair: {net}/{partner}: coupled after {retreat}mm neck-down retreat");
+            if r_from + r_to > 0.0 {
+                log::debug!(
+                    "pair: {net}/{partner}: coupled after {r_from}/{r_to}mm neck-down retreat"
+                );
             }
             found = Some(r);
             break;

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -14,6 +14,7 @@ use vcad_ir::ecad::{Pcb, PcbLayer};
 use vcad_ir::Vec2;
 
 use crate::session::RouteSession;
+use crate::spatial::CopperGeom;
 
 use super::auto::{copper_layers, dist, validate_and_commit, Candidate, Placed};
 use super::congestion::Congestion;
@@ -332,7 +333,8 @@ pub(super) fn try_route_pair(
                    net: &str,
                    from: Vec2,
                    to: Vec2,
-                   to_layer: PcbLayer|
+                   to_layer: PcbLayer,
+                   leg: &Leg|
      -> Option<ConnectorCopper> {
         if dist(from, to) <= 1e-9 {
             return Some((vec![], vec![]));
@@ -345,6 +347,25 @@ pub(super) fn try_route_pair(
             Vec2::new(from.x.min(to.x) - margin, from.y.min(to.y) - margin),
             Vec2::new(from.x.max(to.x) + margin, from.y.max(to.y) + margin),
         );
+        // Multi-goal attachment: the connector may terminate anywhere along
+        // the leg's copper, not only at its endpoint — an offset leg end can
+        // sit against a neighbouring pad where no legal approach exists.
+        let goals: Vec<(CopperGeom, [f64; 2], [f64; 2], PcbLayer)> = leg
+            .segments
+            .iter()
+            .map(|&(a, b, l)| {
+                (
+                    CopperGeom::Segment {
+                        a,
+                        b,
+                        half_w: w / 2.0,
+                    },
+                    [a.x.min(b.x) - w, a.y.min(b.y) - w],
+                    [a.x.max(b.x) + w, a.y.max(b.y) + w],
+                    l,
+                )
+            })
+            .collect();
         let r = route_net_maze3d(
             session,
             &pcb.outline.vertices,
@@ -360,7 +381,7 @@ pub(super) fn try_route_pair(
             120_000,
             0.5,
             Some(window),
-            &[],
+            &goals,
             &[],
             true,
         );
@@ -381,8 +402,9 @@ pub(super) fn try_route_pair(
     };
     let build =
         |session: &RouteSession, leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
-            let (head_segs, head_vias) = connect(session, net, from, leg.first, leg.first_layer)?;
-            let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer)?;
+            let (head_segs, head_vias) =
+                connect(session, net, from, leg.first, leg.first_layer, leg)?;
+            let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer, leg)?;
             // Connectors are the neck-down: they commit at `nw` via the thin
             // channel, while the coupled leg stays at the class width.
             let mut thin = head_segs;
@@ -523,6 +545,7 @@ fn realize_legs(
 mod tests {
     use super::*;
     use crate::session::RouteSession;
+    use crate::spatial::CopperGeom;
     use vcad_ir::ecad::*;
 
     #[test]

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -424,37 +424,111 @@ pub(super) fn try_route_pair(
                 thin_width: nw,
             })
         };
-    // Build-and-commit SEQUENTIALLY: leg 2's connectors are searched against
-    // the session that already holds leg 1's copper, so they route around it
-    // instead of colliding in the necked corridor (69 of the census-3 bails).
-    // Atomicity is preserved by the rollback below.
-    let Some(cand_mine) = build(session, &mine, net, from, to) else {
-        log::debug!("pair: {net}/{partner}: connector routing failed (mine)");
-        restore(session, placed, ripped);
-        return None;
+    // Ordering (census 9's lesson): commit BOTH legs first — they are
+    // parallel and disjoint by construction — then route the four pad
+    // connectors against the complete picture, so no connector can cut the
+    // coupled corridor before the other leg exists. Rollback keeps the
+    // all-or-nothing contract.
+    let leg_cand = |leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Candidate {
+        Candidate {
+            net: net.to_string(),
+            from,
+            to,
+            width: w,
+            segments: leg.segments.clone(),
+            vias: leg.vias.clone(),
+            thin_segments: vec![],
+            thin_width: nw,
+        }
     };
-    let Some(placed_mine) = validate_and_commit(session, pcb, cand_mine, placed) else {
+    let Some(mut placed_mine) =
+        validate_and_commit(session, pcb, leg_cand(&mine, net, from, to), placed)
+    else {
         log::debug!("pair: {net}/{partner}: leg 1 failed validation");
         restore(session, placed, ripped);
         return None;
     };
-    let Some(cand_theirs) = build(session, &theirs, &partner, p_from, p_to) else {
-        log::debug!("pair: {net}/{partner}: connector routing failed (partner)");
+    let Some(mut placed_theirs) = validate_and_commit(
+        session,
+        pcb,
+        leg_cand(&theirs, &partner, p_from, p_to),
+        placed,
+    ) else {
+        log::debug!("pair: {net}/{partner}: leg 2 failed validation — rolled back leg 1");
         for &sp in &placed_mine.spans {
             session.remove(sp);
         }
         restore(session, placed, ripped);
         return None;
     };
-    let Some(placed_theirs) = validate_and_commit(session, pcb, cand_theirs, placed) else {
-        // Leg 2 failed: rip leg 1 back out, restore the partner originals.
-        for &s in &placed_mine.spans {
-            session.remove(s);
+    // Connectors, all four against both committed legs. Committed as thin
+    // copper directly into each leg's Placed (stubs channel).
+    let rollback_all = |session: &mut RouteSession,
+                        placed: &mut Vec<Placed>,
+                        a: &Placed,
+                        b: &Placed,
+                        ripped: Vec<Placed>| {
+        for &sp in a.spans.iter().chain(b.spans.iter()) {
+            session.remove(sp);
         }
-        log::debug!("pair: {net}/{partner}: leg 2 failed validation — rolled back leg 1");
         restore(session, placed, ripped);
-        return None;
     };
+    let attach = |session: &mut RouteSession,
+                  pl: &mut Placed,
+                  leg: &Leg,
+                  pad_a: Vec2,
+                  pad_b: Vec2|
+     -> bool {
+        let net = pl.net.clone();
+        let Some((head, hv)) = connect(session, &net, pad_a, leg.first, leg.first_layer, leg)
+        else {
+            log::debug!("pair-connector: {net} head failed");
+            return false;
+        };
+        for (a, b, l) in &head {
+            let id = crate::spatial::CopperElement {
+                min: [a.x.min(b.x) - nw, a.y.min(b.y) - nw],
+                max: [a.x.max(b.x) + nw, a.y.max(b.y) + nw],
+                net: net.clone(),
+                layer: *l,
+                geom: CopperGeom::Segment {
+                    a: *a,
+                    b: *b,
+                    half_w: nw / 2.0,
+                },
+            };
+            pl.spans.push(session.commit(id));
+            pl.stubs.push((*a, *b, *l));
+        }
+        pl.via_pts.extend(hv);
+        let Some((tail, tv)) = connect(session, &net, pad_b, leg.last, leg.last_layer, leg) else {
+            log::debug!("pair-connector: {net} tail failed");
+            return false;
+        };
+        for (a, b, l) in &tail {
+            let id = crate::spatial::CopperElement {
+                min: [a.x.min(b.x) - nw, a.y.min(b.y) - nw],
+                max: [a.x.max(b.x) + nw, a.y.max(b.y) + nw],
+                net: net.clone(),
+                layer: *l,
+                geom: CopperGeom::Segment {
+                    a: *a,
+                    b: *b,
+                    half_w: nw / 2.0,
+                },
+            };
+            pl.spans.push(session.commit(id));
+            pl.stubs.push((*a, *b, *l));
+        }
+        pl.via_pts.extend(tv);
+        true
+    };
+    if !attach(session, &mut placed_mine, &mine, from, to)
+        || !attach(session, &mut placed_theirs, &theirs, p_from, p_to)
+    {
+        rollback_all(session, placed, &placed_mine, &placed_theirs, ripped);
+        return None;
+    }
 
     let center_len: f64 = r.segments.iter().map(|(a, b, _)| dist(*a, *b)).sum();
     log::info!(

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -543,6 +543,44 @@ fn realize_legs(
         return None;
     }
 
+    // Simplify each centerline run before offsetting: merge collinear steps
+    // and dissolve segments shorter than the offset distance. Offsetting a
+    // grid staircase whose steps are shorter than half_sep folds the offset
+    // polyline back over itself — census 14's twin-blocker shorts.
+    let min_seg = half_sep * 2.0;
+    let simplify = |pts: &[Vec2]| -> Vec<Vec2> {
+        let mut out: Vec<Vec2> = vec![pts[0]];
+        for &p in &pts[1..pts.len() - 1] {
+            let a = *out.last().unwrap();
+            if dist(a, p) < min_seg {
+                continue;
+            }
+            // Drop collinear interior points.
+            if out.len() >= 2 {
+                let b = out[out.len() - 2];
+                let d0 = (a - b).normalize();
+                let d1 = (p - a).normalize();
+                if (d0.x * d1.y - d0.y * d1.x).abs() < 1e-9 && d0.dot(d1) > 0.0 {
+                    out.pop();
+                }
+            }
+            out.push(p);
+        }
+        let last = *pts.last().unwrap();
+        if out.len() >= 2 && dist(*out.last().unwrap(), last) < min_seg {
+            out.pop();
+        }
+        out.push(last);
+        out
+    };
+    let runs: Vec<(PcbLayer, Vec<Vec2>)> = runs
+        .into_iter()
+        .map(|(l, pts)| (l, simplify(&pts)))
+        .collect();
+    if runs.iter().any(|(_, pts)| pts.len() < 2) {
+        return None;
+    }
+
     let leg = |sign: f64| -> Option<Leg> {
         let mut segments: Vec<(Vec2, Vec2, PcbLayer)> = Vec::new();
         let mut vias: Vec<(Vec2, PcbLayer, PcbLayer)> = Vec::new();

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -10,7 +10,7 @@
 //! legs to the actual pads, and commit both nets atomically (all-or-nothing)
 //! through [`validate_and_commit`] — so the DRC-clean invariant is untouched.
 
-use vcad_ir::ecad::{Pcb, PcbLayer};
+use vcad_ir::ecad::{Pcb, PcbLayer, Trace, Via};
 use vcad_ir::Vec2;
 
 use crate::session::RouteSession;
@@ -715,6 +715,115 @@ fn realize_legs(
         })
     };
     Some((leg(1.0)?, leg(-1.0)?))
+}
+
+/// Pair polish: on a FINISHED board, rip each still-uncoupled pair and
+/// re-route it coupled against the settled copper. The board is quiet, the
+/// pair gets a focused high-effort attempt, and failure restores the
+/// original copper — strictly non-regressive per pair.
+///
+/// Returns `(polished, attempted)`.
+pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
+    let nets: Vec<String> = {
+        let mut v: std::collections::BTreeSet<String> = Default::default();
+        for f in &pcb.footprints {
+            for pad in &f.pads {
+                if let Some(n) = &pad.net {
+                    if !n.is_empty() {
+                        v.insert(n.clone());
+                    }
+                }
+            }
+        }
+        v.into_iter().collect()
+    };
+    let classifier = super::classes::classify_nets(&nets);
+    let width = pcb.rules.default_rules.trace_width;
+    let (mut polished, mut attempted) = (0usize, 0usize);
+    for (pn, nn) in &classifier.pairs {
+        let (w, gap) = {
+            // Peek the class geometry for the coupling test pitch.
+            let s = RouteSession::from_pcb(pcb);
+            pair_geometry(&s, pcb, pn, width)
+        };
+        let frac = crate::router::si_claims::coupled_fraction(pcb, pn, nn, (w + gap) * 1.75);
+        if frac >= 0.5 {
+            continue;
+        }
+        let p_pads = pads_of_net(pcb, pn);
+        if p_pads.len() < 2 {
+            continue;
+        }
+        attempted += 1;
+        // Rip both nets' routed copper off a working copy of the board.
+        let mut work = pcb.clone();
+        work.traces.retain(|t| &t.net != pn && &t.net != nn);
+        work.vias.retain(|v| &v.net != pn && &v.net != nn);
+        let mut session = RouteSession::from_pcb(&work);
+        let mut placed: Vec<Placed> = Vec::new();
+        let cong = Congestion::new(&work.outline.vertices);
+        // MST endpoints: the two farthest pads of the P net.
+        let (mut from, mut to, mut best) = (p_pads[0], p_pads[0], -1.0);
+        for i in 0..p_pads.len() {
+            for j in i + 1..p_pads.len() {
+                let d = dist(p_pads[i], p_pads[j]);
+                if d > best {
+                    best = d;
+                    from = p_pads[i];
+                    to = p_pads[j];
+                }
+            }
+        }
+        if let Some((mine, theirs)) = try_route_pair(
+            &mut session,
+            &work,
+            width,
+            pn,
+            from,
+            to,
+            &mut placed,
+            &cong,
+            effort_expansions,
+        ) {
+            for pl in [&mine, &theirs] {
+                for &(a, b, l) in &pl.segments {
+                    work.traces.push(Trace {
+                        start: a,
+                        end: b,
+                        width: pl.width,
+                        layer: l,
+                        net: pl.net.clone(),
+                        source: None,
+                    });
+                }
+                for &(a, b, l) in &pl.stubs {
+                    work.traces.push(Trace {
+                        start: a,
+                        end: b,
+                        width: pl.stub_width,
+                        layer: l,
+                        net: pl.net.clone(),
+                        source: None,
+                    });
+                }
+                for &(pt, la, lb) in &pl.via_pts {
+                    work.vias.push(Via {
+                        position: pt,
+                        diameter: work.rules.default_rules.via_diameter,
+                        drill: work.rules.default_rules.via_drill,
+                        start_layer: la,
+                        end_layer: lb,
+                        net: pl.net.clone(),
+                        source: None,
+                    });
+                }
+            }
+            *pcb = work;
+            polished += 1;
+            log::info!("pair-polish: {pn} + {nn} now coupled");
+        }
+    }
+    (polished, attempted)
 }
 
 #[cfg(test)]

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -261,7 +261,11 @@ pub(super) fn try_route_pair(
         (4.0, 0.0),
         (0.0, 4.0),
         (4.0, 4.0),
+        (8.0, 4.0),
+        (4.0, 8.0),
         (8.0, 8.0),
+        (12.0, 12.0),
+        (16.0, 16.0),
     ] {
         let usable = span - 2.0 * lead;
         if r_from + r_to >= usable - 1.0 {
@@ -864,8 +868,38 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
                     true,
                 );
                 if !r.success {
-                    singles_ok = false;
-                    break 'singles;
+                    // Fall back to the single's ORIGINAL copper when it is
+                    // still legal beside the new pair.
+                    let orig: Vec<(Vec2, Vec2, PcbLayer)> = ripped_copper
+                        .iter()
+                        .filter(|t| &t.net == net)
+                        .map(|t| (t.start, t.end, t.layer))
+                        .collect();
+                    let ovias: Vec<(Vec2, PcbLayer, PcbLayer)> = ripped_vias
+                        .iter()
+                        .filter(|v| &v.net == net)
+                        .map(|v| (v.position, v.start_layer, v.end_layer))
+                        .collect();
+                    let cand = Candidate {
+                        net: net.clone(),
+                        from: pads[0],
+                        to: pads[pads.len() - 1],
+                        width: session.width_for(net, width),
+                        segments: orig,
+                        vias: ovias,
+                        thin_segments: vec![],
+                        thin_width: width,
+                    };
+                    match validate_and_commit(&mut session, &work, cand, &placed) {
+                        Some(pl) => {
+                            rerouted.push(pl);
+                            continue 'singles;
+                        }
+                        None => {
+                            singles_ok = false;
+                            break 'singles;
+                        }
+                    }
                 }
                 let cand = Candidate {
                     net: net.clone(),
@@ -891,10 +925,8 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
             continue;
         }
         // Success: write pair + rerouted singles back onto the working
-        // board (the ripped originals were removed above; reroutes replace
-        // them).
-        drop(ripped_copper);
-        drop(ripped_vias);
+        // board (the ripped originals were removed above; reroutes or
+        // restored originals replace them).
         for pl in rerouted.iter() {
             for &(a, b, l) in &pl.segments {
                 work.traces.push(Trace {

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -304,14 +304,15 @@ pub(super) fn try_route_pair(
     };
 
     // Realize the two legs from the centerline.
-    let (leg_a, leg_b) = match realize_legs(&r.segments, half_sep, via_off) {
-        Some(l) => l,
-        None => {
-            log::debug!("pair: {net}/{partner}: degenerate centerline — bailing");
-            restore(session, placed, ripped);
-            return None;
-        }
-    };
+    let (leg_a, leg_b) =
+        match realize_legs(&r.segments, half_sep, via_off, via_d / 2.0, clearance, w) {
+            Some(l) => l,
+            None => {
+                log::debug!("pair: {net}/{partner}: degenerate centerline — bailing");
+                restore(session, placed, ripped);
+                return None;
+            }
+        };
 
     // Leg → net assignment: the one whose pad connectors are shortest (the
     // non-crossing assignment — crossing connectors are strictly longer).
@@ -527,6 +528,9 @@ fn realize_legs(
     center: &[(Vec2, Vec2, PcbLayer)],
     half_sep: f64,
     via_off: f64,
+    via_r: f64,
+    clearance: f64,
+    w: f64,
 ) -> Option<(Leg, Leg)> {
     // Group the centerline into contiguous same-layer polyline runs.
     let mut runs: Vec<(PcbLayer, Vec<Vec2>)> = Vec::new();
@@ -607,22 +611,61 @@ fn realize_legs(
             if first.is_none() {
                 first = Some((off[0], *layer));
             }
-            // Layer transition from the previous run: one via for this leg,
-            // offset perpendicular from the centerline junction, with jog
-            // connectors on both layers when it doesn't sit on the leg line.
+            // Layer transition: STAGGERED pair vias on the track axis (the
+            // human DDR pattern) — the perpendicular dog-bone interleaved
+            // the two legs' discs and jogs below clearance at corners
+            // (censuses 11–16). The `sign>0` leg vias BEFORE the junction on
+            // the incoming axis, the other AFTER on the outgoing axis; each
+            // jog swerves around the other leg's via when it passes close.
             if let Some((pe, pl)) = prev_end {
-                let junction = pts[0];
-                // Perpendicular at the junction: direction of the new run's
-                // first segment (matches the offset used for the leg points).
-                let n = d_first.perp();
-                let vp = junction + n.scale(run_sign * via_off);
-                if dist(pe, vp) > 1e-9 {
-                    segments.push((pe, vp, pl));
-                }
-                if dist(vp, off[0]) > 1e-9 {
-                    segments.push((vp, off[0], *layer));
-                }
-                vias.push((vp, pl, *layer));
+                let j = pts[0];
+                let d0 = prev_dir.unwrap_or(d_first);
+                let d1 = d_first;
+                let delta = {
+                    let chord = (d0 + d1).length().max(0.5);
+                    ((2.0 * via_r + clearance + 0.04) / chord).max(via_off)
+                };
+                let before = j - d0.scale(delta);
+                let after = j + d1.scale(delta);
+                let (own, other) = if sign > 0.0 {
+                    (before, after)
+                } else {
+                    (after, before)
+                };
+                let s_off = via_r + clearance + w / 2.0 + 0.02;
+                let dodge = |from: Vec2, to: Vec2, obst: Vec2| -> Vec<Vec2> {
+                    let ab = to - from;
+                    let l2 = ab.x * ab.x + ab.y * ab.y;
+                    if l2 < 1e-18 {
+                        return vec![from, to];
+                    }
+                    let t = (((obst.x - from.x) * ab.x + (obst.y - from.y) * ab.y) / l2)
+                        .clamp(0.0, 1.0);
+                    let proj = from + ab.scale(t);
+                    if dist(proj, obst) >= s_off || t <= 1e-6 || t >= 1.0 - 1e-6 {
+                        return vec![from, to];
+                    }
+                    let away = {
+                        let v = proj - obst;
+                        let vl = v.length();
+                        if vl < 1e-9 {
+                            ab.normalize().perp()
+                        } else {
+                            v.scale(1.0 / vl)
+                        }
+                    };
+                    vec![from, obst + away.scale(s_off), to]
+                };
+                let mut emit = |path: Vec<Vec2>, layer: PcbLayer| {
+                    for wp in path.windows(2) {
+                        if dist(wp[0], wp[1]) > 1e-9 {
+                            segments.push((wp[0], wp[1], layer));
+                        }
+                    }
+                };
+                emit(dodge(pe, own, other), pl);
+                emit(dodge(own, off[0], other), *layer);
+                vias.push((own, pl, *layer));
             }
             for wpair in off.windows(2) {
                 if dist(wpair[0], wpair[1]) > 1e-9 {

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -300,26 +300,83 @@ pub(super) fn try_route_pair(
         (leg_b, leg_a)
     };
 
-    let build = |leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Candidate {
-        let mut segments = Vec::with_capacity(leg.segments.len() + 2);
-        if dist(from, leg.first) > 1e-9 {
-            segments.push((from, leg.first, leg.first_layer));
+    // Connector from a pad to a leg end: straight when short, maze-routed at
+    // single width when the crow-flight would thread a pin field (the second
+    // CM5 bail census: 71 leg validations failed on straight stubs crossing
+    // field copper after the neck-down retreat).
+    let connect = |session: &RouteSession,
+                   net: &str,
+                   from: Vec2,
+                   to: Vec2,
+                   to_layer: PcbLayer|
+     -> Option<(Vec<(Vec2, Vec2, PcbLayer)>, Vec<(Vec2, PcbLayer, PcbLayer)>)> {
+        if dist(from, to) <= 1e-9 {
+            return Some((vec![], vec![]));
         }
+        if dist(from, to) <= w * 2.0 {
+            return Some((vec![(from, to, to_layer)], vec![]));
+        }
+        let margin = 2.0 + w;
+        let window = (
+            Vec2::new(from.x.min(to.x) - margin, from.y.min(to.y) - margin),
+            Vec2::new(from.x.max(to.x) + margin, from.y.max(to.y) + margin),
+        );
+        let r = route_net_maze3d(
+            session,
+            &pcb.outline.vertices,
+            &copper,
+            net,
+            from,
+            &copper,
+            to,
+            &[to_layer],
+            w,
+            via_d,
+            Some(cong),
+            50_000,
+            0.5,
+            Some(window),
+            &[],
+            &[],
+            true,
+        );
+        if r.success {
+            Some((r.segments, r.vias))
+        } else {
+            None
+        }
+    };
+    let build = |leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
+        let (head_segs, head_vias) = connect(session, net, from, leg.first, leg.first_layer)?;
+        let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer)?;
+        let mut segments =
+            Vec::with_capacity(leg.segments.len() + head_segs.len() + tail_segs.len());
+        segments.extend(head_segs);
         segments.extend(leg.segments.iter().copied());
-        if dist(leg.last, to) > 1e-9 {
-            segments.push((leg.last, to, leg.last_layer));
-        }
-        Candidate {
+        // Tail connector was searched pad→leg; reverse into leg→pad order.
+        segments.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
+        let mut vias = leg.vias.clone();
+        vias.extend(head_vias);
+        vias.extend(tail_vias);
+        Some(Candidate {
             net: net.to_string(),
             from,
             to,
             width: w,
             segments,
-            vias: leg.vias.clone(),
-        }
+            vias,
+        })
     };
-    let cand_mine = build(&mine, net, from, to);
-    let cand_theirs = build(&theirs, &partner, p_from, p_to);
+    let Some(cand_mine) = build(&mine, net, from, to) else {
+        log::debug!("pair: {net}/{partner}: connector routing failed (mine)");
+        restore(session, placed, ripped);
+        return None;
+    };
+    let Some(cand_theirs) = build(&theirs, &partner, p_from, p_to) else {
+        log::debug!("pair: {net}/{partner}: connector routing failed (partner)");
+        restore(session, placed, ripped);
+        return None;
+    };
 
     // Atomic commit: both legs or neither.
     let Some(placed_mine) = validate_and_commit(session, pcb, cand_mine, placed) else {

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -759,9 +759,6 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
         let mut work = pcb.clone();
         work.traces.retain(|t| &t.net != pn && &t.net != nn);
         work.vias.retain(|v| &v.net != pn && &v.net != nn);
-        let mut session = RouteSession::from_pcb(&work);
-        let mut placed: Vec<Placed> = Vec::new();
-        let cong = Congestion::new(&work.outline.vertices);
         // MST endpoints: the two farthest pads of the P net.
         let (mut from, mut to, mut best) = (p_pads[0], p_pads[0], -1.0);
         for i in 0..p_pads.len() {
@@ -774,7 +771,56 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
                 }
             }
         }
-        if let Some((mine, theirs)) = try_route_pair(
+        // Corridor rip: single-ended (non-pair, non-plane) traces crossing
+        // the pair's corridor band move aside — the same negotiation right
+        // singles hold against each other. Ripped singles re-route after the
+        // pair commits; any that fail restore verbatim only if the pair
+        // failed (the pair outranks a flexible single).
+        let band = 2.0 * (w + gap) + 1.0;
+        let (lo, hi) = (
+            Vec2::new(from.x.min(to.x) - band, from.y.min(to.y) - band),
+            Vec2::new(from.x.max(to.x) + band, from.y.max(to.y) + band),
+        );
+        let plane_nets: std::collections::BTreeSet<&str> = pcb
+            .zones
+            .iter()
+            .filter(|z| !z.net.is_empty())
+            .map(|z| z.net.as_str())
+            .collect();
+        let in_band = |a: Vec2, b: Vec2| {
+            a.x.max(b.x) >= lo.x
+                && a.x.min(b.x) <= hi.x
+                && a.y.max(b.y) >= lo.y
+                && a.y.min(b.y) <= hi.y
+        };
+        let mut ripped_nets: std::collections::BTreeSet<String> = Default::default();
+        for t in &work.traces {
+            if !classifier.is_pair_member(&t.net)
+                && !plane_nets.contains(t.net.as_str())
+                && in_band(t.start, t.end)
+            {
+                ripped_nets.insert(t.net.clone());
+            }
+        }
+        let ripped_copper: Vec<Trace> = work
+            .traces
+            .iter()
+            .filter(|t| ripped_nets.contains(&t.net))
+            .cloned()
+            .collect();
+        let ripped_vias: Vec<Via> = work
+            .vias
+            .iter()
+            .filter(|v| ripped_nets.contains(&v.net))
+            .cloned()
+            .collect();
+        work.traces.retain(|t| !ripped_nets.contains(&t.net));
+        work.vias.retain(|v| !ripped_nets.contains(&v.net));
+
+        let mut session = RouteSession::from_pcb(&work);
+        let mut placed: Vec<Placed> = Vec::new();
+        let cong = Congestion::new(&work.outline.vertices);
+        let pair_result = try_route_pair(
             &mut session,
             &work,
             width,
@@ -784,7 +830,95 @@ pub fn polish_pairs(pcb: &mut Pcb, effort_expansions: usize) -> (usize, usize) {
             &mut placed,
             &cong,
             effort_expansions,
-        ) {
+        );
+        let Some((mine, theirs)) = pair_result else {
+            continue; // original board untouched — nothing was committed to pcb
+        };
+        // Re-route each ripped single against the pair-carrying session; a
+        // single that fails brings the whole attempt down (restore original).
+        let mut singles_ok = true;
+        let mut rerouted: Vec<Placed> = Vec::new();
+        'singles: for net in &ripped_nets {
+            let pads = pads_of_net(&work, net);
+            if pads.len() < 2 {
+                continue;
+            }
+            for i in 1..pads.len() {
+                let r = route_net_maze3d(
+                    &session,
+                    &work.outline.vertices,
+                    &copper_layers(&work),
+                    net,
+                    pads[i - 1],
+                    &copper_layers(&work),
+                    pads[i],
+                    &copper_layers(&work),
+                    session.width_for(net, width),
+                    work.rules.default_rules.via_diameter,
+                    Some(&cong),
+                    effort_expansions,
+                    1.0,
+                    None,
+                    &[],
+                    &[],
+                    true,
+                );
+                if !r.success {
+                    singles_ok = false;
+                    break 'singles;
+                }
+                let cand = Candidate {
+                    net: net.clone(),
+                    from: pads[i - 1],
+                    to: pads[i],
+                    width: session.width_for(net, width),
+                    segments: r.segments,
+                    vias: r.vias,
+                    thin_segments: vec![],
+                    thin_width: width,
+                };
+                match validate_and_commit(&mut session, &work, cand, &placed) {
+                    Some(pl) => rerouted.push(pl),
+                    None => {
+                        singles_ok = false;
+                        break 'singles;
+                    }
+                }
+            }
+        }
+        if !singles_ok {
+            log::debug!("pair-polish: {pn}: displaced single failed to re-route — reverting");
+            continue;
+        }
+        // Success: write pair + rerouted singles back onto the working
+        // board (the ripped originals were removed above; reroutes replace
+        // them).
+        drop(ripped_copper);
+        drop(ripped_vias);
+        for pl in rerouted.iter() {
+            for &(a, b, l) in &pl.segments {
+                work.traces.push(Trace {
+                    start: a,
+                    end: b,
+                    width: pl.width,
+                    layer: l,
+                    net: pl.net.clone(),
+                    source: None,
+                });
+            }
+            for &(pt, la, lb) in &pl.via_pts {
+                work.vias.push(Via {
+                    position: pt,
+                    diameter: work.rules.default_rules.via_diameter,
+                    drill: work.rules.default_rules.via_drill,
+                    start_layer: la,
+                    end_layer: lb,
+                    net: pl.net.clone(),
+                    source: None,
+                });
+            }
+        }
+        {
             for pl in [&mine, &theirs] {
                 for &(a, b, l) in &pl.segments {
                     work.traces.push(Trace {

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -304,12 +304,13 @@ pub(super) fn try_route_pair(
     // single width when the crow-flight would thread a pin field (the second
     // CM5 bail census: 71 leg validations failed on straight stubs crossing
     // field copper after the neck-down retreat).
+    type ConnectorCopper = (Vec<(Vec2, Vec2, PcbLayer)>, Vec<(Vec2, PcbLayer, PcbLayer)>);
     let connect = |session: &RouteSession,
                    net: &str,
                    from: Vec2,
                    to: Vec2,
                    to_layer: PcbLayer|
-     -> Option<(Vec<(Vec2, Vec2, PcbLayer)>, Vec<(Vec2, PcbLayer, PcbLayer)>)> {
+     -> Option<ConnectorCopper> {
         if dist(from, to) <= 1e-9 {
             return Some((vec![], vec![]));
         }

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -160,7 +160,8 @@ pub(super) fn try_route_pair(
     // (census 11: leg segments/jogs stepped outside a 2w+gap corridor onto
     // unprobed copper whenever the search dropped a layer change).
     let via_off = half_sep.max((via_d + clearance) / 2.0 + 0.01);
-    let fat_w = (2.0 * w + gap).max(2.0 * via_off + via_d);
+    let voff_max = via_off.max(via_d / 2.0 + clearance + w / 2.0 + 0.02 - half_sep);
+    let fat_w = (2.0 * w + gap).max(2.0 * (voff_max + via_d / 2.0));
     let copper = copper_layers(pcb);
     let first_layer = *copper.first().unwrap_or(&PcbLayer::FCu);
 
@@ -625,8 +626,14 @@ fn realize_legs(
                     let chord = (d0 + d1).length().max(0.5);
                     ((2.0 * via_r + clearance + 0.04) / chord).max(via_off)
                 };
-                let before = j - d0.scale(delta);
-                let after = j + d1.scale(delta);
+                // Perpendicular clearance: the via must clear the OTHER
+                // leg's line (at half_sep on the far side), so its center
+                // sits at least via_r + clearance + w/2 past the centerline
+                // on its OWN side — a centerline via clobbers both legs
+                // whenever via_r exceeds the gap (the unit repro's finding).
+                let voff = via_off.max(via_r + clearance + w / 2.0 + 0.02 - half_sep);
+                let before = j - d0.scale(delta) + d0.perp().scale(run_sign * voff);
+                let after = j + d1.scale(delta) + d1.perp().scale(run_sign * voff);
                 let (own, other) = if sign > 0.0 {
                     (before, after)
                 } else {
@@ -976,5 +983,84 @@ mod tests {
         )
         .is_none());
         assert_eq!(session.len(), baseline);
+    }
+
+    /// Deterministic repro for the layer-transition geometry (censuses
+    /// 11-17): a copper wall on FCu forces the pair through vias to BCu and
+    /// back. The pair must still route, and every committed P element must
+    /// clear every N element — the twin-blocker class of failures rendered
+    /// as a unit test.
+    #[test]
+    fn pair_layer_transition_keeps_twin_clearance() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let mut pcb = pair_board();
+        // Wall of foreign copper across FCu at x=25, leaving no FCu route.
+        pcb.traces.push(Trace {
+            start: Vec2::new(25.0, 0.0),
+            end: Vec2::new(25.0, 30.0),
+            width: 0.4,
+            layer: PcbLayer::FCu,
+            net: "WALL".into(),
+            source: None,
+        });
+        let mut session = RouteSession::from_pcb(&pcb);
+        let mut placed: Vec<Placed> = Vec::new();
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let r = try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            Vec2::new(5.0, 15.325),
+            Vec2::new(45.0, 15.325),
+            &mut placed,
+            &cong,
+            400_000,
+        );
+        let (mine, theirs) = r.expect("pair must route across the FCu wall via BCu");
+        assert!(
+            !mine.via_pts.is_empty() && !theirs.via_pts.is_empty(),
+            "route must actually change layers"
+        );
+        // Twin clearance: every P segment vs every N segment on shared layers.
+        let clearance = 0.15;
+        let seg_seg = |a1: Vec2, b1: Vec2, a2: Vec2, b2: Vec2| -> f64 {
+            let pt_seg = |p: Vec2, a: Vec2, b: Vec2| -> f64 {
+                let ab = b - a;
+                let l2 = ab.x * ab.x + ab.y * ab.y;
+                if l2 < 1e-18 {
+                    return dist(p, a);
+                }
+                let t = (((p.x - a.x) * ab.x + (p.y - a.y) * ab.y) / l2).clamp(0.0, 1.0);
+                dist(p, a + ab.scale(t))
+            };
+            pt_seg(a1, a2, b2)
+                .min(pt_seg(b1, a2, b2))
+                .min(pt_seg(a2, a1, b1))
+                .min(pt_seg(b2, a1, b1))
+        };
+        let all = |p: &Placed| -> Vec<(Vec2, Vec2, PcbLayer, f64)> {
+            let mut v: Vec<(Vec2, Vec2, PcbLayer, f64)> = p
+                .segments
+                .iter()
+                .map(|&(a, b, l)| (a, b, l, p.width))
+                .collect();
+            v.extend(p.stubs.iter().map(|&(a, b, l)| (a, b, l, p.stub_width)));
+            v
+        };
+        let mut worst = f64::INFINITY;
+        for &(a1, b1, l1, w1) in &all(&mine) {
+            for &(a2, b2, l2, w2) in &all(&theirs) {
+                if l1 != l2 {
+                    continue;
+                }
+                let edge = seg_seg(a1, b1, a2, b2) - w1 / 2.0 - w2 / 2.0;
+                worst = worst.min(edge);
+            }
+        }
+        assert!(
+            worst >= clearance - 1e-9,
+            "twin edge clearance {worst:.3}mm < {clearance}"
+        );
     }
 }

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -213,6 +213,8 @@ pub(super) fn try_route_pair(
     let restore = |session: &mut RouteSession, placed: &mut Vec<Placed>, ripped: Vec<Placed>| {
         for orig in ripped {
             let cand = Candidate {
+                thin_segments: vec![],
+                thin_width: orig.width,
                 net: orig.net.clone(),
                 from: orig.from,
                 to: orig.to,
@@ -321,6 +323,10 @@ pub(super) fn try_route_pair(
     // single width when the crow-flight would thread a pin field (the second
     // CM5 bail census: 71 leg validations failed on straight stubs crossing
     // field copper after the neck-down retreat).
+    // Neck-down width for pad connectors: the board's default single-ended
+    // width. A 0.2mm pair leg cannot pass between 0.4mm-pitch pads; the
+    // 0.08mm single can — exactly how the human escapes these fields.
+    let nw = pcb.rules.default_rules.trace_width.min(w);
     type ConnectorCopper = (Vec<(Vec2, Vec2, PcbLayer)>, Vec<(Vec2, PcbLayer, PcbLayer)>);
     let connect = |session: &RouteSession,
                    net: &str,
@@ -331,7 +337,7 @@ pub(super) fn try_route_pair(
         if dist(from, to) <= 1e-9 {
             return Some((vec![], vec![]));
         }
-        if dist(from, to) <= w * 2.0 {
+        if dist(from, to) <= nw * 2.0 {
             return Some((vec![(from, to, to_layer)], vec![]));
         }
         let margin = 4.0 + w;
@@ -348,7 +354,7 @@ pub(super) fn try_route_pair(
             &copper,
             to,
             &[to_layer],
-            w,
+            nw,
             via_d,
             Some(cong),
             120_000,
@@ -361,6 +367,15 @@ pub(super) fn try_route_pair(
         if r.success {
             Some((r.segments, r.vias))
         } else {
+            log::debug!(
+                "pair-connector: {net} {:.2}mm ({:.2},{:.2})->({:.2},{:.2}) layer {:?} failed",
+                dist(from, to),
+                from.x,
+                from.y,
+                to.x,
+                to.y,
+                to_layer
+            );
             None
         }
     };
@@ -368,12 +383,11 @@ pub(super) fn try_route_pair(
         |session: &RouteSession, leg: &Leg, net: &str, from: Vec2, to: Vec2| -> Option<Candidate> {
             let (head_segs, head_vias) = connect(session, net, from, leg.first, leg.first_layer)?;
             let (tail_segs, tail_vias) = connect(session, net, to, leg.last, leg.last_layer)?;
-            let mut segments =
-                Vec::with_capacity(leg.segments.len() + head_segs.len() + tail_segs.len());
-            segments.extend(head_segs);
-            segments.extend(leg.segments.iter().copied());
+            // Connectors are the neck-down: they commit at `nw` via the thin
+            // channel, while the coupled leg stays at the class width.
+            let mut thin = head_segs;
             // Tail connector was searched pad→leg; reverse into leg→pad order.
-            segments.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
+            thin.extend(tail_segs.into_iter().rev().map(|(a, b, l)| (b, a, l)));
             let mut vias = leg.vias.clone();
             vias.extend(head_vias);
             vias.extend(tail_vias);
@@ -382,8 +396,10 @@ pub(super) fn try_route_pair(
                 from,
                 to,
                 width: w,
-                segments,
+                segments: leg.segments.clone(),
                 vias,
+                thin_segments: thin,
+                thin_width: nw,
             })
         };
     // Build-and-commit SEQUENTIALLY: leg 2's connectors are searched against

--- a/crates/vcad-ecad-pcb/src/router/shove.rs
+++ b/crates/vcad-ecad-pcb/src/router/shove.rs
@@ -374,6 +374,7 @@ mod tests {
             width: 0.25,
             segments,
             stubs: Vec::new(),
+            stub_width: 0.25,
             via_pts: Vec::new(),
             spans: Vec::new(),
         }

--- a/crates/vcad-ecad-pcb/src/router/si_claims.rs
+++ b/crates/vcad-ecad-pcb/src/router/si_claims.rs
@@ -98,7 +98,7 @@ fn seg_len(a: Vec2, b: Vec2) -> f64 {
 /// Fraction of `p_net`'s routed length that runs coupled to `n_net`: sampled
 /// at each P segment midpoint, coupled means some same-layer N segment passes
 /// within `max_sep` (center-to-center).
-fn coupled_fraction(pcb: &Pcb, p_net: &str, n_net: &str, max_sep: f64) -> f64 {
+pub(crate) fn coupled_fraction(pcb: &Pcb, p_net: &str, n_net: &str, max_sep: f64) -> f64 {
     let p_segs: Vec<_> = pcb.traces.iter().filter(|t| t.net == p_net).collect();
     let n_segs: Vec<_> = pcb.traces.iter().filter(|t| t.net == n_net).collect();
     if p_segs.is_empty() || n_segs.is_empty() {

--- a/crates/vcad-ecad-pcb/src/router/si_claims.rs
+++ b/crates/vcad-ecad-pcb/src/router/si_claims.rs
@@ -344,3 +344,26 @@ mod tests {
         assert!(!skew.holds, "5mm > 1.1mm bound");
     }
 }
+
+/// Bridge into the unified `vcad.receipt/1` schema: every SI claim becomes a
+/// [`ReceiptClaim`] with `basis: Measured` — the geometric oracle ran over
+/// the actual board copper — under the [`RECEIPT_DOMAIN`] domain. Broken
+/// bounds are `Fail` claims, not omissions: the receipt is fail-closed.
+pub fn to_receipt_claims(set: &SiClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {
+    use vcad_receipt::{ClaimBasis, ClaimQuantity, OracleRef, ReceiptClaim};
+    let oracle = OracleRef::new("vcad-ecad-pcb::si_claims", env!("CARGO_PKG_VERSION"));
+    set.claims
+        .iter()
+        .map(|c| {
+            let desc = format!("{} <= {} {} — {}", c.name, c.bound, c.unit, c.note);
+            let id = format!("si.{}", c.name);
+            let base = if c.holds {
+                ReceiptClaim::pass(id, RECEIPT_DOMAIN, desc, oracle.clone())
+            } else {
+                ReceiptClaim::fail(id, RECEIPT_DOMAIN, desc, oracle.clone())
+            };
+            base.with_basis(ClaimBasis::Measured)
+                .with_measured(ClaimQuantity::new(c.value, c.unit.clone()))
+        })
+        .collect()
+}

--- a/crates/vcad-ecad-pcb/src/router/si_claims.rs
+++ b/crates/vcad-ecad-pcb/src/router/si_claims.rs
@@ -1,0 +1,346 @@
+//! Signal-integrity claims for the design receipt — `vcad.si-claims/1`.
+//!
+//! Measures the routed copper itself (no simulation): per-group length skew,
+//! intra-pair skew, differential coupled-length fraction, and SI-net via
+//! counts, each judged against explicit bounds. These are `basis: "verified"`
+//! claims in the [`vcad-receipt`] sense — the oracle (geometric measurement
+//! over the actual board copper) ran for real. What they do NOT claim is
+//! spelled out per-claim: no impedance verification (analytic tables are
+//! `predicted`, emitted separately), no crosstalk, no eye simulation.
+//!
+//! The bound defaults come from the traced Raspberry Pi CM5 production board
+//! — hardware that demonstrably boots — making a passing claim set an
+//! *envelope* argument: the copper stays within the measured discipline of a
+//! known-working reference.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use vcad_ir::ecad::Pcb;
+use vcad_ir::Vec2;
+
+use super::classes::NetClassifier;
+use super::length_match::net_routed_length;
+
+/// Schema tag for this claim family.
+pub const CLAIM_SCHEMA: &str = "vcad.si-claims/1";
+
+/// Domain tag in the unified `vcad.receipt/1` schema.
+pub const RECEIPT_DOMAIN: &str = "ecad-si";
+
+/// Bounds a claim set is judged against. Defaults are the human CM5
+/// envelope measured by `si_report` (raw trace-length metric).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SiBounds {
+    /// Max allowed length skew within a match group (mm).
+    pub group_skew_mm: f64,
+    /// Max allowed intra-pair skew (mm).
+    pub pair_skew_mm: f64,
+    /// Min required coupled-length fraction per pair (0..1).
+    pub min_coupled_fraction: f64,
+    /// Max vias per SI net, averaged.
+    pub max_vias_per_si_net: f64,
+}
+
+impl Default for SiBounds {
+    fn default() -> Self {
+        Self {
+            // Human board: DDR groups reach ~10mm raw skew (multi-drop);
+            // RGMII 3.2mm. 10mm is the reference envelope, not a target.
+            group_skew_mm: 10.0,
+            // Human worst intra-pair: 1.074mm.
+            pair_skew_mm: 1.1,
+            // Aspirational floor; the human couples essentially everywhere
+            // outside escape zones.
+            min_coupled_fraction: 0.5,
+            // Human: 222 vias / 98 SI nets ≈ 2.3.
+            max_vias_per_si_net: 3.0,
+        }
+    }
+}
+
+/// One measured claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Claim {
+    /// Claim name, snake_case.
+    pub name: String,
+    /// Measured value.
+    pub value: f64,
+    /// Unit ("1" for dimensionless).
+    pub unit: String,
+    /// Bound the value was judged against.
+    pub bound: f64,
+    /// Whether the value is within the bound.
+    pub holds: bool,
+    /// `"verified"` — the geometric oracle ran over the actual copper.
+    pub basis: String,
+    /// What was measured and what is NOT claimed.
+    pub note: String,
+}
+
+/// The full claim set.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SiClaimSet {
+    /// Schema tag ([`CLAIM_SCHEMA`]).
+    pub schema: String,
+    /// Bounds used.
+    pub bounds: SiBounds,
+    /// The claims.
+    pub claims: Vec<Claim>,
+    /// True when every claim holds.
+    pub all_hold: bool,
+}
+
+fn seg_len(a: Vec2, b: Vec2) -> f64 {
+    ((b.x - a.x).powi(2) + (b.y - a.y).powi(2)).sqrt()
+}
+
+/// Fraction of `p_net`'s routed length that runs coupled to `n_net`: sampled
+/// at each P segment midpoint, coupled means some same-layer N segment passes
+/// within `max_sep` (center-to-center).
+fn coupled_fraction(pcb: &Pcb, p_net: &str, n_net: &str, max_sep: f64) -> f64 {
+    let p_segs: Vec<_> = pcb.traces.iter().filter(|t| t.net == p_net).collect();
+    let n_segs: Vec<_> = pcb.traces.iter().filter(|t| t.net == n_net).collect();
+    if p_segs.is_empty() || n_segs.is_empty() {
+        return 0.0;
+    }
+    let point_seg_dist = |p: Vec2, a: Vec2, b: Vec2| -> f64 {
+        let ab = Vec2::new(b.x - a.x, b.y - a.y);
+        let l2 = ab.x * ab.x + ab.y * ab.y;
+        if l2 < 1e-18 {
+            return seg_len(p, a);
+        }
+        let t = (((p.x - a.x) * ab.x + (p.y - a.y) * ab.y) / l2).clamp(0.0, 1.0);
+        seg_len(p, Vec2::new(a.x + ab.x * t, a.y + ab.y * t))
+    };
+    let (mut coupled, mut total) = (0.0f64, 0.0f64);
+    for ps in &p_segs {
+        let l = seg_len(ps.start, ps.end);
+        total += l;
+        let mid = Vec2::new((ps.start.x + ps.end.x) / 2.0, (ps.start.y + ps.end.y) / 2.0);
+        let near = n_segs
+            .iter()
+            .filter(|ns| ns.layer == ps.layer)
+            .any(|ns| point_seg_dist(mid, ns.start, ns.end) <= max_sep);
+        if near {
+            coupled += l;
+        }
+    }
+    if total > 0.0 {
+        coupled / total
+    } else {
+        0.0
+    }
+}
+
+/// Measure the board against `bounds` and emit the claim set.
+pub fn si_claims(pcb: &Pcb, classifier: &NetClassifier, bounds: &SiBounds) -> SiClaimSet {
+    let mut claims = Vec::new();
+
+    // Worst group skew across all match groups (routed members only).
+    let mut worst_group = (0.0f64, String::new());
+    for (gname, members) in &classifier.match_groups {
+        let lens: Vec<f64> = members
+            .iter()
+            .map(|n| net_routed_length(pcb, n))
+            .filter(|l| *l > 0.0)
+            .collect();
+        if lens.len() > 1 {
+            let skew = lens.iter().cloned().fold(f64::MIN, f64::max)
+                - lens.iter().cloned().fold(f64::MAX, f64::min);
+            if skew > worst_group.0 {
+                worst_group = (skew, gname.clone());
+            }
+        }
+    }
+    claims.push(Claim {
+        name: "worst_group_skew".into(),
+        value: worst_group.0,
+        unit: "mm".into(),
+        bound: bounds.group_skew_mm,
+        holds: worst_group.0 <= bounds.group_skew_mm,
+        basis: "verified".into(),
+        note: format!(
+            "raw trace-length skew over match groups, worst = {} — multi-drop \
+             branch structure and package delays NOT modeled",
+            if worst_group.1.is_empty() {
+                "none"
+            } else {
+                &worst_group.1
+            }
+        ),
+    });
+
+    // Intra-pair skew + coupled fraction, worst over measured pairs.
+    let (mut worst_pair_skew, mut worst_coupled) = (0.0f64, 1.0f64);
+    let mut measured_pairs = 0usize;
+    let gap = pcb.rules.default_rules.diff_pair_gap.unwrap_or(0.25);
+    let w = pcb
+        .rules
+        .default_rules
+        .diff_pair_width
+        .unwrap_or(pcb.rules.default_rules.trace_width);
+    let max_sep = (w + gap) * 1.75;
+    for (p, n) in &classifier.pairs {
+        let (lp, ln) = (net_routed_length(pcb, p), net_routed_length(pcb, n));
+        if lp > 0.0 && ln > 0.0 {
+            measured_pairs += 1;
+            worst_pair_skew = worst_pair_skew.max((lp - ln).abs());
+            worst_coupled = worst_coupled.min(coupled_fraction(pcb, p, n, max_sep));
+        }
+    }
+    claims.push(Claim {
+        name: "worst_intra_pair_skew".into(),
+        value: worst_pair_skew,
+        unit: "mm".into(),
+        bound: bounds.pair_skew_mm,
+        holds: worst_pair_skew <= bounds.pair_skew_mm,
+        basis: "verified".into(),
+        note: format!("over {measured_pairs} routed pairs; time-of-flight NOT converted"),
+    });
+    claims.push(Claim {
+        name: "min_pair_coupled_fraction".into(),
+        value: worst_coupled,
+        unit: "1".into(),
+        bound: bounds.min_coupled_fraction,
+        holds: worst_coupled >= bounds.min_coupled_fraction,
+        basis: "verified".into(),
+        note: "fraction of P length with same-layer N copper within 1.75x pitch; \
+               impedance NOT verified by this claim"
+            .into(),
+    });
+
+    // Vias per SI net.
+    let si_nets: Vec<&String> = classifier.pairs.iter().flat_map(|(p, n)| [p, n]).collect();
+    let mut via_count = 0usize;
+    let mut routed_si = 0usize;
+    for net in &si_nets {
+        let vias = pcb.vias.iter().filter(|v| &v.net == *net).count();
+        if net_routed_length(pcb, net) > 0.0 {
+            routed_si += 1;
+            via_count += vias;
+        }
+    }
+    let vias_per_net = if routed_si > 0 {
+        via_count as f64 / routed_si as f64
+    } else {
+        0.0
+    };
+    claims.push(Claim {
+        name: "vias_per_si_net".into(),
+        value: vias_per_net,
+        unit: "1".into(),
+        bound: bounds.max_vias_per_si_net,
+        holds: vias_per_net <= bounds.max_vias_per_si_net,
+        basis: "verified".into(),
+        note: format!(
+            "{via_count} vias over {routed_si} routed SI nets; each via is a reference \
+             change — return-path continuity NOT verified"
+        ),
+    });
+
+    let all_hold = claims.iter().all(|c| c.holds);
+    SiClaimSet {
+        schema: CLAIM_SCHEMA.into(),
+        bounds: bounds.clone(),
+        claims,
+        all_hold,
+    }
+}
+
+/// Per-group skew table (name → (net_count, skew_mm)), for reports.
+pub fn group_skews(pcb: &Pcb, classifier: &NetClassifier) -> BTreeMap<String, (usize, f64)> {
+    let mut out = BTreeMap::new();
+    for (gname, members) in &classifier.match_groups {
+        let lens: Vec<f64> = members
+            .iter()
+            .map(|n| net_routed_length(pcb, n))
+            .filter(|l| *l > 0.0)
+            .collect();
+        if lens.len() > 1 {
+            let skew = lens.iter().cloned().fold(f64::MIN, f64::max)
+                - lens.iter().cloned().fold(f64::MAX, f64::min);
+            out.insert(gname.clone(), (lens.len(), skew));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router::classes::classify_nets;
+    use vcad_ir::ecad::{PcbLayer, Trace};
+
+    fn board_with(traces: Vec<Trace>) -> Pcb {
+        let mut pcb: Pcb = serde_json::from_value(serde_json::json!({
+            "outline": {"vertices": [], "cutouts": [], "thickness": 1.6},
+            "stackup": {"layers": []},
+            "nets": [],
+            "rules": {
+                "defaultRules": {"name": "Default", "traceWidth": 0.08, "clearance": 0.08,
+                                  "viaDiameter": 0.21, "viaDrill": 0.12,
+                                  "diffPairWidth": 0.2, "diffPairGap": 0.25},
+                "edgeClearance": 0.2, "holeToHole": 0.2, "minAnnularRing": 0.05, "minDrill": 0.1
+            },
+            "footprints": [], "traces": [], "traceArcs": [], "vias": [], "zones": []
+        }))
+        .expect("test board");
+        pcb.traces = traces;
+        pcb
+    }
+
+    fn seg(net: &str, y: f64, x0: f64, x1: f64) -> Trace {
+        Trace {
+            start: Vec2::new(x0, y),
+            end: Vec2::new(x1, y),
+            width: 0.2,
+            layer: PcbLayer::FCu,
+            net: net.into(),
+            source: None,
+        }
+    }
+
+    #[test]
+    fn coupled_pair_passes_uncoupled_fails() {
+        // Tight pair: legs 0.45mm apart over the full run.
+        let tight = board_with(vec![
+            seg("/X.TX_P", 0.0, 0.0, 20.0),
+            seg("/X.TX_N", 0.45, 0.0, 20.0),
+        ]);
+        let c = classify_nets(&["/X.TX_P".into(), "/X.TX_N".into()]);
+        let set = si_claims(&tight, &c, &SiBounds::default());
+        assert!(set.all_hold, "{:?}", set.claims);
+
+        // Split pair: legs 5mm apart — coupled fraction collapses.
+        let split = board_with(vec![
+            seg("/X.TX_P", 0.0, 0.0, 20.0),
+            seg("/X.TX_N", 5.0, 0.0, 20.0),
+        ]);
+        let set = si_claims(&split, &c, &SiBounds::default());
+        let cf = set
+            .claims
+            .iter()
+            .find(|cl| cl.name == "min_pair_coupled_fraction")
+            .unwrap();
+        assert!(!cf.holds);
+        assert!(!set.all_hold);
+    }
+
+    #[test]
+    fn pair_skew_judged_against_bound() {
+        let b = board_with(vec![
+            seg("/X.TX_P", 0.0, 0.0, 20.0),
+            seg("/X.TX_N", 0.45, 0.0, 25.0),
+        ]);
+        let c = classify_nets(&["/X.TX_P".into(), "/X.TX_N".into()]);
+        let set = si_claims(&b, &c, &SiBounds::default());
+        let skew = set
+            .claims
+            .iter()
+            .find(|cl| cl.name == "worst_intra_pair_skew")
+            .unwrap();
+        assert!((skew.value - 5.0).abs() < 1e-9);
+        assert!(!skew.holds, "5mm > 1.1mm bound");
+    }
+}


### PR DESCRIPTION
## Summary
The signal-integrity campaign on the CM5 benchmark: recover electrical intent from net names, route differential pairs coupled at class geometry, tune length-match groups, and judge every board against a machine-checkable SI claim set riding the unified DesignReceipt.

- **Net-class inference** (`router/classes.rs`): 49 diff pairs + 5 match groups recovered from net names; realized as IR class rules (guaranteed dp geometry).
- **Pair-first coupled routing**: pairs route as phantom-fat-trace units in round 0 with neck-down retreat, maze-routed thin connectors (mixed-width commit channel), legs-first ordering, whole-polyline offsetting, cusp handling, and in-line staggered vias — hardened by two geometric unit repros asserting twin clearance over every committed element.
- **`vcad.si-claims/1`** (`router/si_claims.rs`): group skew, intra-pair skew, coupled fraction, via budget — bounds measured from the human CM5 envelope; bridged into `vcad.receipt/1` (basis: Measured, fail-closed). The human board's receipt = Pass (calibration); autorouted boards currently Fail on pair claims (coupling campaign ongoing).
- **Pair polish** (`si_polish`): rip-and-recouple pass for finished boards with corridor rip of flexible singles.
- **10x negotiation speedup**: speculative rounds are search-only under a wall-clock budget; stub-carrying routes restore through the thin channel.
- Examples: `si_report` (skew/impedance/plane tables + receipt JSON), `si_tune` (multi-layer meander tuner), `drc_json`.

Current best board: group-skew and via claims HOLD inside the human envelope; DDR DQ lane skew beats the human reference (4.4mm vs 9.8mm raw).

## Test plan
- 234 unit tests including geometric pair repros (straight-wall + L-corner twin-clearance)
- `cargo clippy --workspace -- -D warnings` clean
- Full-board CM5 pipelines (route → ratchet → verdict ladder → tune → receipt → DRC) exercised end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)