### PR TITLE
fix(mcp): PCB widget shows the placed board in hosts that don't declare the UI capability

### DIFF
--- a/changelog/entries/2026-07-22-pcb-widget-inline-preview.json
+++ b/changelog/entries/2026-07-22-pcb-widget-inline-preview.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-22-pcb-widget-inline-preview",
+  "version": "0.9.4",
+  "date": "2026-07-22",
+  "category": "fix",
+  "title": "PCB widget shows the placed board in every host",
+  "summary": "place_components and other mount tools now always carry an inline preview GLB, so the viewer widget renders the board instead of 'no geometry to preview' in hosts like Claude Code.",
+  "features": ["mcp-viewer", "pcb"],
+  "mcpTools": ["place_components", "get_preview_glb"]
+}

--- a/packages/mcp/src/__tests__/pcb-inline-preview.test.ts
+++ b/packages/mcp/src/__tests__/pcb-inline-preview.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+
+/**
+ * A freshly placed PCB must actually preview in the inline viewer.
+ *
+ * Regression: Claude Code mounts the viewer widget WITHOUT declaring the
+ * `io.modelcontextprotocol/ui` capability at initialize, and its widget →
+ * server `get_preview_glb` round trip is not dependable. When the inline
+ * `_meta` preview was gated on that capability, place_components results in
+ * Claude Code rendered as "no geometry to preview" despite a fully placed
+ * board. The inline preview must ride on mount-tool results for ALL clients
+ * (it's `_meta` — never model-visible, ignored by UI-less hosts).
+ */
+
+async function connect(engine: Engine) {
+  const server = await createServer(engine, { user: null });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test", version: "0.0.0" },
+    { capabilities: {} }, // no UI extension declared — the Claude Code shape
+  );
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+function parse(result: unknown): Record<string, unknown> {
+  const content = (result as { content: Array<{ type: string; text: string }> })
+    .content;
+  return JSON.parse(content[0].text) as Record<string, unknown>;
+}
+
+const SCHEMATIC_ARGS = {
+  components: [
+    {
+      ref: "R1",
+      value: "1k",
+      footprint: "Resistor_SMD:R_0805",
+      x: 0,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive", x: -5, y: 0 },
+        { number: "2", name: "~", type: "Passive", x: 5, y: 0 },
+      ],
+    },
+    {
+      ref: "R2",
+      value: "1k",
+      footprint: "Resistor_SMD:R_0805",
+      x: 20,
+      y: 0,
+      pins: [
+        { number: "1", name: "~", type: "Passive", x: -5, y: 0 },
+        { number: "2", name: "~", type: "Passive", x: 5, y: 0 },
+      ],
+    },
+  ],
+  nets: { MID: ["R1.2", "R2.1"] },
+};
+
+describe("place_components inline preview (no-UI-capability client)", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  it("rides a ready-to-render GLB in _meta and previews via get_preview_glb", async () => {
+    const { client, server } = await connect(engine);
+    const documentId = parse(
+      await client.callTool({
+        name: "create_schematic",
+        arguments: SCHEMATIC_ARGS,
+      }),
+    ).document_id as string;
+
+    const placed = (await client.callTool({
+      name: "place_components",
+      arguments: { document_id: documentId, board_width: 40, board_height: 30 },
+    })) as { _meta?: Record<string, unknown> };
+
+    const inline = placed._meta?.["vcad.io/preview"] as
+      | { document_id?: string; glb?: string }
+      | undefined;
+    expect(inline?.document_id).toBe(documentId);
+    expect(typeof inline?.glb).toBe("string");
+    expect((inline!.glb as string).length).toBeGreaterThan(1000);
+
+    // The widget's fetch path serves the same board.
+    const glb = parse(
+      await client.callTool({
+        name: "get_preview_glb",
+        arguments: { document_id: documentId },
+      }),
+    );
+    expect(glb._vcad_glb).toBeTruthy();
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1416,10 +1416,16 @@ export async function createServer(
           // the content-addressed GLB cache for the poll loop. Best-effort
           // and size-capped; hosts that strip `_meta` (and oversized docs)
           // fall back to the fetch path unchanged.
-          if (
-            def.behavior.mount &&
-            (clientHasInlineUi() || context.assumeUiClient === true)
-          ) {
+          //
+          // NOT gated on the client's declared UI capability: Claude Code
+          // mounts the widget without ever declaring
+          // `extensions["io.modelcontextprotocol/ui"]` at initialize, and in
+          // that host the widget's fallback `get_preview_glb` round trip is
+          // not dependable — gating on the capability left the freshly
+          // placed board rendering as "no geometry to preview". `_meta` is
+          // ignored by UI-less clients and never model-visible, so the only
+          // cost of always attaching is transport bytes.
+          if (def.behavior.mount) {
             await attachInlinePreview(result, docId, engine);
           }
         }

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -1010,7 +1010,13 @@ async function fetchAndRenderGlb(
   })) as ToolResultLike;
   const glb = findInlineGlb(previewResult);
   if (!glb) {
-    setStatus("no geometry to preview", "idle");
+    // An error result (e.g. the session isn't resident on the instance that
+    // answered) is not the same as an empty document — say so instead of
+    // masquerading as "no geometry".
+    setStatus(
+      previewResult?.isError ? "preview unavailable" : "no geometry to preview",
+      "idle",
+    );
     return;
   }
   const ver = findPreviewVersion(previewResult);


### PR DESCRIPTION
## Problem

In Claude Code, the `place_components` widget rendered **"no geometry to preview"** even after a successful placement (screenshot in session). Server-side GLB generation was fine — `get_preview_glb` returns a full layered board when called directly.

## Root cause

The inline `_meta` `vcad.io/preview` GLB (the widget's zero-round-trip first-paint path) was gated on the client declaring `extensions["io.modelcontextprotocol/ui"]` at initialize. The HTTP path always assumes a UI client, but over **stdio Claude Code never declares that capability** — while its desktop host still mounts the widget. With no inline GLB, the widget fell back to its `get_preview_glb` round trip, which is not dependable in that host → empty grid.

## Fix

- Always attach the (1.5MB-capped) inline preview GLB to mount-tool results. `_meta` never reaches the model and UI-less hosts ignore it, so the only cost is transport bytes.
- Viewer: an error result from the preview fetch now reads "preview unavailable" instead of masquerading as "no geometry to preview".
- Lock-in test: a no-capability client (the Claude Code shape) gets `_meta["vcad.io/preview"]` on `place_components` with a real GLB.

Full `@vcad/mcp` suite: 80 files / 905 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)