### PR TITLE
feat(ecad): export a linked KiCad project bundle from export_kicad

### DIFF
--- a/changelog/entries/2026-07-22-kicad-project-bundle.json
+++ b/changelog/entries/2026-07-22-kicad-project-bundle.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-22-kicad-project-bundle",
+  "version": "0.9.4",
+  "date": "2026-07-22",
+  "category": "feat",
+  "title": "Linked KiCad project bundle export",
+  "summary": "export_kicad with a .kicad_pro filename (or bare name) now emits a linked project — .kicad_pro + .kicad_sch + .kicad_pcb with cross-probe symbol↔footprint paths.",
+  "features": ["pcb", "export", "kicad"],
+  "mcpTools": ["export_kicad"]
+}

--- a/crates/vcad-ecad-symbols/src/kicad_write.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_write.rs
@@ -226,11 +226,30 @@ impl NetTable {
 }
 
 // ---------------------------------------------------------------------------
+// Schematic ↔ board linkage
+// ---------------------------------------------------------------------------
+
+/// UUIDs captured while writing a schematic, used to link the board file back
+/// to it so KiCad can cross-probe (click a symbol → highlight its footprint).
+struct SchematicLinks {
+    /// The schematic's root sheet uuid (also recorded in the `.kicad_pro`).
+    root_uuid: String,
+    /// Reference designator (e.g. `R1`) → symbol instance uuid.
+    symbol_uuids: BTreeMap<String, String>,
+    /// The schematic filename, emitted as each footprint's `sheetfile`.
+    sch_filename: String,
+}
+
+// ---------------------------------------------------------------------------
 // PCB writer
 // ---------------------------------------------------------------------------
 
 /// Serialize a [`Pcb`] to a KiCad 9 `.kicad_pcb` board file.
 pub fn write_kicad_pcb(pcb: &Pcb) -> String {
+    write_kicad_pcb_impl(pcb, None)
+}
+
+fn write_kicad_pcb_impl(pcb: &Pcb, links: Option<&SchematicLinks>) -> String {
     let mut e = Emitter::new();
     let nets = NetTable::build(pcb);
 
@@ -256,7 +275,7 @@ pub fn write_kicad_pcb(pcb: &Pcb) -> String {
 
     // Footprints
     for fp in &pcb.footprints {
-        write_footprint(&mut e, fp, &nets);
+        write_footprint(&mut e, fp, &nets, links);
     }
 
     // Board outline (Edge.Cuts)
@@ -378,7 +397,12 @@ fn write_closed_loop(e: &mut Emitter, verts: &[Vec2], edge: &dyn Fn(&mut Emitter
     }
 }
 
-fn write_footprint(e: &mut Emitter, fp: &Footprint, nets: &NetTable) {
+fn write_footprint(
+    e: &mut Emitter,
+    fp: &Footprint,
+    nets: &NetTable,
+    links: Option<&SchematicLinks>,
+) {
     let layer = if fp.front { "F.Cu" } else { "B.Cu" };
     let uuid = e.uuid();
     let name = if fp.footprint_name.is_empty() {
@@ -403,6 +427,16 @@ fn write_footprint(e: &mut Emitter, fp: &Footprint, nets: &NetTable) {
 
     write_fp_property(e, "Reference", &fp.reference, "F.SilkS");
     write_fp_property(e, "Value", &fp.value, "F.Fab");
+
+    // Cross-probe linkage: point the footprint at its schematic symbol
+    // instance (KiCad 9 root-sheet paths are "/<symbol-uuid>").
+    if let Some(links) = links {
+        if let Some(sym_uuid) = links.symbol_uuids.get(&fp.reference) {
+            e.line(2, &format!("(path {})", q(&format!("/{}", sym_uuid))));
+            e.line(2, "(sheetname \"/\")");
+            e.line(2, &format!("(sheetfile {})", q(&links.sch_filename)));
+        }
+    }
 
     for g in &fp.graphics {
         write_fp_graphic(e, g);
@@ -761,8 +795,22 @@ fn arc_points(center: Vec2, radius: f64, start_deg: f64, end_deg: f64) -> (Vec2,
 /// (wires / labels / junctions) preserved.  It is a faithful editable starting
 /// point rather than a pixel-match of KiCad's built-in symbol artwork.
 pub fn write_kicad_sch(sheet: &SchematicSheet) -> String {
+    write_kicad_sch_impl(sheet, "", "").0
+}
+
+/// Writer core shared by [`write_kicad_sch`] and [`write_kicad_project`].
+///
+/// `project_name` is embedded in each symbol's `(instances (project …))`
+/// block and `sch_filename` is recorded in the returned links; both are empty
+/// for a standalone (projectless) export, which keeps that output unchanged.
+fn write_kicad_sch_impl(
+    sheet: &SchematicSheet,
+    project_name: &str,
+    sch_filename: &str,
+) -> (String, SchematicLinks) {
     let mut e = Emitter::new();
     let root_uuid = e.uuid();
+    let mut symbol_uuids = BTreeMap::new();
 
     e.line(0, "(kicad_sch");
     e.line(1, "(version 20250114)");
@@ -780,7 +828,8 @@ pub fn write_kicad_sch(sheet: &SchematicSheet) -> String {
 
     // Component instances.
     for comp in &sheet.components {
-        write_sch_symbol(&mut e, comp, &root_uuid);
+        let uuid = write_sch_symbol(&mut e, comp, &root_uuid, project_name);
+        symbol_uuids.insert(comp.reference.clone(), uuid);
     }
 
     // Wires.
@@ -825,7 +874,14 @@ pub fn write_kicad_sch(sheet: &SchematicSheet) -> String {
     e.line(1, ")");
     e.line(1, "(embedded_fonts no)");
     e.line(0, ")");
-    e.buf
+    (
+        e.buf,
+        SchematicLinks {
+            root_uuid,
+            symbol_uuids,
+            sch_filename: sch_filename.to_string(),
+        },
+    )
 }
 
 /// KiCad pin electrical-type token for a [`PinType`].
@@ -1019,7 +1075,13 @@ fn pin_angle(_comp: &SchematicComponent, pos: Vec2, body: (Vec2, Vec2)) -> f64 {
     }
 }
 
-fn write_sch_symbol(e: &mut Emitter, comp: &SchematicComponent, root_uuid: &str) {
+/// Emit one symbol instance and return its uuid (the board's cross-probe key).
+fn write_sch_symbol(
+    e: &mut Emitter,
+    comp: &SchematicComponent,
+    root_uuid: &str,
+    project_name: &str,
+) -> String {
     let lib_id = comp_lib_id(comp);
     let uuid = e.uuid();
     e.line(1, "(symbol");
@@ -1052,7 +1114,7 @@ fn write_sch_symbol(e: &mut Emitter, comp: &SchematicComponent, root_uuid: &str)
     }
 
     e.line(2, "(instances");
-    e.line(3, "(project \"\"");
+    e.line(3, &format!("(project {}", q(project_name)));
     e.line(4, &format!("(path {}", q(&format!("/{}", root_uuid))));
     e.line(5, &format!("(reference {})", q(&comp.reference)));
     e.line(5, "(unit 1)");
@@ -1060,6 +1122,7 @@ fn write_sch_symbol(e: &mut Emitter, comp: &SchematicComponent, root_uuid: &str)
     e.line(3, ")");
     e.line(2, ")");
     e.line(1, ")");
+    uuid
 }
 
 fn write_inst_property(e: &mut Emitter, key: &str, value: &str, y_off: f64, hide: bool) {
@@ -1103,6 +1166,93 @@ fn write_label(e: &mut Emitter, l: &SchematicLabel) {
     e.line(2, ")");
     e.line(2, &format!("(uuid {})", q(&uuid)));
     e.line(1, ")");
+}
+
+// ---------------------------------------------------------------------------
+// Project bundle writer
+// ---------------------------------------------------------------------------
+
+/// Serialize a linked KiCad 9 project bundle: `<name>.kicad_pro`,
+/// `<name>.kicad_sch`, and `<name>.kicad_pcb` as `(filename, contents)` pairs.
+///
+/// Unlike exporting the two files separately, the bundle is *linked*: each
+/// board footprint carries a `(path "/<symbol-uuid>")` pointing at the
+/// schematic symbol instance with the same reference designator, and the
+/// project file records the schematic's root sheet uuid — so KiCad can
+/// cross-probe (click a symbol → highlight its footprint, and vice versa).
+/// Output is deterministic: the same inputs always produce identical bytes.
+pub fn write_kicad_project(sheet: &SchematicSheet, pcb: &Pcb, name: &str) -> Vec<(String, String)> {
+    let sch_filename = format!("{}.kicad_sch", name);
+    let (sch, links) = write_kicad_sch_impl(sheet, name, &sch_filename);
+    let board = write_kicad_pcb_impl(pcb, Some(&links));
+    let pro = write_kicad_pro(name, &links.root_uuid);
+    vec![
+        (format!("{}.kicad_pro", name), pro),
+        (sch_filename, sch),
+        (format!("{}.kicad_pcb", name), board),
+    ]
+}
+
+/// Minimal valid KiCad 9 project JSON (`meta.version` 3), recording the
+/// schematic's root sheet uuid in `sheets` the way KiCad itself does.
+fn write_kicad_pro(name: &str, root_uuid: &str) -> String {
+    let pro = serde_json::json!({
+        "board": {
+            "3dviewports": [],
+            "design_settings": {
+                "defaults": {},
+                "diff_pair_dimensions": [],
+                "drc_exclusions": [],
+                "meta": { "version": 2 },
+                "rule_severities": {},
+                "rules": {},
+                "track_widths": [],
+                "via_dimensions": []
+            },
+            "layer_presets": [],
+            "viewports": []
+        },
+        "boards": [],
+        "cvpcb": { "equivalence_files": [] },
+        "libraries": {
+            "pinned_footprint_libs": [],
+            "pinned_symbol_libs": []
+        },
+        "meta": {
+            "filename": format!("{}.kicad_pro", name),
+            "version": 3
+        },
+        "net_settings": {
+            "classes": [],
+            "meta": { "version": 4 },
+            "net_colors": null,
+            "netclass_assignments": null,
+            "netclass_patterns": []
+        },
+        "pcbnew": {
+            "last_paths": {
+                "gencad": "",
+                "idf": "",
+                "netlist": "",
+                "plot": "",
+                "pos_files": "",
+                "specctra_dsn": "",
+                "step": "",
+                "svg": "",
+                "vrml": ""
+            },
+            "page_layout_descr_file": ""
+        },
+        "schematic": {
+            "legacy_lib_dir": "",
+            "legacy_lib_list": []
+        },
+        "sheets": [[root_uuid, "Root"]],
+        "text_variables": {}
+    });
+    let mut s = serde_json::to_string_pretty(&pro).expect("static project JSON serializes");
+    s.push('\n');
+    s
 }
 
 #[cfg(test)]
@@ -1444,6 +1594,15 @@ mod tests {
         let sch = dir.join("sheet.kicad_sch");
         std::fs::write(&sch, write_kicad_sch(&sheet)).unwrap();
         println!("wrote {}", sch.display());
+
+        // Linked project bundle in its own subdirectory.
+        let proj_dir = dir.join("project");
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        for (name, contents) in write_kicad_project(&sheet, &sample_pcb(), "vcad_demo") {
+            let path = proj_dir.join(&name);
+            std::fs::write(&path, contents).unwrap();
+            println!("wrote {}", path.display());
+        }
     }
 
     fn sample_sheet() -> SchematicSheet {
@@ -1515,6 +1674,64 @@ mod tests {
             }],
             nets: None,
         }
+    }
+
+    #[test]
+    fn project_bundle_links_symbols_to_footprints() {
+        let sheet = sample_sheet();
+        let pcb = sample_pcb();
+        let files = write_kicad_project(&sheet, &pcb, "demo");
+
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["demo.kicad_pro", "demo.kicad_sch", "demo.kicad_pcb"]
+        );
+        let get = |n: &str| &files.iter().find(|(f, _)| f == n).unwrap().1;
+        let pro = get("demo.kicad_pro");
+        let sch = get("demo.kicad_sch");
+        let board = get("demo.kicad_pcb");
+
+        // The project file parses as JSON and records the sch root sheet uuid.
+        let pro_json: serde_json::Value = serde_json::from_str(pro).expect("valid project JSON");
+        assert_eq!(pro_json["meta"]["filename"], "demo.kicad_pro");
+        let root_uuid = pro_json["sheets"][0][0].as_str().expect("root sheet uuid");
+        assert!(sch.contains(&format!("(uuid \"{}\")", root_uuid)));
+
+        // R1's schematic symbol uuid appears as R1's footprint path in the pcb.
+        // The symbol instance uuid is the `(uuid …)` line inside the `(symbol`
+        // block whose reference is R1.
+        let sym_block = sch
+            .split("\n\t(symbol\n")
+            .find(|b| b.contains("(property \"Reference\" \"R1\""))
+            .expect("R1 symbol instance in sch");
+        let sym_uuid = sym_block
+            .lines()
+            .find_map(|l| l.trim().strip_prefix("(uuid \""))
+            .and_then(|s| s.strip_suffix("\")"))
+            .expect("R1 symbol uuid");
+        assert!(
+            board.contains(&format!("(path \"/{}\")", sym_uuid)),
+            "footprint path should reference R1's symbol uuid {}",
+            sym_uuid
+        );
+        assert!(board.contains("(sheetfile \"demo.kicad_sch\")"));
+
+        // Instances carry the project name; sch symbols use it for cross-probe.
+        assert!(sch.contains("(project \"demo\""));
+
+        // Deterministic: same inputs → identical bytes.
+        assert_eq!(files, write_kicad_project(&sheet, &pcb, "demo"));
+    }
+
+    #[test]
+    fn standalone_exports_unchanged_by_bundle_refactor() {
+        // Standalone sch/pcb writers must not gain project linkage artifacts.
+        let sch = write_kicad_sch(&sample_sheet());
+        assert!(sch.contains("(project \"\""));
+        let board = write_kicad_pcb(&sample_pcb());
+        assert!(!board.contains("(sheetfile"));
+        assert!(!board.contains("(path \"/"));
     }
 
     #[test]

--- a/crates/vcad-ecad-symbols/src/lib.rs
+++ b/crates/vcad-ecad-symbols/src/lib.rs
@@ -42,7 +42,7 @@ use serde::{Deserialize, Serialize};
 pub use kicad_mod::{parse_footprint_lib, FootprintDef, FootprintLib, GraphicDef, PadDef};
 pub use kicad_pcb::parse_kicad_pcb;
 pub use kicad_sym::{parse_symbol_lib, Symbol, SymbolGraphic, SymbolLib, SymbolPin};
-pub use kicad_write::{write_kicad_pcb, write_kicad_sch};
+pub use kicad_write::{write_kicad_pcb, write_kicad_project, write_kicad_sch};
 
 /// A key-value property from a KiCad library element.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -6389,6 +6389,31 @@ mod ecad_wasm {
         Ok(vcad_ecad_symbols::write_kicad_sch(&sheet))
     }
 
+    /// Export a linked KiCad 9 project bundle: `<name>.kicad_pro`,
+    /// `<name>.kicad_sch`, and `<name>.kicad_pcb`, with board footprints
+    /// carrying `(path …)` references to their schematic symbol uuids so
+    /// KiCad can cross-probe between the two editors.
+    ///
+    /// # Arguments
+    /// * `sheet_json` - JSON-serialized `SchematicSheet` struct
+    /// * `pcb_json` - JSON-serialized `Pcb` struct
+    /// * `name` - Project basename (no extension)
+    ///
+    /// # Returns
+    /// Array of `[filename, contents]` string pairs as JsValue.
+    #[wasm_bindgen(js_name = exportKicadProject)]
+    pub fn export_kicad_project(
+        sheet_json: &str,
+        pcb_json: &str,
+        name: &str,
+    ) -> Result<JsValue, JsError> {
+        let sheet: SchematicSheet =
+            serde_json::from_str(sheet_json).map_err(|e| JsError::new(&e.to_string()))?;
+        let pcb: Pcb = serde_json::from_str(pcb_json).map_err(|e| JsError::new(&e.to_string()))?;
+        let files = vcad_ecad_symbols::write_kicad_project(&sheet, &pcb, name);
+        serde_wasm_bindgen::to_value(&files).map_err(|e| JsError::new(&e.to_string()))
+    }
+
     /// Return all builtin symbol definitions.
     ///
     /// # Returns

--- a/packages/engine/src/ecad.ts
+++ b/packages/engine/src/ecad.ts
@@ -898,6 +898,35 @@ export async function exportKicadSch(sheet: SchematicSheet): Promise<string | nu
   }
 }
 
+/**
+ * Export a linked KiCad 9 project bundle (`<name>.kicad_pro` / `.kicad_sch` /
+ * `.kicad_pcb`) with footprint→symbol cross-probe paths. Returns
+ * `[filename, contents]` pairs, or null if the ECAD WASM is unavailable or
+ * predates the bundle export.
+ */
+export async function exportKicadProject(
+  sheet: SchematicSheet,
+  pcb: Pcb,
+  name: string,
+): Promise<Array<[string, string]> | null> {
+  // Structural cast: the checked-in WASM package may predate this binding
+  // (artifacts are only refreshed on main), so probe for it at runtime.
+  const wasm = (await loadEcadWasm()) as {
+    exportKicadProject?: (sheetJson: string, pcbJson: string, name: string) => unknown;
+  } | null;
+  if (!wasm || typeof wasm.exportKicadProject !== "function") return null;
+  try {
+    return wasm.exportKicadProject(
+      JSON.stringify(sheet),
+      JSON.stringify(pcb),
+      name,
+    ) as Array<[string, string]>;
+  } catch (e) {
+    console.warn("[ECAD] KiCad project export failed:", e);
+    return null;
+  }
+}
+
 /** Fill copper pour zones on the PCB. */
 export async function fillZones(pcb: Pcb): Promise<FilledZoneResult[]> {
   const wasm = await loadEcadWasm();

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -193,6 +193,7 @@ export {
   tryExportFabFiles,
   parseKicadPcb,
   exportKicadPcb,
+  exportKicadProject,
   exportKicadSch,
   builtinSymbols,
   footprintForName,

--- a/packages/mcp/src/__tests__/ecad.test.ts
+++ b/packages/mcp/src/__tests__/ecad.test.ts
@@ -1418,6 +1418,46 @@ describe("ecad session flow", () => {
     expect(bad.isError).toBe(true);
   });
 
+  it("export_kicad .kicad_pro exports a linked project bundle", async () => {
+    const created = out(
+      await createSchematic({
+        components: [resistor("R1", 0), resistor("R2", 20)],
+        nets: { MID: ["R1.2", "R2.1"] },
+      }),
+    );
+    const id = created.document_id;
+    out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
+
+    const result = await exportKicad({ document_id: id, filename: "demo.kicad_pro" });
+    if ((result as { isError?: boolean }).isError) {
+      // The checked-in kernel WASM predates exportKicadProject (artifacts are
+      // only refreshed on main); the tool must degrade with a clear error.
+      expect(JSON.stringify(result)).toContain("unavailable");
+      return;
+    }
+    const bundle = out(result);
+    expect(bundle.success).toBe(true);
+    expect(bundle.format).toBe("kicad_project");
+    expect(bundle.document_id).toBe(id);
+    const names = (bundle.files as Array<{ name: string }>).map((f) => f.name);
+    expect(names).toEqual(["demo.kicad_pro", "demo.kicad_sch", "demo.kicad_pcb"]);
+    const get = (n: string) =>
+      (bundle.files as Array<{ name: string; content: string }>).find((f) => f.name === n)!
+        .content;
+    // The project file is valid JSON recording the sheet root uuid.
+    const pro = JSON.parse(get("demo.kicad_pro"));
+    expect(pro.meta.filename).toBe("demo.kicad_pro");
+    const rootUuid = pro.sheets[0][0];
+    expect(get("demo.kicad_sch")).toContain(`(uuid "${rootUuid}")`);
+    // The board footprints are linked to schematic symbols (cross-probe paths).
+    expect(get("demo.kicad_pcb")).toContain('(sheetfile "demo.kicad_sch")');
+    expect(get("demo.kicad_pcb")).toMatch(/\(path "\/[0-9a-f-]{36}"\)/);
+
+    // A bare name (no extension) takes the same bundle path.
+    const bare = out(await exportKicad({ document_id: id, filename: "demo" }));
+    expect(bare.format).toBe("kicad_project");
+  });
+
   it("export_gerber blocks a dirty (unconnected-net) board and returns the DRC summary", async () => {
     const created = out(
       await createSchematic({

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -9577,7 +9577,7 @@
   {
     "name": "export_kicad",
     "title": "Export KiCad",
-    "description": "Export the session as a native, editable KiCad 9 file. filename ending in .kicad_pcb writes the board (footprints, pads, nets, traces, vias, zones, layers, outline); .kicad_sch writes the schematic. Unlike export_gerber (fab-only output), this round-trips: a human can open it in KiCad to finish routing nets the autorouter couldn't close, then re-import. Large files respect the inline byte cap (use output_dir for those).",
+    "description": "Export the session as a native, editable KiCad 9 file. filename ending in .kicad_pcb writes the board (footprints, pads, nets, traces, vias, zones, layers, outline); .kicad_sch writes the schematic; .kicad_pro (or a bare name) writes a linked project bundle (.kicad_pro + .kicad_sch + .kicad_pcb) with footprints tied to their schematic symbols for cross-probing. Unlike export_gerber (fab-only output), this round-trips: a human can open it in KiCad to finish routing nets the autorouter couldn't close, then re-import. Large files respect the inline byte cap (use output_dir for those).",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -9591,7 +9591,7 @@
         },
         "filename": {
           "type": "string",
-          "description": "Output filename ending in .kicad_pcb (board) or .kicad_sch (schematic). The extension selects what is exported: .kicad_pcb writes the session's board (footprints, pads, nets, traces, vias, zones, layers, outline) as a native, editable KiCad 9 file a human can open and finish routing; .kicad_sch writes the session's schematic. Defaults to board.kicad_pcb."
+          "description": "Output filename ending in .kicad_pcb (board), .kicad_sch (schematic), or .kicad_pro (linked project bundle). The extension selects what is exported: .kicad_pcb writes the session's board (footprints, pads, nets, traces, vias, zones, layers, outline) as a native, editable KiCad 9 file a human can open and finish routing; .kicad_sch writes the session's schematic; .kicad_pro (or a bare name with no extension) writes all three files with board footprints linked to their schematic symbols so KiCad can cross-probe (click a symbol → highlight its footprint). Defaults to board.kicad_pcb."
         },
         "output_dir": {
           "type": "string",

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -50,6 +50,7 @@ import {
   exportFabFiles,
   pcbPreviewMeshes,
   exportKicadPcb,
+  exportKicadProject,
   exportKicadSch,
   tryExportFabFiles,
   tryRunDrc,
@@ -1115,11 +1116,14 @@ export const exportKicadSchema = {
     filename: {
       type: "string" as const,
       description:
-        "Output filename ending in .kicad_pcb (board) or .kicad_sch (schematic). " +
-        "The extension selects what is exported: .kicad_pcb writes the session's " +
-        "board (footprints, pads, nets, traces, vias, zones, layers, outline) as a " +
-        "native, editable KiCad 9 file a human can open and finish routing; " +
-        ".kicad_sch writes the session's schematic. Defaults to board.kicad_pcb.",
+        "Output filename ending in .kicad_pcb (board), .kicad_sch (schematic), or " +
+        ".kicad_pro (linked project bundle). The extension selects what is exported: " +
+        ".kicad_pcb writes the session's board (footprints, pads, nets, traces, vias, " +
+        "zones, layers, outline) as a native, editable KiCad 9 file a human can open " +
+        "and finish routing; .kicad_sch writes the session's schematic; .kicad_pro " +
+        "(or a bare name with no extension) writes all three files with board " +
+        "footprints linked to their schematic symbols so KiCad can cross-probe " +
+        "(click a symbol → highlight its footprint). Defaults to board.kicad_pcb.",
     },
     output_dir: {
       type: "string" as const,
@@ -4804,6 +4808,87 @@ function deliverFabFiles(files: FabFile[], diskFailReason?: string) {
 }
 
 /**
+ * Return a linked KiCad project bundle to the caller. When output_dir is
+ * writable the three files land on disk; otherwise they ride inline under the
+ * cap, or offload to the artifact store above it (same mechanism as Gerbers).
+ */
+async function deliverKicadProject(
+  files: FabFile[],
+  name: string,
+  outputDir: string | undefined,
+  documentId: string | undefined,
+) {
+  const total = bundleBytes(files);
+  const docField = documentId ? { document_id: documentId } : {};
+
+  if (outputDir) {
+    try {
+      const fs = await import("node:fs/promises");
+      const { resolveWithinRoot } = await import("./safe-path.js");
+      const dir = resolveWithinRoot(outputDir);
+      await fs.mkdir(dir, { recursive: true });
+      const paths: string[] = [];
+      for (const f of files) {
+        const path = resolveWithinRoot(f.name, dir);
+        await fs.writeFile(path, f.content, "utf8");
+        paths.push(path);
+      }
+      const payload = {
+        success: true,
+        format: "kicad_project" as const,
+        name,
+        bytes: total,
+        paths,
+        note: `Linked KiCad project written; open ${name}.kicad_pro in KiCad 9 to cross-probe schematic and board.`,
+        ...docField,
+      };
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+        structuredContent: { export_kicad: payload },
+      };
+    } catch {
+      // Sandboxed/hosted host — fall through to inline/artifact delivery.
+    }
+  }
+
+  const cap = maxInlineArtifactBytes();
+  if (total <= cap) {
+    const payload = {
+      success: true,
+      format: "kicad_project" as const,
+      name,
+      bytes: total,
+      files,
+      ...docField,
+    };
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+      structuredContent: { export_kicad: payload },
+    };
+  }
+
+  const handle = storeArtifact(files);
+  const payload = {
+    success: true,
+    format: "kicad_project" as const,
+    name,
+    bytes: total,
+    artifact_id: handle.artifact_id,
+    artifact_url: handle.artifact_url,
+    manifest: handle.manifest,
+    expires_at: handle.expires_at,
+    note:
+      "Project files are at artifact_url (the manifest lists each file with bytes + sha256; " +
+      "download one at <artifact_url>/<file>).",
+    ...docField,
+  };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload) }],
+    structuredContent: { export_kicad: payload },
+  };
+}
+
+/**
  * Export the session's board or schematic as a native, editable KiCad 9 file.
  *
  * `.kicad_pcb` serializes the board (the inverse of import_pcb); `.kicad_sch`
@@ -4820,7 +4905,41 @@ export async function exportKicad(args: Record<string, unknown>) {
       : "board.kicad_pcb";
   const outputDir = args.output_dir as string | undefined;
 
-  const ext = filename.toLowerCase().split(".").pop();
+  const ext = filename.includes(".")
+    ? filename.toLowerCase().split(".").pop()
+    : undefined;
+
+  // Linked project bundle: .kicad_pro (or a bare name) exports all three
+  // files — <name>.kicad_pro / .kicad_sch / .kicad_pcb — with board
+  // footprints carrying (path …) references to their schematic symbol uuids
+  // so KiCad can cross-probe.
+  if (ext === "kicad_pro" || ext === undefined) {
+    const name = ext === undefined ? filename : filename.slice(0, -".kicad_pro".length);
+    if (!name) {
+      return ecadError("Project filename must have a basename, e.g. 'board.kicad_pro'.");
+    }
+    const sheet = (doc as Document & { schematic?: SchematicSheet }).schematic;
+    if (!sheet) {
+      return ecadError(
+        "A KiCad project bundle needs a schematic; this document has none. " +
+          "Create one with create_schematic, or export the board alone as .kicad_pcb.",
+      );
+    }
+    const pcb = getDocPcb(doc);
+    if (!pcb) {
+      return ecadError(
+        "A KiCad project bundle needs a board; this document has none. " +
+          "Export the schematic alone as .kicad_sch.",
+      );
+    }
+    const bundle = await exportKicadProject(sheet, pcb, name);
+    if (!bundle) {
+      return ecadError("KiCad project export unavailable (kernel WASM not loaded or outdated)");
+    }
+    const files = bundle.map(([n, c]) => ({ name: n, content: c }));
+    return deliverKicadProject(files, name, outputDir, documentId);
+  }
+
   let content: string | null;
   let format: "kicad_pcb" | "kicad_sch";
 
@@ -13034,7 +13153,10 @@ export const toolDefs: ToolDef[] = [
     description:
       "Export the session as a native, editable KiCad 9 file. " +
       "filename ending in .kicad_pcb writes the board (footprints, pads, nets, " +
-      "traces, vias, zones, layers, outline); .kicad_sch writes the schematic. " +
+      "traces, vias, zones, layers, outline); .kicad_sch writes the schematic; " +
+      ".kicad_pro (or a bare name) writes a linked project bundle (.kicad_pro + " +
+      ".kicad_sch + .kicad_pcb) with footprints tied to their schematic symbols " +
+      "for cross-probing. " +
       "Unlike export_gerber (fab-only output), this round-trips: a human can open " +
       "it in KiCad to finish routing nets the autorouter couldn't close, then " +
       "re-import. Large files respect the inline byte cap (use output_dir for those).",


### PR DESCRIPTION
## What

`export_kicad` can now emit a **linked KiCad 9 project** — `<name>.kicad_pro` + `<name>.kicad_sch` + `<name>.kicad_pcb` — instead of only standalone single files.

## Why

We exported `.kicad_sch` and `.kicad_pcb` from two writers with independent deterministic uuid counters, so the two files had no relationship to each other. KiCad could open both, but cross-probing (click a symbol → highlight its footprint) never worked: nothing tied a footprint back to its schematic symbol.

## How

- **`write_kicad_project(sheet, pcb, name) -> Vec<(String, String)>`** in `crates/vcad-ecad-symbols/src/kicad_write.rs` returns `(filename, contents)` pairs for the three files.
- The schematic writer core now returns a `SchematicLinks { root_uuid, symbol_uuids, sch_filename }` alongside its text — `symbol_uuids` maps reference designator (`R1`) → symbol instance uuid, both allocated from the same counter-based `Emitter`, so output stays byte-stable.
- The board writer takes those links and stamps each footprint whose reference matches a schematic symbol with `(path "/<symbol-uuid>")`, `(sheetname "/")`, and `(sheetfile "<name>.kicad_sch")`.
- `.kicad_pro` is minimal valid KiCad 9 project JSON (`meta.version` 3) recording the schematic root sheet uuid in `sheets: [[<uuid>, "Root"]]`.
- Wired through as `exportKicadProject`: WASM binding in `vcad-kernel-wasm` → `packages/engine/src/ecad.ts` → MCP `export_kicad`. A `.kicad_pro` filename **or a bare name with no extension** takes the bundle path; delivery reuses the existing `output_dir` / inline-cap / artifact-store mechanism (same as Gerbers).

## Format note for reviewers

The issue description suggested the sheet root uuid should appear in the pcb footprint paths. Verified against **real KiCad 9.0.3 files** (the templates shipped inside `KiCad.app`, plus an existing local project) that this is not the case: pcb footprint paths carry **only** the symbol instance uuid (`/<symbol-uuid>`). The root sheet uuid appears in the `.kicad_pro` `sheets` array and in the schematic's `(instances (project "<name>" (path "/<root-uuid>" …)))` block. That's what this implements.

## Backwards compatibility

Single-file `.kicad_pcb` and `.kicad_sch` exports are unchanged, byte for byte — `standalone_exports_unchanged_by_bundle_refactor` asserts the standalone board gains no `(path …)`/`(sheetfile …)` lines and the standalone schematic keeps `(project "")`.

The engine wrapper probes `typeof wasm.exportKicadProject === "function"` before calling it, because the checked-in `packages/kernel-wasm/vcad_kernel_wasm*` artifacts are only refreshed on `main` by `wasm-refresh.yml` (this PR deliberately does **not** commit a rebuild, per the repo policy). Until that runs post-merge, hosted MCP returns a clear "unavailable" error rather than throwing, and the MCP test tolerates that branch.

## Verification

- `cargo test -p vcad-ecad-symbols` — 77 pass, including new tests for symbol↔footprint linkage, `.kicad_pro` JSON parsing, determinism, and standalone-output stability.
- `cargo clippy -p vcad-ecad-symbols -p vcad-kernel-wasm -- -D warnings` clean; `cargo fmt --all --check` clean.
- **`kicad-cli` 9.0.3** (`sch erc` and `pcb drc`) loads the generated bundle without parse errors.
- `npm test -w @vcad/mcp` — 80 files / 906 tests pass. Tool-surface fixture regenerated with `UPDATE_TOOL_SURFACE=1` for the description change. Also ran a full `tsc --noEmit` on `@vcad/mcp` since its build uses `--noCheck`.
- `npm test -w @vcad/engine` — 119 pass.
- Temporarily rebuilt the WASM locally to confirm the new MCP test exercises the real success path (not the degraded branch), then restored the checked-in artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
