### PR TITLE
fix(mcp): inline board preview after every PCB mutation

### DIFF
--- a/changelog/entries/2026-07-23-pcb-mutation-inline-preview.json
+++ b/changelog/entries/2026-07-23-pcb-mutation-inline-preview.json
@@ -6,5 +6,5 @@
   "title": "Inline board preview after every PCB mutation",
   "summary": "route_nets, add_zone, and other copper mutations now attach the layered board GLB, so the inline widget no longer shows 'no geometry to preview' on board-only sessions.",
   "features": ["pcb", "mcp-apps", "preview"],
-  "mcpTools": ["route_nets", "add_zone", "set_placement", "set_board_outline"]
+  "mcpTools": ["route_nets", "add_zone", "set_placement", "set_board_outline", "add_net_tie", "delete_net_tie", "add_via_array", "route_diff_pair", "length_match_traces"]
 }

--- a/changelog/entries/2026-07-23-pcb-mutation-inline-preview.json
+++ b/changelog/entries/2026-07-23-pcb-mutation-inline-preview.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-23-pcb-mutation-inline-preview",
+  "version": "0.9.4",
+  "date": "2026-07-23",
+  "category": "fix",
+  "title": "Inline board preview after every PCB mutation",
+  "summary": "route_nets, add_zone, and other copper mutations now attach the layered board GLB, so the inline widget no longer shows 'no geometry to preview' on board-only sessions.",
+  "features": ["pcb", "mcp-apps", "preview"],
+  "mcpTools": ["route_nets", "add_zone", "set_placement", "set_board_outline"]
+}

--- a/packages/mcp/src/__tests__/pcb-inline-preview.test.ts
+++ b/packages/mcp/src/__tests__/pcb-inline-preview.test.ts
@@ -88,6 +88,27 @@ describe("place_components inline preview (no-UI-capability client)", () => {
     expect(typeof inline?.glb).toBe("string");
     expect((inline!.glb as string).length).toBeGreaterThan(1000);
 
+    // Non-mount PCB mutators must ride the inline GLB too: the mounted
+    // widget's fetch fallback isn't dependable in Claude Code, and a
+    // board-only document has no CAD part scene to fall back on — without
+    // this, route_nets / add_zone results rendered "no geometry to preview".
+    for (const call of [
+      { name: "route_nets", arguments: { document_id: documentId } },
+      {
+        name: "add_zone",
+        arguments: { document_id: documentId, net: "MID", layer: "FCu", fill_board: true },
+      },
+    ]) {
+      const mutated = (await client.callTool(call)) as {
+        _meta?: Record<string, unknown>;
+      };
+      const meta = mutated._meta?.["vcad.io/preview"] as
+        | { document_id?: string; glb?: string }
+        | undefined;
+      expect(meta?.document_id, `${call.name} inline preview`).toBe(documentId);
+      expect((meta?.glb ?? "").length, `${call.name} glb size`).toBeGreaterThan(1000);
+    }
+
     // The widget's fetch path serves the same board.
     const glb = parse(
       await client.callTool({

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -18,7 +18,7 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Engine, getKernelWasm, resetKernelWasm } from "@vcad/engine";
-import { commandRegistry } from "@vcad/core";
+import { commandRegistry, getPcbNodeIds } from "@vcad/core";
 import type { Document } from "@vcad/ir";
 import {
   documents,
@@ -1425,7 +1425,12 @@ export async function createServer(
           // placed board rendering as "no geometry to preview". `_meta` is
           // ignored by UI-less clients and never model-visible, so the only
           // cost of always attaching is transport bytes.
-          if (def.behavior.mount) {
+          // PCB-mutating tools (route_nets, add_zone, …) aren't mount tools,
+          // but the already-mounted widget's fetch path has the same
+          // dependability problem — without the inline GLB a board-only
+          // session renders "no geometry to preview" after every copper
+          // mutation. Attach for any geometry write on a PCB session too.
+          if (def.behavior.mount || sessionHasPcb(docId)) {
             await attachInlinePreview(result, docId, engine);
           }
         }
@@ -1594,6 +1599,25 @@ function attachPreviewHandle(
       type: "text",
       text: JSON.stringify({ document_id: docId }),
     });
+  }
+}
+
+/**
+ * Does this session document contain a PCB (a `PcbBoard` root or the legacy
+ * bare `doc.pcb`)? Gates the inline `_meta` preview attach for non-mount PCB
+ * mutators — board-only documents have no CAD part scene, so the widget's
+ * fetch fallback is the only alternative and it isn't dependable in every
+ * host.
+ */
+function sessionHasPcb(docId: string): boolean {
+  try {
+    const doc = getSession(docId);
+    return (
+      getPcbNodeIds(doc).length > 0 ||
+      Boolean((doc as { pcb?: unknown }).pcb)
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -12837,7 +12837,7 @@ export const toolDefs: ToolDef[] = [
       "re-checked in one call without running run_drc.",
     inputSchema: setPlacementSchema,
     handler: (a) => setPlacement(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "set_board_outline",
@@ -12846,7 +12846,7 @@ export const toolDefs: ToolDef[] = [
       "Resize or reshape the board outline in place \u2014 rectangle (board_width/height), circle/annulus (board_shape), or any polygon (outline) \u2014 WITHOUT re-placing components, traces, vias, or zones. Unlike re-running place_components, the floorplan is preserved; any footprint whose origin ends up off the new board is reported in `off_board` rather than silently relocated. Mutates the session document. Verify-on-write: the result carries `drc_delta` \u2014 the DRC violations this call introduced (shorts/clearance/connectivity/manufacturing, capped sample with positions) with `clean` to branch on in one step.",
     inputSchema: setBoardOutlineSchema,
     handler: (a) => setBoardOutline(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "add_zone",
@@ -12858,7 +12858,7 @@ export const toolDefs: ToolDef[] = [
       "session document.",
     inputSchema: addZoneSchema,
     handler: (a) => addZone(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "delete_zone",
@@ -12910,7 +12910,7 @@ export const toolDefs: ToolDef[] = [
       "Declare an intentional junction between >= 2 nets (a net-tie) so DRC treats them as one node where they meet \u2014 required for wye/star motor neutrals, split grounds (GND+AGND), and current-sense shunt taps, which are otherwise reported as shorts. With `position`+`radius` the tie is region-scoped: clearance/short checks are exempt only for contacts inside the region, and connectivity accepts nets joined through copper when each has a tie-covered contact there \u2014 a stray crossing of the same nets elsewhere still fires. Without them the exemption is board-wide (prefer scoped: it keeps DRC honest away from the junction). Nets must exist on the board. Returns the updated tie list with indices. Mutates the session document. Verify-on-write: the result carries `drc_delta` \u2014 the DRC violations this call introduced or resolved (a tie edit changes short/clearance exemptions) with `clean` to branch on in one step.",
     inputSchema: addNetTieSchema,
     handler: (a) => addNetTie(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "delete_net_tie",
@@ -12919,7 +12919,7 @@ export const toolDefs: ToolDef[] = [
       "Remove a net tie by `index`, or by matching `nets` (set equality, order-insensitive) and/or `position` \u2014 the take-back for a bad add_net_tie. Any junction copper stays on the board; DRC will report it as a short again. Returns the deleted tie and the updated tie list. Mutates the session document. Verify-on-write: the result carries `drc_delta` \u2014 the DRC violations this call introduced or resolved (a tie edit changes short/clearance exemptions) with `clean` to branch on in one step.",
     inputSchema: deleteNetTieSchema,
     handler: (a) => deleteNetTie(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "undo",
@@ -12968,7 +12968,7 @@ export const toolDefs: ToolDef[] = [
       "Place many vias at once \u2014 a grid over a rectangular `region` (thermal vias under FETs, GND-plane stitching) or an explicit `points` list. Grid vias are clipped to the board outline by default. Mutates the session document. Verify-on-write: the result carries `drc_delta` \u2014 the DRC violations this call introduced (shorts/clearance/connectivity/manufacturing, capped sample with positions) with `clean` to branch on in one step.",
     inputSchema: addViaArraySchema,
     handler: (a) => addViaArray(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "add_motor_winding",
@@ -13096,7 +13096,7 @@ export const toolDefs: ToolDef[] = [
       "clear channel); verify with run_drc / critique_route afterwards.",
     inputSchema: routeDiffPairSchema,
     handler: (a) => routeDiffPair(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "length_match_traces",
@@ -13111,7 +13111,7 @@ export const toolDefs: ToolDef[] = [
       "runs carry drc_delta.",
     inputSchema: lengthMatchTracesSchema,
     handler: (a) => lengthMatchTraces(a) as ToolResult | Promise<ToolResult>,
-    behavior: behavior({ writesDoc: true }),
+    behavior: behavior({ writesDoc: true, geometry: true }),
   },
   {
     name: "critique_route",


### PR DESCRIPTION
## What

PCB-mutating tools (`route_nets`, `add_zone`, `set_placement`, etc.) now attach the layered board GLB to their result's `_meta` (`vcad.io/preview`), so the inline MCP widget renders the board after every copper mutation instead of showing "no geometry to preview".

## Why

The inline `_meta` preview from #626 only rode `mount: true` tool results. But `route_nets` / `add_zone` and the other copper mutators aren't mount tools, so their results carried no GLB — and Claude Code's widget `get_preview_glb` fallback isn't dependable. On a **board-only** session (no CAD part scene), that fallback is the only alternative, so the widget rendered "no geometry to preview" even though `describe_pcb` reported `preview_mesh_count: 16` and `render_pcb` worked.

The layered board GLB builder already existed (`pcbPreviewMeshes → buildGlb` in `preview.ts`, the same path the app's 3D board preview uses) — it just was never invoked for these tools.

## What changed

- **`server.ts`**: dispatch now attaches the inline board GLB for any geometry-writing tool when the session document contains a PCB (`sessionHasPcb`: a `PcbBoard` root or legacy `doc.pcb`), not just mount tools.
- **`ecad.ts`**: added the missing `behavior.geometry` flag to `add_zone`, `set_board_outline`, `set_placement`, `add_net_tie`/`delete_net_tie`, `add_via_array`, `route_diff_pair`, `length_match_traces` — so they carry a preview handle + version bump too.
- **`pcb-inline-preview.test.ts`**: extended the existing no-UI-capability regression test to call `route_nets` and `add_zone` after placement and assert each result carries a non-empty (`>1000` chars) `vcad.io/preview` GLB.
- Changelog entry (user-facing fix).

## Testing

Rebuilt the mcp dist first (workspace dist staleness), then ran the full mcp suite: **906 passed, 2 skipped, 0 failures**.

> [!NOTE]
> Reviewer gotcha surfaced while writing the test: `add_zone` layer names are `FCu`, not `F.Cu`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)