### PR TITLE
fix(ecad): route_nets connectivity guard + rescue dropped receipt

### DIFF
--- a/changelog/entries/2026-07-23-route-nets-connectivity-guard.json
+++ b/changelog/entries/2026-07-23-route-nets-connectivity-guard.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-23-route-nets-connectivity-guard",
+  "version": "0.9.4",
+  "date": "2026-07-23",
+  "category": "fix",
+  "title": "route_nets connectivity guard + receipt no longer dropped",
+  "summary": "route_nets now detects, retries/rolls back, and reports nets its re-route left in more disjoint copper groups; receipt:true survives large-board result slimming.",
+  "features": ["pcb", "autorouter", "receipts"],
+  "mcpTools": ["route_nets"]
+}

--- a/packages/mcp/src/__tests__/route-receipt.test.ts
+++ b/packages/mcp/src/__tests__/route-receipt.test.ts
@@ -72,6 +72,13 @@ describe("route_nets receipt — the agent gets a verdict instead of {document_i
     expect(r1.receipt.headline).toBeTruthy();
     expect(r1.receipt.coverage).toBe("full");
 
+    // Before/after DRC totals must ride in the receipt — both the error
+    // slice and the full violation counts.
+    expect(typeof r1.receipt.errors.before).toBe("number");
+    expect(typeof r1.receipt.errors.after).toBe("number");
+    expect(typeof r1.receipt.violations.before).toBe("number");
+    expect(typeof r1.receipt.violations.after).toBe("number");
+
     // Routing-specific fields must always be present in the receipt
     expect(Array.isArray(r1.receipt.nets_routed)).toBe(true);
     expect(r1.receipt.nets_routed.length).toBeGreaterThan(0);
@@ -155,6 +162,39 @@ describe("route_nets receipt — the agent gets a verdict instead of {document_i
     expect(Array.isArray(r.receipt.short_pairs)).toBe(true);
     const delta = r.receipt.deltaByRule as Record<string, number>;
     expect(r.receipt.shortsIntroduced).toBe(Math.max(0, delta.Short ?? 0));
+  });
+
+  it("a scoped re-route never leaves a net in more disjoint copper groups (guard retries/rolls back)", async () => {
+    const { netContinuity } = await import("@vcad/engine");
+    const id = await placedBoard();
+    out(await routeNets({ document_id: id }));
+
+    const doc = documents.get(id)!;
+    const nodeIds = getPcbNodeIds(doc);
+    const pcb = nodeIds.length > 0 ? getNodePcb(doc, nodeIds[0]!) : null;
+    expect(pcb).not.toBeNull();
+    if (!pcb) return;
+
+    const before = await netContinuity(pcb, "GND");
+    if (!before) return; // kernel unavailable — guard is off by design
+
+    // Scoped re-route of a couple of signal nets: any collateral damage on
+    // GND (stale rip-up / negotiated rip-up side effects) must be caught by
+    // the connectivity guard — retried, or rolled back, and reported.
+    const r = out(await routeNets({ document_id: id, nets: ["SIG1", "SIG2"] }));
+    expect(r.success).toBe(true);
+
+    const after = await netContinuity(pcb, "GND");
+    expect(after).not.toBeNull();
+    if (!after) return;
+    if (before.islands > 0) {
+      // The invariant the guard enforces: connectivity never silently worse.
+      // A rolled-back net restores its pre-call copper, so its island count
+      // is back at `before` — and the regression is reported either way.
+      if (after.islands > before.islands) {
+        expect(r.connectivity_regressions?.GND).toBeDefined();
+      }
+    }
   });
 
   it("is opt-in — no receipt field unless requested", async () => {

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -279,6 +279,46 @@ describe("get_document body survives inline-UI slimming", () => {
       document_id: "doc_pcb",
     });
   });
+
+  it("slimming a route_nets result preserves its receipt (field report: receipt:true came back as bare {document_id})", () => {
+    const receipt = {
+      tool: "route_nets",
+      verdict: "improved",
+      violations: { before: 12, after: 3 },
+      deltaByRule: { Clearance: -9 },
+      padding: "y".repeat(9000), // push past the 8192-char slim threshold
+    };
+    const result = {
+      content: [
+        { type: "text", text: JSON.stringify({ success: true, receipt, document_id: "doc_pcb" }) },
+      ],
+    };
+    slimPreviewForInlineUi(result, "doc_pcb", "route_nets", true);
+    expect(result.content).toHaveLength(2);
+    const parsed = JSON.parse(result.content[1].text);
+    expect(parsed.document_id).toBe("doc_pcb");
+    expect(parsed.receipt).toBeDefined();
+    expect(parsed.receipt.verdict).toBe("improved");
+    expect(parsed.receipt.violations).toEqual({ before: 12, after: 3 });
+  });
+
+  it("slimming preserves receipt_error when the receipt could not be built", () => {
+    const result = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            success: true,
+            receipt_error: "receipt requested but the after-route DRC snapshot could not verify the board: too large",
+            filler: "z".repeat(9000),
+          }),
+        },
+      ],
+    };
+    slimPreviewForInlineUi(result, "doc_pcb", "route_nets", true);
+    const parsed = JSON.parse(result.content[1].text);
+    expect(parsed.receipt_error).toContain("could not verify");
+  });
 });
 
 describe("session persistence (save_document / load_document)", () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1547,12 +1547,32 @@ export function slimPreviewForInlineUi(
   );
   if (!alwaysSlim && totalChars <= 8192) return;
 
+  // A verification receipt (route_nets `receipt:true`, and any future
+  // receipt-bearing mutator) is the deliverable, not preview bulk — slimming
+  // it away silently un-verifies the call (field report: route_nets
+  // receipt:true came back as bare {document_id} on a large board). Carry the
+  // receipt fields through the slim.
+  const verdict: Record<string, unknown> = {};
+  for (const c of result.content) {
+    if (c.type !== "text") continue;
+    try {
+      const parsed = JSON.parse(c.text) as Record<string, unknown>;
+      if (parsed && typeof parsed === "object") {
+        if (parsed.receipt !== undefined) verdict.receipt = parsed.receipt;
+        if (parsed.receipt_error !== undefined) verdict.receipt_error = parsed.receipt_error;
+        if (verdict.receipt !== undefined || verdict.receipt_error !== undefined) break;
+      }
+    } catch {
+      // non-JSON content (VCode, prose) — nothing to preserve from it
+    }
+  }
+
   const summary =
     `CAD document ready (${docId}). Geometry is available in the inline 3D viewer. ` +
     "Use get_document for the full IR, inspect_cad for metrics, or export_cad to export.";
   result.content = [
     { type: "text", text: summary },
-    { type: "text", text: JSON.stringify({ document_id: docId }) },
+    { type: "text", text: JSON.stringify({ document_id: docId, ...verdict }) },
   ];
 }
 

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -3187,9 +3187,13 @@ export async function routeNets(args: Record<string, unknown>) {
   } else {
     islandsBefore = await netIslandCounts(pcb, guardNets);
     if (islandsBefore) {
+      // Deep clone: Trace.start/.end and Via.position are nested Vec2 objects,
+      // so a shallow spread would leave the snapshot sharing them with live
+      // copper — a future in-place edit during routing would corrupt the
+      // rollback baseline. structuredClone makes the snapshot fully independent.
       copperBefore = {
-        traces: pcb.traces.map((t) => ({ ...t })),
-        vias: pcb.vias.map((v) => ({ ...v })),
+        traces: pcb.traces.map((t) => structuredClone(t)),
+        vias: pcb.vias.map((v) => structuredClone(v)),
       };
     } else {
       guardSkipped =

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -3043,6 +3043,28 @@ function detectStaleNets(pcb: Pcb): Set<string> {
   return stale;
 }
 
+/** Per-net disjoint copper-group (galvanic island) counts via the kernel.
+ *  Returns null when the kernel is unavailable — the connectivity guard is
+ *  then OFF (and reported as such), never silently "clean". */
+async function netIslandCounts(
+  pcb: Pcb,
+  nets: Iterable<string>,
+): Promise<Map<string, number> | null> {
+  const counts = new Map<string, number>();
+  for (const net of nets) {
+    const c = await kernelNetContinuity(pcb, net);
+    if (!c) return null;
+    counts.set(net, c.islands);
+  }
+  return counts;
+}
+
+/** Nets the connectivity guard watches: every routable (>=2 pad) net. A
+ *  regression can land on a net the caller never named (stale rip-up,
+ *  negotiated rip-up side effects), so the watch set is board-wide. Capped
+ *  because each kernel continuity query serializes the whole board. */
+const CONNECTIVITY_GUARD_MAX_NETS = 300;
+
 /** Heuristic power/ground net names, for the `power_first` routing strategy. */
 const POWER_NET_RE =
   /(^|[_\-/])(A?D?GND|VCC|VDD[A]?|VBAT|VBUS|VIN|VOUT|VSYS|VREF|PWR|POWER|\d+V\d*)(\d*)([_\-/]|$)/i;
@@ -3136,6 +3158,44 @@ export async function routeNets(args: Record<string, unknown>) {
     if (t.source === "manual" && targetNets.has(t.net)) manualNets.add(t.net);
   }
   for (const n of manualNets) targetNets.delete(n);
+
+  // Connectivity guard: snapshot per-net disjoint copper-group counts before
+  // any rip-up so the result can report every net this call left WORSE
+  // connected (field report: a scoped re-route took GND from 4 galvanic
+  // groups to 14 and the result said nothing). Also snapshot the copper
+  // itself so an unrepairable regression can be rolled back net-by-net.
+  const guardNets = [...netConnections.entries()]
+    .filter(([, conns]) => conns.length >= 2)
+    .map(([n]) => n);
+  let guardSkipped: string | null = null;
+  let islandsBefore: Map<string, number> | null = null;
+  let copperBefore: { traces: typeof pcb.traces; vias: typeof pcb.vias } | null = null;
+  // Each continuity query serializes the whole board into the kernel, so the
+  // guard is also budgeted by copper-element count, not just net count.
+  const guardElements =
+    pcb.traces.length +
+    pcb.vias.length +
+    pcb.zones.length +
+    pcb.footprints.reduce((n, fp) => n + fp.pads.length, 0);
+  const maxGuardElements = Number(
+    process.env.VCAD_ROUTE_GUARD_MAX_ELEMENTS ?? 50_000,
+  );
+  if (guardNets.length > CONNECTIVITY_GUARD_MAX_NETS) {
+    guardSkipped = `connectivity-regression guard skipped: ${guardNets.length} nets exceeds the ${CONNECTIVITY_GUARD_MAX_NETS}-net budget — verify with run_drc (NetIslands)`;
+  } else if (guardElements > maxGuardElements) {
+    guardSkipped = `connectivity-regression guard skipped: ${guardElements} copper elements exceeds the ${maxGuardElements} budget (VCAD_ROUTE_GUARD_MAX_ELEMENTS) — verify with run_drc (NetIslands)`;
+  } else {
+    islandsBefore = await netIslandCounts(pcb, guardNets);
+    if (islandsBefore) {
+      copperBefore = {
+        traces: pcb.traces.map((t) => ({ ...t })),
+        vias: pcb.vias.map((v) => ({ ...v })),
+      };
+    } else {
+      guardSkipped =
+        "connectivity-regression guard unavailable (kernel WASM not loaded) — verify with run_drc";
+    }
+  }
 
   let tracesRemoved = 0;
   let viasRemoved = 0;
@@ -3307,6 +3367,69 @@ export async function routeNets(args: Record<string, unknown>) {
     }
   }
 
+  // Connectivity-regression guard, part 2: any net whose copper now forms
+  // MORE disjoint groups than before this call regressed — the router (or a
+  // stale rip-up side effect) broke connectivity it was supposed to preserve.
+  // Retry the regressed nets once against the otherwise-final board; a net
+  // still worse after the retry gets its pre-call copper restored (rollback),
+  // so a route_nets call can never silently degrade a net's connectivity.
+  const connectivityRegressions: Record<
+    string,
+    { groups_before: number; groups_after: number; action: "repaired-by-retry" | "rolled_back" }
+  > = {};
+  if (islandsBefore && copperBefore) {
+    const before = islandsBefore;
+    const worseNets = async (nets: Iterable<string>): Promise<Map<string, number> | null> => {
+      const counts = await netIslandCounts(pcb, nets);
+      if (!counts) return null;
+      const worse = new Map<string, number>();
+      for (const [n, after] of counts) {
+        const b = before.get(n) ?? 0;
+        if (b > 0 && after > b) worse.set(n, after);
+      }
+      return worse;
+    };
+    let worse = await worseNets(guardNets);
+    if (worse && worse.size > 0) {
+      // Retry: rip the regressed nets' autorouted copper and route just them
+      // again — the rest of the board (this pass's other copper included) is
+      // now a fixed obstacle field, which often resolves the negotiated
+      // rip-up collateral that caused the regression.
+      const retrySet = new Set(
+        [...worse.keys()].filter((n) => !preservedNets.has(n)),
+      );
+      if (retrySet.size > 0) {
+        pcb.traces = pcb.traces.filter((t) => !retrySet.has(t.net) || t.source === "manual");
+        pcb.vias = pcb.vias.filter((v) => !retrySet.has(v.net) || v.source === "manual");
+        const retried = await routeAll(pcb, width, [...retrySet], effort);
+        applyRoute(retried);
+      }
+      const stillWorse = (await worseNets(worse.keys())) ?? worse;
+      for (const [n, afterRoute] of worse) {
+        if (!stillWorse.has(n)) {
+          connectivityRegressions[n] = {
+            groups_before: before.get(n)!,
+            groups_after: afterRoute,
+            action: "repaired-by-retry",
+          };
+          continue;
+        }
+        // Rollback: restore the net's pre-call copper verbatim. The restored
+        // copper is checked against the final board by the caller's next DRC
+        // (and by the `receipt` after-snapshot below when requested).
+        pcb.traces = pcb.traces.filter((t) => t.net !== n);
+        pcb.vias = pcb.vias.filter((v) => v.net !== n);
+        for (const t of copperBefore.traces) if (t.net === n) pcb.traces.push(t);
+        for (const v of copperBefore.vias) if (v.net === n) pcb.vias.push(v);
+        connectivityRegressions[n] = {
+          groups_before: before.get(n)!,
+          groups_after: stillWorse.get(n)!,
+          action: "rolled_back",
+        };
+      }
+    }
+  }
+
   const planeStitched = [...routedNets].filter((n) => planeNets.has(n)).sort();
 
   // Overall routability in [0, 1]: how close the board is to fully routed. A
@@ -3362,14 +3485,35 @@ export async function routeNets(args: Record<string, unknown>) {
     );
   }
 
+  if (guardSkipped) warnings.push(guardSkipped);
+  const regressedNets = Object.keys(connectivityRegressions).sort();
+  if (regressedNets.length > 0) {
+    const rolled = regressedNets.filter(
+      (n) => connectivityRegressions[n]!.action === "rolled_back",
+    );
+    warnings.push(
+      `connectivity regression on ${regressedNets.length} net(s) — this call left their copper in more disjoint groups than before (${regressedNets
+        .map((n) => `${n}: ${connectivityRegressions[n]!.groups_before}→${connectivityRegressions[n]!.groups_after}`)
+        .join(", ")}). Regressed nets were re-routed once${
+        rolled.length > 0
+          ? `; ${rolled.join(", ")} stayed worse and had their pre-call copper restored (rolled back) — the restored copper may now conflict with newly routed nets, run run_drc`
+          : " and repaired"
+      }`,
+    );
+  }
+
   const receiptField: Record<string, unknown> = {};
   // Only build a receipt when both snapshots actually verified — a receipt
   // diffed against an unverifiable (kernel-rejected) board would be meaningless.
+  // But a requested receipt is never SILENTLY dropped: an unverifiable
+  // snapshot yields `receipt_error` with the reason instead of nothing.
   if (wantReceipt && beforeSnap && beforeSnap.success) {
     const after = await drcPcb(pcb, "full", 500);
     // Only build a receipt when the after-snapshot also verified — an
     // unverifiable (kernel-rejected) board has no byNetPair to diff against.
-    if (after.success) {
+    if (!after.success) {
+      receiptField.receipt_error = `receipt requested but the after-route DRC snapshot could not verify the board: ${after.reason}`;
+    } else {
       const entry = buildEntry(
         { tool: "route_nets", args: { nets: netsFilter, trace_width: traceWidth }, before: beforeSnap, after },
         0,
@@ -3380,6 +3524,10 @@ export async function routeNets(args: Record<string, unknown>) {
       }
       receiptField.receipt = {
         ...agentView(entry, ctx.documentId ?? ""),
+        // Total violation counts of the two snapshots — `errors` (from
+        // agentView) is only the error-severity slice; agents diff the board
+        // on the full count.
+        violations: { before: entry.before.violations, after: entry.after.violations },
         nets_routed: [...routedNets].sort(),
         nets_unrouted: [...unroutedNets].sort(),
         traces_added: tracesAdded,
@@ -3390,6 +3538,8 @@ export async function routeNets(args: Record<string, unknown>) {
         short_pairs: shortPairs,
       };
     }
+  } else if (wantReceipt && beforeSnap && !beforeSnap.success) {
+    receiptField.receipt_error = `receipt requested but the before-route DRC snapshot could not verify the board: ${beforeSnap.reason}`;
   }
 
   return {
@@ -3419,6 +3569,9 @@ export async function routeNets(args: Record<string, unknown>) {
           ...(unroutedNets.size > 0 ? { unrouted_nets: [...unroutedNets] } : {}),
           ...(dedupedDiagnostics.length > 0 ? { unrouted_diagnostics: dedupedDiagnostics } : {}),
           ...(fallbackNets.size > 0 ? { fallback_nets: [...fallbackNets] } : {}),
+          ...(regressedNets.length > 0
+            ? { connectivity_regressions: connectivityRegressions }
+            : {}),
           ...(warnings.length > 0 ? { warnings } : {}),
           ...receiptField,
           ...docResultPayload(ctx),


### PR DESCRIPTION
Two related `route_nets` bugs surfaced during an RP2040 motor-board session.

## (1) Silent connectivity regression

A targeted `route_nets(nets=[BIN1, GND, M1B, NSLEEP, QSPI_SD0, XIN, DVDD], effort=10)` call took **GND from 4 disjoint copper groups to 14** — the router regressed a net mid-pass and the result reported nothing.

`route_nets` now runs a connectivity guard on every call:
- **Before** any rip-up it snapshots per-net galvanic-island counts (kernel `netContinuity`) for **every** routable (≥2-pad) net — board-wide, because stale-rip-up and negotiated-rip-up collateral can land on a net the caller never named — plus a copper snapshot for rollback.
- **After** routing, any net now in more disjoint groups than before is re-ripped and re-routed once against the otherwise-final board (which often clears the negotiated collateral). A net still worse after the retry gets its **pre-call copper restored verbatim (rollback)**.
- The result reports `connectivity_regressions: { NET: { groups_before, groups_after, action: "repaired-by-retry" | "rolled_back" } }` and a human-readable warning.
- The guard is budgeted by net count (300) and copper-element count (`VCAD_ROUTE_GUARD_MAX_ELEMENTS`, default 50k) and **reports when it's skipped or the kernel is unavailable** — it never silently checks nothing.

Net effect: the GND 4→14 case now either repairs, or rolls back to 4, and always says so.

## (2) `receipt:true` returned only `document_id`

The receipt was built correctly inside `routeNets`, but `slimPreviewForInlineUi` (server.ts) replaces any geometry-tool payload over 8192 chars with a bare `{document_id}` stub for clients with inline UI. On a real routed board the payload crosses that threshold, so the receipt was thrown away before it reached the caller.

- Slimming now carries `receipt` / `receipt_error` through into the stub.
- The receipt is now **fail-closed**: an unverifiable before/after DRC snapshot yields `receipt_error` with the reason instead of an omitted field.
- The receipt gained `violations: { before, after }` (full DRC totals) alongside the existing error-severity `errors` slice.

## Tests

- `route-receipt.test.ts`: asserts the receipt carries before/after violation + error counts; new test that a scoped re-route never leaves a net in more disjoint copper groups unreported.
- `tools.test.ts`: a >8k `route_nets` result keeps its receipt (exact field-report repro); `receipt_error` survives slimming.

Full `@vcad/mcp` suite: **909 passed / 2 skipped**. Typecheck clean.

Changelog entry added (`fix`, user-facing router behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
