### PR TITLE
fix(mcp): artifact URL 404s — durable-store migration gap + local dead links

### DIFF
--- a/changelog/entries/2026-07-23-artifact-url-404.json
+++ b/changelog/entries/2026-07-23-artifact-url-404.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-23-artifact-url-404",
+  "version": "0.9.4",
+  "date": "2026-07-23",
+  "category": "fix",
+  "title": "Artifact links no longer 404",
+  "summary": "mcp.vcad.io artifact URLs (render PNGs, fab bundles) now survive across serverless instances, and a local MCP server no longer mints absolute hosted URLs it cannot serve.",
+  "features": ["mcp", "artifacts"],
+  "mcpTools": ["render_pcb", "render_view", "export_gerber", "export_cad"]
+}

--- a/packages/mcp/src/__tests__/artifact-store.test.ts
+++ b/packages/mcp/src/__tests__/artifact-store.test.ts
@@ -60,6 +60,30 @@ describe("artifact-store", () => {
     expect(file!.buf.toString("utf8")).toBe("G04 top*");
   });
 
+  it("mints relative URLs when memory-only, absolute mcp.vcad.io when durable", () => {
+    // Memory-only (no VCAD_MCP_PUBLIC_URL, no Supabase env): an absolute
+    // mcp.vcad.io link would be a guaranteed 404 — that host never saw the
+    // bytes. The handle stays relative, which trust-boundary accepts.
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const local = storeArtifact([{ name: "x.gbr", content: "hi" }]);
+    expect(local.artifact_url).toBe(`/artifacts/${local.artifact_id}`);
+    expect(parseArtifactId(local.artifact_url)).toBe(local.artifact_id);
+
+    // Durable store: the persisted row IS readable from the hosted origin.
+    process.env.SUPABASE_URL = "https://fake.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "service-role-test-key";
+    try {
+      const hosted = storeArtifact([{ name: "y.gbr", content: "hi" }]);
+      expect(hosted.artifact_url).toBe(
+        `https://mcp.vcad.io/artifacts/${hosted.artifact_id}`,
+      );
+    } finally {
+      delete process.env.SUPABASE_URL;
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    }
+  });
+
   it("resolves a handle by raw id and by artifact_url", () => {
     process.env.VCAD_MCP_PUBLIC_URL = "https://mcp.example.com";
     const handle = storeArtifact([{ name: "x.gbr", content: "hi" }]);

--- a/packages/mcp/src/tools/artifact-store.ts
+++ b/packages/mcp/src/tools/artifact-store.ts
@@ -103,14 +103,22 @@ function evict(now: number): void {
 }
 
 /** Public base URL of this deployment, for building shareable artifact links.
- *  Mirrors the live-share link builder. */
+ *  Mirrors the live-share link builder. Empty string → links stay relative
+ *  (`/artifacts/<id>`), which trust-boundary and parseArtifactId both accept. */
 function publicBaseUrl(): string {
-  const raw = process.env.VCAD_MCP_PUBLIC_URL || "https://mcp.vcad.io";
-  try {
-    return new URL(raw).origin;
-  } catch {
-    return "https://mcp.vcad.io";
+  const raw = process.env.VCAD_MCP_PUBLIC_URL;
+  if (raw) {
+    try {
+      return new URL(raw).origin;
+    } catch {
+      // fall through to the durability-gated default
+    }
   }
+  // Only a durable store may claim the hosted origin by default: the persisted
+  // row is readable from mcp.vcad.io. A memory-only instance (stdio/local dev)
+  // minting an absolute mcp.vcad.io link hands out a guaranteed 404 — its
+  // bytes exist nowhere that host can see.
+  return isArtifactStoreDurable() ? "https://mcp.vcad.io" : "";
 }
 
 /** The capability URL for an artifact id (possession of the id is the grant). */


### PR DESCRIPTION
## Problem
`render_pcb` / `render_view` returned `https://mcp.vcad.io/artifacts/...` URLs that 404'd, so "Show Image" in clients was a dead link.

## Root causes
1. **Prod DB missing migrations 032–036** — `mcp_artifacts` (durable artifact table, migration 033) was never created, so the best-effort persist silently failed on every write and any other/cold serverless instance 404'd. Fixed operationally with `supabase db push` (also restores `mcp_tool_packs`, order enrichment, `mcp_macros`). Verified live: a hosted-minted artifact now returns 200 from fresh instances.
2. **Memory-only servers minted absolute hosted URLs** — `publicBaseUrl()` fell back to `https://mcp.vcad.io` unconditionally, so a local stdio server (durable env absent) handed out hosted links whose bytes only existed in its own process. Now the hosted-origin default is gated on `isArtifactStoreDurable()`; memory-only handles stay relative (`/artifacts/<id>`), which trust-boundary and `parseArtifactId` already accept.

## Test
New case: memory-only → relative URL; durable env → absolute `mcp.vcad.io` URL. Full `@vcad/mcp` suite: 907 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)