### PR TITLE
feat(constraints): unified design constraints — PCB + sketch + cross-domain part anchors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
       matrix:
         toolchain: [stable, nightly]
     steps:
+      # The full workspace build now overflows the stock runner disk
+      # ("No space left on device" during linking) — drop the big
+      # preinstalled toolchains we never use before building.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost /opt/hostedtoolcache/CodeQL
+          df -h /
       - uses: actions/checkout@v6
       - name: Clone sibling repos
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6907,6 +6907,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcad-design-constraints"
+version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "vcad-ecad-pcb",
+ "vcad-ir",
+ "vcad-kernel-constraints",
+]
+
+[[package]]
 name = "vcad-desktop"
 version = "0.9.4"
 dependencies = [
@@ -7652,6 +7663,7 @@ dependencies = [
  "vcad-app",
  "vcad-chat",
  "vcad-crdt",
+ "vcad-design-constraints",
  "vcad-diff",
  "vcad-ecad-export",
  "vcad-ecad-parts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/vcad-kernel-step",
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
+    "crates/vcad-design-constraints",
     "crates/vcad-kernel-diff",
     "crates/vcad-kernel-antenna",
     "crates/vcad-kernel-neutronics",
@@ -113,6 +114,7 @@ default-members = [
     "crates/vcad-kernel-step",
     "crates/vcad-kernel",
     "crates/vcad-kernel-constraints",
+    "crates/vcad-design-constraints",
     "crates/vcad-kernel-diff",
     "crates/vcad-kernel-antenna",
     "crates/vcad-kernel-neutronics",
@@ -220,6 +222,7 @@ vcad-kernel-shell = { path = "crates/vcad-kernel-shell", version = "0.9.4" }
 vcad-kernel-sheet = { path = "crates/vcad-kernel-sheet", version = "0.9.4" }
 vcad-kernel-step = { path = "crates/vcad-kernel-step", version = "0.9.4" }
 vcad-kernel-constraints = { path = "crates/vcad-kernel-constraints", version = "0.9.4" }
+vcad-design-constraints = { path = "crates/vcad-design-constraints", version = "0.9.4" }
 vcad-kernel-diff = { path = "crates/vcad-kernel-diff", version = "0.9.4" }
 vcad-kernel-antenna = { path = "crates/vcad-kernel-antenna", version = "0.9.4" }
 vcad-kernel-neutronics = { path = "crates/vcad-kernel-neutronics", version = "0.9.4" }

--- a/changelog/entries/2026-07-23-design-constraints.json
+++ b/changelog/entries/2026-07-23-design-constraints.json
@@ -1,0 +1,21 @@
+{
+  "id": "2026-07-23-design-constraints",
+  "version": "0.9.4",
+  "date": "2026-07-23",
+  "category": "feat",
+  "title": "Design constraints: solver-enforced geometry, everywhere",
+  "summary": "Document-level geometric constraints across PCB layout, sketches, and part edges — formula dimensions, driven measurements, receipt-verified, with a Constrain tool in the board editor.",
+  "features": [
+    "constraints",
+    "pcb",
+    "sketch",
+    "parametric",
+    "receipts"
+  ],
+  "mcpTools": [
+    "add_constraint",
+    "delete_constraint",
+    "list_constraints",
+    "solve_constraints"
+  ]
+}

--- a/crates/vcad-app/src/feature.rs
+++ b/crates/vcad-app/src/feature.rs
@@ -356,6 +356,13 @@ pub enum FeatureInput {
         #[serde(skip_serializing_if = "Option::is_none")]
         studies: Option<String>,
     },
+    /// Persisted document-level design constraints (singleton, like scene
+    /// settings): JSON-serialized `Vec<DesignConstraint>`.
+    DesignConstraints {
+        /// Constraints data (JSON-serialized `Vec<DesignConstraint>`).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        constraints: Option<String>,
+    },
     /// Document animation timeline (singleton, like scene settings):
     /// JSON-serialized `Timeline`.
     Timeline {
@@ -397,6 +404,7 @@ impl FeatureInput {
             Self::Schematic { .. } => "schematic",
             Self::Molecule { .. } => "molecule",
             Self::AnalysisStudies { .. } => "analysis-studies",
+            Self::DesignConstraints { .. } => "design-constraints",
             Self::Timeline { .. } => "timeline",
         }
     }
@@ -731,6 +739,11 @@ impl FeatureInput {
                     p.insert("studies".into(), Value::String(v.clone()));
                 }
             }
+            Self::DesignConstraints { constraints } => {
+                if let Some(v) = constraints {
+                    p.insert("constraints".into(), Value::String(v.clone()));
+                }
+            }
             Self::Timeline { timeline } => {
                 if let Some(v) = timeline {
                     p.insert("timeline".into(), Value::String(v.clone()));
@@ -900,6 +913,9 @@ impl FeatureInput {
             },
             "analysis-studies" => Self::AnalysisStudies {
                 studies: get_str(params, "studies"),
+            },
+            "design-constraints" => Self::DesignConstraints {
+                constraints: get_str(params, "constraints"),
             },
             "timeline" => Self::Timeline {
                 timeline: get_str(params, "timeline"),

--- a/crates/vcad-app/src/materializer.rs
+++ b/crates/vcad-app/src/materializer.rs
@@ -153,6 +153,10 @@ pub fn materialize(crdt: &CrdtDocument) -> MaterializeResult {
                 materialize_analysis_studies(&mut doc, feature);
                 continue;
             }
+            "design-constraints" => {
+                materialize_design_constraints(&mut doc, feature);
+                continue;
+            }
             _ => {}
         }
 
@@ -205,7 +209,8 @@ fn materialize_feature(
         | FeatureInput::DrawingSettings { .. }
         | FeatureInput::Schematic { .. }
         | FeatureInput::Molecule { .. }
-        | FeatureInput::AnalysisStudies { .. } => return None,
+        | FeatureInput::AnalysisStudies { .. }
+        | FeatureInput::DesignConstraints { .. } => return None,
         _ => {}
     }
 
@@ -1310,6 +1315,15 @@ fn materialize_molecule(doc: &mut Document, feature: &FeatureState) {
     }) = FeatureInput::from_crdt_params(&feature.kind, &feature.params)
     {
         doc.molecule = serde_json::from_str(&json).ok();
+    }
+}
+
+fn materialize_design_constraints(doc: &mut Document, feature: &FeatureState) {
+    if let Some(FeatureInput::DesignConstraints {
+        constraints: Some(json),
+    }) = FeatureInput::from_crdt_params(&feature.kind, &feature.params)
+    {
+        doc.constraints = serde_json::from_str(&json).unwrap_or_default();
     }
 }
 

--- a/crates/vcad-design-constraints/Cargo.toml
+++ b/crates/vcad-design-constraints/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vcad-design-constraints"
+description = "Document-level design constraint solver: sketches, PCB layout, and cross-domain part anchors through one LM solve"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+vcad-ir = { workspace = true }
+vcad-kernel-constraints = { workspace = true }
+vcad-ecad-pcb = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]

--- a/crates/vcad-design-constraints/src/lib.rs
+++ b/crates/vcad-design-constraints/src/lib.rs
@@ -1,0 +1,99 @@
+//! Document-level design constraint solver.
+//!
+//! Lowers [`vcad_ir::constraints::DesignConstraint`]s — spanning PCB layout
+//! (footprints, board outline), sketches, and mechanical part anchors — into
+//! per-plane [`Sketch2D`] systems solved by the Levenberg-Marquardt solver in
+//! `vcad-kernel-constraints`, then writes the solved geometry back into the
+//! document.
+//!
+//! Solve model:
+//! - Constraints are partitioned into **planar groups** by the node their
+//!   free anchors reference (one group per PCB board node, one per sketch
+//!   node). Groups solve independently.
+//! - **Mechanical geometry is authoritative**: `PartEdge` anchors resolve
+//!   through an injected [`AnchorResolver`] to world coordinates, project
+//!   into the group plane, and enter the solve as *fixed* reference
+//!   geometry. Constraints pull boards and sketches toward parts, never the
+//!   reverse.
+//! - **Driven dimensions** are excluded from the solve entirely (zero
+//!   residuals) and measured from the solved geometry afterward.
+//! - Anchor resolution is **fail-closed**: a bad footprint ref, an
+//!   out-of-range outline index, or an ambiguous/lost part edge skips that
+//!   constraint with an error entry; it never silently rebinds.
+
+#![warn(missing_docs)]
+
+mod lower;
+mod measure;
+mod report;
+
+pub use measure::constraint_residual;
+pub use report::{ConstraintResidual, DesignSolveReport, DrivenValue, GroupReport};
+
+use vcad_ir::Document;
+
+/// Resolves cross-domain part anchors to world-space geometry.
+///
+/// Implemented by callers that can evaluate part geometry (the kernel, the
+/// WASM bindings). The solver crate itself stays kernel-free.
+pub trait AnchorResolver {
+    /// World-space endpoints (mm) of the part edge named by two adjacent
+    /// face names, fail-closed: ambiguous or lost names are errors.
+    fn resolve_part_edge(
+        &self,
+        node: vcad_ir::NodeId,
+        face_a: &str,
+        face_b: &str,
+    ) -> Result<([f64; 3], [f64; 3]), String>;
+}
+
+/// A resolver for documents with no part anchors: every part-edge lookup
+/// fails with a clear message.
+pub struct NoPartAnchors;
+
+impl AnchorResolver for NoPartAnchors {
+    fn resolve_part_edge(
+        &self,
+        node: vcad_ir::NodeId,
+        face_a: &str,
+        face_b: &str,
+    ) -> Result<([f64; 3], [f64; 3]), String> {
+        Err(format!(
+            "part-edge anchor {face_a}/{face_b} on node {node}: no part geometry resolver available"
+        ))
+    }
+}
+
+/// Options for a solve pass.
+#[derive(Debug, Clone, Default)]
+pub struct SolveOptions {
+    /// Temporarily pin these footprints (by board node + reference) at
+    /// their current positions for this solve only — used by interactive
+    /// drag so the dragged part anchors the solve. Never persisted.
+    pub extra_fixed: Vec<(vcad_ir::NodeId, String)>,
+}
+
+/// Solve the document's constraints and write solved geometry (footprint
+/// positions/rotations, outline vertices, sketch segment points) back into
+/// `doc`. Driven dimension values are back-annotated as literal numbers.
+pub fn solve_design_constraints(
+    doc: &mut Document,
+    resolver: &dyn AnchorResolver,
+    options: &SolveOptions,
+) -> DesignSolveReport {
+    lower::run(doc, resolver, options, true)
+}
+
+/// Validate and measure the document's constraints without mutating
+/// geometry: resolves anchors, reports DOF, and measures every dimensional
+/// constraint's current value.
+pub fn check_design_constraints(
+    doc: &Document,
+    resolver: &dyn AnchorResolver,
+) -> DesignSolveReport {
+    let mut clone = doc.clone();
+    lower::run(&mut clone, resolver, &SolveOptions::default(), false)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vcad-design-constraints/src/lower.rs
+++ b/crates/vcad-design-constraints/src/lower.rs
@@ -1,0 +1,893 @@
+//! Lowering of document constraints into per-plane `Sketch2D` solves.
+
+use std::collections::HashMap;
+
+use vcad_ir::constraints::{Anchor, ConstraintKind, DesignConstraint, SketchPointRef};
+use vcad_ir::ecad::Pcb;
+use vcad_ir::expr_parser::parse_and_eval;
+use vcad_ir::parameters::{resolve_parameters, Expr};
+use vcad_ir::{CsgOp, Document, NodeId, SketchSegment2D};
+
+use vcad_kernel_constraints::{Constraint, EntityId, EntityRef, Sketch2D, SolveStatus};
+
+use crate::measure::measure_constraint;
+use crate::report::{ConstraintResidual, DesignSolveReport, DrivenValue, GroupReport};
+use crate::{AnchorResolver, SolveOptions};
+
+/// Tolerance for "did this coordinate move" reporting.
+const MOVE_EPS: f64 = 1e-9;
+/// Tolerance for detecting shared sketch endpoints.
+const WELD_EPS: f64 = 1e-6;
+
+/// What kind of plane a solve group lives on.
+enum GroupDomain {
+    Pcb,
+    Sketch {
+        origin: [f64; 3],
+        x_dir: [f64; 3],
+        y_dir: [f64; 3],
+    },
+}
+
+/// One planar solve group under construction.
+struct Group {
+    node: NodeId,
+    domain: GroupDomain,
+    sketch: Sketch2D,
+    /// footprint ref → origin point entity.
+    fp_points: HashMap<String, EntityId>,
+    /// footprint ref → rotation pseudo-circle entity.
+    fp_rotations: HashMap<String, EntityId>,
+    /// footprint ref → pad name → pad point entity.
+    pad_points: HashMap<(String, String), EntityId>,
+    /// outline vertex index → point entity.
+    outline_points: HashMap<u32, EntityId>,
+    /// outline edge index → line entity.
+    outline_edges: HashMap<u32, EntityId>,
+    /// (segment, point) → point entity, for sketch groups.
+    sketch_points: HashMap<(u32, SketchPointRef), EntityId>,
+    /// segment index → line entity, for sketch groups (line segments only).
+    sketch_lines: HashMap<u32, EntityId>,
+    /// Lowered driving-constraint count (for the report).
+    constraint_count: usize,
+}
+
+impl Group {
+    fn new(node: NodeId, domain: GroupDomain) -> Self {
+        Group {
+            node,
+            domain,
+            sketch: Sketch2D::new(),
+            fp_points: HashMap::new(),
+            fp_rotations: HashMap::new(),
+            pad_points: HashMap::new(),
+            outline_points: HashMap::new(),
+            outline_edges: HashMap::new(),
+            sketch_points: HashMap::new(),
+            sketch_lines: HashMap::new(),
+            constraint_count: 0,
+        }
+    }
+
+    /// Project a world point into this group's plane coordinates.
+    fn project(&self, p: [f64; 3]) -> (f64, f64) {
+        match &self.domain {
+            GroupDomain::Pcb => (p[0], p[1]),
+            GroupDomain::Sketch {
+                origin,
+                x_dir,
+                y_dir,
+            } => {
+                let d = [p[0] - origin[0], p[1] - origin[1], p[2] - origin[2]];
+                (
+                    d[0] * x_dir[0] + d[1] * x_dir[1] + d[2] * x_dir[2],
+                    d[0] * y_dir[0] + d[1] * y_dir[1] + d[2] * y_dir[2],
+                )
+            }
+        }
+    }
+}
+
+fn pcb_of(doc: &Document, node: NodeId) -> Option<&Pcb> {
+    match &doc.nodes.get(&node)?.op {
+        CsgOp::PcbBoard { board } => Some(board),
+        _ => None,
+    }
+}
+
+fn pcb_of_mut(doc: &mut Document, node: NodeId) -> Option<&mut Pcb> {
+    match &mut doc.nodes.get_mut(&node)?.op {
+        CsgOp::PcbBoard { board } => Some(board),
+        _ => None,
+    }
+}
+
+/// Evaluate a dimensional value expression against the parameter env.
+fn eval_expr(expr: &Expr, env: &HashMap<String, f64>) -> Result<f64, String> {
+    match expr {
+        Expr::Number(v) => Ok(*v),
+        Expr::Formula(f) => parse_and_eval(f, env).map_err(|e| format!("formula \"{f}\": {e}")),
+    }
+}
+
+/// The node a constraint's free (non-part) anchors belong to, validated to
+/// be unique. Part-edge anchors are fixed references and may live anywhere.
+fn group_node(kind: &ConstraintKind) -> Result<NodeId, String> {
+    if let ConstraintKind::Rotation { node, .. } = kind {
+        return Ok(*node);
+    }
+    let free: Vec<NodeId> = kind
+        .anchors()
+        .iter()
+        .filter(|a| !matches!(a, Anchor::PartEdge { .. }))
+        .map(|a| a.node())
+        .collect();
+    let Some(first) = free.first().copied() else {
+        return Err("constraint references only fixed part geometry; nothing to solve".into());
+    };
+    if free.iter().any(|n| *n != first) {
+        return Err(format!(
+            "free anchors span multiple nodes ({free:?}); one constraint may only drive one board or sketch"
+        ));
+    }
+    Ok(first)
+}
+
+/// Entity handle for a lowered anchor: a point ref, or a line entity.
+enum Lowered {
+    Point(EntityRef),
+    Line(EntityId),
+}
+
+impl Lowered {
+    fn point(&self) -> Result<EntityRef, String> {
+        match self {
+            Lowered::Point(p) => Ok(*p),
+            Lowered::Line(_) => Err("expected a point anchor, got an edge".into()),
+        }
+    }
+    fn line(&self) -> Result<EntityId, String> {
+        match self {
+            Lowered::Line(l) => Ok(*l),
+            Lowered::Point(_) => Err("expected an edge anchor, got a point".into()),
+        }
+    }
+}
+
+/// Lower one anchor into the group, creating entities on demand.
+#[allow(clippy::too_many_lines)]
+fn lower_anchor(
+    doc: &Document,
+    group: &mut Group,
+    resolver: &dyn AnchorResolver,
+    anchor: &Anchor,
+    free_rotation_refs: &[String],
+    warnings: &mut Vec<String>,
+) -> Result<Lowered, String> {
+    match anchor {
+        Anchor::PcbFootprint { node, r#ref, pad } => {
+            let pcb =
+                pcb_of(doc, *node).ok_or_else(|| format!("node {node} is not a PCB board"))?;
+            let fp = pcb
+                .footprints
+                .iter()
+                .find(|f| f.reference == *r#ref)
+                .ok_or_else(
+                    || format!("footprint \"{ref}\" not found on board {node}", ref = r#ref),
+                )?;
+            let origin = *group
+                .fp_points
+                .entry(r#ref.clone())
+                .or_insert_with(|| group.sketch.add_point(fp.position.x, fp.position.y));
+            let Some(pad_name) = pad else {
+                return Ok(Lowered::Point(EntityRef::Point(origin)));
+            };
+            let pad_obj = fp.pads.iter().find(|p| p.number == *pad_name).ok_or_else(
+                || format!("pad \"{pad_name}\" not found on footprint \"{ref}\"", ref = r#ref),
+            )?;
+            let key = (r#ref.clone(), pad_name.clone());
+            if let Some(id) = group.pad_points.get(&key) {
+                return Ok(Lowered::Point(EntityRef::Point(*id)));
+            }
+            // Pad rides the origin through a rigid offset evaluated at the
+            // footprint's current rotation. If that rotation is itself free
+            // in this solve, the offset is an approximation — warn.
+            if free_rotation_refs.contains(r#ref) {
+                warnings.push(format!(
+                    "pad anchor {ref}.{pad_name} uses the footprint's current rotation; combined with a free rotation constraint the offset is approximate",
+                    ref = r#ref
+                ));
+            }
+            let world = vcad_ecad_pcb::geometry::pad_world_position(fp, pad_obj);
+            let (dx, dy) = (world.x - fp.position.x, world.y - fp.position.y);
+            let pad_pt = group.sketch.add_point(world.x, world.y);
+            group.sketch.add_constraint(Constraint::OffsetCoincident {
+                point_a: EntityRef::Point(origin),
+                point_b: EntityRef::Point(pad_pt),
+                dx,
+                dy,
+            });
+            group.pad_points.insert(key, pad_pt);
+            Ok(Lowered::Point(EntityRef::Point(pad_pt)))
+        }
+        Anchor::PcbOutlineVertex { node, index } => {
+            let pcb =
+                pcb_of(doc, *node).ok_or_else(|| format!("node {node} is not a PCB board"))?;
+            let n = pcb.outline.vertices.len() as u32;
+            if *index >= n {
+                return Err(format!(
+                    "outline vertex {index} out of range (outline has {n} vertices)"
+                ));
+            }
+            let v = pcb.outline.vertices[*index as usize];
+            let id = *group
+                .outline_points
+                .entry(*index)
+                .or_insert_with(|| group.sketch.add_point(v.x, v.y));
+            Ok(Lowered::Point(EntityRef::Point(id)))
+        }
+        Anchor::PcbOutlineEdge { node, index } => {
+            let pcb =
+                pcb_of(doc, *node).ok_or_else(|| format!("node {node} is not a PCB board"))?;
+            let n = pcb.outline.vertices.len() as u32;
+            if *index >= n {
+                return Err(format!(
+                    "outline edge {index} out of range (outline has {n} vertices)"
+                ));
+            }
+            if let Some(id) = group.outline_edges.get(index) {
+                return Ok(Lowered::Line(*id));
+            }
+            let j = (*index + 1) % n;
+            let a = pcb.outline.vertices[*index as usize];
+            let b = pcb.outline.vertices[j as usize];
+            let pa = *group
+                .outline_points
+                .entry(*index)
+                .or_insert_with(|| group.sketch.add_point(a.x, a.y));
+            let pb = *group
+                .outline_points
+                .entry(j)
+                .or_insert_with(|| group.sketch.add_point(b.x, b.y));
+            let line = group.sketch.add_line(pa, pb);
+            group.outline_edges.insert(*index, line);
+            Ok(Lowered::Line(line))
+        }
+        Anchor::SketchPoint {
+            node,
+            segment,
+            point,
+        } => {
+            // Sketch groups lower every segment up front (see
+            // `ensure_sketch_group`), so the entity must already exist.
+            let _ = node;
+            group
+                .sketch_points
+                .get(&(*segment, *point))
+                .map(|id| Lowered::Point(EntityRef::Point(*id)))
+                .ok_or_else(|| format!("sketch segment {segment} has no {point:?} point"))
+        }
+        Anchor::SketchSegment { node, segment } => {
+            let _ = node;
+            group
+                .sketch_lines
+                .get(segment)
+                .map(|id| Lowered::Line(*id))
+                .ok_or_else(|| {
+                    format!(
+                        "sketch segment {segment} is not a line segment (arcs can't be edge anchors)"
+                    )
+                })
+        }
+        Anchor::PartEdge {
+            node,
+            face_a,
+            face_b,
+            ..
+        } => {
+            let (a, b) = resolver.resolve_part_edge(*node, face_a, face_b)?;
+            let (ax, ay) = group.project(a);
+            let (bx, by) = group.project(b);
+            let pa = group.sketch.add_point(ax, ay);
+            let pb = group.sketch.add_point(bx, by);
+            group.sketch.add_constraint(Constraint::Fixed {
+                point: EntityRef::Point(pa),
+                x: ax,
+                y: ay,
+            });
+            group.sketch.add_constraint(Constraint::Fixed {
+                point: EntityRef::Point(pb),
+                x: bx,
+                y: by,
+            });
+            let line = group.sketch.add_line(pa, pb);
+            Ok(Lowered::Line(line))
+        }
+    }
+}
+
+/// Midpoint of a part edge, as a point entity (for point-context part
+/// anchors like Coincident-with-part-edge).
+fn lower_anchor_as_point(
+    doc: &Document,
+    group: &mut Group,
+    resolver: &dyn AnchorResolver,
+    anchor: &Anchor,
+    free_rotation_refs: &[String],
+    warnings: &mut Vec<String>,
+) -> Result<EntityRef, String> {
+    if let Anchor::PartEdge {
+        node,
+        face_a,
+        face_b,
+        ..
+    } = anchor
+    {
+        let (a, b) = resolver.resolve_part_edge(*node, face_a, face_b)?;
+        let mid = [
+            (a[0] + b[0]) / 2.0,
+            (a[1] + b[1]) / 2.0,
+            (a[2] + b[2]) / 2.0,
+        ];
+        let (mx, my) = group.project(mid);
+        let p = group.sketch.add_point(mx, my);
+        group.sketch.add_constraint(Constraint::Fixed {
+            point: EntityRef::Point(p),
+            x: mx,
+            y: my,
+        });
+        return Ok(EntityRef::Point(p));
+    }
+    lower_anchor(doc, group, resolver, anchor, free_rotation_refs, warnings)?.point()
+}
+
+/// A point-or-edge anchor lowered for line contexts: part edges and outline
+/// edges give their line; anything else is an error.
+fn lower_anchor_as_line(
+    doc: &Document,
+    group: &mut Group,
+    resolver: &dyn AnchorResolver,
+    anchor: &Anchor,
+    warnings: &mut Vec<String>,
+) -> Result<EntityId, String> {
+    lower_anchor(doc, group, resolver, anchor, &[], warnings)?.line()
+}
+
+/// Pre-populate a sketch group with every segment of the sketch, welding
+/// endpoints that coincide by value so the profile stays connected.
+fn ensure_sketch_group(group: &mut Group, segments: &[SketchSegment2D]) {
+    let mut welded: Vec<(f64, f64, EntityId)> = Vec::new();
+    let mut get_point = |group: &mut Group, x: f64, y: f64| -> EntityId {
+        for (wx, wy, id) in &welded {
+            if (wx - x).abs() < WELD_EPS && (wy - y).abs() < WELD_EPS {
+                return *id;
+            }
+        }
+        let id = group.sketch.add_point(x, y);
+        welded.push((x, y, id));
+        id
+    };
+    for (i, seg) in segments.iter().enumerate() {
+        let i = i as u32;
+        match seg {
+            SketchSegment2D::Line { start, end } => {
+                let s = get_point(group, start.x, start.y);
+                let e = get_point(group, end.x, end.y);
+                group.sketch_points.insert((i, SketchPointRef::Start), s);
+                group.sketch_points.insert((i, SketchPointRef::End), e);
+                let line = group.sketch.add_line(s, e);
+                group.sketch_lines.insert(i, line);
+            }
+            SketchSegment2D::Arc {
+                start, end, center, ..
+            } => {
+                let s = get_point(group, start.x, start.y);
+                let e = get_point(group, end.x, end.y);
+                let c = get_point(group, center.x, center.y);
+                group.sketch_points.insert((i, SketchPointRef::Start), s);
+                group.sketch_points.insert((i, SketchPointRef::End), e);
+                group.sketch_points.insert((i, SketchPointRef::Center), c);
+                group.sketch.add_arc(s, e, c, true);
+            }
+        }
+    }
+}
+
+/// Lower one driving constraint into its group. Returns Err to skip it.
+fn lower_constraint(
+    doc: &Document,
+    group: &mut Group,
+    resolver: &dyn AnchorResolver,
+    kind: &ConstraintKind,
+    env: &HashMap<String, f64>,
+    free_rotation_refs: &[String],
+    warnings: &mut Vec<String>,
+) -> Result<(), String> {
+    let mut point = |group: &mut Group, a: &Anchor| {
+        lower_anchor_as_point(doc, group, resolver, a, free_rotation_refs, warnings)
+    };
+    match kind {
+        ConstraintKind::Coincident { a, b } | ConstraintKind::Concentric { a, b } => {
+            let (pa, pb) = (point(group, a)?, point(group, b)?);
+            group.sketch.add_constraint(Constraint::Coincident {
+                point_a: pa,
+                point_b: pb,
+            });
+        }
+        ConstraintKind::Distance { a, b, value } => {
+            let d = eval_expr(value, env)?;
+            let (pa, pb) = (point(group, a)?, point(group, b)?);
+            group.sketch.add_constraint(Constraint::Distance {
+                point_a: pa,
+                point_b: pb,
+                distance: d,
+            });
+        }
+        ConstraintKind::HorizontalDistance { a, value } => {
+            let x = eval_expr(value, env)?;
+            let p = point(group, a)?;
+            group
+                .sketch
+                .add_constraint(Constraint::HorizontalDistance { point: p, x });
+        }
+        ConstraintKind::VerticalDistance { a, value } => {
+            let y = eval_expr(value, env)?;
+            let p = point(group, a)?;
+            group
+                .sketch
+                .add_constraint(Constraint::VerticalDistance { point: p, y });
+        }
+        ConstraintKind::Horizontal { a, b } => {
+            let line = pair_line(doc, group, resolver, a, b, free_rotation_refs, warnings)?;
+            group.sketch.add_constraint(Constraint::Horizontal { line });
+        }
+        ConstraintKind::Vertical { a, b } => {
+            let line = pair_line(doc, group, resolver, a, b, free_rotation_refs, warnings)?;
+            group.sketch.add_constraint(Constraint::Vertical { line });
+        }
+        ConstraintKind::Parallel { a, b } => {
+            let la = lower_anchor_as_line(doc, group, resolver, a, warnings)?;
+            let lb = lower_anchor_as_line(doc, group, resolver, b, warnings)?;
+            group.sketch.add_constraint(Constraint::Parallel {
+                line_a: la,
+                line_b: lb,
+            });
+        }
+        ConstraintKind::Perpendicular { a, b } => {
+            let la = lower_anchor_as_line(doc, group, resolver, a, warnings)?;
+            let lb = lower_anchor_as_line(doc, group, resolver, b, warnings)?;
+            group.sketch.add_constraint(Constraint::Perpendicular {
+                line_a: la,
+                line_b: lb,
+            });
+        }
+        ConstraintKind::EqualLength { a, b } => {
+            let la = lower_anchor_as_line(doc, group, resolver, a, warnings)?;
+            let lb = lower_anchor_as_line(doc, group, resolver, b, warnings)?;
+            group.sketch.add_constraint(Constraint::EqualLength {
+                line_a: la,
+                line_b: lb,
+            });
+        }
+        ConstraintKind::Length { a, value } => {
+            let len = eval_expr(value, env)?;
+            let la = lower_anchor_as_line(doc, group, resolver, a, warnings)?;
+            group.sketch.add_constraint(Constraint::Length {
+                line: la,
+                length: len,
+            });
+        }
+        ConstraintKind::PointOnEdge { point: p, edge } => {
+            let pt = point(group, p)?;
+            let line = lower_anchor_as_line(doc, group, resolver, edge, warnings)?;
+            group
+                .sketch
+                .add_constraint(Constraint::PointOnLine { point: pt, line });
+        }
+        ConstraintKind::Fixed { a } => {
+            let p = point(group, a)?;
+            let (x, y) = current_point(group, p)?;
+            group
+                .sketch
+                .add_constraint(Constraint::Fixed { point: p, x, y });
+        }
+        ConstraintKind::Rotation { node, r#ref, value } => {
+            let deg = eval_expr(value, env)?;
+            let circle = ensure_rotation_circle(doc, group, *node, r#ref)?;
+            group.sketch.add_constraint(Constraint::Radius {
+                circle,
+                radius: deg,
+            });
+        }
+        ConstraintKind::Symmetric { a, b, axis } => {
+            let (pa, pb) = (point(group, a)?, point(group, b)?);
+            let ax = lower_anchor_as_line(doc, group, resolver, axis, warnings)?;
+            group.sketch.add_constraint(Constraint::Symmetric {
+                point_a: pa,
+                point_b: pb,
+                axis: ax,
+            });
+        }
+        ConstraintKind::Angle { a, b, value } => {
+            let deg = eval_expr(value, env)?;
+            let la = lower_anchor_as_line(doc, group, resolver, a, warnings)?;
+            let lb = lower_anchor_as_line(doc, group, resolver, b, warnings)?;
+            group.sketch.add_constraint(Constraint::Angle {
+                line_a: la,
+                line_b: lb,
+                angle_rad: deg.to_radians(),
+            });
+        }
+    }
+    group.constraint_count += 1;
+    Ok(())
+}
+
+/// For Horizontal/Vertical: a single edge-like anchor passed twice means
+/// "this edge"; otherwise the two point anchors get a connecting line.
+fn pair_line(
+    doc: &Document,
+    group: &mut Group,
+    resolver: &dyn AnchorResolver,
+    a: &Anchor,
+    b: &Anchor,
+    free_rotation_refs: &[String],
+    warnings: &mut Vec<String>,
+) -> Result<EntityId, String> {
+    if a.is_edge() && a == b {
+        return lower_anchor_as_line(doc, group, resolver, a, warnings);
+    }
+    let pa = lower_anchor_as_point(doc, group, resolver, a, free_rotation_refs, warnings)?;
+    let pb = lower_anchor_as_point(doc, group, resolver, b, free_rotation_refs, warnings)?;
+    let (ia, ib) = (deref_point(pa)?, deref_point(pb)?);
+    Ok(group.sketch.add_line(ia, ib))
+}
+
+fn deref_point(r: EntityRef) -> Result<EntityId, String> {
+    match r {
+        EntityRef::Point(id) => Ok(id),
+        _ => Err("expected a plain point entity".into()),
+    }
+}
+
+fn current_point(group: &Group, r: EntityRef) -> Result<(f64, f64), String> {
+    let id = match r {
+        EntityRef::Point(id) => id,
+        _ => return Err("expected a plain point entity".into()),
+    };
+    group
+        .sketch
+        .get_point(id)
+        .ok_or_else(|| "entity is not a point".into())
+}
+
+/// The pseudo-circle whose radius parameter carries a footprint's rotation
+/// in degrees.
+fn ensure_rotation_circle(
+    doc: &Document,
+    group: &mut Group,
+    node: NodeId,
+    r#ref: &str,
+) -> Result<EntityId, String> {
+    if let Some(id) = group.fp_rotations.get(r#ref) {
+        return Ok(*id);
+    }
+    let pcb = pcb_of(doc, node).ok_or_else(|| format!("node {node} is not a PCB board"))?;
+    let fp = pcb
+        .footprints
+        .iter()
+        .find(|f| f.reference == r#ref)
+        .ok_or_else(|| format!("footprint \"{ref}\" not found on board {node}", ref = r#ref))?;
+    let origin = *group
+        .fp_points
+        .entry(r#ref.to_string())
+        .or_insert_with(|| group.sketch.add_point(fp.position.x, fp.position.y));
+    let circle = group.sketch.add_circle(origin, fp.rotation);
+    group.fp_rotations.insert(r#ref.to_string(), circle);
+    Ok(circle)
+}
+
+/// Refs that have a driving Rotation constraint (rotation is a free param).
+fn free_rotation_refs(constraints: &[DesignConstraint]) -> Vec<String> {
+    constraints
+        .iter()
+        .filter(|c| !c.driven)
+        .filter_map(|c| match &c.kind {
+            ConstraintKind::Rotation { r#ref, .. } => Some(r#ref.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn status_str(s: SolveStatus) -> (&'static str, bool) {
+    match s {
+        SolveStatus::Converged => ("converged", true),
+        SolveStatus::MaxIterations => ("maxIterations", false),
+        SolveStatus::LambdaOverflow => ("lambdaOverflow", false),
+        SolveStatus::NoConstraints => ("noConstraints", true),
+        SolveStatus::NoParameters => ("noParameters", true),
+        SolveStatus::SingularMatrix => ("singularMatrix", false),
+    }
+}
+
+/// The main lowering + solve + write-back pass shared by solve and check.
+pub(crate) fn run(
+    doc: &mut Document,
+    resolver: &dyn AnchorResolver,
+    options: &SolveOptions,
+    write_back: bool,
+) -> DesignSolveReport {
+    let mut report = DesignSolveReport {
+        converged: true,
+        ..Default::default()
+    };
+    if doc.constraints.is_empty() && options.extra_fixed.is_empty() {
+        return report;
+    }
+
+    // 1. Parameter environment (fail-closed per formula, not globally).
+    let env = match resolve_parameters(&doc.parameters) {
+        Ok(env) => env,
+        Err(e) => {
+            report
+                .errors
+                .push(format!("parameter resolution failed: {e}"));
+            HashMap::new()
+        }
+    };
+
+    let free_rot = free_rotation_refs(&doc.constraints);
+
+    // 2. Partition into groups.
+    let mut groups: Vec<Group> = Vec::new();
+    let mut group_index: HashMap<u64, usize> = HashMap::new();
+    let constraints = doc.constraints.clone();
+    for c in &constraints {
+        if c.driven {
+            continue; // driven dims contribute nothing to the solve
+        }
+        let node = match group_node(&c.kind) {
+            Ok(n) => n,
+            Err(e) => {
+                report.errors.push(format!("constraint {}: {e}", c.id));
+                continue;
+            }
+        };
+        let idx = match group_index.get(&node) {
+            Some(i) => *i,
+            None => {
+                let domain = match doc.nodes.get(&node).map(|n| &n.op) {
+                    Some(CsgOp::PcbBoard { .. }) => GroupDomain::Pcb,
+                    Some(CsgOp::Sketch2D {
+                        origin,
+                        x_dir,
+                        y_dir,
+                        ..
+                    }) => GroupDomain::Sketch {
+                        origin: [origin.x, origin.y, origin.z],
+                        x_dir: [x_dir.x, x_dir.y, x_dir.z],
+                        y_dir: [y_dir.x, y_dir.y, y_dir.z],
+                    },
+                    _ => {
+                        report.errors.push(format!(
+                            "constraint {}: node {node} is neither a PCB board nor a sketch",
+                            c.id
+                        ));
+                        continue;
+                    }
+                };
+                let mut group = Group::new(node, domain);
+                if let Some(CsgOp::Sketch2D { segments, .. }) = doc.nodes.get(&node).map(|n| &n.op)
+                {
+                    ensure_sketch_group(&mut group, segments);
+                }
+                groups.push(group);
+                group_index.insert(node, groups.len() - 1);
+                groups.len() - 1
+            }
+        };
+        let mut warnings = Vec::new();
+        if let Err(e) = lower_constraint(
+            doc,
+            &mut groups[idx],
+            resolver,
+            &c.kind,
+            &env,
+            &free_rot,
+            &mut warnings,
+        ) {
+            report.errors.push(format!("constraint {}: {e}", c.id));
+        }
+        report.warnings.extend(warnings);
+    }
+
+    // 3. Interactive extra-fixed pins.
+    for (node, r#ref) in &options.extra_fixed {
+        let Some(idx) = group_index.get(node) else {
+            continue; // no constraints on that board — nothing to pin against
+        };
+        let group = &mut groups[*idx];
+        let Some(pcb) = pcb_of(doc, *node) else {
+            continue;
+        };
+        let Some(fp) = pcb.footprints.iter().find(|f| f.reference == *r#ref) else {
+            continue;
+        };
+        let origin = *group
+            .fp_points
+            .entry(r#ref.clone())
+            .or_insert_with(|| group.sketch.add_point(fp.position.x, fp.position.y));
+        group.sketch.add_constraint(Constraint::Fixed {
+            point: EntityRef::Point(origin),
+            x: fp.position.x,
+            y: fp.position.y,
+        });
+    }
+
+    // 4. Solve each group and write back.
+    for group in &mut groups {
+        let result = group.sketch.solve_default();
+        let (status, ok) = status_str(result.status);
+        report.groups.push(GroupReport {
+            node: group.node,
+            status: status.to_string(),
+            converged: ok,
+            iterations: result.iterations,
+            residual_norm: result.residual_norm,
+            dof: i64::from(group.sketch.degrees_of_freedom()),
+            constraint_count: group.constraint_count,
+        });
+        if !ok {
+            report.converged = false;
+            continue;
+        }
+        if !write_back {
+            continue;
+        }
+        write_back_group(doc, group, &mut report);
+    }
+
+    // 5. Measure dimensional values (driven always; all dims on check).
+    for c in &constraints {
+        let measure_this = c.driven || !write_back;
+        if !measure_this || !c.kind.is_dimensional() {
+            continue;
+        }
+        match measure_constraint(doc, resolver, &c.kind) {
+            Ok(v) => report.driven_values.push(DrivenValue {
+                id: c.id.clone(),
+                value: v,
+            }),
+            Err(e) => report
+                .errors
+                .push(format!("constraint {}: cannot measure: {e}", c.id)),
+        }
+    }
+
+    // 5b. Per-constraint residuals against the (possibly just-solved)
+    // geometry — the receipt layer's Holds/Violated evidence.
+    for c in &constraints {
+        let target = c.kind.value().and_then(|v| eval_expr(v, &env).ok());
+        match crate::measure::constraint_residual(doc, resolver, &c.kind, target) {
+            Ok(r) => report.residuals.push(ConstraintResidual {
+                id: c.id.clone(),
+                residual: r,
+                driven: c.driven,
+            }),
+            Err(e) => report
+                .errors
+                .push(format!("constraint {}: cannot verify: {e}", c.id)),
+        }
+    }
+
+    // 6. Back-annotate driven dims into the document.
+    if write_back {
+        for dv in &report.driven_values {
+            if let Some(c) = doc.constraints.iter_mut().find(|c| c.id == dv.id) {
+                if c.driven {
+                    if let Some(v) = c.kind.value_mut() {
+                        *v = Expr::Number(dv.value);
+                    }
+                }
+            }
+        }
+    }
+
+    report
+}
+
+/// Copy solved entity positions back into the document.
+fn write_back_group(doc: &mut Document, group: &Group, report: &mut DesignSolveReport) {
+    match &group.domain {
+        GroupDomain::Pcb => {
+            let node = group.node;
+            // Collect solved values first (immutable borrow of group).
+            let fps: Vec<(String, f64, f64)> = group
+                .fp_points
+                .iter()
+                .filter_map(|(r, id)| group.sketch.get_point(*id).map(|(x, y)| (r.clone(), x, y)))
+                .collect();
+            let rots: Vec<(String, f64)> = group
+                .fp_rotations
+                .iter()
+                .filter_map(|(r, id)| group.sketch.get_radius(*id).map(|deg| (r.clone(), deg)))
+                .collect();
+            let verts: Vec<(u32, f64, f64)> = group
+                .outline_points
+                .iter()
+                .filter_map(|(i, id)| group.sketch.get_point(*id).map(|(x, y)| (*i, x, y)))
+                .collect();
+            let Some(pcb) = pcb_of_mut(doc, node) else {
+                return;
+            };
+            for (r, x, y) in fps {
+                if let Some(fp) = pcb.footprints.iter_mut().find(|f| f.reference == r) {
+                    if (fp.position.x - x).abs() > MOVE_EPS || (fp.position.y - y).abs() > MOVE_EPS
+                    {
+                        fp.position.x = x;
+                        fp.position.y = y;
+                        if !report.moved_footprints.contains(&r) {
+                            report.moved_footprints.push(r.clone());
+                        }
+                    }
+                }
+            }
+            for (r, deg) in rots {
+                if let Some(fp) = pcb.footprints.iter_mut().find(|f| f.reference == r) {
+                    if (fp.rotation - deg).abs() > MOVE_EPS {
+                        fp.rotation = deg;
+                        if !report.moved_footprints.contains(&r) {
+                            report.moved_footprints.push(r.clone());
+                        }
+                    }
+                }
+            }
+            for (i, x, y) in verts {
+                if let Some(v) = pcb.outline.vertices.get_mut(i as usize) {
+                    if (v.x - x).abs() > MOVE_EPS || (v.y - y).abs() > MOVE_EPS {
+                        v.x = x;
+                        v.y = y;
+                        report.moved_vertices.push(format!("{node}:{i}"));
+                    }
+                }
+            }
+        }
+        GroupDomain::Sketch { .. } => {
+            let node = group.node;
+            let solved: Vec<((u32, SketchPointRef), (f64, f64))> = group
+                .sketch_points
+                .iter()
+                .filter_map(|(k, id)| group.sketch.get_point(*id).map(|p| (*k, p)))
+                .collect();
+            let Some(CsgOp::Sketch2D { segments, .. }) =
+                doc.nodes.get_mut(&node).map(|n| &mut n.op)
+            else {
+                return;
+            };
+            let mut moved = false;
+            for ((seg, which), (x, y)) in solved {
+                let Some(segment) = segments.get_mut(seg as usize) else {
+                    continue;
+                };
+                let target = match (segment, which) {
+                    (SketchSegment2D::Line { start, .. }, SketchPointRef::Start) => Some(start),
+                    (SketchSegment2D::Line { end, .. }, SketchPointRef::End) => Some(end),
+                    (SketchSegment2D::Arc { start, .. }, SketchPointRef::Start) => Some(start),
+                    (SketchSegment2D::Arc { end, .. }, SketchPointRef::End) => Some(end),
+                    (SketchSegment2D::Arc { center, .. }, SketchPointRef::Center) => Some(center),
+                    _ => None,
+                };
+                if let Some(v) = target {
+                    if (v.x - x).abs() > MOVE_EPS || (v.y - y).abs() > MOVE_EPS {
+                        v.x = x;
+                        v.y = y;
+                        moved = true;
+                    }
+                }
+            }
+            if moved {
+                report.moved_sketches.push(node);
+            }
+        }
+    }
+}

--- a/crates/vcad-design-constraints/src/measure.rs
+++ b/crates/vcad-design-constraints/src/measure.rs
@@ -1,0 +1,341 @@
+//! Direct measurement of dimensional constraints from document geometry —
+//! used for driven-dimension back-annotation and receipt verification.
+
+use vcad_ir::constraints::{Anchor, ConstraintKind, SketchPointRef};
+use vcad_ir::{CsgOp, Document, NodeId};
+
+use crate::AnchorResolver;
+
+/// Plane frame for projecting world-space part anchors.
+struct Plane {
+    origin: [f64; 3],
+    x_dir: [f64; 3],
+    y_dir: [f64; 3],
+}
+
+impl Plane {
+    fn xy() -> Self {
+        Plane {
+            origin: [0.0; 3],
+            x_dir: [1.0, 0.0, 0.0],
+            y_dir: [0.0, 1.0, 0.0],
+        }
+    }
+
+    fn project(&self, p: [f64; 3]) -> (f64, f64) {
+        let d = [
+            p[0] - self.origin[0],
+            p[1] - self.origin[1],
+            p[2] - self.origin[2],
+        ];
+        (
+            d[0] * self.x_dir[0] + d[1] * self.x_dir[1] + d[2] * self.x_dir[2],
+            d[0] * self.y_dir[0] + d[1] * self.y_dir[1] + d[2] * self.y_dir[2],
+        )
+    }
+}
+
+fn plane_for(doc: &Document, node: NodeId) -> Plane {
+    match doc.nodes.get(&node).map(|n| &n.op) {
+        Some(CsgOp::Sketch2D {
+            origin,
+            x_dir,
+            y_dir,
+            ..
+        }) => Plane {
+            origin: [origin.x, origin.y, origin.z],
+            x_dir: [x_dir.x, x_dir.y, x_dir.z],
+            y_dir: [y_dir.x, y_dir.y, y_dir.z],
+        },
+        _ => Plane::xy(),
+    }
+}
+
+/// The plane a constraint measures in: that of its first free anchor's node.
+fn measure_plane(doc: &Document, kind: &ConstraintKind) -> Plane {
+    if let ConstraintKind::Rotation { node, .. } = kind {
+        return plane_for(doc, *node);
+    }
+    kind.anchors()
+        .iter()
+        .find(|a| !matches!(a, Anchor::PartEdge { .. }))
+        .map(|a| plane_for(doc, a.node()))
+        .unwrap_or_else(Plane::xy)
+}
+
+/// In-plane position of a point-like anchor.
+fn anchor_point(
+    doc: &Document,
+    resolver: &dyn AnchorResolver,
+    plane: &Plane,
+    anchor: &Anchor,
+) -> Result<(f64, f64), String> {
+    match anchor {
+        Anchor::PcbFootprint { node, r#ref, pad } => {
+            let pcb = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::PcbBoard { board }) => board,
+                _ => return Err(format!("node {node} is not a PCB board")),
+            };
+            let fp = pcb
+                .footprints
+                .iter()
+                .find(|f| f.reference == *r#ref)
+                .ok_or_else(|| format!("footprint \"{ref}\" not found", ref = r#ref))?;
+            match pad {
+                None => Ok((fp.position.x, fp.position.y)),
+                Some(pad_name) => {
+                    let p = fp
+                        .pads
+                        .iter()
+                        .find(|p| p.number == *pad_name)
+                        .ok_or_else(|| format!("pad \"{pad_name}\" not found"))?;
+                    let w = vcad_ecad_pcb::geometry::pad_world_position(fp, p);
+                    Ok((w.x, w.y))
+                }
+            }
+        }
+        Anchor::PcbOutlineVertex { node, index } => {
+            let pcb = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::PcbBoard { board }) => board,
+                _ => return Err(format!("node {node} is not a PCB board")),
+            };
+            pcb.outline
+                .vertices
+                .get(*index as usize)
+                .map(|v| (v.x, v.y))
+                .ok_or_else(|| format!("outline vertex {index} out of range"))
+        }
+        Anchor::SketchPoint {
+            node,
+            segment,
+            point,
+        } => {
+            let segments = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::Sketch2D { segments, .. }) => segments,
+                _ => return Err(format!("node {node} is not a sketch")),
+            };
+            let seg = segments
+                .get(*segment as usize)
+                .ok_or_else(|| format!("sketch segment {segment} out of range"))?;
+            use vcad_ir::SketchSegment2D as S;
+            match (seg, point) {
+                (S::Line { start, .. } | S::Arc { start, .. }, SketchPointRef::Start) => {
+                    Ok((start.x, start.y))
+                }
+                (S::Line { end, .. } | S::Arc { end, .. }, SketchPointRef::End) => {
+                    Ok((end.x, end.y))
+                }
+                (S::Arc { center, .. }, SketchPointRef::Center) => Ok((center.x, center.y)),
+                _ => Err(format!("segment {segment} has no {point:?} point")),
+            }
+        }
+        Anchor::PartEdge {
+            node,
+            face_a,
+            face_b,
+            ..
+        } => {
+            let (a, b) = resolver.resolve_part_edge(*node, face_a, face_b)?;
+            let mid = [
+                (a[0] + b[0]) / 2.0,
+                (a[1] + b[1]) / 2.0,
+                (a[2] + b[2]) / 2.0,
+            ];
+            Ok(plane.project(mid))
+        }
+        Anchor::PcbOutlineEdge { .. } | Anchor::SketchSegment { .. } => {
+            Err("edge anchor used where a point is required".into())
+        }
+    }
+}
+
+/// A pair of in-plane points (an edge's endpoints).
+type EdgePoints = ((f64, f64), (f64, f64));
+
+/// In-plane endpoints of an edge-like anchor.
+fn anchor_edge(
+    doc: &Document,
+    resolver: &dyn AnchorResolver,
+    plane: &Plane,
+    anchor: &Anchor,
+) -> Result<EdgePoints, String> {
+    match anchor {
+        Anchor::PcbOutlineEdge { node, index } => {
+            let pcb = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::PcbBoard { board }) => board,
+                _ => return Err(format!("node {node} is not a PCB board")),
+            };
+            let n = pcb.outline.vertices.len();
+            let i = *index as usize;
+            if i >= n {
+                return Err(format!("outline edge {index} out of range"));
+            }
+            let a = pcb.outline.vertices[i];
+            let b = pcb.outline.vertices[(i + 1) % n];
+            Ok(((a.x, a.y), (b.x, b.y)))
+        }
+        Anchor::SketchSegment { node, segment } => {
+            let segments = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::Sketch2D { segments, .. }) => segments,
+                _ => return Err(format!("node {node} is not a sketch")),
+            };
+            use vcad_ir::SketchSegment2D as S;
+            segments
+                .get(*segment as usize)
+                .map(|seg| match seg {
+                    S::Line { start, end } | S::Arc { start, end, .. } => {
+                        ((start.x, start.y), (end.x, end.y))
+                    }
+                })
+                .ok_or_else(|| format!("sketch segment {segment} out of range"))
+        }
+        Anchor::PartEdge {
+            node,
+            face_a,
+            face_b,
+            ..
+        } => {
+            let (a, b) = resolver.resolve_part_edge(*node, face_a, face_b)?;
+            Ok((plane.project(a), plane.project(b)))
+        }
+        _ => Err("point anchor used where an edge is required".into()),
+    }
+}
+
+/// Measure the current value of a dimensional constraint (mm or degrees).
+pub(crate) fn measure_constraint(
+    doc: &Document,
+    resolver: &dyn AnchorResolver,
+    kind: &ConstraintKind,
+) -> Result<f64, String> {
+    let plane = measure_plane(doc, kind);
+    match kind {
+        ConstraintKind::Distance { a, b, .. } => {
+            let pa = anchor_point(doc, resolver, &plane, a)?;
+            let pb = anchor_point(doc, resolver, &plane, b)?;
+            Ok(((pa.0 - pb.0).powi(2) + (pa.1 - pb.1).powi(2)).sqrt())
+        }
+        ConstraintKind::HorizontalDistance { a, .. } => {
+            Ok(anchor_point(doc, resolver, &plane, a)?.0)
+        }
+        ConstraintKind::VerticalDistance { a, .. } => Ok(anchor_point(doc, resolver, &plane, a)?.1),
+        ConstraintKind::Length { a, .. } => {
+            let (pa, pb) = anchor_edge(doc, resolver, &plane, a)?;
+            Ok(((pa.0 - pb.0).powi(2) + (pa.1 - pb.1).powi(2)).sqrt())
+        }
+        ConstraintKind::Rotation { node, r#ref, .. } => {
+            let pcb = match doc.nodes.get(node).map(|n| &n.op) {
+                Some(CsgOp::PcbBoard { board }) => board,
+                _ => return Err(format!("node {node} is not a PCB board")),
+            };
+            pcb.footprints
+                .iter()
+                .find(|f| f.reference == *r#ref)
+                .map(|f| f.rotation)
+                .ok_or_else(|| format!("footprint \"{ref}\" not found", ref = r#ref))
+        }
+        ConstraintKind::Angle { a, b, .. } => {
+            let (a1, a2) = anchor_edge(doc, resolver, &plane, a)?;
+            let (b1, b2) = anchor_edge(doc, resolver, &plane, b)?;
+            let da = (a2.0 - a1.0, a2.1 - a1.1);
+            let db = (b2.0 - b1.0, b2.1 - b1.1);
+            let cross = da.0 * db.1 - da.1 * db.0;
+            let dot = da.0 * db.0 + da.1 * db.1;
+            Ok(cross.atan2(dot).to_degrees().abs())
+        }
+        _ => Err("constraint is not dimensional".into()),
+    }
+}
+
+/// Residual magnitude of any constraint kind against current geometry —
+/// used by receipt verification ("does this constraint still hold?").
+pub fn constraint_residual(
+    doc: &Document,
+    resolver: &dyn AnchorResolver,
+    kind: &ConstraintKind,
+    target: Option<f64>,
+) -> Result<f64, String> {
+    let plane = measure_plane(doc, kind);
+    let point = |a: &Anchor| anchor_point(doc, resolver, &plane, a);
+    let edge = |a: &Anchor| anchor_edge(doc, resolver, &plane, a);
+    let dir = |e: ((f64, f64), (f64, f64))| {
+        let d = ((e.1 .0 - e.0 .0), (e.1 .1 - e.0 .1));
+        let len = (d.0 * d.0 + d.1 * d.1).sqrt();
+        if len < 1e-12 {
+            (0.0, 0.0)
+        } else {
+            (d.0 / len, d.1 / len)
+        }
+    };
+    match kind {
+        ConstraintKind::Coincident { a, b } | ConstraintKind::Concentric { a, b } => {
+            let (pa, pb) = (point(a)?, point(b)?);
+            Ok(((pa.0 - pb.0).powi(2) + (pa.1 - pb.1).powi(2)).sqrt())
+        }
+        ConstraintKind::Horizontal { a, b } => {
+            if a.is_edge() && a == b {
+                let e = edge(a)?;
+                Ok((e.1 .1 - e.0 .1).abs())
+            } else {
+                Ok((point(a)?.1 - point(b)?.1).abs())
+            }
+        }
+        ConstraintKind::Vertical { a, b } => {
+            if a.is_edge() && a == b {
+                let e = edge(a)?;
+                Ok((e.1 .0 - e.0 .0).abs())
+            } else {
+                Ok((point(a)?.0 - point(b)?.0).abs())
+            }
+        }
+        ConstraintKind::Parallel { a, b } => {
+            let (da, db) = (dir(edge(a)?), dir(edge(b)?));
+            Ok((da.0 * db.1 - da.1 * db.0).abs())
+        }
+        ConstraintKind::Perpendicular { a, b } => {
+            let (da, db) = (dir(edge(a)?), dir(edge(b)?));
+            Ok((da.0 * db.0 + da.1 * db.1).abs())
+        }
+        ConstraintKind::EqualLength { a, b } => {
+            let la = {
+                let e = edge(a)?;
+                ((e.0 .0 - e.1 .0).powi(2) + (e.0 .1 - e.1 .1).powi(2)).sqrt()
+            };
+            let lb = {
+                let e = edge(b)?;
+                ((e.0 .0 - e.1 .0).powi(2) + (e.0 .1 - e.1 .1).powi(2)).sqrt()
+            };
+            Ok((la - lb).abs())
+        }
+        ConstraintKind::PointOnEdge { point: p, edge: e } => {
+            let pt = point(p)?;
+            let ((sx, sy), (ex, ey)) = edge(e)?;
+            let (dx, dy) = (ex - sx, ey - sy);
+            let len = (dx * dx + dy * dy).sqrt();
+            if len < 1e-12 {
+                return Err("degenerate edge".into());
+            }
+            Ok((((pt.0 - sx) * dy - (pt.1 - sy) * dx) / len).abs())
+        }
+        ConstraintKind::Symmetric { a, b, axis } => {
+            let (pa, pb) = (point(a)?, point(b)?);
+            let ((sx, sy), (ex, ey)) = edge(axis)?;
+            let (dx, dy) = (ex - sx, ey - sy);
+            let len = (dx * dx + dy * dy).sqrt();
+            if len < 1e-12 {
+                return Err("degenerate axis".into());
+            }
+            let da = ((pa.0 - sx) * dy - (pa.1 - sy) * dx) / len;
+            let db = ((pb.0 - sx) * dy - (pb.1 - sy) * dx) / len;
+            // Mirror: signed distances sum to zero, midpoint on axis dir.
+            Ok((da + db).abs())
+        }
+        ConstraintKind::Fixed { .. } => Ok(0.0),
+        _ => {
+            // Dimensional kinds: |measured - target|.
+            let measured = measure_constraint(doc, resolver, kind)?;
+            let target = target.ok_or("dimensional constraint requires a resolved target")?;
+            Ok((measured - target).abs())
+        }
+    }
+}

--- a/crates/vcad-design-constraints/src/report.rs
+++ b/crates/vcad-design-constraints/src/report.rs
@@ -1,0 +1,73 @@
+//! Solve report types (serialized to JSON for WASM/MCP consumers).
+
+use serde::{Deserialize, Serialize};
+
+/// A measured value for one driven (reference) dimension.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DrivenValue {
+    /// Constraint id.
+    pub id: String,
+    /// Measured value (mm or degrees, per the constraint kind).
+    pub value: f64,
+}
+
+/// Residual magnitude of one constraint against current geometry.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConstraintResidual {
+    /// Constraint id.
+    pub id: String,
+    /// |error| in the constraint's natural units (mm or degrees; 0 = holds
+    /// exactly). Driven dimensions report drift from their stored value.
+    pub residual: f64,
+    /// Whether the constraint is a driven (reference) dimension.
+    pub driven: bool,
+}
+
+/// Per-plane solve group outcome.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupReport {
+    /// The node this group solved (PCB board or sketch node).
+    pub node: u64,
+    /// Solver status string (`converged`, `maxIterations`, …).
+    pub status: String,
+    /// Whether this group converged.
+    pub converged: bool,
+    /// Levenberg-Marquardt iterations used.
+    pub iterations: usize,
+    /// Final residual norm.
+    pub residual_norm: f64,
+    /// Remaining degrees of freedom (negative = over-constrained).
+    pub dof: i64,
+    /// Number of driving constraints lowered in this group.
+    pub constraint_count: usize,
+}
+
+/// Aggregate result of a design-constraint solve or check pass.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DesignSolveReport {
+    /// Whether every solve group converged (vacuously true with none).
+    pub converged: bool,
+    /// Per-group outcomes.
+    pub groups: Vec<GroupReport>,
+    /// Footprint references whose position or rotation changed.
+    pub moved_footprints: Vec<String>,
+    /// Outline vertex indices that moved, as `node:index` strings.
+    pub moved_vertices: Vec<String>,
+    /// Sketch nodes whose segments moved.
+    pub moved_sketches: Vec<u64>,
+    /// Measured values for driven dimensions (and, on check passes, for
+    /// every dimensional constraint).
+    pub driven_values: Vec<DrivenValue>,
+    /// Per-constraint residuals against the final geometry (0 = holds).
+    pub residuals: Vec<ConstraintResidual>,
+    /// Constraints that could not be lowered (bad refs, lost part anchors,
+    /// unresolvable formulas), as human-readable messages. The rest of the
+    /// system still solves.
+    pub errors: Vec<String>,
+    /// Non-fatal caveats (e.g. pad anchor combined with free rotation).
+    pub warnings: Vec<String>,
+}

--- a/crates/vcad-design-constraints/src/tests.rs
+++ b/crates/vcad-design-constraints/src/tests.rs
@@ -1,0 +1,499 @@
+//! Unit tests for the document-level constraint solver.
+
+use std::collections::HashMap;
+
+use vcad_ir::constraints::{Anchor, ConstraintKind, DesignConstraint};
+use vcad_ir::ecad::{
+    BoardOutline, DesignRules, Footprint, LayerStackup, NetClassRules, Pcb, PcbLayer, StackupLayer,
+};
+use vcad_ir::parameters::{Expr, Parameter};
+use vcad_ir::{CsgOp, Document, Node, Vec2};
+
+use crate::{
+    check_design_constraints, solve_design_constraints, AnchorResolver, NoPartAnchors, SolveOptions,
+};
+
+const BOARD: u64 = 1;
+
+fn footprint(reference: &str, x: f64, y: f64) -> Footprint {
+    Footprint {
+        reference: reference.to_string(),
+        value: String::new(),
+        footprint_name: "R_0805".to_string(),
+        position: Vec2::new(x, y),
+        rotation: 0.0,
+        front: true,
+        pads: vec![],
+        graphics: vec![],
+        model_3d: None,
+        properties: HashMap::new(),
+    }
+}
+
+fn board_doc(footprints: Vec<Footprint>) -> Document {
+    let pcb = Pcb {
+        outline: BoardOutline {
+            vertices: vec![
+                Vec2::new(0.0, 0.0),
+                Vec2::new(100.0, 0.0),
+                Vec2::new(100.0, 80.0),
+                Vec2::new(0.0, 80.0),
+            ],
+            cutouts: vec![],
+            thickness: 1.6,
+        },
+        stackup: LayerStackup {
+            layers: vec![StackupLayer {
+                layer: PcbLayer::FCu,
+                copper_thickness: Some(0.035),
+                dielectric_thickness: None,
+                dielectric_er: None,
+                material: None,
+            }],
+        },
+        nets: vec![],
+        rules: DesignRules {
+            default_rules: NetClassRules {
+                name: "default".to_string(),
+                trace_width: 0.25,
+                clearance: 0.2,
+                via_diameter: 0.6,
+                via_drill: 0.3,
+                diff_pair_gap: None,
+                diff_pair_width: None,
+            },
+            class_rules: vec![],
+            net_class_assignments: HashMap::new(),
+            edge_clearance: 0.5,
+            hole_to_hole: 0.5,
+            min_annular_ring: 0.15,
+            min_drill: 0.3,
+        },
+        footprints,
+        traces: vec![],
+        trace_arcs: vec![],
+        vias: vec![],
+        zones: vec![],
+        keepouts: vec![],
+        net_ties: vec![],
+    };
+    let mut doc = Document::new();
+    doc.nodes.insert(
+        BOARD,
+        Node {
+            id: BOARD,
+            name: Some("board".to_string()),
+            op: CsgOp::PcbBoard {
+                board: Box::new(pcb),
+            },
+        },
+    );
+    doc
+}
+
+fn fp_anchor(r: &str) -> Anchor {
+    Anchor::PcbFootprint {
+        node: BOARD,
+        r#ref: r.to_string(),
+        pad: None,
+    }
+}
+
+fn constraint(id: &str, kind: ConstraintKind) -> DesignConstraint {
+    DesignConstraint {
+        id: id.to_string(),
+        label: None,
+        kind,
+        driven: false,
+    }
+}
+
+fn board_pcb(doc: &Document) -> &Pcb {
+    match &doc.nodes[&BOARD].op {
+        CsgOp::PcbBoard { board } => board,
+        _ => panic!("not a board"),
+    }
+}
+
+#[test]
+fn distance_with_fixed_anchor_converges() {
+    let mut doc = board_doc(vec![
+        footprint("U1", 10.0, 10.0),
+        footprint("U2", 30.0, 10.0),
+    ]);
+    doc.constraints = vec![
+        constraint("c1", ConstraintKind::Fixed { a: fp_anchor("U1") }),
+        constraint(
+            "c2",
+            ConstraintKind::Distance {
+                a: fp_anchor("U1"),
+                b: fp_anchor("U2"),
+                value: Expr::num(10.0),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    assert_eq!(report.moved_footprints, vec!["U2".to_string()]);
+    let pcb = board_pcb(&doc);
+    let u1 = &pcb.footprints[0].position;
+    let u2 = &pcb.footprints[1].position;
+    let d = ((u1.x - u2.x).powi(2) + (u1.y - u2.y).powi(2)).sqrt();
+    assert!((d - 10.0).abs() < 1e-6, "distance = {d}");
+    assert!((u1.x - 10.0).abs() < 1e-9, "U1 must not move");
+}
+
+#[test]
+fn formula_dimension_resolves_parameters() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0), footprint("U2", 5.0, 0.0)]);
+    doc.parameters
+        .insert("spacing".to_string(), Parameter::literal(20.0));
+    doc.constraints = vec![
+        constraint("c1", ConstraintKind::Fixed { a: fp_anchor("U1") }),
+        constraint(
+            "c2",
+            ConstraintKind::Distance {
+                a: fp_anchor("U1"),
+                b: fp_anchor("U2"),
+                value: Expr::formula("spacing / 2 + 5"),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    let pcb = board_pcb(&doc);
+    let u2 = &pcb.footprints[1].position;
+    let d = (u2.x.powi(2) + u2.y.powi(2)).sqrt();
+    assert!((d - 15.0).abs() < 1e-6, "distance = {d}");
+}
+
+#[test]
+fn outline_edge_length_solves_exact() {
+    let mut doc = board_doc(vec![]);
+    doc.constraints = vec![
+        constraint(
+            "c1",
+            ConstraintKind::Fixed {
+                a: Anchor::PcbOutlineVertex {
+                    node: BOARD,
+                    index: 0,
+                },
+            },
+        ),
+        constraint(
+            "c2",
+            ConstraintKind::Horizontal {
+                a: Anchor::PcbOutlineEdge {
+                    node: BOARD,
+                    index: 0,
+                },
+                b: Anchor::PcbOutlineEdge {
+                    node: BOARD,
+                    index: 0,
+                },
+            },
+        ),
+        constraint(
+            "c3",
+            ConstraintKind::Length {
+                a: Anchor::PcbOutlineEdge {
+                    node: BOARD,
+                    index: 0,
+                },
+                value: Expr::num(120.0),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    let pcb = board_pcb(&doc);
+    let (v0, v1) = (pcb.outline.vertices[0], pcb.outline.vertices[1]);
+    assert!((v0.x).abs() < 1e-9 && (v0.y).abs() < 1e-9, "v0 fixed");
+    let len = ((v1.x - v0.x).powi(2) + (v1.y - v0.y).powi(2)).sqrt();
+    assert!((len - 120.0).abs() < 1e-6, "edge length = {len}");
+    assert!((v1.y - v0.y).abs() < 1e-6, "edge horizontal");
+}
+
+#[test]
+fn rotation_constraint_sets_footprint_rotation() {
+    let mut doc = board_doc(vec![footprint("J1", 10.0, 10.0)]);
+    doc.constraints = vec![constraint(
+        "c1",
+        ConstraintKind::Rotation {
+            node: BOARD,
+            r#ref: "J1".to_string(),
+            value: Expr::num(90.0),
+        },
+    )];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    let pcb = board_pcb(&doc);
+    assert!((pcb.footprints[0].rotation - 90.0).abs() < 1e-6);
+    assert_eq!(report.moved_footprints, vec!["J1".to_string()]);
+}
+
+#[test]
+fn driven_dimension_is_measured_not_enforced() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0), footprint("U2", 30.0, 40.0)]);
+    doc.constraints = vec![DesignConstraint {
+        id: "c1".to_string(),
+        label: None,
+        kind: ConstraintKind::Distance {
+            a: fp_anchor("U1"),
+            b: fp_anchor("U2"),
+            value: Expr::num(0.0), // stale; should be back-annotated to 50
+        },
+        driven: true,
+    }];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged);
+    // Nothing moved (no driving constraints).
+    assert!(report.moved_footprints.is_empty());
+    assert_eq!(report.driven_values.len(), 1);
+    assert!((report.driven_values[0].value - 50.0).abs() < 1e-9);
+    // Back-annotated into the document.
+    assert_eq!(
+        doc.constraints[0].kind.value().unwrap().as_number(),
+        Some(50.0)
+    );
+}
+
+#[test]
+fn over_constrained_reports_negative_dof_without_panic() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0)]);
+    doc.constraints = vec![
+        constraint("c1", ConstraintKind::Fixed { a: fp_anchor("U1") }),
+        constraint(
+            "c2",
+            ConstraintKind::HorizontalDistance {
+                a: fp_anchor("U1"),
+                value: Expr::num(50.0), // conflicts with Fixed at x=0
+            },
+        ),
+        constraint(
+            "c3",
+            ConstraintKind::VerticalDistance {
+                a: fp_anchor("U1"),
+                value: Expr::num(50.0),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert_eq!(report.groups.len(), 1);
+    assert!(report.groups[0].dof < 0, "dof = {}", report.groups[0].dof);
+    // Conflicting targets: must not converge, and must not write back.
+    assert!(!report.converged);
+    let pcb = board_pcb(&doc);
+    assert!((pcb.footprints[0].position.x).abs() < 1e-9);
+}
+
+#[test]
+fn bad_reference_is_skipped_and_rest_solves() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0)]);
+    doc.constraints = vec![
+        constraint(
+            "bad",
+            ConstraintKind::Fixed {
+                a: Anchor::PcbFootprint {
+                    node: BOARD,
+                    r#ref: "NOPE".to_string(),
+                    pad: None,
+                },
+            },
+        ),
+        constraint(
+            "good",
+            ConstraintKind::HorizontalDistance {
+                a: fp_anchor("U1"),
+                value: Expr::num(25.0),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert_eq!(report.errors.len(), 1);
+    assert!(report.errors[0].contains("NOPE"), "{:?}", report.errors);
+    assert!(report.converged);
+    assert!((board_pcb(&doc).footprints[0].position.x - 25.0).abs() < 1e-6);
+}
+
+#[test]
+fn part_edge_anchor_pulls_footprint() {
+    struct WallResolver;
+    impl AnchorResolver for WallResolver {
+        fn resolve_part_edge(
+            &self,
+            _node: vcad_ir::NodeId,
+            face_a: &str,
+            _face_b: &str,
+        ) -> Result<([f64; 3], [f64; 3]), String> {
+            if face_a == "enclosure:front" {
+                // A vertical edge at x = 42 in world space.
+                Ok(([42.0, 0.0, 0.0], [42.0, 80.0, 0.0]))
+            } else {
+                Err("lost".to_string())
+            }
+        }
+    }
+    let mut doc = board_doc(vec![footprint("J1", 5.0, 40.0)]);
+    doc.constraints = vec![constraint(
+        "c1",
+        ConstraintKind::PointOnEdge {
+            point: fp_anchor("J1"),
+            edge: Anchor::PartEdge {
+                node: 99,
+                face_a: "enclosure:front".to_string(),
+                face_b: "enclosure:right".to_string(),
+                hint: None,
+            },
+        },
+    )];
+    let report = solve_design_constraints(&mut doc, &WallResolver, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    let j1 = &board_pcb(&doc).footprints[0].position;
+    assert!((j1.x - 42.0).abs() < 1e-6, "J1.x = {}", j1.x);
+
+    // A lost part edge fail-closes with an error, moving nothing.
+    let mut doc2 = board_doc(vec![footprint("J1", 5.0, 40.0)]);
+    doc2.constraints = vec![constraint(
+        "c1",
+        ConstraintKind::PointOnEdge {
+            point: Anchor::PcbFootprint {
+                node: BOARD,
+                r#ref: "J1".to_string(),
+                pad: None,
+            },
+            edge: Anchor::PartEdge {
+                node: 99,
+                face_a: "enclosure:missing".to_string(),
+                face_b: "enclosure:right".to_string(),
+                hint: None,
+            },
+        },
+    )];
+    let report2 = solve_design_constraints(&mut doc2, &WallResolver, &SolveOptions::default());
+    assert!(!report2.errors.is_empty(), "{:?}", report2.errors);
+    assert!((board_pcb(&doc2).footprints[0].position.x - 5.0).abs() < 1e-9);
+}
+
+#[test]
+fn extra_fixed_anchors_dragged_footprint() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0), footprint("U2", 10.0, 0.0)]);
+    doc.constraints = vec![constraint(
+        "c1",
+        ConstraintKind::Distance {
+            a: fp_anchor("U1"),
+            b: fp_anchor("U2"),
+            value: Expr::num(10.0),
+        },
+    )];
+    // Simulate a drag: U2 was just moved to (30, 0); pin it for this solve.
+    match &mut doc.nodes.get_mut(&BOARD).unwrap().op {
+        CsgOp::PcbBoard { board } => board.footprints[1].position = Vec2::new(30.0, 0.0),
+        _ => unreachable!(),
+    }
+    let report = solve_design_constraints(
+        &mut doc,
+        &NoPartAnchors,
+        &SolveOptions {
+            extra_fixed: vec![(BOARD, "U2".to_string())],
+        },
+    );
+    assert!(report.converged, "{report:?}");
+    let pcb = board_pcb(&doc);
+    let (u1, u2) = (&pcb.footprints[0].position, &pcb.footprints[1].position);
+    assert!((u2.x - 30.0).abs() < 1e-6, "dragged footprint stays put");
+    let d = ((u1.x - u2.x).powi(2) + (u1.y - u2.y).powi(2)).sqrt();
+    assert!((d - 10.0).abs() < 1e-6, "U1 followed: d = {d}");
+}
+
+#[test]
+fn sketch_group_solves_and_writes_back() {
+    use vcad_ir::{SketchSegment2D, Vec3};
+    let mut doc = Document::new();
+    const SKETCH: u64 = 5;
+    doc.nodes.insert(
+        SKETCH,
+        Node {
+            id: SKETCH,
+            name: None,
+            op: CsgOp::Sketch2D {
+                origin: Vec3::new(0.0, 0.0, 0.0),
+                x_dir: Vec3::new(1.0, 0.0, 0.0),
+                y_dir: Vec3::new(0.0, 1.0, 0.0),
+                segments: vec![
+                    SketchSegment2D::Line {
+                        start: Vec2::new(0.0, 0.0),
+                        end: Vec2::new(9.0, 0.5),
+                    },
+                    SketchSegment2D::Line {
+                        start: Vec2::new(9.0, 0.5),
+                        end: Vec2::new(0.0, 5.0),
+                    },
+                ],
+                holes: None,
+            },
+        },
+    );
+    let start0 = Anchor::SketchPoint {
+        node: SKETCH,
+        segment: 0,
+        point: vcad_ir::constraints::SketchPointRef::Start,
+    };
+    let end0 = Anchor::SketchPoint {
+        node: SKETCH,
+        segment: 0,
+        point: vcad_ir::constraints::SketchPointRef::End,
+    };
+    doc.constraints = vec![
+        constraint("c1", ConstraintKind::Fixed { a: start0.clone() }),
+        constraint(
+            "c2",
+            ConstraintKind::Horizontal {
+                a: start0.clone(),
+                b: end0.clone(),
+            },
+        ),
+        constraint(
+            "c3",
+            ConstraintKind::Distance {
+                a: start0,
+                b: end0,
+                value: Expr::num(10.0),
+            },
+        ),
+    ];
+    let report = solve_design_constraints(&mut doc, &NoPartAnchors, &SolveOptions::default());
+    assert!(report.converged, "{report:?}");
+    assert_eq!(report.moved_sketches, vec![SKETCH]);
+    let (end, start1) = match &doc.nodes[&SKETCH].op {
+        CsgOp::Sketch2D { segments, .. } => match (&segments[0], &segments[1]) {
+            (SketchSegment2D::Line { end, .. }, SketchSegment2D::Line { start, .. }) => {
+                (*end, *start)
+            }
+            _ => panic!(),
+        },
+        _ => panic!(),
+    };
+    assert!((end.y).abs() < 1e-6, "horizontal: end.y = {}", end.y);
+    assert!((end.x - 10.0).abs() < 1e-6, "length: end.x = {}", end.x);
+    // Welded shared endpoint moved with it.
+    assert!((start1.x - end.x).abs() < 1e-9 && (start1.y - end.y).abs() < 1e-9);
+}
+
+#[test]
+fn check_measures_without_mutating() {
+    let mut doc = board_doc(vec![footprint("U1", 0.0, 0.0), footprint("U2", 30.0, 40.0)]);
+    doc.constraints = vec![constraint(
+        "c1",
+        ConstraintKind::Distance {
+            a: fp_anchor("U1"),
+            b: fp_anchor("U2"),
+            value: Expr::num(10.0),
+        },
+    )];
+    let before = board_pcb(&doc).footprints[1].position;
+    let report = check_design_constraints(&doc, &NoPartAnchors);
+    assert_eq!(report.driven_values.len(), 1);
+    assert!((report.driven_values[0].value - 50.0).abs() < 1e-9);
+    assert_eq!(board_pcb(&doc).footprints[1].position, before);
+}

--- a/crates/vcad-ir/src/constraints.rs
+++ b/crates/vcad-ir/src/constraints.rs
@@ -1,0 +1,466 @@
+//! Document-level design constraints spanning sketches, PCB layout, and
+//! mechanical parts.
+//!
+//! Unlike per-editor constraint state, these live on the
+//! [`Document`](crate::Document) (`constraints: Vec<DesignConstraint>`) and
+//! reference geometry through the universal [`Anchor`] vocabulary, so one
+//! solver pass can keep a board outline dimensioned, footprints aligned, and
+//! a connector coincident with an enclosure cutout — and every constraint
+//! doubles as a verifiable receipt claim.
+//!
+//! Dimensional constraints hold an [`Expr`] value, so a dimension can be a
+//! formula over named document parameters ("board_width - 2*edge_margin");
+//! changing a parameter re-solves the whole set. A constraint with
+//! `driven: true` is a reference dimension: it contributes no residuals and
+//! its value is back-annotated from the solved geometry after each solve.
+
+use serde::{Deserialize, Serialize};
+
+use crate::parameters::Expr;
+use crate::NodeId;
+
+/// Which point of a sketch segment an [`Anchor::SketchPoint`] grips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(rename_all = "camelCase")]
+pub enum SketchPointRef {
+    /// Segment start point.
+    Start,
+    /// Segment end point.
+    End,
+    /// Arc center point.
+    Center,
+}
+
+/// Geometric snapshot of a part edge for fallback resolution, mirroring the
+/// kernel naming crate's `EdgeHint`. Recorded when the anchor is created so
+/// the edge can be re-found geometrically if topological names drift.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(rename_all = "camelCase")]
+pub struct EdgeHintIr {
+    /// Edge midpoint in world coordinates (mm).
+    pub midpoint: [f64; 3],
+    /// Unit direction of the edge.
+    pub direction: [f64; 3],
+    /// Edge length in mm.
+    pub length: f64,
+}
+
+/// A stable reference to a piece of geometry a constraint grips.
+///
+/// Anchors are the universal target vocabulary: PCB footprints and outline
+/// geometry, sketch segment points, and named mechanical part edges all
+/// address through the same type, which is what lets one constraint relate
+/// geometry across domains.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum Anchor {
+    /// A PCB footprint's origin, or a named pad center when `pad` is set.
+    #[serde(rename_all = "camelCase")]
+    PcbFootprint {
+        /// PcbBoard node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// Footprint reference designator ("U1", "J3").
+        r#ref: String,
+        /// Pad name/number on that footprint; `None` = footprint origin.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "ts-rs", ts(optional))]
+        pad: Option<String>,
+    },
+    /// A board outline vertex by index into `outline.vertices`.
+    ///
+    /// Known fragility: rewriting the outline invalidates indices, so
+    /// outline-mutating tools drop (and report) referencing constraints.
+    #[serde(rename_all = "camelCase")]
+    PcbOutlineVertex {
+        /// PcbBoard node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// 0-based vertex index.
+        index: u32,
+    },
+    /// A board outline edge from vertex `index` to `index + 1` (wrapping).
+    #[serde(rename_all = "camelCase")]
+    PcbOutlineEdge {
+        /// PcbBoard node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// 0-based index of the edge's start vertex.
+        index: u32,
+    },
+    /// A point of a sketch segment (start/end/center).
+    #[serde(rename_all = "camelCase")]
+    SketchPoint {
+        /// Sketch2D node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// 0-based segment index into the sketch's `segments`.
+        segment: u32,
+        /// Which point of the segment.
+        point: SketchPointRef,
+    },
+    /// A whole sketch segment as an edge (its start→end chord for arcs).
+    #[serde(rename_all = "camelCase")]
+    SketchSegment {
+        /// Sketch2D node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// 0-based segment index into the sketch's `segments`.
+        segment: u32,
+    },
+    /// A mechanical part edge named by its two adjacent faces via the
+    /// topological naming system (`vcad-kernel-naming` `FaceName` strings,
+    /// e.g. `"cube:top"` / `"cube:front"`). Resolution is fail-closed:
+    /// ambiguous or lost names skip the constraint with an error rather
+    /// than silently rebinding.
+    #[serde(rename_all = "camelCase")]
+    PartEdge {
+        /// Part root node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// First adjacent face name.
+        face_a: String,
+        /// Second adjacent face name.
+        face_b: String,
+        /// Geometric snapshot for fallback resolution.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[cfg_attr(feature = "ts-rs", ts(optional))]
+        hint: Option<EdgeHintIr>,
+    },
+}
+
+impl Anchor {
+    /// The node this anchor references.
+    pub fn node(&self) -> NodeId {
+        match self {
+            Anchor::PcbFootprint { node, .. }
+            | Anchor::PcbOutlineVertex { node, .. }
+            | Anchor::PcbOutlineEdge { node, .. }
+            | Anchor::SketchPoint { node, .. }
+            | Anchor::SketchSegment { node, .. }
+            | Anchor::PartEdge { node, .. } => *node,
+        }
+    }
+
+    /// Whether this anchor is edge-like (has a direction), as required by
+    /// `Parallel`/`Perpendicular`/`Horizontal`/`Vertical`-on-edge and
+    /// `PointOnEdge`/`Symmetric` axes.
+    pub fn is_edge(&self) -> bool {
+        matches!(
+            self,
+            Anchor::PcbOutlineEdge { .. } | Anchor::SketchSegment { .. } | Anchor::PartEdge { .. }
+        )
+    }
+}
+
+/// The geometric relationship a [`DesignConstraint`] asserts.
+///
+/// Dimensional variants carry an [`Expr`] value (literal number or a formula
+/// over document parameters). Distances/lengths are mm; angles/rotations are
+/// degrees.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ConstraintKind {
+    /// Two point anchors at the same position.
+    #[serde(rename_all = "camelCase")]
+    Coincident {
+        /// First point.
+        a: Anchor,
+        /// Second point.
+        b: Anchor,
+    },
+    /// Euclidean distance between two point anchors equals `value` (mm).
+    #[serde(rename_all = "camelCase")]
+    Distance {
+        /// First point.
+        a: Anchor,
+        /// Second point.
+        b: Anchor,
+        /// Target distance in mm.
+        value: Expr,
+    },
+    /// Anchor's X coordinate equals `value` (mm, board/sketch plane frame).
+    #[serde(rename_all = "camelCase")]
+    HorizontalDistance {
+        /// The point.
+        a: Anchor,
+        /// Target X in mm.
+        value: Expr,
+    },
+    /// Anchor's Y coordinate equals `value` (mm).
+    #[serde(rename_all = "camelCase")]
+    VerticalDistance {
+        /// The point.
+        a: Anchor,
+        /// Target Y in mm.
+        value: Expr,
+    },
+    /// Two point anchors share the same Y (horizontal alignment), or an
+    /// edge anchor lies horizontal when `a` is edge-like and `b` is omitted
+    /// via the same edge's endpoints.
+    #[serde(rename_all = "camelCase")]
+    Horizontal {
+        /// First point (or edge start).
+        a: Anchor,
+        /// Second point (or edge end).
+        b: Anchor,
+    },
+    /// Two point anchors share the same X (vertical alignment).
+    #[serde(rename_all = "camelCase")]
+    Vertical {
+        /// First point.
+        a: Anchor,
+        /// Second point.
+        b: Anchor,
+    },
+    /// Two edge anchors are parallel.
+    #[serde(rename_all = "camelCase")]
+    Parallel {
+        /// First edge.
+        a: Anchor,
+        /// Second edge.
+        b: Anchor,
+    },
+    /// Two edge anchors are perpendicular.
+    #[serde(rename_all = "camelCase")]
+    Perpendicular {
+        /// First edge.
+        a: Anchor,
+        /// Second edge.
+        b: Anchor,
+    },
+    /// Two edge anchors have equal length.
+    #[serde(rename_all = "camelCase")]
+    EqualLength {
+        /// First edge.
+        a: Anchor,
+        /// Second edge.
+        b: Anchor,
+    },
+    /// Edge anchor's length equals `value` (mm).
+    #[serde(rename_all = "camelCase")]
+    Length {
+        /// The edge.
+        a: Anchor,
+        /// Target length in mm.
+        value: Expr,
+    },
+    /// A point anchor lies on an edge anchor's carrier line.
+    #[serde(rename_all = "camelCase")]
+    PointOnEdge {
+        /// The point.
+        point: Anchor,
+        /// The edge.
+        edge: Anchor,
+    },
+    /// Two point anchors at the same position (alias of coincident used for
+    /// hole↔boss intent; kept distinct for reporting/UI semantics).
+    #[serde(rename_all = "camelCase")]
+    Concentric {
+        /// First center.
+        a: Anchor,
+        /// Second center.
+        b: Anchor,
+    },
+    /// Lock a point anchor at its current position.
+    #[serde(rename_all = "camelCase")]
+    Fixed {
+        /// The point.
+        a: Anchor,
+    },
+    /// A footprint's rotation equals `value` (degrees).
+    #[serde(rename_all = "camelCase")]
+    Rotation {
+        /// PcbBoard node id.
+        #[cfg_attr(feature = "ts-rs", ts(type = "number"))]
+        node: NodeId,
+        /// Footprint reference designator.
+        r#ref: String,
+        /// Target rotation in degrees.
+        value: Expr,
+    },
+    /// Two point anchors are mirror images across an edge anchor axis.
+    #[serde(rename_all = "camelCase")]
+    Symmetric {
+        /// First point.
+        a: Anchor,
+        /// Second point.
+        b: Anchor,
+        /// Mirror axis (edge-like anchor).
+        axis: Anchor,
+    },
+    /// Angle between two edge anchors equals `value` (degrees).
+    #[serde(rename_all = "camelCase")]
+    Angle {
+        /// First edge.
+        a: Anchor,
+        /// Second edge.
+        b: Anchor,
+        /// Target angle in degrees.
+        value: Expr,
+    },
+}
+
+impl ConstraintKind {
+    /// The dimensional value expression, if this kind carries one.
+    pub fn value(&self) -> Option<&Expr> {
+        match self {
+            ConstraintKind::Distance { value, .. }
+            | ConstraintKind::HorizontalDistance { value, .. }
+            | ConstraintKind::VerticalDistance { value, .. }
+            | ConstraintKind::Length { value, .. }
+            | ConstraintKind::Rotation { value, .. }
+            | ConstraintKind::Angle { value, .. } => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Mutable access to the dimensional value expression (for driven
+    /// back-annotation).
+    pub fn value_mut(&mut self) -> Option<&mut Expr> {
+        match self {
+            ConstraintKind::Distance { value, .. }
+            | ConstraintKind::HorizontalDistance { value, .. }
+            | ConstraintKind::VerticalDistance { value, .. }
+            | ConstraintKind::Length { value, .. }
+            | ConstraintKind::Rotation { value, .. }
+            | ConstraintKind::Angle { value, .. } => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Whether this is a dimensional constraint (carries a value).
+    pub fn is_dimensional(&self) -> bool {
+        self.value().is_some()
+    }
+
+    /// All anchors this constraint references.
+    pub fn anchors(&self) -> Vec<&Anchor> {
+        match self {
+            ConstraintKind::Coincident { a, b }
+            | ConstraintKind::Distance { a, b, .. }
+            | ConstraintKind::Horizontal { a, b }
+            | ConstraintKind::Vertical { a, b }
+            | ConstraintKind::Parallel { a, b }
+            | ConstraintKind::Perpendicular { a, b }
+            | ConstraintKind::EqualLength { a, b }
+            | ConstraintKind::Concentric { a, b }
+            | ConstraintKind::Angle { a, b, .. } => vec![a, b],
+            ConstraintKind::HorizontalDistance { a, .. }
+            | ConstraintKind::VerticalDistance { a, .. }
+            | ConstraintKind::Length { a, .. }
+            | ConstraintKind::Fixed { a } => vec![a],
+            ConstraintKind::PointOnEdge { point, edge } => vec![point, edge],
+            ConstraintKind::Symmetric { a, b, axis } => vec![a, b, axis],
+            ConstraintKind::Rotation { .. } => vec![],
+        }
+    }
+}
+
+/// A persisted, solver-enforced design constraint.
+///
+/// Stored in `Document.constraints`; solved by `vcad-design-constraints`;
+/// re-verified fail-closed as a `constraint.<label-or-id>` receipt claim.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+#[serde(rename_all = "camelCase")]
+pub struct DesignConstraint {
+    /// Stable id ("c1", "c2", …) for edit/delete and claim identity.
+    pub id: String,
+    /// Optional human label used for the receipt claim name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub label: Option<String>,
+    /// The geometric relationship.
+    pub kind: ConstraintKind,
+    /// Driven (reference) dimension: contributes no residuals to the solve;
+    /// its value is back-annotated from solved geometry instead. Only
+    /// meaningful on dimensional kinds.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub driven: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fp(node: NodeId, r: &str) -> Anchor {
+        Anchor::PcbFootprint {
+            node,
+            r#ref: r.to_string(),
+            pad: None,
+        }
+    }
+
+    #[test]
+    fn constraint_roundtrip() {
+        let c = DesignConstraint {
+            id: "c1".to_string(),
+            label: Some("usb-inset".to_string()),
+            kind: ConstraintKind::Distance {
+                a: fp(3, "J1"),
+                b: Anchor::PcbOutlineVertex { node: 3, index: 0 },
+                value: Expr::formula("board_width - 2*edge_margin"),
+            },
+            driven: false,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: DesignConstraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+        // driven=false is omitted from the wire form.
+        assert!(!json.contains("driven"));
+    }
+
+    #[test]
+    fn anchor_tags_are_camel_case() {
+        let a = Anchor::PartEdge {
+            node: 7,
+            face_a: "cube:top".to_string(),
+            face_b: "cube:front".to_string(),
+            hint: None,
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        assert!(json.contains("\"kind\":\"partEdge\""), "{json}");
+        assert!(json.contains("\"faceA\""), "{json}");
+    }
+
+    #[test]
+    fn driven_roundtrip_and_value_access() {
+        let mut c = DesignConstraint {
+            id: "c2".to_string(),
+            label: None,
+            kind: ConstraintKind::Distance {
+                a: fp(1, "U1"),
+                b: fp(1, "U2"),
+                value: Expr::num(10.0),
+            },
+            driven: true,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"driven\":true"));
+        let back: DesignConstraint = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+        *c.kind.value_mut().unwrap() = Expr::num(12.5);
+        assert_eq!(c.kind.value().unwrap().as_number(), Some(12.5));
+        assert!(c.kind.is_dimensional());
+    }
+
+    #[test]
+    fn old_documents_without_constraints_parse() {
+        // An empty document serializes without a `constraints` key (wire
+        // compat), and such JSON deserializes to an empty set.
+        let json = serde_json::to_string(&crate::Document::new()).unwrap();
+        assert!(!json.contains("\"constraints\""), "{json}");
+        let doc: crate::Document = serde_json::from_str(&json).unwrap();
+        assert!(doc.constraints.is_empty());
+    }
+}

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 pub mod animation;
+pub mod constraints;
 pub mod ecad;
 pub mod expr_parser;
 pub mod file_io;
@@ -1889,6 +1890,12 @@ pub struct Document {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub clearance_specs: Vec<ClearanceSpec>,
 
+    /// Document-level design constraints spanning sketches, PCB layout, and
+    /// mechanical parts. Solved by the design-constraint solver and
+    /// re-verified fail-closed as receipt claims (Holds/Stale/Violated).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<constraints::DesignConstraint>,
+
     /// Persisted solver studies (structural FEA, tolerance stackup, …) for
     /// the unified Analyze mode. Like `clearance_specs`, studies are
     /// re-verified against the current geometry rather than computed once —
@@ -2116,6 +2123,7 @@ impl Default for Document {
             parameters: HashMap::new(),
             bindings: Bindings::new(),
             clearance_specs: Vec::new(),
+            constraints: Vec::new(),
             analysis_studies: Vec::new(),
             drawing: None,
             timeline: None,

--- a/crates/vcad-kernel-constraints/src/constraint.rs
+++ b/crates/vcad-kernel-constraints/src/constraint.rs
@@ -145,6 +145,21 @@ pub enum Constraint {
         y: f64,
     },
 
+    /// Two points hold a fixed offset: `point_b = point_a + (dx, dy)`.
+    ///
+    /// A rigid link between two free points — e.g. a pad center riding a
+    /// footprint origin. Error: `[b.x - a.x - dx, b.y - a.y - dy]`
+    OffsetCoincident {
+        /// Base point reference.
+        point_a: EntityRef,
+        /// Offset point reference.
+        point_b: EntityRef,
+        /// Offset along X.
+        dx: f64,
+        /// Offset along Y.
+        dy: f64,
+    },
+
     /// A point lies on an arc or circle.
     ///
     /// Error: `|p - center| - radius`
@@ -285,6 +300,7 @@ impl Constraint {
     pub fn num_residuals(&self) -> usize {
         match self {
             Constraint::Coincident { .. } => 2,
+            Constraint::OffsetCoincident { .. } => 2,
             Constraint::Fixed { .. } => 2,
             Constraint::Concentric { .. } => 2,
             Constraint::Midpoint { .. } => 2,

--- a/crates/vcad-kernel-constraints/src/residual.rs
+++ b/crates/vcad-kernel-constraints/src/residual.rs
@@ -138,6 +138,17 @@ pub fn compute_constraint_residuals(
             vec![c1x - c2x, c1y - c2y]
         }
 
+        Constraint::OffsetCoincident {
+            point_a,
+            point_b,
+            dx,
+            dy,
+        } => {
+            let (ax, ay) = get_point_coords(*point_a, params, entities);
+            let (bx, by) = get_point_coords(*point_b, params, entities);
+            vec![bx - ax - dx, by - ay - dy]
+        }
+
         Constraint::Fixed { point, x, y } => {
             let (px, py) = get_point_coords(*point, params, entities);
             vec![px - x, py - y]

--- a/crates/vcad-kernel-constraints/src/symbolic.rs
+++ b/crates/vcad-kernel-constraints/src/symbolic.rs
@@ -370,6 +370,18 @@ pub(crate) fn build_residual_exprs(
                 residuals.push(c1y - c2y);
             }
 
+            Constraint::OffsetCoincident {
+                point_a,
+                point_b,
+                dx,
+                dy,
+            } => {
+                let (ax, ay) = sym_point(*point_a, entities);
+                let (bx, by) = sym_point(*point_b, entities);
+                residuals.push(bx - ax - ExprId::from_f64(*dx));
+                residuals.push(by - ay - ExprId::from_f64(*dy));
+            }
+
             Constraint::Fixed { point, x, y } => {
                 let (px, py) = sym_point(*point, entities);
                 let tx = ExprId::from_f64(*x);

--- a/crates/vcad-kernel-wasm/Cargo.toml
+++ b/crates/vcad-kernel-wasm/Cargo.toml
@@ -59,7 +59,7 @@ physics = ["dep:vcad-kernel-physics"]
 atoms = ["dep:vcad-kernel-atoms", "vcad-kernel-atoms/wasm"]
 slicer = ["dep:vcad-slicer", "dep:vcad-slicer-gcode", "dep:vcad-slicer-bambu"]
 cam = ["dep:vcad-kernel-cam"]
-ecad = ["dep:vcad-ecad-pcb", "dep:vcad-ecad-schematic", "dep:vcad-ecad-sim", "dep:vcad-ecad-export", "dep:vcad-ecad-symbols", "dep:vcad-ecad-parts", "dep:vcad-ecad-verify"]
+ecad = ["dep:vcad-design-constraints", "dep:vcad-ecad-pcb", "dep:vcad-ecad-schematic", "dep:vcad-ecad-sim", "dep:vcad-ecad-export", "dep:vcad-ecad-symbols", "dep:vcad-ecad-parts", "dep:vcad-ecad-verify"]
 embroidery = ["dep:vcad-embroidery", "dep:vcad-embroidery-pes", "dep:vcad-embroidery-dst"]
 ts-rs = ["dep:ts-rs"]
 
@@ -110,6 +110,10 @@ optional = true
 
 [dependencies.vcad-kernel-cam]
 path = "../vcad-kernel-cam"
+optional = true
+
+[dependencies.vcad-design-constraints]
+path = "../vcad-design-constraints"
 optional = true
 
 [dependencies.vcad-ecad-pcb]

--- a/crates/vcad-kernel-wasm/src/design_constraints.rs
+++ b/crates/vcad-kernel-wasm/src/design_constraints.rs
@@ -1,0 +1,191 @@
+//! WASM bindings for the document-level design-constraint solver.
+//!
+//! Stateless, following the `solveSketchSegments` pattern: the caller sends
+//! the whole document as JSON and receives the updated document plus a
+//! solve report. Part-edge anchors are resolved by evaluating the
+//! referenced part nodes with this crate's own evaluator and querying the
+//! kernel's fail-closed topological-naming resolution.
+
+use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use wasm_bindgen::prelude::*;
+
+use vcad_design_constraints::{
+    check_design_constraints, solve_design_constraints, AnchorResolver, DesignSolveReport,
+    SolveOptions,
+};
+
+/// Resolves part-edge anchors by evaluating document nodes on demand
+/// (memoized per call) and asking the kernel for the named edge.
+struct DocResolver<'a> {
+    doc: &'a vcad_ir::Document,
+    cache: RefCell<HashMap<vcad_ir::NodeId, Option<crate::Solid>>>,
+}
+
+impl AnchorResolver for DocResolver<'_> {
+    fn resolve_part_edge(
+        &self,
+        node: vcad_ir::NodeId,
+        face_a: &str,
+        face_b: &str,
+    ) -> Result<([f64; 3], [f64; 3]), String> {
+        let mut cache = self.cache.borrow_mut();
+        let solid = cache
+            .entry(node)
+            .or_insert_with(|| crate::evaluate_node(self.doc, node).ok());
+        let Some(solid) = solid else {
+            return Err(format!("part node {node} failed to evaluate"));
+        };
+        let (a, b) = solid
+            .inner
+            .resolve_named_edge(face_a, face_b)
+            .map_err(|e| format!("part edge {face_a}/{face_b} on node {node}: {e}"))?;
+        Ok(([a.x, a.y, a.z], [b.x, b.y, b.z]))
+    }
+}
+
+/// Optional inputs for [`solve_design_constraints_wasm`].
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireOptions {
+    /// Footprints to pin at their current position for this solve only:
+    /// `[{ node, ref }]`. Used for interactive drag anchoring.
+    #[serde(default)]
+    extra_fixed: Vec<WireExtraFixed>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WireExtraFixed {
+    node: u64,
+    r#ref: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WireResult<'a> {
+    document: &'a vcad_ir::Document,
+    report: &'a DesignSolveReport,
+}
+
+fn parse_doc(doc_json: &str) -> Result<vcad_ir::Document, JsError> {
+    serde_json::from_str(doc_json).map_err(|e| JsError::new(&format!("document JSON: {e}")))
+}
+
+fn parse_options(options_json: &str) -> Result<SolveOptions, JsError> {
+    let wire: WireOptions = if options_json.trim().is_empty() {
+        WireOptions::default()
+    } else {
+        serde_json::from_str(options_json)
+            .map_err(|e| JsError::new(&format!("options JSON: {e}")))?
+    };
+    Ok(SolveOptions {
+        extra_fixed: wire
+            .extra_fixed
+            .into_iter()
+            .map(|f| (f.node, f.r#ref))
+            .collect(),
+    })
+}
+
+/// Solve the document's design constraints and return
+/// `{ document, report }` — the updated document (footprint positions and
+/// rotations, outline vertices, sketch points, back-annotated driven
+/// dimensions) plus the solve report (per-group status, DOF, moved
+/// geometry, errors).
+#[wasm_bindgen(js_name = solveDesignConstraints)]
+pub fn solve_design_constraints_wasm(
+    doc_json: &str,
+    options_json: &str,
+) -> Result<String, JsError> {
+    let mut doc = parse_doc(doc_json)?;
+    let options = parse_options(options_json)?;
+    let snapshot = doc.clone();
+    let resolver = DocResolver {
+        doc: &snapshot,
+        cache: RefCell::new(HashMap::new()),
+    };
+    let report = solve_design_constraints(&mut doc, &resolver, &options);
+    let out = WireResult {
+        document: &doc,
+        report: &report,
+    };
+    serde_json::to_string(&out).map_err(|e| JsError::new(&format!("serialize: {e}")))
+}
+
+/// Validate and measure the document's constraints without mutating
+/// anything. Returns the solve report JSON (dimensional constraints all
+/// measured into `drivenValues`).
+#[wasm_bindgen(js_name = checkDesignConstraints)]
+pub fn check_design_constraints_wasm(doc_json: &str) -> Result<String, JsError> {
+    let doc = parse_doc(doc_json)?;
+    let resolver = DocResolver {
+        doc: &doc,
+        cache: RefCell::new(HashMap::new()),
+    };
+    let report = check_design_constraints(&doc, &resolver);
+    serde_json::to_string(&report).map_err(|e| JsError::new(&format!("serialize: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-Rust mirror of the wire API (wasm-bindgen entry points can't run
+    //! on the host, but the logic underneath can).
+
+    use super::*;
+
+    #[test]
+    fn solve_via_wire_api_shapes() {
+        // A board with two footprints and one distance constraint, sent
+        // through the same JSON path the JS caller uses.
+        let doc_json = r#"{
+            "version": "0.1",
+            "nodes": {
+                "1": { "id": 1, "name": "board", "op": { "type": "PcbBoard", "board": {
+                    "outline": { "vertices": [{"x":0,"y":0},{"x":50,"y":0},{"x":50,"y":40},{"x":0,"y":40}], "cutouts": [], "thickness": 1.6 },
+                    "stackup": { "layers": [] },
+                    "nets": [],
+                    "rules": { "defaultRules": { "name": "d", "traceWidth": 0.25, "clearance": 0.2, "viaDiameter": 0.6, "viaDrill": 0.3 }, "edgeClearance": 0.5, "holeToHole": 0.5, "minAnnularRing": 0.15, "minDrill": 0.3 },
+                    "footprints": [
+                        { "ref": "U1", "value": "", "footprintName": "X", "position": {"x": 5, "y": 5}, "pads": [] },
+                        { "ref": "U2", "value": "", "footprintName": "X", "position": {"x": 20, "y": 5}, "pads": [] }
+                    ],
+                    "traces": [], "vias": [], "zones": []
+                } } }
+            },
+            "materials": {},
+            "part_materials": {},
+            "roots": [],
+            "constraints": [
+                { "id": "c1", "kind": { "type": "fixed", "a": { "kind": "pcbFootprint", "node": 1, "ref": "U1" } } },
+                { "id": "c2", "kind": { "type": "distance",
+                    "a": { "kind": "pcbFootprint", "node": 1, "ref": "U1" },
+                    "b": { "kind": "pcbFootprint", "node": 1, "ref": "U2" },
+                    "value": 10.0 } }
+            ]
+        }"#;
+        let mut doc = parse_doc(doc_json).expect("doc parses");
+        let options = parse_options("{}").expect("options parse");
+        let snapshot = doc.clone();
+        let resolver = DocResolver {
+            doc: &snapshot,
+            cache: RefCell::new(HashMap::new()),
+        };
+        let report = solve_design_constraints(&mut doc, &resolver, &options);
+        assert!(report.converged, "{report:?}");
+        assert_eq!(report.moved_footprints, vec!["U2".to_string()]);
+        let json = serde_json::to_string(&WireResult {
+            document: &doc,
+            report: &report,
+        })
+        .unwrap();
+        assert!(json.contains("\"movedFootprints\":[\"U2\"]"), "{json}");
+    }
+
+    #[test]
+    fn options_parse_extra_fixed() {
+        let opts = parse_options(r#"{ "extraFixed": [{ "node": 1, "ref": "U2" }] }"#).unwrap();
+        assert_eq!(opts.extra_fixed, vec![(1, "U2".to_string())]);
+    }
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -9,6 +9,8 @@
 
 #[cfg(feature = "ecad")]
 pub mod circuit_sim;
+#[cfg(feature = "ecad")]
+pub mod design_constraints;
 pub mod document_diff;
 pub mod document_engine;
 pub mod keybindings;

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -86,6 +86,13 @@ import {
   deriveParts,
   computeNextIds,
 } from "@vcad/core";
+
+// Dev-only debug handle: lets browser tooling and automated verification
+// reach the live stores without going through the UI.
+if (import.meta.env.DEV && typeof window !== "undefined") {
+  (window as unknown as { __vcadDocumentStore?: unknown }).__vcadDocumentStore =
+    useDocumentStore;
+}
 import type { Document } from "@vcad/ir";
 import { useEngine } from "@/hooks/useEngine";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";

--- a/packages/app/src/components/SketchPropertyPanel.tsx
+++ b/packages/app/src/components/SketchPropertyPanel.tsx
@@ -498,6 +498,9 @@ export function SketchPropertyPanel() {
           });
           if (partId) {
             select(partId);
+            // Constraints outlive the session: persist them on the document
+            // anchored at the new sketch node (reload/receipts/parameters).
+            useDocumentStore.getState().persistSketchConstraints(partId, constraints);
             analytics.extrudeApplied();
             analytics.sketchCompleted(constraints.length);
             addToast("Created Extrude", "success");
@@ -513,6 +516,7 @@ export function SketchPropertyPanel() {
           const partId = addRevolve(plane, origin, segments, origin, axisDir, pendingOperation.angleDeg);
           if (partId) {
             select(partId);
+            useDocumentStore.getState().persistSketchConstraints(partId, constraints);
             analytics.sketchCompleted(constraints.length);
             addToast("Created Revolve", "success");
           } else {

--- a/packages/app/src/components/electronics/CircuitTabTools.tsx
+++ b/packages/app/src/components/electronics/CircuitTabTools.tsx
@@ -11,7 +11,7 @@
  * (handleTabClick + autoSwitchTab); this component just renders tools.
  */
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Cursor } from "@phosphor-icons/react/dist/ssr/Cursor";
 import { ArrowsOutCardinal } from "@phosphor-icons/react/dist/ssr/ArrowsOutCardinal";
 import { Plugs } from "@phosphor-icons/react/dist/ssr/Plugs";
@@ -21,6 +21,7 @@ import { PencilSimple } from "@phosphor-icons/react/dist/ssr/PencilSimple";
 import { Tag } from "@phosphor-icons/react/dist/ssr/Tag";
 import { Path } from "@phosphor-icons/react/dist/ssr/Path";
 import { MagnetStraight } from "@phosphor-icons/react/dist/ssr/MagnetStraight";
+import { Angle } from "@phosphor-icons/react/dist/ssr/Angle";
 import { Cube } from "@phosphor-icons/react/dist/ssr/Cube";
 import { Ruler } from "@phosphor-icons/react/dist/ssr/Ruler";
 import { ArrowSquareDown } from "@phosphor-icons/react/dist/ssr/ArrowSquareDown";
@@ -237,6 +238,15 @@ export function CircuitTabTools() {
         <Ruler size={20} />
       </ToolbarButton>
       <ToolbarButton
+        tooltip="Constrain"
+        active={pcbTool === "constrain"}
+        onClick={() => setPcbTool("constrain")}
+        iconColor={ELECTRONICS_TAB_COLORS.pcb}
+      >
+        <Angle size={20} />
+      </ToolbarButton>
+      {pcbTool === "constrain" && <PcbConstrainControls />}
+      <ToolbarButton
         tooltip="Delete (D)"
         active={pcbTool === "delete"}
         onClick={() => setPcbTool("delete")}
@@ -343,3 +353,140 @@ export function CircuitTabTools() {
 }
 
 export default CircuitTabTools;
+
+
+// ---------------------------------------------------------------------------
+// Constrain tool inline controls
+// ---------------------------------------------------------------------------
+
+const CONSTRAINT_TYPES = [
+  { id: "coincident", label: "Coinc" },
+  { id: "horizontal", label: "H" },
+  { id: "vertical", label: "V" },
+  { id: "distance", label: "Dist" },
+  { id: "fixed", label: "Fix" },
+] as const;
+
+function PcbConstrainControls() {
+  const pcbConstraintType = useElectronicsStore((s) => s.pcbConstraintType);
+  const setPcbConstraintType = useElectronicsStore((s) => s.setPcbConstraintType);
+  const pending = useElectronicsStore((s) => s.pcbConstraintPending);
+  const setPending = useElectronicsStore((s) => s.setPcbConstraintPending);
+  const setPcbSolveStatus = useElectronicsStore((s) => s.setPcbSolveStatus);
+  const activeBoardNodeId = useCoreElectronicsStore((s) => s.activeBoardNodeId);
+  const addDesignConstraint = useDocumentStore((s) => s.addDesignConstraint);
+  const documentState = useDocumentStore.getState();
+  const [value, setValue] = useState("");
+
+  const commit = useCallback(
+    (type: string, targets: { kind: string; ref?: string; idx?: number }[], val?: number | string) => {
+      if (activeBoardNodeId == null) return;
+      const node = Number(activeBoardNodeId);
+      // Anchor per picked target. Footprints reference by ref (survives
+      // reorder); outline vertices by index (documented fragility).
+      const anchor = (t: { kind: string; ref?: string; idx?: number }) =>
+        t.kind === "footprint"
+          ? { kind: "pcbFootprint" as const, node, ref: t.ref! }
+          : { kind: "pcbOutlineVertex" as const, node, index: t.idx! };
+      let kind: Record<string, unknown> | null = null;
+      if (type === "fixed" && targets[0]) kind = { type: "fixed", a: anchor(targets[0]) };
+      else if (targets.length === 2) {
+        const [a, b] = [anchor(targets[0]!), anchor(targets[1]!)];
+        if (type === "coincident") kind = { type: "coincident", a, b };
+        else if (type === "horizontal") kind = { type: "horizontal", a, b };
+        else if (type === "vertical") kind = { type: "vertical", a, b };
+        else if (type === "distance") kind = { type: "distance", a, b, value: val ?? 0 };
+      }
+      if (!kind) return;
+      const report = addDesignConstraint({
+        kind: kind as never,
+        driven: false,
+      });
+      if (report) {
+        const dof = report.groups.reduce((acc, g) => acc + g.dof, 0);
+        setPcbSolveStatus({
+          converged: report.converged,
+          dof,
+          overConstrained: report.groups.some((g) => g.dof < 0),
+        });
+      }
+    },
+    [activeBoardNodeId, addDesignConstraint, setPcbSolveStatus],
+  );
+
+  // Non-dimensional constraints commit as soon as targets are picked;
+  // dimensional ones wait for the value input below.
+  useEffect(() => {
+    if (!pending) return;
+    if (pending.type !== "distance") {
+      commit(pending.type, pending.targets);
+      setPending(null);
+    } else {
+      // Prefill with the current measured distance between the targets.
+      const doc = documentState.document;
+      const nodeId = activeBoardNodeId != null ? Number(activeBoardNodeId) : null;
+      if (nodeId != null && pending.targets.length === 2) {
+        const pcb = doc.nodes[String(nodeId)]?.op as
+          | { type: string; board?: { footprints: { ref: string; position: { x: number; y: number } }[]; outline: { vertices: { x: number; y: number }[] } } }
+          | undefined;
+        const board = pcb?.board;
+        if (board) {
+          const pos = (t: { kind: string; ref?: string; idx?: number }) =>
+            t.kind === "footprint"
+              ? board.footprints.find((f) => f.ref === t.ref)?.position
+              : board.outline.vertices[t.idx ?? -1];
+          const [pa, pb] = [pos(pending.targets[0]!), pos(pending.targets[1]!)];
+          if (pa && pb) setValue(Math.hypot(pa.x - pb.x, pa.y - pb.y).toFixed(2));
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pending]);
+
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      {CONSTRAINT_TYPES.map((t) => (
+        <button
+          key={t.id}
+          className={`rounded px-1.5 py-0.5 text-[10px] font-mono border ${
+            pcbConstraintType === t.id
+              ? "border-orange-500 text-orange-500"
+              : "border-border text-muted-foreground hover:text-foreground"
+          }`}
+          onClick={() => setPcbConstraintType(t.id)}
+          title={t.id}
+        >
+          {t.label}
+        </button>
+      ))}
+      {pending?.type === "distance" && (
+        <>
+          <input
+            className="w-20 rounded border border-border bg-transparent px-1 py-0.5 text-[10px] font-mono"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="mm or =expr"
+            title="Distance in mm, or a formula over document parameters"
+          />
+          <button
+            className="rounded border border-orange-500 px-1.5 py-0.5 text-[10px] font-mono text-orange-500"
+            onClick={() => {
+              const raw = value.trim();
+              const num = Number(raw);
+              const val = raw.startsWith("=")
+                ? raw.slice(1)
+                : Number.isFinite(num) && raw !== ""
+                  ? num
+                  : raw;
+              commit("distance", pending.targets, val);
+              setPending(null);
+              setValue("");
+            }}
+          >
+            Apply
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/app/src/components/electronics/EcadFeatureInspector.tsx
+++ b/packages/app/src/components/electronics/EcadFeatureInspector.tsx
@@ -266,6 +266,7 @@ function ComponentFootprintPanel({ compRef }: { compRef: string }) {
             <Row label="Pads" value={String(fp.pads.length)} />
           </>
         )}
+        {fp && <FootprintConstraints compRef={compRef} />}
         {nets.size > 0 && (
           <div className="pt-1 border-t border-border mt-1">
             <div className="text-[10px] text-text-muted mb-0.5">Nets:</div>
@@ -313,6 +314,78 @@ export function Row({
       <span className={danger ? "text-danger font-medium" : "text-text"}>
         {value}
       </span>
+    </div>
+  );
+}
+
+
+// ---------------------------------------------------------------------------
+// Design constraints on the selected footprint
+// ---------------------------------------------------------------------------
+
+function FootprintConstraints({ compRef }: { compRef: string }) {
+  const constraints = useDocumentStore((s) => s.document.constraints);
+  const removeDesignConstraint = useDocumentStore((s) => s.removeDesignConstraint);
+  const updateDesignConstraint = useDocumentStore((s) => s.updateDesignConstraint);
+
+  const mine = (constraints ?? []).filter((c) =>
+    Object.values(c.kind as unknown as Record<string, unknown>).some(
+      (v) =>
+        v != null &&
+        typeof v === "object" &&
+        (v as { kind?: string; ref?: string }).kind === "pcbFootprint" &&
+        (v as { ref?: string }).ref === compRef,
+    ) || (c.kind as { ref?: string }).ref === compRef,
+  );
+  if (mine.length === 0) return null;
+
+  return (
+    <div className="pt-1 border-t border-border mt-1">
+      <div className="text-[10px] text-text-muted mb-0.5">Constraints:</div>
+      {mine.map((c) => {
+        const type = (c.kind as { type: string }).type;
+        const value = (c.kind as { value?: number | string }).value;
+        return (
+          <div key={c.id} className="flex items-center justify-between gap-1 text-[10px]">
+            <span className="font-mono text-text-muted">
+              {type}
+              {c.driven ? " (ref)" : ""}
+            </span>
+            <span className="flex items-center gap-1">
+              {value !== undefined && (
+                <input
+                  className="w-16 text-[10px] text-text bg-transparent border border-border rounded px-1 py-0.5 text-right"
+                  defaultValue={String(value)}
+                  onBlur={(e) => {
+                    const raw = e.target.value.trim();
+                    const num = Number(raw);
+                    updateDesignConstraint(c.id, {
+                      value: Number.isFinite(num) && raw !== "" ? num : raw,
+                    });
+                  }}
+                  title="Value (mm/deg) or formula over document parameters"
+                />
+              )}
+              {value !== undefined && (
+                <button
+                  className={`rounded border px-1 ${c.driven ? "border-orange-500 text-orange-500" : "border-border text-text-muted"}`}
+                  title="Toggle driven (reference) dimension"
+                  onClick={() => updateDesignConstraint(c.id, { driven: !c.driven })}
+                >
+                  ref
+                </button>
+              )}
+              <button
+                className="rounded border border-border px-1 text-text-muted hover:text-danger"
+                title="Delete constraint"
+                onClick={() => removeDesignConstraint(c.id)}
+              >
+                ×
+              </button>
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/app/src/components/electronics/ElectronicsPanelHeader.tsx
+++ b/packages/app/src/components/electronics/ElectronicsPanelHeader.tsx
@@ -210,6 +210,8 @@ export function ElectronicsPanelHeader() {
   const pcbActiveLayer = useElectronicsStore((s) => s.pcbActiveLayer);
   const pcbLayers = useElectronicsStore((s) => s.pcbLayers);
   const drcViolations = useElectronicsStore((s) => s.drcViolations);
+  const pcbSolveStatus = useElectronicsStore((s) => s.pcbSolveStatus);
+  const constraintCount = useDocumentStore((s) => s.document.constraints?.length ?? 0);
   const ercViolations = useElectronicsStore((s) => s.ercViolations);
   const receiptCount = useElectronicsStore((s) => s.receiptEntries.length);
   const showReceiptPanel = useElectronicsStore((s) => s.showReceiptPanel);
@@ -236,6 +238,24 @@ export function ElectronicsPanelHeader() {
           {pcb && <BoardSizeControl pcb={pcb} />}
         </span>
         <div className="flex items-center gap-2 shrink-0">
+          {constraintCount > 0 && (
+            <span
+              className="inline-flex items-center gap-1"
+              title="Design constraints: solve status / degrees of freedom"
+            >
+              {pcbSolveStatus == null ? (
+                <span className="text-text-muted">{constraintCount} constraints</span>
+              ) : pcbSolveStatus.overConstrained || !pcbSolveStatus.converged ? (
+                <span className="text-danger font-medium">
+                  {pcbSolveStatus.overConstrained ? "Over-constrained" : "Not converged"}
+                </span>
+              ) : pcbSolveStatus.dof === 0 ? (
+                <span className="text-success font-medium">Solved</span>
+              ) : (
+                <span className="text-text-muted">{pcbSolveStatus.dof} DOF</span>
+              )}
+            </span>
+          )}
           <span className="inline-flex items-center gap-1" title="DRC errors / warnings">
             <span className="text-text-muted">DRC</span>
             <span className={drcErrors > 0 ? "text-danger font-medium" : "text-text-muted"}>

--- a/packages/app/src/components/electronics/pcb3d/PcbConstraints3D.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbConstraints3D.tsx
@@ -1,0 +1,173 @@
+/**
+ * Design-constraint overlay for the 3D board view: glyphs at constraint
+ * midpoints, dimension leaders with values (driven dimensions dashed and
+ * muted — measurements, not drivers), and orange rings on the targets the
+ * constrain tool has picked so far.
+ */
+
+import { useMemo } from "react";
+import { Line, Html } from "@react-three/drei";
+import type { DesignConstraint, Pcb, Anchor } from "@vcad/ir";
+import type { ConstraintTarget } from "@/stores/electronics-store";
+import { layerZ } from "./pcb-geometry";
+
+interface Props {
+  pcb: Pcb;
+  nodeId: number;
+  constraints: DesignConstraint[];
+  pickedTargets: ConstraintTarget[];
+  boardThickness: number;
+  explosion: number;
+}
+
+const GLYPHS: Record<string, string> = {
+  coincident: "⌖",
+  concentric: "◎",
+  horizontal: "—",
+  vertical: "|",
+  parallel: "∥",
+  perpendicular: "⊥",
+  equalLength: "=",
+  fixed: "⚓",
+  symmetric: "⋈",
+  pointOnEdge: "⌐",
+};
+
+/** Board-frame position of a point-like anchor, or null. */
+function anchorPos(pcb: Pcb, nodeId: number, a: Anchor): { x: number; y: number } | null {
+  if (Number((a as { node?: number }).node) !== nodeId) return null;
+  if (a.kind === "pcbFootprint") {
+    const fp = pcb.footprints.find((f) => f.ref === a.ref);
+    if (!fp) return null;
+    if (a.pad) {
+      const pad = fp.pads.find((p) => p.number === a.pad);
+      if (!pad) return null;
+      const ang = ((fp.rotation ?? 0) * Math.PI) / 180;
+      return {
+        x: fp.position.x + pad.position.x * Math.cos(ang) - pad.position.y * Math.sin(ang),
+        y: fp.position.y + pad.position.x * Math.sin(ang) + pad.position.y * Math.cos(ang),
+      };
+    }
+    return { x: fp.position.x, y: fp.position.y };
+  }
+  if (a.kind === "pcbOutlineVertex") {
+    const v = pcb.outline.vertices[a.index];
+    return v ? { x: v.x, y: v.y } : null;
+  }
+  if (a.kind === "pcbOutlineEdge") {
+    const n = pcb.outline.vertices.length;
+    const v1 = pcb.outline.vertices[a.index];
+    const v2 = pcb.outline.vertices[(a.index + 1) % n];
+    return v1 && v2 ? { x: (v1.x + v2.x) / 2, y: (v1.y + v2.y) / 2 } : null;
+  }
+  return null;
+}
+
+function constraintAnchors(kind: DesignConstraint["kind"]): Anchor[] {
+  return Object.values(kind as unknown as Record<string, unknown>).filter(
+    (v): v is Anchor => v != null && typeof v === "object" && "kind" in (v as object),
+  );
+}
+
+function labelStyle(driven: boolean): React.CSSProperties {
+  return {
+    pointerEvents: "none",
+    fontSize: "10px",
+    fontFamily: "JetBrains Mono, monospace",
+    whiteSpace: "nowrap",
+    color: driven ? "var(--text-muted, #9ca3af)" : "var(--text, #e5e7eb)",
+    fontStyle: driven ? "italic" : "normal",
+    background: "rgba(0,0,0,0.55)",
+    padding: "1px 4px",
+    borderRadius: "3px",
+  };
+}
+
+export function PcbConstraints3D({
+  pcb,
+  nodeId,
+  constraints,
+  pickedTargets,
+  boardThickness,
+  explosion,
+}: Props) {
+  const z = layerZ("FCu", boardThickness, explosion) + 0.12;
+
+  const items = useMemo(() => {
+    return constraints
+      .map((c) => {
+        const anchors = constraintAnchors(c.kind);
+        const points = anchors
+          .map((a) => anchorPos(pcb, nodeId, a))
+          .filter((p): p is { x: number; y: number } => p !== null);
+        if (points.length === 0) return null;
+        const mid = {
+          x: points.reduce((s, p) => s + p.x, 0) / points.length,
+          y: points.reduce((s, p) => s + p.y, 0) / points.length,
+        };
+        const type = (c.kind as { type: string }).type;
+        const value = (c.kind as { value?: number | string }).value;
+        return { c, type, value, points, mid };
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null);
+  }, [constraints, pcb, nodeId]);
+
+  const picked = useMemo(
+    () =>
+      pickedTargets
+        .map((t) =>
+          t.kind === "footprint"
+            ? pcb.footprints.find((f) => f.ref === t.ref)?.position
+            : pcb.outline.vertices[t.idx],
+        )
+        .filter((p): p is { x: number; y: number } => p != null),
+    [pickedTargets, pcb],
+  );
+
+  if (items.length === 0 && picked.length === 0) return null;
+
+  return (
+    <group>
+      {items.map(({ c, type, value, points, mid }) => {
+        const dimensional = value !== undefined;
+        const driven = c.driven === true;
+        return (
+          <group key={c.id}>
+            {dimensional && points.length === 2 && (
+              <Line
+                points={[
+                  [points[0]!.x, points[0]!.y, z],
+                  [points[1]!.x, points[1]!.y, z],
+                ]}
+                color={driven ? "#9ca3af" : "#e5e7eb"}
+                lineWidth={1}
+                dashed={driven}
+                dashSize={0.5}
+                gapSize={0.35}
+                transparent
+                opacity={0.75}
+              />
+            )}
+            <Html position={[mid.x, mid.y, z]} center zIndexRange={[20, 0]}>
+              <div style={labelStyle(driven)}>
+                {dimensional
+                  ? `${typeof value === "number" ? value.toFixed(2) : String(value)}${
+                      type === "angle" || type === "rotation" ? "°" : ""
+                    }${driven ? " (ref)" : ""}`
+                  : (GLYPHS[type] ?? type)}
+              </div>
+            </Html>
+          </group>
+        );
+      })}
+
+      {/* Orange = action: targets picked by the constrain tool */}
+      {picked.map((p, i) => (
+        <mesh key={`pick-${i}`} position={[p.x, p.y, z + 0.02]}>
+          <ringGeometry args={[1.0, 1.25, 24]} />
+          <meshBasicMaterial color="#f97316" transparent opacity={0.9} />
+        </mesh>
+      ))}
+    </group>
+  );
+}

--- a/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
+++ b/packages/app/src/components/electronics/pcb3d/PcbScene.tsx
@@ -20,6 +20,7 @@ import { PcbComponentBodies3D } from "./PcbComponentBodies3D";
 import { PcbRatsnest3D } from "./PcbRatsnest3D";
 import { PcbRoutePreview3D } from "./PcbRoutePreview3D";
 import { PcbDrcMarkers3D } from "./PcbDrcMarkers3D";
+import { PcbConstraints3D } from "./PcbConstraints3D";
 
 export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const { invalidate } = useThree();
@@ -52,6 +53,11 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
   const updateRoutePreview = useElectronicsStore((s) => s.updateRoutePreview);
   const startPcbDrag = useElectronicsStore((s) => s.startPcbDrag);
   const cancelPcbDrag = useElectronicsStore((s) => s.cancelPcbDrag);
+  const pcbConstraintTargets = useElectronicsStore((s) => s.pcbConstraintTargets);
+  const pushConstraintTarget = useElectronicsStore((s) => s.pushConstraintTarget);
+  const setPcbSolveStatus = useElectronicsStore((s) => s.setPcbSolveStatus);
+  const solveDesignConstraints = useDocumentStore((s) => s.solveDesignConstraints);
+  const documentConstraints = useDocumentStore((s) => s.document.constraints);
   const moveFootprint = useDocumentStore((s) => s.moveFootprint);
   const removeTrace = useDocumentStore((s) => s.removeTrace);
   const removeVia = useDocumentStore((s) => s.removeVia);
@@ -102,6 +108,31 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
             return;
           }
         }
+      }
+
+      // Constrain tool: pick footprints (or outline vertices on a miss)
+      if (pcbTool === "constrain") {
+        for (let i = pcb.footprints.length - 1; i >= 0; i--) {
+          const fp = pcb.footprints[i]!;
+          const halfW = 5, halfH = 5;
+          if (
+            pcbPos.x >= fp.position.x - halfW &&
+            pcbPos.x <= fp.position.x + halfW &&
+            pcbPos.y >= fp.position.y - halfH &&
+            pcbPos.y <= fp.position.y + halfH
+          ) {
+            pushConstraintTarget({ kind: "footprint", ref: fp.ref });
+            return;
+          }
+        }
+        for (let i = 0; i < pcb.outline.vertices.length; i++) {
+          const v = pcb.outline.vertices[i]!;
+          if (Math.hypot(pcbPos.x - v.x, pcbPos.y - v.y) < 1.5) {
+            pushConstraintTarget({ kind: "outlineVertex", idx: i });
+            return;
+          }
+        }
+        return;
       }
 
       // Select tool: hit-test elements
@@ -239,9 +270,32 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
 
   const onPlanePointerUp = useCallback(() => {
     if (pcbDragging) {
+      // Drag-end re-solve: the dragged footprint anchors the solve (a
+      // temporary Fixed pin — never persisted), so constraints pull the
+      // rest of the board into consistency around the user's gesture.
+      if (
+        activeBoardNodeId != null &&
+        (documentConstraints?.length ?? 0) > 0 &&
+        pcb
+      ) {
+        const fp = pcb.footprints[pcbDragging.fpIdx];
+        if (fp) {
+          const report = solveDesignConstraints({
+            extraFixed: [{ node: Number(activeBoardNodeId), ref: fp.ref }],
+          });
+          if (report) {
+            const dof = report.groups.reduce((a, g) => a + g.dof, 0);
+            setPcbSolveStatus({
+              converged: report.converged,
+              dof,
+              overConstrained: report.groups.some((g) => g.dof < 0),
+            });
+          }
+        }
+      }
       cancelPcbDrag();
     }
-  }, [pcbDragging, cancelPcbDrag]);
+  }, [pcbDragging, cancelPcbDrag, activeBoardNodeId, documentConstraints, pcb, solveDesignConstraints, setPcbSolveStatus]);
 
   if (!pcb) return null;
 
@@ -341,6 +395,18 @@ export function PcbScene({ showBoard = true }: { showBoard?: boolean } = {}) {
           routePreview={routePreview}
           boardThickness={boardThickness}
           activeLayer={pcbActiveLayer}
+          explosion={stackupExplosion}
+        />
+      )}
+
+      {/* Design-constraint glyphs + dimension leaders */}
+      {activeBoardNodeId != null && (
+        <PcbConstraints3D
+          pcb={pcb}
+          nodeId={Number(activeBoardNodeId)}
+          constraints={documentConstraints ?? []}
+          pickedTargets={pcbConstraintTargets}
+          boardThickness={boardThickness}
           explosion={stackupExplosion}
         />
       )}

--- a/packages/app/src/stores/electronics-store.ts
+++ b/packages/app/src/stores/electronics-store.ts
@@ -21,7 +21,20 @@ import type { PcbBoardPartInfo, ReceiptEntry } from "@vcad/core";
 
 /** The electronics workspace shows one view at a time; the toolbar toggles. */
 export type ElectronicsLayout = "schematic" | "board";
-export type PcbTool = "select" | "move" | "route" | "length-tune" | "delete";
+export type PcbTool = "select" | "move" | "route" | "length-tune" | "delete" | "constrain";
+
+/** A target picked by the constrain tool. */
+export type ConstraintTarget =
+  | { kind: "footprint"; ref: string }
+  | { kind: "outlineVertex"; idx: number };
+
+/** Constraint sub-tools offered by the toolbar. */
+export type PcbConstraintType =
+  | "coincident"
+  | "horizontal"
+  | "vertical"
+  | "distance"
+  | "fixed";
 export type SchTool = "select" | "move" | "place" | "wire" | "label" | "delete";
 
 export type ElectronicsSelection =
@@ -167,6 +180,14 @@ export interface ElectronicsState {
 
   // PCB drag state
   pcbDragging: { fpIdx: number; startPos: Vec2 } | null;
+  /** Active constraint sub-tool. */
+  pcbConstraintType: PcbConstraintType;
+  /** Targets picked so far by the constrain tool (max 2). */
+  pcbConstraintTargets: ConstraintTarget[];
+  /** Dimensional constraint awaiting a value before commit. */
+  pcbConstraintPending: { type: PcbConstraintType; targets: ConstraintTarget[] } | null;
+  /** Last design-constraint solve outcome (status chip). */
+  pcbSolveStatus: { converged: boolean; dof: number; overConstrained: boolean } | null;
 
   // Real-time validation
   drcViolations: DrcViolationResult[];
@@ -215,6 +236,11 @@ export interface ElectronicsState {
   select: (sel: ElectronicsSelection) => void;
   setHoveredNet: (netId: string | null) => void;
   setPcbTool: (t: PcbTool) => void;
+  setPcbConstraintType: (t: PcbConstraintType) => void;
+  pushConstraintTarget: (t: ConstraintTarget) => void;
+  clearConstraintPicks: () => void;
+  setPcbConstraintPending: (p: { type: PcbConstraintType; targets: ConstraintTarget[] } | null) => void;
+  setPcbSolveStatus: (s: { converged: boolean; dof: number; overConstrained: boolean } | null) => void;
   setSchTool: (t: SchTool) => void;
   setPcbActiveLayer: (l: PcbLayer) => void;
   inferLayerFromPad: (layers: PcbLayer[]) => void;
@@ -332,6 +358,10 @@ export const useElectronicsStore = create<ElectronicsState>((set, get) => ({
   schRefCounters: {},
 
   pcbDragging: null,
+  pcbConstraintType: "distance" as PcbConstraintType,
+  pcbConstraintTargets: [],
+  pcbConstraintPending: null,
+  pcbSolveStatus: null,
 
   drcViolations: [],
   ercViolations: [],
@@ -415,7 +445,27 @@ export const useElectronicsStore = create<ElectronicsState>((set, get) => ({
       routeActive: pcbTool === "route" ? undefined : false,
       routeStartPad: pcbTool === "route" ? undefined : null,
       routePreview: pcbTool === "route" ? undefined : [],
+      pcbConstraintTargets: [],
+      pcbConstraintPending: null,
     }),
+  setPcbConstraintType: (pcbConstraintType) =>
+    set({ pcbConstraintType, pcbConstraintTargets: [], pcbConstraintPending: null }),
+  pushConstraintTarget: (t) =>
+    set((state) => {
+      const targets = [...state.pcbConstraintTargets, t];
+      const needed = state.pcbConstraintType === "fixed" ? 1 : 2;
+      if (targets.length < needed) return { pcbConstraintTargets: targets };
+      // Enough targets: dimensional types wait for a value, the rest are
+      // committed by the toolbar effect watching pcbConstraintPending.
+      return {
+        pcbConstraintTargets: [],
+        pcbConstraintPending: { type: state.pcbConstraintType, targets },
+      };
+    }),
+  clearConstraintPicks: () =>
+    set({ pcbConstraintTargets: [], pcbConstraintPending: null }),
+  setPcbConstraintPending: (pcbConstraintPending) => set({ pcbConstraintPending }),
+  setPcbSolveStatus: (pcbSolveStatus) => set({ pcbSolveStatus }),
   setSchTool: (schTool) => set({ schTool }),
 
   // Principle 5: layer follows intent

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -368,3 +368,4 @@ export type {
   ChangelogEntry,
   ChangelogCategory,
 } from "./changelog/index.js";
+export { sketchConstraintToDesign, mergeSketchConstraints, referencesSketchNode } from "./sketch-constraint-persist.js";

--- a/packages/core/src/sketch-constraint-persist.ts
+++ b/packages/core/src/sketch-constraint-persist.ts
@@ -1,0 +1,144 @@
+/**
+ * Translation from editor-session sketch constraints (`SketchConstraint`,
+ * segment-index based) into persisted document-level `DesignConstraint`s
+ * anchored at a sketch node — so constraints survive save/reload, re-solve
+ * on parameter change, and certify as receipt claims instead of dying with
+ * the editing session.
+ */
+
+import type {
+  Anchor,
+  DesignConstraint,
+  EntityRef,
+  NodeId,
+  SketchConstraint,
+} from "@vcad/ir";
+
+function pointAnchor(node: NodeId, ref: EntityRef): Anchor | null {
+  const seg = ref.index;
+  switch (ref.type) {
+    case "LineStart":
+    case "ArcStart":
+    case "Point": // free points don't exist in the app's segment model
+      return { kind: "sketchPoint", node: Number(node), segment: seg, point: "start" };
+    case "LineEnd":
+    case "ArcEnd":
+      return { kind: "sketchPoint", node: Number(node), segment: seg, point: "end" };
+    case "Center":
+      return { kind: "sketchPoint", node: Number(node), segment: seg, point: "center" };
+    default:
+      return null;
+  }
+}
+
+function segmentAnchor(node: NodeId, segment: number): Anchor {
+  return { kind: "sketchSegment", node: Number(node), segment };
+}
+
+/**
+ * Translate one session constraint. Returns null for kinds the document
+ * model doesn't carry (currently Radius — circles are render-only arcs).
+ */
+export function sketchConstraintToDesign(
+  node: NodeId,
+  c: SketchConstraint,
+): DesignConstraint["kind"] | null {
+  switch (c.type) {
+    case "Coincident": {
+      const a = pointAnchor(node, c.pointA);
+      const b = pointAnchor(node, c.pointB);
+      return a && b ? { type: "coincident", a, b } : null;
+    }
+    case "Horizontal":
+      return {
+        type: "horizontal",
+        a: segmentAnchor(node, c.line),
+        b: segmentAnchor(node, c.line),
+      };
+    case "Vertical":
+      return {
+        type: "vertical",
+        a: segmentAnchor(node, c.line),
+        b: segmentAnchor(node, c.line),
+      };
+    case "Parallel":
+      return {
+        type: "parallel",
+        a: segmentAnchor(node, c.lineA),
+        b: segmentAnchor(node, c.lineB),
+      };
+    case "Perpendicular":
+      return {
+        type: "perpendicular",
+        a: segmentAnchor(node, c.lineA),
+        b: segmentAnchor(node, c.lineB),
+      };
+    case "Fixed": {
+      const a = pointAnchor(node, c.point);
+      return a ? { type: "fixed", a } : null;
+    }
+    case "Distance": {
+      const a = pointAnchor(node, c.pointA);
+      const b = pointAnchor(node, c.pointB);
+      return a && b ? { type: "distance", a, b, value: c.distance } : null;
+    }
+    case "Length":
+      return { type: "length", a: segmentAnchor(node, c.line), value: c.length };
+    case "EqualLength":
+      return {
+        type: "equalLength",
+        a: segmentAnchor(node, c.lineA),
+        b: segmentAnchor(node, c.lineB),
+      };
+    case "Angle":
+      return {
+        type: "angle",
+        a: segmentAnchor(node, c.lineA),
+        b: segmentAnchor(node, c.lineB),
+        value: c.angleDeg,
+      };
+    case "Radius":
+      return null; // no document-level radius kind yet
+    default:
+      return null;
+  }
+}
+
+/** Does this design constraint reference the given sketch node? */
+export function referencesSketchNode(c: DesignConstraint, node: NodeId): boolean {
+  return Object.values(c.kind as unknown as Record<string, unknown>).some((v) => {
+    const a = v as { kind?: string; node?: number };
+    return (
+      a != null &&
+      typeof a === "object" &&
+      (a.kind === "sketchPoint" || a.kind === "sketchSegment") &&
+      Number(a.node) === Number(node)
+    );
+  });
+}
+
+/**
+ * Merge a sketch's session constraints into a document constraint set:
+ * existing constraints for that sketch node are replaced; everything else
+ * is preserved. Ids continue the document's "cN" sequence.
+ */
+export function mergeSketchConstraints(
+  existing: DesignConstraint[],
+  node: NodeId,
+  session: SketchConstraint[],
+): DesignConstraint[] {
+  const kept = existing.filter((c) => !referencesSketchNode(c, node));
+  let max = 0;
+  for (const c of kept) {
+    const m = /^c(\d+)$/.exec(c.id);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  const translated: DesignConstraint[] = [];
+  for (const sc of session) {
+    const kind = sketchConstraintToDesign(node, sc);
+    if (kind) {
+      translated.push({ id: `c${++max}`, kind, driven: false });
+    }
+  }
+  return [...kept, ...translated];
+}

--- a/packages/core/src/stores/document-store.ts
+++ b/packages/core/src/stores/document-store.ts
@@ -1,12 +1,16 @@
 import { create } from "zustand";
+import { getKernelWasmSync } from "../wasm-singleton.js";
+import { mergeSketchConstraints } from "../sketch-constraint-persist.js";
 import type {
   Bindings,
+  DesignConstraint,
   Document,
   Expr,
   NodeId,
   Parameter,
   Vec3,
   SketchSegment2D,
+  SketchConstraint,
   PathCurve,
   Transform3D,
   SweepOp,
@@ -483,6 +487,37 @@ export interface DocumentState {
   setBoardOutline: (outline: BoardOutline) => void;
   /** Resize the board to a W×H rectangle (origin corner at [0,0]), preserving thickness + cutouts. */
   resizeBoard: (width: number, height: number) => void;
+
+  // Design constraints (document-level geometric solver)
+  /** Persist a committed sketch's session constraints onto the document,
+   *  anchored at its sketch node (replaces prior constraints for that node). */
+  persistSketchConstraints: (partId: string, session: SketchConstraint[]) => void;
+  /** Append a design constraint (id auto-assigned) and re-solve. */
+  addDesignConstraint: (constraint: Omit<DesignConstraint, "id">) => DesignConstraintSolveReport | null;
+  /** Remove a design constraint by id. Geometry stays where it is. */
+  removeDesignConstraint: (id: string) => void;
+  /** Patch a dimensional constraint's value / driven flag, then re-solve. */
+  updateDesignConstraint: (
+    id: string,
+    patch: { value?: number | string; driven?: boolean },
+  ) => DesignConstraintSolveReport | null;
+  /** Re-solve the document's design constraints via the kernel WASM solver.
+   *  `extraFixed` pins footprints for this solve only (drag anchoring). */
+  solveDesignConstraints: (opts?: {
+    extraFixed?: Array<{ node: number; ref: string }>;
+  }) => DesignConstraintSolveReport | null;
+}
+
+/** Subset of the kernel's design-constraint solve report the app consumes. */
+export interface DesignConstraintSolveReport {
+  converged: boolean;
+  groups: Array<{ node: number; status: string; converged: boolean; dof: number }>;
+  movedFootprints: string[];
+  movedVertices: string[];
+  drivenValues: Array<{ id: string; value: number }>;
+  residuals: Array<{ id: string; residual: number; driven: boolean }>;
+  errors: string[];
+  warnings: string[];
 }
 
 // ---------------------------------------------------------------------------
@@ -782,6 +817,44 @@ function getOrCreateDrawingFeature(state: DocumentState): string {
     return result.createdFeatureId;
   }
   return "";
+}
+
+let _constraintsFeatureId: string | null = null;
+
+/** The singleton design-constraints CRDT feature (created on demand). */
+function getOrCreateConstraintsFeature(state: DocumentState): string {
+  const engine = state._crdtEngine!;
+  if (_constraintsFeatureId) return _constraintsFeatureId;
+
+  const featuresJson = engine.get_ordered_features_json();
+  const features: { id: string; kind: string }[] = JSON.parse(featuresJson);
+  const existing = features.find((f) => f.kind === "design-constraints");
+  if (existing) {
+    _constraintsFeatureId = existing.id;
+    return existing.id;
+  }
+
+  const result = engine.create_feature("design-constraints", "{}");
+  if (result.createdFeatureId) {
+    _constraintsFeatureId = result.createdFeatureId;
+    return result.createdFeatureId;
+  }
+  return "";
+}
+
+/** Write the design-constraint set back to its CRDT feature. */
+function setCrdtConstraints(
+  state: DocumentState,
+  constraints: DesignConstraint[],
+): Partial<DocumentState> {
+  const fid = getOrCreateConstraintsFeature(state);
+  if (!fid) return {};
+  const result = state._crdtEngine!.set_param(
+    fid,
+    "constraints",
+    JSON.stringify(crdtStr(JSON.stringify(constraints))),
+  );
+  return applyLegacyResult(result);
 }
 
 function getOrCreateSchematicFeature(state: DocumentState): string {
@@ -2416,5 +2489,106 @@ export const useDocumentStore = create<DocumentState>((set, get) => ({
       ],
     };
     set({ ...setCrdtPcb(state, pcb), isDirty: true });
+  },
+
+  persistSketchConstraints: (partId, session) => {
+    const state = get();
+    const part = state.partIndex.get(partId) as { sketchNodeId?: NodeId } | undefined;
+    const sketchNode = part?.sketchNodeId;
+    if (sketchNode == null) return;
+    const next = mergeSketchConstraints(
+      state.document.constraints ?? [],
+      sketchNode,
+      session,
+    );
+    if (next.length === 0 && (state.document.constraints ?? []).length === 0) return;
+    set({ ...setCrdtConstraints(state, next), isDirty: true });
+  },
+
+  addDesignConstraint: (constraint) => {
+    const state = get();
+    const existing = state.document.constraints ?? [];
+    let max = 0;
+    for (const c of existing) {
+      const m = /^c(\d+)$/.exec(c.id);
+      if (m) max = Math.max(max, Number(m[1]));
+    }
+    const next = [...existing, { ...constraint, id: `c${max + 1}` } as DesignConstraint];
+    set({ ...setCrdtConstraints(state, next), isDirty: true });
+    return get().solveDesignConstraints();
+  },
+
+  removeDesignConstraint: (id) => {
+    const state = get();
+    const existing = state.document.constraints ?? [];
+    const next = existing.filter((c) => c.id !== id);
+    if (next.length === existing.length) return;
+    // Deleting only frees degrees of freedom — no re-solve needed.
+    set({ ...setCrdtConstraints(state, next), isDirty: true });
+  },
+
+  updateDesignConstraint: (id, patch) => {
+    const state = get();
+    const existing = state.document.constraints ?? [];
+    const next = existing.map((c) => {
+      if (c.id !== id) return c;
+      const kind = { ...c.kind } as Record<string, unknown>;
+      if (patch.value !== undefined && "value" in kind) kind.value = patch.value;
+      return {
+        ...c,
+        kind: kind as DesignConstraint["kind"],
+        ...(patch.driven !== undefined ? { driven: patch.driven } : {}),
+      };
+    });
+    set({ ...setCrdtConstraints(state, next), isDirty: true });
+    return get().solveDesignConstraints();
+  },
+
+  solveDesignConstraints: (opts) => {
+    const state = get();
+    if ((state.document.constraints ?? []).length === 0) return null;
+    // Same guard pattern as sketch solving: WASM may not be hydrated in
+    // tests — degrade to a no-op rather than crash.
+    const wasm = getKernelWasmSync() as unknown as {
+      solveDesignConstraints?: (doc: string, opts: string) => string;
+    } | null;
+    if (!wasm || typeof wasm.solveDesignConstraints !== "function") return null;
+    try {
+      const resultJson = wasm.solveDesignConstraints(
+        JSON.stringify(state.document),
+        JSON.stringify(opts?.extraFixed ? { extraFixed: opts.extraFixed } : {}),
+      );
+      const result = JSON.parse(resultJson) as {
+        document: Document;
+        report: DesignConstraintSolveReport;
+      };
+      const { report } = result;
+      // Apply the solved board back through the CRDT (single-board app
+      // model, like setCrdtPcb's other callers). Sketch groups re-solve on
+      // the MCP/kernel path; the app UI scope is the PCB editor.
+      let patch: Partial<DocumentState> = {};
+      const movedBoard = report.groups.find(
+        (g) => g.converged && getNodePcb(result.document, g.node),
+      );
+      if (
+        movedBoard &&
+        (report.movedFootprints.length > 0 || report.movedVertices.length > 0)
+      ) {
+        const pcb = getNodePcb(result.document, movedBoard.node);
+        if (pcb) patch = setCrdtPcb(get(), structuredClone(pcb));
+      }
+      // Back-annotated driven dimensions ride the constraints feature.
+      if (report.drivenValues.length > 0) {
+        patch = {
+          ...patch,
+          ...setCrdtConstraints(get(), result.document.constraints ?? []),
+        };
+      }
+      set({ ...patch, isDirty: true });
+      return report;
+    } catch (e) {
+      console.warn("[document-store] solveDesignConstraints failed:", e);
+      return null;
+    }
   },
 }));

--- a/packages/docs/content/architecture/kernel-features.mdx
+++ b/packages/docs/content/architecture/kernel-features.mdx
@@ -94,6 +94,10 @@ A circular pattern turns one hole into a bolt circle in a single operation:
 
 `vcad-kernel-sketch` models 2D profiles (lines, arcs) on arbitrary planes, and `vcad-kernel-constraints` solves geometric constraints — coincident, horizontal/vertical, parallel, perpendicular, tangent, distance, length, radius, angle, equal-length, fixed — with a Levenberg-Marquardt solver using adaptive damping. Sketches feed every profile-based operation below.
 
+### Design Constraints (Document-Level)
+
+`vcad-design-constraints` generalizes the sketch solver to the whole document: one constraint set spans PCB layout (footprint positions/rotations, board-outline vertices and edges), sketch geometry, and mechanical part edges addressed through the topological naming system. Dimensional constraints are expression-valued (`"board_width - 2*edge_margin"`) over named document parameters, so changing a parameter re-solves the layout; `driven: true` makes a reference dimension that is measured and back-annotated instead of enforced. Cross-domain constraints treat part geometry as authoritative — a connector can be held coincident with an enclosure cutout edge, with fail-closed anchor resolution (an ambiguous or lost edge name skips the constraint with an error, never a silent rebind). Every constraint doubles as a `constraint.*` receipt claim, re-verified as Holds / Stale / Violated by `verify_receipt`. Exposed via the `add_constraint` / `list_constraints` / `solve_constraints` MCP tools and the board editor's Constrain tool.
+
 ### Extrude, Revolve, Sweep, Loft
 
 `vcad-kernel-sweep` turns closed sketch profiles into solids. Revolve spins a profile around an axis:

--- a/packages/engine/src/ecad.ts
+++ b/packages/engine/src/ecad.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+  Document,
   SchematicSheet,
   Pcb,
   Trace,
@@ -180,6 +181,66 @@ async function verifyWithKernel<T>(
 export async function isEcadAvailable(): Promise<boolean> {
   const wasm = await loadEcadWasm();
   return wasm !== null;
+}
+
+/** Per-plane group outcome of a design-constraint solve. */
+export interface ConstraintGroupReport {
+  node: number;
+  status: string;
+  converged: boolean;
+  iterations: number;
+  residualNorm: number;
+  dof: number;
+  constraintCount: number;
+}
+
+/** Aggregate report from the document-level design-constraint solver. */
+export interface DesignSolveReport {
+  converged: boolean;
+  groups: ConstraintGroupReport[];
+  movedFootprints: string[];
+  movedVertices: string[];
+  movedSketches: number[];
+  drivenValues: Array<{ id: string; value: number }>;
+  residuals: Array<{ id: string; residual: number; driven: boolean }>;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Solve the document's design constraints in the kernel. Returns the updated
+ * document (footprint positions/rotations, outline vertices, sketch points,
+ * back-annotated driven dimensions) plus the solve report. Fail-closed: a
+ * missing kernel or a parse error is an `errored` outcome, never a silent
+ * no-op "success".
+ */
+export async function solveDesignConstraints(
+  doc: Document,
+  options?: { extraFixed?: Array<{ node: number; ref: string }> },
+): Promise<VerifyOutcome<{ document: Document; report: DesignSolveReport }>> {
+  return verifyWithKernel("design constraints", (wasm) => {
+    if (typeof wasm.solveDesignConstraints !== "function") {
+      throw new Error("kernel WASM predates solveDesignConstraints");
+    }
+    return JSON.parse(
+      wasm.solveDesignConstraints(JSON.stringify(doc), JSON.stringify(options ?? {})),
+    ) as { document: Document; report: DesignSolveReport };
+  });
+}
+
+/**
+ * Validate and measure the document's constraints without mutating anything —
+ * every dimensional constraint's current value lands in `drivenValues`.
+ */
+export async function checkDesignConstraints(
+  doc: Document,
+): Promise<VerifyOutcome<DesignSolveReport>> {
+  return verifyWithKernel("design constraints (check)", (wasm) => {
+    if (typeof wasm.checkDesignConstraints !== "function") {
+      throw new Error("kernel WASM predates checkDesignConstraints");
+    }
+    return JSON.parse(wasm.checkDesignConstraints(JSON.stringify(doc))) as DesignSolveReport;
+  });
 }
 
 /**

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -218,7 +218,10 @@ export {
   verifySubstitution,
   buildReceipt,
   verifyReceipt,
+  solveDesignConstraints,
+  checkDesignConstraints,
 } from "./ecad.js";
+export type { DesignSolveReport, ConstraintGroupReport } from "./ecad.js";
 export type {
   EcadProbe,
   DrcViolationResult,

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -105,6 +105,80 @@ contributors: Array<StudyContributor>,
 requirement: StudyRequirement, };
 
 /**
+ * A stable reference to a piece of geometry a constraint grips.
+ *
+ * Anchors are the universal target vocabulary: PCB footprints and outline
+ * geometry, sketch segment points, and named mechanical part edges all
+ * address through the same type, which is what lets one constraint relate
+ * geometry across domains.
+ */
+export type Anchor = { "kind": "pcbFootprint", 
+/**
+ * PcbBoard node id.
+ */
+node: number, 
+/**
+ * Footprint reference designator ("U1", "J3").
+ */
+ref: string, 
+/**
+ * Pad name/number on that footprint; `None` = footprint origin.
+ */
+pad?: string, } | { "kind": "pcbOutlineVertex", 
+/**
+ * PcbBoard node id.
+ */
+node: number, 
+/**
+ * 0-based vertex index.
+ */
+index: number, } | { "kind": "pcbOutlineEdge", 
+/**
+ * PcbBoard node id.
+ */
+node: number, 
+/**
+ * 0-based index of the edge's start vertex.
+ */
+index: number, } | { "kind": "sketchPoint", 
+/**
+ * Sketch2D node id.
+ */
+node: number, 
+/**
+ * 0-based segment index into the sketch's `segments`.
+ */
+segment: number, 
+/**
+ * Which point of the segment.
+ */
+point: SketchPointRef, } | { "kind": "sketchSegment", 
+/**
+ * Sketch2D node id.
+ */
+node: number, 
+/**
+ * 0-based segment index into the sketch's `segments`.
+ */
+segment: number, } | { "kind": "partEdge", 
+/**
+ * Part root node id.
+ */
+node: number, 
+/**
+ * First adjacent face name.
+ */
+faceA: string, 
+/**
+ * Second adjacent face name.
+ */
+faceB: string, 
+/**
+ * Geometric snapshot for fallback resolution.
+ */
+hint?: EdgeHintIr, };
+
+/**
  * A single keyframe: value at time `t` (seconds), eased from the previous key.
  */
 export type AnimKey = { 
@@ -519,6 +593,155 @@ min_mm: number,
  * chamber floor. Penetration beyond the tolerance still fails.
  */
 allow_contact?: boolean, };
+
+/**
+ * The geometric relationship a [`DesignConstraint`] asserts.
+ *
+ * Dimensional variants carry an [`Expr`] value (literal number or a formula
+ * over document parameters). Distances/lengths are mm; angles/rotations are
+ * degrees.
+ */
+export type ConstraintKind = { "type": "coincident", 
+/**
+ * First point.
+ */
+a: Anchor, 
+/**
+ * Second point.
+ */
+b: Anchor, } | { "type": "distance", 
+/**
+ * First point.
+ */
+a: Anchor, 
+/**
+ * Second point.
+ */
+b: Anchor, 
+/**
+ * Target distance in mm.
+ */
+value: Expr, } | { "type": "horizontalDistance", 
+/**
+ * The point.
+ */
+a: Anchor, 
+/**
+ * Target X in mm.
+ */
+value: Expr, } | { "type": "verticalDistance", 
+/**
+ * The point.
+ */
+a: Anchor, 
+/**
+ * Target Y in mm.
+ */
+value: Expr, } | { "type": "horizontal", 
+/**
+ * First point (or edge start).
+ */
+a: Anchor, 
+/**
+ * Second point (or edge end).
+ */
+b: Anchor, } | { "type": "vertical", 
+/**
+ * First point.
+ */
+a: Anchor, 
+/**
+ * Second point.
+ */
+b: Anchor, } | { "type": "parallel", 
+/**
+ * First edge.
+ */
+a: Anchor, 
+/**
+ * Second edge.
+ */
+b: Anchor, } | { "type": "perpendicular", 
+/**
+ * First edge.
+ */
+a: Anchor, 
+/**
+ * Second edge.
+ */
+b: Anchor, } | { "type": "equalLength", 
+/**
+ * First edge.
+ */
+a: Anchor, 
+/**
+ * Second edge.
+ */
+b: Anchor, } | { "type": "length", 
+/**
+ * The edge.
+ */
+a: Anchor, 
+/**
+ * Target length in mm.
+ */
+value: Expr, } | { "type": "pointOnEdge", 
+/**
+ * The point.
+ */
+point: Anchor, 
+/**
+ * The edge.
+ */
+edge: Anchor, } | { "type": "concentric", 
+/**
+ * First center.
+ */
+a: Anchor, 
+/**
+ * Second center.
+ */
+b: Anchor, } | { "type": "fixed", 
+/**
+ * The point.
+ */
+a: Anchor, } | { "type": "rotation", 
+/**
+ * PcbBoard node id.
+ */
+node: number, 
+/**
+ * Footprint reference designator.
+ */
+ref: string, 
+/**
+ * Target rotation in degrees.
+ */
+value: Expr, } | { "type": "symmetric", 
+/**
+ * First point.
+ */
+a: Anchor, 
+/**
+ * Second point.
+ */
+b: Anchor, 
+/**
+ * Mirror axis (edge-like anchor).
+ */
+axis: Anchor, } | { "type": "angle", 
+/**
+ * First edge.
+ */
+a: Anchor, 
+/**
+ * Second edge.
+ */
+b: Anchor, 
+/**
+ * Target angle in degrees.
+ */
+value: Expr, };
 
 /**
  * Provenance of a piece of copper: who placed it.
@@ -1107,6 +1330,32 @@ courtyard_aabb: Box3D,
 ipc: IpcGoals, };
 
 /**
+ * A persisted, solver-enforced design constraint.
+ *
+ * Stored in `Document.constraints`; solved by `vcad-design-constraints`;
+ * re-verified fail-closed as a `constraint.<label-or-id>` receipt claim.
+ */
+export type DesignConstraint = { 
+/**
+ * Stable id ("c1", "c2", …) for edit/delete and claim identity.
+ */
+id: string, 
+/**
+ * Optional human label used for the receipt claim name.
+ */
+label?: string, 
+/**
+ * The geometric relationship.
+ */
+kind: ConstraintKind, 
+/**
+ * Driven (reference) dimension: contributes no residuals to the solve;
+ * its value is back-annotated from solved geometry instead. Only
+ * meaningful on dimensional kinds.
+ */
+driven: boolean, };
+
+/**
  * The unified, versioned verification receipt for a design.
  */
 export type DesignReceipt = { 
@@ -1246,6 +1495,12 @@ bindings?: Bindings,
  */
 clearance_specs?: Array<ClearanceSpec>, 
 /**
+ * Document-level design constraints spanning sketches, PCB layout, and
+ * mechanical parts. Solved by the design-constraint solver and
+ * re-verified fail-closed as receipt claims (Holds/Stale/Violated).
+ */
+constraints?: Array<DesignConstraint>, 
+/**
  * Persisted solver studies (structural FEA, tolerance stackup, …) for
  * the unified Analyze mode. Like `clearance_specs`, studies are
  * re-verified against the current geometry rather than computed once —
@@ -1371,6 +1626,25 @@ ovalHeight?: number, };
  * Interpolation easing between two keyframes.
  */
 export type Ease = "linear" | "step" | "ease-in-out";
+
+/**
+ * Geometric snapshot of a part edge for fallback resolution, mirroring the
+ * kernel naming crate's `EdgeHint`. Recorded when the anchor is created so
+ * the edge can be re-found geometrically if topological names drift.
+ */
+export type EdgeHintIr = { 
+/**
+ * Edge midpoint in world coordinates (mm).
+ */
+midpoint: [number, number, number], 
+/**
+ * Unit direction of the edge.
+ */
+direction: [number, number, number], 
+/**
+ * Edge length in mm.
+ */
+length: number, };
 
 /**
  * A declarative edge selector, resolved against the current topology at
@@ -3063,6 +3337,11 @@ visibleEdgeColor?: number,
  * Outline color of edges occluded by other geometry, packed 0xRRGGBB (default 0x000000).
  */
 hiddenEdgeColor?: number, };
+
+/**
+ * Which point of a sketch segment an [`Anchor::SketchPoint`] grips.
+ */
+export type SketchPointRef = "start" | "end" | "center";
 
 /**
  * A segment of a 2D sketch profile.

--- a/packages/mcp/src/__tests__/parameters.test.ts
+++ b/packages/mcp/src/__tests__/parameters.test.ts
@@ -73,10 +73,10 @@ describe("parameter tools (handlers)", () => {
     expect(params[0].resolved).toBeCloseTo(10, 9);
   });
 
-  it("set_parameters batch-updates with a changed diff", () => {
+  it("set_parameters batch-updates with a changed diff", async () => {
     documents.set("doc_test", cylinderDoc(10));
     const out = json(
-      setParameters({ document_id: "doc_test", parameters: { r: 15 } }, engine),
+      await setParameters({ document_id: "doc_test", parameters: { r: 15 } }, engine),
     );
     expect(out.updated).toBe(1);
     const changed = out.changed as Array<Record<string, unknown>>;
@@ -86,14 +86,14 @@ describe("parameter tools (handlers)", () => {
     expect(doc.parameters?.r.value).toBe(15);
   });
 
-  it("set_parameters rejects unknown parameters without partial application", () => {
+  it("set_parameters rejects unknown parameters without partial application", async () => {
     documents.set("doc_test", cylinderDoc(10));
-    expect(() =>
+    await expect(
       setParameters(
         { document_id: "doc_test", parameters: { r: 12, nope: 3 } },
         engine,
       ),
-    ).toThrow(/Unknown parameter/);
+    ).rejects.toThrow(/Unknown parameter/);
     // r must be untouched — the batch validated before applying anything.
     const doc = documents.get("doc_test") as Document;
     expect(doc.parameters?.r.value).toBe(10);

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1604,7 +1604,7 @@
   {
     "name": "set_parameters",
     "title": "Set Parameters",
-    "description": "Batch-update named parameter values on an open session document (e.g. { \"r\": 12, \"h\": 8 }). Every name must already be declared; values must be finite numbers. Returns a `changed` diff of the deltas and re-evaluates geometry integrity. Undoable and persisted.",
+    "description": "Batch-update named parameter values on an open session document (e.g. { \"r\": 12, \"h\": 8 }). Every name must already be declared; values must be finite numbers. Returns a `changed` diff of the deltas and re-evaluates geometry integrity. When the document has design constraints, they re-solve automatically (constraint_solve in the result) — a parameter change relayouts everything bound to it. Undoable and persisted.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1671,6 +1671,103 @@
     },
     "annotations": {
       "readOnlyHint": true
+    }
+  },
+  {
+    "name": "add_constraint",
+    "title": "Add Constraint",
+    "description": "Add solver-enforced geometric constraints to the document and solve immediately — KiCad-v11-class constraints generalized to the whole design: PCB footprints and board outline, sketch points, and named mechanical part edges (cross-domain: 'USB connector coincident with the enclosure cutout'). Dimensional values accept formulas over document parameters; set_parameters re-solves. `driven: true` makes a reference dimension (measured, back-annotated, never enforced). Constraints persist and re-verify via build_receipt / verify_receipt as constraint.* claims (Holds/Stale/Violated). The solver moves footprints, outline vertices, and sketch points — never copper or part geometry; re-run route_nets when moved footprints were routed.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id."
+        },
+        "constraints": {
+          "type": "array",
+          "description": "Constraints to add. Each entry is a tagged kind object plus optional `label` (receipt claim name) and `driven` (reference dimension: measured, not enforced). Kinds: coincident{a,b}, distance{a,b,value}, horizontalDistance{a,value}, verticalDistance{a,value}, horizontal{a,b}, vertical{a,b}, parallel{a,b}, perpendicular{a,b}, equalLength{a,b}, length{a,value}, pointOnEdge{point,edge}, concentric{a,b}, fixed{a}, rotation{node,ref,value}, symmetric{a,b,axis}, angle{a,b,value}. Dimensional `value` is a number (mm/deg) or a formula string over document parameters (\"board_width - 2*margin\"). An anchor: {kind:'pcbFootprint', node, ref, pad?} (footprint origin or named pad), {kind:'pcbOutlineVertex'|'pcbOutlineEdge', node, index}, {kind:'sketchPoint', node, segment, point:'start'|'end'|'center'}, or {kind:'partEdge', node, faceA, faceB} (topological face names, e.g. 'n7:top'/'n7:front' — resolved fail-closed; part geometry is authoritative and never moves).",
+          "items": {
+            "type": "object"
+          }
+        }
+      },
+      "required": [
+        "document_id",
+        "constraints"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": false
+    }
+  },
+  {
+    "name": "delete_constraint",
+    "title": "Delete Constraint",
+    "description": "Delete a design constraint by id or label (or `all: true` to clear the set). Frees degrees of freedom; geometry stays where it is.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id."
+        },
+        "id": {
+          "type": "string",
+          "description": "Constraint id (or label) to delete."
+        },
+        "all": {
+          "type": "boolean",
+          "description": "Delete every constraint."
+        }
+      },
+      "required": [
+        "document_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": false
+    }
+  },
+  {
+    "name": "list_constraints",
+    "title": "List Constraints",
+    "description": "List the document's design constraints with their current measured values and residuals, per-group degrees of freedom, and over/under-constrained status. Use before deleting or when a solve reports non-convergence.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id."
+        },
+        "document": {
+          "type": "object",
+          "description": "Inline Document IR (stateless path)."
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "solve_constraints",
+    "title": "Solve Constraints",
+    "description": "Re-solve the document's design constraints against current geometry — run after set_placement, set_board_outline, or sketch edits that may have violated them. Reports per-group convergence and DOF, moved footprints/vertices/sketches, and back-annotates driven dimensions.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id."
+        }
+      },
+      "required": [
+        "document_id"
+      ]
+    },
+    "annotations": {
+      "readOnlyHint": false
     }
   },
   {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -124,6 +124,7 @@ import { toolDefs as exportToolDefs } from "./tools/export.js";
 import { toolDefs as inspectToolDefs } from "./tools/inspect.js";
 import { toolDefs as measureToolDefs } from "./tools/measure.js";
 import { toolDefs as parametersToolDefs } from "./tools/parameters.js";
+import { toolDefs as designConstraintsToolDefs } from "./tools/design-constraints.js";
 import { toolDefs as printCheckToolDefs } from "./tools/print-check.js";
 import { toolDefs as renderToolDefs } from "./tools/render.js";
 import { toolDefs as verifyToolDefs } from "./tools/verify.js";
@@ -311,6 +312,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...inspectToolDefs,
   ...measureToolDefs,
   ...parametersToolDefs,
+  ...designConstraintsToolDefs,
   ...printCheckToolDefs,
   ...renderToolDefs,
   ...verifyToolDefs,
@@ -404,6 +406,11 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "list_parameters",
   "set_parameters",
   "parameter_gradient",
+  // ── Design constraints (document-level geometric solver) ───
+  "add_constraint",
+  "delete_constraint",
+  "list_constraints",
+  "solve_constraints",
   // ── Topology optimization ──────────────────────────────────
   "topology_optimize",
   // ── Charged-particle optics (fusor / IEC / trap family) ────

--- a/packages/mcp/src/tools/constraint-claims.ts
+++ b/packages/mcp/src/tools/constraint-claims.ts
@@ -1,0 +1,241 @@
+/**
+ * Receipt claims for document-level design constraints.
+ *
+ * Every persisted `DesignConstraint` doubles as a verifiable claim: the
+ * `constraint.<label-or-id>` family. `build_receipt` measures each
+ * constraint's residual against current geometry (Pass when it holds within
+ * tolerance, Unverifiable when an anchor can't be resolved — fail-closed);
+ * `verify_receipt` re-measures and classifies Holds / Stale / Violated, the
+ * same contract as `mech.clearance.*`.
+ */
+
+import type {
+  DesignConstraint,
+  DesignReceipt,
+  Document,
+  OracleRef,
+  ReceiptClaim,
+  ReceiptStatus,
+} from "@vcad/ir";
+import { checkDesignConstraints } from "@vcad/engine";
+
+/** Claim-id prefix for the design-constraint family. */
+export const CONSTRAINT_CLAIM_PREFIX = "constraint.";
+
+const CONSTRAINT_DOMAIN = "constraint";
+
+const CONSTRAINT_ORACLE: OracleRef = {
+  id: "vcad-design-constraints/residual",
+  version: "unknown",
+};
+
+/** Residual (mm or degrees) within which a constraint counts as holding. */
+export const CONSTRAINT_HOLD_TOL = 1e-4;
+
+/** Residual drift beyond this (while still holding) reads as Stale. */
+const STALE_EPS = 1e-6;
+
+/** Payload stored in a claim's `details` for later re-verification. */
+interface StoredConstraintClaim {
+  constraint_id: string;
+  type: string;
+  residual: number;
+  driven: boolean;
+}
+
+function claimIdFor(c: DesignConstraint): string {
+  return `${CONSTRAINT_CLAIM_PREFIX}${c.label ?? c.id}`;
+}
+
+function describe(c: DesignConstraint): string {
+  const kind = (c.kind as { type?: string }).type ?? "constraint";
+  return `${c.driven ? "driven " : ""}${kind} constraint "${c.label ?? c.id}" holds`;
+}
+
+/**
+ * One claim per persisted constraint, measured against current geometry.
+ * Fail-closed: a constraint whose residual can't be computed (lost part
+ * anchor, bad ref) is Unverifiable, never silently passing.
+ */
+export async function constraintReceiptClaims(doc: Document): Promise<ReceiptClaim[]> {
+  const constraints = doc.constraints ?? [];
+  if (constraints.length === 0) return [];
+  const outcome = await checkDesignConstraints(doc);
+  const byId = new Map<string, { residual: number; driven: boolean }>();
+  if (outcome.status === "ok") {
+    for (const r of outcome.value.residuals) byId.set(r.id, r);
+  }
+  return constraints.map((c) => {
+    const id = claimIdFor(c);
+    const base = {
+      id,
+      domain: CONSTRAINT_DOMAIN,
+      description: describe(c),
+      subject: c.id,
+      oracle: CONSTRAINT_ORACLE,
+    };
+    if (outcome.status !== "ok") {
+      return {
+        ...base,
+        verdict: "unverifiable" as const,
+        details: `constraint solver unavailable: ${outcome.reason}`,
+      };
+    }
+    const r = byId.get(c.id);
+    if (!r) {
+      return {
+        ...base,
+        verdict: "unverifiable" as const,
+        details: "residual could not be measured (unresolvable anchor?)",
+      };
+    }
+    const holds = c.driven || r.residual <= CONSTRAINT_HOLD_TOL;
+    const stored: StoredConstraintClaim = {
+      constraint_id: c.id,
+      type: (c.kind as { type?: string }).type ?? "unknown",
+      residual: r.residual,
+      driven: c.driven ?? false,
+    };
+    return {
+      ...base,
+      verdict: holds ? ("pass" as const) : ("fail" as const),
+      measured: { value: r.residual, unit: "mm" },
+      details: JSON.stringify(stored),
+    };
+  });
+}
+
+/**
+ * Drop constraints whose board-outline vertex/edge indices no longer exist
+ * (a rewritten outline invalidates indices). Returns the dropped ids so the
+ * mutating tool can report them. Call after `set_board_outline`.
+ */
+export function pruneOutlineConstraints(
+  doc: Document,
+  outlineVertexCount: (node: number) => number | undefined,
+): string[] {
+  const constraints = doc.constraints ?? [];
+  const dropped: string[] = [];
+  doc.constraints = constraints.filter((c) => {
+    for (const v of Object.values(c.kind as unknown as Record<string, unknown>)) {
+      const a = v as { kind?: string; node?: number; index?: number };
+      if (
+        a &&
+        typeof a === "object" &&
+        (a.kind === "pcbOutlineVertex" || a.kind === "pcbOutlineEdge")
+      ) {
+        const n = outlineVertexCount(a.node ?? -1);
+        if (n !== undefined && (a.index ?? 0) >= n) {
+          dropped.push(c.id);
+          return false;
+        }
+      }
+    }
+    return true;
+  });
+  return dropped;
+}
+
+/** Standard "constraints may now be violated" warning for board mutators. */
+export function constraintStaleWarning(doc: Document): string | undefined {
+  const n = doc.constraints?.length ?? 0;
+  if (n === 0) return undefined;
+  return `${n} design constraint(s) exist and may now be violated — run solve_constraints (or list_constraints to inspect)`;
+}
+
+/** Does a receipt carry any constraint claims? */
+export function hasConstraintClaims(receipt: DesignReceipt): boolean {
+  return (receipt.claims ?? []).some((c) => c.id.startsWith(CONSTRAINT_CLAIM_PREFIX));
+}
+
+/** Per-constraint re-verification status. */
+export interface ConstraintCheckStatus {
+  label: string;
+  status: "Holds" | "Stale" | "Violated";
+  residual?: number;
+  stored_residual?: number;
+  reason?: string;
+}
+
+function worst(statuses: ConstraintCheckStatus[]): ReceiptStatus {
+  if (statuses.some((s) => s.status === "Violated")) return "Violated";
+  if (statuses.some((s) => s.status === "Stale")) return "Stale";
+  return "Holds";
+}
+
+/**
+ * Re-verify every constraint claim in a receipt against current geometry:
+ * Violated (residual exceeds tolerance, or unmeasurable — fail-closed),
+ * Stale (holds, but the residual moved from the stored snapshot), Holds.
+ */
+export async function verifyConstraintClaims(
+  doc: Document,
+  receipt: DesignReceipt,
+): Promise<{ status: ReceiptStatus; checks: ConstraintCheckStatus[] }> {
+  const checks: ConstraintCheckStatus[] = [];
+  const outcome = await checkDesignConstraints(doc);
+  const byId = new Map<string, { residual: number; driven: boolean }>();
+  if (outcome.status === "ok") {
+    for (const r of outcome.value.residuals) byId.set(r.id, r);
+  }
+  for (const claim of receipt.claims ?? []) {
+    if (!claim.id.startsWith(CONSTRAINT_CLAIM_PREFIX)) continue;
+    const label = claim.id.slice(CONSTRAINT_CLAIM_PREFIX.length);
+    let stored: StoredConstraintClaim | undefined;
+    try {
+      const parsed = claim.details ? (JSON.parse(claim.details) as StoredConstraintClaim) : undefined;
+      if (parsed && typeof parsed.constraint_id === "string" && typeof parsed.residual === "number") {
+        stored = parsed;
+      }
+    } catch {
+      /* not JSON */
+    }
+    if (!stored) {
+      checks.push({
+        label,
+        status: "Violated",
+        reason: "stored claim carries no re-verifiable payload",
+      });
+      continue;
+    }
+    if (outcome.status !== "ok") {
+      checks.push({
+        label,
+        status: "Violated",
+        stored_residual: stored.residual,
+        reason: `cannot re-measure: ${outcome.reason}`,
+      });
+      continue;
+    }
+    const now = byId.get(stored.constraint_id);
+    if (!now) {
+      checks.push({
+        label,
+        status: "Violated",
+        stored_residual: stored.residual,
+        reason: "constraint no longer exists on the document (or its anchor is unresolvable)",
+      });
+      continue;
+    }
+    if (!stored.driven && now.residual > CONSTRAINT_HOLD_TOL) {
+      checks.push({
+        label,
+        status: "Violated",
+        residual: now.residual,
+        stored_residual: stored.residual,
+        reason: `residual ${now.residual} exceeds tolerance ${CONSTRAINT_HOLD_TOL}`,
+      });
+    } else if (Math.abs(now.residual - stored.residual) > STALE_EPS) {
+      checks.push({
+        label,
+        status: "Stale",
+        residual: now.residual,
+        stored_residual: stored.residual,
+        reason: "still holds, but geometry moved since the receipt was built",
+      });
+    } else {
+      checks.push({ label, status: "Holds", residual: now.residual });
+    }
+  }
+  return { status: worst(checks), checks };
+}

--- a/packages/mcp/src/tools/design-constraints.ts
+++ b/packages/mcp/src/tools/design-constraints.ts
@@ -1,0 +1,361 @@
+/**
+ * Document-level design-constraint tools — KiCad-v11-class geometric
+ * constraints, generalized to the whole vcad document.
+ *
+ *  - `add_constraint` — batch-add constraints (footprints, board outline,
+ *    sketch points, named part edges) and auto-solve.
+ *  - `delete_constraint` / `list_constraints` — manage the persisted set.
+ *  - `solve_constraints` — explicit re-solve (after set_placement /
+ *    set_board_outline / geometry edits).
+ *
+ * Dimensions are expressions: a distance can be `"board_width - 2*margin"`
+ * over named document parameters — `set_parameters` re-solves the set.
+ * Mechanical part anchors are authoritative: constraints pull boards and
+ * sketches toward parts, never the reverse. The solver never touches
+ * copper; when solved footprints have routed traces, re-run `route_nets`.
+ */
+
+import { behavior, type ToolDef } from "./tool-def.js";
+import type { Anchor, ConstraintKind, DesignConstraint, Document } from "@vcad/ir";
+import {
+  checkDesignConstraints,
+  solveDesignConstraints,
+  type DesignSolveReport,
+} from "@vcad/engine";
+import { resolveDocInput } from "./session-core.js";
+import { getNodePcb, getPcbNodeIds } from "@vcad/core";
+import { summarizePlacementDrc } from "./ecad.js";
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+function jsonResult(payload: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+}
+
+function err(text: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${text}` }], isError: true };
+}
+
+const anchorDescription =
+  "An anchor: {kind:'pcbFootprint', node, ref, pad?} (footprint origin or " +
+  "named pad), {kind:'pcbOutlineVertex'|'pcbOutlineEdge', node, index}, " +
+  "{kind:'sketchPoint', node, segment, point:'start'|'end'|'center'}, or " +
+  "{kind:'partEdge', node, faceA, faceB} (topological face names, e.g. " +
+  "'n7:top'/'n7:front' — resolved fail-closed; part geometry is " +
+  "authoritative and never moves).";
+
+export const addConstraintSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: { type: "string" as const, description: "Session id." },
+    constraints: {
+      type: "array" as const,
+      description:
+        "Constraints to add. Each entry is a tagged kind object plus optional " +
+        "`label` (receipt claim name) and `driven` (reference dimension: " +
+        "measured, not enforced). Kinds: coincident{a,b}, distance{a,b,value}, " +
+        "horizontalDistance{a,value}, verticalDistance{a,value}, " +
+        "horizontal{a,b}, vertical{a,b}, parallel{a,b}, perpendicular{a,b}, " +
+        "equalLength{a,b}, length{a,value}, pointOnEdge{point,edge}, " +
+        "concentric{a,b}, fixed{a}, rotation{node,ref,value}, " +
+        "symmetric{a,b,axis}, angle{a,b,value}. Dimensional `value` is a " +
+        "number (mm/deg) or a formula string over document parameters " +
+        "(\"board_width - 2*margin\"). " +
+        anchorDescription,
+      items: { type: "object" as const },
+    },
+  },
+  required: ["document_id", "constraints"],
+};
+
+export const deleteConstraintSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: { type: "string" as const, description: "Session id." },
+    id: { type: "string" as const, description: "Constraint id (or label) to delete." },
+    all: { type: "boolean" as const, description: "Delete every constraint." },
+  },
+  required: ["document_id"],
+};
+
+export const listConstraintsSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: { type: "string" as const, description: "Session id." },
+    document: { type: "object" as const, description: "Inline Document IR (stateless path)." },
+  },
+};
+
+export const solveConstraintsSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: { type: "string" as const, description: "Session id." },
+  },
+  required: ["document_id"],
+};
+
+/** Next free "cN" id given the existing set. */
+function nextId(existing: DesignConstraint[]): number {
+  let max = 0;
+  for (const c of existing) {
+    const m = /^c(\d+)$/.exec(c.id);
+    if (m) max = Math.max(max, Number(m[1]));
+  }
+  return max + 1;
+}
+
+/** Apply a solved document back onto the session object in place. */
+function applySolved(doc: Document, solved: Document): void {
+  doc.nodes = solved.nodes;
+  doc.constraints = solved.constraints;
+}
+
+/** Post-solve caveats: routed copper under moved footprints. */
+function copperWarnings(doc: Document, report: DesignSolveReport): string[] {
+  if (report.movedFootprints.length === 0) return [];
+  for (const nodeId of getPcbNodeIds(doc)) {
+    const pcb = getNodePcb(doc, nodeId);
+    if (pcb && (pcb.traces?.length || pcb.vias?.length)) {
+      return [
+        `moved footprints (${report.movedFootprints.join(", ")}) may have routed copper — re-run route_nets`,
+      ];
+    }
+  }
+  return [];
+}
+
+/** Placement DRC for the first board when footprints moved. */
+async function placementDrcIfMoved(doc: Document, report: DesignSolveReport) {
+  if (report.movedFootprints.length === 0) return undefined;
+  const nodeId = getPcbNodeIds(doc)[0];
+  const pcb = nodeId != null ? getNodePcb(doc, nodeId) : null;
+  return pcb ? await summarizePlacementDrc(pcb) : undefined;
+}
+
+async function solveAndReport(doc: Document, documentId?: string): Promise<ToolResult> {
+  const outcome = await solveDesignConstraints(doc);
+  if (outcome.status !== "ok") {
+    return err(`constraint solve unavailable: ${outcome.reason}`);
+  }
+  const { document: solved, report } = outcome.value;
+  applySolved(doc, solved);
+  const placementDrc = await placementDrcIfMoved(doc, report);
+  const warnings = [...report.warnings, ...copperWarnings(doc, report)];
+  return jsonResult({
+    success: report.converged && report.errors.length === 0,
+    report: { ...report, warnings },
+    ...(placementDrc ? { placement_drc: placementDrc } : {}),
+    ...(documentId ? { document_id: documentId } : {}),
+  });
+}
+
+/** Split a wire entry into (kind, label, driven), validating the tag. */
+function parseEntry(
+  entry: Record<string, unknown>,
+): { kind: ConstraintKind; label?: string; driven: boolean } | string {
+  const { label, driven, id: _ignored, ...kindFields } = entry;
+  const type = kindFields.type;
+  if (typeof type !== "string") return "each constraint needs a `type` field";
+  const known = [
+    "coincident",
+    "distance",
+    "horizontalDistance",
+    "verticalDistance",
+    "horizontal",
+    "vertical",
+    "parallel",
+    "perpendicular",
+    "equalLength",
+    "length",
+    "pointOnEdge",
+    "concentric",
+    "fixed",
+    "rotation",
+    "symmetric",
+    "angle",
+  ];
+  if (!known.includes(type)) return `unknown constraint type "${type}"`;
+  return {
+    kind: kindFields as unknown as ConstraintKind,
+    label: typeof label === "string" ? label : undefined,
+    driven: driven === true,
+  };
+}
+
+/** Validate anchors against the document so bad refs fail at add time. */
+function validateAnchors(doc: Document, kind: ConstraintKind): string | undefined {
+  const anchors: Anchor[] = [];
+  for (const v of Object.values(kind as unknown as Record<string, unknown>)) {
+    if (v && typeof v === "object" && "kind" in (v as Record<string, unknown>)) {
+      anchors.push(v as Anchor);
+    }
+  }
+  for (const a of anchors) {
+    const node = doc.nodes[String((a as { node: number }).node)];
+    if (!node) return `anchor references missing node ${(a as { node: number }).node}`;
+    if (a.kind === "pcbFootprint") {
+      const pcb = getNodePcb(doc, (a as { node: number }).node);
+      if (!pcb) return `node ${(a as { node: number }).node} is not a PCB board`;
+      const fp = pcb.footprints.find((f) => f.ref === (a as { ref: string }).ref);
+      if (!fp) return `footprint "${(a as { ref: string }).ref}" not found`;
+    }
+    if (a.kind === "pcbOutlineVertex" || a.kind === "pcbOutlineEdge") {
+      const pcb = getNodePcb(doc, (a as { node: number }).node);
+      if (!pcb) return `node ${(a as { node: number }).node} is not a PCB board`;
+      const n = pcb.outline.vertices?.length ?? 0;
+      if ((a as { index: number }).index >= n) {
+        return `outline index ${(a as { index: number }).index} out of range (${n} vertices)`;
+      }
+    }
+  }
+  return undefined;
+}
+
+export async function addConstraint(args: Record<string, unknown>): Promise<ToolResult> {
+  const ctx = resolveDocInput(args);
+  const entries = Array.isArray(args.constraints)
+    ? (args.constraints as Array<Record<string, unknown>>)
+    : undefined;
+  if (!entries || entries.length === 0) {
+    return err("`constraints` must be a non-empty array of constraint objects");
+  }
+  ctx.doc.constraints ??= [];
+  let id = nextId(ctx.doc.constraints);
+  const added: string[] = [];
+  for (const entry of entries) {
+    const parsed = parseEntry(entry);
+    if (typeof parsed === "string") return err(parsed);
+    const bad = validateAnchors(ctx.doc, parsed.kind);
+    if (bad) return err(`constraint ${added.length + 1}: ${bad}`);
+    const cid = `c${id++}`;
+    ctx.doc.constraints.push({
+      id: cid,
+      ...(parsed.label !== undefined ? { label: parsed.label } : {}),
+      kind: parsed.kind,
+      driven: parsed.driven,
+    } as DesignConstraint);
+    added.push(cid);
+  }
+  const result = await solveAndReport(ctx.doc, ctx.documentId);
+  if (result.isError) return result;
+  const payload = JSON.parse(result.content[0].text) as Record<string, unknown>;
+  return jsonResult({ added, ...payload });
+}
+
+export async function deleteConstraint(args: Record<string, unknown>): Promise<ToolResult> {
+  const ctx = resolveDocInput(args);
+  const constraints = ctx.doc.constraints ?? [];
+  if (args.all === true) {
+    const removed = constraints.length;
+    ctx.doc.constraints = [];
+    return jsonResult({ removed, ...(ctx.documentId ? { document_id: ctx.documentId } : {}) });
+  }
+  const id = typeof args.id === "string" ? args.id : "";
+  if (!id) return err("pass `id` (constraint id or label) or `all: true`");
+  const before = constraints.length;
+  ctx.doc.constraints = constraints.filter((c) => c.id !== id && c.label !== id);
+  const removed = before - ctx.doc.constraints.length;
+  if (removed === 0) {
+    return err(`no constraint with id or label "${id}" — see list_constraints`);
+  }
+  // Deleting only frees DOF; no re-solve needed.
+  return jsonResult({ removed, ...(ctx.documentId ? { document_id: ctx.documentId } : {}) });
+}
+
+export async function listConstraints(args: Record<string, unknown>): Promise<ToolResult> {
+  const ctx = resolveDocInput(args);
+  const constraints = ctx.doc.constraints ?? [];
+  if (constraints.length === 0) {
+    return jsonResult({
+      constraints: [],
+      hint: "add_constraint persists solver-enforced geometric relationships",
+    });
+  }
+  const outcome = await checkDesignConstraints(ctx.doc);
+  const report = outcome.status === "ok" ? outcome.value : undefined;
+  const residuals = new Map(report?.residuals.map((r) => [r.id, r.residual]) ?? []);
+  const measured = new Map(report?.drivenValues.map((d) => [d.id, d.value]) ?? []);
+  return jsonResult({
+    constraints: constraints.map((c) => ({
+      ...c,
+      ...(measured.has(c.id) ? { measured: measured.get(c.id) } : {}),
+      ...(residuals.has(c.id) ? { residual: residuals.get(c.id) } : {}),
+    })),
+    ...(report
+      ? {
+          groups: report.groups,
+          converged: report.converged,
+          errors: report.errors,
+        }
+      : { check: "unavailable — kernel WASM not loaded" }),
+    ...(ctx.documentId ? { document_id: ctx.documentId } : {}),
+  });
+}
+
+export async function solveConstraints(args: Record<string, unknown>): Promise<ToolResult> {
+  const ctx = resolveDocInput(args);
+  if (!ctx.doc.constraints || ctx.doc.constraints.length === 0) {
+    return err("document has no constraints — add some with add_constraint");
+  }
+  return solveAndReport(ctx.doc, ctx.documentId);
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "add_constraint",
+    pack: null,
+    description:
+      "Add solver-enforced geometric constraints to the document and solve " +
+      "immediately — KiCad-v11-class constraints generalized to the whole " +
+      "design: PCB footprints and board outline, sketch points, and named " +
+      "mechanical part edges (cross-domain: 'USB connector coincident with " +
+      "the enclosure cutout'). Dimensional values accept formulas over " +
+      "document parameters; set_parameters re-solves. `driven: true` makes a " +
+      "reference dimension (measured, back-annotated, never enforced). " +
+      "Constraints persist and re-verify via build_receipt / verify_receipt " +
+      "as constraint.* claims (Holds/Stale/Violated). The solver moves " +
+      "footprints, outline vertices, and sketch points — never copper or " +
+      "part geometry; re-run route_nets when moved footprints were routed.",
+    inputSchema: addConstraintSchema,
+    handler: (a) => addConstraint(a),
+    behavior: behavior({ writesDoc: true }),
+  },
+  {
+    name: "delete_constraint",
+    pack: null,
+    description:
+      "Delete a design constraint by id or label (or `all: true` to clear " +
+      "the set). Frees degrees of freedom; geometry stays where it is.",
+    inputSchema: deleteConstraintSchema,
+    handler: (a) => deleteConstraint(a),
+    behavior: behavior({ writesDoc: true }),
+  },
+  {
+    name: "list_constraints",
+    pack: null,
+    description:
+      "List the document's design constraints with their current measured " +
+      "values and residuals, per-group degrees of freedom, and " +
+      "over/under-constrained status. Use before deleting or when a solve " +
+      "reports non-convergence.",
+    inputSchema: listConstraintsSchema,
+    handler: (a) => listConstraints(a),
+    behavior: behavior({}),
+  },
+  {
+    name: "solve_constraints",
+    pack: null,
+    description:
+      "Re-solve the document's design constraints against current geometry " +
+      "— run after set_placement, set_board_outline, or sketch edits that " +
+      "may have violated them. Reports per-group convergence and DOF, moved " +
+      "footprints/vertices/sketches, and back-annotates driven dimensions.",
+    inputSchema: solveConstraintsSchema,
+    handler: (a) => solveConstraints(a),
+    behavior: behavior({ writesDoc: true }),
+  },
+];

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -43,6 +43,13 @@ import {
   hasClearanceClaims,
   verifyClearanceClaims,
 } from "./clearance.js";
+import {
+  constraintReceiptClaims,
+  constraintStaleWarning,
+  hasConstraintClaims,
+  pruneOutlineConstraints,
+  verifyConstraintClaims,
+} from "./constraint-claims.js";
 import { getNodePcb, getPcbNodeIds, buildEntry, agentView, diffViolations } from "@vcad/core";
 import {
   computeRatsnest,
@@ -7382,12 +7389,24 @@ export async function setBoardOutline(args: Record<string, unknown>) {
   const width = round3(Math.max(...xs) - Math.min(...xs));
   const height = round3(Math.max(...ys) - Math.min(...ys));
 
+  // A rewritten outline invalidates vertex indices — drop constraints whose
+  // indices are now out of range (reported), and warn about the rest.
+  const droppedConstraints = pruneOutlineConstraints(ctx.doc, (node) => {
+    const p = getNodePcb(ctx.doc, node);
+    return p ? (p.outline.vertices?.length ?? 0) : undefined;
+  });
+  const constraintWarning = constraintStaleWarning(ctx.doc);
+
   return {
     content: [
       {
         type: "text" as const,
         text: JSON.stringify({
           success: true,
+          ...(droppedConstraints.length > 0
+            ? { dropped_constraints: droppedConstraints }
+            : {}),
+          ...(constraintWarning ? { constraint_warning: constraintWarning } : {}),
           outline: {
             width,
             height,
@@ -8675,6 +8694,12 @@ export async function setPlacement(args: Record<string, unknown>) {
       `no footprints updated${unknownRefs.length ? ` — all refs unknown: ${unknownRefs.join(", ")}` : ""}`,
     );
   }
+
+  // Explicit placements deliberately do NOT auto-solve constraints — that
+  // would silently undo the caller's just-requested positions when they
+  // conflict. Warn instead so agency stays with the caller.
+  const staleWarning = constraintStaleWarning(ctx.doc);
+  if (staleWarning) warnings.push(staleWarning);
 
   // Re-check the floorplan after the move so the caller can branch on the
   // result in one call — the move→re-check loop never has to reach run_drc.
@@ -12752,22 +12777,26 @@ export async function buildReceipt(args: Record<string, unknown>, engine?: Engin
   const pcb = getDocPcb(ctx.doc);
   const clearanceSpecs = ctx.doc.clearance_specs ?? [];
   if (!pcb) {
-    if (clearanceSpecs.length === 0) {
+    if (clearanceSpecs.length === 0 && (ctx.doc.constraints ?? []).length === 0) {
       return {
         content: [
           {
             type: "text" as const,
-            text: "Error: Document has no PCB and no clearance specs — nothing to certify. (Persist mechanical assertions with check_clearance + label first.)",
+            text: "Error: Document has no PCB, no clearance specs, and no design constraints — nothing to certify. (Persist assertions with check_clearance + label or add_constraint first.)",
           },
         ],
         isError: true,
       };
     }
-    // Mechanical-only receipt: re-measure every persisted clearance spec.
+    // Mechanical-only receipt: re-measure every persisted clearance spec
+    // and design constraint.
     const unified: DesignReceipt = {
       schema: RECEIPT_SCHEMA,
       ...(ctx.documentId ? { document_id: ctx.documentId } : {}),
-      claims: clearanceReceiptClaims(ctx.doc, engine),
+      claims: [
+        ...clearanceReceiptClaims(ctx.doc, engine),
+        ...(await constraintReceiptClaims(ctx.doc)),
+      ],
     };
     return {
       content: [
@@ -12838,6 +12867,10 @@ export async function buildReceipt(args: Record<string, unknown>, engine?: Engin
   // board+mechanics document certifies both domains in one receipt.
   if (clearanceSpecs.length > 0) {
     unified.claims.push(...clearanceReceiptClaims(ctx.doc, engine));
+  }
+  // Design constraints certify as constraint.* claims in the same ledger.
+  if ((ctx.doc.constraints ?? []).length > 0) {
+    unified.claims.push(...(await constraintReceiptClaims(ctx.doc)));
   }
 
   // The receipt rides in structuredContent so the inline viewer renders it
@@ -12937,13 +12970,14 @@ export async function verifyReceipt(args: Record<string, unknown>, engine?: Engi
     }
   }
   const clearanceReceipt = unified && hasClearanceClaims(unified) ? unified : undefined;
+  const constraintReceipt = unified && hasConstraintClaims(unified) ? unified : undefined;
 
-  if (!legacy && !clearanceReceipt) {
+  if (!legacy && !clearanceReceipt && !constraintReceipt) {
     return {
       content: [
         {
           type: "text" as const,
-          text: "Error: `receipt` carries nothing re-verifiable — pass a PCB Receipt (board_hash) or a unified DesignReceipt with mech.clearance claims, as produced by build_receipt.",
+          text: "Error: `receipt` carries nothing re-verifiable — pass a PCB Receipt (board_hash) or a unified DesignReceipt with mech.clearance or constraint.* claims, as produced by build_receipt.",
         },
       ],
       isError: true,
@@ -12993,10 +13027,17 @@ export async function verifyReceipt(args: Record<string, unknown>, engine?: Engi
     statuses.push(clearance.status);
   }
 
+  let constraintChecks: Awaited<ReturnType<typeof verifyConstraintClaims>> | undefined;
+  if (constraintReceipt) {
+    constraintChecks = await verifyConstraintClaims(ctx.doc, constraintReceipt);
+    statuses.push(constraintChecks.status);
+  }
+
   const payload = {
     status: worstStatus(statuses),
     ...(boardHash ? { board_hash: boardHash } : {}),
     ...(clearance ? { clearance } : {}),
+    ...(constraintChecks ? { constraints: constraintChecks } : {}),
   };
   return {
     content: [{ type: "text" as const, text: JSON.stringify(payload) }],

--- a/packages/mcp/src/tools/parameters.ts
+++ b/packages/mcp/src/tools/parameters.ts
@@ -19,7 +19,7 @@
 
 import type { Engine, PartParameterGradient } from "@vcad/engine";
 import { behavior, type ToolDef } from "./tool-def.js";
-import { resolveParameters } from "@vcad/engine";
+import { resolveParameters, solveDesignConstraints } from "@vcad/engine";
 import type { Document, Expr, Parameter } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
 import { getSession, resolveDocInput } from "./session-core.js";
@@ -123,7 +123,7 @@ interface ParameterDelta {
   value: number;
 }
 
-export function setParameters(input: unknown, engine: Engine): ToolResult {
+export async function setParameters(input: unknown, engine: Engine): Promise<ToolResult> {
   const args = (input ?? {}) as Record<string, unknown>;
   const documentId = String(args.document_id ?? "");
   if (!documentId) {
@@ -163,10 +163,26 @@ export function setParameters(input: unknown, engine: Engine): ToolResult {
     param.value = value as number;
   }
 
+  // Parameters drive constraint dimensions ("board_width - 2*margin") —
+  // re-solve the document's design constraints so a parameter change
+  // relayouts everything bound to it in the same call.
+  let constraintSolve: Record<string, unknown> | undefined;
+  if ((doc.constraints ?? []).length > 0) {
+    const outcome = await solveDesignConstraints(doc);
+    if (outcome.status === "ok") {
+      doc.nodes = outcome.value.document.nodes;
+      doc.constraints = outcome.value.document.constraints;
+      constraintSolve = outcome.value.report as unknown as Record<string, unknown>;
+    } else {
+      constraintSolve = { unavailable: outcome.reason };
+    }
+  }
+
   const result: ToolResult = jsonResult({
     document_id: documentId,
     updated: changed.length,
     changed,
+    ...(constraintSolve ? { constraint_solve: constraintSolve } : {}),
   });
   result.structuredContent = { changed };
 
@@ -249,7 +265,7 @@ export const toolDefs: ToolDef[] = [
     name: "set_parameters",
     pack: null,
     description:
-      "Batch-update named parameter values on an open session document (e.g. { \"r\": 12, \"h\": 8 }). Every name must already be declared; values must be finite numbers. Returns a `changed` diff of the deltas and re-evaluates geometry integrity. Undoable and persisted.",
+      "Batch-update named parameter values on an open session document (e.g. { \"r\": 12, \"h\": 8 }). Every name must already be declared; values must be finite numbers. Returns a `changed` diff of the deltas and re-evaluates geometry integrity. When the document has design constraints, they re-solve automatically (constraint_solve in the result) — a parameter change relayouts everything bound to it. Undoable and persisted.",
     inputSchema: setParametersSchema,
     // Batch-updates named parameters → geometry changes, so it must
     // snapshot (undo) and persist like any other document mutator.

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -151,6 +151,12 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
   },
   parameter_gradient: { title: "Parameter Gradient", annotations: RO },
 
+  // ── Design constraints (document-level geometric solver) ───────────────
+  add_constraint: { title: "Add Constraint", annotations: RW },
+  delete_constraint: { title: "Delete Constraint", annotations: RW },
+  list_constraints: { title: "List Constraints", annotations: RO },
+  solve_constraints: { title: "Solve Constraints", annotations: RW },
+
   // ── Print-then-measure calibration loop ────────────────────────────────
   predict_print: { title: "Predict Print", annotations: RO },
   record_measurement: { title: "Record Measurement", annotations: RW },

--- a/scripts/gen-ir-types.mjs
+++ b/scripts/gen-ir-types.mjs
@@ -80,7 +80,7 @@ if (files.length === 0) {
 //       reader code, e.g. `front !== false`) treats them as optional.
 const FORCE_OPTIONAL = {
   Instance: ["tags"],
-  Document: ["parameters", "bindings", "clearance_specs", "analysis_studies"],
+  Document: ["parameters", "bindings", "clearance_specs", "analysis_studies", "constraints"],
   DesignRules: ["classRules", "netClassAssignments"],
   BoardOutline: ["cutouts"],
   Zone: ["holes", "priority", "minArea", "fillType", "thermalRelief"],


### PR DESCRIPTION
## What

Document-level geometric constraints — the answer to KiCad v11's planegcs-based PCB constraints, generalized to the whole vcad document instead of one editor:

- **Universal anchors, one constraint set.** `Document.constraints: Vec<DesignConstraint>` (new `crates/vcad-ir/src/constraints.rs`) referencing PCB footprints/pads, board-outline vertices/edges, sketch points/segments, and **mechanical part edges** via the topological-naming system (`FaceName` pairs, fail-closed — ambiguous/lost names skip with an error, never a silent rebind).
- **Dimensions are expressions.** A distance can be `"board_width - 2*edge_margin"` over named document parameters; `set_parameters` auto-re-solves the whole set. `driven: true` makes a reference dimension (0 residuals, measured and back-annotated after each solve) — KiCad's driven-dimension parity.
- **Cross-domain, parts authoritative.** Part-edge anchors resolve through an `AnchorResolver` (kernel `resolve_named_edge`) and enter the solve as fixed references — "connector coincident with the enclosure cutout edge" pulls the board, never the part.
- **Constraints are claims.** Each constraint doubles as a `constraint.*` receipt claim: `build_receipt` certifies (Pass/Fail/Unverifiable, fail-closed), `verify_receipt` re-verifies Holds/Stale/Violated.

## Pieces

| Layer | Change |
|---|---|
| Solver | New `crates/vcad-design-constraints`: lowers per-plane groups (per board / per sketch) onto the existing LM `Sketch2D` solver; rotation rides a pseudo-circle radius param; new `OffsetCoincident` kernel constraint couples pads to origins. 11 unit tests. |
| WASM | `solveDesignConstraints` / `checkDesignConstraints` (stateless doc-in/doc-out; `extraFixed` pins the dragged footprint for interactive solves). |
| MCP | `add_constraint` / `delete_constraint` / `list_constraints` / `solve_constraints`; `set_placement`/`set_board_outline` warn rather than silently undoing the caller; outline rewrites drop out-of-range vertex-index constraints and report them. |
| App | Constrain tool in the board editor (type sub-row, formula-capable value input), dimension leaders + glyphs in the 3D view (driven dims dashed/muted), DOF status chip, inspector edit/delete, drag-end re-solve. Persistence via a new `design-constraints` CRDT feature kind. |
| Sketch | Session sketch constraints now persist onto the document on extrude/revolve commit (previously lost on save). |

## Verification

- `cargo test --workspace`, `cargo clippy --workspace --exclude vcad-desktop -- -D warnings`, `cargo fmt --check`, `ir:gen`/`ir:check`, all workspace TS builds, 936 MCP tests — green.
- MCP e2e: schematic → place → formula-valued distance solved exactly → `set_parameters` relayout in one call → receipt claims pass → deliberate `set_placement` move → verify **Violated** → `solve_constraints` → **Holds**.
- Cross-domain e2e: footprint pulled onto a cube's named edge through kernel evaluation of the part.
- In-browser: store-level solve converges and writes back through the CRDT (undoable), dimension label renders on the board, Constrain tool + sub-row functional.

## Reviewer notes

- **No wasm artifacts committed** — `wasm-refresh.yml` rebuilds them on merge; local testing needs a `packages/kernel-wasm` rebuild for the new exports (both MCP and app degrade gracefully against the old wasm).
- Known v1 limits (documented in code + `kernel-features.mdx`): outline vertex indices are fragile under outline rewrites (drop-and-report), pad anchor + free rotation is an approximation with a warning, cross-domain constraints are MCP-only in the app (no part-edge picking UI yet), one-way part→board solving.
- `App.tsx` gains a dev-only `window.__vcadDocumentStore` debug handle (DEV builds only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)