### PR TITLE
fix(ci): build mcp server packages in dependency order for publish

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -42,8 +42,16 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install
         run: npm ci
-      - name: Build workspace (checked-in kernel WASM)
-        run: VCAD_WASM_SKIP=1 npm run build --workspaces --if-present
+      - name: Build server packages (checked-in kernel WASM)
+        # Explicit dependency order — `npm run build --workspaces` does NOT
+        # topologically sort, so @vcad/app can build before its deps and fail
+        # the step. Same package set + order as services/mcp/build.sh; the
+        # rest of the workspace (app, docs, leaderboard) is irrelevant here.
+        run: |
+          npm run build -w @vcad/ir
+          npm run build -w @vcad/engine
+          npm run build -w @vcad/core
+          npm run build -w @vcad/mcp
       - name: Stage npm bundle
         run: |
           BASE=$(node -p "require('./packages/mcp/package.json').version")

--- a/packages/mcp/scripts/serve.mjs
+++ b/packages/mcp/scripts/serve.mjs
@@ -69,12 +69,18 @@ const fingerprint = sourceFingerprint();
 const entry = join(mcpDir, "dist", "index.js");
 
 if (readStamp() !== fingerprint || !existsSync(entry)) {
-  log("dist is stale (or unstamped) — rebuilding workspace from source…");
-  execSync("npm run build --workspaces --if-present", {
-    cwd: repo,
-    stdio: ["ignore", process.stderr, process.stderr], // keep stdout clean for MCP
-    env: { ...process.env, VCAD_WASM_SKIP: "1" },
-  });
+  log("dist is stale (or unstamped) — rebuilding server packages from source…");
+  // Explicit dependency order — `npm run build --workspaces` does NOT
+  // topologically sort (proven by the first mcp-publish CI run, where
+  // @vcad/app built before its deps and failed). Same set + order as
+  // services/mcp/build.sh.
+  for (const pkg of ["@vcad/ir", "@vcad/engine", "@vcad/core", "@vcad/mcp"]) {
+    execSync(`npm run build -w ${pkg}`, {
+      cwd: repo,
+      stdio: ["ignore", process.stderr, process.stderr], // keep stdout clean for MCP
+      env: { ...process.env, VCAD_WASM_SKIP: "1" },
+    });
+  }
   writeFileSync(
     stampPath,
     JSON.stringify({ fingerprint, builtAt: new Date().toISOString() }, null, 2),


### PR DESCRIPTION
npm run build --workspaces does not topologically sort — the first
mcp-publish run had @vcad/app build before ir/engine/core and fail the
step. Build the four server packages explicitly (same set + order as
services/mcp/build.sh) in both the publish workflow and serve.mjs.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
