### PR TITLE
render_view refuses over-dense documents instead of crashing

### DIFF
--- a/changelog/entries/2026-07-23-render-view-triangle-guard.json
+++ b/changelog/entries/2026-07-23-render-view-triangle-guard.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-23-render-view-triangle-guard",
+  "version": "0.9.4",
+  "date": "2026-07-23",
+  "category": "fix",
+  "title": "render_view refuses over-dense documents instead of crashing",
+  "summary": "Documents tessellating past 120k triangles (e.g. large sphere patterns) now get an actionable error from render_view instead of OOM-killing the server with a >100 MB per-triangle SVG.",
+  "features": ["render"],
+  "mcpTools": ["render_view"]
+}

--- a/packages/mcp/src/__tests__/render-triangle-guard.test.ts
+++ b/packages/mcp/src/__tests__/render-triangle-guard.test.ts
@@ -1,0 +1,58 @@
+/**
+ * render_view must refuse documents whose tessellation is too dense to
+ * render, instead of OOM-killing the process. The drafting renderer emits
+ * one SVG element per visible triangle, so a ~380k-triangle document (e.g.
+ * a 20×20 sphere pattern) built a >100 MB SVG and took the instance down
+ * with it — the agent saw only a 502. The mutation-integrity pass already
+ * counts triangles; render_view consults that count up front.
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderView, rasterize } from "../tools/render.js";
+import { openDocument } from "../tools/session.js";
+import { recordTriangles } from "../tools/session-core.js";
+
+function openSession(): string {
+  const out = openDocument({});
+  const parsed = JSON.parse(out.content[0]!.text) as { document_id: string };
+  return parsed.document_id;
+}
+
+describe("render_view triangle guard", () => {
+  it("refuses a session whose last integrity pass exceeded the budget", async () => {
+    const id = openSession();
+    recordTriangles(id, 384_024);
+    const out = await renderView({ document_id: id });
+    expect(out.isError).toBe(true);
+    const payload = JSON.parse(
+      (out.content[0] as { type: "text"; text: string }).text,
+    ) as { error: string; hint: string };
+    expect(payload.error).toMatch(/render refused/);
+    expect(payload.error).toMatch(/384024 triangles/);
+    expect(payload.hint).toMatch(/inspect_cad/);
+  });
+
+  it("still renders a session under the budget", async () => {
+    const id = openSession();
+    recordTriangles(id, 61_464);
+    const out = await renderView({ document_id: id });
+    // Empty doc renders (or degrades to SVG without resvg) — but must not
+    // trip the triangle guard.
+    const text = out.content.find((c) => c.type === "text") as
+      | { type: "text"; text: string }
+      | undefined;
+    expect(text?.text ?? "").not.toMatch(/render refused/);
+  });
+
+  it("rasterize refuses an SVG beyond the raster byte cap", async () => {
+    // A structurally valid SVG padded past the cap — must be refused before
+    // reaching resvg, not OOM inside it.
+    const pad = "<!-- x -->".repeat((64 * 1024 * 1024) / 10 + 1);
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">${pad}</svg>`;
+    const out = await rasterize(svg, 200);
+    expect(out.png).toBeNull();
+    if (out.png === null) {
+      expect(out.reason).toMatch(/rasterization refused/);
+    }
+  });
+});

--- a/packages/mcp/src/tools/batch-edit.ts
+++ b/packages/mcp/src/tools/batch-edit.ts
@@ -23,7 +23,12 @@
  */
 
 import type { Document } from "@vcad/ir";
-import { documents, getSession, recordLastChanged } from "./session.js";
+import {
+  documents,
+  getSession,
+  recordLastChanged,
+  recordTriangles,
+} from "./session.js";
 import {
   runMutation,
   snapshotParts,
@@ -305,7 +310,10 @@ export function applyEdits(
     ]);
     if (engine) {
       const integrity = computeIntegrity(working, engine);
-      if (integrity) appendIntegrity(result, integrity);
+      if (integrity) {
+        appendIntegrity(result, integrity);
+        recordTriangles(documentId, integrity.triangles);
+      }
     }
   }
   return result;

--- a/packages/mcp/src/tools/loon.ts
+++ b/packages/mcp/src/tools/loon.ts
@@ -6,7 +6,7 @@ import type { Engine } from "@vcad/engine";
 import { toVCode } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
 import { hydrateMacros, macroPrelude, type InlineLoon } from "./loon-macros.js";
-import { documents, getSession } from "./session-core.js";
+import { documents, getSession, recordTriangles } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import type { ToolResult } from "./tool-result.js";
 
@@ -146,7 +146,10 @@ export const toolDefs: ToolDef[] = [
         if (doc) {
           if (targetId) documents.set(targetId, doc);
           const integrity = computeIntegrity(doc, ctx.engine);
-          if (integrity) appendIntegrity(result, integrity);
+          if (integrity) {
+            appendIntegrity(result, integrity);
+            if (targetId) recordTriangles(targetId, integrity.triangles);
+          }
         }
       } catch {
         // Best-effort: never fail the authoring call over accounting.

--- a/packages/mcp/src/tools/parameters.ts
+++ b/packages/mcp/src/tools/parameters.ts
@@ -22,7 +22,11 @@ import { behavior, type ToolDef } from "./tool-def.js";
 import { resolveParameters, solveDesignConstraints } from "@vcad/engine";
 import type { Document, Expr, Parameter } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
-import { getSession, resolveDocInput } from "./session-core.js";
+import {
+  getSession,
+  resolveDocInput,
+  recordTriangles,
+} from "./session-core.js";
 
 /** MCP result shape used across these tools. */
 type ToolResult = {
@@ -189,7 +193,10 @@ export async function setParameters(input: unknown, engine: Engine): Promise<Too
   // Geometry changed under the new parameter values — carry an integrity
   // certificate like every other mutation.
   const integrity = computeIntegrity(doc, engine);
-  if (integrity) appendIntegrity(result, integrity);
+  if (integrity) {
+    appendIntegrity(result, integrity);
+    recordTriangles(documentId, integrity.triangles);
+  }
 
   return result;
 }

--- a/packages/mcp/src/tools/registry-dispatch.ts
+++ b/packages/mcp/src/tools/registry-dispatch.ts
@@ -15,7 +15,7 @@ import {
   applyToolOutcome,
   listPartsFromDocument,
 } from "@vcad/core";
-import { getSession, recordLastChanged } from "./session.js";
+import { getSession, recordLastChanged, recordTriangles } from "./session.js";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
 import {
   describeSceneResult,
@@ -422,7 +422,10 @@ export function dispatchRegistryTool(
     // out-of-band inspect_cad (torr session-3 field report).
     if (engine) {
       const integrity = computeIntegrity(doc, engine);
-      if (integrity) appendIntegrity(result, integrity);
+      if (integrity) {
+        appendIntegrity(result, integrity);
+        recordTriangles(documentId, integrity.triangles);
+      }
     }
   }
   return result;

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -16,7 +16,12 @@ import { getKernelWasm, resetKernelWasm, computeRatsnest } from "@vcad/engine";
 import type { NetlistResult } from "@vcad/engine";
 import { getNodePcb, getPcbNodeIds } from "@vcad/core";
 import type { Document, Pcb } from "@vcad/ir";
-import { getSession, resolveDocInput, getLastChanged } from "./session.js";
+import {
+  getSession,
+  resolveDocInput,
+  getLastChanged,
+  getLastTriangles,
+} from "./session.js";
 import { validatePcb, pcbValidationError } from "./pcb-validate.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import type { ToolResult } from "./tool-result.js";
@@ -128,6 +133,21 @@ const DEFAULT_WIDTH_PX = 800;
 const MAX_NODES = 10_000;
 const MAX_PATTERN_INSTANCES = 50_000;
 
+/** Triangle budget for the drafting renderer. It emits one SVG element per
+ *  visible triangle, so triangles ≈ SVG bytes ≈ rasterizer memory: a ~190k-
+ *  triangle document serializes to a >100 MB SVG that resvg refuses ("nodes
+ *  limit reached"), and ~380k triangles OOM-kill the process outright (the
+ *  agent sees only a 502). The mutation-integrity pass counts triangles for
+ *  free, so a known-oversized document is refused with an actionable error
+ *  instead of crashing the instance. */
+const MAX_RENDER_TRIANGLES = 120_000;
+
+/** SVG beyond this many bytes is never handed to the rasterizer — resvg
+ *  builds a node per element, and feeding it a giant SVG is an OOM, not an
+ *  error return. Backstop for documents whose triangle count wasn't known
+ *  pre-render (inline docs, cold sessions). */
+const MAX_RASTER_SVG_BYTES = 64 * 1024 * 1024;
+
 /** Raw SVG beyond this many bytes is withheld from the fallback text
  *  block — a complex document can otherwise inject megabytes into the
  *  model context in a single tool result. */
@@ -167,6 +187,15 @@ export async function rasterize(
   widthPx: number,
   background = "white",
 ): Promise<RasterOutcome> {
+  const svgBytes = Buffer.byteLength(svg, "utf8");
+  if (svgBytes > MAX_RASTER_SVG_BYTES) {
+    return {
+      png: null,
+      reason:
+        `rasterization refused: SVG is ${svgBytes} bytes ` +
+        `(cap ${MAX_RASTER_SVG_BYTES}) — the document is too dense to raster safely`,
+    };
+  }
   let ResvgCtor: typeof import("@resvg/resvg-js").Resvg;
   try {
     ({ Resvg: ResvgCtor } = await import("@resvg/resvg-js"));
@@ -206,6 +235,28 @@ export async function renderView(
     2048,
     Math.max(64, Number.isFinite(widthRaw) ? Math.round(widthRaw) : DEFAULT_WIDTH_PX),
   );
+
+  const knownTriangles = documentId ? getLastTriangles(documentId) : null;
+  if (knownTriangles !== null && knownTriangles > MAX_RENDER_TRIANGLES) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error:
+              `render refused: document tessellates to ${knownTriangles} triangles ` +
+              `(render limit ${MAX_RENDER_TRIANGLES})`,
+            document_id: documentId,
+            hint:
+              "The renderer emits per-triangle SVG, so documents this dense exhaust memory. " +
+              "Reduce pattern counts / sphere counts, render a subset via `focus`, or " +
+              "inspect numerically via inspect_cad / measure. For full geometry use export_cad.",
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
 
   const tooComplex = complexityGuard(doc);
   if (tooComplex) {
@@ -589,13 +640,36 @@ export async function renderView(
     }, [asset]);
   }
 
+  const svgBytes = Buffer.byteLength(svg, "utf8");
+  // A rasterization failure on an SVG too big to inline leaves nothing
+  // usable to return — fail loudly with a way forward instead of shipping
+  // an empty "svg_omitted" shrug the agent can't act on.
+  if (raster.reason !== "module-missing" && svgBytes > MAX_INLINE_SVG_BYTES) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: `render failed: ${raster.reason}`,
+            document_id: documentId,
+            view: viewLabel,
+            svg_bytes: svgBytes,
+            hint:
+              "The document is too dense for the per-triangle SVG renderer. Reduce " +
+              "pattern counts, render a subset via `focus`, or inspect numerically " +
+              "via inspect_cad / measure. For full geometry use export_cad.",
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
   // Rasterizer unavailable or failed — degrade to raw SVG text (size
   // capped) rather than failing, with an honest note about why.
   const note =
     raster.reason === "module-missing"
       ? "Install @resvg/resvg-js for PNG output; returning raw SVG."
       : `PNG ${raster.reason}; returning raw SVG.`;
-  const svgBytes = Buffer.byteLength(svg, "utf8");
   return {
     content: [
       {

--- a/packages/mcp/src/tools/session-core.ts
+++ b/packages/mcp/src/tools/session-core.ts
@@ -215,6 +215,7 @@ export function undoLastSnapshot(documentId: string): Document | null {
 export function clearHistory(documentId: string): void {
   sessionHistory.delete(documentId);
   lastChangedParts.delete(documentId);
+  lastTriangleCount.delete(documentId);
 }
 
 // ─── Last mutation diff (per session) ─────────────────────────────────────────
@@ -239,4 +240,29 @@ export function recordLastChanged(documentId: string, partIds: string[]): void {
  *  mutation has been recorded on this instance. */
 export function getLastChanged(documentId: string): string[] | null {
   return lastChangedParts.get(documentId) ?? null;
+}
+
+// ─── Last known tessellation size (per session) ──────────────────────────────
+//
+// The drafting renderer emits one SVG element per visible triangle, so a
+// document's triangle count is a direct proxy for render memory: a ~380k-
+// triangle document serializes to a >100 MB SVG string that OOMs the process
+// before the rasterizer ever reports an error. Every mutation already pays
+// for a full integrity evaluation (which counts triangles); remembering that
+// number lets render_view refuse an un-renderable document up front instead
+// of crashing the instance.
+
+/** document_id → triangle count from the most recent integrity evaluation. */
+const lastTriangleCount = new Map<string, number>();
+
+/** Record the document's triangle count from a mutation's integrity pass. */
+export function recordTriangles(documentId: string, triangles: number): void {
+  if (!documentId) return;
+  lastTriangleCount.set(documentId, triangles);
+}
+
+/** Triangle count from the session's most recent integrity evaluation, or
+ *  null when no mutation has been recorded on this instance. */
+export function getLastTriangles(documentId: string): number | null {
+  return lastTriangleCount.get(documentId) ?? null;
 }

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -45,6 +45,8 @@ export {
   clearHistory,
   recordLastChanged,
   getLastChanged,
+  recordTriangles,
+  getLastTriangles,
   type DocInputCtx,
 } from "./session-core.js";
 


### PR DESCRIPTION
## Summary

Documents tessellating to >120k triangles (e.g. large sphere patterns) now receive an actionable error from `render_view` instead of OOM-killing the server. The drafting renderer emits one SVG element per visible triangle, so a ~380k-triangle document serializes to a >100 MB SVG that exhausts memory before the rasterizer can report an error. This change tracks triangle counts from mutation integrity passes and refuses rendering up front.

## Key Changes

- **Triangle budget enforcement**: Added `MAX_RENDER_TRIANGLES = 120_000` constant and pre-render check in `renderView()` that consults the session's last known triangle count (from the most recent mutation's integrity pass). Documents exceeding the budget receive a structured error with actionable hints instead of crashing.

- **SVG byte cap for rasterization**: Added `MAX_RASTER_SVG_BYTES = 64 MB` guard in `rasterize()` to refuse SVGs before they reach resvg, preventing OOM inside the rasterizer itself.

- **Triangle count tracking**: New `recordTriangles()` and `getLastTriangles()` functions in `session-core.ts` store the triangle count from each mutation's integrity evaluation. All mutation entry points (`applyEdits`, `setParameters`, `dispatchRegistryTool`, `loon` macro execution) now call `recordTriangles()` after computing integrity.

- **Graceful degradation on rasterization failure**: When rasterization fails on an SVG too large to inline (>16 MB), `renderView()` now returns a structured error instead of silently omitting the SVG, giving the agent a way forward.

- **Test coverage**: Added `render-triangle-guard.test.ts` with three test cases:
  - Refuses rendering when triangle count exceeds budget
  - Still renders documents under the budget
  - `rasterize()` refuses SVGs beyond the byte cap

## Implementation Details

- Triangle counts are stored per-session in a `Map<string, number>` and cleared when session history is cleared.
- The triangle guard runs before complexity checks, failing fast on known-oversized documents.
- Error messages include hints to reduce pattern counts, use `focus` to render subsets, or switch to `inspect_cad`/`measure` for numerical inspection.
- The rasterization byte cap is a backstop for documents whose triangle count wasn't known pre-render (inline docs, cold sessions).

https://claude.ai/code/session_01JEtPmXfYiwBi8bgcHfUcYT