### PR TITLE
Autorouter respects keepouts and board-edge clearance

### DIFF
--- a/changelog/entries/2026-07-24-router-keepout-edge-clearance.json
+++ b/changelog/entries/2026-07-24-router-keepout-edge-clearance.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-24-router-keepout-edge-clearance",
+  "version": "0.9.4",
+  "date": "2026-07-24",
+  "category": "fix",
+  "title": "Autorouter respects keepouts and board-edge clearance",
+  "summary": "route_nets' legality oracle now indexes no-tracks keepouts and the board outline (incl. cutouts), so routes never cross keepouts or hug the edge inside edge_clearance; multi-round negotiation can no longer finish below the single-round baseline.",
+  "features": ["pcb", "autorouter", "drc"],
+  "mcpTools": ["route_nets", "run_drc", "validate_for_fab"]
+}

--- a/crates/vcad-ecad-pcb/examples/negotiation_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/negotiation_bench.rs
@@ -1,0 +1,348 @@
+//! Negotiated-congestion benchmark: greedy + rip-up vs PathFinder negotiation.
+//!
+//! The autorouter's negotiation loop (`RouteOptions::negotiation_rounds`) is
+//! the OrthoRoute/PathFinder lesson applied to vcad's grid router: rather than
+//! letting the first net to claim a contested corridor keep it forever, every
+//! round deposits history cost on corridors that starved a connection, and the
+//! next round's flexible nets route around them. With `negotiation_rounds: 1`
+//! the loop reduces exactly to the historical greedy + rip-up router, which
+//! makes an in-repo A/B trivial: same board, same options, one knob.
+//!
+//! This example generates deterministic congested boards (no external
+//! fixtures needed), routes each with negotiation off and on, and prints a
+//! completion/via/length/time scoreboard:
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example negotiation_bench
+//! ```
+//!
+//! Scenarios:
+//! - `crossing-bus-N`: N nets between two pad columns with reversed order, so
+//!   every net crosses every other — the canonical negotiation stress.
+//! - `pin-grid-N`: an N×N grid of pads paired across the grid center, a
+//!   BGA-escape-shaped knot where early greedy routes wall off later ones.
+//! - `corridor-N`: N nets funneled through a keepout pinch far narrower than
+//!   their combined demand, so completion depends on who yields the corridor.
+
+use std::time::Instant;
+
+use vcad_ecad_pcb::drc::check_drc;
+use vcad_ecad_pcb::router::{route_all_with_opts, RouteAllResult, RouteOptions};
+use vcad_ir::ecad::*;
+use vcad_ir::Vec2;
+
+fn pad(num: &str, x: f64, y: f64, net: &str) -> Pad {
+    Pad {
+        number: num.into(),
+        pad_type: PadType::SMD,
+        shape: PadShape::Rect {
+            width: 1.0,
+            height: 1.0,
+        },
+        position: Vec2::new(x, y),
+        rotation: 0.0,
+        drill: None,
+        net: Some(net.into()),
+        layers: vec![PcbLayer::FCu],
+    }
+}
+
+fn fp(reference: &str, pads: Vec<Pad>) -> Footprint {
+    Footprint {
+        reference: reference.into(),
+        value: "x".into(),
+        footprint_name: "bench".into(),
+        position: Vec2::new(0.0, 0.0),
+        rotation: 0.0,
+        front: true,
+        pads,
+        graphics: vec![],
+        model_3d: None,
+        properties: Default::default(),
+    }
+}
+
+fn board(w: f64, h: f64, footprints: Vec<Footprint>, keepouts: Vec<Keepout>) -> Pcb {
+    Pcb {
+        outline: BoardOutline {
+            vertices: vec![
+                Vec2::new(0.0, 0.0),
+                Vec2::new(w, 0.0),
+                Vec2::new(w, h),
+                Vec2::new(0.0, h),
+            ],
+            cutouts: vec![],
+            thickness: 1.6,
+        },
+        stackup: LayerStackup {
+            layers: vec![
+                StackupLayer {
+                    layer: PcbLayer::FCu,
+                    copper_thickness: Some(0.035),
+                    dielectric_thickness: Some(1.5),
+                    dielectric_er: Some(4.5),
+                    material: Some("FR4".into()),
+                },
+                StackupLayer {
+                    layer: PcbLayer::BCu,
+                    copper_thickness: Some(0.035),
+                    dielectric_thickness: None,
+                    dielectric_er: None,
+                    material: None,
+                },
+            ],
+        },
+        nets: vec![],
+        rules: DesignRules {
+            default_rules: NetClassRules {
+                name: "Default".into(),
+                trace_width: 0.25,
+                clearance: 0.2,
+                via_diameter: 0.8,
+                via_drill: 0.4,
+                diff_pair_gap: None,
+                diff_pair_width: None,
+            },
+            class_rules: vec![],
+            net_class_assignments: Default::default(),
+            edge_clearance: 0.5,
+            hole_to_hole: 0.5,
+            min_annular_ring: 0.15,
+            min_drill: 0.2,
+        },
+        footprints,
+        traces: vec![],
+        trace_arcs: vec![],
+        vias: vec![],
+        zones: vec![],
+        keepouts,
+        net_ties: vec![],
+    }
+}
+
+/// N nets between a left and a right pad column, with the right column's net
+/// order reversed — every net must cross every other net.
+fn crossing_bus(n: usize) -> Pcb {
+    let pitch = 2.0;
+    let h = (n as f64 + 1.0) * pitch + 4.0;
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    for i in 0..n {
+        let y = 4.0 + i as f64 * pitch;
+        let net = format!("N{i}");
+        left.push(pad(&format!("L{i}"), 4.0, y, &net));
+        // Reversed order on the right: net i lands at row n-1-i.
+        let yr = 4.0 + (n - 1 - i) as f64 * pitch;
+        right.push(pad(&format!("R{i}"), 46.0, yr, &net));
+    }
+    board(50.0, h, vec![fp("J1", left), fp("J2", right)], vec![])
+}
+
+/// n×n pad grid; each pad in the left half pairs with its point-reflection
+/// through the grid center, so every connection threads the middle.
+fn pin_grid(n: usize) -> Pcb {
+    let pitch = 2.5;
+    let span = (n as f64 - 1.0) * pitch;
+    let margin = 6.0;
+    let size = span + 2.0 * margin;
+    let mut pads = Vec::new();
+    let mut k = 0usize;
+    for r in 0..n {
+        for c in 0..n / 2 {
+            // Left half column c pairs with mirrored (n-1-r, n-1-c).
+            let (mr, mc) = (n - 1 - r, n - 1 - c);
+            let net = format!("G{k}");
+            pads.push(pad(
+                &format!("A{k}"),
+                margin + c as f64 * pitch,
+                margin + r as f64 * pitch,
+                &net,
+            ));
+            pads.push(pad(
+                &format!("B{k}"),
+                margin + mc as f64 * pitch,
+                margin + mr as f64 * pitch,
+                &net,
+            ));
+            k += 1;
+        }
+    }
+    board(size, size, vec![fp("U1", pads)], vec![])
+}
+
+/// N nets that must all pass through a keepout pinch whose width supports far
+/// fewer tracks than the demand — completion hinges on negotiation deciding
+/// which nets take the long way around.
+fn corridor(n: usize) -> Pcb {
+    let pitch = 2.0;
+    let h = (n as f64 + 1.0) * pitch + 8.0;
+    let w = 60.0;
+    let gap = 3.0; // pinch aperture (mm) — a handful of 0.25/0.2 tracks
+    let slot_y0 = h / 2.0 - gap / 2.0;
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    for i in 0..n {
+        let y = 6.0 + i as f64 * pitch;
+        let net = format!("C{i}");
+        left.push(pad(&format!("L{i}"), 4.0, y, &net));
+        right.push(pad(&format!("R{i}"), w - 4.0, y, &net));
+    }
+    let wall = |y0: f64, y1: f64| Keepout {
+        outline: vec![
+            Vec2::new(w / 2.0 - 1.0, y0),
+            Vec2::new(w / 2.0 + 1.0, y0),
+            Vec2::new(w / 2.0 + 1.0, y1),
+            Vec2::new(w / 2.0 - 1.0, y1),
+        ],
+        layers: vec![PcbLayer::FCu, PcbLayer::BCu],
+        no_tracks: true,
+        no_vias: true,
+        no_pour: false,
+        no_components: false,
+    };
+    board(
+        w,
+        h,
+        vec![fp("J1", left), fp("J2", right)],
+        // Lower wall reaches the board edge; the upper wall stops 4 mm short,
+        // leaving a long detour over the top. Negotiation decides which nets
+        // take the pinch and which yield to the detour.
+        vec![wall(0.0, slot_y0), wall(slot_y0 + gap, h - 4.0)],
+    )
+}
+
+struct Score {
+    routed: usize,
+    total: usize,
+    vias: usize,
+    copper_mm: f64,
+    secs: f64,
+    drc: usize,
+}
+
+/// Copper-legality errors only: `UnconnectedNet` is excluded because it counts
+/// *incomplete* routing (the completion column already reports that), not
+/// *illegal* copper — including it would let the routed/unrouted delta mask
+/// clearance violations in the before/after comparison.
+fn drc_errors(pcb: &Pcb) -> usize {
+    use vcad_ecad_pcb::drc::{DrcRuleType, DrcSeverity};
+    check_drc(pcb)
+        .iter()
+        .filter(|v| v.severity == DrcSeverity::Error && v.rule != DrcRuleType::UnconnectedNet)
+        .count()
+}
+
+fn run(pcb: &Pcb, negotiation_rounds: usize) -> Score {
+    let width = pcb.rules.default_rules.trace_width;
+    let t0 = Instant::now();
+    let r: RouteAllResult = route_all_with_opts(
+        pcb,
+        width,
+        &[],
+        &RouteOptions {
+            negotiation_rounds,
+            ..Default::default()
+        },
+    );
+    let secs = t0.elapsed().as_secs_f64();
+    let copper_mm = r
+        .traces
+        .iter()
+        .map(|t| ((t.end.x - t.start.x).powi(2) + (t.end.y - t.start.y).powi(2)).sqrt())
+        .sum();
+    // DRC on the applied result — negotiation must never trade legality for
+    // completion (history only adds cost; the clearance invariant is intact).
+    let mut applied = pcb.clone();
+    for t in &r.traces {
+        applied.traces.push(Trace {
+            start: t.start,
+            end: t.end,
+            width: t.width,
+            layer: t.layer,
+            net: t.net.clone(),
+            source: None,
+        });
+    }
+    for v in &r.vias {
+        applied.vias.push(Via {
+            position: v.position,
+            diameter: applied.rules.default_rules.via_diameter,
+            drill: applied.rules.default_rules.via_drill,
+            start_layer: v.start_layer,
+            end_layer: v.end_layer,
+            net: v.net.clone(),
+            source: None,
+        });
+    }
+    // Compare against the bare board so any pre-existing land-pattern
+    // violations don't count against the router — only copper it added can
+    // add errors (connectivity errors are excluded in `drc_errors`).
+    let drc = drc_errors(&applied).saturating_sub(drc_errors(pcb));
+    if drc > 0 {
+        use vcad_ecad_pcb::drc::{DrcRuleType, DrcSeverity};
+        for v in check_drc(&applied)
+            .iter()
+            .filter(|v| v.severity == DrcSeverity::Error && v.rule != DrcRuleType::UnconnectedNet)
+            .take(8)
+        {
+            eprintln!(
+                "  drc {:?} at ({:.2},{:.2}): {}",
+                v.rule, v.position.x, v.position.y, v.message
+            );
+        }
+    }
+    Score {
+        routed: r.routed_nets.len(),
+        total: r.routed_nets.len() + r.unrouted_nets.len(),
+        vias: r.vias.len(),
+        copper_mm,
+        secs,
+        drc,
+    }
+}
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+
+    let scenarios: Vec<(String, Pcb)> = vec![
+        ("crossing-bus-12".into(), crossing_bus(12)),
+        ("crossing-bus-24".into(), crossing_bus(24)),
+        ("pin-grid-8".into(), pin_grid(8)),
+        ("pin-grid-12".into(), pin_grid(12)),
+        ("corridor-16".into(), corridor(16)),
+        ("corridor-24".into(), corridor(24)),
+    ];
+
+    println!(
+        "{:<18} {:>22} {:>22}  delta",
+        "scenario", "greedy+ripup", "negotiated"
+    );
+    for (name, pcb) in &scenarios {
+        let pre = drc_errors(pcb);
+        if pre > 0 {
+            eprintln!("note: {name} bare board has {pre} pre-existing DRC error(s)");
+        }
+        let base = run(pcb, 1); // reduces exactly to the historical router
+        let nego = run(pcb, vcad_ecad_pcb::router::auto::DEFAULT_NEGOTIATION_ROUNDS);
+        assert_eq!(base.drc, 0, "{name}: baseline emitted DRC errors");
+        assert_eq!(nego.drc, 0, "{name}: negotiation emitted DRC errors");
+        assert!(
+            nego.routed >= base.routed,
+            "{name}: negotiation regressed below greedy + rip-up ({} < {})",
+            nego.routed,
+            base.routed
+        );
+        println!(
+            "{:<18} {:>10} {:>6.1}s {:>4}v {:>10} {:>6.1}s {:>4}v  {:+} nets, {:+.0} mm",
+            name,
+            format!("{}/{}", base.routed, base.total),
+            base.secs,
+            base.vias,
+            format!("{}/{}", nego.routed, nego.total),
+            nego.secs,
+            nego.vias,
+            nego.routed as i64 - base.routed as i64,
+            nego.copper_mm - base.copper_mm,
+        );
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -330,11 +330,19 @@ pub fn route_all_with_opts(
     // region is unchanged — re-proving known failures was pure waste.
     let mut round_cache = FailCache::new();
 
+    // Set when convergence is detected before the scheduled last round: the
+    // next round is a final fine-retry polish of the best pass, then we stop.
+    // Without this, the early-stop skipped the fine-pitch retry that only the
+    // last round enables — a multi-round run could then end *below* the
+    // single-round baseline, whose round 0 IS the last round and gets the
+    // retry (observed on the corridor benchmark: 4 rounds routed 16/24 where
+    // 1 round routed 18/24).
+    let mut polish = false;
     for round in 0..rounds {
         // Round 0 is the pure baseline (no push-shove); the fallback and the
         // history field are enhancement layers applied from round 1 onward.
         let use_push_shove = opts.use_push_shove && round > 0;
-        let last_round_flag = round + 1 == rounds;
+        let last_round_flag = polish || round + 1 == rounds;
         let (session, placed, pending) = if round == 0 {
             // Full pass, longest connections first: the historical baseline.
             let mut ordered = rats.clone();
@@ -356,7 +364,12 @@ pub fn route_all_with_opts(
                 use_push_shove,
                 opts.effective_ripup_rounds(),
                 opts.effective_expansions(),
-                last_round_flag,
+                // Always run round 0 with the rescue/fine-retry arsenal: it
+                // must reproduce the single-round baseline EXACTLY, or
+                // keep-best's no-regression guarantee is vacuous (a 4-round
+                // run once routed fewer nets than a 1-round run because only
+                // the last round armed the rescue pass).
+                true,
                 &opts.priority_nets,
             )
         } else {
@@ -387,7 +400,7 @@ pub fn route_all_with_opts(
             placed.len(),
             pending.len(),
         );
-        let last_round = round + 1 == rounds;
+        let last_round = last_round_flag;
         if !last_round && !pending.is_empty() {
             // Raise each still-unrouted net's priority for next round.
             for (net, _, _) in &pending {
@@ -408,9 +421,22 @@ pub fn route_all_with_opts(
             .unwrap_or(true);
         if is_better {
             best = Some((session, placed, pending));
+            if last_round {
+                break;
+            }
         } else if round > 0 {
-            log::info!("negotiation converged after round {} — stopping", round + 1);
-            break;
+            if last_round {
+                log::info!("negotiation converged after round {} — stopping", round + 1);
+                break;
+            }
+            // Converged below the scheduled last round: spend one more round
+            // as a fine-retry polish of the best pass before stopping, so the
+            // early stop never forfeits the last-round-only retry.
+            log::info!(
+                "negotiation converged after round {} — final fine-retry round",
+                round + 1
+            );
+            polish = true;
         }
 
         let fully_routed = best.as_ref().map(|(_, _, p)| p.is_empty()).unwrap_or(false);
@@ -421,6 +447,14 @@ pub fn route_all_with_opts(
 
     let (mut session, mut placed, pending) =
         best.expect("negotiation always runs at least one pass");
+
+    // The rescue stages below solve *legality* knots, not corridor contention:
+    // run them on a flat history field. Inheriting the negotiation deposits
+    // inflated their searches (history cost widens A*'s frontier until the
+    // expansion budget dies) — observed as joint repair recovering 2 nets on a
+    // flat field but 0 on the polluted one, a multi-round run thereby ending
+    // below the single-round baseline.
+    let cong = Congestion::new(&pcb.outline.vertices);
 
     // Fan-out rescue (issue #289 part 1): connections rip-up still couldn't
     // place — most often a net into a fine-pitch pad that can't be escaped on
@@ -1203,12 +1237,15 @@ fn incremental_round(
         cong,
         use_push_shove,
         max_expansions,
-        false,
+        // Speculative rounds stay search-only (no rescue arsenal), but the
+        // final polish round — the only one flagged fine_retry — gets the
+        // same rescue + fine-pitch retry the single-round baseline's last
+        // round enjoys, so keep-best genuinely never regresses below it.
+        fine_retry,
         Some(budget_ms),
         fail_cache,
         &HashMap::new(),
     );
-    let _ = fine_retry;
     log::info!(
         "incremental round: stuck={n_stuck} -> placed={} pending={} in {:.1}s",
         placed.len(),

--- a/crates/vcad-ecad-pcb/src/router/maze.rs
+++ b/crates/vcad-ecad-pcb/src/router/maze.rs
@@ -721,7 +721,9 @@ impl Raster {
         let nl = layers.len();
         let mut states = vec![CELL_WIDE; plane * nl];
 
-        // Cells outside the board outline are blocked on every layer.
+        // Cells outside the board outline are blocked on every layer. (Cells
+        // *near* the outline are handled by the session's board-edge obstacle
+        // elements, whose per-net clearance is the rules' edge_clearance.)
         if grid.bounded {
             for iy in 0..grid.ny {
                 for ix in 0..grid.nx {

--- a/crates/vcad-ecad-pcb/src/session.rs
+++ b/crates/vcad-ecad-pcb/src/session.rs
@@ -29,6 +29,17 @@ use vcad_ir::Vec2;
 use crate::drc::{build_net_clearance_map, build_net_trace_width_map, NetTieGroups};
 use crate::spatial::{copper_elements, CopperElement, CopperGeom};
 
+/// Reserved net name for keepout boundary obstacles. Contains a control
+/// character so no schematic net can collide with it (probes exempt same-net
+/// copper — a colliding real net would route through keepouts freely).
+const KEEPOUT_NET: &str = "\u{1}keepout";
+
+/// Reserved net name for board-outline (and cutout) edge obstacles. Indexed
+/// with a per-net clearance equal to the rules' `edge_clearance`, so every
+/// probe-based path — maze raster, push-shove validation, via commits,
+/// legalization shortcuts — enforces DRC's `EdgeClearance` by construction.
+const EDGE_NET: &str = "\u{1}board-edge";
+
 /// Stable handle to a committed copper span in a [`RouteSession`].
 ///
 /// Remains valid across compaction — removing other spans never renumbers it.
@@ -167,7 +178,64 @@ pub struct RouteSession {
 impl RouteSession {
     /// Build a session seeded with every copper element on `pcb`.
     pub fn from_pcb(pcb: &Pcb) -> Self {
-        let elems = copper_elements(pcb);
+        let mut elems = copper_elements(pcb);
+        // No-tracks keepouts become session obstacles so the router's oracle
+        // matches DRC's `check_keepout`: their boundary edges are indexed as
+        // zero-width capsules under a reserved net name no real net can carry
+        // (so they block every candidate; probes only exempt same-net copper).
+        // Boundary-only is sufficient — any route entering the region must
+        // cross an edge — and, unlike copper_elements, this stays session-local
+        // so DRC's clearance pass never sees the phantom segments.
+        for keepout in &pcb.keepouts {
+            if !keepout.no_tracks || keepout.outline.len() < 3 {
+                continue;
+            }
+            for layer in keepout.layers.iter().filter(|l| l.is_copper()) {
+                for i in 0..keepout.outline.len() {
+                    let a = keepout.outline[i];
+                    let b = keepout.outline[(i + 1) % keepout.outline.len()];
+                    elems.push(CopperElement {
+                        min: [a.x.min(b.x), a.y.min(b.y)],
+                        max: [a.x.max(b.x), a.y.max(b.y)],
+                        net: KEEPOUT_NET.into(),
+                        layer: *layer,
+                        geom: CopperGeom::Segment { a, b, half_w: 0.0 },
+                    });
+                }
+            }
+        }
+        // Board outline and cutout edges, on every copper layer, under the
+        // reserved edge net (clearance = rules.edge_clearance, wired below).
+        let stackup_copper: Vec<PcbLayer> = pcb
+            .stackup
+            .layers
+            .iter()
+            .map(|l| l.layer)
+            .filter(|l| l.is_copper())
+            .collect();
+        let mut edge_ring = |poly: &[vcad_ir::Vec2]| {
+            if poly.len() < 3 {
+                return;
+            }
+            for layer in &stackup_copper {
+                for i in 0..poly.len() {
+                    let a = poly[i];
+                    let b = poly[(i + 1) % poly.len()];
+                    elems.push(CopperElement {
+                        min: [a.x.min(b.x), a.y.min(b.y)],
+                        max: [a.x.max(b.x), a.y.max(b.y)],
+                        net: EDGE_NET.into(),
+                        layer: *layer,
+                        geom: CopperGeom::Segment { a, b, half_w: 0.0 },
+                    });
+                }
+            }
+        };
+        edge_ring(&pcb.outline.vertices);
+        for cutout in &pcb.outline.cutouts {
+            edge_ring(cutout);
+        }
+        let elems = elems;
         let live = vec![true; elems.len()];
         let bounds: Vec<[f64; 4]> = elems
             .iter()
@@ -198,7 +266,8 @@ impl RouteSession {
             .map(|(id, elem)| SessionElement { id, elem })
             .collect();
         let default_clearance = pcb.rules.default_rules.clearance;
-        let net_clearance = build_net_clearance_map(pcb);
+        let mut net_clearance = build_net_clearance_map(pcb);
+        net_clearance.insert(EDGE_NET.into(), pcb.rules.edge_clearance);
         let max_clearance = net_clearance
             .values()
             .copied()
@@ -671,6 +740,76 @@ mod tests {
     }
 
     #[test]
+    fn probe_blocks_no_tracks_keepout() {
+        // A no-tracks keepout square straddling the candidate path must make
+        // the probe illegal — the oracle mirrors DRC's check_keepout, so the
+        // router can never emit copper through a keepout.
+        let mut pcb = empty_pcb();
+        pcb.keepouts.push(Keepout {
+            outline: vec![
+                Vec2::new(45.0, 45.0),
+                Vec2::new(55.0, 45.0),
+                Vec2::new(55.0, 55.0),
+                Vec2::new(45.0, 55.0),
+            ],
+            layers: vec![PcbLayer::FCu],
+            no_tracks: true,
+            no_vias: false,
+            no_pour: false,
+            no_components: false,
+        });
+        let session = RouteSession::from_pcb(&pcb);
+        // Crosses the keepout boundary: illegal.
+        let r = session.probe(&seg(50.0, 0.125), PcbLayer::FCu, "SIG", 0.2);
+        assert!(
+            !r.legal,
+            "trace through a no-tracks keepout must be blocked"
+        );
+        // Well clear of the keepout: legal.
+        let r = session.probe(&seg(20.0, 0.125), PcbLayer::FCu, "SIG", 0.2);
+        assert!(r.legal);
+    }
+
+    #[test]
+    fn keepout_without_no_tracks_does_not_block() {
+        // A components-only keepout is not a routing obstacle.
+        let mut pcb = empty_pcb();
+        pcb.keepouts.push(Keepout {
+            outline: vec![
+                Vec2::new(45.0, 45.0),
+                Vec2::new(55.0, 45.0),
+                Vec2::new(55.0, 55.0),
+                Vec2::new(45.0, 55.0),
+            ],
+            layers: vec![PcbLayer::FCu],
+            no_tracks: false,
+            no_vias: false,
+            no_pour: false,
+            no_components: true,
+        });
+        let session = RouteSession::from_pcb(&pcb);
+        let r = session.probe(&seg(50.0, 0.125), PcbLayer::FCu, "SIG", 0.2);
+        assert!(r.legal, "no-components keepout must not block traces");
+    }
+
+    #[test]
+    fn probe_enforces_board_edge_clearance() {
+        // rules().edge_clearance is 0.5: a trace whose copper comes within
+        // 0.5mm of the outline must probe illegal, matching DRC EdgeClearance.
+        let session = RouteSession::from_pcb(&empty_pcb());
+        // Centerline 0.4mm from the y=0 edge, half width 0.125 → copper edge
+        // at 0.275mm from the outline: violation.
+        let r = session.probe(&seg(0.4, 0.125), PcbLayer::FCu, "SIG", 0.2);
+        assert!(
+            !r.legal,
+            "copper 0.275mm from the board edge must be blocked"
+        );
+        // Centerline 0.7mm from the edge → copper edge at 0.575mm: legal.
+        let r = session.probe(&seg(0.7, 0.125), PcbLayer::FCu, "SIG", 0.2);
+        assert!(r.legal, "copper 0.575mm from the board edge is legal");
+    }
+
+    #[test]
     fn net_tie_exempts_blocker() {
         let mut pcb = empty_pcb();
         pcb.traces.push(h_trace(50.0, "GND"));
@@ -688,6 +827,8 @@ mod tests {
     #[test]
     fn ids_stay_stable_across_compaction() {
         let mut session = RouteSession::from_pcb(&empty_pcb());
+        // Board-edge obstacle elements are part of the base count.
+        let base = session.len();
         // Commit a row of well-separated spans.
         let ids: Vec<SpanId> = (0..20)
             .map(|i| {
@@ -713,6 +854,6 @@ mod tests {
             !r.legal,
             "surviving span must still be probed after compaction"
         );
-        assert_eq!(session.len(), 5);
+        assert_eq!(session.len(), base + 5);
     }
 }


### PR DESCRIPTION
## Summary

The autorouter's legality oracle now enforces no-tracks keepouts and board-edge clearance during routing, preventing routes from crossing keepouts or violating edge clearance constraints. Additionally, multi-round negotiation now correctly applies a final fine-retry polish round when convergence is detected early, ensuring it never finishes below the single-round baseline.

## Key Changes

- **Keepout enforcement in RouteSession**: No-tracks keepouts are now indexed as zero-width capsule obstacles under a reserved net name (`\u{1}keepout`) during session initialization. Their boundary edges block all candidate routes, matching DRC's `check_keepout` behavior. Only keepouts with `no_tracks: true` are enforced; other keepout types (components-only, pour-only) do not block routing.

- **Board-edge clearance enforcement**: Board outline and cutout edges are indexed as zero-width segments under a reserved edge net (`\u{1}board-edge`) with clearance equal to `rules.edge_clearance`. This ensures all routes maintain the required clearance from board edges by construction, matching DRC's `EdgeClearance` rule.

- **Negotiation convergence polish round**: When early convergence is detected (before the scheduled final round), the router now runs one additional fine-retry polish round on the best pass before stopping. This ensures the early-stop path never forfeits the last-round-only rescue arsenal (fine-pitch retry, joint repair, etc.), preventing multi-round runs from regressing below single-round baselines.

- **Round 0 rescue arsenal**: Round 0 (the pure greedy baseline) now always runs with the rescue/fine-retry arsenal enabled, ensuring single-round routing reproduces the exact baseline that multi-round negotiation uses as a comparison point.

- **Flat history for rescue stages**: The fan-out and joint-repair rescue stages now run on a flat congestion field (no negotiation history deposits) to avoid inflating search frontiers and reducing legality-knot recovery effectiveness.

- **Negotiation benchmark example**: Added `negotiation_bench.rs` demonstrating the negotiation loop on three deterministic congestion scenarios (crossing-bus, pin-grid, corridor). The benchmark compares greedy+rip-up (1 round) vs. negotiated routing with default rounds, printing completion/via/length/time scoreboards. All scenarios are generated in-repo with no external fixtures.

## Tests

Added three new session tests:
- `probe_blocks_no_tracks_keepout`: Verifies no-tracks keepouts block crossing routes
- `keepout_without_no_tracks_does_not_block`: Confirms non-blocking keepout types don't obstruct routing
- `probe_enforces_board_edge_clearance`: Validates edge clearance enforcement at the probe level

Updated `ids_stay_stable_across_compaction` to account for board-edge obstacle elements in the base session count.

## Changelog

Added entry documenting the fix for autorouter keepout and edge-clearance enforcement, affecting `route_nets`, `run_drc`, and `validate_for_fab` tools.

https://claude.ai/code/session_013cZpmkSCuLpQ2CKm8xAyEB