### PR TITLE
Kill the TS expression-parser mirror: expressions.ts → kernel WASM bindings

### DIFF
--- a/crates/vcad-kernel-wasm/src/expressions.rs
+++ b/crates/vcad-kernel-wasm/src/expressions.rs
@@ -1,0 +1,234 @@
+//! Parametric-expression WASM bindings.
+//!
+//! Exposes the `vcad-ir` expression parser/evaluator and the `vcad-eval`
+//! parameter/binding resolution pre-pass to TypeScript, so the engine's
+//! `expressions.ts` can be a thin wrapper instead of a hand-maintained
+//! mirror of the grammar. Rust is the single source of truth for
+//! expression semantics.
+//!
+//! The AST crosses the boundary in the wire shape the TS side has always
+//! used (`{ kind: "num" | "ident" | "binary" | "unary" | "call", ... }`)
+//! so existing consumers that walk the AST (e.g. parameter rename) keep
+//! working unchanged.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use vcad_ir::expr_parser::{self, Ast, BinOp, UnOp};
+use wasm_bindgen::prelude::*;
+
+// ============================================================================
+// Wire AST (matches the historical TS discriminated union)
+// ============================================================================
+
+/// Expression AST in the TS wire shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WireAst {
+    /// Literal number.
+    Num {
+        /// The value.
+        value: f64,
+    },
+    /// Identifier reference.
+    Ident {
+        /// Identifier name.
+        name: String,
+    },
+    /// Binary operation.
+    Binary {
+        /// Operator symbol: `+ - * / % ^`.
+        op: String,
+        /// Left operand.
+        lhs: Box<WireAst>,
+        /// Right operand.
+        rhs: Box<WireAst>,
+    },
+    /// Unary operation.
+    Unary {
+        /// Operator symbol: `+` or `-`.
+        op: String,
+        /// Operand.
+        arg: Box<WireAst>,
+    },
+    /// Function call.
+    Call {
+        /// Function name.
+        name: String,
+        /// Arguments.
+        args: Vec<WireAst>,
+    },
+}
+
+fn bin_op_str(op: BinOp) -> &'static str {
+    match op {
+        BinOp::Add => "+",
+        BinOp::Sub => "-",
+        BinOp::Mul => "*",
+        BinOp::Div => "/",
+        BinOp::Mod => "%",
+        BinOp::Pow => "^",
+    }
+}
+
+fn bin_op_from_str(s: &str) -> Option<BinOp> {
+    Some(match s {
+        "+" => BinOp::Add,
+        "-" => BinOp::Sub,
+        "*" => BinOp::Mul,
+        "/" => BinOp::Div,
+        "%" => BinOp::Mod,
+        "^" => BinOp::Pow,
+        _ => return None,
+    })
+}
+
+impl From<&Ast> for WireAst {
+    fn from(ast: &Ast) -> Self {
+        match ast {
+            Ast::Number(v) => WireAst::Num { value: *v },
+            Ast::Ident(name) => WireAst::Ident { name: name.clone() },
+            Ast::Binary { op, lhs, rhs } => WireAst::Binary {
+                op: bin_op_str(*op).to_string(),
+                lhs: Box::new(WireAst::from(lhs.as_ref())),
+                rhs: Box::new(WireAst::from(rhs.as_ref())),
+            },
+            Ast::Unary { op, arg } => WireAst::Unary {
+                op: match op {
+                    UnOp::Neg => "-".to_string(),
+                    UnOp::Pos => "+".to_string(),
+                },
+                arg: Box::new(WireAst::from(arg.as_ref())),
+            },
+            Ast::Call { name, args } => WireAst::Call {
+                name: name.clone(),
+                args: args.iter().map(WireAst::from).collect(),
+            },
+        }
+    }
+}
+
+impl TryFrom<&WireAst> for Ast {
+    type Error = String;
+
+    fn try_from(w: &WireAst) -> Result<Self, Self::Error> {
+        Ok(match w {
+            WireAst::Num { value } => Ast::Number(*value),
+            WireAst::Ident { name } => Ast::Ident(name.clone()),
+            WireAst::Binary { op, lhs, rhs } => Ast::Binary {
+                op: bin_op_from_str(op).ok_or_else(|| format!("unknown binary op '{op}'"))?,
+                lhs: Box::new(Ast::try_from(lhs.as_ref())?),
+                rhs: Box::new(Ast::try_from(rhs.as_ref())?),
+            },
+            WireAst::Unary { op, arg } => Ast::Unary {
+                op: match op.as_str() {
+                    "-" => UnOp::Neg,
+                    "+" => UnOp::Pos,
+                    other => return Err(format!("unknown unary op '{other}'")),
+                },
+                arg: Box::new(Ast::try_from(arg.as_ref())?),
+            },
+            WireAst::Call { name, args } => Ast::Call {
+                name: name.clone(),
+                args: args
+                    .iter()
+                    .map(Ast::try_from)
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+        })
+    }
+}
+
+fn json_serializer() -> serde_wasm_bindgen::Serializer {
+    // Plain JS objects (not Maps) so TS consumers can index the result.
+    serde_wasm_bindgen::Serializer::json_compatible()
+}
+
+// ============================================================================
+// Bindings
+// ============================================================================
+
+/// Parse an expression string into its wire AST.
+/// Errors carry the message `parse error at offset N: ...`.
+#[wasm_bindgen(js_name = exprParse)]
+pub fn expr_parse(src: &str) -> Result<JsValue, JsError> {
+    let ast = expr_parser::parse(src).map_err(|e| JsError::new(&e.to_string()))?;
+    WireAst::from(&ast)
+        .serialize(&json_serializer())
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Evaluate a previously parsed wire AST against `env` (a plain
+/// `{ name: number }` object).
+#[wasm_bindgen(js_name = exprEvalAst)]
+pub fn expr_eval_ast(ast: JsValue, env: JsValue) -> Result<f64, JsError> {
+    let wire: WireAst =
+        serde_wasm_bindgen::from_value(ast).map_err(|e| JsError::new(&e.to_string()))?;
+    let ast = Ast::try_from(&wire).map_err(|e| JsError::new(&e))?;
+    let env: HashMap<String, f64> =
+        serde_wasm_bindgen::from_value(env).map_err(|e| JsError::new(&e.to_string()))?;
+    expr_parser::eval(&ast, &env).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Parse and evaluate an expression string in one shot.
+#[wasm_bindgen(js_name = exprEvaluate)]
+pub fn expr_evaluate(src: &str, env: JsValue) -> Result<f64, JsError> {
+    let env: HashMap<String, f64> =
+        serde_wasm_bindgen::from_value(env).map_err(|e| JsError::new(&e.to_string()))?;
+    expr_parser::parse_and_eval(src, &env).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Resolve a `{ name: Parameter }` map (JSON string) into a concrete
+/// environment, returned as a JSON string `{ name: number }`.
+#[wasm_bindgen(js_name = resolveParametersJson)]
+pub fn resolve_parameters_json(params_json: &str) -> Result<String, JsError> {
+    let params: HashMap<String, vcad_ir::Parameter> =
+        serde_json::from_str(params_json).map_err(|e| JsError::new(&e.to_string()))?;
+    let env = vcad_ir::resolve_parameters(&params).map_err(|e| JsError::new(&e.to_string()))?;
+    serde_json::to_string(&env).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Resolve a whole document: evaluate parameters, apply bindings onto
+/// concrete node fields. Takes the document as a JSON string and returns
+/// `{"doc": <resolved document>, "env": {name: number}}` as a JSON string.
+#[wasm_bindgen(js_name = resolveDocumentJson)]
+pub fn resolve_document_json(doc_json: &str) -> Result<String, JsError> {
+    let doc: vcad_ir::Document =
+        serde_json::from_str(doc_json).map_err(|e| JsError::new(&e.to_string()))?;
+    let (resolved, env) =
+        vcad_eval::resolve_document_cloned(&doc).map_err(|e| JsError::new(&e.to_string()))?;
+    #[derive(Serialize)]
+    struct Out {
+        doc: vcad_ir::Document,
+        env: HashMap<String, f64>,
+    }
+    serde_json::to_string(&Out { doc: resolved, env }).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wire_ast_round_trips() {
+        let ast = expr_parser::parse("min(-a, 2) * (b + 1) ^ 2 % 3").unwrap();
+        let wire = WireAst::from(&ast);
+        let back = Ast::try_from(&wire).unwrap();
+        assert_eq!(ast, back);
+    }
+
+    #[test]
+    fn wire_ast_serde_shape_matches_ts() {
+        let ast = expr_parser::parse("x + 1").unwrap();
+        let json = serde_json::to_value(WireAst::from(&ast)).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "kind": "binary",
+                "op": "+",
+                "lhs": { "kind": "ident", "name": "x" },
+                "rhs": { "kind": "num", "value": 1.0 },
+            })
+        );
+    }
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -13,6 +13,7 @@ pub mod circuit_sim;
 pub mod design_constraints;
 pub mod document_diff;
 pub mod document_engine;
+pub mod expressions;
 pub mod keybindings;
 pub mod sheet_metal;
 pub mod sketch_session;

--- a/packages/engine/src/__tests__/expressions.test.ts
+++ b/packages/engine/src/__tests__/expressions.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import type { Document } from "@vcad/ir";
+import { getKernelWasm } from "../wasm-singleton.js";
 import {
   EvalError,
   ParseError,
@@ -12,7 +13,14 @@ import {
   resolveParameters,
 } from "../expressions.js";
 
-describe("expression parser (TS, matches tang-expr)", () => {
+// expressions.ts is a thin wrapper over the kernel WASM expression
+// bindings; these fixtures verify the binding end-to-end (marshalling,
+// error mapping, and the Rust parser/evaluator semantics behind it).
+beforeAll(async () => {
+  await getKernelWasm();
+});
+
+describe("expression parser (WASM binding)", () => {
   const env = { x: 3, y: 4, wheelbase: 1000 };
 
   it.each([

--- a/packages/engine/src/expressions.ts
+++ b/packages/engine/src/expressions.ts
@@ -1,30 +1,31 @@
 /**
- * Parametric expression parser and resolver.
+ * Parametric expression parsing and resolution — thin wrapper over the
+ * kernel WASM bindings (`crates/vcad-kernel-wasm/src/expressions.rs`).
  *
- * Mirrors the grammar and semantics of `tang-expr::parser` on the Rust
- * side. Both evaluators consume the same `.vcad` document shape and
- * MUST agree bit-for-bit on shared fixtures (see
- * `__tests__/expressions.test.ts`).
+ * The grammar and evaluation semantics live in ONE place: the Rust
+ * expression parser in `crates/vcad-ir/src/expr_parser.rs` (plus the
+ * parameter/binding resolution pass in `vcad-ir::parameters` and
+ * `vcad-eval::resolve`). This module only marshals values across the
+ * WASM boundary and preserves the historical TS public API (`parse`,
+ * `evaluate`, `evalAst`, `freeVars`, `resolveParameters`,
+ * `resolveDocument`, `ParseError`, `EvalError`).
  *
- * Grammar (Pratt-style precedence climbing):
+ * Requires the kernel WASM singleton to be initialized (`getKernelWasm()`
+ * / `Engine.init()`); every entry point throws a descriptive error
+ * otherwise. There is deliberately NO TypeScript fallback parser — a
+ * second implementation is exactly the bit-for-bit drift hazard this
+ * wrapper exists to remove.
  *
- * ```
- * expr    := term (('+' | '-') term)*
- * term    := unary (('*' | '/' | '%') unary)*
- * unary   := ('-' | '+') unary | power
- * power   := atom ('^' unary)?                   // right-assoc, tighter than unary
- * atom    := NUMBER | IDENT ('(' args? ')')? | '(' expr ')'
- * ```
- *
- * Supported functions: sin, cos, tan, asin, acos, atan, atan2, sqrt,
- * abs, floor, ceil, round, ln, log (=ln), log2, exp, pow, min, max,
- * deg, rad. Constants: pi, tau, e.
+ * `freeVars` and `parseBindingKey` are pure structural helpers over data
+ * shapes (the wire AST and the `"{nodeId}:{fieldPath}"` key format) and
+ * stay in TS — they encode no grammar or math semantics.
  */
 
-import type { Bindings, Document, Expr, Parameter } from "@vcad/ir";
+import type { Document, Expr, Parameter } from "@vcad/ir";
+import { getKernelWasmSync } from "./wasm-singleton.js";
 
 // ---------------------------------------------------------------------------
-// AST
+// AST (wire shape produced by the Rust parser)
 // ---------------------------------------------------------------------------
 
 export type Ast =
@@ -57,181 +58,83 @@ export class EvalError extends Error {
   }
 }
 
+/** Rust `ParseError` Display: `parse error at offset N: <message>`. */
+const PARSE_ERROR_RE = /^parse error at offset (\d+): (.*)$/s;
+
+/**
+ * Map an error thrown by a WASM expression binding onto the historical
+ * TS error classes. Parse failures keep their byte offset; everything
+ * else (undefined variable, arity, math domain, ...) becomes EvalError.
+ */
+function toExpressionError(e: unknown): Error {
+  const message = e instanceof Error ? e.message : String(e);
+  const m = PARSE_ERROR_RE.exec(message);
+  if (m) return new ParseError(m[2], Number(m[1]));
+  return new EvalError(message);
+}
+
 // ---------------------------------------------------------------------------
-// Lexer
+// WASM access
 // ---------------------------------------------------------------------------
 
-type Tok =
-  | { kind: "num"; value: number; offset: number }
-  | { kind: "ident"; value: string; offset: number }
-  | { kind: "sym"; value: string; offset: number }
-  | { kind: "end"; offset: number };
-
-function isDigit(c: string): boolean {
-  return c >= "0" && c <= "9";
-}
-function isAlpha(c: string): boolean {
-  return (c >= "A" && c <= "Z") || (c >= "a" && c <= "z") || c === "_";
-}
-function isAlnum(c: string): boolean {
-  return isAlpha(c) || isDigit(c);
+interface ExpressionWasm {
+  exprParse(src: string): Ast;
+  exprEvalAst(ast: Ast, env: Record<string, number>): number;
+  exprEvaluate(src: string, env: Record<string, number>): number;
+  resolveParametersJson(paramsJson: string): string;
+  resolveDocumentJson(docJson: string): string;
 }
 
-function lex(src: string): Tok[] {
-  const out: Tok[] = [];
-  let i = 0;
-  while (i < src.length) {
-    const c = src[i];
-    if (c === " " || c === "\t" || c === "\n" || c === "\r") {
-      i++;
-      continue;
-    }
-    if (isDigit(c) || (c === "." && i + 1 < src.length && isDigit(src[i + 1]))) {
-      const start = i;
-      let hasDot = false;
-      let hasExp = false;
-      while (i < src.length) {
-        const ch = src[i];
-        if (isDigit(ch)) {
-          i++;
-        } else if (ch === "." && !hasDot && !hasExp) {
-          hasDot = true;
-          i++;
-        } else if ((ch === "e" || ch === "E") && !hasExp) {
-          hasExp = true;
-          i++;
-          if (i < src.length && (src[i] === "+" || src[i] === "-")) i++;
-        } else {
-          break;
-        }
-      }
-      const lit = src.slice(start, i);
-      const n = Number(lit);
-      if (!Number.isFinite(n)) throw new ParseError(`invalid number '${lit}'`, start);
-      out.push({ kind: "num", value: n, offset: start });
-      continue;
-    }
-    if (isAlpha(c)) {
-      const start = i;
-      while (i < src.length && isAlnum(src[i])) i++;
-      out.push({ kind: "ident", value: src.slice(start, i), offset: start });
-      continue;
-    }
-    if ("+-*/%^(),".includes(c)) {
-      out.push({ kind: "sym", value: c, offset: i });
-      i++;
-      continue;
-    }
-    throw new ParseError(`unexpected character '${c}'`, i);
+function requireWasm(fn: keyof ExpressionWasm): ExpressionWasm {
+  const mod = getKernelWasmSync() as unknown as ExpressionWasm | null;
+  if (!mod) {
+    throw new Error(
+      `${fn}: kernel WASM is not initialized — await getKernelWasm() (or Engine.init()) before using expression APIs`,
+    );
   }
-  out.push({ kind: "end", offset: src.length });
-  return out;
+  if (typeof mod[fn] !== "function") {
+    throw new Error(
+      `${fn} is not exported by this kernel WASM build — rebuild packages/kernel-wasm`,
+    );
+  }
+  return mod;
 }
 
 // ---------------------------------------------------------------------------
-// Parser
+// Parse / eval
 // ---------------------------------------------------------------------------
 
+/** Parse an expression string into an AST. Throws ParseError. */
 export function parse(src: string): Ast {
-  const toks = lex(src);
-  let pos = 0;
-  const peek = () => toks[pos];
-  const eat = (): Tok => toks[pos++];
-  const eatSym = (want: string, what: string) => {
-    const t = peek();
-    if (t.kind !== "sym" || t.value !== want)
-      throw new ParseError(`expected ${what}`, t.offset);
-    pos++;
-  };
-
-  const parseExpr = (): Ast => {
-    let lhs = parseTerm();
-    while (true) {
-      const t = peek();
-      if (t.kind !== "sym" || (t.value !== "+" && t.value !== "-")) break;
-      pos++;
-      const rhs = parseTerm();
-      lhs = { kind: "binary", op: t.value as BinOp, lhs, rhs };
-    }
-    return lhs;
-  };
-
-  const parseTerm = (): Ast => {
-    let lhs = parseUnary();
-    while (true) {
-      const t = peek();
-      if (t.kind !== "sym" || (t.value !== "*" && t.value !== "/" && t.value !== "%")) break;
-      pos++;
-      const rhs = parseUnary();
-      lhs = { kind: "binary", op: t.value as BinOp, lhs, rhs };
-    }
-    return lhs;
-  };
-
-  const parseUnary = (): Ast => {
-    const t = peek();
-    if (t.kind === "sym" && (t.value === "-" || t.value === "+")) {
-      pos++;
-      const arg = parseUnary();
-      return { kind: "unary", op: t.value as UnOp, arg };
-    }
-    return parsePower();
-  };
-
-  const parsePower = (): Ast => {
-    const lhs = parseAtom();
-    const t = peek();
-    if (t.kind === "sym" && t.value === "^") {
-      pos++;
-      const rhs = parseUnary(); // right-assoc, tighter than unary
-      return { kind: "binary", op: "^", lhs, rhs };
-    }
-    return lhs;
-  };
-
-  const parseAtom = (): Ast => {
-    const t = peek();
-    if (t.kind === "num") {
-      pos++;
-      return { kind: "num", value: t.value };
-    }
-    if (t.kind === "sym" && t.value === "(") {
-      pos++;
-      const e = parseExpr();
-      eatSym(")", "')'");
-      return e;
-    }
-    if (t.kind === "ident") {
-      pos++;
-      const next = peek();
-      if (next.kind === "sym" && next.value === "(") {
-        pos++;
-        const args: Ast[] = [];
-        if (!(peek().kind === "sym" && (peek() as { value: string }).value === ")")) {
-          args.push(parseExpr());
-          while (peek().kind === "sym" && (peek() as { value: string }).value === ",") {
-            pos++;
-            args.push(parseExpr());
-          }
-        }
-        eatSym(")", "')'");
-        return { kind: "call", name: t.value, args };
-      }
-      return { kind: "ident", name: t.value };
-    }
-    throw new ParseError("expected number, identifier, or '('", t.offset);
-  };
-
-  const ast = parseExpr();
-  const tail = peek();
-  if (tail.kind !== "end") throw new ParseError("unexpected trailing input", tail.offset);
-  return ast;
+  try {
+    return requireWasm("exprParse").exprParse(src);
+  } catch (e) {
+    throw toExpressionError(e);
+  }
 }
 
-// ---------------------------------------------------------------------------
-// Eval
-// ---------------------------------------------------------------------------
+/** Evaluate a parsed AST against an environment. Throws EvalError. */
+export function evalAst(ast: Ast, env: Record<string, number>): number {
+  try {
+    return requireWasm("exprEvalAst").exprEvalAst(ast, env);
+  } catch (e) {
+    throw toExpressionError(e);
+  }
+}
 
+/** Parse and evaluate in one shot. Throws ParseError or EvalError. */
+export function evaluate(source: string, env: Record<string, number>): number {
+  try {
+    return requireWasm("exprEvaluate").exprEvaluate(source, env);
+  } catch (e) {
+    throw toExpressionError(e);
+  }
+}
+
+/**
+ * Collect free identifiers referenced by an AST (excluding the named
+ * constants `pi`, `tau`, `e`), in first-appearance order.
+ */
 export function freeVars(ast: Ast): string[] {
   const out: string[] = [];
   const walk = (a: Ast) => {
@@ -258,128 +161,6 @@ export function freeVars(ast: Ast): string[] {
   return out;
 }
 
-export function evalAst(ast: Ast, env: Record<string, number>): number {
-  switch (ast.kind) {
-    case "num":
-      return ast.value;
-    case "ident":
-      if (ast.name === "pi") return Math.PI;
-      if (ast.name === "tau") return Math.PI * 2;
-      if (ast.name === "e") return Math.E;
-      if (!(ast.name in env)) throw new EvalError(`undefined variable: ${ast.name}`);
-      return env[ast.name];
-    case "binary": {
-      const l = evalAst(ast.lhs, env);
-      const r = evalAst(ast.rhs, env);
-      switch (ast.op) {
-        case "+":
-          return l + r;
-        case "-":
-          return l - r;
-        case "*":
-          return l * r;
-        case "/":
-          if (r === 0) throw new EvalError("math domain error: division by zero");
-          return l / r;
-        case "%":
-          if (r === 0) throw new EvalError("math domain error: modulo by zero");
-          // rem_euclid equivalent
-          return ((l % r) + r) % r;
-        case "^":
-          return Math.pow(l, r);
-      }
-      return 0;
-    }
-    case "unary": {
-      const v = evalAst(ast.arg, env);
-      return ast.op === "-" ? -v : v;
-    }
-    case "call":
-      return callBuiltin(ast.name, ast.args.map((a) => evalAst(a, env)));
-  }
-}
-
-function callBuiltin(name: string, v: number[]): number {
-  const arity = (n: number) => {
-    if (v.length !== n)
-      throw new EvalError(`function '${name}' expected ${n} argument(s), got ${v.length}`);
-  };
-  switch (name) {
-    case "sin":
-      arity(1);
-      return Math.sin(v[0]);
-    case "cos":
-      arity(1);
-      return Math.cos(v[0]);
-    case "tan":
-      arity(1);
-      return Math.tan(v[0]);
-    case "asin":
-      arity(1);
-      return Math.asin(v[0]);
-    case "acos":
-      arity(1);
-      return Math.acos(v[0]);
-    case "atan":
-      arity(1);
-      return Math.atan(v[0]);
-    case "atan2":
-      arity(2);
-      return Math.atan2(v[0], v[1]);
-    case "sqrt":
-      arity(1);
-      if (v[0] < 0) throw new EvalError("math domain error: sqrt of negative");
-      return Math.sqrt(v[0]);
-    case "abs":
-      arity(1);
-      return Math.abs(v[0]);
-    case "floor":
-      arity(1);
-      return Math.floor(v[0]);
-    case "ceil":
-      arity(1);
-      return Math.ceil(v[0]);
-    case "round":
-      arity(1);
-      // Match Rust's f64::round (ties away from zero).
-      return Math.sign(v[0]) * Math.round(Math.abs(v[0]));
-    case "ln":
-    case "log":
-      arity(1);
-      if (v[0] <= 0) throw new EvalError("math domain error: log of non-positive");
-      return Math.log(v[0]);
-    case "log2":
-      arity(1);
-      if (v[0] <= 0) throw new EvalError("math domain error: log2 of non-positive");
-      return Math.log2(v[0]);
-    case "exp":
-      arity(1);
-      return Math.exp(v[0]);
-    case "pow":
-      arity(2);
-      return Math.pow(v[0], v[1]);
-    case "min":
-      arity(2);
-      return Math.min(v[0], v[1]);
-    case "max":
-      arity(2);
-      return Math.max(v[0], v[1]);
-    case "deg":
-      arity(1);
-      return (v[0] * 180) / Math.PI;
-    case "rad":
-      arity(1);
-      return (v[0] * Math.PI) / 180;
-    default:
-      throw new EvalError(`unknown function: ${name}`);
-  }
-}
-
-/** Parse and evaluate in one shot. */
-export function evaluate(source: string, env: Record<string, number>): number {
-  return evalAst(parse(source), env);
-}
-
 // ---------------------------------------------------------------------------
 // Document resolution
 // ---------------------------------------------------------------------------
@@ -395,56 +176,15 @@ export function parseBindingKey(raw: string): { nodeId: string; fieldPath: strin
 export function resolveParameters(
   params: Record<string, Parameter> | undefined,
 ): Record<string, number> {
-  if (!params) return {};
-  // Parse each formula once and build a dep graph.
-  const asts: Record<string, Ast | null> = {};
-  for (const [name, p] of Object.entries(params)) {
-    if (typeof p.value === "number") {
-      asts[name] = null;
-    } else {
-      asts[name] = parse(p.value);
-    }
+  if (!params || Object.keys(params).length === 0) return {};
+  try {
+    const json = requireWasm("resolveParametersJson").resolveParametersJson(
+      JSON.stringify(params),
+    );
+    return JSON.parse(json) as Record<string, number>;
+  } catch (e) {
+    throw toExpressionError(e);
   }
-  const deps: Record<string, string[]> = {};
-  for (const [name, ast] of Object.entries(asts)) {
-    const refs: string[] = [];
-    if (ast) {
-      for (const v of freeVars(ast)) {
-        if (v in params) refs.push(v);
-      }
-    }
-    deps[name] = refs;
-  }
-  // DFS topo-sort with cycle detection.
-  const marks: Record<string, "white" | "gray" | "black"> = {};
-  for (const name of Object.keys(params)) marks[name] = "white";
-  const order: string[] = [];
-  const stack: string[] = [];
-  const visit = (node: string) => {
-    if (marks[node] === "black") return;
-    if (marks[node] === "gray") {
-      const idx = stack.indexOf(node);
-      const path = [...stack.slice(idx), node];
-      throw new EvalError(`cycle in parameter dependencies: ${path.join(" → ")}`);
-    }
-    marks[node] = "gray";
-    stack.push(node);
-    for (const child of deps[node] ?? []) visit(child);
-    stack.pop();
-    marks[node] = "black";
-    order.push(node);
-  };
-  for (const name of Object.keys(params)) visit(name);
-  const env: Record<string, number> = {};
-  for (const name of order) {
-    const p = params[name];
-    if (typeof p.value === "number") {
-      env[name] = p.value;
-    } else {
-      env[name] = evalAst(asts[name]!, env);
-    }
-  }
-  return env;
 }
 
 /** Resolve a single Expr against a parameter env. Returns NaN on error. */
@@ -457,12 +197,13 @@ export function evalExprSafe(expr: Expr, env: Record<string, number>): number {
 }
 
 /**
- * Produce a deep-cloned document with parameters resolved and bindings
- * applied to concrete fields. The returned doc is safe to hand to the
- * WASM kernel or the TS fallback evaluator — it contains no expressions.
+ * Produce a resolved copy of the document: parameters evaluated in
+ * dependency order, bindings applied to concrete fields. The returned
+ * doc is safe to hand to the WASM kernel or the TS fallback evaluator —
+ * it contains no unresolved expressions.
  *
- * If the document has no parameters and no bindings, a cheap shallow
- * clone is returned unchanged.
+ * If the document has no parameters and no bindings, the original doc
+ * is returned unchanged (no round-trip cost).
  */
 export function resolveDocument(doc: Document): {
   doc: Document;
@@ -473,66 +214,10 @@ export function resolveDocument(doc: Document): {
   if (!hasParams && !hasBindings) {
     return { doc, env: {} };
   }
-  const env = resolveParameters(doc.parameters);
-  const cloned: Document = structuredClone(doc);
-  // Deterministic iteration: sort by nodeId then fieldPath.
-  const entries: Array<[string, Expr]> = Object.entries(cloned.bindings ?? {});
-  entries.sort(([a], [b]) => {
-    const ka = parseBindingKey(a);
-    const kb = parseBindingKey(b);
-    if (!ka || !kb) return a.localeCompare(b);
-    const nidA = Number(ka.nodeId);
-    const nidB = Number(kb.nodeId);
-    if (nidA !== nidB) return nidA - nidB;
-    return ka.fieldPath.localeCompare(kb.fieldPath);
-  });
-  for (const [key, expr] of entries) {
-    const parsed = parseBindingKey(key);
-    if (!parsed) continue;
-    const value = typeof expr === "number" ? expr : evaluate(expr, env);
-    applyBinding(cloned, parsed.nodeId, parsed.fieldPath, value);
-  }
-  return { doc: cloned, env };
-}
-
-/** Mutate `node.op` so that the concrete field at `fieldPath` becomes `value`. */
-function applyBinding(doc: Document, nodeId: string, fieldPath: string, value: number): void {
-  const node = doc.nodes[nodeId];
-  if (!node) throw new EvalError(`binding references missing node '${nodeId}'`);
-  const op = node.op as unknown as Record<string, unknown>;
-
-  // Helper: write into nested object using dotted path, creating nothing.
-  const writeNested = (root: unknown, path: string[]): boolean => {
-    let cursor = root as Record<string, unknown>;
-    for (let i = 0; i < path.length - 1; i++) {
-      const key = path[i];
-      if (cursor == null || typeof cursor !== "object" || !(key in cursor)) return false;
-      cursor = cursor[key] as Record<string, unknown>;
-    }
-    const leaf = path[path.length - 1];
-    if (cursor == null || typeof cursor !== "object") return false;
-    cursor[leaf] = value;
-    return true;
-  };
-
-  // Handle optional scalar fields that may not yet exist on the op.
-  const leaf = fieldPath;
-  if (!fieldPath.includes(".")) {
-    // Integer-like field handling for segments / count — round and clamp.
-    if (leaf === "segments" || leaf === "count") {
-      op[leaf] = Math.max(0, Math.round(value));
-    } else {
-      op[leaf] = value;
-    }
-    return;
-  }
-  const parts = fieldPath.split(".");
-  const ok = writeNested(op, parts);
-  if (!ok) {
-    throw new EvalError(
-      `binding '${nodeId}:${fieldPath}' — field path not valid on op type '${String(
-        (op as { type?: unknown }).type,
-      )}'`,
-    );
+  try {
+    const json = requireWasm("resolveDocumentJson").resolveDocumentJson(JSON.stringify(doc));
+    return JSON.parse(json) as { doc: Document; env: Record<string, number> };
+  } catch (e) {
+    throw toExpressionError(e);
   }
 }


### PR DESCRIPTION
## What

`packages/engine/src/expressions.ts` (538 lines) was a hand-maintained mirror of the Rust expression grammar, with a header demanding it "MUST agree bit-for-bit" with tang-expr semantics. This PR removes the duplication:

- **New WASM module** `crates/vcad-kernel-wasm/src/expressions.rs`: `exprParse`, `exprEvalAst`, `exprEvaluate`, `resolveParametersJson`, `resolveDocumentJson`, delegating to `vcad-ir::expr_parser`, `vcad_ir::resolve_parameters`, and `vcad_eval::resolve_document_cloned` (which also brings `pcb.*` binding paths the TS mirror never supported). A `WireAst` serde type emits the AST in the exact discriminated-union shape (`{kind: "binary", op: "+", ...}`) TS consumers already walk; unit tests pin the wire shape and round-trip.
- **`expressions.ts` rewritten** as ~230 lines of marshalling with zero grammar/math semantics. Public API unchanged (`parse`, `evaluate`, `evalAst`, `freeVars`, `evalExprSafe`, `resolveParameters`, `resolveDocument`, `parseBindingKey`, `ParseError` with `.offset`, `EvalError`, `Ast`) — no consumer edits needed in app/core/mcp. `freeVars`/`parseBindingKey` stay pure-TS structural helpers. Rust error strings map back to the historical `ParseError`/`EvalError` classes.
- **Shared-fixture test repointed**: `expressions.test.ts` keeps all fixtures, now awaits `getKernelWasm()` in `beforeAll` and verifies the binding end-to-end. All fixtures pass unmodified against the Rust semantics.

## Reviewer notes

- **No sync/no-WASM fallback, by design.** Every consumer runs after `Engine.init()` / MCP startup (both initialize the WASM singleton), so the wrapper uses `getKernelWasmSync()` and throws a descriptive error if called pre-init. A TS fallback parser would be exactly the drift hazard this removes; documented in the file header.
- Not re-exported through the `vcad-kernel` unified crate because `vcad-eval` depends on `vcad-kernel` (would cycle); the wasm crate already depended on `vcad-eval`.
- Two intentional fail-closed deltas vs the old mirror: bindings to field paths an op doesn't have now error instead of writing junk properties, and `asin`/`acos` out-of-domain raise `EvalError` instead of returning NaN.
- WASM artifacts (`packages/kernel-wasm/vcad_kernel_wasm*`) are **not** committed per policy — `wasm-refresh.yml` rebuilds them on main; PR CI builds WASM from source.

## Verification

- `cargo test --workspace` clean; `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` clean; `cargo fmt --check` clean
- All TS workspace builds and tests pass (engine 119 tests incl. the repointed fixtures, app/core/mcp suites) against a locally rebuilt WASM artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)