### PR TITLE
refactor(engine): make Rust canonical for timeline sequence sampling

### DIFF
--- a/crates/vcad-ir/src/animation.rs
+++ b/crates/vcad-ir/src/animation.rs
@@ -6,6 +6,8 @@
 //! expressed as shot *intents* (turntable, orbit, focus) rather than raw
 //! keyframes so agents author cinematography declaratively.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::Vec3;
@@ -170,6 +172,62 @@ fn default_fps() -> f64 {
     24.0
 }
 
+/// A per-frame camera pose in orbit coordinates, compiled from the
+/// timeline's declarative [`CameraShot`]s by [`Timeline::sample_sequence`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct CameraPose {
+    /// Azimuth around the scene, degrees.
+    #[serde(rename = "azimuthDeg")]
+    pub azimuth_deg: f64,
+    /// Elevation above the horizon, degrees.
+    #[serde(rename = "elevationDeg")]
+    pub elevation_deg: f64,
+    /// Distance factor (1 = default framing, 0.5 = half distance).
+    pub dolly: f64,
+    /// Optional part/instance id the camera is framing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub target: Option<String>,
+}
+
+impl Default for CameraPose {
+    fn default() -> Self {
+        Self {
+            azimuth_deg: 0.0,
+            elevation_deg: 30.0,
+            dolly: 1.0,
+            target: None,
+        }
+    }
+}
+
+/// Sampled state for a single frame of the timeline.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct SequenceFrame {
+    /// Frame index (0-based).
+    pub index: u32,
+    /// Time in seconds.
+    pub t: f64,
+    /// Animated parameter name → value at `t`.
+    pub params: BTreeMap<String, f64>,
+    /// Joint id → state at `t`.
+    pub joints: BTreeMap<String, f64>,
+    /// Instance id → visible (track value > 0.5).
+    pub visibility: BTreeMap<String, bool>,
+    /// Global exploded-view factor (0 = assembled).
+    pub explode: f64,
+    /// Camera pose compiled from the timeline's shots.
+    pub camera: CameraPose,
+    /// True iff params differ from the previous frame (frame 0: true if
+    /// any parameter track exists).
+    #[serde(rename = "geometryDirty")]
+    pub geometry_dirty: bool,
+}
+
 impl Timeline {
     /// Number of frames when sampled at `fps` (at least 1, inclusive of t=0).
     pub fn frame_count(&self) -> usize {
@@ -204,6 +262,111 @@ impl Timeline {
             Ease::EaseInOut => u * u * (3.0 - 2.0 * u),
         };
         Some(a.value + (b.value - a.value) * u)
+    }
+
+    /// Compile the camera shots into a pose at time `t`, carrying `prev`
+    /// state. The last shot whose `[start_s, end_s)` contains `t` wins on
+    /// overlap; gaps hold the previous pose.
+    fn camera_pose_at(shots: &[CameraShot], t: f64, prev: &CameraPose) -> CameraPose {
+        let active = shots.iter().rfind(|s| t >= s.start_s && t < s.end_s);
+        let Some(shot) = active else {
+            return prev.clone();
+        };
+        let span = shot.end_s - shot.start_s;
+        let u = if span <= 0.0 {
+            1.0
+        } else {
+            (t - shot.start_s) / span
+        };
+        match &shot.kind {
+            CameraShotKind::Turntable {
+                degrees,
+                elevation_deg,
+            } => CameraPose {
+                azimuth_deg: degrees * u,
+                elevation_deg: *elevation_deg,
+                dolly: 1.0,
+                target: None,
+            },
+            CameraShotKind::Orbit { from, to } => CameraPose {
+                azimuth_deg: from[0] + (to[0] - from[0]) * u,
+                elevation_deg: from[1] + (to[1] - from[1]) * u,
+                dolly: 1.0,
+                target: None,
+            },
+            CameraShotKind::Focus { target, dolly } => CameraPose {
+                azimuth_deg: prev.azimuth_deg,
+                elevation_deg: prev.elevation_deg,
+                dolly: 1.0 + (dolly - 1.0) * u,
+                target: Some(target.clone()),
+            },
+            CameraShotKind::Static { .. } => CameraPose::default(),
+        }
+    }
+
+    /// Sample the timeline into a full per-frame sequence: track values
+    /// bucketed by target kind, camera poses compiled from shot intents,
+    /// and a `geometry_dirty` flag marking frames whose parameter values
+    /// changed (frame 0 is dirty iff any parameter track exists).
+    ///
+    /// `fps <= 0` falls back to 24; the sequence always has at least 2
+    /// frames (t=0 and the final frame) and is inclusive of both ends.
+    pub fn sample_sequence(&self) -> Vec<SequenceFrame> {
+        let fps = if self.fps > 0.0 { self.fps } else { 24.0 };
+        let frame_count = (((self.duration_s * fps).round() as i64) + 1).max(2) as u32;
+        let has_param_tracks = self
+            .tracks
+            .iter()
+            .any(|tr| matches!(tr.target, AnimTarget::Parameter { .. }));
+
+        let mut frames = Vec::with_capacity(frame_count as usize);
+        let mut prev_params: Option<BTreeMap<String, f64>> = None;
+        let mut prev_pose = CameraPose::default();
+
+        for index in 0..frame_count {
+            let t = f64::from(index) / fps;
+            let mut params = BTreeMap::new();
+            let mut joints = BTreeMap::new();
+            let mut visibility = BTreeMap::new();
+            let mut explode = 0.0;
+
+            for track in &self.tracks {
+                let value = Self::sample_track(track, t).unwrap_or(0.0);
+                match &track.target {
+                    AnimTarget::Parameter { name } => {
+                        params.insert(name.clone(), value);
+                    }
+                    AnimTarget::Joint { joint_id } => {
+                        joints.insert(joint_id.clone(), value);
+                    }
+                    AnimTarget::Visibility { instance_id } => {
+                        visibility.insert(instance_id.clone(), value > 0.5);
+                    }
+                    AnimTarget::Explode => explode = value,
+                }
+            }
+
+            let camera = Self::camera_pose_at(&self.camera, t, &prev_pose);
+            prev_pose = camera.clone();
+
+            let geometry_dirty = match &prev_params {
+                None => has_param_tracks,
+                Some(prev) => params.iter().any(|(name, v)| prev.get(name) != Some(v)),
+            };
+            prev_params = Some(params.clone());
+
+            frames.push(SequenceFrame {
+                index,
+                t,
+                params,
+                joints,
+                visibility,
+                explode,
+                camera,
+                geometry_dirty,
+            });
+        }
+        frames
     }
 }
 
@@ -260,6 +423,164 @@ mod tests {
             camera: vec![],
         };
         assert_eq!(tl.frame_count(), 49);
+    }
+
+    fn timeline(
+        duration_s: f64,
+        fps: f64,
+        tracks: Vec<AnimTrack>,
+        camera: Vec<CameraShot>,
+    ) -> Timeline {
+        Timeline {
+            duration_s,
+            fps,
+            tracks,
+            camera,
+        }
+    }
+
+    #[test]
+    fn sequence_frame_count_and_fps_fallback() {
+        let frames = timeline(2.0, 24.0, vec![], vec![]).sample_sequence();
+        assert_eq!(frames.len(), 49);
+        assert_eq!(frames[0].t, 0.0);
+        assert!((frames[48].t - 2.0).abs() < 1e-12);
+        // fps <= 0 falls back to 24
+        assert_eq!(
+            timeline(1.0, 0.0, vec![], vec![]).sample_sequence().len(),
+            25
+        );
+        // at least 2 frames
+        assert_eq!(
+            timeline(0.0, 24.0, vec![], vec![]).sample_sequence().len(),
+            2
+        );
+    }
+
+    #[test]
+    fn sequence_tracks_and_geometry_dirty() {
+        let tl = timeline(
+            1.0,
+            4.0,
+            vec![
+                AnimTrack {
+                    target: AnimTarget::Parameter {
+                        name: "width".into(),
+                    },
+                    keys: vec![key(0.0, 10.0, Ease::Linear), key(1.0, 20.0, Ease::Linear)],
+                },
+                AnimTrack {
+                    target: AnimTarget::Joint {
+                        joint_id: "j1".into(),
+                    },
+                    keys: vec![key(0.0, 0.0, Ease::Linear), key(1.0, 90.0, Ease::Linear)],
+                },
+                AnimTrack {
+                    target: AnimTarget::Visibility {
+                        instance_id: "lid".into(),
+                    },
+                    keys: vec![key(0.0, 1.0, Ease::Linear), key(0.5, 0.0, Ease::Step)],
+                },
+                AnimTrack {
+                    target: AnimTarget::Explode,
+                    keys: vec![key(0.0, 0.0, Ease::Linear), key(1.0, 1.0, Ease::Linear)],
+                },
+            ],
+            vec![],
+        );
+        let frames = tl.sample_sequence();
+        assert_eq!(frames.len(), 5);
+        assert_eq!(frames[0].params["width"], 10.0);
+        assert_eq!(frames[2].params["width"], 15.0);
+        assert_eq!(frames[4].joints["j1"], 90.0);
+        assert!(frames[0].visibility["lid"]);
+        assert!(!frames[3].visibility["lid"]);
+        assert_eq!(frames[2].explode, 0.5);
+        assert!(frames.iter().all(|f| f.geometry_dirty));
+        // static params → only frame 0 dirty; no param tracks → never dirty
+        let static_tl = timeline(
+            1.0,
+            2.0,
+            vec![AnimTrack {
+                target: AnimTarget::Parameter {
+                    name: "width".into(),
+                },
+                keys: vec![key(0.0, 10.0, Ease::Linear)],
+            }],
+            vec![],
+        );
+        let sf = static_tl.sample_sequence();
+        assert!(sf[0].geometry_dirty);
+        assert!(!sf[1].geometry_dirty);
+        let none = timeline(1.0, 2.0, vec![], vec![]).sample_sequence();
+        assert!(!none[0].geometry_dirty);
+    }
+
+    #[test]
+    fn sequence_camera_shots() {
+        // Turntable sweeps azimuth; t past the shot holds the last pose.
+        let frames = timeline(
+            2.0,
+            2.0,
+            vec![],
+            vec![CameraShot {
+                start_s: 0.0,
+                end_s: 2.0,
+                kind: CameraShotKind::Turntable {
+                    degrees: 360.0,
+                    elevation_deg: 45.0,
+                },
+            }],
+        )
+        .sample_sequence();
+        assert_eq!(frames[0].camera.azimuth_deg, 0.0);
+        assert_eq!(frames[0].camera.elevation_deg, 45.0);
+        assert!((frames[2].camera.azimuth_deg - 180.0).abs() < 1e-12);
+        assert_eq!(frames[4].camera.azimuth_deg, frames[3].camera.azimuth_deg);
+
+        // No shots → default pose.
+        let plain = timeline(1.0, 2.0, vec![], vec![]).sample_sequence();
+        assert_eq!(plain[0].camera, CameraPose::default());
+
+        // Orbit then Focus: focus holds prior az/el, dollies toward target.
+        let frames = timeline(
+            2.0,
+            2.0,
+            vec![],
+            vec![
+                CameraShot {
+                    start_s: 0.0,
+                    end_s: 1.0,
+                    kind: CameraShotKind::Orbit {
+                        from: [0.0, 10.0],
+                        to: [90.0, 40.0],
+                    },
+                },
+                CameraShot {
+                    start_s: 1.0,
+                    end_s: 2.0,
+                    kind: CameraShotKind::Focus {
+                        target: "lid".into(),
+                        dolly: 0.5,
+                    },
+                },
+            ],
+        )
+        .sample_sequence();
+        assert!((frames[1].camera.azimuth_deg - 45.0).abs() < 1e-12);
+        assert!((frames[3].camera.dolly - 0.75).abs() < 1e-12);
+        assert_eq!(frames[3].camera.target.as_deref(), Some("lid"));
+        assert_eq!(frames[3].camera.azimuth_deg, frames[1].camera.azimuth_deg);
+    }
+
+    #[test]
+    fn sequence_frame_json_shape() {
+        let frames = timeline(0.0, 24.0, vec![], vec![]).sample_sequence();
+        let json = serde_json::to_string(&frames[0]).unwrap();
+        assert!(json.contains(r#""geometryDirty""#));
+        assert!(json.contains(r#""azimuthDeg""#));
+        // absent target is omitted, matching the TS CameraPose shape
+        assert!(!json.contains(r#""target""#));
     }
 
     #[test]

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -2913,5 +2913,8 @@ mod ts_tests {
         // Re-runnable verification receipt (not reachable from Document).
         crate::ecad::Receipt::export_all().expect("Receipt export failed");
         crate::ecad::ReceiptStatus::export_all().expect("ReceiptStatus export failed");
+        // Timeline sampling output (produced by sample_sequence, not
+        // reachable from Document).
+        crate::animation::SequenceFrame::export_all().expect("SequenceFrame export failed");
     }
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -504,6 +504,34 @@ pub fn estimate_cost_for_process(
     serde_wasm_bindgen::to_value(&estimate).map_err(|e| JsError::new(&e.to_string()))
 }
 
+// =============================================================================
+// Animation timeline sampling
+// =============================================================================
+
+/// Sample a document timeline into its full per-frame sequence.
+///
+/// `timeline_json` must deserialize into `vcad_ir::animation::Timeline`.
+/// Returns a JSON array of `SequenceFrame` objects (params/joints/
+/// visibility/explode/camera/geometryDirty per frame) — one call per
+/// sequence, so callers never cross the WASM boundary per track or frame.
+#[wasm_bindgen]
+pub fn sample_timeline_sequence(timeline_json: &str) -> Result<String, JsError> {
+    let tl: vcad_ir::animation::Timeline = serde_json::from_str(timeline_json)
+        .map_err(|e| JsError::new(&format!("invalid timeline JSON: {e}")))?;
+    serde_json::to_string(&tl.sample_sequence()).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Sample a single animation track's value at time `t` seconds.
+///
+/// `track_json` must deserialize into `vcad_ir::animation::AnimTrack`.
+/// A track with no keys samples to 0.
+#[wasm_bindgen]
+pub fn sample_timeline_track(track_json: &str, t: f64) -> Result<f64, JsError> {
+    let track: vcad_ir::animation::AnimTrack = serde_json::from_str(track_json)
+        .map_err(|e| JsError::new(&format!("invalid track JSON: {e}")))?;
+    Ok(vcad_ir::animation::Timeline::sample_track(&track, t).unwrap_or(0.0))
+}
+
 /// Initialize the WASM module (sets up panic hook for better error messages).
 #[wasm_bindgen(start)]
 pub fn init() {

--- a/packages/engine/src/__tests__/sequence.test.ts
+++ b/packages/engine/src/__tests__/sequence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import type { AnimTrack, Document, Timeline } from "@vcad/ir";
 import { createDocument } from "@vcad/ir";
 import {
@@ -6,6 +6,15 @@ import {
   sampleSequence,
   sampleTrackValue,
 } from "../sequence.js";
+import { getKernelWasm } from "../wasm-singleton.js";
+
+// The samplers are thin wrappers over the Rust reference
+// (Timeline::sample_sequence); the expectations below were captured from
+// the prior TypeScript implementation, so this suite doubles as the
+// TS↔Rust agreement fixture.
+beforeAll(async () => {
+  await getKernelWasm();
+});
 
 function track(target: AnimTrack["target"], keys: AnimTrack["keys"]): AnimTrack {
   return { target, keys };

--- a/packages/engine/src/sequence.ts
+++ b/packages/engine/src/sequence.ts
@@ -2,124 +2,54 @@
  * Animation sequencer — samples a document's `Timeline` into per-frame
  * state (parameters, joints, visibility, explode, camera pose).
  *
- * Interpolation semantics mirror the Rust reference in
- * `crates/vcad-ir/src/animation.rs` (`Timeline::sample_track`): values
- * clamp before the first / after the last key; between keys the
- * destination key's ease drives the blend (linear, step, smoothstep).
- * Camera shots are declarative intents compiled to per-frame poses.
+ * Thin wrapper over the Rust reference implementation
+ * (`Timeline::sample_sequence` in `crates/vcad-ir/src/animation.rs`),
+ * reached through the kernel WASM bindings `sample_timeline_sequence` /
+ * `sample_timeline_track` — one boundary crossing per sequence (or per
+ * track sample), never per frame. The kernel WASM module must be
+ * initialized (`await getKernelWasm()`) before calling the samplers;
+ * `poseDocument` is pure document surgery and needs no WASM.
  */
 
 import type {
   AnimTrack,
-  CameraShot,
+  CameraPose,
   Document,
+  SequenceFrame,
   Timeline,
 } from "@vcad/ir";
+import { getKernelWasmSync } from "./wasm-singleton.js";
 
-/** A per-frame camera pose in orbit coordinates. */
-export interface CameraPose {
-  /** Azimuth around the scene, degrees. */
-  azimuthDeg: number;
-  /** Elevation above the horizon, degrees. */
-  elevationDeg: number;
-  /** Distance factor (1 = default framing, 0.5 = half distance). */
-  dolly: number;
-  /** Optional part/instance id the camera is framing. */
-  target?: string;
+export type { CameraPose, SequenceFrame };
+
+interface TimelineSamplerWasm {
+  sample_timeline_sequence(timelineJson: string): string;
+  sample_timeline_track(trackJson: string, t: number): number;
 }
 
-/** Sampled state for a single frame of the timeline. */
-export interface SequenceFrame {
-  /** Frame index (0-based). */
-  index: number;
-  /** Time in seconds. */
-  t: number;
-  /** Animated parameter name → value at `t`. */
-  params: Record<string, number>;
-  /** Joint id → state at `t`. */
-  joints: Record<string, number>;
-  /** Instance id → visible (track value > 0.5). */
-  visibility: Record<string, boolean>;
-  /** Global exploded-view factor (0 = assembled). */
-  explode: number;
-  /** Camera pose compiled from the timeline's shots. */
-  camera: CameraPose;
-  /** True iff params differ from the previous frame (frame 0: true if any parameter track exists). */
-  geometryDirty: boolean;
+function requireWasm(): TimelineSamplerWasm {
+  const mod = getKernelWasmSync() as unknown as Partial<TimelineSamplerWasm> | null;
+  if (
+    !mod ||
+    typeof mod.sample_timeline_sequence !== "function" ||
+    typeof mod.sample_timeline_track !== "function"
+  ) {
+    throw new Error(
+      "kernel WASM not initialized (or too old for timeline sampling) — await getKernelWasm() before sampling sequences",
+    );
+  }
+  return mod as TimelineSamplerWasm;
 }
-
-const DEFAULT_POSE: CameraPose = { azimuthDeg: 0, elevationDeg: 30, dolly: 1 };
 
 /**
  * Sample a track's value at time `t` with easing between keys.
  *
- * Matches `Timeline::sample_track` in the Rust IR: clamps outside the key
- * range; between keys `a` and `b`, `u = (t - a.t) / (b.t - a.t)` shaped by
- * the destination key `b`'s ease.
+ * Delegates to `Timeline::sample_track` in the Rust IR: clamps outside the
+ * key range; between keys `a` and `b`, `u = (t - a.t) / (b.t - a.t)` shaped
+ * by the destination key `b`'s ease. An empty track samples to 0.
  */
 export function sampleTrackValue(track: AnimTrack, t: number): number {
-  const keys = track.keys;
-  if (keys.length === 0) return 0;
-  const first = keys[0];
-  if (t <= first.t) return first.value;
-  const last = keys[keys.length - 1];
-  if (t >= last.t) return last.value;
-  const idx = keys.findIndex((k) => k.t > t);
-  const a = keys[idx - 1];
-  const b = keys[idx];
-  const span = b.t - a.t;
-  let u = span <= 0 ? 1 : (t - a.t) / span;
-  switch (b.ease ?? "linear") {
-    case "step":
-      u = u >= 1 ? 1 : 0;
-      break;
-    case "ease-in-out":
-      u = u * u * (3 - 2 * u);
-      break;
-    default:
-      break;
-  }
-  return a.value + (b.value - a.value) * u;
-}
-
-/** Compile the camera shots into a pose at time `t`, carrying `prev` state. */
-function cameraPoseAt(
-  shots: CameraShot[],
-  t: number,
-  prevPose: CameraPose,
-): CameraPose {
-  // Last shot whose [startS, endS) contains t wins on overlap.
-  let active: CameraShot | undefined;
-  for (const shot of shots) {
-    if (t >= shot.startS && t < shot.endS) active = shot;
-  }
-  if (!active) return prevPose;
-  const span = active.endS - active.startS;
-  const u = span <= 0 ? 1 : (t - active.startS) / span;
-  const kind = active.kind;
-  switch (kind.type) {
-    case "Turntable":
-      return {
-        azimuthDeg: kind.degrees * u,
-        elevationDeg: kind.elevationDeg,
-        dolly: 1,
-      };
-    case "Orbit":
-      return {
-        azimuthDeg: kind.from[0] + (kind.to[0] - kind.from[0]) * u,
-        elevationDeg: kind.from[1] + (kind.to[1] - kind.from[1]) * u,
-        dolly: 1,
-      };
-    case "Focus":
-      return {
-        azimuthDeg: prevPose.azimuthDeg,
-        elevationDeg: prevPose.elevationDeg,
-        dolly: 1 + (kind.dolly - 1) * u,
-        target: kind.target,
-      };
-    case "Static":
-      return { ...DEFAULT_POSE };
-  }
+  return requireWasm().sample_timeline_track(JSON.stringify(track), t);
 }
 
 /**
@@ -132,66 +62,8 @@ export function sampleSequence(
 ): SequenceFrame[] {
   const timeline = timelineOverride ?? doc.timeline;
   if (!timeline) return [];
-  const fps = timeline.fps && timeline.fps > 0 ? timeline.fps : 24;
-  const frameCount = Math.max(
-    2,
-    Math.round(timeline.durationS * fps) + 1,
-  );
-  const tracks = timeline.tracks ?? [];
-  const shots = timeline.camera ?? [];
-  const hasParamTracks = tracks.some((tr) => tr.target.type === "Parameter");
-
-  const frames: SequenceFrame[] = [];
-  let prevParams: Record<string, number> | undefined;
-  let prevPose: CameraPose = { ...DEFAULT_POSE };
-
-  for (let index = 0; index < frameCount; index++) {
-    const t = index / fps;
-    const params: Record<string, number> = {};
-    const joints: Record<string, number> = {};
-    const visibility: Record<string, boolean> = {};
-    let explode = 0;
-
-    for (const track of tracks) {
-      const value = sampleTrackValue(track, t);
-      const target = track.target;
-      switch (target.type) {
-        case "Parameter":
-          params[target.name] = value;
-          break;
-        case "Joint":
-          joints[target.jointId] = value;
-          break;
-        case "Visibility":
-          visibility[target.instanceId] = value > 0.5;
-          break;
-        case "Explode":
-          explode = value;
-          break;
-      }
-    }
-
-    const camera = cameraPoseAt(shots, t, prevPose);
-    prevPose = camera;
-
-    const geometryDirty =
-      prevParams === undefined
-        ? hasParamTracks
-        : Object.keys(params).some((name) => params[name] !== prevParams![name]);
-    prevParams = params;
-
-    frames.push({
-      index,
-      t,
-      params,
-      joints,
-      visibility,
-      explode,
-      camera,
-      geometryDirty,
-    });
-  }
-  return frames;
+  const json = requireWasm().sample_timeline_sequence(JSON.stringify(timeline));
+  return JSON.parse(json) as SequenceFrame[];
 }
 
 /**

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -386,6 +386,28 @@ min: Vec3,
 max: Vec3, };
 
 /**
+ * A per-frame camera pose in orbit coordinates, compiled from the
+ * timeline's declarative [`CameraShot`]s by [`Timeline::sample_sequence`].
+ */
+export type CameraPose = { 
+/**
+ * Azimuth around the scene, degrees.
+ */
+azimuthDeg: number, 
+/**
+ * Elevation above the horizon, degrees.
+ */
+elevationDeg: number, 
+/**
+ * Distance factor (1 = default framing, 0.5 = half distance).
+ */
+dolly: number, 
+/**
+ * Optional part/instance id the camera is framing.
+ */
+target?: string, };
+
+/**
  * A saved camera position/orientation.
  */
 export type CameraPreset = { 
@@ -3269,6 +3291,44 @@ start: Vec2,
  * Wire end point.
  */
 end: Vec2, };
+
+/**
+ * Sampled state for a single frame of the timeline.
+ */
+export type SequenceFrame = { 
+/**
+ * Frame index (0-based).
+ */
+index: number, 
+/**
+ * Time in seconds.
+ */
+t: number, 
+/**
+ * Animated parameter name → value at `t`.
+ */
+params: Record<string, number>, 
+/**
+ * Joint id → state at `t`.
+ */
+joints: Record<string, number>, 
+/**
+ * Instance id → visible (track value > 0.5).
+ */
+visibility: Record<string, boolean>, 
+/**
+ * Global exploded-view factor (0 = assembled).
+ */
+explode: number, 
+/**
+ * Camera pose compiled from the timeline's shots.
+ */
+camera: CameraPose, 
+/**
+ * True iff params differ from the previous frame (frame 0: true if
+ * any parameter track exists).
+ */
+geometryDirty: boolean, };
 
 /**
  * Direction tag for sheet-metal flanges. Wire-compatible with

--- a/packages/mcp/src/tools/animate.ts
+++ b/packages/mcp/src/tools/animate.ts
@@ -372,6 +372,7 @@ export async function animate(
     );
   }
   doc.timeline = timeline;
+  await getKernelWasm(); // sampleSequence runs in the kernel WASM
   const frames = sampleSequence(doc);
   return ok({
     duration_s: timeline.durationS,
@@ -737,6 +738,7 @@ export async function renderSequence(
     );
   }
 
+  await getKernelWasm(); // sampleSequence runs in the kernel WASM
   const frames = sampleSequence(doc, timeline);
   if (frames.length > MAX_FRAMES) {
     return err(
@@ -1039,6 +1041,7 @@ export async function exportVideo(
     return err(`timeline invalid:\n${issues.map((i) => i.problem).join("\n")}`);
   }
 
+  await getKernelWasm(); // sampleSequence runs in the kernel WASM
   const frames = sampleSequence(doc, timeline);
   if (frames.length > MAX_FRAMES) {
     return err(


### PR DESCRIPTION
## What

`packages/engine/src/sequence.ts` (219 lines) duplicated the interpolation semantics of `Timeline::sample_track` in `crates/vcad-ir/src/animation.rs`, plus TS-only camera-shot compilation and per-frame sequence sampling. This PR makes Rust the single implementation:

- **vcad-ir**: adds `CameraPose`, `SequenceFrame`, and `Timeline::sample_sequence()` — a full port of the TS sequencer (Turntable/Orbit/Focus/Static shot compilation, last-overlapping-shot-wins, gaps hold the previous pose, `geometryDirty` flagging, fps<=0 → 24 fallback, min 2 frames). Serde renames keep the JSON wire shape byte-identical to the old TS objects.
- **vcad-kernel-wasm**: new bindings `sample_timeline_sequence(timelineJson)` (one call per sequence — matches how the MCP `animate`/`render_sequence`/`export_video` consumers use it) and `sample_timeline_track(trackJson, t)`.
- **sequence.ts** is now a thin wrapper (~95 lines): `sampleTrackValue`/`sampleSequence` delegate to WASM; `poseDocument` stays pure TS (document surgery only). All exports preserved; `CameraPose`/`SequenceFrame` types are now ts-rs-generated in `@vcad/ir`.
- **MCP** `animate.ts`: `await getKernelWasm()` added before the three `sampleSequence` call sites.

## Why

One less hand-mirrored TS/Rust pair to keep in sync; camera compilation now lives next to the timeline IR it interprets.

## Reviewer notes

- The pre-existing `sequence.test.ts` expectations were captured from the prior TS implementation, so the suite doubles as the TS↔Rust agreement fixture — it passes unchanged against the WASM sampler. The same cases are mirrored as Rust unit tests, including a JSON-shape assertion.
- Kernel WASM artifacts are deliberately **not** committed (`wasm-refresh.yml` owns them on main); PR CI builds WASM from source.
- Verified: `cargo test --workspace`, `cargo clippy --workspace --exclude vcad-desktop -- -D warnings`, `cargo fmt --check`, all TS workspace builds + tests (engine 119, mcp 939).

🤖 Generated with [Claude Code](https://claude.com/claude-code)