### PR TITLE
refactor(kernel): single source of truth for mesh mass properties

### DIFF
--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -17,6 +17,8 @@ use vcad_kernel_topo::{FaceId, Orientation, Topology};
 pub mod clearance;
 mod creased_normals;
 pub mod frozen;
+pub mod mesh_props;
+pub use mesh_props::{compute_mesh_properties, MeshBBox, MeshProperties};
 mod render_bake;
 
 pub use clearance::{mesh_clearance, ClearanceResult};

--- a/crates/vcad-kernel-tessellate/src/mesh_props.rs
+++ b/crates/vcad-kernel-tessellate/src/mesh_props.rs
@@ -1,0 +1,198 @@
+//! Mesh mass-property math: divergence-theorem volume, surface area,
+//! bounding box, and volume-weighted center of mass for a triangle soup.
+//!
+//! This is the single source of truth for tessellation-bound inspection
+//! metrics — the WASM binding `computeMeshProperties` (consumed by the app
+//! and the MCP server's `inspect_cad` / `measure` / fabricate cost models)
+//! wraps [`compute_mesh_properties`] directly.
+
+/// An axis-aligned bounding box (`[x, y, z]` min / max corners).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshBBox {
+    /// Minimum corner.
+    pub min: [f64; 3],
+    /// Maximum corner.
+    pub max: [f64; 3],
+}
+
+/// Aggregate mass properties of a triangle mesh.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshProperties {
+    /// Enclosed volume (mm³ for mm positions), absolute value.
+    pub volume: f64,
+    /// Total surface area (mm²).
+    pub area: f64,
+    /// Axis-aligned bounding box over all referenced vertices.
+    pub bbox: MeshBBox,
+    /// Center of mass. Volume-weighted (divergence theorem) for a closed,
+    /// consistently wound mesh; falls back to the area-weighted surface
+    /// centroid when the volume integral is unreliable (open meshes, or a
+    /// centroid that lands outside the bbox — geometrically impossible for
+    /// a real solid).
+    pub center_of_mass: [f64; 3],
+    /// Number of triangles integrated.
+    pub triangles: usize,
+}
+
+/// Compute volume, surface area, bounding box, and center of mass for a
+/// triangle mesh given flat `[x, y, z, ...]` positions and `[i0, i1, i2, ...]`
+/// indices. Degenerate index triples (out of range or truncated) are skipped.
+pub fn compute_mesh_properties(positions: &[f32], indices: &[u32]) -> MeshProperties {
+    let mut volume = 0.0_f64;
+    let mut area = 0.0_f64;
+    // Volume-weighted centroid accumulator.
+    let mut c = [0.0_f64; 3];
+    // Area-weighted surface centroid accumulator (fallback).
+    let mut ac = [0.0_f64; 3];
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    let mut triangles = 0_usize;
+
+    let vertex = |i: u32| -> Option<[f64; 3]> {
+        let i = i as usize * 3;
+        if i + 2 >= positions.len() {
+            return None;
+        }
+        Some([
+            positions[i] as f64,
+            positions[i + 1] as f64,
+            positions[i + 2] as f64,
+        ])
+    };
+
+    for tri in indices.chunks_exact(3) {
+        let (Some(p1), Some(p2), Some(p3)) = (vertex(tri[0]), vertex(tri[1]), vertex(tri[2]))
+        else {
+            continue;
+        };
+        triangles += 1;
+
+        // Signed volume of the tetrahedron (origin, p1, p2, p3).
+        let v = (p1[0] * (p2[1] * p3[2] - p3[1] * p2[2]) - p2[0] * (p1[1] * p3[2] - p3[1] * p1[2])
+            + p3[0] * (p1[1] * p2[2] - p2[1] * p1[2]))
+            / 6.0;
+        volume += v;
+
+        let e1 = [p2[0] - p1[0], p2[1] - p1[1], p2[2] - p1[2]];
+        let e2 = [p3[0] - p1[0], p3[1] - p1[1], p3[2] - p1[2]];
+        let cross = [
+            e1[1] * e2[2] - e1[2] * e2[1],
+            e1[2] * e2[0] - e1[0] * e2[2],
+            e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        let a = (cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2]).sqrt() / 2.0;
+        area += a;
+
+        for k in 0..3 {
+            // Tet centroid is (0 + p1 + p2 + p3) / 4; area centroid is /3.
+            c[k] += v * (p1[k] + p2[k] + p3[k]) / 4.0;
+            ac[k] += a * (p1[k] + p2[k] + p3[k]) / 3.0;
+            for p in [&p1, &p2, &p3] {
+                min[k] = min[k].min(p[k]);
+                max[k] = max[k].max(p[k]);
+            }
+        }
+    }
+
+    let abs_volume = volume.abs();
+    let mut com: Option<[f64; 3]> = None;
+    if abs_volume > 1e-10 {
+        let candidate = [c[0] / volume, c[1] / volume, c[2] / volume];
+        let eps = 1e-9
+            * (max[0] - min[0])
+                .max(max[1] - min[1])
+                .max(max[2] - min[2])
+                .max(1.0);
+        let in_bbox = (0..3).all(|k| candidate[k] >= min[k] - eps && candidate[k] <= max[k] + eps);
+        if in_bbox {
+            com = Some(candidate);
+        }
+    }
+    let center_of_mass = com.unwrap_or(if area > 0.0 {
+        [ac[0] / area, ac[1] / area, ac[2] / area]
+    } else {
+        [0.0; 3]
+    });
+
+    MeshProperties {
+        volume: abs_volume,
+        area,
+        bbox: MeshBBox { min, max },
+        center_of_mass,
+        triangles,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Axis-aligned box mesh from `min` to `max`, outward-wound.
+    fn box_mesh(min: [f32; 3], max: [f32; 3]) -> (Vec<f32>, Vec<u32>) {
+        let [x0, y0, z0] = min;
+        let [x1, y1, z1] = max;
+        let positions = vec![
+            x0, y0, z0, x1, y0, z0, x1, y1, z0, x0, y1, z0, // bottom ring
+            x0, y0, z1, x1, y0, z1, x1, y1, z1, x0, y1, z1, // top ring
+        ];
+        #[rustfmt::skip]
+        let indices = vec![
+            0, 2, 1, 0, 3, 2, // bottom (−z)
+            4, 5, 6, 4, 6, 7, // top (+z)
+            0, 1, 5, 0, 5, 4, // −y
+            2, 3, 7, 2, 7, 6, // +y
+            1, 2, 6, 1, 6, 5, // +x
+            3, 0, 4, 3, 4, 7, // −x
+        ];
+        (positions, indices)
+    }
+
+    #[test]
+    fn unit_cube_pins_known_values() {
+        let (pos, idx) = box_mesh([0.0; 3], [1.0; 3]);
+        let p = compute_mesh_properties(&pos, &idx);
+        assert!((p.volume - 1.0).abs() < 1e-9);
+        assert!((p.area - 6.0).abs() < 1e-9);
+        assert_eq!(p.triangles, 12);
+        assert_eq!(p.bbox.min, [0.0; 3]);
+        assert_eq!(p.bbox.max, [1.0; 3]);
+        for k in 0..3 {
+            assert!((p.center_of_mass[k] - 0.5).abs() < 1e-9, "com axis {k}");
+        }
+    }
+
+    #[test]
+    fn offset_box_center_of_mass_follows_offset() {
+        let (pos, idx) = box_mesh([10.0, -4.0, 2.0], [14.0, 0.0, 12.0]);
+        let p = compute_mesh_properties(&pos, &idx);
+        assert!((p.volume - 4.0 * 4.0 * 10.0).abs() < 1e-6);
+        let expected = [12.0, -2.0, 7.0];
+        for k in 0..3 {
+            assert!(
+                (p.center_of_mass[k] - expected[k]).abs() < 1e-6,
+                "com axis {k}: {} vs {}",
+                p.center_of_mass[k],
+                expected[k]
+            );
+        }
+    }
+
+    #[test]
+    fn open_mesh_falls_back_to_surface_centroid() {
+        // Single triangle in the z=3 plane: no enclosed volume, centroid
+        // must still land inside the bbox (area-weighted fallback).
+        let pos = vec![0.0, 0.0, 3.0, 2.0, 0.0, 3.0, 0.0, 2.0, 3.0];
+        let idx = vec![0, 1, 2];
+        let p = compute_mesh_properties(&pos, &idx);
+        assert!((p.area - 2.0).abs() < 1e-9);
+        assert!((p.center_of_mass[2] - 3.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn degenerate_indices_are_skipped() {
+        let pos = vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let idx = vec![0, 1, 2, 0, 1, 99]; // second triple out of range
+        let p = compute_mesh_properties(&pos, &idx);
+        assert_eq!(p.triangles, 1);
+    }
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -6958,38 +6958,30 @@ pub fn derive_parts(doc_json: &str) -> Result<JsValue, JsError> {
 /// Returns volume in mm³ (same units as positions).
 #[wasm_bindgen(js_name = computeMeshVolume)]
 pub fn compute_mesh_volume(positions: &[f32], indices: &[u32]) -> f64 {
-    let mut vol = 0.0_f64;
-    for tri in indices.chunks(3) {
-        if tri.len() < 3 {
-            break;
-        }
-        let (i0, i1, i2) = (
-            tri[0] as usize * 3,
-            tri[1] as usize * 3,
-            tri[2] as usize * 3,
-        );
-        if i2 + 2 >= positions.len() {
-            continue;
-        }
-        let v0 = [
-            positions[i0] as f64,
-            positions[i0 + 1] as f64,
-            positions[i0 + 2] as f64,
-        ];
-        let v1 = [
-            positions[i1] as f64,
-            positions[i1 + 1] as f64,
-            positions[i1 + 2] as f64,
-        ];
-        let v2 = [
-            positions[i2] as f64,
-            positions[i2 + 1] as f64,
-            positions[i2 + 2] as f64,
-        ];
-        vol += v0[0] * (v1[1] * v2[2] - v2[1] * v1[2]) - v1[0] * (v0[1] * v2[2] - v2[1] * v0[2])
-            + v2[0] * (v0[1] * v1[2] - v1[1] * v0[2]);
-    }
-    (vol / 6.0).abs()
+    vcad_kernel::compute_mesh_properties(positions, indices).volume
+}
+
+/// Compute aggregate mass properties of a triangle mesh: divergence-theorem
+/// volume, surface area, axis-aligned bounding box, volume-weighted center
+/// of mass (with an area-weighted surface-centroid fallback for open or
+/// inconsistently wound meshes), and triangle count.
+///
+/// Positions are `[x, y, z, ...]` (flat f32), indices are `[i0, i1, i2, ...]`.
+/// Returns `{ volume, area, bbox: { min: {x,y,z}, max: {x,y,z} },
+/// centerOfMass: {x,y,z}, triangles }` in the same units as positions (mm).
+#[wasm_bindgen(js_name = computeMeshProperties)]
+pub fn compute_mesh_properties_js(positions: &[f32], indices: &[u32]) -> Result<JsValue, JsError> {
+    let p = vcad_kernel::compute_mesh_properties(positions, indices);
+    let xyz = |v: [f64; 3]| serde_json::json!({ "x": v[0], "y": v[1], "z": v[2] });
+    let out = serde_json::json!({
+        "volume": p.volume,
+        "area": p.area,
+        "bbox": { "min": xyz(p.bbox.min), "max": xyz(p.bbox.max) },
+        "centerOfMass": xyz(p.center_of_mass),
+        "triangles": p.triangles,
+    });
+    out.serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .map_err(|e| JsError::new(&e.to_string()))
 }
 
 /// Differentiate a document's mass-property + bounding-box QoIs with respect

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -59,6 +59,7 @@ use vcad_kernel_step::StepError;
 use vcad_kernel_tessellate::{mesh_clearance, tessellate_brep, TriangleMesh};
 
 pub use vcad_kernel_tessellate::ClearanceResult;
+pub use vcad_kernel_tessellate::{compute_mesh_properties, MeshBBox, MeshProperties};
 
 /// Error returned when STEP export fails.
 #[derive(Debug)]

--- a/crates/vcad-kernel/tests/mesh_properties_pins.rs
+++ b/crates/vcad-kernel/tests/mesh_properties_pins.rs
@@ -1,0 +1,45 @@
+//! Pins known mass-property values for `compute_mesh_properties` — the
+//! canonical (Rust) source of truth consumed by the WASM binding
+//! `computeMeshProperties` and every TS inspection path.
+
+use std::f64::consts::PI;
+use vcad_kernel::{compute_mesh_properties, Solid};
+
+#[test]
+fn unit_cube_mass_properties() {
+    let mesh = Solid::cube(1.0, 1.0, 1.0).to_mesh(64);
+    let p = compute_mesh_properties(&mesh.vertices, &mesh.indices);
+    assert!((p.volume - 1.0).abs() < 1e-6, "volume {}", p.volume);
+    assert!((p.area - 6.0).abs() < 1e-6, "area {}", p.area);
+    for k in 0..3 {
+        assert!((p.center_of_mass[k] - 0.5).abs() < 1e-6, "com axis {k}");
+    }
+    assert!(p.bbox.min.iter().all(|&v| v.abs() < 1e-6));
+    assert!(p.bbox.max.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+}
+
+#[test]
+fn offset_cylinder_mass_properties() {
+    let (r, h, segments) = (5.0, 20.0, 256_u32);
+    let solid = Solid::cylinder(r, h, segments).translate(10.0, -3.0, 4.0);
+    let mesh = solid.to_mesh(256);
+    let p = compute_mesh_properties(&mesh.vertices, &mesh.indices);
+
+    // Tessellated cylinder volume/area converge to the analytic values from
+    // below; at 256 segments the polygonal deficit is < 0.05%.
+    let vol_exact = PI * r * r * h;
+    let area_exact = 2.0 * PI * r * r + 2.0 * PI * r * h;
+    assert!((p.volume - vol_exact).abs() / vol_exact < 5e-4);
+    assert!((p.area - area_exact).abs() / area_exact < 5e-4);
+
+    // Axis at (10, -3), base at z=4 → COM at (10, -3, 14).
+    let expected = [10.0, -3.0, 14.0];
+    for k in 0..3 {
+        assert!(
+            (p.center_of_mass[k] - expected[k]).abs() < 1e-3,
+            "com axis {k}: {} vs {}",
+            p.center_of_mass[k],
+            expected[k]
+        );
+    }
+}

--- a/packages/core/src/utils/geometry.ts
+++ b/packages/core/src/utils/geometry.ts
@@ -38,7 +38,12 @@ export function computeVolume(mesh: TriangleMesh): number {
   return computeVolumeTS(mesh);
 }
 
-/** TypeScript fallback for volume computation. */
+/**
+ * TypeScript fallback for volume computation, used only until the async
+ * WASM import resolves in the browser. Mirrors the canonical kernel
+ * implementation in crates/vcad-kernel-tessellate/src/mesh_props.rs —
+ * change that first, this second.
+ */
 function computeVolumeTS(mesh: TriangleMesh): number {
   const numTriangles = mesh.indices.length / 3;
   let volume = 0;

--- a/packages/mcp/src/fabricate/geometry.ts
+++ b/packages/mcp/src/fabricate/geometry.ts
@@ -2,9 +2,11 @@
  * vcad Fabricate — lean geometry measurement for cost models.
  *
  * A trimmed-down cousin of the inspect_cad math: evaluates the document and
- * aggregates volume / surface area / bounding box across all parts. Cost
- * models only need volume, footprint, and the max bounding dimension, so this
- * intentionally skips per-part mass / center-of-mass.
+ * aggregates volume / surface area / bounding box across all parts via the
+ * kernel's `computeMeshProperties` (shared through `tools/inspect.js` — no
+ * local mesh math). Cost models only need volume, footprint, and the max
+ * bounding dimension, so this intentionally skips per-part mass /
+ * center-of-mass.
  *
  * Tolerant by design: a PCB/ecad document (or any doc the kernel can't mesh
  * into solids) yields ok:false with zeroed metrics, and the caller falls back
@@ -13,43 +15,8 @@
 
 import type { Document } from "@vcad/ir";
 import type { Engine, TriangleMesh } from "@vcad/engine";
+import { computeMeshProperties } from "../tools/inspect.js";
 import type { GeometryMetrics } from "./types.js";
-
-function vertex(mesh: TriangleMesh, index: number): [number, number, number] {
-  const i = index * 3;
-  return [mesh.positions[i], mesh.positions[i + 1], mesh.positions[i + 2]];
-}
-
-/** Signed volume of the tetrahedron (origin, p1, p2, p3). */
-function signedTetVolume(
-  p1: [number, number, number],
-  p2: [number, number, number],
-  p3: [number, number, number],
-): number {
-  return (
-    (p1[0] * (p2[1] * p3[2] - p3[1] * p2[2]) -
-      p2[0] * (p1[1] * p3[2] - p3[1] * p1[2]) +
-      p3[0] * (p1[1] * p2[2] - p2[1] * p1[2])) /
-    6.0
-  );
-}
-
-function triArea(
-  p1: [number, number, number],
-  p2: [number, number, number],
-  p3: [number, number, number],
-): number {
-  const ax = p2[0] - p1[0],
-    ay = p2[1] - p1[1],
-    az = p2[2] - p1[2];
-  const bx = p3[0] - p1[0],
-    by = p3[1] - p1[1],
-    bz = p3[2] - p1[2];
-  const cx = ay * bz - az * by;
-  const cy = az * bx - ax * bz;
-  const cz = ax * by - ay * bx;
-  return Math.sqrt(cx * cx + cy * cy + cz * cz) / 2.0;
-}
 
 const EMPTY: GeometryMetrics = {
   ok: false,
@@ -77,21 +44,15 @@ export function measureDocument(ir: Document, engine: Engine): GeometryMetrics {
   const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
 
   for (const part of scene.parts) {
-    const mesh = part.mesh;
-    const numTris = mesh.indices.length / 3;
-    for (let t = 0; t < numTris; t++) {
-      const p1 = vertex(mesh, mesh.indices[t * 3]);
-      const p2 = vertex(mesh, mesh.indices[t * 3 + 1]);
-      const p3 = vertex(mesh, mesh.indices[t * 3 + 2]);
-      volume += signedTetVolume(p1, p2, p3);
-      area += triArea(p1, p2, p3);
-      for (const p of [p1, p2, p3]) {
-        for (let k = 0; k < 3; k++) {
-          if (p[k] < min[k]) min[k] = p[k];
-          if (p[k] > max[k]) max[k] = p[k];
-        }
-      }
-    }
+    const props = computeMeshProperties(part.mesh);
+    volume += props.volume;
+    area += props.area;
+    min[0] = Math.min(min[0], props.bbox.min.x);
+    min[1] = Math.min(min[1], props.bbox.min.y);
+    min[2] = Math.min(min[2], props.bbox.min.z);
+    max[0] = Math.max(max[0], props.bbox.max.x);
+    max[1] = Math.max(max[1], props.bbox.max.y);
+    max[2] = Math.max(max[2], props.bbox.max.z);
   }
 
   if (!Number.isFinite(min[0])) return { ...EMPTY };
@@ -103,7 +64,7 @@ export function measureDocument(ir: Document, engine: Engine): GeometryMetrics {
   return {
     ok: true,
     parts: scene.parts.length,
-    volume_mm3: Math.abs(volume),
+    volume_mm3: volume,
     surface_area_mm2: area,
     footprint_mm2: dx * dy,
     max_dim_mm: Math.max(dx, dy, dz),

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -8,7 +8,12 @@
  * all three reuse the tessellation-bound mesh math exported from here.
  */
 
-import { transformMesh, type Engine, type TriangleMesh } from "@vcad/engine";
+import {
+  getKernelWasmSync,
+  transformMesh,
+  type Engine,
+  type TriangleMesh,
+} from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { isoperimetricViolation } from "./integrity.js";
 import { resolveDocInput } from "./session-core.js";
@@ -62,53 +67,14 @@ export interface InspectResult {
   warnings?: string[];
 }
 
-/** Calculate signed volume of a triangle with origin. */
-function signedVolumeOfTriangle(
-  p1: [number, number, number],
-  p2: [number, number, number],
-  p3: [number, number, number],
-): number {
-  return (
-    (p1[0] * (p2[1] * p3[2] - p3[1] * p2[2]) -
-      p2[0] * (p1[1] * p3[2] - p3[1] * p1[2]) +
-      p3[0] * (p1[1] * p2[2] - p2[1] * p1[2])) /
-    6.0
-  );
-}
-
-/** Calculate area of a triangle. */
-function triangleArea(
-  p1: [number, number, number],
-  p2: [number, number, number],
-  p3: [number, number, number],
-): number {
-  // Cross product of edges
-  const ax = p2[0] - p1[0];
-  const ay = p2[1] - p1[1];
-  const az = p2[2] - p1[2];
-  const bx = p3[0] - p1[0];
-  const by = p3[1] - p1[1];
-  const bz = p3[2] - p1[2];
-
-  const cx = ay * bz - az * by;
-  const cy = az * bx - ax * bz;
-  const cz = ax * by - ay * bx;
-
-  return Math.sqrt(cx * cx + cy * cy + cz * cz) / 2.0;
-}
-
-/** Get vertex position from mesh. */
-function getVertex(
-  mesh: TriangleMesh,
-  index: number,
-): [number, number, number] {
-  const i = index * 3;
-  return [mesh.positions[i], mesh.positions[i + 1], mesh.positions[i + 2]];
-}
-
-/** Compute properties for a single mesh. Exported so `measure` and the
- *  per-part `inspect_part` / `describe_scene` tools share one implementation
- *  of the tessellation-bound volume/area/bbox/centroid math. */
+/** Compute properties for a single mesh. Exported so `measure`, the
+ *  per-part `inspect_part` / `describe_scene` tools, and the fabricate cost
+ *  models share one implementation of the tessellation-bound
+ *  volume/area/bbox/centroid math — the kernel's `compute_mesh_properties`
+ *  (crates/vcad-kernel-tessellate/src/mesh_props.rs), reached through the
+ *  WASM binding. There is deliberately no TS reimplementation: the kernel
+ *  is the single source of truth, and the WASM module is always initialized
+ *  before any tool can evaluate a document. */
 export function computeMeshProperties(mesh: TriangleMesh): {
   volume: number;
   area: number;
@@ -116,103 +82,40 @@ export function computeMeshProperties(mesh: TriangleMesh): {
   centroid: { x: number; y: number; z: number };
   triangles: number;
 } {
-  const numTriangles = mesh.indices.length / 3;
-
-  let volume = 0;
-  let area = 0;
-  let cx = 0,
-    cy = 0,
-    cz = 0;
-  // Area-weighted surface centroid — fallback when the signed-volume
-  // integral is unreliable (open or inconsistently wound meshes, e.g.
-  // thin sheet-metal bodies). Always lands inside the bounding box.
-  let acx = 0,
-    acy = 0,
-    acz = 0;
-
-  const bbox: BoundingBox = {
-    min: { x: Infinity, y: Infinity, z: Infinity },
-    max: { x: -Infinity, y: -Infinity, z: -Infinity },
-  };
-
-  for (let t = 0; t < numTriangles; t++) {
-    const i0 = mesh.indices[t * 3];
-    const i1 = mesh.indices[t * 3 + 1];
-    const i2 = mesh.indices[t * 3 + 2];
-
-    const p1 = getVertex(mesh, i0);
-    const p2 = getVertex(mesh, i1);
-    const p3 = getVertex(mesh, i2);
-
-    // Volume via divergence theorem
-    const v = signedVolumeOfTriangle(p1, p2, p3);
-    volume += v;
-
-    // Surface area
-    const a = triangleArea(p1, p2, p3);
-    area += a;
-
-    // Centroid contribution (weighted by signed volume)
-    cx += v * (p1[0] + p2[0] + p3[0]) / 4;
-    cy += v * (p1[1] + p2[1] + p3[1]) / 4;
-    cz += v * (p1[2] + p2[2] + p3[2]) / 4;
-
-    // Area-weighted centroid contribution
-    acx += (a * (p1[0] + p2[0] + p3[0])) / 3;
-    acy += (a * (p1[1] + p2[1] + p3[1])) / 3;
-    acz += (a * (p1[2] + p2[2] + p3[2])) / 3;
-
-    // Bounding box
-    for (const p of [p1, p2, p3]) {
-      bbox.min.x = Math.min(bbox.min.x, p[0]);
-      bbox.min.y = Math.min(bbox.min.y, p[1]);
-      bbox.min.z = Math.min(bbox.min.z, p[2]);
-      bbox.max.x = Math.max(bbox.max.x, p[0]);
-      bbox.max.y = Math.max(bbox.max.y, p[1]);
-      bbox.max.z = Math.max(bbox.max.z, p[2]);
-    }
+  const wasm = getKernelWasmSync() as {
+    computeMeshProperties?: (
+      positions: Float32Array,
+      indices: Uint32Array,
+    ) => {
+      volume: number;
+      area: number;
+      bbox: BoundingBox;
+      centerOfMass: { x: number; y: number; z: number };
+      triangles: number;
+    };
+  } | null;
+  if (!wasm) {
+    throw new Error("kernel WASM is not initialized — call Engine.init first");
   }
-
-  // Normalize centroid by volume. The volume-weighted centroid is only
-  // valid for a closed, consistently wound mesh — on open meshes the
-  // signed-tet contributions partially cancel and the division can throw
-  // the centroid anywhere, including outside the bounding box (which is
-  // geometrically impossible for a real COM). Validate against the bbox
-  // and fall back to the area-weighted surface centroid when it fails.
-  const absVolume = Math.abs(volume);
-  let centroid: { x: number; y: number; z: number } | null = null;
-  if (absVolume > 1e-10) {
-    centroid = { x: cx / volume, y: cy / volume, z: cz / volume };
-    const eps =
-      1e-9 *
-      Math.max(
-        bbox.max.x - bbox.min.x,
-        bbox.max.y - bbox.min.y,
-        bbox.max.z - bbox.min.z,
-        1,
-      );
-    const inBbox =
-      centroid.x >= bbox.min.x - eps &&
-      centroid.x <= bbox.max.x + eps &&
-      centroid.y >= bbox.min.y - eps &&
-      centroid.y <= bbox.max.y + eps &&
-      centroid.z >= bbox.min.z - eps &&
-      centroid.z <= bbox.max.z + eps;
-    if (!inBbox) centroid = null;
+  if (typeof wasm.computeMeshProperties !== "function") {
+    throw new Error(
+      "computeMeshProperties is not in this kernel build — rebuild vcad-kernel-wasm",
+    );
   }
-  if (centroid === null) {
-    centroid =
-      area > 0
-        ? { x: acx / area, y: acy / area, z: acz / area }
-        : { x: 0, y: 0, z: 0 };
-  }
-
+  const props = wasm.computeMeshProperties(
+    mesh.positions instanceof Float32Array
+      ? mesh.positions
+      : new Float32Array(mesh.positions),
+    mesh.indices instanceof Uint32Array
+      ? mesh.indices
+      : new Uint32Array(mesh.indices),
+  );
   return {
-    volume: absVolume,
-    area,
-    bbox,
-    centroid,
-    triangles: numTriangles,
+    volume: props.volume,
+    area: props.area,
+    bbox: props.bbox,
+    centroid: props.centerOfMass,
+    triangles: props.triangles,
   };
 }
 


### PR DESCRIPTION
## What

Mesh property math — divergence-theorem volume, surface area, bbox, and volume-weighted center of mass — was reimplemented **four times** in TypeScript. Center of mass in particular had *no* shared source of truth, so each copy could drift independently.

This makes Rust canonical and reduces the TS call sites to thin wrappers.

**New canonical implementation:** `compute_mesh_properties` in `crates/vcad-kernel-tessellate/src/mesh_props.rs` — returns volume, area, bbox, center of mass, and triangle count. Re-exported from the unified `vcad-kernel` API and exposed as the WASM binding `computeMeshProperties`. It carries the area-weighted surface-centroid fallback and bbox sanity check that previously only existed inside the MCP inspect tool. `computeMeshVolume` now delegates to it rather than duplicating the volume loop.

**Call sites rewritten:**

| File | Before | After |
|---|---|---|
| `packages/mcp/src/tools/inspect.ts` | ~110 lines incl. COM + bbox check, no WASM path | WASM wrapper; `measure.ts` / per-part tools reuse it unchanged |
| `packages/mcp/src/fabricate/geometry.ts` | ~90 lines, no WASM path | aggregates via the shared helper; tolerant `ok:false` behavior preserved |
| `packages/core/src/utils/geometry.ts` | WASM-first w/ TS fallback | unchanged behavior, fallback annotated as mirroring Rust |

## Why the two survivors

- **`core/utils/geometry.ts` keeps its TS fallback** — there's a real window in the browser before the async WASM import resolves. It's now documented as mirroring the canonical Rust ("change that first, this second").
- **`mcp/tools/integrity.ts` was deliberately left alone** — it needs *signed* per-part volume for winding diagnostics, interleaved with open-edge accounting. Different job, not mass properties.

The new MCP wrapper throws `"computeMeshProperties is not in this kernel build — rebuild vcad-kernel-wasm"` when the binding is absent, matching the existing `engine/atoms.ts` precedent rather than silently falling back to drifting TS math.

## Tests

New `crates/vcad-kernel/tests/mesh_properties_pins.rs` pins known values:
- unit cube → V=1, A=6, COM=(0.5, 0.5, 0.5)
- cylinder r=5 h=20 offset to (10, −3, 4) → COM=(10, −3, 14), volume/area within 0.05% of analytic

Plus unit tests in `mesh_props.rs` for the offset box, the open-mesh centroid fallback (must stay inside the bbox), and degenerate/out-of-range index triples.

## Verification

- `cargo test --workspace` — clean
- `cargo fmt --all --check` — clean
- `cargo clippy -p vcad-kernel-tessellate -p vcad-kernel -p vcad-kernel-wasm -- -D warnings` — clean
- TS: all workspace builds and tests pass
- Smoke-tested the binding end-to-end in Node against a hand-built cube mesh → exact expected values

Full-workspace clippy was blocked locally by a permission prompt, so CI is the check of record for the untouched crates.

## Reviewer notes

- **No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts are committed** (per repo policy — `wasm-refresh.yml` on main owns them). I rebuilt them locally to test and reverted. Anyone running the MCP tests in a checkout of this branch needs `npm run build -w vcad-kernel-wasm` first; CI builds WASM from source, so PR checks are unaffected.
- No changelog entry: internal refactor, no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)