### PR TITLE
refactor(kernel-math): re-export exact predicates from tang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,6 +4019,7 @@ dependencies = [
 name = "phyz"
 version = "0.3.0"
 dependencies = [
+ "phyz-math",
  "tang",
 ]
 
@@ -5693,6 +5694,7 @@ name = "tang"
 version = "0.2.0"
 dependencies = [
  "paste",
+ "robust",
 ]
 
 [[package]]
@@ -7420,7 +7422,6 @@ dependencies = [
 name = "vcad-kernel-math"
 version = "0.9.4"
 dependencies = [
- "robust",
  "tang",
 ]
 

--- a/crates/vcad-kernel-math/Cargo.toml
+++ b/crates/vcad-kernel-math/Cargo.toml
@@ -7,5 +7,4 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-tang = { workspace = true }
-robust = "1.1"
+tang = { workspace = true, features = ["exact"] }

--- a/crates/vcad-kernel-math/src/predicates.rs
+++ b/crates/vcad-kernel-math/src/predicates.rs
@@ -1,7 +1,8 @@
 //! Exact geometric predicates using adaptive-precision arithmetic.
 //!
-//! This module provides robust geometric predicates based on Shewchuk's
-//! algorithms. These predicates use adaptive precision: fast when possible,
+//! This module re-exports the robust geometric predicates from `tang`
+//! (Shewchuk's algorithms via the `robust` crate, behind tang's `exact`
+//! feature). These predicates use adaptive precision: fast when possible,
 //! exact when needed. They eliminate the need for epsilon-based tolerance
 //! tuning that doesn't scale with geometry size.
 //!
@@ -16,234 +17,18 @@
 //!
 //! - [`point_on_segment_2d`]: Test if a point lies on a line segment
 //! - [`point_on_plane`]: Test if a point lies on a plane defined by three points
+//!
+//! Two derived predicates are kept local rather than re-exported because
+//! their semantics differ from tang's versions of the same name:
+//! [`point_on_segment_2d`] (tang's accepts any collinear point when the
+//! segment is degenerate) and [`point_side_of_line`] (tang's returns `None`
+//! near endpoints instead of on collinearity).
 
-use crate::{Point2, Point3};
+pub use tang::predicates::{
+    are_collinear_2d, are_coplanar, incircle, insphere, orient2d, orient3d, point_on_plane, Sign,
+};
 
-/// The sign of a geometric predicate result.
-///
-/// For orientation predicates:
-/// - `Positive`: Counter-clockwise (2D) or above plane (3D)
-/// - `Zero`: Collinear (2D) or coplanar (3D)
-/// - `Negative`: Clockwise (2D) or below plane (3D)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Sign {
-    /// Strictly negative value
-    Negative,
-    /// Exactly zero
-    Zero,
-    /// Strictly positive value
-    Positive,
-}
-
-impl Sign {
-    /// Create a Sign from an f64 value.
-    ///
-    /// Note: This should only be used with results from exact predicates,
-    /// not with raw floating-point computations.
-    #[inline]
-    pub fn from_f64(v: f64) -> Self {
-        if v > 0.0 {
-            Sign::Positive
-        } else if v < 0.0 {
-            Sign::Negative
-        } else {
-            Sign::Zero
-        }
-    }
-
-    /// Returns true if the sign is positive.
-    #[inline]
-    pub fn is_positive(self) -> bool {
-        matches!(self, Sign::Positive)
-    }
-
-    /// Returns true if the sign is negative.
-    #[inline]
-    pub fn is_negative(self) -> bool {
-        matches!(self, Sign::Negative)
-    }
-
-    /// Returns true if the sign is zero.
-    #[inline]
-    pub fn is_zero(self) -> bool {
-        matches!(self, Sign::Zero)
-    }
-}
-
-// =============================================================================
-// 2D Predicates
-// =============================================================================
-
-/// Determine the orientation of point `c` relative to the directed line from `a` to `b`.
-///
-/// Returns:
-/// - `Positive`: `c` is to the left of the line (counter-clockwise)
-/// - `Zero`: `c` is on the line (collinear with `a` and `b`)
-/// - `Negative`: `c` is to the right of the line (clockwise)
-///
-/// This is equivalent to the sign of the 2D cross product `(b - a) × (c - a)`.
-///
-/// # Example
-///
-/// ```
-/// use vcad_kernel_math::{Point2, predicates::{orient2d, Sign}};
-///
-/// let a = Point2::new(0.0, 0.0);
-/// let b = Point2::new(1.0, 0.0);
-/// let c = Point2::new(0.5, 1.0);
-///
-/// assert_eq!(orient2d(&a, &b, &c), Sign::Positive); // c is above the line
-/// ```
-#[inline]
-pub fn orient2d(a: &Point2, b: &Point2, c: &Point2) -> Sign {
-    let result = robust::orient2d(
-        robust::Coord { x: a.x, y: a.y },
-        robust::Coord { x: b.x, y: b.y },
-        robust::Coord { x: c.x, y: c.y },
-    );
-    Sign::from_f64(result)
-}
-
-/// Determine if point `d` is inside, on, or outside the circumcircle of triangle `abc`.
-///
-/// The triangle `abc` must be oriented counter-clockwise. If `abc` is clockwise,
-/// the result is negated.
-///
-/// Returns:
-/// - `Positive`: `d` is inside the circumcircle
-/// - `Zero`: `d` is on the circumcircle
-/// - `Negative`: `d` is outside the circumcircle
-///
-/// # Example
-///
-/// ```
-/// use vcad_kernel_math::{Point2, predicates::{incircle, Sign}};
-///
-/// let a = Point2::new(0.0, 0.0);
-/// let b = Point2::new(1.0, 0.0);
-/// let c = Point2::new(0.5, 0.866); // approximately equilateral
-/// let d = Point2::new(0.5, 0.3);   // inside the circle
-///
-/// assert_eq!(incircle(&a, &b, &c, &d), Sign::Positive);
-/// ```
-#[inline]
-pub fn incircle(a: &Point2, b: &Point2, c: &Point2, d: &Point2) -> Sign {
-    let result = robust::incircle(
-        robust::Coord { x: a.x, y: a.y },
-        robust::Coord { x: b.x, y: b.y },
-        robust::Coord { x: c.x, y: c.y },
-        robust::Coord { x: d.x, y: d.y },
-    );
-    Sign::from_f64(result)
-}
-
-// =============================================================================
-// 3D Predicates
-// =============================================================================
-
-/// Determine the orientation of point `d` relative to the plane through `a`, `b`, `c`.
-///
-/// Returns the sign of the determinant:
-/// ```text
-/// | ax-dx  ay-dy  az-dz |
-/// | bx-dx  by-dy  bz-dz |
-/// | cx-dx  cy-dy  cz-dz |
-/// ```
-///
-/// Interpretation:
-/// - `Positive`: `d` is below the plane (when `a`, `b`, `c` appear counter-clockwise
-///   viewed from above)
-/// - `Zero`: `d` is on the plane (coplanar with `a`, `b`, `c`)
-/// - `Negative`: `d` is above the plane
-///
-/// Note: "above" and "below" are relative to the plane's orientation defined by
-/// the right-hand rule applied to the counter-clockwise vertex ordering.
-///
-/// # Example
-///
-/// ```
-/// use vcad_kernel_math::{Point3, predicates::{orient3d, Sign}};
-///
-/// // Triangle in XY plane with vertices going counter-clockwise when viewed from +Z
-/// let a = Point3::new(0.0, 0.0, 0.0);
-/// let b = Point3::new(1.0, 0.0, 0.0);
-/// let c = Point3::new(0.0, 1.0, 0.0);
-/// let d = Point3::new(0.0, 0.0, 1.0);
-///
-/// // d is at +Z, which is "above" the plane, so orient3d returns Negative
-/// assert_eq!(orient3d(&a, &b, &c, &d), Sign::Negative);
-/// ```
-#[inline]
-pub fn orient3d(a: &Point3, b: &Point3, c: &Point3, d: &Point3) -> Sign {
-    let result = robust::orient3d(
-        robust::Coord3D {
-            x: a.x,
-            y: a.y,
-            z: a.z,
-        },
-        robust::Coord3D {
-            x: b.x,
-            y: b.y,
-            z: b.z,
-        },
-        robust::Coord3D {
-            x: c.x,
-            y: c.y,
-            z: c.z,
-        },
-        robust::Coord3D {
-            x: d.x,
-            y: d.y,
-            z: d.z,
-        },
-    );
-    Sign::from_f64(result)
-}
-
-/// Determine if point `e` is inside, on, or outside the circumsphere of tetrahedron `abcd`.
-///
-/// The tetrahedron `abcd` must be positively oriented (orient3d(a,b,c,d) > 0).
-/// If negatively oriented, the result is negated.
-///
-/// Returns:
-/// - `Positive`: `e` is inside the circumsphere
-/// - `Zero`: `e` is on the circumsphere
-/// - `Negative`: `e` is outside the circumsphere
-#[inline]
-pub fn insphere(a: &Point3, b: &Point3, c: &Point3, d: &Point3, e: &Point3) -> Sign {
-    let result = robust::insphere(
-        robust::Coord3D {
-            x: a.x,
-            y: a.y,
-            z: a.z,
-        },
-        robust::Coord3D {
-            x: b.x,
-            y: b.y,
-            z: b.z,
-        },
-        robust::Coord3D {
-            x: c.x,
-            y: c.y,
-            z: c.z,
-        },
-        robust::Coord3D {
-            x: d.x,
-            y: d.y,
-            z: d.z,
-        },
-        robust::Coord3D {
-            x: e.x,
-            y: e.y,
-            z: e.z,
-        },
-    );
-    Sign::from_f64(result)
-}
-
-// =============================================================================
-// Derived Predicates
-// =============================================================================
+use crate::Point2;
 
 /// Test if point `p` lies on the line segment from `a` to `b`.
 ///
@@ -268,54 +53,14 @@ pub fn point_on_segment_2d(p: &Point2, a: &Point2, b: &Point2) -> bool {
     }
 
     // Now we know p is collinear with a and b.
-    // Check if p is between a and b by checking that dot products have correct signs.
-    // p is on segment if (p - a) · (b - a) >= 0 and (p - b) · (a - b) >= 0
-    //
-    // Since we already know collinearity, we can use a simpler bounding box check:
-    // p is on segment if its coords are within the bbox of a and b.
+    // Since we already know collinearity, a bounding box check suffices;
+    // it also handles a degenerate segment (a == b) correctly.
     let min_x = a.x.min(b.x);
     let max_x = a.x.max(b.x);
     let min_y = a.y.min(b.y);
     let max_y = a.y.max(b.y);
 
     p.x >= min_x && p.x <= max_x && p.y >= min_y && p.y <= max_y
-}
-
-/// Test if point `p` lies on the plane defined by points `a`, `b`, and `c`.
-///
-/// Returns true if `p` is coplanar with the triangle `abc`.
-///
-/// # Example
-///
-/// ```
-/// use vcad_kernel_math::{Point3, predicates::point_on_plane};
-///
-/// let a = Point3::new(0.0, 0.0, 0.0);
-/// let b = Point3::new(1.0, 0.0, 0.0);
-/// let c = Point3::new(0.0, 1.0, 0.0);
-/// let p = Point3::new(0.5, 0.5, 0.0);
-///
-/// assert!(point_on_plane(&p, &a, &b, &c)); // p is on the XY plane
-/// ```
-#[inline]
-pub fn point_on_plane(p: &Point3, a: &Point3, b: &Point3, c: &Point3) -> bool {
-    orient3d(a, b, c, p).is_zero()
-}
-
-/// Test if four points are coplanar.
-///
-/// Returns true if points `a`, `b`, `c`, and `d` all lie on the same plane.
-#[inline]
-pub fn are_coplanar(a: &Point3, b: &Point3, c: &Point3, d: &Point3) -> bool {
-    orient3d(a, b, c, d).is_zero()
-}
-
-/// Test if three 2D points are collinear.
-///
-/// Returns true if points `a`, `b`, and `c` all lie on the same line.
-#[inline]
-pub fn are_collinear_2d(a: &Point2, b: &Point2, c: &Point2) -> bool {
-    orient2d(a, b, c).is_zero()
 }
 
 /// Determine which side of a line segment a point is on, with segment endpoint handling.
@@ -337,6 +82,7 @@ pub fn point_side_of_line(p: &Point2, a: &Point2, b: &Point2) -> Option<Sign> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Point3;
 
     // ==========================================================================
     // orient2d tests
@@ -506,6 +252,15 @@ mod tests {
     }
 
     #[test]
+    fn test_point_on_segment_2d_degenerate_segment() {
+        // a == b: only p == a should count as "on segment"
+        let a = Point2::new(1.0, 1.0);
+        assert!(point_on_segment_2d(&a, &a, &a));
+        let p = Point2::new(2.0, 2.0);
+        assert!(!point_on_segment_2d(&p, &a, &a));
+    }
+
+    #[test]
     fn test_point_on_plane_on() {
         let a = Point3::new(0.0, 0.0, 0.0);
         let b = Point3::new(1.0, 0.0, 0.0);
@@ -544,5 +299,22 @@ mod tests {
 
         let d = Point2::new(2.0, 2.1);
         assert!(!are_collinear_2d(&a, &b, &d));
+    }
+
+    #[test]
+    fn test_point_side_of_line() {
+        let a = Point2::new(0.0, 0.0);
+        let b = Point2::new(1.0, 0.0);
+        assert_eq!(
+            point_side_of_line(&Point2::new(0.5, 1.0), &a, &b),
+            Some(Sign::Positive)
+        );
+        assert_eq!(
+            point_side_of_line(&Point2::new(0.5, -1.0), &a, &b),
+            Some(Sign::Negative)
+        );
+        // Collinear points (including endpoints) return None
+        assert_eq!(point_side_of_line(&Point2::new(0.5, 0.0), &a, &b), None);
+        assert_eq!(point_side_of_line(&a, &a, &b), None);
     }
 }


### PR DESCRIPTION
## What

`crates/vcad-kernel-math/src/predicates.rs` (548 lines, with its own direct `robust = "1.1"` dep) duplicated the exact geometric predicates that `tang` already ships behind its `exact` feature. This PR enables `tang`'s `exact` feature, re-exports the shared predicates, and drops the `robust` dependency — cutting ~230 lines of duplicated implementation while preserving every `vcad_kernel_math::predicates::*` public path.

## Changed

- **Cargo.toml**: `tang = { workspace = true, features = ["exact"] }`; removed direct `robust = "1.1"`.
- **predicates.rs**: `Sign`, `orient2d`, `orient3d`, `incircle`, `insphere`, `point_on_plane`, `are_coplanar`, `are_collinear_2d` are now re-exports from `tang::predicates` (verified semantically equivalent via a line-by-line diff).

## Semantic delta — two functions kept local

Two derived predicates stay implemented locally because tang's same-named versions have **different** contracts:

1. **`point_side_of_line`** — vcad returns `None` when collinear; tang returns `None` when within `1e-10` of an endpoint. Downstream ray-casting relies on vcad's contract.
2. **`point_on_segment_2d`** — differs only on a degenerate segment (`a == b`): vcad's bbox check correctly requires `p == a`, tang's dot-product check accepts any collinear point. A regression test pins the degenerate case.

## Verification

- `cargo test -p vcad-kernel-math` — 30 tests + 1 doctest pass
- `cargo test --workspace` — 0 failures
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean

No wasm artifacts touched; no changelog entry (internal refactor).

## Follow-up

Worth upstreaming the degenerate-segment fix + extra docs/tests to tang; once tang matches, both local functions could also be re-exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
