### PR TITLE
chore(deps): workspace-manage phyz path dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,10 @@ thiserror = "2"
 tang = { path = "../tang/crates/tang", version = "0.2" }
 tang-la = { path = "../tang/crates/tang-la", version = "0.1" }
 tang-expr = { path = "../tang/crates/tang-expr", version = "0.1" }
+phyz = { path = "../phyz/crates/phyz", version = "0.3" }
+phyz-gpu = { path = "../phyz/crates/phyz-gpu", version = "0.1" }
+phyz-model = { path = "../phyz/crates/phyz-model", version = "0.1" }
+phyz-math = { path = "../phyz/crates/phyz-math", version = "0.1" }
 slotmap = "1"
 anyhow = "1"
 toml = "0.8"

--- a/crates/vcad-kernel-physics/Cargo.toml
+++ b/crates/vcad-kernel-physics/Cargo.toml
@@ -13,7 +13,7 @@ vcad-kernel-tessellate = { workspace = true }
 vcad-kernel-diff = { workspace = true }
 vcad-kernel-primitives = { workspace = true }
 vcad-kernel-math = { workspace = true }
-phyz = { path = "../../../phyz/crates/phyz", version = "0.3" }
+phyz = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 stl_io = "0.8"

--- a/crates/vcad-sim/Cargo.toml
+++ b/crates/vcad-sim/Cargo.toml
@@ -10,10 +10,10 @@ publish = false
 [dependencies]
 vcad-ir = { workspace = true }
 vcad-kernel-physics = { workspace = true }
-phyz = { path = "../../../phyz/crates/phyz" }
-phyz-gpu = { path = "../../../phyz/crates/phyz-gpu" }
-phyz-model = { path = "../../../phyz/crates/phyz-model" }
-phyz-math = { path = "../../../phyz/crates/phyz-math" }
+phyz = { workspace = true }
+phyz-gpu = { workspace = true }
+phyz-model = { workspace = true }
+phyz-math = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 


### PR DESCRIPTION
Move the phyz path dependencies into the root [workspace.dependencies] table, matching the convention already used for the sibling tang workspace.

## Why

tang deps flow through [workspace.dependencies] (root Cargo.toml), but the phyz deps bypassed it:

- crates/vcad-kernel-physics/Cargo.toml pinned phyz via a raw path dep ({ path = "../../../phyz/crates/phyz", version = "0.3" })
- crates/vcad-sim/Cargo.toml declared phyz, phyz-gpu, phyz-model, phyz-math as raw path deps with no version pins

Paths and versions were duplicated/inconsistent across crates with no single source of truth.

## Changes

- Root Cargo.toml: add [workspace.dependencies] entries for phyz (0.3), phyz-gpu, phyz-model, phyz-math (0.1, matching the phyz workspace version), all pointing at ../phyz/crates/* right under the existing tang entries.
- vcad-kernel-physics and vcad-sim: switch all four to { workspace = true }.

Version pins were read from the phyz repo: only phyz sets its own version = 0.3.0; the other three inherit the phyz workspace version = 0.1.0.

## Verification

- cargo build -p vcad-kernel-physics -p vcad-sim — passes
- cargo clippy --workspace --exclude vcad-desktop -- -D warnings — clean

No changelog entry (build hygiene, no user-facing behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)