### PR TITLE
docs: require cloning phyz sibling repo + document worktree symlinks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,20 +10,36 @@ vcad is an open-source parametric CAD system aiming to replace Fusion 360, Onsha
 
 ## Prerequisites
 
-vcad depends on the `tang` math workspace at a **sibling path** (`../tang`). Clone it
-next to vcad before running `cargo build`:
+vcad depends on the `tang` math workspace and the `phyz` physics workspace at
+**sibling paths** (`../tang`, `../phyz`). Clone both next to vcad before running
+`cargo build` — a default build fails without either (`vcad-kernel-physics` and
+`vcad-sim` are in default-members, and `vcad-kernel-wasm`'s default `physics`
+feature pulls phyz in too):
 
 ```bash
 git clone git@github.com:ecto/tang.git ../tang
+git clone git@github.com:ecto/phyz.git ../phyz
 ```
 
 Cargo paths in the workspace (`tang`, `tang-la`, `tang-expr`) all point at
-`../tang/crates/*`.
+`../tang/crates/*`; `vcad-kernel-physics` and `vcad-sim` point at
+`../../../phyz/crates/*` (i.e. `../phyz` relative to the repo root).
 
 **Fresh worktrees** (`.claude/worktrees/*`) start with no `node_modules` — run `npm ci`
 before any npm/tauri command. Tauri needs the `cargo-tauri` binary (installed globally
 via `cargo install tauri-cli`); the npm scripts invoke it as `cargo tauri`, so no local
 `tauri` on PATH is required.
+
+Worktree roots live at `.claude/worktrees/<name>`, so the sibling path deps
+resolve to `.claude/worktrees/tang` and `.claude/worktrees/phyz`. Symlinks
+inside `.claude/worktrees/` make this work (`tang -> /Users/cam/Developer/tang`,
+`phyz -> /Users/cam/Developer/phyz`); they must exist — or be created — before
+`cargo` commands will build from a worktree (run from the **main** checkout):
+
+```bash
+ln -sfn "$(cd .. && pwd)/tang" .claude/worktrees/tang
+ln -sfn "$(cd .. && pwd)/phyz" .claude/worktrees/phyz
+```
 
 After `npm ci`, the app imports from `@vcad/core`, `@vcad/engine`, `@vcad/ir`, `@vcad/mcp`
 which all resolve to `dist/index.js` — so workspace packages must be built before

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ vcad/
 
 ## Development
 
-> **Heads up:** vcad depends on the `tang` math workspace at a **sibling path**
-> (`../tang`). Clone it next to vcad before any `cargo` command, or the
-> workspace will fail to resolve:
+> **Heads up:** vcad depends on the `tang` math workspace and the `phyz`
+> physics workspace at **sibling paths** (`../tang`, `../phyz`). Clone both
+> next to vcad before any `cargo` command, or the workspace will fail to
+> resolve:
 >
 > ```bash
 > git clone git@github.com:ecto/tang.git ../tang
+> git clone git@github.com:ecto/phyz.git ../phyz
 > ```
 
 ```bash


### PR DESCRIPTION
## What changed

Both the README and `CLAUDE.md` told contributors to clone `tang` as a sibling (`../tang`) but never mentioned `phyz` — even though a default `cargo build` fails without it.

- **README.md** — the Development heads-up now requires cloning both `tang` and `phyz` as siblings, with both clone commands.
- **CLAUDE.md** — the Prerequisites section now requires `phyz`, explains *why* a default build needs it, and notes the phyz path-dep layout. The worktree section documents the `tang`/`phyz` symlinks inside `.claude/worktrees/` that make `../tang`/`../phyz` resolve from worktree roots, with `ln -sfn` commands to (re)create them.

## Why

A default build pulls in phyz through several paths:
- `crates/vcad-kernel-physics/Cargo.toml` uses `phyz = { path = "../../../phyz/crates/phyz" }`
- `crates/vcad-sim/Cargo.toml` uses `phyz`, `phyz-gpu`, `phyz-model`, `phyz-math` path deps
- Both crates are in `default-members`; `vcad-cli` depends on `vcad-kernel-physics` unconditionally; `vcad-kernel-wasm`'s default `physics` feature pulls it in too.

So a fresh clone with only `tang` next to it won't build. This brings the docs in line with what the workspace already requires.

## Reviewer notes

- Docs-only change; no changelog entry (per the CLAUDE.md changelog-skip rules).
- Verified: the phyz path deps resolve to `../phyz` as documented, both sibling repos + referenced crates exist, both worktree symlinks exist, and `cargo metadata` resolves the full workspace from this worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)