### PR TITLE
refactor(physics): contain phyz type leaks in vcad-kernel-physics public API

### DIFF
--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -736,48 +736,66 @@ pub fn rollout_gradient_via_density(
 // Adjoint-backed rollout gradients (phyz trajectory adjoint for ∂J/∂p)
 // ---------------------------------------------------------------------------
 
-/// A structured, adjoint-differentiable rollout description.
+/// Low-level phyz interop — the one place `phyz` types cross the crate's
+/// public surface.
 ///
-/// [`rollout_gradient`] takes an opaque closure and therefore has to probe
-/// `∂J/∂p` by finite differences (~20 re-simulations per body). This spec
-/// exposes the rollout's structure — model builder, initial state, open-loop
-/// control schedule, final-state objective with its analytic gradient — so
-/// the phyz **trajectory adjoint** ([`phyz::diff`]) can compute `∂J/∂p`
-/// exactly in one backward pass.
-///
-/// # Contract
-///
-/// - `build_model` must install body `i`'s inertia **exactly as**
-///   `props[i].to_spatial_inertia()` — i.e. in the CAD body frame. Mounting
-///   (rotating/offsetting the body relative to its joint) belongs in the
-///   joint's `parent_to_joint` and `axis`, *not* in a transformed inertia;
-///   a transformed inertia would silently decouple `∂J/∂p` from the seam's
-///   `dp/dθ`. Violations are detected and panic.
-/// - Joints: single-DOF (revolute/prismatic) + fixed, like phyz's adjoint.
-/// - `ctrl` is open-loop: it must not read the state.
-/// - The rollout the adjoint differentiates is phyz's semi-implicit Euler
-///   (`v' = v + dt·qdd`, `q' = q + dt·v'`) — the same integrator the m8
-///   test rollouts hand-roll, so the FD path and the adjoint path price the
-///   same trajectory.
-#[allow(clippy::type_complexity)]
-pub struct AdjointRolloutSpec<'a> {
-    /// Build the (contact-free unless used via
-    /// [`contact_rollout_gradient`]) phyz model at the given mass
-    /// properties. See the type-level contract.
-    pub build_model: Box<dyn Fn(&[BodyMassProps]) -> phyz::Model + 'a>,
-    /// Initial joint positions (length `nq`).
-    pub q0: Vec<f64>,
-    /// Initial joint velocities (length `nv`).
-    pub v0: Vec<f64>,
-    /// Number of integration steps.
-    pub steps: usize,
-    /// Open-loop control at step `t` (length `nv`).
-    pub ctrl: Box<dyn Fn(usize) -> phyz::math::DVec + 'a>,
-    /// Final-state objective `J = g(q_T, v_T)`.
-    pub objective_value: Box<dyn Fn(&[f64], &[f64]) -> f64 + 'a>,
-    /// Analytic objective gradient `(∂g/∂q_T, ∂g/∂v_T)`.
-    pub objective_gradient: Box<dyn Fn(&[f64], &[f64]) -> (Vec<f64>, Vec<f64>) + 'a>,
+/// vcad-kernel-physics otherwise wraps phyz completely (no phyz types in
+/// public APIs). The adjoint-backed gradients are the exception: callers
+/// describe the rollout by *building a phyz model themselves*, so
+/// [`AdjointRolloutSpec`](interop::AdjointRolloutSpec) necessarily carries
+/// `phyz::Model` / `phyz::math::DVec`. Anything imported from here couples
+/// your code to phyz's API; the wrapped entry points
+/// ([`rollout_gradient_adjoint`], [`contact_rollout_gradient`]) are the
+/// supported surface.
+pub mod interop {
+    use super::BodyMassProps;
+
+    /// A structured, adjoint-differentiable rollout description.
+    ///
+    /// [`rollout_gradient`](super::rollout_gradient) takes an opaque closure
+    /// and therefore has to probe
+    /// `∂J/∂p` by finite differences (~20 re-simulations per body). This spec
+    /// exposes the rollout's structure — model builder, initial state, open-loop
+    /// control schedule, final-state objective with its analytic gradient — so
+    /// the phyz **trajectory adjoint** ([`phyz::diff`]) can compute `∂J/∂p`
+    /// exactly in one backward pass.
+    ///
+    /// # Contract
+    ///
+    /// - `build_model` must install body `i`'s inertia **exactly as**
+    ///   `props[i].to_spatial_inertia()` — i.e. in the CAD body frame. Mounting
+    ///   (rotating/offsetting the body relative to its joint) belongs in the
+    ///   joint's `parent_to_joint` and `axis`, *not* in a transformed inertia;
+    ///   a transformed inertia would silently decouple `∂J/∂p` from the seam's
+    ///   `dp/dθ`. Violations are detected and panic.
+    /// - Joints: single-DOF (revolute/prismatic) + fixed, like phyz's adjoint.
+    /// - `ctrl` is open-loop: it must not read the state.
+    /// - The rollout the adjoint differentiates is phyz's semi-implicit Euler
+    ///   (`v' = v + dt·qdd`, `q' = q + dt·v'`) — the same integrator the m8
+    ///   test rollouts hand-roll, so the FD path and the adjoint path price the
+    ///   same trajectory.
+    #[allow(clippy::type_complexity)]
+    pub struct AdjointRolloutSpec<'a> {
+        /// Build the (contact-free unless used via
+        /// [`super::contact_rollout_gradient`]) phyz model at the given mass
+        /// properties. See the type-level contract.
+        pub build_model: Box<dyn Fn(&[BodyMassProps]) -> phyz::Model + 'a>,
+        /// Initial joint positions (length `nq`).
+        pub q0: Vec<f64>,
+        /// Initial joint velocities (length `nv`).
+        pub v0: Vec<f64>,
+        /// Number of integration steps.
+        pub steps: usize,
+        /// Open-loop control at step `t` (length `nv`).
+        pub ctrl: Box<dyn Fn(usize) -> phyz::math::DVec + 'a>,
+        /// Final-state objective `J = g(q_T, v_T)`.
+        pub objective_value: Box<dyn Fn(&[f64], &[f64]) -> f64 + 'a>,
+        /// Analytic objective gradient `(∂g/∂q_T, ∂g/∂v_T)`.
+        pub objective_gradient: Box<dyn Fn(&[f64], &[f64]) -> (Vec<f64>, Vec<f64>) + 'a>,
+    }
 }
+
+use interop::AdjointRolloutSpec;
 
 /// Check the [`AdjointRolloutSpec::build_model`] contract: the model's body
 /// inertias must be the props verbatim (CAD body frame, no mount transform

--- a/crates/vcad-kernel-physics/src/joints.rs
+++ b/crates/vcad-kernel-physics/src/joints.rs
@@ -66,7 +66,7 @@ impl MotorTarget {
 /// Create a phyz joint from a vcad joint definition.
 ///
 /// Returns the phyz Joint and the parent-to-joint spatial transform.
-pub fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, PhysicsError> {
+pub(crate) fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, PhysicsError> {
     // Convert parent anchor from mm to meters — this becomes the translation
     // in the parent-to-joint transform.
     let anchor = Vec3::new(
@@ -128,7 +128,7 @@ pub fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, PhysicsError> 
 /// so child geometry and inertia must be expressed in this frame: for a
 /// point `p` in the child part's local mm coordinates,
 /// `p_body = R^T * (p - child_anchor)`.
-pub fn joint_frame_rotation(kind: &JointKind) -> Mat3 {
+pub(crate) fn joint_frame_rotation(kind: &JointKind) -> Mat3 {
     match kind {
         JointKind::Revolute { axis, .. } | JointKind::Cylindrical { axis } => {
             rotation_aligning_z_to(Vec3::new(axis.x, axis.y, axis.z).normalize())

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -48,8 +48,8 @@ mod world;
 pub use diff::{
     contact_rollout_gradient, nominal_mass_props, rollout_gradient, rollout_gradient_adjoint,
     rollout_gradient_via_density, rollout_gradient_with_anchors, rollout_gradient_with_surface,
-    surface_gradient, AdjointRolloutSpec, AnchorFdSteps, BodyMassProps, ContactConfig, DiffBody,
-    MassPropFdSteps, SurfaceTerm,
+    surface_gradient, AnchorFdSteps, BodyMassProps, ContactConfig, DiffBody, MassPropFdSteps,
+    SurfaceTerm,
 };
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};

--- a/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
+++ b/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
@@ -25,9 +25,10 @@ use phyz::math::{DVec, SpatialTransform, Vec3};
 use phyz::{Joint, JointType, Model, ModelBuilder};
 use vcad_kernel_diff::{ParamSeeding, SurfaceSeed};
 use vcad_kernel_geom::CylinderSurface;
+use vcad_kernel_physics::diff::interop::AdjointRolloutSpec;
 use vcad_kernel_physics::{
-    nominal_mass_props, rollout_gradient, rollout_gradient_adjoint, AdjointRolloutSpec,
-    BodyMassProps, DiffBody, MassPropFdSteps,
+    nominal_mass_props, rollout_gradient, rollout_gradient_adjoint, BodyMassProps, DiffBody,
+    MassPropFdSteps,
 };
 use vcad_kernel_primitives::{make_cylinder, BRepSolid};
 use vcad_kernel_tessellate::TessellationParams;

--- a/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
+++ b/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
@@ -40,9 +40,8 @@ use phyz::math::{DVec, Mat3, SpatialTransform, Vec3};
 use phyz::{Joint, JointType, Model, ModelBuilder};
 use vcad_kernel_diff::{ParamSeeding, SurfaceSeed};
 use vcad_kernel_geom::CylinderSurface;
-use vcad_kernel_physics::{
-    contact_rollout_gradient, AdjointRolloutSpec, BodyMassProps, ContactConfig, DiffBody,
-};
+use vcad_kernel_physics::diff::interop::AdjointRolloutSpec;
+use vcad_kernel_physics::{contact_rollout_gradient, BodyMassProps, ContactConfig, DiffBody};
 use vcad_kernel_primitives::{make_cylinder, BRepSolid};
 use vcad_kernel_tessellate::TessellationParams;
 


### PR DESCRIPTION
## What

`vcad-kernel-physics` is meant to wrap `phyz` so no `phyz` types appear in its public API — its `lib.rs` re-exports (`RobotEnv`, `Action`, `Observation`, `PhysicsWorld`, `JointState`, `PhysicsError`) are all phyz-free. Two leaks remained; this PR contains both.

### 1. `joints.rs` — `pub` fns returning phyz types → `pub(crate)`

- `vcad_joint_to_phyz(...) -> Result<phyz::model::Joint, _>`
- `joint_frame_rotation(...) -> phyz::math::Mat3` (found during the audit — same class of leak)

**Audit:** both have only in-crate consumers (`world.rs`). `vcad-sim` legitimately spans the seam but keeps its own mirror (`build_phyz_model_joint` in `batch.rs`) targeting the separate `phyz_model::Joint` type required by `phyz-gpu`, so nothing external depends on these. Now `pub(crate)`.

### 2. `diff.rs` — `AdjointRolloutSpec` → new `diff::interop` module

`AdjointRolloutSpec`'s fields are `Box<dyn Fn(&[BodyMassProps]) -> phyz::Model>` and `Box<dyn Fn(usize) -> phyz::math::DVec>`. The caller *builds the phyz model itself*, so these types can't be wrapped away without breaking the adjoint contract. Instead of hiding it, the spec now lives in a `diff::interop` module documented as the one intentional place phyz types cross the public surface. The flat `AdjointRolloutSpec` re-export is dropped from the crate root; consumers reach it via `vcad_kernel_physics::diff::interop::AdjointRolloutSpec`.

**Audit:** the only consumers were this crate's own M11 integration tests. The wasm bindings and `vcad-eval` use `vcad_kernel_diff`, not this module.

## Unchanged

The wrapped differentiable-rollout entry points — `rollout_gradient_adjoint` and `contact_rollout_gradient` — keep their signatures and crate-root re-exports. The two M11 tests were updated to import the spec via `diff::interop`.

## Verification

- `cargo test -p vcad-kernel-physics -p vcad-sim` — all green
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean
- `cargo fmt --all --check` — clean

No changelog entry (internal refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
