### PR TITLE
docs(kernel-math): clarify Transform is intentionally affine, not tang's rigid Transform

### DIFF
--- a/crates/vcad-kernel-math/src/lib.rs
+++ b/crates/vcad-kernel-math/src/lib.rs
@@ -30,6 +30,10 @@ pub type Point2 = tang::Point2<f64>;
 pub type Vec2 = tang::Vec2<f64>;
 
 /// A 4x4 affine transformation matrix.
+///
+/// Intentionally distinct from `tang::Transform` (rigid-only): vcad needs
+/// full affine — non-uniform scale (`CsgOp::Scale`) and reflection (mirror
+/// ops) — which a rotation+translation pair cannot represent.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Transform {
     /// The underlying 4x4 matrix.


### PR DESCRIPTION
## What

Adds a doc comment to `vcad-kernel-math::Transform` explaining why it is intentionally a full affine `Mat4`, distinct from `tang::Transform` (rigid rotation+translation only).

## Why

A stale doc comment on `tang::Transform` claimed it "replaces both vcad's `Transform` … and phyz's `SpatialTransform`." That migration never happened and, for vcad, cannot:

- vcad's `Transform` needs **full affine** — `Transform::scale` backs `CsgOp::Scale`, and `Transform::reflection` backs mirror ops (upper-left 3x3 determinant = -1, driving winding reversal). A rigid rotation+translation pair can't represent either.
- phyz never used `tang::Transform` either — `phyz-math` aliases `tang::SpatialTransform` (the Featherstone spatial-algebra type), which tang provides separately.

The companion reword of tang's own doc comment lands in the `ecto/tang` repo (sibling workspace, not part of this PR). This PR is the vcad-side note recording *why* the two `Transform` types are deliberately distinct, so nobody re-attempts the "migration."

## Notes for reviewer

- Docs-only; no behavior change.
- `cargo build -p vcad-kernel-math` verified clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)