### PR TITLE
feat(router): fab-ready fix loop (prune, mutual-legality verdicts, class widths)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7019,6 +7019,7 @@ dependencies = [
  "tang-expr",
  "thiserror 2.0.18",
  "toml 0.8.23",
+ "vcad-ecad-export",
  "vcad-ecad-package",
  "vcad-ecad-sim",
  "vcad-ecad-symbols",

--- a/crates/vcad-ecad-pcb/Cargo.toml
+++ b/crates/vcad-ecad-pcb/Cargo.toml
@@ -25,6 +25,7 @@ log = "0.4"
 
 [dev-dependencies]
 vcad-ecad-sim = { path = "../vcad-ecad-sim" }
+vcad-ecad-export = { path = "../vcad-ecad-export" }
 vcad-ecad-symbols = { workspace = true }
 env_logger = "0.11"
 

--- a/crates/vcad-ecad-pcb/examples/board_export.rs
+++ b/crates/vcad-ecad-pcb/examples/board_export.rs
@@ -1,0 +1,45 @@
+//! Export a routed board (`.pcb.json` from cm5_bench) to every supported
+//! fabrication/interchange format: Gerbers, Excellon drills, KiCad board,
+//! BOM CSV, and pick-and-place CSV.
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example board_export -- routed.pcb.json out_dir/
+//! ```
+
+use std::fs;
+use std::path::Path;
+use vcad_ir::ecad::Pcb;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input = args.next().expect("usage: board_export <board.pcb.json> <out_dir>");
+    let out = args.next().expect("usage: board_export <board.pcb.json> <out_dir>");
+    let out = Path::new(&out);
+    fs::create_dir_all(out).expect("create out dir");
+
+    let pcb: Pcb = serde_json::from_str(&fs::read_to_string(&input).expect("read board"))
+        .expect("parse board json");
+
+    let gerbers = vcad_ecad_export::gerber::generate_gerbers(&pcb).expect("gerbers");
+    for (name, content) in &gerbers {
+        fs::write(out.join(name), content).expect("write gerber");
+    }
+    println!("gerbers: {} files", gerbers.len());
+
+    let mut drill = Vec::new();
+    vcad_ecad_export::excellon::write_excellon(&mut drill, &pcb).expect("excellon");
+    fs::write(out.join("drill.drl"), &drill).expect("write drill");
+
+    fs::write(out.join("board.kicad_pcb"), vcad_ecad_symbols::write_kicad_pcb(&pcb))
+        .expect("write kicad");
+
+    let mut bom = Vec::new();
+    vcad_ecad_export::bom::write_bom(&mut bom, &pcb).expect("bom");
+    fs::write(out.join("bom.csv"), &bom).expect("write bom");
+
+    let mut pnp = Vec::new();
+    vcad_ecad_export::pick_place::write_pick_place(&mut pnp, &pcb).expect("pick place");
+    fs::write(out.join("pick_place.csv"), &pnp).expect("write pnp");
+
+    println!("exported to {}", out.display());
+}

--- a/crates/vcad-ecad-pcb/examples/board_export.rs
+++ b/crates/vcad-ecad-pcb/examples/board_export.rs
@@ -12,8 +12,12 @@ use vcad_ir::ecad::Pcb;
 
 fn main() {
     let mut args = std::env::args().skip(1);
-    let input = args.next().expect("usage: board_export <board.pcb.json> <out_dir>");
-    let out = args.next().expect("usage: board_export <board.pcb.json> <out_dir>");
+    let input = args
+        .next()
+        .expect("usage: board_export <board.pcb.json> <out_dir>");
+    let out = args
+        .next()
+        .expect("usage: board_export <board.pcb.json> <out_dir>");
     let out = Path::new(&out);
     fs::create_dir_all(out).expect("create out dir");
 
@@ -30,8 +34,11 @@ fn main() {
     vcad_ecad_export::excellon::write_excellon(&mut drill, &pcb).expect("excellon");
     fs::write(out.join("drill.drl"), &drill).expect("write drill");
 
-    fs::write(out.join("board.kicad_pcb"), vcad_ecad_symbols::write_kicad_pcb(&pcb))
-        .expect("write kicad");
+    fs::write(
+        out.join("board.kicad_pcb"),
+        vcad_ecad_symbols::write_kicad_pcb(&pcb),
+    )
+    .expect("write kicad");
 
     let mut bom = Vec::new();
     vcad_ecad_export::bom::write_bom(&mut bom, &pcb).expect("bom");

--- a/crates/vcad-ecad-pcb/examples/cm5_verdict.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_verdict.rs
@@ -77,6 +77,23 @@ fn main() {
         .filter(|l| l.is_copper())
         .collect();
     let width = pcb.rules.default_rules.trace_width;
+    // Per-net class widths: SI-class nets must be routed and committed at
+    // their class width (the DRC's MinTraceWidth rule is per-net) — a joint
+    // path at default width would land 500+ width violations on a board
+    // whose pairs are classed at 0.2 mm.
+    let net_width: std::collections::HashMap<String, f64> = pcb
+        .rules
+        .class_rules
+        .iter()
+        .flat_map(|rule| {
+            pcb.rules
+                .net_class_assignments
+                .get(&rule.name)
+                .into_iter()
+                .flatten()
+                .map(move |net| (net.clone(), rule.trace_width))
+        })
+        .collect();
 
     // Cluster connections whose bboxes (inflated 2mm) overlap. Two rules keep
     // the certificates honest: a cluster never holds two connections of the
@@ -118,7 +135,13 @@ fn main() {
     let (mut routed, mut proved, mut unknown) = (0usize, 0usize, 0usize);
     for (lo, hi, conns) in &clusters {
         let names: Vec<&str> = conns.iter().map(|c| c.0.as_str()).collect();
-        match route_window_complete(&session, (*lo, *hi), &layers, conns, width, budget) {
+        // Search at the widest class width in the cluster (conservative:
+        // guarantees the found corridors fit every member's committed width).
+        let cluster_width = conns
+            .iter()
+            .map(|(n, _, _)| net_width.get(n).copied().unwrap_or(width))
+            .fold(width, f64::max);
+        match route_window_complete(&session, (*lo, *hi), &layers, conns, cluster_width, budget) {
             CompleteOutcome::Routed(paths) => {
                 // Fail-closed: the window router's coarse grid can hide
                 // sub-clearance gaps its pitch cannot see, and joint paths
@@ -126,45 +149,47 @@ fn main() {
                 // through the (pair-aware) session before trusting the
                 // routing; a path the oracle rejects downgrades the cluster
                 // to an honest unknown.
-                let all_legal = conns.iter().zip(&paths).all(|((net, _, _), path)| {
-                    path.iter().all(|&(a, b, l)| {
+                // Probe-then-commit PER PATH, in order: cluster paths are
+                // node-disjoint on the coarse window grid, but the grid pitch
+                // can hide sub-clearance gaps BETWEEN two paths of the same
+                // cluster (observed: two same-cluster diagonals overlapping
+                // at 0.000mm). Probing each path against the session AFTER
+                // its clustermates committed makes mutual legality exact; a
+                // path that fails downgrades only itself to unknown.
+                let mut cluster_routed = 0usize;
+                for ((net, _, _), path) in conns.iter().zip(&paths) {
+                    let w = net_width.get(net).copied().unwrap_or(width);
+                    let legal = path.iter().all(|&(a, b, l)| {
                         let g = vcad_ecad_pcb::spatial::CopperGeom::Segment {
                             a,
                             b,
-                            half_w: width / 2.0,
+                            half_w: w / 2.0,
                         };
                         session.probe(&g, l, net, session.clearance_for(net)).legal
-                    })
-                });
-                if !all_legal {
-                    unknown += conns.len();
-                    println!("UNKNOWN  {names:?} (paths failed oracle probe)");
-                    continue;
-                }
-                routed += conns.len();
-                let segs: usize = paths.iter().map(|p| p.len()).sum();
-                println!("ROUTED   {names:?} ({segs} segments found)");
-                // Commit the found copper twice: into the live SESSION so
-                // every later cluster treats this win as an obstacle (mutual
-                // legality — without this, two clusters can route through
-                // each other), and into the board file so it carries the win.
-                for ((net, _, _), path) in conns.iter().zip(&paths) {
+                    });
+                    if !legal {
+                        unknown += 1;
+                        println!("UNKNOWN  [{net:?}] (path failed oracle probe)");
+                        continue;
+                    }
+                    cluster_routed += 1;
+                    let w = net_width.get(net).copied().unwrap_or(width);
                     for (a, b, layer) in path {
                         session.commit(CopperElement {
-                            min: [a.x.min(b.x) - width, a.y.min(b.y) - width],
-                            max: [a.x.max(b.x) + width, a.y.max(b.y) + width],
+                            min: [a.x.min(b.x) - w, a.y.min(b.y) - w],
+                            max: [a.x.max(b.x) + w, a.y.max(b.y) + w],
                             net: net.clone(),
                             layer: *layer,
                             geom: CopperGeom::Segment {
                                 a: *a,
                                 b: *b,
-                                half_w: width / 2.0,
+                                half_w: w / 2.0,
                             },
                         });
                         pcb.traces.push(vcad_ir::ecad::Trace {
                             start: *a,
                             end: *b,
-                            width,
+                            width: w,
                             layer: *layer,
                             net: net.clone(),
                             source: None,
@@ -195,6 +220,13 @@ fn main() {
                             });
                         }
                     }
+                }
+                routed += cluster_routed;
+                if cluster_routed > 0 {
+                    println!(
+                        "ROUTED   {names:?} ({cluster_routed}/{} committed)",
+                        conns.len()
+                    );
                 }
             }
             CompleteOutcome::ProvedInfeasible { reason } => {

--- a/crates/vcad-ecad-pcb/examples/drc_json.rs
+++ b/crates/vcad-ecad-pcb/examples/drc_json.rs
@@ -23,7 +23,13 @@ fn main() {
     let mut shown: BTreeMap<String, usize> = BTreeMap::new();
     for v in &violations {
         *by_rule.entry(format!("{:?}", v.rule)).or_default() += 1;
-        if matches!(v.rule, DrcRuleType::Short | DrcRuleType::Clearance) {
+        if matches!(
+            v.rule,
+            DrcRuleType::Short
+                | DrcRuleType::Clearance
+                | DrcRuleType::MinTraceWidth
+                | DrcRuleType::NetIslands
+        ) {
             hard += 1;
             let show = focus
                 .as_deref()

--- a/crates/vcad-ecad-pcb/examples/kicad2json.rs
+++ b/crates/vcad-ecad-pcb/examples/kicad2json.rs
@@ -1,0 +1,7 @@
+fn main() {
+    let mut a = std::env::args().skip(1);
+    let src = a.next().unwrap();
+    let dst = a.next().unwrap();
+    let pcb = vcad_ecad_symbols::parse_kicad_pcb(&std::fs::read_to_string(&src).unwrap()).unwrap();
+    std::fs::write(&dst, serde_json::to_string(&pcb).unwrap()).unwrap();
+}

--- a/crates/vcad-ecad-pcb/examples/prune_copper.rs
+++ b/crates/vcad-ecad-pcb/examples/prune_copper.rs
@@ -1,0 +1,19 @@
+//! Remove dangling copper (islands touching no pad/pour of their net) from a
+//! routed `.pcb.json`. See [`vcad_ecad_pcb::drc::prune_dangling_copper`].
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example prune_copper -- in.pcb.json out.pcb.json
+//! ```
+
+use vcad_ir::ecad::Pcb;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input = args.next().expect("usage: prune_copper <in> <out>");
+    let output = args.next().expect("usage: prune_copper <in> <out>");
+    let mut pcb: Pcb =
+        serde_json::from_str(&std::fs::read_to_string(&input).expect("read")).expect("parse");
+    let (t, v) = vcad_ecad_pcb::drc::prune_dangling_copper(&mut pcb);
+    println!("pruned {t} dangling traces, {v} dangling vias");
+    std::fs::write(&output, serde_json::to_string(&pcb).expect("ser")).expect("write");
+}

--- a/crates/vcad-ecad-pcb/examples/strip_nets.rs
+++ b/crates/vcad-ecad-pcb/examples/strip_nets.rs
@@ -1,0 +1,35 @@
+//! Strip all board-level copper (traces + vias) of the named nets from a
+//! routed `.pcb.json` — the first half of the DRC fix loop: offenders are
+//! stripped here, then re-routed through the session-probed ladder
+//! (`cm5_verdict`), which only commits legal copper.
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example strip_nets -- in.pcb.json out.pcb.json NET1 NET2 ...
+//! ```
+
+use vcad_ir::ecad::Pcb;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let input = args
+        .next()
+        .expect("usage: strip_nets <in.pcb.json> <out.pcb.json> <net>...");
+    let output = args
+        .next()
+        .expect("usage: strip_nets <in.pcb.json> <out.pcb.json> <net>...");
+    let nets: Vec<String> = args.collect();
+    assert!(!nets.is_empty(), "no nets given");
+
+    let mut pcb: Pcb =
+        serde_json::from_str(&std::fs::read_to_string(&input).expect("read")).expect("parse");
+    let before = (pcb.traces.len(), pcb.vias.len());
+    pcb.traces.retain(|t| !nets.contains(&t.net));
+    pcb.vias.retain(|v| !nets.contains(&v.net));
+    println!(
+        "stripped {} traces, {} vias across {} nets",
+        before.0 - pcb.traces.len(),
+        before.1 - pcb.vias.len(),
+        nets.len()
+    );
+    std::fs::write(&output, serde_json::to_string(&pcb).expect("serialize")).expect("write");
+}

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -2447,6 +2447,53 @@ fn build_connectivity(pcb: &Pcb) -> (Vec<ConnNode>, Dsu) {
     (nodes, dsu)
 }
 
+/// Remove dangling copper: board-level traces and vias whose galvanic island
+/// touches no pad and no pour fragment of their net — copper connected to
+/// nothing, left behind by rip-up/restore cycles. Uses the same connectivity
+/// model as DRC's island detection, so exactly the islands DRC reports as
+/// "copper only, no pads" are removed. Returns `(traces_removed,
+/// vias_removed)`.
+pub fn prune_dangling_copper(pcb: &mut Pcb) -> (usize, usize) {
+    let (nodes, mut dsu) = build_connectivity(pcb);
+    // Node order in build_conn_nodes: traces, then vias, then pads/pours.
+    let n_traces = pcb.traces.len();
+    let n_vias = pcb.vias.len();
+
+    // Component roots that are anchored: hold a pad or a pour fragment.
+    let mut anchored: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for (i, node) in nodes.iter().enumerate() {
+        let is_anchor = node.pad.is_some() || matches!(node.geom, NodeGeom::Pour(_));
+        if is_anchor {
+            let root = dsu.find(i);
+            anchored.insert(root);
+        }
+    }
+
+    let keep_trace: Vec<bool> = (0..n_traces)
+        .map(|i| anchored.contains(&dsu.find(i)))
+        .collect();
+    let keep_via: Vec<bool> = (0..n_vias)
+        .map(|i| anchored.contains(&dsu.find(n_traces + i)))
+        .collect();
+
+    let mut ti = 0;
+    pcb.traces.retain(|_| {
+        let k = keep_trace[ti];
+        ti += 1;
+        k
+    });
+    let mut vi = 0;
+    pcb.vias.retain(|_| {
+        let k = keep_via[vi];
+        vi += 1;
+        k
+    });
+    (
+        keep_trace.iter().filter(|k| !**k).count(),
+        keep_via.iter().filter(|k| !**k).count(),
+    )
+}
+
 /// A direct geometric touch between two connectivity nodes — one edge of the
 /// contact graph — with the approximate location where the copper meets.
 /// Cross-net edges are the candidate shorts (each judged against the net-tie

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -1086,6 +1086,12 @@ fn route_pass(
         if pending.is_empty() {
             break;
         }
+        // Keep-best: a rip-up round can end with FEWER placed connections
+        // than it started (it rips victims it then fails to restore — the
+        // CM5 logs show 504 -> 489 over a 46-minute round). The negotiation
+        // loop above snapshots and discards regressing rounds; this loop
+        // must too, or one bad round permanently costs the board copper.
+        let snapshot = (session.clone(), placed.clone(), pending.clone());
         let placed_before = placed.len();
         let sw_rip = Stopwatch::start();
         pending = ripup_pass(
@@ -1109,7 +1115,12 @@ fn route_pass(
             pending.len(),
             sw_rip.ms() / 1000.0,
         );
-        if placed.len() <= placed_before {
+        if placed.len() < placed_before {
+            log::info!("ripup round regressed — restoring pre-round snapshot");
+            (session, placed, pending) = snapshot;
+            break;
+        }
+        if placed.len() == placed_before {
             break;
         }
     }

--- a/crates/vcad-kernel-gpu/src/shaders/wavefront_batch.wgsl
+++ b/crates/vcad-kernel-gpu/src/shaders/wavefront_batch.wgsl
@@ -81,9 +81,15 @@ fn candidate(search: u32, base: u32, x: i32, y: i32, l: u32, cost: u32) -> u32 {
 }
 
 @compute @workgroup_size(256)
-fn relax_batch(@builtin(global_invocation_id) gid: vec3<u32>) {
+fn relax_batch(
+    @builtin(global_invocation_id) gid: vec3<u32>,
+    @builtin(num_workgroups) nwg: vec3<u32>,
+) {
     let total = total_nodes();
-    let flat = gid.x;
+    // 2D dispatch grid: hosts split workgroups over (x, y) because a single
+    // dispatch dimension is capped at 65535 — a full-board batch needs ~2x
+    // that. Flatten back to the linear node index.
+    let flat = gid.y * (nwg.x * 256u) + gid.x;
     if flat >= total * params.n_searches {
         return;
     }

--- a/crates/vcad-kernel-gpu/src/wavefront_batch.rs
+++ b/crates/vcad-kernel-gpu/src/wavefront_batch.rs
@@ -274,7 +274,15 @@ pub async fn distance_fields_batch_async(
     let bind_ab = bind(&dist_a, &dist_b);
     let bind_ba = bind(&dist_b, &dist_a);
 
+    // Metal/wgpu cap each dispatch dimension at 65535 workgroups; a
+    // full-board batch exceeds that in one dimension (observed 129052 —
+    // the dispatch poisoned the encoder and silently killed the GPU path
+    // for the rest of the run). Split over a 2D grid; the shader flattens
+    // (x, y) back to the linear index via num_workgroups.
     let groups = ((n * total) as u32).div_ceil(256);
+    let max_dim = ctx.device.limits().max_compute_workgroups_per_dimension;
+    let groups_x = groups.min(max_dim);
+    let groups_y = groups.div_ceil(groups_x);
     // Worst-case sweep bound: longest shortest path < total nodes.
     let max_sweeps = 4 * (nx + ny + nl);
     let mut sweeps_done = 0usize;
@@ -294,7 +302,7 @@ pub async fn distance_fields_batch_async(
             });
             pass.set_pipeline(&pipeline);
             pass.set_bind_group(0, if current_is_a { &bind_ab } else { &bind_ba }, &[]);
-            pass.dispatch_workgroups(groups, 1, 1);
+            pass.dispatch_workgroups(groups_x, groups_y, 1);
             drop(pass);
             current_is_a = !current_is_a;
             sweeps_done += 1;


### PR DESCRIPTION
Tooling that took the routed CM5 to zero route-attributable DRC violations (details in commit message). Companion to the merged #669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)