### PR TITLE
fix(physics): track phyz's widened Joint struct in the m11 tests

### DIFF
--- a/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
+++ b/crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs
@@ -133,6 +133,9 @@ fn pendulum_model(props: &[BodyMassProps]) -> Model {
         axis: Vec3::new(1.0, 0.0, 0.0),
         damping: 0.0,
         limits: None,
+        // phyz's Joint grew limit stiffness/damping, armature, spring, and
+        // friction-loss fields; this pendulum wants all of them neutral.
+        ..Default::default()
     };
     ModelBuilder::new()
         .gravity(Vec3::new(0.0, -9.81, 0.0))

--- a/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
+++ b/crates/vcad-kernel-physics/tests/m11_contact_gradient.rs
@@ -98,6 +98,9 @@ fn lying_cylinder_model(props: &[BodyMassProps]) -> Model {
         axis: Vec3::new(0.0, -1.0, 0.0),
         damping: 0.0,
         limits: None,
+        // phyz's Joint grew limit stiffness/damping, armature, spring, and
+        // friction-loss fields; this free roller wants all of them neutral.
+        ..Default::default()
     };
     ModelBuilder::new()
         .gravity(Vec3::new(0.0, 0.0, -9.81))


### PR DESCRIPTION
## Why

vcad CI clones the sibling `phyz` repo at **its** main tip. phyz has since added six fields to `Joint` (joint-limit enforcement + actuator gear/ctrlrange — `limit_stiffness`, `limit_damping`, `armature`, `stiffness`, `spring_ref`, `friction_loss`), so vcad's two `Joint { .. }` literals no longer compile:

```
error[E0063]: missing fields `armature`, `friction_loss`, `limit_damping` and 3 other fields
  --> crates/vcad-kernel-physics/tests/m11_adjoint_rollout.rs:130:17
```

This fails `cargo test --workspace` on **every** open PR and on main's next run. vcad main was last green at `408aab2` (00:39 UTC); nothing in vcad changed since — phyz did.

## What

phyz ships `impl Default for Joint`, so both literals close with `..Default::default()`. The new fields default to neutral values (`armature`/`stiffness`/`spring_ref`/`friction_loss` = 0), and the limit stiffness/damping defaults are inert while `limits: None` — which both of these models use. So the pendulum's and the roller's dynamics are unchanged and the adjoint / contact-gradient assertions stand as written.

Only `vcad_ir::Joint` construction sites elsewhere in the tree (gym.rs, vcode.rs, materializer.rs) — different type, unaffected.

## Verification caveat

**I could not compile this locally.** The checkout at `/Users/cam/Developer/phyz` is at `5747051`, which predates the `impl Default for Joint` this fix relies on — so the fix compiles against phyz main (what CI uses) but not against the older local copy. CI is the oracle here; `cargo fmt -p vcad-kernel-physics --check` is clean.

Worth knowing more broadly: local vcad builds are currently compiling against a phyz that is ~20 commits behind CI's (EPA rewrite, joint limits, actuation, MPM/gravity fixes). If any of those changed *behavior* vcad's physics tests depend on, this PR unblocks compilation and the next CI run will surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)