### PR TITLE
fix(ecad): stop double-counting element rotation in Eagle .brd pads

### DIFF
--- a/crates/vcad-ecad-symbols/src/eagle_brd.rs
+++ b/crates/vcad-ecad-symbols/src/eagle_brd.rs
@@ -215,13 +215,21 @@ pub fn parse_eagle_brd(text: &str) -> Result<Pcb, String> {
         let pads: Vec<Pad> = pkg_pads
             .iter()
             .map(|pp| {
-                // Element rotation (+ mirror = bottom side, x flips).
-                let mut p = pp.pos;
+                // Package pads live in the package's own frame, so their
+                // offsets and `rot` are ALREADY relative to the element —
+                // which is exactly what the IR stores. Composing the element
+                // rotation in here would double-count it: every consumer goes
+                // through `pad_world_position` (`fp + R(fp.rotation)·pad`) and
+                // `fp.rotation + pad.rotation`. Only the mirror is baked in,
+                // because the IR has no per-pad mirror flag: Eagle's `MRθ` is
+                // "mirror across Y, then rotate by θ", so M composes inside
+                // R(θ) and survives as x → -x, angle → -angle.
+                let mut local = pp.pos;
+                let mut pad_rot = pp.rot;
                 if mirrored {
-                    p.x = -p.x;
+                    local.x = -local.x;
+                    pad_rot = -pad_rot;
                 }
-                let (s, c) = rot.to_radians().sin_cos();
-                let local = Vec2::new(p.x * c - p.y * s, p.x * s + p.y * c);
                 let side = if mirrored {
                     PcbLayer::BCu
                 } else {
@@ -241,7 +249,7 @@ pub fn parse_eagle_brd(text: &str) -> Result<Pcb, String> {
                         }
                     },
                     position: local,
-                    rotation: pp.rot + rot,
+                    rotation: pad_rot,
                     drill: (!pp.smd).then_some(DrillSpec {
                         diameter: pp.drill,
                         oval: false,
@@ -417,5 +425,62 @@ mod tests {
         // Mirrored element lands on the back.
         assert!(!pcb.footprints[1].front);
         assert_eq!(pcb.footprints[1].pads[0].layers, vec![PcbLayer::BCu]);
+    }
+
+    /// Pad offsets and angles are stored RELATIVE to the footprint — the
+    /// element rotation lives on `Footprint::rotation` only. Composing it into
+    /// the pad (as `pp.rot + rot`, or by pre-rotating `pp.pos`) double-counts
+    /// it once every consumer applies `fp + R(fp.rotation)·pad`.
+    #[test]
+    fn pad_transform_is_relative_to_the_footprint() {
+        // 2×1 pads at ±0.5 in x, one of them turned 90° in the package frame.
+        let brd = r##"<?xml version="1.0"?>
+<eagle version="9.6.0"><drawing><board>
+<plain/>
+<libraries><library name="l">
+  <package name="P"><smd name="1" x="-0.5" y="0" dx="1.0" dy="0.5" layer="1"/>
+                    <smd name="2" x="0.5" y="0" dx="1.0" dy="0.5" layer="1" rot="R90"/></package>
+</library></libraries>
+<elements>
+  <element name="A" library="l" package="P" x="10" y="20" rot="R90"/>
+  <element name="B" library="l" package="P" x="30" y="40" rot="MR90"/>
+</elements>
+<signals/>
+</board></drawing></eagle>"##;
+        let pcb = parse_eagle_brd(brd).expect("parse");
+
+        let a = &pcb.footprints[0];
+        assert_eq!(a.rotation, 90.0);
+        // Unrotated package offsets survive verbatim…
+        assert_eq!(a.pads[0].position, Vec2::new(-0.5, 0.0));
+        assert_eq!(a.pads[1].position, Vec2::new(0.5, 0.0));
+        // …and pad angles are the package's own, not package + element.
+        assert_eq!(a.pads[0].rotation, 0.0);
+        assert_eq!(a.pads[1].rotation, 90.0);
+
+        // Round-trip through the canonical consumer transform: pad 1 of a
+        // 90°-rotated element sits directly "below" its origin, long axis
+        // now vertical (0° pad + 90° element).
+        let w = |p: &Pad| {
+            let (s, c) = a.rotation.to_radians().sin_cos();
+            Vec2::new(
+                a.position.x + p.position.x * c - p.position.y * s,
+                a.position.y + p.position.x * s + p.position.y * c,
+            )
+        };
+        let (p0, p1) = (w(&a.pads[0]), w(&a.pads[1]));
+        assert!((p0 - Vec2::new(10.0, 19.5)).length() < 1e-9, "{p0:?}");
+        assert!((p1 - Vec2::new(10.0, 20.5)).length() < 1e-9, "{p1:?}");
+        // Long axes stay 1.0 apart on a 1.0×0.5 pad ⇒ edges touch, never overlap.
+        assert!((p1 - p0).length() >= 1.0 - 1e-9);
+
+        // Mirrored: x flips in the package frame, angle negates, rotation is
+        // still just the element's.
+        let b = &pcb.footprints[1];
+        assert!(!b.front);
+        assert_eq!(b.rotation, 90.0);
+        assert_eq!(b.pads[0].position, Vec2::new(0.5, 0.0));
+        assert_eq!(b.pads[1].position, Vec2::new(-0.5, 0.0));
+        assert_eq!(b.pads[1].rotation, -90.0);
     }
 }


### PR DESCRIPTION
## Verdict: wrong — same class of bug as the KiCad importer (#684), by a different route.

KiCad stores pad angles absolutely, so the fix there was to subtract. Eagle is the opposite: `<smd rot>` lives inside `<package>` in `<libraries>`, i.e. the package's own frame, so it is **already relative** to the `<element>` that places it. `eagle_brd.rs` composed the element rotation in anyway — both by pre-rotating the pad offset and by `rotation: pp.rot + rot`. Since every downstream consumer applies `pad_world_position` (`fp + R(fp.rotation)·pad`) and `fp.rotation + pad.rotation`, the element rotation was applied twice.

## Evidence 1 — correlation over `.scratch/moteus.brd` (152 elements)

If package pad angles were absolute they would track the element. They don't:

| element rot | pkg smd rot | count |
|---|---|---|
| R0 | R0 | 61 |
| R0 | R90 | 25 |
| R0 | R180 | 42 |
| R90 | R0 | 6 |
| R90 | R90 | 3 |
| R90 | R180 | 30 |
| R180 | R0 | 60 |
| R180 | R90 | 20 |
| R180 | R180 | 22 |
| R270 | R0 | 48 |
| R270 | R180 | 40 |
| MR0 | R90 | 6 |
| MR90 | R180 | 34 |
| MR180 | R0 | 24 |
| MR270 | R0 | 4 |

Every element rotation carries a spread of pad angles, and every pad angle appears under multiple element rotations — independent, i.e. relative.

## Evidence 2 — geometry

Distance from each imported pad centre to the nearest point of its **own net's** human-routed copper (397 pad↔net pairs on the moteus board):

| | median | pads > 0.5 mm off |
|---|---|---|
| before | 0.881 mm | 279 |
| after | **0.000 mm** | 138 |

Zero median: with the composition removed, pads land exactly on the ground-truth routing the board shipped with. (The residual >0.5 mm count is pads whose net copper starts at a different pad — the median is the discriminating statistic.)

## Evidence 3 — DRC on the fixture, copper stripped

`cargo build --release -p vcad-ecad-pcb --features gpu --example cm5_bench --example drc_json`, board parsed natively from `.brd` with traces/vias/zones cleared:

| | total | short/clearance | Short | Clearance | CourtyardOverlap |
|---|---|---|---|---|---|
| before | 303 | 124 | 49 | 75 | 100 |
| after | **111** | **14** | 4 | 10 | 18 |

`UnconnectedNet` stays at 79 in both (all copper stripped), so the delta is entirely pad placement.

## Fix

At the import boundary only, so the eleven downstream consumers that compose `fp.rotation + pad.rotation` stay correct. Mirroring is still baked into the pad because the IR has no per-pad mirror flag: Eagle's `MRθ` is mirror-then-rotate, so `M` composes inside `R(θ)` and survives as `x → -x`, `angle → -angle`.

New test `pad_transform_is_relative_to_the_footprint` pins the contract for both `R90` and `MR90` elements, and round-trips through the canonical consumer transform to assert the pads land where Eagle puts them and don't overlap.

`cargo test -p vcad-ecad-symbols` (116 pass) and `cargo clippy -p vcad-ecad-symbols --all-targets -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)