### PR TITLE
test(ecad): regression harness pinning pad rotation across the whole pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,15 +4015,48 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
+version = "0.3.1"
+dependencies = [
+ "phyz-collision",
+ "phyz-contact",
+ "phyz-diff",
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
+]
+
+[[package]]
+name = "phyz-collision"
+version = "0.3.1"
 dependencies = [
  "phyz-math",
+ "phyz-model",
+]
+
+[[package]]
+name = "phyz-contact"
+version = "0.3.1"
+dependencies = [
+ "phyz-collision",
+ "phyz-math",
+ "phyz-model",
+]
+
+[[package]]
+name = "phyz-diff"
+version = "0.3.1"
+dependencies = [
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
  "tang",
+ "tang-expr",
+ "tang-la",
 ]
 
 [[package]]
 name = "phyz-gpu"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
@@ -4036,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "phyz-math"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "tang",
  "tang-la",
@@ -4044,21 +4077,25 @@ dependencies = [
 
 [[package]]
 name = "phyz-md"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "phyz-math",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_distr",
+ "rayon",
 ]
 
 [[package]]
 name = "phyz-model"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "phyz-math",
 ]
 
 [[package]]
 name = "phyz-rigid"
-version = "0.1.0"
+version = "0.3.1"
 dependencies = [
  "phyz-math",
  "phyz-model",
@@ -4512,6 +4549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7010,6 +7057,17 @@ dependencies = [
  "vcad-ecad-pcb",
  "vcad-ecad-symbols",
  "vcad-ir",
+]
+
+[[package]]
+name = "vcad-ecad-invariants"
+version = "0.9.4"
+dependencies = [
+ "vcad-ecad-export",
+ "vcad-ecad-pcb",
+ "vcad-ecad-symbols",
+ "vcad-ir",
+ "vcad-render",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -291,8 +291,6 @@ vcad-ecad-pcb = { path = "crates/vcad-ecad-pcb", version = "0.9.4" }
 vcad-ecad-verify = { path = "crates/vcad-ecad-verify", version = "0.9.4" }
 vcad-ecad-source = { path = "crates/vcad-ecad-source", version = "0.9.4" }
 vcad-ecad-export = { path = "crates/vcad-ecad-export", version = "0.9.4" }
-vcad-ecad-invariants = { path = "crates/vcad-ecad-invariants", version = "0.9.4" }
-vcad-render = { path = "crates/vcad-render", version = "0.9.3" }
 vcad-ecad-fabprep = { path = "crates/vcad-ecad-fabprep", version = "0.9.4" }
 vcad-ecad-sim = { path = "crates/vcad-ecad-sim", version = "0.9.4" }
 vcad-ecad-diff = { path = "crates/vcad-ecad-diff", version = "0.9.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ members = [
     "crates/vcad-ecad-verify",
     "crates/vcad-ecad-source",
     "crates/vcad-ecad-export",
+    "crates/vcad-ecad-invariants",
     "crates/vcad-ecad-fabprep",
     "crates/vcad-ecad-sim",
     "crates/vcad-ecad-diff",
@@ -172,6 +173,7 @@ default-members = [
     "crates/vcad-ecad-verify",
     "crates/vcad-ecad-source",
     "crates/vcad-ecad-export",
+    "crates/vcad-ecad-invariants",
     "crates/vcad-ecad-fabprep",
     "crates/vcad-ecad-sim",
     "crates/vcad-ecad-diff",
@@ -289,6 +291,8 @@ vcad-ecad-pcb = { path = "crates/vcad-ecad-pcb", version = "0.9.4" }
 vcad-ecad-verify = { path = "crates/vcad-ecad-verify", version = "0.9.4" }
 vcad-ecad-source = { path = "crates/vcad-ecad-source", version = "0.9.4" }
 vcad-ecad-export = { path = "crates/vcad-ecad-export", version = "0.9.4" }
+vcad-ecad-invariants = { path = "crates/vcad-ecad-invariants", version = "0.9.4" }
+vcad-render = { path = "crates/vcad-render", version = "0.9.3" }
 vcad-ecad-fabprep = { path = "crates/vcad-ecad-fabprep", version = "0.9.4" }
 vcad-ecad-sim = { path = "crates/vcad-ecad-sim", version = "0.9.4" }
 vcad-ecad-diff = { path = "crates/vcad-ecad-diff", version = "0.9.4" }

--- a/crates/vcad-ecad-invariants/Cargo.toml
+++ b/crates/vcad-ecad-invariants/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "vcad-ecad-invariants"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cross-surface geometry invariants for the ECAD pipeline: a rotated-footprint corpus and the assertions that every consumer sees the same physical pad."
+
+[dependencies]
+vcad-ir = { workspace = true }
+vcad-ecad-pcb = { workspace = true }
+
+[dev-dependencies]
+vcad-ecad-export = { workspace = true }
+vcad-ecad-symbols = { workspace = true }
+vcad-render = { path = "../vcad-render", default-features = false }

--- a/crates/vcad-ecad-invariants/src/lib.rs
+++ b/crates/vcad-ecad-invariants/src/lib.rs
@@ -1,0 +1,427 @@
+//! Cross-surface geometry invariants for the ECAD pipeline.
+//!
+//! A pad is one physical rectangle of copper. Every stage of the pipeline —
+//! DRC connectivity, the router's spatial index, the Gerber writer, the SVG
+//! renderer, the KiCad reader/writer — has its own opinion about where that
+//! rectangle is, and until this crate existed nothing asserted they agreed.
+//!
+//! Two shipped bugs came out of that gap, both on 2026-07-25:
+//!
+//! 1. The KiCad importer stored pad angles **absolutely** while every geometry
+//!    consumer composes `fp.rotation + pad.rotation`, double-counting the
+//!    footprint rotation. A TQFN's 0.25 x 0.875mm pads at 0.5mm pitch came out
+//!    turned 90 degrees, so neighbouring pads OVERLAPPED — 648 phantom DRC
+//!    violations on the CM5 fixture.
+//! 2. The Gerber exporter ignored pad rotation entirely — 828 CM5 pads emitted
+//!    in the wrong orientation, on the files that actually get fabricated.
+//!
+//! This crate provides the [`corpus`] of small synthetic boards that exercise
+//! rotation, and [`PadRect`] — the canonical world-space rectangle a pad
+//! occupies, derived from [`vcad_ecad_pcb::geometry::pad_world_position`] plus
+//! the composed shape rotation. The tests in `tests/` assert every surface
+//! reproduces it to micrometres.
+
+#![warn(missing_docs)]
+
+use std::collections::HashMap;
+
+use vcad_ir::ecad::{
+    BoardOutline, DesignRules, Footprint, LayerStackup, Net, NetClassRules, Pad, PadShape, PadType,
+    Pcb, PcbLayer, StackupLayer,
+};
+use vcad_ir::Vec2;
+
+/// Agreement tolerance between surfaces, in mm (one micrometre).
+///
+/// Tight on purpose: these are all closed-form transforms of the same numbers,
+/// so any real disagreement is a *different formula*, not accumulated error.
+pub const TOL_MM: f64 = 1e-6;
+
+// ---------------------------------------------------------------------------
+// The canonical pad rectangle
+// ---------------------------------------------------------------------------
+
+/// The world-space oriented rectangle a pad occupies.
+///
+/// This is the source of truth every other surface is measured against:
+/// centre from [`vcad_ecad_pcb::geometry::pad_world_position`], extents from
+/// the pad shape, angle from `fp.rotation + pad.rotation`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PadRect {
+    /// Board-space centre (mm).
+    pub center: Vec2,
+    /// Half-extent along the pad's local X axis (mm).
+    pub half_w: f64,
+    /// Half-extent along the pad's local Y axis (mm).
+    pub half_h: f64,
+    /// Total rotation, degrees CCW (`fp.rotation + pad.rotation`).
+    pub rot_deg: f64,
+    /// True when the shape is a disc, and therefore rotation-invariant.
+    pub is_round: bool,
+}
+
+impl PadRect {
+    /// The canonical rectangle for `pad` on `fp`.
+    pub fn of(fp: &Footprint, pad: &Pad) -> Self {
+        let center = vcad_ecad_pcb::geometry::pad_world_position(fp, pad);
+        let (w, h) = vcad_ecad_pcb::geometry::pad_dimensions(&pad.shape);
+        PadRect {
+            center,
+            half_w: w / 2.0,
+            half_h: h / 2.0,
+            rot_deg: fp.rotation + pad.rotation,
+            is_round: matches!(pad.shape, PadShape::Circle { .. }),
+        }
+    }
+
+    /// The four corners, counter-clockwise from the local `(-w, -h)` corner.
+    pub fn corners(&self) -> [Vec2; 4] {
+        let (s, c) = self.rot_deg.to_radians().sin_cos();
+        let place = |dx: f64, dy: f64| {
+            Vec2::new(
+                self.center.x + dx * c - dy * s,
+                self.center.y + dx * s + dy * c,
+            )
+        };
+        [
+            place(-self.half_w, -self.half_h),
+            place(self.half_w, -self.half_h),
+            place(self.half_w, self.half_h),
+            place(-self.half_w, self.half_h),
+        ]
+    }
+
+    /// Corners as an unordered, rotation-canonical set: sorted lexicographically
+    /// so two surfaces that wind the rectangle differently still compare equal.
+    pub fn corner_set(&self) -> Vec<Vec2> {
+        let mut v = self.corners().to_vec();
+        v.sort_by(|a, b| {
+            a.x.partial_cmp(&b.x)
+                .unwrap()
+                .then(a.y.partial_cmp(&b.y).unwrap())
+        });
+        v
+    }
+
+    /// Largest corner-to-corner deviation from `other` (mm), comparing the
+    /// rectangles as point sets. Round pads compare centre and radius instead,
+    /// since their corners are meaningless.
+    pub fn max_deviation(&self, other: &PadRect) -> f64 {
+        if self.is_round && other.is_round {
+            return (self.center.x - other.center.x)
+                .abs()
+                .max((self.center.y - other.center.y).abs())
+                .max((self.half_w - other.half_w).abs());
+        }
+        let (a, b) = (self.corner_set(), other.corner_set());
+        a.iter()
+            .zip(b.iter())
+            .map(|(p, q)| (p.x - q.x).abs().max((p.y - q.y).abs()))
+            .fold(0.0f64, f64::max)
+    }
+
+    /// Whether this rectangle overlaps `other`, by the separating-axis test on
+    /// the two rectangles' four edge normals.
+    pub fn overlaps(&self, other: &PadRect) -> bool {
+        let (a, b) = (self.corners(), other.corners());
+        for quad in [&a, &b] {
+            // Two distinct edge directions per rectangle.
+            for i in 0..2 {
+                let e = Vec2::new(quad[i + 1].x - quad[i].x, quad[i + 1].y - quad[i].y);
+                let axis = Vec2::new(-e.y, e.x);
+                let proj = |q: &[Vec2; 4]| {
+                    let mut lo = f64::INFINITY;
+                    let mut hi = f64::NEG_INFINITY;
+                    for p in q {
+                        let d = p.x * axis.x + p.y * axis.y;
+                        lo = lo.min(d);
+                        hi = hi.max(d);
+                    }
+                    (lo, hi)
+                };
+                let (alo, ahi) = proj(&a);
+                let (blo, bhi) = proj(&b);
+                // A shared edge is not an overlap; require real interior
+                // interpenetration.
+                if ahi <= blo + TOL_MM || bhi <= alo + TOL_MM {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The corpus
+// ---------------------------------------------------------------------------
+
+/// A named board in the rotation corpus.
+pub struct CorpusBoard {
+    /// Human-readable case name, used in assertion messages.
+    pub name: String,
+    /// The board.
+    pub pcb: Pcb,
+}
+
+/// Rotations every corpus part is placed at.
+pub const ROTATIONS: [f64; 6] = [0.0, 45.0, 90.0, 135.0, 180.0, 270.0];
+
+/// The rotated-footprint corpus: small synthetic boards with non-square pads
+/// (rect, roundrect, oval) on footprints at every angle in [`ROTATIONS`], on
+/// both board sides, plus a fine-pitch part whose pads overlap if the rotation
+/// is wrong.
+pub fn corpus() -> Vec<CorpusBoard> {
+    let mut out = Vec::new();
+
+    for &rot in &ROTATIONS {
+        for &front in &[true, false] {
+            let side = if front { "front" } else { "back" };
+            out.push(CorpusBoard {
+                name: format!("shapes@{rot}deg/{side}"),
+                pcb: board(vec![shapes_footprint(rot, front)]),
+            });
+            out.push(CorpusBoard {
+                name: format!("tqfn@{rot}deg/{side}"),
+                pcb: board(vec![fine_pitch_tqfn(rot, front)]),
+            });
+        }
+        // A part whose pads carry their own local rotation on top of the
+        // footprint's, so a surface that reads only one of the two angles is
+        // caught even when the other is zero.
+        out.push(CorpusBoard {
+            name: format!("padlocal@{rot}deg"),
+            pcb: board(vec![pad_local_rotation_footprint(rot)]),
+        });
+    }
+
+    out
+}
+
+/// Every `(footprint, pad)` pair in a board, as `(fp_index, pad_index)`.
+pub fn pad_indices(pcb: &Pcb) -> Vec<(usize, usize)> {
+    pcb.footprints
+        .iter()
+        .enumerate()
+        .flat_map(|(i, fp)| (0..fp.pads.len()).map(move |j| (i, j)))
+        .collect()
+}
+
+/// A part carrying one of each non-square shape, deliberately elongated so a
+/// wrong angle is a visibly different rectangle.
+fn shapes_footprint(rot: f64, front: bool) -> Footprint {
+    let layer = if front { PcbLayer::FCu } else { PcbLayer::BCu };
+    Footprint {
+        reference: "U1".to_string(),
+        value: "SHAPES".to_string(),
+        footprint_name: "ROT_SHAPES".to_string(),
+        position: Vec2::new(20.0, 15.0),
+        rotation: rot,
+        front,
+        pads: vec![
+            pad("1", PadShape::Rect { width: 2.4, height: 0.6 }, Vec2::new(-3.0, 0.0), 0.0, layer, "N1"),
+            pad(
+                "2",
+                PadShape::RoundRect { width: 2.4, height: 0.6, corner_ratio: 0.25 },
+                Vec2::new(0.0, 0.0),
+                0.0,
+                layer,
+                "N2",
+            ),
+            pad("3", PadShape::Oval { width: 2.4, height: 0.6 }, Vec2::new(3.0, 0.0), 0.0, layer, "N3"),
+            // A disc, which must stay rotation-invariant.
+            pad("4", PadShape::Circle { diameter: 1.0 }, Vec2::new(0.0, 2.5), 0.0, layer, "N4"),
+        ],
+        graphics: vec![],
+        model_3d: None,
+        properties: HashMap::new(),
+    }
+}
+
+/// A part where the pads carry a local rotation of their own, on top of the
+/// footprint's. Catches a surface that reads `fp.rotation` or `pad.rotation`
+/// alone rather than composing both.
+fn pad_local_rotation_footprint(rot: f64) -> Footprint {
+    Footprint {
+        reference: "U2".to_string(),
+        value: "PADROT".to_string(),
+        footprint_name: "ROT_PADLOCAL".to_string(),
+        position: Vec2::new(8.0, 30.0),
+        rotation: rot,
+        front: true,
+        pads: vec![
+            pad("1", PadShape::Rect { width: 2.0, height: 0.5 }, Vec2::new(-2.0, 0.0), 30.0, PcbLayer::FCu, "P1"),
+            pad("2", PadShape::Oval { width: 2.0, height: 0.5 }, Vec2::new(2.0, 0.0), -60.0, PcbLayer::FCu, "P2"),
+        ],
+        graphics: vec![],
+        model_3d: None,
+        properties: HashMap::new(),
+    }
+}
+
+/// The case with teeth: a 0.5mm-pitch TQFN edge with 0.25 x 0.875mm pads, the
+/// exact geometry the KiCad double-count bug turned 90 degrees.
+///
+/// Correctly oriented, the pads' long axis runs *across* the pitch and
+/// neighbours clear each other by 0.25mm. Turn them 90 degrees and the
+/// 0.875mm long axis lies *along* a 0.5mm pitch — neighbours overlap by
+/// 0.375mm. A wrong answer here is a DRC violation, not a different number.
+pub fn fine_pitch_tqfn(rot: f64, front: bool) -> Footprint {
+    let layer = if front { PcbLayer::FCu } else { PcbLayer::BCu };
+    let pitch = 0.5;
+    let pads = (0..6)
+        .map(|i| {
+            let y = (i as f64 - 2.5) * pitch;
+            pad(
+                &format!("{}", i + 1),
+                PadShape::Rect { width: 0.875, height: 0.25 },
+                Vec2::new(-2.0, y),
+                0.0,
+                layer,
+                &format!("Q{}", i + 1),
+            )
+        })
+        .collect();
+    Footprint {
+        reference: "U3".to_string(),
+        value: "TQFN".to_string(),
+        footprint_name: "TQFN-24_0.5mm".to_string(),
+        position: Vec2::new(30.0, 30.0),
+        rotation: rot,
+        front,
+        pads,
+        graphics: vec![],
+        model_3d: None,
+        properties: HashMap::new(),
+    }
+}
+
+fn pad(
+    number: &str,
+    shape: PadShape,
+    position: Vec2,
+    rotation: f64,
+    layer: PcbLayer,
+    net: &str,
+) -> Pad {
+    Pad {
+        number: number.to_string(),
+        pad_type: PadType::SMD,
+        shape,
+        position,
+        rotation,
+        drill: None,
+        net: Some(net.to_string()),
+        layers: vec![layer],
+    }
+}
+
+/// A minimal 2-layer board around the given footprints.
+pub fn board(footprints: Vec<Footprint>) -> Pcb {
+    let nets: Vec<Net> = footprints
+        .iter()
+        .flat_map(|f| f.pads.iter())
+        .filter_map(|p| p.net.clone())
+        .map(|n| Net {
+            id: n.clone(),
+            name: n,
+        })
+        .collect();
+    Pcb {
+        outline: BoardOutline {
+            vertices: vec![
+                Vec2::new(0.0, 0.0),
+                Vec2::new(50.0, 0.0),
+                Vec2::new(50.0, 50.0),
+                Vec2::new(0.0, 50.0),
+            ],
+            cutouts: vec![],
+            thickness: 1.6,
+        },
+        stackup: LayerStackup {
+            layers: vec![
+                StackupLayer {
+                    layer: PcbLayer::FCu,
+                    copper_thickness: Some(0.035),
+                    dielectric_thickness: Some(1.53),
+                    dielectric_er: Some(4.5),
+                    material: None,
+                },
+                StackupLayer {
+                    layer: PcbLayer::BCu,
+                    copper_thickness: Some(0.035),
+                    dielectric_thickness: None,
+                    dielectric_er: None,
+                    material: None,
+                },
+            ],
+        },
+        nets,
+        rules: DesignRules {
+            default_rules: NetClassRules {
+                name: "Default".to_string(),
+                trace_width: 0.2,
+                clearance: 0.2,
+                via_diameter: 0.6,
+                via_drill: 0.3,
+                diff_pair_gap: None,
+                diff_pair_width: None,
+            },
+            class_rules: vec![],
+            net_class_assignments: HashMap::new(),
+            edge_clearance: 0.5,
+            hole_to_hole: 0.5,
+            min_annular_ring: 0.13,
+            min_drill: 0.2,
+        },
+        footprints,
+        traces: vec![],
+        trace_arcs: vec![],
+        vias: vec![],
+        zones: vec![],
+        keepouts: vec![],
+        net_ties: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The corpus is only worth anything if the fine-pitch case really does
+    /// overlap when turned. Pin both directions so the fixture can't silently
+    /// lose its teeth.
+    #[test]
+    fn fine_pitch_pads_clear_correctly_and_overlap_when_turned() {
+        let fp = fine_pitch_tqfn(0.0, true);
+        let rects: Vec<PadRect> = fp.pads.iter().map(|p| PadRect::of(&fp, p)).collect();
+        for w in rects.windows(2) {
+            assert!(
+                !w[0].overlaps(&w[1]),
+                "correctly oriented TQFN pads must clear each other"
+            );
+        }
+
+        // Now the bug: every pad turned by the footprint angle a second time.
+        let mut turned = fine_pitch_tqfn(90.0, true);
+        for p in &mut turned.pads {
+            p.rotation += 90.0;
+        }
+        let bad: Vec<PadRect> = turned.pads.iter().map(|p| PadRect::of(&turned, p)).collect();
+        assert!(
+            bad.windows(2).any(|w| w[0].overlaps(&w[1])),
+            "double-counted rotation must make neighbouring TQFN pads overlap — \
+             otherwise this corpus case has no teeth"
+        );
+    }
+
+    #[test]
+    fn corpus_covers_every_rotation_and_both_sides() {
+        let c = corpus();
+        for &r in &ROTATIONS {
+            assert!(c.iter().any(|b| b.name.contains(&format!("@{r}deg"))));
+        }
+        assert!(c.iter().any(|b| b.name.ends_with("/back")));
+        assert!(!c.is_empty());
+    }
+}

--- a/crates/vcad-ecad-invariants/src/lib.rs
+++ b/crates/vcad-ecad-invariants/src/lib.rs
@@ -219,18 +219,49 @@ fn shapes_footprint(rot: f64, front: bool) -> Footprint {
         rotation: rot,
         front,
         pads: vec![
-            pad("1", PadShape::Rect { width: 2.4, height: 0.6 }, Vec2::new(-3.0, 0.0), 0.0, layer, "N1"),
+            pad(
+                "1",
+                PadShape::Rect {
+                    width: 2.4,
+                    height: 0.6,
+                },
+                Vec2::new(-3.0, 0.0),
+                0.0,
+                layer,
+                "N1",
+            ),
             pad(
                 "2",
-                PadShape::RoundRect { width: 2.4, height: 0.6, corner_ratio: 0.25 },
+                PadShape::RoundRect {
+                    width: 2.4,
+                    height: 0.6,
+                    corner_ratio: 0.25,
+                },
                 Vec2::new(0.0, 0.0),
                 0.0,
                 layer,
                 "N2",
             ),
-            pad("3", PadShape::Oval { width: 2.4, height: 0.6 }, Vec2::new(3.0, 0.0), 0.0, layer, "N3"),
+            pad(
+                "3",
+                PadShape::Oval {
+                    width: 2.4,
+                    height: 0.6,
+                },
+                Vec2::new(3.0, 0.0),
+                0.0,
+                layer,
+                "N3",
+            ),
             // A disc, which must stay rotation-invariant.
-            pad("4", PadShape::Circle { diameter: 1.0 }, Vec2::new(0.0, 2.5), 0.0, layer, "N4"),
+            pad(
+                "4",
+                PadShape::Circle { diameter: 1.0 },
+                Vec2::new(0.0, 2.5),
+                0.0,
+                layer,
+                "N4",
+            ),
         ],
         graphics: vec![],
         model_3d: None,
@@ -250,8 +281,28 @@ fn pad_local_rotation_footprint(rot: f64) -> Footprint {
         rotation: rot,
         front: true,
         pads: vec![
-            pad("1", PadShape::Rect { width: 2.0, height: 0.5 }, Vec2::new(-2.0, 0.0), 30.0, PcbLayer::FCu, "P1"),
-            pad("2", PadShape::Oval { width: 2.0, height: 0.5 }, Vec2::new(2.0, 0.0), -60.0, PcbLayer::FCu, "P2"),
+            pad(
+                "1",
+                PadShape::Rect {
+                    width: 2.0,
+                    height: 0.5,
+                },
+                Vec2::new(-2.0, 0.0),
+                30.0,
+                PcbLayer::FCu,
+                "P1",
+            ),
+            pad(
+                "2",
+                PadShape::Oval {
+                    width: 2.0,
+                    height: 0.5,
+                },
+                Vec2::new(2.0, 0.0),
+                -60.0,
+                PcbLayer::FCu,
+                "P2",
+            ),
         ],
         graphics: vec![],
         model_3d: None,
@@ -274,7 +325,10 @@ pub fn fine_pitch_tqfn(rot: f64, front: bool) -> Footprint {
             let y = (i as f64 - 2.5) * pitch;
             pad(
                 &format!("{}", i + 1),
-                PadShape::Rect { width: 0.875, height: 0.25 },
+                PadShape::Rect {
+                    width: 0.875,
+                    height: 0.25,
+                },
                 Vec2::new(-2.0, y),
                 0.0,
                 layer,
@@ -407,7 +461,11 @@ mod tests {
         for p in &mut turned.pads {
             p.rotation += 90.0;
         }
-        let bad: Vec<PadRect> = turned.pads.iter().map(|p| PadRect::of(&turned, p)).collect();
+        let bad: Vec<PadRect> = turned
+            .pads
+            .iter()
+            .map(|p| PadRect::of(&turned, p))
+            .collect();
         assert!(
             bad.windows(2).any(|w| w[0].overlaps(&w[1])),
             "double-counted rotation must make neighbouring TQFN pads overlap — \

--- a/crates/vcad-ecad-invariants/tests/cm5_no_overlap.rs
+++ b/crates/vcad-ecad-invariants/tests/cm5_no_overlap.rs
@@ -118,7 +118,11 @@ fn cm5_pads_of_different_nets_do_not_overlap() {
             })
         })
         .collect();
-    assert!(pads.len() > 1000, "fixture looks wrong: {} pads", pads.len());
+    assert!(
+        pads.len() > 1000,
+        "fixture looks wrong: {} pads",
+        pads.len()
+    );
 
     // Bucket by a grid cell so this is a sweep, not an O(n^2) scan over ~9k
     // pads. Cell size covers the largest pad, so any overlapping pair shares

--- a/crates/vcad-ecad-invariants/tests/cm5_no_overlap.rs
+++ b/crates/vcad-ecad-invariants/tests/cm5_no_overlap.rs
@@ -1,0 +1,194 @@
+//! The invariant on the real board: after import, no two pads of *different*
+//! nets may overlap.
+//!
+//! This is the assertion that fails loudly on the original bug. The KiCad
+//! importer stored pad angles absolutely while every geometry consumer composes
+//! `fp.rotation + pad.rotation`, so every rotated footprint had its rotation
+//! counted twice; on the CM5 fixture that turned fine-pitch pads into
+//! overlapping copper and produced 648 phantom DRC violations.
+//!
+//! The fixture is an 11MB reverse-engineered third-party board and is not
+//! committed (`.scratch/` is gitignored), and the run takes far longer than the
+//! unit suite, so this test is `#[ignore]`d. Run it with:
+//!
+//! ```text
+//! cargo test -p vcad-ecad-invariants --test cm5_no_overlap -- --ignored
+//! ```
+//!
+//! Point it at a copy elsewhere with `VCAD_CM5_PCB=/path/to/CM5RevEng.kicad_pcb`.
+
+use std::path::PathBuf;
+
+use vcad_ecad_invariants::PadRect;
+
+/// Pad pairs that overlap in the *source* board, not because of anything vcad
+/// does to them. CM5RevEng is reverse-engineered, and these nine pairs are
+/// components placed on top of each other in the file itself — absolute zero is
+/// not achievable on an imported fixture, so the invariant is "no overlap
+/// beyond this pinned baseline".
+///
+/// The evidence that they are not orientation bugs: their centre separations
+/// are 0.01mm to 0.74mm against pads 0.25mm to 1.3mm wide — the copper simply
+/// coincides — and `R53.2/C174.1` is a pair where *both* footprints sit at 0
+/// degrees, which no rotation handling, right or wrong, can explain.
+///
+/// Shrinking this list is good news. Growing it is the regression this test
+/// exists to catch: adding an entry needs the same kind of evidence.
+const KNOWN_SOURCE_OVERLAPS: &[(&str, &str)] = &[
+    ("C12.2", "C13.1"),
+    ("C138.1", "C139.2"),
+    ("C139.1", "C68.2"),
+    ("C136.2", "C69.1"),
+    ("C138.2", "C76.2"),
+    ("C174.1", "R53.2"),
+    ("C3.1", "U6.5"),
+    ("C3.1", "U6.6"),
+    ("C216.1", "Y2.1"),
+];
+
+/// Order-independent key for a pad pair.
+fn pair_key(a: &str, b: &str) -> (String, String) {
+    if a <= b {
+        (a.to_string(), b.to_string())
+    } else {
+        (b.to_string(), a.to_string())
+    }
+}
+
+fn fixture_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("VCAD_CM5_PCB") {
+        let p = PathBuf::from(p);
+        return p.exists().then_some(p);
+    }
+    // CARGO_MANIFEST_DIR is <repo>/crates/vcad-ecad-invariants.
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()?
+        .parent()?
+        .to_path_buf();
+    let p = root.join(".scratch/CM5RevEng.kicad_pcb");
+    p.exists().then_some(p)
+}
+
+#[test]
+#[ignore = "needs the uncommitted 11MB CM5 fixture; run with --ignored"]
+fn cm5_pads_of_different_nets_do_not_overlap() {
+    let Some(path) = fixture_path() else {
+        panic!(
+            "CM5 fixture not found. Place it at .scratch/CM5RevEng.kicad_pcb \
+             or set VCAD_CM5_PCB."
+        );
+    };
+    let text = std::fs::read_to_string(&path).expect("read fixture");
+    let pcb = vcad_ecad_symbols::parse_kicad_pcb(&text).expect("parse fixture");
+
+    // Flatten to (net, label, rect), keeping only netted pads — an unnetted pad
+    // cannot short anything.
+    struct P {
+        net: String,
+        label: String,
+        rect: PadRect,
+        /// Copper layers this pad sits on. Two pads on opposite sides may
+        /// legitimately occupy the same XY.
+        layers: Vec<vcad_ir::ecad::PcbLayer>,
+    }
+    let pads: Vec<P> = pcb
+        .footprints
+        .iter()
+        .flat_map(|fp| {
+            fp.pads.iter().filter_map(move |pad| {
+                let net = pad.net.clone()?;
+                if net.is_empty() {
+                    return None;
+                }
+                let layers: Vec<_> = pad
+                    .layers
+                    .iter()
+                    .copied()
+                    .filter(|l| l.is_copper())
+                    .collect();
+                if layers.is_empty() {
+                    return None;
+                }
+                Some(P {
+                    net,
+                    label: format!("{}.{}", fp.reference, pad.number),
+                    rect: PadRect::of(fp, pad),
+                    layers,
+                })
+            })
+        })
+        .collect();
+    assert!(pads.len() > 1000, "fixture looks wrong: {} pads", pads.len());
+
+    // Bucket by a grid cell so this is a sweep, not an O(n^2) scan over ~9k
+    // pads. Cell size covers the largest pad, so any overlapping pair shares
+    // or neighbours a cell.
+    let reach = pads
+        .iter()
+        .map(|p| p.rect.half_w.hypot(p.rect.half_h))
+        .fold(0.0f64, f64::max);
+    let cell = (reach * 2.0).max(1.0);
+    let key = |x: f64, y: f64| ((x / cell).floor() as i64, (y / cell).floor() as i64);
+
+    let mut grid: std::collections::HashMap<(i64, i64), Vec<usize>> = Default::default();
+    for (i, p) in pads.iter().enumerate() {
+        grid.entry(key(p.rect.center.x, p.rect.center.y))
+            .or_default()
+            .push(i);
+    }
+
+    let mut overlaps: Vec<String> = Vec::new();
+    for (&(cx, cy), bucket) in &grid {
+        for dx in -1..=1 {
+            for dy in -1..=1 {
+                let Some(other) = grid.get(&(cx + dx, cy + dy)) else {
+                    continue;
+                };
+                for &i in bucket {
+                    for &j in other {
+                        if j <= i {
+                            continue;
+                        }
+                        let (a, b) = (&pads[i], &pads[j]);
+                        if a.net == b.net {
+                            continue;
+                        }
+                        if !a.layers.iter().any(|l| b.layers.contains(l)) {
+                            continue;
+                        }
+                        if a.rect.overlaps(&b.rect) {
+                            let key = pair_key(&a.label, &b.label);
+                            if KNOWN_SOURCE_OVERLAPS
+                                .iter()
+                                .any(|&(x, y)| pair_key(x, y) == key)
+                            {
+                                continue;
+                            }
+                            overlaps.push(format!(
+                                "{} ({}) overlaps {} ({})",
+                                a.label, a.net, b.label, b.net
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    overlaps.sort();
+    overlaps.dedup();
+
+    assert!(
+        overlaps.is_empty(),
+        "{} different-net pad pairs overlap after import, beyond the {} pinned \
+         source-board pairs — pad orientation is wrong somewhere in the import \
+         path. First 20:\n{}",
+        overlaps.len(),
+        KNOWN_SOURCE_OVERLAPS.len(),
+        overlaps
+            .iter()
+            .take(20)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+}

--- a/crates/vcad-ecad-invariants/tests/common/gerber.rs
+++ b/crates/vcad-ecad-invariants/tests/common/gerber.rs
@@ -1,0 +1,192 @@
+//! Recover the pad rectangle a Gerber file actually describes.
+//!
+//! Shared by the cross-surface test; lives here rather than in the library so
+//! the crate itself doesn't take a dependency on the exporter.
+
+use std::collections::HashMap;
+
+use vcad_ecad_invariants::PadRect;
+use vcad_ir::Vec2;
+
+/// An aperture recovered from a `%ADD...%` definition (plus its macro body, if
+/// it is a rotated one).
+#[derive(Debug, Clone)]
+pub struct Aperture {
+    /// Width along the aperture's local X (mm). Diameter, for a circle.
+    pub width: f64,
+    /// Height along the aperture's local Y (mm). Diameter, for a circle.
+    pub height: f64,
+    /// Rotation in degrees CCW.
+    pub rot_deg: f64,
+    /// True for a plain `C` circle aperture.
+    pub is_round: bool,
+}
+
+/// A flash: an aperture struck at a board coordinate.
+#[derive(Debug, Clone)]
+pub struct Flash {
+    /// Board-space centre (mm).
+    pub center: Vec2,
+    /// The aperture struck.
+    pub aperture: Aperture,
+}
+
+impl Flash {
+    /// The pad rectangle this flash describes.
+    pub fn rect(&self) -> PadRect {
+        PadRect {
+            center: self.center,
+            half_w: self.aperture.width / 2.0,
+            half_h: self.aperture.height / 2.0,
+            rot_deg: self.aperture.rot_deg,
+            is_round: self.aperture.is_round,
+        }
+    }
+}
+
+/// Parse every `D03` flash out of a Gerber layer, resolving its aperture.
+///
+/// Understands `C`, `R`, `O` and the `ROT<code>` aperture macros this repo's
+/// exporter emits for rotated pads (a `21` centre-line primitive, optionally
+/// capped by two `1` circles for an obround).
+pub fn parse_flashes(gerber: &str) -> Vec<Flash> {
+    // 1) Macro bodies, keyed by macro name.
+    let mut macros: HashMap<String, Aperture> = HashMap::new();
+    let mut current_macro: Option<String> = None;
+    let mut body: Vec<String> = Vec::new();
+
+    let flush = |name: &Option<String>, body: &[String], macros: &mut HashMap<String, Aperture>| {
+        let Some(name) = name else { return };
+        // The centre-line primitive carries the whole orientation; the cap
+        // circles only round the ends off.
+        // An obround's cap circles extend it by one cap diameter along the
+        // long axis, so the centre line alone under-reads the total width.
+        let caps: f64 = body
+            .iter()
+            .filter_map(|l| {
+                let f: Vec<&str> = l.split(',').collect();
+                (f.first() == Some(&"1") && f.len() >= 3).then(|| f[2].parse::<f64>().unwrap())
+            })
+            .fold(0.0f64, f64::max);
+        for line in body {
+            let f: Vec<&str> = line.split(',').collect();
+            if f.first() == Some(&"21") && f.len() >= 7 {
+                macros.insert(
+                    name.clone(),
+                    Aperture {
+                        width: f[2].parse::<f64>().unwrap() + caps,
+                        height: f[3].parse().unwrap(),
+                        rot_deg: f[6].parse().unwrap(),
+                        is_round: false,
+                    },
+                );
+                return;
+            }
+        }
+        // Circle-only macro (a degenerate obround).
+        for line in body {
+            let f: Vec<&str> = line.split(',').collect();
+            if f.first() == Some(&"1") && f.len() >= 3 {
+                let d: f64 = f[2].parse().unwrap();
+                macros.insert(
+                    name.clone(),
+                    Aperture {
+                        width: d,
+                        height: d,
+                        rot_deg: 0.0,
+                        is_round: true,
+                    },
+                );
+                return;
+            }
+        }
+    };
+
+    for raw in gerber.lines() {
+        let line = raw.trim();
+        if let Some(rest) = line.strip_prefix("%AM") {
+            flush(&current_macro, &body, &mut macros);
+            body.clear();
+            current_macro = Some(rest.trim_end_matches('*').to_string());
+            continue;
+        }
+        if current_macro.is_some() {
+            if line.starts_with("%AD") {
+                flush(&current_macro, &body, &mut macros);
+                body.clear();
+                current_macro = None;
+            } else {
+                body.push(line.trim_end_matches(['%', '*']).to_string());
+                continue;
+            }
+        }
+    }
+    flush(&current_macro, &body, &mut macros);
+
+    // 2) Aperture definitions.
+    let mut apertures: HashMap<u32, Aperture> = HashMap::new();
+    for raw in gerber.lines() {
+        let line = raw.trim();
+        let Some(rest) = line.strip_prefix("%ADD") else {
+            continue;
+        };
+        let rest = rest.trim_end_matches("*%");
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        let Ok(code) = digits.parse::<u32>() else {
+            continue;
+        };
+        let spec = &rest[digits.len()..];
+        let ap = if let Some(dims) = spec.strip_prefix("C,") {
+            let d: f64 = dims.parse().unwrap();
+            Aperture {
+                width: d,
+                height: d,
+                rot_deg: 0.0,
+                is_round: true,
+            }
+        } else if let Some(dims) = spec.strip_prefix("R,").or(spec.strip_prefix("O,")) {
+            let (w, h) = dims.split_once('X').unwrap();
+            Aperture {
+                width: w.parse().unwrap(),
+                height: h.parse().unwrap(),
+                rot_deg: 0.0,
+                is_round: false,
+            }
+        } else if let Some(m) = macros.get(spec) {
+            m.clone()
+        } else {
+            continue;
+        };
+        apertures.insert(code, ap);
+    }
+
+    // 3) Flashes.
+    let mut out = Vec::new();
+    let mut current: Option<u32> = None;
+    for raw in gerber.lines() {
+        let line = raw.trim();
+        if let Some(rest) = line.strip_prefix('D') {
+            if let Ok(code) = rest.trim_end_matches('*').parse::<u32>() {
+                current = Some(code);
+                continue;
+            }
+        }
+        if !line.ends_with("D03*") || !line.starts_with('X') {
+            continue;
+        }
+        let Some(ap) = current.and_then(|c| apertures.get(&c)) else {
+            continue;
+        };
+        let body = line.trim_end_matches("D03*");
+        let (x, y) = body[1..].split_once('Y').unwrap();
+        // Coordinates are integer nanometres (6 decimal places, mm units).
+        out.push(Flash {
+            center: Vec2::new(
+                x.parse::<f64>().unwrap() / 1_000_000.0,
+                y.parse::<f64>().unwrap() / 1_000_000.0,
+            ),
+            aperture: ap.clone(),
+        });
+    }
+    out
+}

--- a/crates/vcad-ecad-invariants/tests/common/mod.rs
+++ b/crates/vcad-ecad-invariants/tests/common/mod.rs
@@ -1,0 +1,3 @@
+//! Shared helpers for the invariant tests.
+
+pub mod gerber;

--- a/crates/vcad-ecad-invariants/tests/cross_surface.rs
+++ b/crates/vcad-ecad-invariants/tests/cross_surface.rs
@@ -1,0 +1,294 @@
+//! Every surface must see the same physical pad.
+//!
+//! For each pad in the rotated-footprint corpus, the world-space rectangle is
+//! compared between:
+//!
+//! - `geometry::pad_world_position` + the composed shape rotation (truth),
+//! - the DRC's connectivity nodes,
+//! - the router's spatial index,
+//! - the Gerber aperture and flash,
+//! - the SVG renderer.
+//!
+//! Tolerance is one micrometre. These are all closed-form transforms of the
+//! same numbers — a disagreement is a different formula, which is exactly what
+//! shipped twice on 2026-07-25.
+
+mod common;
+
+use common::gerber::parse_flashes;
+
+use vcad_ecad_invariants::{corpus, pad_indices, PadRect, TOL_MM};
+use vcad_ecad_pcb::spatial::{CopperGeom, SpatialIndex};
+use vcad_ir::ecad::PcbLayer;
+use vcad_ir::Vec2;
+
+/// Convert a narrowphase copper geometry back into a pad rectangle.
+fn rect_of_geom(g: &CopperGeom) -> PadRect {
+    match *g {
+        CopperGeom::Rect {
+            center,
+            half_w,
+            half_h,
+            rot,
+        } => PadRect {
+            center,
+            half_w,
+            half_h,
+            rot_deg: rot.to_degrees(),
+            is_round: false,
+        },
+        CopperGeom::Disc { center, r } => PadRect {
+            center,
+            half_w: r,
+            half_h: r,
+            rot_deg: 0.0,
+            is_round: true,
+        },
+        CopperGeom::Segment { .. } => panic!("a pad must not be a segment"),
+    }
+}
+
+fn assert_agrees(case: &str, surface: &str, key: &str, truth: &PadRect, got: &PadRect) {
+    let dev = truth.max_deviation(got);
+    assert!(
+        dev <= TOL_MM,
+        "{case}: {surface} disagrees with pad_world_position for pad {key} by {dev:.6}mm\n\
+         truth: {truth:?}\n  {surface}: {got:?}"
+    );
+}
+
+#[test]
+fn drc_connectivity_nodes_agree() {
+    for b in corpus() {
+        let nodes = vcad_ecad_pcb::drc::connectivity_pad_geoms(&b.pcb);
+        for (i, j) in pad_indices(&b.pcb) {
+            let fp = &b.pcb.footprints[i];
+            let pad = &fp.pads[j];
+            let key = (fp.reference.clone(), pad.number.clone());
+            let (_, geom) = nodes
+                .iter()
+                .find(|(k, _)| *k == key)
+                .unwrap_or_else(|| panic!("{}: DRC lost pad {key:?}", b.name));
+            assert_agrees(
+                &b.name,
+                "DRC connectivity",
+                &pad.number,
+                &PadRect::of(fp, pad),
+                &rect_of_geom(geom),
+            );
+        }
+    }
+}
+
+#[test]
+fn router_spatial_index_agrees() {
+    for b in corpus() {
+        let index = SpatialIndex::from_pcb(&b.pcb);
+        let elements = index.query_region([-1e3, -1e3], [1e3, 1e3]);
+        for (i, j) in pad_indices(&b.pcb) {
+            let fp = &b.pcb.footprints[i];
+            let pad = &fp.pads[j];
+            // Corpus nets are unique per pad, so the net names the element.
+            let net = pad.net.as_deref().unwrap();
+            let el = elements
+                .iter()
+                .find(|e| e.net == net)
+                .unwrap_or_else(|| panic!("{}: spatial index lost pad {net}", b.name));
+            let truth = PadRect::of(fp, pad);
+            assert_agrees(
+                &b.name,
+                "spatial index",
+                &pad.number,
+                &truth,
+                &rect_of_geom(&el.geom),
+            );
+            // The broadphase AABB must still contain the true copper, or the
+            // R-tree filters out pairs the narrowphase would have caught.
+            let hull: Vec<Vec2> = if truth.is_round {
+                vec![
+                    Vec2::new(truth.center.x - truth.half_w, truth.center.y - truth.half_w),
+                    Vec2::new(truth.center.x + truth.half_w, truth.center.y + truth.half_w),
+                ]
+            } else {
+                truth.corners().to_vec()
+            };
+            for c in hull {
+                assert!(
+                    c.x >= el.min[0] - TOL_MM
+                        && c.x <= el.max[0] + TOL_MM
+                        && c.y >= el.min[1] - TOL_MM
+                        && c.y <= el.max[1] + TOL_MM,
+                    "{}: broadphase AABB does not cover rotated pad {net}",
+                    b.name
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn gerber_apertures_agree() {
+    for b in corpus() {
+        let files = vcad_ecad_export::gerber::generate_gerbers(&b.pcb).expect("gerbers");
+        for (i, j) in pad_indices(&b.pcb) {
+            let fp = &b.pcb.footprints[i];
+            let pad = &fp.pads[j];
+            let layer = pad.layers[0];
+            let name = match layer {
+                PcbLayer::FCu => "F_Cu.gbr",
+                PcbLayer::BCu => "B_Cu.gbr",
+                other => panic!("{}: corpus pad on unexpected layer {other:?}", b.name),
+            }
+            .to_string();
+            assert!(
+                files.contains_key(&name),
+                "{}: no copper gerber {name}",
+                b.name
+            );
+
+            let truth = PadRect::of(fp, pad);
+            let flashes = parse_flashes(&files[&name]);
+            // Find the flash at this pad's centre; its aperture must describe
+            // the same rectangle.
+            let hit = flashes
+                .iter()
+                .map(|f| f.rect())
+                .find(|r| {
+                    (r.center.x - truth.center.x).abs() < 1e-4
+                        && (r.center.y - truth.center.y).abs() < 1e-4
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{}: no Gerber flash at pad {} centre {:?}",
+                        b.name, pad.number, truth.center
+                    )
+                });
+            // Gerber coordinates are quantised to nanometres, so allow that on
+            // top of the agreement tolerance.
+            let dev = truth.max_deviation(&hit);
+            assert!(
+                dev <= 1e-5,
+                "{}: Gerber aperture disagrees for pad {} by {dev:.7}mm\n  truth: {truth:?}\n  gerber: {hit:?}",
+                b.name,
+                pad.number
+            );
+        }
+    }
+}
+
+#[test]
+fn svg_renderer_agrees() {
+    for b in corpus() {
+        for (i, j) in pad_indices(&b.pcb) {
+            let fp = &b.pcb.footprints[i];
+            let pad = &fp.pads[j];
+            let truth = PadRect::of(fp, pad);
+            let Some(quad) = vcad_render::pcb::pad_world_quad(fp, pad) else {
+                // Circles: only the centre is meaningful.
+                let (origin, _) = vcad_render::pcb::pad_placement(fp, pad);
+                assert!(
+                    (origin.x - truth.center.x).abs() <= TOL_MM
+                        && (origin.y - truth.center.y).abs() <= TOL_MM,
+                    "{}: renderer centre disagrees for round pad {}",
+                    b.name,
+                    pad.number
+                );
+                continue;
+            };
+            let mut got = quad.to_vec();
+            let mut want = truth.corners().to_vec();
+            let by_xy = |a: &Vec2, b: &Vec2| {
+                a.x.partial_cmp(&b.x)
+                    .unwrap()
+                    .then(a.y.partial_cmp(&b.y).unwrap())
+            };
+            got.sort_by(by_xy);
+            want.sort_by(by_xy);
+            for (g, w) in got.iter().zip(want.iter()) {
+                assert!(
+                    (g.x - w.x).abs() <= TOL_MM && (g.y - w.y).abs() <= TOL_MM,
+                    "{}: SVG renderer corner disagrees for pad {}: {g:?} vs {w:?}",
+                    b.name,
+                    pad.number
+                );
+            }
+        }
+    }
+}
+
+/// The renderer's public quad is only worth asserting on if the SVG really is
+/// drawn from it. Pin the emitted geometry itself.
+///
+/// The SVG transform is a uniform scale, a Y flip and a translation, so the
+/// polygon's *shape* survives it exactly: side lengths keep their ratio, and
+/// the long axis lands at `-rot` in screen space. Both are transform-free, so
+/// this asserts on the real output without reconstructing the viewport.
+#[test]
+fn svg_output_carries_the_pad_rotation() {
+    for b in corpus() {
+        let svg = vcad_render::pcb::render_pcb_svg(&b.pcb, &[PcbLayer::FCu, PcbLayer::BCu], 20.0);
+        let polys: Vec<Vec<Vec2>> = svg
+            .split("points=\"")
+            .skip(1)
+            .filter_map(|s| s.split_once('"').map(|(p, _)| p))
+            .map(|p| {
+                p.split_whitespace()
+                    .filter_map(|v| v.split_once(','))
+                    .map(|(x, y)| Vec2::new(x.parse().unwrap(), y.parse().unwrap()))
+                    .collect()
+            })
+            .filter(|v: &Vec<Vec2>| v.len() == 4)
+            .collect();
+
+        for (i, j) in pad_indices(&b.pcb) {
+            let fp = &b.pcb.footprints[i];
+            let pad = &fp.pads[j];
+            let truth = PadRect::of(fp, pad);
+            if truth.is_round || (truth.half_w - truth.half_h).abs() < 1e-9 {
+                continue; // no distinguishable long axis
+            }
+            // Oval pads are drawn as a round-capped stroke, not a polygon.
+            if matches!(pad.shape, vcad_ir::ecad::PadShape::Oval { .. }) {
+                continue;
+            }
+            let want_ratio = truth.half_w / truth.half_h;
+            // Screen space flips Y, so a board-space angle t appears at -t.
+            let want_deg = norm180(-truth.rot_deg);
+
+            let found = polys.iter().any(|p| {
+                let e0 = (p[1].x - p[0].x, p[1].y - p[0].y);
+                let e1 = (p[2].x - p[1].x, p[2].y - p[1].y);
+                let l0 = (e0.0 * e0.0 + e0.1 * e0.1).sqrt();
+                let l1 = (e1.0 * e1.0 + e1.1 * e1.1).sqrt();
+                if l0 <= 0.0 || l1 <= 0.0 {
+                    return false;
+                }
+                let ratio = l0 / l1;
+                if (ratio - want_ratio).abs() > 1e-3 * want_ratio.max(1.0) {
+                    return false;
+                }
+                let deg = norm180(e0.1.atan2(e0.0).to_degrees());
+                angle_close(deg, want_deg)
+            });
+            assert!(
+                found,
+                "{}: no SVG polygon carries pad {}'s {:.1}deg orientation and {want_ratio:.3} aspect",
+                b.name, pad.number, truth.rot_deg
+            );
+        }
+    }
+}
+
+fn norm180(d: f64) -> f64 {
+    let r = d % 180.0;
+    if r < 0.0 {
+        r + 180.0
+    } else {
+        r
+    }
+}
+
+fn angle_close(a: f64, b: f64) -> bool {
+    let d = (a - b).abs() % 180.0;
+    d.min(180.0 - d) < 0.05
+}

--- a/crates/vcad-ecad-invariants/tests/round_trip.rs
+++ b/crates/vcad-ecad-invariants/tests/round_trip.rs
@@ -1,0 +1,75 @@
+//! `parse_kicad_pcb(write_kicad_pcb(board))` must preserve every pad's world
+//! rectangle, at every rotation in the corpus.
+//!
+//! KiCad stores a pad's angle absolutely (it includes the footprint's
+//! orientation); vcad's IR stores it relative, because every geometry consumer
+//! composes `fp.rotation + pad.rotation`. Reader and writer must therefore be
+//! exact inverses. They were not: the reader kept the absolute angle, so every
+//! rotated footprint had its rotation counted twice.
+
+use vcad_ecad_invariants::{corpus, pad_indices, PadRect, TOL_MM};
+
+#[test]
+fn kicad_round_trip_preserves_every_pad_rectangle() {
+    for b in corpus() {
+        let text = vcad_ecad_symbols::write_kicad_pcb(&b.pcb);
+        let back = vcad_ecad_symbols::parse_kicad_pcb(&text)
+            .unwrap_or_else(|e| panic!("{}: re-parse failed: {e:?}", b.name));
+
+        assert_eq!(
+            back.footprints.len(),
+            b.pcb.footprints.len(),
+            "{}: footprint count changed across the round trip",
+            b.name
+        );
+
+        for (i, j) in pad_indices(&b.pcb) {
+            let before_fp = &b.pcb.footprints[i];
+            let before = &before_fp.pads[j];
+            let after_fp = &back.footprints[i];
+            let after = after_fp
+                .pads
+                .iter()
+                .find(|p| p.number == before.number)
+                .unwrap_or_else(|| {
+                    panic!("{}: pad {} lost across the round trip", b.name, before.number)
+                });
+
+            let want = PadRect::of(before_fp, before);
+            let got = PadRect::of(after_fp, after);
+            let dev = want.max_deviation(&got);
+            assert!(
+                dev <= TOL_MM,
+                "{}: pad {} moved {dev:.6}mm across the KiCad round trip\n  before: {want:?}\n  after:  {got:?}",
+                b.name,
+                before.number
+            );
+        }
+    }
+}
+
+/// The fine-pitch case, stated as the consequence rather than the number: a
+/// TQFN whose pads clear each other before the round trip must still clear
+/// them after. Under the double-count bug they overlapped.
+#[test]
+fn kicad_round_trip_keeps_fine_pitch_pads_apart() {
+    for &rot in &vcad_ecad_invariants::ROTATIONS {
+        let pcb = vcad_ecad_invariants::board(vec![vcad_ecad_invariants::fine_pitch_tqfn(
+            rot, true,
+        )]);
+        let back = vcad_ecad_symbols::parse_kicad_pcb(&vcad_ecad_symbols::write_kicad_pcb(&pcb))
+            .expect("re-parse");
+        let fp = &back.footprints[0];
+        let rects: Vec<PadRect> = fp.pads.iter().map(|p| PadRect::of(fp, p)).collect();
+        for a in 0..rects.len() {
+            for b in (a + 1)..rects.len() {
+                assert!(
+                    !rects[a].overlaps(&rects[b]),
+                    "TQFN at {rot}deg: pads {} and {} overlap after a KiCad round trip",
+                    fp.pads[a].number,
+                    fp.pads[b].number
+                );
+            }
+        }
+    }
+}

--- a/crates/vcad-ecad-invariants/tests/round_trip.rs
+++ b/crates/vcad-ecad-invariants/tests/round_trip.rs
@@ -32,7 +32,10 @@ fn kicad_round_trip_preserves_every_pad_rectangle() {
                 .iter()
                 .find(|p| p.number == before.number)
                 .unwrap_or_else(|| {
-                    panic!("{}: pad {} lost across the round trip", b.name, before.number)
+                    panic!(
+                        "{}: pad {} lost across the round trip",
+                        b.name, before.number
+                    )
                 });
 
             let want = PadRect::of(before_fp, before);
@@ -54,9 +57,8 @@ fn kicad_round_trip_preserves_every_pad_rectangle() {
 #[test]
 fn kicad_round_trip_keeps_fine_pitch_pads_apart() {
     for &rot in &vcad_ecad_invariants::ROTATIONS {
-        let pcb = vcad_ecad_invariants::board(vec![vcad_ecad_invariants::fine_pitch_tqfn(
-            rot, true,
-        )]);
+        let pcb =
+            vcad_ecad_invariants::board(vec![vcad_ecad_invariants::fine_pitch_tqfn(rot, true)]);
         let back = vcad_ecad_symbols::parse_kicad_pcb(&vcad_ecad_symbols::write_kicad_pcb(&pcb))
             .expect("re-parse");
         let fp = &back.footprints[0];

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -1309,6 +1309,24 @@ fn single_layer_mask(layer: PcbLayer) -> u16 {
         .unwrap_or(0)
 }
 
+/// The copper geometry the connectivity graph sees for each *pad*, keyed by
+/// `(footprint reference, pad number)`.
+///
+/// Exposed so the cross-surface rotation invariants can assert that DRC's view
+/// of a pad is the same physical rectangle as
+/// [`crate::geometry::pad_world_position`] plus the composed rotation — the
+/// agreement nothing checked when the KiCad importer double-counted footprint
+/// rotation and invented 648 phantom violations on the CM5 fixture.
+pub fn connectivity_pad_geoms(pcb: &Pcb) -> Vec<((String, String), CopperGeom)> {
+    build_conn_nodes(pcb)
+        .into_iter()
+        .filter_map(|n| match (n.pad, n.geom) {
+            (Some(key), NodeGeom::Copper(g)) => Some((key, g)),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Geometry of a connectivity node.
 enum NodeGeom {
     /// Copper segment / disc / rect (trace, via, pad).

--- a/crates/vcad-render/src/pcb.rs
+++ b/crates/vcad-render/src/pcb.rs
@@ -703,6 +703,34 @@ fn draw_bore(out: &mut String, xf: &Xf, center: Vec2, drill: f64, p: &Palette) {
 }
 
 /// Build a rotated rectangle polygon (4 corners) centred at `origin`.
+/// Board-space centre and total rotation (degrees CCW) this renderer draws a
+/// pad at: the footprint origin plus the pad offset turned by the footprint
+/// angle, and `fp.rotation + pad.rotation`.
+pub fn pad_placement(fp: &vcad_ir::ecad::Footprint, pad: &Pad) -> (Vec2, f64) {
+    (
+        place(fp.position, fp.rotation, pad.position.x, pad.position.y),
+        fp.rotation + pad.rotation,
+    )
+}
+
+/// The four board-space corners of a non-circular pad as this renderer draws
+/// it, counter-clockwise from the local `(-w/2, -h/2)` corner.
+///
+/// Returns `None` for shapes with no rectangular extent (circle, custom).
+/// Exposed so the cross-surface rotation invariants can assert the SVG shows
+/// the same physical rectangle as DRC, the router index, and the Gerber.
+pub fn pad_world_quad(fp: &vcad_ir::ecad::Footprint, pad: &Pad) -> Option<[Vec2; 4]> {
+    let (origin, rot) = pad_placement(fp, pad);
+    let (w, h) = match &pad.shape {
+        PadShape::Rect { width, height }
+        | PadShape::Oval { width, height }
+        | PadShape::RoundRect { width, height, .. } => (*width, *height),
+        PadShape::Circle { .. } | PadShape::Custom { .. } => return None,
+    };
+    let p = rect_poly(origin, rot, w, h);
+    Some([p[0], p[1], p[2], p[3]])
+}
+
 fn rect_poly(origin: Vec2, rot: f64, w: f64, h: f64) -> Vec<Vec2> {
     let hw = w / 2.0;
     let hh = h / 2.0;
@@ -1258,8 +1286,7 @@ pub fn render_pcb_svg_opts(
         for pad in &fp.pads {
             let pad_layer = pad.layers.iter().copied().find(|l| want(*l));
             let Some(pl) = pad_layer else { continue };
-            let origin = place(fp.position, fp.rotation, pad.position.x, pad.position.y);
-            let total_rot = fp.rotation + pad.rotation;
+            let (origin, total_rot) = pad_placement(fp, pad);
             let matched = hl_on
                 && (hl.reference(&fp.reference)
                     || pad.net.as_deref().map(|n| hl.net(n)).unwrap_or(false));


### PR DESCRIPTION
Two rotation bugs shipped on 2026-07-25. Both were real, both reached users, and
neither was caught — because nothing in the pipeline asserted that a pad occupies
the same physical rectangle from one stage to the next.

1. The KiCad importer stored pad angles **absolutely** while every geometry
   consumer composes `fp.rotation + pad.rotation`, double-counting the footprint
   rotation. A TQFN's 0.25 x 0.875mm pads at 0.5mm pitch came out turned 90
   degrees, so neighbouring pads **overlapped** — 648 phantom DRC violations on
   the CM5 fixture (#684).
2. The Gerber exporter ignored pad rotation entirely — 828 CM5 pads emitted in
   the wrong orientation, on the files that actually get fabricated.

Both are now fixed — #684 and #686. Nothing stops the third one, so this PR is
the harness that catches all three. It is tests only: no production behaviour
changes beyond three new public accessors the assertions need.

> **Rebased.** This originally carried its own fix for the Gerber bug. #686
> landed the same fix independently and better — cross-validated against KiCad's
> own export (13527/13792 apertures agreeing, 0 wrong). I dropped mine and
> rebased onto it. **The harness passed against #686's implementation
> unmodified**, which is the strongest evidence available that it pins the
> invariant rather than a particular implementation of it: two people wrote the
> rotated-aperture logic independently, with different macro names and different
> normalisation, and the same test accepts both.

## The corpus

`crates/vcad-ecad-invariants` carries small synthetic boards:

- rect, roundrect, oval and circle pads on footprints at 0/45/90/135/180/270
  degrees, front and back side;
- a part whose pads carry a **local** angle of their own (30 and -60 degrees) on
  top of the footprint's, so a surface reading only one of the two angles is
  caught even when the other is zero;
- a 0.5mm-pitch TQFN with 0.25 x 0.875mm pads — the case with teeth. Oriented
  correctly the pads clear by 0.25mm; turned 90 degrees the long axis lies along
  the pitch and they overlap by 0.375mm. A wrong answer there is a DRC
  violation, not a different number. A lib test pins both directions, so the
  fixture cannot silently lose its teeth.

## The assertions

**Cross-surface agreement**, to one micrometre, between:

| surface | how the rectangle is recovered |
|---|---|
| `geometry::pad_world_position` + composed rotation | source of truth |
| DRC connectivity nodes | new `drc::connectivity_pad_geoms` over the real `build_conn_nodes` |
| router spatial index | `SpatialIndex::from_pcb` narrowphase geom, **plus** a check that the broadphase AABB still covers the rotated pad |
| Gerber | the emitted file is parsed back — aperture definitions, `%AM` macros and `D03` flashes |
| SVG renderer | new `pcb::pad_world_quad` |

Rectangles are compared as *point sets*, so a surface that winds its corners
differently or reports `-60` where another reports `120` still compares equal —
only genuinely different copper fails.

Because `pad_world_quad` is only worth asserting on if the SVG is really drawn
from it, a second test parses the rendered SVG and checks each pad polygon's
**aspect ratio and long-axis angle**. Both survive the viewport transform
exactly (uniform scale + Y flip + translate), so this pins the real output
without reconstructing the viewport.

**Round-trip invariance**: `parse_kicad_pcb(write_kicad_pcb(board))` preserves
every pad's world rectangle at every rotation in the corpus, and the fine-pitch
TQFN's pads still clear each other afterwards.

**The real fixture**: no two pads of different nets, sharing a copper layer, may
overlap after importing `.scratch/CM5RevEng.kicad_pcb`. `#[ignore]`d (the fixture
is an uncommitted 11MB file; `VCAD_CM5_PCB` overrides the path):

```bash
cargo test -p vcad-ecad-invariants --test cm5_no_overlap -- --ignored
```

Two things surfaced while making this pass, both worth flagging:

- The layer filter is load-bearing. Without it the test reports 513 overlaps that
  are just front-side and back-side pads sharing an XY footprint.
- Absolute zero is not achievable on an imported fixture. Nine pairs overlap in
  the **source file** — components placed on top of each other by the
  reverse-engineering — with centre separations of 0.01mm to 0.74mm against pads
  0.25mm to 1.3mm wide. `R53.2/C174.1` is the clincher: both footprints sit at 0
  degrees, so no rotation handling, right or wrong, can explain it. Those nine
  are pinned in a documented allowlist; the assertion is "nothing beyond this
  baseline". Shrinking the list is good news; growing it needs the same evidence.

## Proving the harness works

A test that passes both ways proves nothing, so each bug was temporarily
reintroduced and the suite re-run.

**Bug 1** — importer keeps the absolute angle (`pad.rotation = normalize_deg(pad.rotation)`
in `kicad_pcb.rs`). **Three tests went red:**

```
kicad_round_trip_preserves_every_pad_rectangle ... FAILED
  shapes@45deg/front: pad 1 moved 2.260660mm across the KiCad round trip
kicad_round_trip_keeps_fine_pitch_pads_apart ... FAILED
  TQFN at 90deg: pads 1 and 2 overlap after a KiCad round trip
cm5_pads_of_different_nets_do_not_overlap ... FAILED
  52 different-net pad pairs overlap after import, beyond the 9 pinned
  source-board pairs
```

That middle failure is the original bug stated as its consequence: the pads
overlap.

**Bug 2** — `let angle = 0.0;` in #686's Gerber pad resolver. **One test went red:**

```
gerber_apertures_agree ... FAILED
  padlocal@0deg: Gerber aperture disagrees for pad 1 by 0.9665064mm
```

Note which case caught it: `padlocal@0deg`, the fixture whose footprint sits at 0
degrees and whose pads carry their own 30-degree angle. Without that case the
first failure would have come from a rotated footprint and the pad-local half of
the composition would have gone untested.

Both edits were reverted; the suite is green. Both injections were re-run after
the rebase, against the code as it now stands, so the evidence above describes
this tree and not an earlier one.

## Gates

- `cargo test --workspace` — clean: 275 test binaries, 3548 tests, 0 failures.
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean.
  (Adding `--all-targets` surfaces 4 errors in `vcad-kernel-booleans` tests — a
  crate this PR does not touch, so they are pre-existing.)

The CM5 test is excluded from both, by design: it is `#[ignore]`d and needs the
uncommitted fixture. It was run manually and passes.

Note this targets `fix/short-pair-coupling` (#684/#686), which is unmerged —
retarget to `main` once that lands.

New public seams, all in service of the invariants: `drc::connectivity_pad_geoms`,
`render::pcb::pad_placement`, `render::pcb::pad_world_quad`.
