### PR TITLE
fix(router): stop committing copper the exact oracle never saw

### DIFF
--- a/changelog/entries/2026-07-25-router-pair-connector-vias.json
+++ b/changelog/entries/2026-07-25-router-pair-connector-vias.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-router-pair-connector-vias",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "Autoroute no longer routes traces through diff-pair vias",
+  "summary": "Differential-pair breakout vias were written onto the board but never registered with the router's clearance oracle, so later nets were routed straight through the barrel.",
+  "features": ["pcb", "routing", "drc"],
+  "mcpTools": ["route_nets", "route_diff_pair", "run_drc"]
+}

--- a/crates/vcad-ecad-pcb/examples/cm5_bench.rs
+++ b/crates/vcad-ecad-pcb/examples/cm5_bench.rs
@@ -242,6 +242,13 @@ fn main() {
             source: None,
         });
     }
+    // Stage bisection: dump the board as route_all left it, before si_finish
+    // rewrites any of it.
+    if let Ok(p) = std::env::var("VCAD_DUMP_PRESI") {
+        std::fs::write(&p, serde_json::to_string(&pcb).expect("serialize board"))
+            .expect("write pre-si board json");
+        eprintln!("wrote pre-si board {p}");
+    }
     if std::env::var("VCAD_SI_FINISH").as_deref() != Ok("0") {
         let t1 = Instant::now();
         let fin = vcad_ecad_pcb::router::si_finish(&mut pcb, 2_000_000, 2000);

--- a/crates/vcad-ecad-pcb/examples/overlap_report.rs
+++ b/crates/vcad-ecad-pcb/examples/overlap_report.rs
@@ -1,0 +1,229 @@
+//! Exact (0.000mm) cross-net trace overlaps on a routed board, found
+//! geometrically rather than via the DRC message text, and cross-examined
+//! against the router's own oracle.
+//!
+//! For each overlapping pair it asks `RouteSession::probe` whether the second
+//! trace is legal on a board holding the first. `LEGAL` means the oracle
+//! accepts physically overlapping copper (an oracle bug); `ILLEGAL` means some
+//! commit path put the copper down without asking.
+//!
+//! ```bash
+//! cargo run --release -p vcad-ecad-pcb --example overlap_report -- board.pcb.json
+//! ```
+
+use std::collections::BTreeMap;
+use vcad_ecad_pcb::session::RouteSession;
+use vcad_ecad_pcb::spatial::CopperGeom;
+use vcad_ir::ecad::{Pcb, Trace};
+use vcad_ir::Vec2;
+
+/// Distance between two segment capsules' centerlines.
+fn seg_seg_dist(a0: Vec2, a1: Vec2, b0: Vec2, b1: Vec2) -> f64 {
+    let d = |p: Vec2, x: Vec2, y: Vec2| {
+        let xy = y - x;
+        let l2 = xy.x * xy.x + xy.y * xy.y;
+        let t = if l2 <= 0.0 {
+            0.0
+        } else {
+            (((p - x).x * xy.x + (p - x).y * xy.y) / l2).clamp(0.0, 1.0)
+        };
+        (p - (x + xy.scale(t))).length()
+    };
+    // Segment intersection ⇒ zero.
+    let cross = |p: Vec2, q: Vec2, r: Vec2| (q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x);
+    let (d1, d2, d3, d4) = (
+        cross(a0, a1, b0),
+        cross(a0, a1, b1),
+        cross(b0, b1, a0),
+        cross(b0, b1, a1),
+    );
+    if ((d1 > 0.0) != (d2 > 0.0)) && ((d3 > 0.0) != (d4 > 0.0)) {
+        return 0.0;
+    }
+    d(b0, a0, a1)
+        .min(d(b1, a0, a1))
+        .min(d(a0, b0, b1))
+        .min(d(a1, b0, b1))
+}
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: overlap_report <board.pcb.json>");
+    let pcb: Pcb =
+        serde_json::from_str(&std::fs::read_to_string(&path).expect("read")).expect("parse");
+
+    // Bucket by layer so the O(n^2) sweep stays cheap.
+    let mut by_layer: BTreeMap<String, Vec<&Trace>> = BTreeMap::new();
+    for t in &pcb.traces {
+        by_layer
+            .entry(format!("{:?}", t.layer))
+            .or_default()
+            .push(t);
+    }
+
+    let session = RouteSession::from_pcb(&pcb);
+
+    // What kind of copper does each overlapping trace actually hit? The DRC's
+    // "trace net A to net B" covers traces, pads, vias and zone fill alike.
+    {
+        let is_via = |c: Vec2, r: f64| {
+            pcb.vias
+                .iter()
+                .any(|v| (v.position - c).length() < 1e-6 && (v.diameter / 2.0 - r).abs() < 1e-6)
+        };
+        let mut kinds: BTreeMap<&str, usize> = BTreeMap::new();
+        let mut total = 0usize;
+        for t in &pcb.traces {
+            let hw = t.width / 2.0;
+            let g = CopperGeom::Segment {
+                a: t.start,
+                b: t.end,
+                half_w: hw,
+            };
+            let (lo, hi) = (
+                [
+                    t.start.x.min(t.end.x) - hw - 1.0,
+                    t.start.y.min(t.end.y) - hw - 1.0,
+                ],
+                [
+                    t.start.x.max(t.end.x) + hw + 1.0,
+                    t.start.y.max(t.end.y) + hw + 1.0,
+                ],
+            );
+            session.for_each_blocking(t.layer, &t.net, lo, hi, |other, _, _, _| {
+                if g.distance_to(other) > 1e-9 {
+                    return;
+                }
+                total += 1;
+                *kinds
+                    .entry(match other {
+                        CopperGeom::Segment { .. } => "trace",
+                        CopperGeom::Disc { center, r } => {
+                            if is_via(*center, *r) {
+                                "via"
+                            } else {
+                                "round pad"
+                            }
+                        }
+                        CopperGeom::Rect { .. } => "rect pad",
+                    })
+                    .or_default() += 1;
+            });
+        }
+        // Which vias are the offenders?
+        let mut via_nets: BTreeMap<String, usize> = BTreeMap::new();
+        for t in &pcb.traces {
+            let hw = t.width / 2.0;
+            let g = CopperGeom::Segment {
+                a: t.start,
+                b: t.end,
+                half_w: hw,
+            };
+            for v in &pcb.vias {
+                if v.net == t.net || !layer_spanned(&pcb, v, t.layer) {
+                    continue;
+                }
+                let d = g.distance_to(&CopperGeom::Disc {
+                    center: v.position,
+                    r: v.diameter / 2.0,
+                });
+                if d <= 1e-9 {
+                    *via_nets.entry(v.net.clone()).or_default() += 1;
+                }
+            }
+        }
+        println!("vias whose barrel a foreign trace runs through:");
+        for (nname, c) in &via_nets {
+            println!("  {c:4}  {nname}");
+        }
+        println!();
+        println!("exact overlaps by partner kind (each counted once per trace):");
+        for (k, c) in &kinds {
+            println!("  {c:5}  trace vs {k}");
+        }
+        println!("  {total:5}  total\n");
+    }
+
+    let mut pairs: Vec<(&Trace, &Trace)> = Vec::new();
+    for ts in by_layer.values() {
+        for i in 0..ts.len() {
+            for j in (i + 1)..ts.len() {
+                let (a, b) = (ts[i], ts[j]);
+                if a.net == b.net {
+                    continue;
+                }
+                let gap =
+                    seg_seg_dist(a.start, a.end, b.start, b.end) - a.width / 2.0 - b.width / 2.0;
+                if gap <= 1e-9 {
+                    pairs.push((a, b));
+                }
+            }
+        }
+    }
+
+    let mut classes: BTreeMap<String, usize> = BTreeMap::new();
+    let mut probe_legal = 0usize;
+    for (n, (a, b)) in pairs.iter().enumerate() {
+        // Ask the oracle about `b` on a board that still holds `a`. Same-net
+        // copper of `b` is excluded by the probe itself, so the full session
+        // is the right thing to ask against.
+        let pr = session.probe(
+            &CopperGeom::Segment {
+                a: b.start,
+                b: b.end,
+                half_w: b.width / 2.0,
+            },
+            b.layer,
+            &b.net,
+            session.clearance_for(&b.net),
+        );
+        let saw_a = pr.blockers.iter().any(|bl| bl.net == a.net);
+        if !saw_a {
+            probe_legal += 1;
+        }
+        *classes
+            .entry(format!(
+                "{} w={:.3}/{:.3}",
+                if saw_a {
+                    "oracle-refuses"
+                } else {
+                    "ORACLE-ACCEPTS"
+                },
+                a.width,
+                b.width
+            ))
+            .or_default() += 1;
+        if n < 30 {
+            println!(
+                "{:>15} {:?} ({:7.3},{:7.3})-({:7.3},{:7.3}) w{:.3}  X  {:>15} ({:7.3},{:7.3})-({:7.3},{:7.3}) w{:.3}   oracle: {}",
+                a.net, a.layer, a.start.x, a.start.y, a.end.x, a.end.y, a.width,
+                b.net, b.start.x, b.start.y, b.end.x, b.end.y, b.width,
+                if saw_a { "refuses" } else { "ACCEPTS" },
+            );
+        }
+    }
+    println!(
+        "\n{} exact cross-net trace overlaps; oracle accepts {probe_legal} of them",
+        pairs.len()
+    );
+    for (k, c) in classes {
+        println!("  {c:4}  {k}");
+    }
+}
+
+/// Is `layer` inside the via's start..end span?
+fn layer_spanned(pcb: &Pcb, v: &vcad_ir::ecad::Via, layer: vcad_ir::ecad::PcbLayer) -> bool {
+    let copper: Vec<vcad_ir::ecad::PcbLayer> = pcb
+        .stackup
+        .layers
+        .iter()
+        .filter(|l| l.layer.is_copper())
+        .map(|l| l.layer)
+        .collect();
+    let idx = |l: vcad_ir::ecad::PcbLayer| copper.iter().position(|&c| c == l);
+    match (idx(v.start_layer), idx(v.end_layer), idx(layer)) {
+        (Some(a), Some(b), Some(c)) => c >= a.min(b) && c <= a.max(b),
+        _ => true,
+    }
+}

--- a/crates/vcad-ecad-pcb/src/router/auto.rs
+++ b/crates/vcad-ecad-pcb/src/router/auto.rs
@@ -701,6 +701,11 @@ pub fn route_all_with_opts(
         }
     }
 
+    // Invariant audit over everything this pass is about to emit — placed
+    // routes plus the plane stitching — against the settled session.
+    audit_placed(&session, pcb, &placed);
+    audit_stitch(&session, pcb, &stitch, width);
+
     // Flatten the placed connections into the result.
     let mut traces = Vec::new();
     let mut vias = Vec::new();
@@ -1385,7 +1390,132 @@ fn route_pass(
         pending = gpu_negotiate_rounds(&mut session, pcb, &mut placed, pending, width);
     }
 
+    audit_placed(&session, pcb, &placed);
     (session, placed, pending)
+}
+
+/// Invariant audit (`VCAD_ROUTE_AUDIT=1`): every piece of copper the pass
+/// reports must still be legal against the session it lives in.
+///
+/// The probe skips same-net elements, so a `Placed` element probed against the
+/// live session is judged purely on its foreign neighbours — exactly the
+/// contract "no path may commit copper the exact oracle has not accepted
+/// against the state it will actually live in". Anything logged here is a
+/// commit path that skipped the oracle, or copper that is on the board but not
+/// in the session; the kind (`segment` / `stub` / `via`) names the stage.
+fn audit_placed(session: &RouteSession, pcb: &Pcb, placed: &[Placed]) {
+    if std::env::var("VCAD_ROUTE_AUDIT").as_deref() != Ok("1") {
+        return;
+    }
+    let via_r = pcb.rules.default_rules.via_diameter / 2.0;
+    let copper = copper_layers(pcb);
+    let mut bad = 0usize;
+    let mut report = |kind: &str, net: &str, at: Vec2, pr: &crate::session::ProbeResult| {
+        if pr.legal {
+            return;
+        }
+        bad += 1;
+        log::warn!(
+            "AUDIT {kind} {net} at ({:.3},{:.3}) illegal: {:.3}mm to {}",
+            at.x,
+            at.y,
+            pr.min_clearance,
+            pr.blockers.first().map(|b| b.net.as_str()).unwrap_or("?"),
+        );
+    };
+    for pl in placed {
+        let clr = session.clearance_for(&pl.net);
+        for &(a, b, l) in &pl.segments {
+            let g = CopperGeom::Segment {
+                a,
+                b,
+                half_w: pl.width / 2.0,
+            };
+            report("segment", &pl.net, a, &session.probe(&g, l, &pl.net, clr));
+        }
+        for &(a, b, l) in &pl.stubs {
+            let g = CopperGeom::Segment {
+                a,
+                b,
+                half_w: pl.stub_width / 2.0,
+            };
+            report("stub", &pl.net, a, &session.probe(&g, l, &pl.net, clr));
+        }
+        for &(p, la, lb) in &pl.via_pts {
+            let g = CopperGeom::Disc {
+                center: p,
+                r: via_r,
+            };
+            let (ia, ib) = (
+                copper.iter().position(|&l| l == la).unwrap_or(0),
+                copper
+                    .iter()
+                    .position(|&l| l == lb)
+                    .unwrap_or(copper.len().saturating_sub(1)),
+            );
+            for &l in &copper[ia.min(ib)..=ia.max(ib)] {
+                report("via", &pl.net, p, &session.probe(&g, l, &pl.net, clr));
+            }
+        }
+    }
+    log::info!(
+        "AUDIT: {bad} illegal element(s) across {} routes",
+        placed.len()
+    );
+}
+
+/// The stitching half of [`audit_placed`]: plane-stitch stubs and vias are
+/// emitted alongside the placed routes and must clear foreign copper too.
+fn audit_stitch(session: &RouteSession, pcb: &Pcb, stitch: &Stitch, width: f64) {
+    if std::env::var("VCAD_ROUTE_AUDIT").as_deref() != Ok("1") {
+        return;
+    }
+    let via_r = pcb.rules.default_rules.via_diameter / 2.0;
+    let copper = copper_layers(pcb);
+    let mut bad = 0usize;
+    for (a, b, net, l) in &stitch.stubs {
+        let g = CopperGeom::Segment {
+            a: *a,
+            b: *b,
+            half_w: session.width_for(net, width) / 2.0,
+        };
+        let pr = session.probe(&g, *l, net, session.clearance_for(net));
+        if !pr.legal {
+            bad += 1;
+            log::warn!(
+                "AUDIT stitch-stub {net} at ({:.3},{:.3}) illegal: {:.3}mm to {}",
+                a.x,
+                a.y,
+                pr.min_clearance,
+                pr.blockers.first().map(|b| b.net.as_str()).unwrap_or("?"),
+            );
+        }
+    }
+    for (p, net) in &stitch.vias {
+        let g = CopperGeom::Disc {
+            center: *p,
+            r: via_r,
+        };
+        for &l in &copper {
+            let pr = session.probe(&g, l, net, session.clearance_for(net));
+            if !pr.legal {
+                bad += 1;
+                log::warn!(
+                    "AUDIT stitch-via {net} at ({:.3},{:.3}) {l:?} illegal: {:.3}mm to {}",
+                    p.x,
+                    p.y,
+                    pr.min_clearance,
+                    pr.blockers.first().map(|b| b.net.as_str()).unwrap_or("?"),
+                );
+                break;
+            }
+        }
+    }
+    log::info!(
+        "AUDIT stitch: {bad} illegal element(s) across {} stubs / {} vias",
+        stitch.stubs.len(),
+        stitch.vias.len()
+    );
 }
 
 /// The deferred rescue arsenal, run once over the connections GPU negotiation

--- a/crates/vcad-ecad-pcb/src/router/legalize.rs
+++ b/crates/vcad-ecad-pcb/src/router/legalize.rs
@@ -38,6 +38,9 @@ use std::collections::BTreeSet;
 use vcad_ir::ecad::{CopperSource, Pcb, PcbLayer, Trace, Via};
 use vcad_ir::Vec2;
 
+use crate::session::RouteSession;
+use crate::spatial::CopperGeom;
+
 use super::auto::{copper_layers, RoutedTrace, RoutedVia};
 use crate::drc::{
     analyze_net_continuity, check_drc_in_region, dangling_copper_mask, DrcRuleType, DrcViolation,
@@ -229,6 +232,17 @@ fn d2(a: Vec2, b: Vec2) -> f64 {
 /// the union of the cluster's layer spans; traces that ended on a dropped via
 /// are reconnected to the survivor with a short same-net jog on their own
 /// layer. Returns the number of vias removed.
+///
+/// Both of those moves place copper that the router's oracle never saw. The
+/// widened span puts a barrel on layers the original via did not occupy, and
+/// the jog is a brand new trace; the old justification ("the jog stays inside
+/// copper the via already claimed") only holds on the layers the via already
+/// claimed. So both are probed here against the candidate board, and a cluster
+/// whose merge would land on foreign copper is left alone — its vias stay
+/// hole-to-hole illegal and the fail-closed demotion below strips the net,
+/// which is the honest outcome. Unchecked, this was the second source of exact
+/// 0.000mm overlaps on a full CM5 route: foreign traces sitting inside a
+/// merged via's newly-claimed inner-layer pad.
 fn merge_same_net_vias(
     pcb: &Pcb,
     traces: &mut Vec<RoutedTrace>,
@@ -240,6 +254,35 @@ fn merge_same_net_vias(
     let min_spacing = pcb.rules.hole_to_hole;
     let stack = copper_layers(pcb);
     let layer_idx = |l: PcbLayer| stack.iter().position(|&s| s == l).unwrap_or(0);
+    // The oracle for this stage: the board as the caller will actually commit
+    // it. Same-net copper is excluded by the probe, so a cluster is judged
+    // purely on the foreign copper it would newly touch — but only on copper
+    // that will still be there. At this point the output still carries the
+    // speculative emitters' debris (abandoned fan-out stubs, escape vias for
+    // routes rip-up replaced: on the CM5, 1855 dead traces), which
+    // `prune_dangling` deletes moments later. Judging against phantom
+    // obstacles refused every merge on the board and left the duplicate vias
+    // for the demotion pass to strip.
+    let session = {
+        let mut cand = candidate_pcb(pcb, traces, vias);
+        let (keep_trace, keep_via) = dangling_copper_mask(&cand);
+        // Only the NEW copper may be dropped — `candidate_pcb` appends it after
+        // the board's own, which is never pruned and stays an obstacle here.
+        let (t0, v0) = (pcb.traces.len(), pcb.vias.len());
+        let mut ti = 0;
+        cand.traces.retain(|_| {
+            let k = ti < t0 || keep_trace[ti];
+            ti += 1;
+            k
+        });
+        let mut vi = 0;
+        cand.vias.retain(|_| {
+            let k = vi < v0 || keep_via[vi];
+            vi += 1;
+            k
+        });
+        RouteSession::from_pcb(&cand)
+    };
 
     // Union-find over the new vias: same net + illegal hole spacing → cluster.
     let mut parent: Vec<usize> = (0..vias.len()).collect();
@@ -291,61 +334,130 @@ fn merge_same_net_vias(
         let cx = members.iter().map(|&i| vias[i].position.x).sum::<f64>() / n;
         let cy = members.iter().map(|&i| vias[i].position.y).sum::<f64>() / n;
         let centroid = Vec2::new(cx, cy);
-        let &keep = members
-            .iter()
-            .min_by(|&&a, &&b| {
-                d2(vias[a].position, centroid)
-                    .partial_cmp(&d2(vias[b].position, centroid))
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            })
-            .expect("cluster is non-empty");
-
+        // Survivor preference: nearest the centroid. The legality gate below
+        // can veto a survivor (its widened barrel or a reconnect jog would
+        // land on foreign copper), and a different member of the same cluster
+        // often passes — so this is an ordering, not a single choice.
+        let mut order: Vec<usize> = members.clone();
+        order.sort_by(|&a, &b| {
+            d2(vias[a].position, centroid)
+                .partial_cmp(&d2(vias[b].position, centroid))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         // Union of layer spans, in stackup order.
-        let lo = members
+        let lo_all = members
             .iter()
             .map(|&i| layer_idx(vias[i].start_layer))
             .min()
             .unwrap_or(0);
-        let hi = members
+        let hi_all = members
             .iter()
             .map(|&i| layer_idx(vias[i].end_layer))
             .max()
             .unwrap_or(stack.len().saturating_sub(1));
-        let keep_pos = vias[keep].position;
-        vias[keep].start_layer = stack[lo];
-        vias[keep].end_layer = stack[hi];
 
-        for &i in members {
-            if i == keep {
+        let mut chosen: Option<(usize, Vec<RoutedTrace>)> = None;
+        for &keep in &order {
+            let (lo, hi) = (lo_all, hi_all);
+            let keep_pos = vias[keep].position;
+            let net = vias[keep].net.clone();
+            let clr = session.clearance_for(&net);
+            let (via_d, _) = via_geom_for(pcb, &net);
+            // Layers the survivor would newly occupy: everything in the union span
+            // outside its own original span.
+            let (own_lo, own_hi) = {
+                let (a, b) = (
+                    layer_idx(vias[keep].start_layer),
+                    layer_idx(vias[keep].end_layer),
+                );
+                (a.min(b), a.max(b))
+            };
+            let disc = CopperGeom::Disc {
+                center: keep_pos,
+                r: via_d / 2.0,
+            };
+            let span_ok = (lo..=hi)
+                .filter(|&li| li < own_lo || li > own_hi)
+                .all(|li| session.probe(&disc, stack[li], &net, clr).legal);
+            if !span_ok {
+                log::debug!(
+                    "legalize: not merging {net} via cluster at ({:.3},{:.3}) — the widened \
+                 barrel would land on foreign copper",
+                    keep_pos.x,
+                    keep_pos.y
+                );
                 continue;
             }
-            drop.insert(i);
-            let gone = vias[i].position;
-            if d2(gone, keep_pos).sqrt() <= POS_EPS {
-                continue; // exact duplicate — nothing to reconnect
+
+            // Same for the reconnect jogs: build them first, probe them all, and
+            // only then commit the cluster.
+            let mut cluster_jogs: Vec<RoutedTrace> = Vec::new();
+            let mut jog_ok = true;
+            for &i in members {
+                if i == keep {
+                    continue;
+                }
+                let gone = vias[i].position;
+                if d2(gone, keep_pos).sqrt() <= POS_EPS {
+                    continue;
+                }
+                let mut jogged: BTreeSet<usize> = BTreeSet::new();
+                for t in traces.iter() {
+                    if t.net != vias[i].net {
+                        continue;
+                    }
+                    if d2(t.start, gone).sqrt() > POS_EPS && d2(t.end, gone).sqrt() > POS_EPS {
+                        continue;
+                    }
+                    let li = layer_idx(t.layer);
+                    if jogged.insert(li) {
+                        cluster_jogs.push(RoutedTrace {
+                            start: gone,
+                            end: keep_pos,
+                            width: t.width,
+                            layer: t.layer,
+                            net: t.net.clone(),
+                        });
+                    }
+                }
             }
-            // Reconnect: every new trace that ended on the dropped via gets a
-            // same-net jog from the old via position to the survivor, on the
-            // trace's own layer. The holes overlapped, so the jog is shorter
-            // than a via pad — it stays inside copper the via already claimed.
-            let mut jogged: BTreeSet<usize> = BTreeSet::new();
-            for t in traces.iter() {
-                if t.net != vias[i].net {
-                    continue;
+            for j in &cluster_jogs {
+                let g = CopperGeom::Segment {
+                    a: j.start,
+                    b: j.end,
+                    half_w: j.width / 2.0,
+                };
+                if !session
+                    .probe(&g, j.layer, &j.net, session.clearance_for(&j.net))
+                    .legal
+                {
+                    jog_ok = false;
+                    break;
                 }
-                if d2(t.start, gone).sqrt() > POS_EPS && d2(t.end, gone).sqrt() > POS_EPS {
-                    continue;
-                }
-                let li = layer_idx(t.layer);
-                if jogged.insert(li) {
-                    connectors.push(RoutedTrace {
-                        start: gone,
-                        end: keep_pos,
-                        width: t.width,
-                        layer: t.layer,
-                        net: t.net.clone(),
-                    });
-                }
+            }
+            if !jog_ok {
+                log::debug!(
+                    "legalize: not merging {net} via cluster at ({:.3},{:.3}) — a reconnect \
+                 jog would cross foreign copper",
+                    keep_pos.x,
+                    keep_pos.y
+                );
+                continue;
+            }
+
+            chosen = Some((keep, cluster_jogs));
+            break;
+        }
+        let Some((keep, cluster_jogs)) = chosen else {
+            continue;
+        };
+        vias[keep].start_layer = stack[lo_all];
+        vias[keep].end_layer = stack[hi_all];
+        connectors.extend(cluster_jogs);
+
+        for &i in members {
+            if i != keep {
+                drop.insert(i);
             }
         }
     }
@@ -646,6 +758,60 @@ mod tests {
             .filter(|v| v.rule == DrcRuleType::HoleToHole)
             .collect();
         assert!(h2h.is_empty(), "merge must clear HoleToHole, got {h2h:?}");
+    }
+
+    /// A merge that would drive copper through another net is refused, and the
+    /// still-illegal cluster is then stripped fail-closed rather than returned.
+    ///
+    /// The reconnect jog used to be emitted unconditionally on the theory that
+    /// it "stays inside copper the via already claimed" — which says nothing
+    /// about what else is on that layer. Here a foreign trace sits between the
+    /// two drills, so the jog would cross it at 0.000mm. Both vias carry BCu
+    /// copper, so neither can be the survivor — whichever is kept, the jog
+    /// that reconnects the other runs along the blocked layer.
+    #[test]
+    fn merge_refused_when_the_reconnect_jog_would_short() {
+        let mut pcb = board();
+        // Foreign BOARD copper straight across the jog's path on BCu. It has to
+        // be board copper: new copper with no pad anchor is dead by
+        // construction and the prune deletes it, so the gate rightly ignores it.
+        pcb.traces.push(Trace {
+            start: Vec2::new(10.15, 8.0),
+            end: Vec2::new(10.15, 12.0),
+            width: 0.25,
+            layer: PcbLayer::BCu,
+            net: "B".into(),
+            source: None,
+        });
+        let mut traces = vec![
+            rtrace((5.0, 10.0), (10.0, 10.0), "A", PcbLayer::BCu),
+            rtrace((10.3, 10.0), (20.0, 10.0), "A", PcbLayer::BCu),
+        ];
+        let mut vias = vec![rvia(10.0, 10.0, "A"), rvia(10.3, 10.0, "A")];
+        let report = legalize(&pcb, &mut traces, &mut vias, &[]);
+        assert_eq!(report.merged_vias, 0, "the merge must be refused");
+        assert!(
+            !traces.iter().any(|t| t.net == "A"
+                && t.layer == PcbLayer::BCu
+                && (t.start - Vec2::new(10.15, 10.0)).length() < 0.2
+                && (t.end - Vec2::new(10.15, 10.0)).length() < 0.2),
+            "no jog may be emitted across the foreign trace"
+        );
+        // Fail-closed: the cluster is still hole-to-hole illegal, so the DRC
+        // loop strips A rather than returning an unmanufacturable board.
+        assert_eq!(report.demoted.len(), 1);
+        assert_eq!(report.demoted[0].0, "A");
+        let candidate = candidate_pcb(&pcb, &traces, &vias);
+        let hard: Vec<_> = crate::drc::check_drc(&candidate)
+            .into_iter()
+            .filter(|v| {
+                matches!(
+                    v.rule,
+                    DrcRuleType::HoleToHole | DrcRuleType::Clearance | DrcRuleType::Short
+                )
+            })
+            .collect();
+        assert!(hard.is_empty(), "output must be clean, got {hard:?}");
     }
 
     /// Different-net vias can't merge: the net whose via is illegally close to

--- a/crates/vcad-ecad-pcb/src/router/pair.rs
+++ b/crates/vcad-ecad-pcb/src/router/pair.rs
@@ -784,56 +784,57 @@ pub(super) fn try_route_pair_reason(
             thin_width: nw,
         }
     };
-    // Connectors, all four against both committed legs. Committed as thin
-    // copper directly into each leg's Placed (stubs channel).
+    // Connectors, all four against both committed legs. Every one of them goes
+    // through `validate_and_commit` — the same exact oracle the legs use — and
+    // its output is merged into the leg's `Placed` (copper on the stubs
+    // channel, vias on `via_pts`).
+    //
+    // This used to hand-roll `session.commit` for the connector's segments and
+    // push its VIAS straight onto `pl.via_pts` without committing them at all.
+    // Those vias were real: they were written onto the output board like any
+    // other. But the session never learned about them, so no later route could
+    // be refused for crossing one — the oracle cannot decline copper it has
+    // never been shown. On a full CM5 route that was 61 of the 72 exact
+    // (0.000mm) cross-net overlaps: foreign traces driven clean through a pair
+    // connector's via barrel, every offending via on a `_P`/`_N` net.
     let attach = |session: &mut RouteSession,
+                  placed: &[Placed],
                   pl: &mut Placed,
                   leg: &Leg,
                   pad_a: Vec2,
                   pad_b: Vec2|
      -> bool {
         let net = pl.net.clone();
-        let Some((head, hv)) = connect(session, &net, pad_a, leg.first, leg.first_layer, leg)
-        else {
-            log::debug!("pair-connector: {net} head failed");
-            return false;
-        };
-        for (a, b, l) in &head {
-            let id = crate::spatial::CopperElement {
-                min: [a.x.min(b.x) - nw, a.y.min(b.y) - nw],
-                max: [a.x.max(b.x) + nw, a.y.max(b.y) + nw],
-                net: net.clone(),
-                layer: *l,
-                geom: CopperGeom::Segment {
-                    a: *a,
-                    b: *b,
-                    half_w: nw / 2.0,
-                },
+        for (pad, end, end_layer, which) in [
+            (pad_a, leg.first, leg.first_layer, "head"),
+            (pad_b, leg.last, leg.last_layer, "tail"),
+        ] {
+            let Some((copper, vias)) = connect(session, &net, pad, end, end_layer, leg) else {
+                log::debug!("pair-connector: {net} {which} failed");
+                return false;
             };
-            pl.spans.push(session.commit(id));
-            pl.stubs.push((*a, *b, *l));
-        }
-        pl.via_pts.extend(hv);
-        let Some((tail, tv)) = connect(session, &net, pad_b, leg.last, leg.last_layer, leg) else {
-            log::debug!("pair-connector: {net} tail failed");
-            return false;
-        };
-        for (a, b, l) in &tail {
-            let id = crate::spatial::CopperElement {
-                min: [a.x.min(b.x) - nw, a.y.min(b.y) - nw],
-                max: [a.x.max(b.x) + nw, a.y.max(b.y) + nw],
+            // Same-net context for the commit's via-reuse test: the leg's own
+            // vias live on `pl`, which is not in `placed` yet.
+            let mut ctx: Vec<Placed> = placed.iter().filter(|p| p.net == net).cloned().collect();
+            ctx.push(pl.clone());
+            let cand = Candidate {
                 net: net.clone(),
-                layer: *l,
-                geom: CopperGeom::Segment {
-                    a: *a,
-                    b: *b,
-                    half_w: nw / 2.0,
-                },
+                from: pad,
+                to: end,
+                width: nw,
+                segments: vec![],
+                vias,
+                thin_segments: copper,
+                thin_width: nw,
             };
-            pl.spans.push(session.commit(id));
-            pl.stubs.push((*a, *b, *l));
+            let Some(p) = validate_and_commit(session, pcb, cand, &ctx) else {
+                log::debug!("pair-connector: {net} {which} failed validation");
+                return false;
+            };
+            pl.spans.extend(p.spans);
+            pl.stubs.extend(p.stubs);
+            pl.via_pts.extend(p.via_pts);
         }
-        pl.via_pts.extend(tv);
         true
     };
     // Connector retreat. A coupled corridor can be perfectly good and still be
@@ -900,8 +901,8 @@ pub(super) fn try_route_pair_reason(
             last_bail = PairBail::LegValidation;
             continue;
         };
-        if attach(session, &mut placed_mine, &mine, from, to)
-            && attach(session, &mut placed_theirs, &theirs, p_from, p_to)
+        if attach(session, placed, &mut placed_mine, &mine, from, to)
+            && attach(session, placed, &mut placed_theirs, &theirs, p_from, p_to)
         {
             if r_from + r_to > 0.0 {
                 log::debug!(
@@ -2093,6 +2094,86 @@ mod tests {
                     pl.net
                 );
             }
+        }
+    }
+
+    /// Every via a pair route REPORTS must be a via the session KNOWS about.
+    ///
+    /// The four pad connectors are maze routes, and when the pads sit on a
+    /// layer the coupled legs don't use, each connector carries a via to get
+    /// there. Those vias are written onto the output board like any other — so
+    /// if the session never receives them, the oracle cannot refuse a later
+    /// route that drives straight through the barrel. It is not a near-miss:
+    /// the copper physically overlaps at 0.000mm, and no probe was ever wrong,
+    /// because no probe was ever asked.
+    #[test]
+    fn pair_connector_vias_are_visible_to_the_oracle() {
+        let mut pcb = pair_board();
+        // Put all four pads on BCu only, so the FCu coupled legs can only be
+        // reached through a connector via.
+        for f in &mut pcb.footprints {
+            for p in &mut f.pads {
+                p.layers = vec![PcbLayer::BCu];
+            }
+        }
+        // ...and wall BCu off mid-board so the coupled run has to live on FCu.
+        pcb.traces.push(vcad_ir::ecad::Trace {
+            start: Vec2::new(25.0, 0.0),
+            end: Vec2::new(25.0, 30.0),
+            width: 1.0,
+            layer: PcbLayer::BCu,
+            net: "WALL".into(),
+            source: None,
+        });
+        let mut session = RouteSession::from_pcb(&pcb);
+        let cong = Congestion::new(&pcb.outline.vertices);
+        let mut placed = Vec::new();
+        let Some((p, n)) = try_route_pair(
+            &mut session,
+            &pcb,
+            0.25,
+            "/ETH.2_P",
+            Vec2::new(5.0, 15.325),
+            Vec2::new(45.0, 15.325),
+            &mut placed,
+            &cong,
+            200_000,
+        ) else {
+            panic!("pair with BCu pads must still route");
+        };
+        let vias: Vec<_> = p.via_pts.iter().chain(n.via_pts.iter()).collect();
+        assert!(
+            !vias.is_empty(),
+            "fixture is vacuous: the connectors placed no vias"
+        );
+        let via_r = pcb.rules.default_rules.via_diameter / 2.0;
+        for &&(pt, la, lb) in &vias {
+            for layer in [la, lb] {
+                let pr = session.probe(
+                    &crate::spatial::CopperGeom::Disc {
+                        center: pt,
+                        r: via_r,
+                    },
+                    layer,
+                    "SOME-OTHER-NET",
+                    pcb.rules.default_rules.clearance,
+                );
+                assert!(
+                    !pr.legal,
+                    "via at ({:.3},{:.3}) on {layer:?} is reported on the board but \
+                     absent from the session — a foreign net can be routed through it",
+                    pt.x, pt.y
+                );
+            }
+        }
+        // And the drill barrel likewise: hole-to-hole must see it.
+        for &&(pt, _, _) in &vias {
+            assert!(
+                !session.probe_via_drill(pt, "SOME-OTHER-NET").legal,
+                "via drill at ({:.3},{:.3}) is absent from the session's hole census",
+                pt.x,
+                pt.y
+            );
         }
     }
 


### PR DESCRIPTION
## The bug

The campaign's central invariant is "GPU proposes, the exact CPU oracle disposes" — every commit goes through `RouteSession::probe`. It held only for the copper that happened to route through `validate_and_commit`. Two paths put copper on the board without the session ever being shown it, and a full CM5 route carried **73 exact (0.000mm) cross-net overlaps** as a result — copper physically on top of copper, against a stripped-fixture floor of 12 pad-level overlaps inherent to the import.

Neither was a probe bug. In both cases the oracle would have refused the copper; it was never asked.

### 1. Differential-pair breakout connectors (`router/pair.rs`)

`attach` hand-rolled `session.commit` for the connector's segments and pushed its **vias** straight onto the `Placed` without committing them at all. Those vias were written onto the output board like any other via — but the session had no copper and no drill at that position, so no later route could be refused for crossing one.

61 of the 72 measured overlaps were foreign traces driven clean through a pair connector's barrel, and **every** offending via was on a `_P`/`_N` net. Connectors now go through `validate_and_commit`, the same gate the legs already used.

### 2. Same-net via merging (`router/legalize.rs`)

The surviving via of a merged cluster had its layer span widened to the union of the cluster's spans, and reconnect jogs were emitted — both with no legality check at all. The old justification for the jog ("it stays inside copper the via already claimed") says nothing about what else is on that layer, and the widened barrel claims inner layers nobody probed.

Both are now probed against the board as it will actually be committed. A vetoed survivor falls through to the next member of the cluster; a cluster that cannot merge legally is left alone for the existing fail-closed demotion rather than merged into a short.

Two subtleties that mattered: the gate must ignore the speculative debris `prune_dangling` deletes moments later (1855 dead traces on the CM5 — judging against phantom obstacles refuses every merge), but must **not** ignore board copper, which is never pruned.

## How the second one was found

`VCAD_ROUTE_AUDIT=1` (new, env-gated, zero cost otherwise) re-probes every element a pass emits — placed routes plus plane stitching — against the session it lives in. It reported `0 illegal element(s) across 582 routes` while the emitted board still had 13 overlaps, which put the divergence unambiguously *after* the routing pass. `examples/overlap_report.rs` (also new) finds exact overlaps geometrically and cross-examines each against the oracle; it is how the 61-of-72 trace-vs-via split was measured.

## Measured — full CM5 route

`VCAD_GPU_BATCH=1 VCAD_GPU_NEGOTIATE=1 cm5_bench CM5RevEng.kicad_pcb 1 999999`

| | before | after |
|---|---|---|
| exact cross-net trace overlaps | 72 | **0** |
| Clearance | 173 | **23** (stripped-fixture floor: 23) |
| Short | 845 | 285 |
| HoleToHole | 17 | 1 |
| routability | 0.994 | 0.988 |
| coupled pairs | 47 | 46 |

Route-attributable clearance violations reach zero.

**On the routability number:** it does drop 0.6pp, and that is expected rather than incidental. The baseline's 0.994 counted connections whose copper physically overlapped other nets — 61 traces running through via barrels are shorts, not routes — and the newly-visible barrels legitimately consume routing space. `merged 0 vias` in the new logs is not the gate being over-strict: with connector vias now real and drill-probed, the duplicate vias that merging existed to clean up mostly never get created (HoleToHole 17 → 1).

## Tests

- `pair_connector_vias_are_visible_to_the_oracle` — every via a pair route reports must be one the session knows about (copper probe + drill census). Verified to fail on the old via handling and pass on the new.
- `merge_refused_when_the_reconnect_jog_would_short` — a merge whose jog would cross foreign copper is refused, and the cluster is then stripped fail-closed rather than returned.

`cargo test -p vcad-ecad-pcb --features gpu` — 294 passed.
`cargo clippy -p vcad-ecad-pcb --features gpu -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)