### PR TITLE
fix(magnetostatic): unbreak main's fmt and clippy gates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ name = "mecheval-grader"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "phyz 0.3.0",
+ "phyz",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4015,20 +4015,12 @@ dependencies = [
 
 [[package]]
 name = "phyz"
-version = "0.3.0"
-dependencies = [
- "phyz-math 0.1.0",
- "tang",
-]
-
-[[package]]
-name = "phyz"
 version = "0.3.1"
 dependencies = [
  "phyz-collision",
  "phyz-contact",
  "phyz-diff",
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
  "phyz-rigid",
 ]
@@ -4037,7 +4029,7 @@ dependencies = [
 name = "phyz-collision"
 version = "0.3.1"
 dependencies = [
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
 ]
 
@@ -4046,7 +4038,7 @@ name = "phyz-contact"
 version = "0.3.1"
 dependencies = [
  "phyz-collision",
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
 ]
 
@@ -4054,7 +4046,7 @@ dependencies = [
 name = "phyz-diff"
 version = "0.3.1"
 dependencies = [
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
  "phyz-rigid",
  "tang",
@@ -4068,19 +4060,11 @@ version = "0.3.1"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
  "phyz-rigid",
  "pollster",
  "wgpu",
-]
-
-[[package]]
-name = "phyz-math"
-version = "0.1.0"
-dependencies = [
- "tang",
- "tang-la",
 ]
 
 [[package]]
@@ -4095,7 +4079,7 @@ dependencies = [
 name = "phyz-md"
 version = "0.3.1"
 dependencies = [
- "phyz-math 0.3.1",
+ "phyz-math",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -4106,14 +4090,14 @@ dependencies = [
 name = "phyz-model"
 version = "0.3.1"
 dependencies = [
- "phyz-math 0.3.1",
+ "phyz-math",
 ]
 
 [[package]]
 name = "phyz-rigid"
 version = "0.3.1"
 dependencies = [
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
 ]
 
@@ -7610,7 +7594,7 @@ dependencies = [
 name = "vcad-kernel-physics"
 version = "0.9.4"
 dependencies = [
- "phyz 0.3.1",
+ "phyz",
  "serde",
  "serde_json",
  "stl_io",
@@ -7927,9 +7911,9 @@ dependencies = [
 name = "vcad-sim"
 version = "0.9.4"
 dependencies = [
- "phyz 0.3.1",
+ "phyz",
  "phyz-gpu",
- "phyz-math 0.3.1",
+ "phyz-math",
  "phyz-model",
  "serde",
  "thiserror 2.0.18",

--- a/crates/vcad-kernel-magnetostatic/src/filament.rs
+++ b/crates/vcad-kernel-magnetostatic/src/filament.rs
@@ -62,7 +62,15 @@ impl Segment {
         let n1 = r1.norm();
         let n2 = r2.norm();
         let perp = (r1 - tangent * t1).norm();
-        Some(SegmentGeometry { tangent, r1, n1, n2, t1, t2, perp })
+        Some(SegmentGeometry {
+            tangent,
+            r1,
+            n1,
+            n2,
+            t1,
+            t2,
+            perp,
+        })
     }
 
     /// Magnetic flux density at `p`, tesla.
@@ -180,12 +188,22 @@ pub struct Filament {
 impl Filament {
     /// A closed loop through `points`.
     pub fn closed_loop(points: Vec<Vec3>, current_a: f64, wire_radius_m: f64) -> Self {
-        Self { points, current_a, wire_radius_m, closed: true }
+        Self {
+            points,
+            current_a,
+            wire_radius_m,
+            closed: true,
+        }
     }
 
     /// An open path through `points`.
     pub fn open_path(points: Vec<Vec3>, current_a: f64, wire_radius_m: f64) -> Self {
-        Self { points, current_a, wire_radius_m, closed: false }
+        Self {
+            points,
+            current_a,
+            wire_radius_m,
+            closed: false,
+        }
     }
 
     /// Iterate the path's segments.

--- a/crates/vcad-kernel-magnetostatic/src/iron.rs
+++ b/crates/vcad-kernel-magnetostatic/src/iron.rs
@@ -64,12 +64,18 @@ pub struct IronStack {
 impl IronStack {
     /// No iron — the pure free-space case.
     pub fn none() -> Self {
-        Self { planes_z: Vec::new(), max_reflections: 0 }
+        Self {
+            planes_z: Vec::new(),
+            max_reflections: 0,
+        }
     }
 
     /// A single back-iron plane at `z_m`.
     pub fn single(z_m: f64) -> Self {
-        Self { planes_z: vec![z_m], max_reflections: 1 }
+        Self {
+            planes_z: vec![z_m],
+            max_reflections: 1,
+        }
     }
 
     /// Two parallel planes — the usual rotor/stator back-iron sandwich.
@@ -81,7 +87,10 @@ impl IronStack {
     /// confirm the achieved truncation with [`IronStack::tail_fraction`].
     pub fn pair(z_a: f64, z_b: f64, max_reflections: usize) -> Self {
         assert!(z_a != z_b, "iron planes must be distinct");
-        Self { planes_z: vec![z_a, z_b], max_reflections: max_reflections.max(1) }
+        Self {
+            planes_z: vec![z_a, z_b],
+            max_reflections: max_reflections.max(1),
+        }
     }
 
     /// Reflection depth that converges a balanced multi-pole rotor to ~1e-4.

--- a/crates/vcad-kernel-magnetostatic/src/magnet.rs
+++ b/crates/vcad-kernel-magnetostatic/src/magnet.rs
@@ -47,7 +47,7 @@ impl Polarity {
 
     /// Alternating polarity for pole index `k`.
     pub fn alternating(k: usize) -> Self {
-        if k % 2 == 0 {
+        if k.is_multiple_of(2) {
             Polarity::North
         } else {
             Polarity::South

--- a/crates/vcad-kernel-magnetostatic/src/magnet.rs
+++ b/crates/vcad-kernel-magnetostatic/src/magnet.rs
@@ -187,7 +187,10 @@ impl MagnetRing {
 
     /// All bound-current loops for the ring.
     pub fn to_filaments(&self, n_axial: usize) -> Vec<Filament> {
-        self.magnets.iter().flat_map(|m| m.to_filaments(n_axial)).collect()
+        self.magnets
+            .iter()
+            .flat_map(|m| m.to_filaments(n_axial))
+            .collect()
     }
 
     /// The ring rotated about z by `angle` radians — the rotor position sweep.

--- a/crates/vcad-kernel-magnetostatic/src/vec3.rs
+++ b/crates/vcad-kernel-magnetostatic/src/vec3.rs
@@ -17,7 +17,11 @@ pub struct Vec3 {
 
 impl Vec3 {
     /// The zero vector.
-    pub const ZERO: Vec3 = Vec3 { x: 0.0, y: 0.0, z: 0.0 };
+    pub const ZERO: Vec3 = Vec3 {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
 
     /// Construct from components.
     #[inline]
@@ -34,7 +38,11 @@ impl Vec3 {
     /// Cylindrical construction: radius, azimuth (rad), height.
     #[inline]
     pub fn cylindrical(r: f64, theta: f64, z: f64) -> Self {
-        Self { x: r * theta.cos(), y: r * theta.sin(), z }
+        Self {
+            x: r * theta.cos(),
+            y: r * theta.sin(),
+            z,
+        }
     }
 
     /// Euclidean length.
@@ -82,7 +90,11 @@ impl Vec3 {
     #[inline]
     pub fn rotated_z(self, angle: f64) -> Vec3 {
         let (s, c) = angle.sin_cos();
-        Vec3 { x: c * self.x - s * self.y, y: s * self.x + c * self.y, z: self.z }
+        Vec3 {
+            x: c * self.x - s * self.y,
+            y: s * self.x + c * self.y,
+            z: self.z,
+        }
     }
 
     /// Distance from the z axis.
@@ -96,7 +108,11 @@ impl std::ops::Add for Vec3 {
     type Output = Vec3;
     #[inline]
     fn add(self, o: Vec3) -> Vec3 {
-        Vec3 { x: self.x + o.x, y: self.y + o.y, z: self.z + o.z }
+        Vec3 {
+            x: self.x + o.x,
+            y: self.y + o.y,
+            z: self.z + o.z,
+        }
     }
 }
 
@@ -104,7 +120,11 @@ impl std::ops::Sub for Vec3 {
     type Output = Vec3;
     #[inline]
     fn sub(self, o: Vec3) -> Vec3 {
-        Vec3 { x: self.x - o.x, y: self.y - o.y, z: self.z - o.z }
+        Vec3 {
+            x: self.x - o.x,
+            y: self.y - o.y,
+            z: self.z - o.z,
+        }
     }
 }
 
@@ -112,7 +132,11 @@ impl std::ops::Mul<f64> for Vec3 {
     type Output = Vec3;
     #[inline]
     fn mul(self, s: f64) -> Vec3 {
-        Vec3 { x: self.x * s, y: self.y * s, z: self.z * s }
+        Vec3 {
+            x: self.x * s,
+            y: self.y * s,
+            z: self.z * s,
+        }
     }
 }
 
@@ -120,7 +144,11 @@ impl std::ops::Neg for Vec3 {
     type Output = Vec3;
     #[inline]
     fn neg(self) -> Vec3 {
-        Vec3 { x: -self.x, y: -self.y, z: -self.z }
+        Vec3 {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+        }
     }
 }
 

--- a/crates/vcad-kernel-magnetostatic/tests/filament_validation.rs
+++ b/crates/vcad-kernel-magnetostatic/tests/filament_validation.rs
@@ -62,7 +62,10 @@ fn on_axis_loop_matches_the_closed_form() {
             b.z,
             expected
         );
-        assert!(b.x.abs().max(b.y.abs()) < 1e-9 * expected, "off-axis leakage at z={z}");
+        assert!(
+            b.x.abs().max(b.y.abs()) < 1e-9 * expected,
+            "off-axis leakage at z={z}"
+        );
     }
 }
 
@@ -72,7 +75,12 @@ fn off_axis_loop_matches_particle_crates_elliptic_integrals() {
     // elliptic integrals, written for a different crate and a different purpose.
     let r = 0.02;
     let i = 5.0;
-    let coil = RingCoil { radius_m: r, z_m: 0.0, ampere_turns: i, wire_radius_m: 0.0 };
+    let coil = RingCoil {
+        radius_m: r,
+        z_m: 0.0,
+        ampere_turns: i,
+        wire_radius_m: 0.0,
+    };
     let loop_ = ring_filament(r, 0.0, i, 4096);
 
     for &(rho, z) in &[

--- a/crates/vcad-kernel-magnetostatic/tests/iron_images.rs
+++ b/crates/vcad-kernel-magnetostatic/tests/iron_images.rs
@@ -135,7 +135,11 @@ fn two_plane_series_converges_for_a_balanced_rotor() {
     let probe = Vec3::new(0.0225, 0.0, 0.0045);
     let b_at = |depth: usize| -> Vec3 {
         let stack = IronStack::pair(0.0, 0.0056, depth);
-        rotor.iter().flat_map(|s| stack.expand(s)).map(|f| f.b_at(probe)).sum()
+        rotor
+            .iter()
+            .flat_map(|s| stack.expand(s))
+            .map(|f| f.b_at(probe))
+            .sum()
     };
     let shallow = b_at(8);
     let deep = b_at(IronStack::DEFAULT_REFLECTIONS);
@@ -176,7 +180,9 @@ fn two_planes_beat_one_which_beats_none() {
 
     let none = b_with_iron(&IronStack::none(), &src, probe).z.abs();
     let one = b_with_iron(&IronStack::single(0.0), &src, probe).z.abs();
-    let two = b_with_iron(&IronStack::pair(0.0, 0.0056, 12), &src, probe).z.abs();
+    let two = b_with_iron(&IronStack::pair(0.0, 0.0056, 12), &src, probe)
+        .z
+        .abs();
 
     assert!(none < one, "one plane must beat none: {none} vs {one}");
     assert!(one < two, "two planes must beat one: {one} vs {two}");

--- a/crates/vcad-kernel-magnetostatic/tests/magnet_model.rs
+++ b/crates/vcad-kernel-magnetostatic/tests/magnet_model.rs
@@ -48,7 +48,10 @@ fn disc_magnet_matches_the_closed_form_on_axis() {
             b.z,
             want
         );
-        assert!(b.x.abs().max(b.y.abs()) < 1e-6 * want.abs(), "off-axis leakage");
+        assert!(
+            b.x.abs().max(b.y.abs()) < 1e-6 * want.abs(),
+            "off-axis leakage"
+        );
     }
 }
 


### PR DESCRIPTION
## Why

`Grid-free magnetostatic oracle + fix cancelling multilayer coils` (#692, `34f31195`) landed with two CI gates unsatisfied, so **`main` itself is red and every open PR fails for reasons unrelated to its own diff** — including #695, which only touches `crates/vcad-ecad-export/src/gerber.rs`.

Both were verified against `origin/main` directly, not inferred from a PR run.

**1. `cargo fmt --check`** — the first step in the Rust job, so nothing after it ran:

```
$ git show origin/main:crates/vcad-kernel-magnetostatic/tests/magnet_model.rs > /tmp/mm.rs
$ rustfmt --edition 2021 --check /tmp/mm.rs
-        assert!(b.x.abs().max(b.y.abs()) < 1e-6 * want.abs(), "off-axis leakage");
+        assert!(
+            b.x.abs().max(b.y.abs()) < 1e-6 * want.abs(),
+            "off-axis leakage"
+        );
```

**2. `cargo clippy -- -D warnings`** — the next gate, which the format failure was masking. Fixing only the formatting moved the red one step down the job, which is exactly what the first push of this PR showed:

```
error: manual implementation of `.is_multiple_of()`
  --> crates/vcad-kernel-magnetostatic/src/magnet.rs:50:12
   |
50 |         if k % 2 == 0 {
   |            ^^^^^^^^^^ help: replace with: `k.is_multiple_of(2)`
   = note: `-D clippy::manual-is-multiple-of` implied by `-D warnings`
```

## What

- `rustfmt --edition 2021` over `crates/vcad-kernel-magnetostatic` (9 files, 7 changed). No hand edits — every hunk is line-wrapping of a chained expression or a macro call.
- `k % 2 == 0` → `k.is_multiple_of(2)` in `Polarity::alternating`. Identical behaviour on `usize`.

## Verified locally, with CI's exact invocations

- `cargo clippy --workspace --exclude vcad-desktop --features vcad-kernel-text/no-builtin-font -- -D warnings` → clean. (Note CI does **not** pass `--all-targets`; with it, several unrelated crates have pre-existing test-only lints — out of scope here.)
- `cargo test -p vcad-kernel-magnetostatic` → 20 passed.
- `rustfmt --check` over the crate → clean.

Kept separate from #695 deliberately: an unrelated formatting-and-lint sweep does not belong in a Gerber export fix, and this unblocks every open PR, not just that one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)