### PR TITLE
Honor blind/buried via layer spans in Gerber, Excellon and KiCad export

### DIFF
--- a/changelog/entries/2026-07-25-via-layer-spans-in-fab-export.json
+++ b/changelog/entries/2026-07-25-via-layer-spans-in-fab-export.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-via-layer-spans-in-fab-export",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "Fab export honors blind and buried via spans",
+  "summary": "Gerber, Excellon and KiCad exports flashed and drilled every via on every copper layer, shorting any board with blind or buried vias.",
+  "features": ["pcb", "fabrication", "gerber", "excellon", "kicad"],
+  "mcpTools": ["export_gerber", "export_kicad", "fab_prep", "validate_for_fab"]
+}

--- a/crates/vcad-ecad-export/src/excellon.rs
+++ b/crates/vcad-ecad-export/src/excellon.rs
@@ -20,6 +20,86 @@ pub enum ExcellonError {
     NoDrills,
 }
 
+/// A via layer span, normalized so the shallower (more front-ward) copper
+/// layer comes first. `(FCu, BCu)` is a through-hole.
+pub type DrillSpan = (PcbLayer, PcbLayer);
+
+/// The through-hole span: front copper to back copper.
+pub const THROUGH_SPAN: DrillSpan = (PcbLayer::FCu, PcbLayer::BCu);
+
+/// Order a via's endpoints outer-first so spans compare and name consistently.
+fn normalize_span(start: PcbLayer, end: PcbLayer) -> DrillSpan {
+    let a = start.copper_position().unwrap_or(0);
+    let b = end.copper_position().unwrap_or(u8::MAX);
+    if a <= b {
+        (start, end)
+    } else {
+        (end, start)
+    }
+}
+
+/// Excellon filename for a drill span, following the KiCad convention:
+/// `drill.drl` for through-holes, `drill-In1_Cu-In2_Cu.drl` for a buried span.
+fn span_filename(span: DrillSpan) -> String {
+    if span == THROUGH_SPAN {
+        return "drill.drl".into();
+    }
+    format!("drill-{}-{}.drl", layer_token(span.0), layer_token(span.1))
+}
+
+fn layer_token(layer: PcbLayer) -> &'static str {
+    match layer {
+        PcbLayer::FCu => "F_Cu",
+        PcbLayer::BCu => "B_Cu",
+        PcbLayer::In1Cu => "In1_Cu",
+        PcbLayer::In2Cu => "In2_Cu",
+        PcbLayer::In3Cu => "In3_Cu",
+        PcbLayer::In4Cu => "In4_Cu",
+        PcbLayer::In5Cu => "In5_Cu",
+        PcbLayer::In6Cu => "In6_Cu",
+        PcbLayer::In7Cu => "In7_Cu",
+        PcbLayer::In8Cu => "In8_Cu",
+        _ => "Unknown",
+    }
+}
+
+/// Every drill span present on the board, through-hole first, then blind and
+/// buried spans in stack order. The through span is always included — pad
+/// drills live there, and consumers expect a `drill.drl` to exist.
+fn spans(pcb: &Pcb) -> Vec<DrillSpan> {
+    let mut set: std::collections::BTreeSet<(u8, u8)> = Default::default();
+    for via in &pcb.vias {
+        let (a, b) = normalize_span(via.start_layer, via.end_layer);
+        set.insert((
+            a.copper_position().unwrap_or(0),
+            b.copper_position().unwrap_or(u8::MAX),
+        ));
+    }
+    set.remove(&(0, u8::MAX));
+
+    // Through-hole first, then blind/buried spans in stack order. The through
+    // file is always emitted, even on an all-SMD board: consumers expect a
+    // `drill.drl` to exist, and an empty one is an honest answer.
+    std::iter::once(THROUGH_SPAN)
+        .chain(set.into_iter().map(|(a, b)| (layer_at(a), layer_at(b))))
+        .collect()
+}
+
+fn layer_at(position: u8) -> PcbLayer {
+    match position {
+        0 => PcbLayer::FCu,
+        1 => PcbLayer::In1Cu,
+        2 => PcbLayer::In2Cu,
+        3 => PcbLayer::In3Cu,
+        4 => PcbLayer::In4Cu,
+        5 => PcbLayer::In5Cu,
+        6 => PcbLayer::In6Cu,
+        7 => PcbLayer::In7Cu,
+        8 => PcbLayer::In8Cu,
+        _ => PcbLayer::BCu,
+    }
+}
+
 /// A single drill hit (hole location).
 #[derive(Debug, Clone)]
 struct DrillHit {
@@ -32,11 +112,15 @@ struct DrillHit {
 /// Returns a `BTreeMap` so tools are ordered by ascending diameter. The key is
 /// the diameter in mm rounded to 4 decimal places (encoded as an integer in
 /// units of 0.0001 mm for exact comparison).
-fn collect_holes(pcb: &Pcb) -> BTreeMap<i64, Vec<DrillHit>> {
+fn collect_holes(pcb: &Pcb, span: DrillSpan) -> BTreeMap<i64, Vec<DrillHit>> {
     let mut holes: BTreeMap<i64, Vec<DrillHit>> = BTreeMap::new();
 
-    // Holes from footprint pads.
+    // Holes from footprint pads. Pad drills are always through-holes, so they
+    // only belong in the through-hole file.
     for fp in &pcb.footprints {
+        if span != THROUGH_SPAN {
+            break;
+        }
         let cos_r = fp.rotation.to_radians().cos();
         let sin_r = fp.rotation.to_radians().sin();
 
@@ -52,8 +136,15 @@ fn collect_holes(pcb: &Pcb) -> BTreeMap<i64, Vec<DrillHit>> {
         }
     }
 
-    // Holes from vias.
+    // Holes from vias that belong to this span. A blind or buried via is
+    // drilled in a separate operation from the through-holes (and from other
+    // spans), which is how a fab prices and sequences the job — merging them
+    // into one file silently asks for a through-hole where the board needs a
+    // blind one.
     for via in &pcb.vias {
+        if normalize_span(via.start_layer, via.end_layer) != span {
+            continue;
+        }
         let key = (via.drill * 10_000.0).round() as i64;
         holes.entry(key).or_default().push(DrillHit {
             x: via.position.x,
@@ -69,12 +160,46 @@ fn collect_holes(pcb: &Pcb) -> BTreeMap<i64, Vec<DrillHit>> {
 /// Writes the complete Excellon file (header with tool definitions, drill hit
 /// coordinates, and footer) to `writer`. Coordinates are in metric (mm) with
 /// 4 decimal places.
+/// Writes the **through-hole** drill file (pad drills plus full-stack vias).
+/// Blind and buried vias live in their own per-span files — use
+/// [`generate_drill_files`] to get the complete set.
 pub fn write_excellon<W: Write>(writer: &mut W, pcb: &Pcb) -> Result<(), ExcellonError> {
-    let holes = collect_holes(pcb);
+    write_excellon_span(writer, pcb, THROUGH_SPAN)
+}
+
+/// Generate every Excellon drill file the board needs, as
+/// `(filename, content)` pairs — one per distinct via span, plus the
+/// through-hole file. Spans are emitted through-hole first.
+pub fn generate_drill_files(pcb: &Pcb) -> Result<Vec<(String, String)>, ExcellonError> {
+    let mut out = Vec::new();
+    for span in spans(pcb) {
+        let mut buf = Vec::new();
+        write_excellon_span(&mut buf, pcb, span)?;
+        out.push((
+            span_filename(span),
+            String::from_utf8_lossy(&buf).into_owned(),
+        ));
+    }
+    Ok(out)
+}
+
+/// Generate the Excellon file for one drill span.
+pub fn write_excellon_span<W: Write>(
+    writer: &mut W,
+    pcb: &Pcb,
+    span: DrillSpan,
+) -> Result<(), ExcellonError> {
+    let holes = collect_holes(pcb, span);
 
     // Header.
     writeln!(writer, "M48")?;
     writeln!(writer, ";Generated by vcad-ecad-export")?;
+    writeln!(
+        writer,
+        ";TYPE=PLATED ;SPAN={},{}",
+        layer_token(span.0),
+        layer_token(span.1)
+    )?;
     writeln!(writer, ";FORMAT={{-:-/ absolute / metric / decimal}}")?;
     writeln!(writer, "FMAT,2")?;
     writeln!(writer, "METRIC,TZ")?;
@@ -291,7 +416,7 @@ mod tests {
     #[test]
     fn excellon_groups_holes_by_diameter() {
         let pcb = test_pcb();
-        let holes = collect_holes(&pcb);
+        let holes = collect_holes(&pcb, THROUGH_SPAN);
 
         // Two distinct diameters: 0.3 mm (via) and 1.0 mm (THT).
         assert_eq!(holes.len(), 2);
@@ -301,5 +426,99 @@ mod tests {
 
         assert_eq!(holes[&key_03].len(), 1, "expected 1 via hole");
         assert_eq!(holes[&key_10].len(), 3, "expected 3 THT pad holes");
+    }
+
+    /// A board with one through via and two blind/buried vias on distinct
+    /// spans. Drills for different spans are separate fab operations, priced
+    /// and sequenced separately — collapsing them into one file asks for a
+    /// through-hole where the board needs a blind one.
+    fn mixed_span_pcb() -> Pcb {
+        let mut pcb = test_pcb();
+        pcb.vias.push(Via {
+            position: Vec2::new(31.0, 21.0),
+            diameter: 0.4,
+            drill: 0.2,
+            // Deliberately reversed: normalization must order it In1→In2.
+            start_layer: PcbLayer::In2Cu,
+            end_layer: PcbLayer::In1Cu,
+            net: "1".into(),
+            source: None,
+        });
+        pcb.vias.push(Via {
+            position: Vec2::new(32.0, 22.0),
+            diameter: 0.4,
+            drill: 0.2,
+            start_layer: PcbLayer::FCu,
+            end_layer: PcbLayer::In1Cu,
+            net: "1".into(),
+            source: None,
+        });
+        pcb
+    }
+
+    #[test]
+    fn drill_files_are_split_by_span() {
+        let files = generate_drill_files(&mixed_span_pcb()).unwrap();
+        let names: Vec<&str> = files.iter().map(|(n, _)| n.as_str()).collect();
+
+        assert_eq!(
+            names,
+            vec![
+                "drill.drl",
+                "drill-F_Cu-In1_Cu.drl",
+                "drill-In1_Cu-In2_Cu.drl",
+            ],
+            "expected one drill file per span, through-hole first"
+        );
+
+        let by_name = |want: &str| -> &str { &files.iter().find(|(n, _)| n == want).unwrap().1 };
+
+        // Each span's hole belongs to exactly one file.
+        let through = by_name("drill.drl");
+        assert!(through.contains("X30.0000Y20.0000"), "through via missing");
+        assert!(
+            !through.contains("X31.0000Y21.0000") && !through.contains("X32.0000Y22.0000"),
+            "buried/blind via drilled as a through-hole"
+        );
+
+        let buried = by_name("drill-In1_Cu-In2_Cu.drl");
+        assert!(buried.contains("X31.0000Y21.0000"), "buried via missing");
+        assert!(
+            !buried.contains("X30.0000Y20.0000") && !buried.contains("X32.0000Y22.0000"),
+            "buried span file carries holes from another span"
+        );
+
+        let blind = by_name("drill-F_Cu-In1_Cu.drl");
+        assert!(blind.contains("X32.0000Y22.0000"), "blind via missing");
+        assert!(
+            !blind.contains("X30.0000Y20.0000") && !blind.contains("X31.0000Y21.0000"),
+            "blind span file carries holes from another span"
+        );
+
+        // Pad drills are through-holes and belong only in the through file.
+        assert!(through.contains("X10.0000Y20.0000"), "THT pad missing");
+        assert!(
+            !buried.contains("X10.0000Y20.0000") && !blind.contains("X10.0000Y20.0000"),
+            "pad drill duplicated into a blind/buried span file"
+        );
+
+        // Every file is a well-formed Excellon program.
+        for (name, content) in &files {
+            assert!(content.starts_with("M48\n"), "{name}: missing M48 header");
+            assert!(content.contains("M30\n"), "{name}: missing M30 footer");
+        }
+    }
+
+    /// `write_excellon` keeps its through-hole-only contract, so callers that
+    /// only want the through file don't silently pick up blind vias.
+    #[test]
+    fn write_excellon_emits_only_through_holes() {
+        let mut buf = Vec::new();
+        write_excellon(&mut buf, &mixed_span_pcb()).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        assert!(output.contains("X30.0000Y20.0000"));
+        assert!(!output.contains("X31.0000Y21.0000"));
+        assert!(!output.contains("X32.0000Y22.0000"));
     }
 }

--- a/crates/vcad-ecad-export/src/gerber.rs
+++ b/crates/vcad-ecad-export/src/gerber.rs
@@ -522,9 +522,14 @@ pub fn write_gerber_layer<W: Write>(
         }
     }
 
-    // 2) Via pads on copper layers.
+    // 2) Via pads — only on the copper layers the via actually spans. A blind
+    //    or buried via flashed outside its span is copper the board does not
+    //    have, and shorts whatever runs under it.
     if layer.is_copper() {
         for via in &pcb.vias {
+            if !layer.spanned_by(via.start_layer, via.end_layer) {
+                continue;
+            }
             let dcode = apertures.register(ApertureShape::Circle {
                 diameter: via.diameter,
             });
@@ -1525,6 +1530,87 @@ mod tests {
                 "{name}: missing format spec"
             );
             assert!(content.contains("M02*"), "{name}: missing end-of-file");
+        }
+    }
+
+    /// A board whose only via is buried between two inner layers, placed
+    /// somewhere no pad or trace reaches so its flash is unmistakable.
+    fn buried_via_pcb() -> Pcb {
+        let mut pcb = test_pcb();
+        pcb.footprints.clear();
+        pcb.zones.clear();
+        pcb.traces.clear();
+        pcb.vias = vec![Via {
+            position: Vec2::new(30.0, 20.0),
+            diameter: 0.8,
+            drill: 0.3,
+            start_layer: PcbLayer::In2Cu,
+            end_layer: PcbLayer::In1Cu,
+            net: "1".into(),
+            source: None,
+        }];
+        pcb
+    }
+
+    /// A blind or buried via must not put copper on layers outside its span.
+    ///
+    /// Flashing every via on every copper layer is a dead short: on the CM5
+    /// fixture a via spanning In2.Cu–In1.Cu landed on In4.Cu 0.006mm from a
+    /// track on a different net.
+    #[test]
+    fn buried_via_flashes_only_within_its_span() {
+        let pcb = buried_via_pcb();
+        let via_x = mm_to_coord(30.0);
+        let via_y = mm_to_coord(20.0);
+        let expected = format!("X{via_x}Y{via_y}D03*");
+
+        for layer in [PcbLayer::In1Cu, PcbLayer::In2Cu] {
+            let mut buf = Vec::new();
+            write_gerber_layer(&mut buf, &pcb, layer).unwrap();
+            let output = String::from_utf8(buf).unwrap();
+            assert!(
+                output.contains(&expected),
+                "{layer:?} is inside the via's span but has no via flash"
+            );
+        }
+
+        for layer in [
+            PcbLayer::FCu,
+            PcbLayer::BCu,
+            PcbLayer::In3Cu,
+            PcbLayer::In4Cu,
+        ] {
+            let mut buf = Vec::new();
+            write_gerber_layer(&mut buf, &pcb, layer).unwrap();
+            let output = String::from_utf8(buf).unwrap();
+            assert!(
+                !output.contains(&expected),
+                "{layer:?} is outside the In2.Cu–In1.Cu span but carries the via's pad"
+            );
+        }
+    }
+
+    /// A genuine through-hole via still reaches every copper layer.
+    #[test]
+    fn through_via_flashes_on_all_copper_layers() {
+        let mut pcb = buried_via_pcb();
+        pcb.vias[0].start_layer = PcbLayer::FCu;
+        pcb.vias[0].end_layer = PcbLayer::BCu;
+        let expected = format!("X{}Y{}D03*", mm_to_coord(30.0), mm_to_coord(20.0));
+
+        for layer in [
+            PcbLayer::FCu,
+            PcbLayer::In1Cu,
+            PcbLayer::In4Cu,
+            PcbLayer::BCu,
+        ] {
+            let mut buf = Vec::new();
+            write_gerber_layer(&mut buf, &pcb, layer).unwrap();
+            let output = String::from_utf8(buf).unwrap();
+            assert!(
+                output.contains(&expected),
+                "{layer:?} is inside a through via's span but has no via flash"
+            );
         }
     }
 }

--- a/crates/vcad-ecad-export/src/lib.rs
+++ b/crates/vcad-ecad-export/src/lib.rs
@@ -14,6 +14,6 @@ pub mod gerber;
 pub mod pick_place;
 
 pub use bom::write_bom;
-pub use excellon::{write_excellon, ExcellonError};
+pub use excellon::{generate_drill_files, write_excellon, ExcellonError};
 pub use gerber::{generate_gerbers, write_gerber_layer, GerberError};
 pub use pick_place::write_pick_place;

--- a/crates/vcad-ecad-fabprep/src/package.rs
+++ b/crates/vcad-ecad-fabprep/src/package.rs
@@ -127,14 +127,17 @@ pub fn write_fab_package(
         written.push(write(dir, name, content)?);
     }
 
-    let mut drill = Vec::new();
-    vcad_ecad_export::excellon::write_excellon(&mut drill, pcb).map_err(|e| {
+    // One drill file per via span — blind and buried vias are drilled
+    // separately from the through-holes.
+    let drills = vcad_ecad_export::excellon::generate_drill_files(pcb).map_err(|e| {
         PackageError::Serialize {
-            what: "drill.drl".into(),
+            what: "drill files".into(),
             message: e.to_string(),
         }
     })?;
-    written.push(write(dir, "drill.drl", &drill)?);
+    for (name, content) in &drills {
+        written.push(write(dir, name, content.as_bytes())?);
+    }
 
     written.push(write(
         dir,
@@ -211,6 +214,52 @@ mod tests {
         assert!(
             written.iter().any(|w| w.ends_with(".gbr")),
             "no gerbers written: {written:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Blind and buried vias are drilled in separate operations from the
+    /// through-holes, so the package carries one drill file per span. Merged
+    /// into a single `drill.drl`, a blind via is fabricated as a through-hole
+    /// and shorts every layer it crosses.
+    #[test]
+    fn blind_and_buried_vias_get_their_own_drill_files() {
+        let mut pcb = test_board();
+        with_smd_pad(&mut pcb, "R1", "1", 2.0, 2.0, "A");
+        with_smd_pad(&mut pcb, "R1", "2", 8.0, 2.0, "A");
+        with_trace(&mut pcb, "A", 2.0, 2.0, 8.0, 2.0);
+        pcb.vias.push(vcad_ir::ecad::Via {
+            position: vcad_ir::Vec2::new(5.0, 2.0),
+            diameter: 0.4,
+            drill: 0.2,
+            start_layer: vcad_ir::ecad::PcbLayer::FCu,
+            end_layer: vcad_ir::ecad::PcbLayer::In1Cu,
+            net: "A".into(),
+            source: None,
+        });
+        let outcome = run_fab_prep(
+            &mut pcb,
+            &FabPrepOptions {
+                route_remaining: false,
+                prune_dangling: false,
+                ..Default::default()
+            },
+        );
+
+        let dir = tmpdir("spans");
+        let written = write_fab_package(&dir, &pcb, &outcome, None).expect("package");
+        assert!(
+            written.iter().any(|w| w == "drill.drl"),
+            "through-hole drill file missing: {written:?}"
+        );
+        assert!(
+            written.iter().any(|w| w == "drill-F_Cu-In1_Cu.drl"),
+            "blind via span has no drill file of its own: {written:?}"
+        );
+        let through = std::fs::read_to_string(dir.join("drill.drl")).unwrap();
+        assert!(
+            !through.contains("X5.0000Y2.0000"),
+            "blind via drilled as a through-hole:\n{through}"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/vcad-ecad-pcb/examples/board_export.rs
+++ b/crates/vcad-ecad-pcb/examples/board_export.rs
@@ -30,9 +30,11 @@ fn main() {
     }
     println!("gerbers: {} files", gerbers.len());
 
-    let mut drill = Vec::new();
-    vcad_ecad_export::excellon::write_excellon(&mut drill, &pcb).expect("excellon");
-    fs::write(out.join("drill.drl"), &drill).expect("write drill");
+    let drills = vcad_ecad_export::excellon::generate_drill_files(&pcb).expect("excellon");
+    for (name, content) in &drills {
+        fs::write(out.join(name), content).expect("write drill");
+    }
+    println!("drill files: {} spans", drills.len());
 
     fs::write(
         out.join("board.kicad_pcb"),

--- a/crates/vcad-ecad-symbols/src/kicad_write.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_write.rs
@@ -740,7 +740,26 @@ fn write_arc(e: &mut Emitter, a: &TraceArc, nets: &NetTable) {
 
 fn write_via(e: &mut Emitter, v: &Via, nets: &NetTable) {
     let uuid = e.uuid();
-    e.line(1, "(via");
+    // KiCad reads a via's span as (outer, inner) in stack order; handed the
+    // pair reversed it falls back to a through-hole, which shorts every layer
+    // the via was never meant to touch.
+    let (top, bottom) = if v.start_layer.copper_position().unwrap_or(0)
+        <= v.end_layer.copper_position().unwrap_or(u8::MAX)
+    {
+        (v.start_layer, v.end_layer)
+    } else {
+        (v.end_layer, v.start_layer)
+    };
+    // The type token comes immediately after `via`; without it KiCad treats
+    // any via as through-hole regardless of its layer pair. KiCad's only
+    // non-through tokens are `blind` (its BLIND_BURIED type, covering both
+    // blind and buried) and `micro` — `buried` is not a token and makes the
+    // board fail to load outright.
+    if top == PcbLayer::FCu && bottom == PcbLayer::BCu {
+        e.line(1, "(via");
+    } else {
+        e.line(1, "(via blind");
+    }
     e.line(
         2,
         &format!("(at {} {})", num(v.position.x), num(v.position.y)),
@@ -749,11 +768,7 @@ fn write_via(e: &mut Emitter, v: &Via, nets: &NetTable) {
     e.line(2, &format!("(drill {})", num(v.drill)));
     e.line(
         2,
-        &format!(
-            "(layers {} {})",
-            q(layer_name(v.start_layer)),
-            q(layer_name(v.end_layer))
-        ),
+        &format!("(layers {} {})", q(layer_name(top)), q(layer_name(bottom))),
     );
     e.line(2, &format!("(net {})", nets.id(&v.net)));
     e.line(2, &format!("(uuid {})", q(&uuid)));
@@ -3997,5 +4012,56 @@ mod tests {
             !text.contains("endpoint_off_grid"),
             "four-edge symbol put a connection point off the KiCad grid:\n{text}"
         );
+    }
+
+    /// A blind or buried via must keep its span through the KiCad writer.
+    ///
+    /// Written as a bare `(via ... (layers "F.Cu" "B.Cu"))` — or with the
+    /// endpoints handed over reversed — KiCad reads it as a through-hole, and
+    /// the via shorts every layer it was never meant to touch.
+    #[test]
+    fn buried_via_keeps_its_span_and_type() {
+        let mut pcb = sample_pcb();
+        pcb.vias[0].start_layer = PcbLayer::In2Cu;
+        pcb.vias[0].end_layer = PcbLayer::In1Cu;
+
+        let text = write_kicad_pcb(&pcb);
+        assert!(
+            text.contains("(via blind"),
+            "buried via not typed — KiCad will drill it through:\n{text}"
+        );
+        assert!(
+            text.contains("(layers \"In1.Cu\" \"In2.Cu\")"),
+            "via span not written outer-first:\n{text}"
+        );
+        assert!(
+            !text.contains("(layers \"F.Cu\" \"B.Cu\")"),
+            "buried via written as a full-stack span:\n{text}"
+        );
+
+        let reparsed = crate::kicad_pcb::parse_kicad_pcb(&text).expect("re-parse");
+        assert_eq!(reparsed.vias.len(), 1);
+        assert_eq!(reparsed.vias[0].start_layer, PcbLayer::In1Cu);
+        assert_eq!(reparsed.vias[0].end_layer, PcbLayer::In2Cu);
+    }
+
+    /// A via that touches an outer layer but not both is blind, not buried.
+    #[test]
+    fn blind_via_is_typed_blind() {
+        let mut pcb = sample_pcb();
+        pcb.vias[0].start_layer = PcbLayer::In1Cu;
+        pcb.vias[0].end_layer = PcbLayer::FCu;
+
+        let text = write_kicad_pcb(&pcb);
+        assert!(text.contains("(via blind"), "blind via not typed:\n{text}");
+        assert!(text.contains("(layers \"F.Cu\" \"In1.Cu\")"));
+    }
+
+    /// A genuine through via stays untyped and full-stack.
+    #[test]
+    fn through_via_stays_untyped() {
+        let text = write_kicad_pcb(&sample_pcb());
+        assert!(!text.contains("(via blind"));
+        assert!(text.contains("(layers \"F.Cu\" \"B.Cu\")"));
     }
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -6466,13 +6466,11 @@ mod ecad_wasm {
                 .iter()
                 .any(|fp| fp.pads.iter().any(|p| p.drill.is_some()));
         if has_holes {
-            let mut buf = Vec::new();
-            vcad_ecad_export::write_excellon(&mut buf, &pcb)
-                .map_err(|e| JsError::new(&e.to_string()))?;
-            files.push(FabFile {
-                name: "drill.drl".into(),
-                content: String::from_utf8_lossy(&buf).into_owned(),
-            });
+            for (name, content) in vcad_ecad_export::excellon::generate_drill_files(&pcb)
+                .map_err(|e| JsError::new(&e.to_string()))?
+            {
+                files.push(FabFile { name, content });
+            }
         }
 
         let mut buf = Vec::new();


### PR DESCRIPTION
## What

The three fabrication writers all discarded a via's `startLayer`/`endLayer`:

- **Gerber** (`write_gerber_layer`) flashed every via on every copper layer.
- **Excellon** emitted all holes as through-holes.
- **KiCad** wrote every via as `F.Cu - B.Cu`.

On any board with blind or buried vias that is a dead short — copper lands on layers the board does not have it on, over whatever else runs there. This is fab-fatal and affects every package this exporter has produced.

## Why our DRC didn't catch it

The defect is purely in export. `PcbLayer::spanned_by` already existed in `vcad_ir::ecad`, and DRC (`vcad-ecad-pcb/src/spatial.rs`) was already using it — so DRC correctly reported the routed board clean while the artifacts it shipped were shorted. KiCad's DRC on those artifacts flagged ~200 shorts.

## Changes

**Gerber** — via flashes gated on `layer.spanned_by(via.start_layer, via.end_layer)`.

**Excellon** — new `generate_drill_files(pcb) -> Vec<(name, content)>`, one file per distinct span (`drill.drl`, `drill-F_Cu-In1_Cu.drl`, …), each with a `;SPAN=` header. Spans are normalized outer-first, so a reversed IR pair (In2→In1) files identically to In1→In2. Pad drills stay in the through file only, which is always emitted even on an all-SMD board. `write_excellon` keeps its signature but is now explicitly through-hole-only; the three callers (fab-prep package, kernel-wasm `ecadExportFab`, the `board_export` example) emit the full set.

**KiCad** — two defects, not one: the span was written in IR order, and non-through vias carried no type token.

> ⚠️ Reviewer note: KiCad's only non-through token is `blind` (its `BLIND_BURIED` type covers both blind and buried). Emitting `buried` makes the board **fail to load outright** — I hit that and backed it out.

## Verification

Measured on the CM5 fixture (`board.pcb.json`, 363 vias, 303 of them blind/buried):

- The reported `/MIPI0.D0_N` via (In2.Cu→In1.Cu) now appears on In1.Cu and In2.Cu only — absent from In4.Cu, where `/PCIe.RX_P` ran 0.006mm away.
- 26 drill files; hit count conserved exactly (367 = 363 vias + 4 pad drills), nothing duplicated or dropped.
- KiCad's own DRC on the exported board: `shorting_items` **199 → 113**, and now *below* KiCad's 199-per-type reporting cap, so that's an exact number rather than a truncated one. The remaining 113 are pad↔track / pad↔pad on the source fixture (e.g. U4's unnetted pads); only 9 involve a via at all.

**One thing worth flagging:** `via_dangling` went 65 → 89 and `track_dangling` 102 → 104. That's the export now telling the truth — previously every via touched copper on every layer, so KiCad could never see a via that connects to nothing on the layers it actually spans. Pre-existing routing artifacts on the fixture that the broken export was masking, not new damage.

## Tests

- `buried_via_flashes_only_within_its_span`, `through_via_flashes_on_all_copper_layers` (gerber)
- `drill_files_are_split_by_span`, `write_excellon_emits_only_through_holes` (excellon, including the reversed-endpoint case)
- `buried_via_keeps_its_span_and_type`, `blind_via_is_typed_blind`, `through_via_stays_untyped` (kicad, with a write→re-parse round trip)
- `blind_and_buried_vias_get_their_own_drill_files` (fab-prep package layer)

`cargo test` clean on all four crates that touch this (`ecad-export`, `ecad-symbols`, `ecad-fabprep`, `ecad-pcb`); `kernel-wasm` compiles. `cargo fmt` + `clippy -D warnings` clean.

I did not run the full workspace suite — it exceeded a 10-minute budget. The four dependents of `vcad-ecad-export` are the complete blast radius per Cargo.toml, and all were tested. No TS change needed: `ecad.ts` passes `FabFile[]` through generically with no hardcoded filename. No wasm artifacts committed, per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
