### PR TITLE
fab-prep: probe and commit the whole via barrel, drill included

### DIFF
--- a/changelog/entries/2026-07-25-fabprep-via-commit-parity.json
+++ b/changelog/entries/2026-07-25-fabprep-via-commit-parity.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-fabprep-via-commit-parity",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "fab-prep no longer commits vias its oracle never saw",
+  "summary": "The fab-prep router committed via barrels unprobed and unindexed, landing inner-layer shorts and hole-to-hole violations; every barrel is now probed and committed on all layers it spans, drill included.",
+  "features": ["pcb", "routing", "drc", "fab"],
+  "mcpTools": ["fab_prep", "run_drc"]
+}

--- a/crates/vcad-ecad-fabprep/src/lib.rs
+++ b/crates/vcad-ecad-fabprep/src/lib.rs
@@ -628,8 +628,12 @@ mod tests {
             &FabPrepOptions {
                 route_remaining: false,
                 prune_dangling: false,
-                // One round is enough to prove the loop tried and stopped.
-                max_rounds: 1,
+                // No rounds: with nothing allowed to strip the crossing pair,
+                // the short survives and must be named. (Given a round, the
+                // loop strips both nets and the fail-closed commit gate
+                // refuses to re-route them into the same 0.3mm-drill
+                // congestion — an honest unroutable, tested separately.)
+                max_rounds: 0,
                 ..Default::default()
             },
         )

--- a/crates/vcad-ecad-fabprep/src/render.rs
+++ b/crates/vcad-ecad-fabprep/src/render.rs
@@ -445,7 +445,10 @@ mod tests {
             &FabPrepOptions {
                 route_remaining: false,
                 prune_dangling: false,
-                max_rounds: 1,
+                // No rounds: the strip-and-re-route loop must not be given a
+                // chance to replace the short with an honest unroutable, so
+                // the geometric offender is what the report has to name.
+                max_rounds: 0,
                 ..Default::default()
             },
         )

--- a/crates/vcad-ecad-fabprep/src/verdict.rs
+++ b/crates/vcad-ecad-fabprep/src/verdict.rs
@@ -10,10 +10,13 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use vcad_ecad_pcb::ratsnest::{compute_ratsnest, NetConnection, Netlist, NetlistNet};
-use vcad_ecad_pcb::router::complete::{route_window_complete, CompleteOutcome};
+use vcad_ecad_pcb::router::classes::via_geom_for;
+use vcad_ecad_pcb::router::complete::{
+    path_vias, route_window_complete_pinned, CompleteOutcome, ViaClass, WindowBudget,
+};
 use vcad_ecad_pcb::session::RouteSession;
 use vcad_ecad_pcb::spatial::{CopperElement, CopperGeom};
-use vcad_ir::ecad::{Pcb, Trace, Via};
+use vcad_ir::ecad::{Pcb, PcbLayer, Trace, Via};
 use vcad_ir::Vec2;
 
 /// Search knobs for one pass of the ladder.
@@ -174,13 +177,30 @@ pub fn route_remaining(pcb: &mut Pcb, opts: VerdictOptions) -> VerdictSummary {
             .iter()
             .map(|(n, _, _)| net_width.get(n).copied().unwrap_or(width))
             .fold(width, f64::max);
-        match route_window_complete(
+        // Hand the router the via geometry the commit below actually writes, so
+        // its grid pitch carries the hole-to-hole floor and its barrels are
+        // drill-probed in-search. Without it the search spaces vias by copper
+        // clearance alone and proposes paths the fail-closed commit has to
+        // throw away as unknowns.
+        let via_class = conns.iter().map(|(n, _, _)| via_geom_for(pcb, n)).fold(
+            (
+                pcb.rules.default_rules.via_diameter,
+                pcb.rules.default_rules.via_drill,
+            ),
+            |(ad, adr), (d, dr)| (ad.max(d), adr.max(dr)),
+        );
+        match route_window_complete_pinned(
             &session,
             (*lo, *hi),
             &layers,
             conns,
+            &[],
             cluster_width,
-            opts.budget,
+            Some(ViaClass {
+                pad_diameter: via_class.0,
+                drill: via_class.1,
+            }),
+            WindowBudget::new(opts.budget),
         ) {
             CompleteOutcome::Routed(paths) => {
                 // Probe-then-commit PER PATH, in order. Cluster paths are
@@ -198,7 +218,7 @@ pub fn route_remaining(pcb: &mut Pcb, opts: VerdictOptions) -> VerdictSummary {
                             half_w: w / 2.0,
                         };
                         session.probe(&g, l, net, session.clearance_for(net)).legal
-                    });
+                    }) && vias_legal(pcb, &session, net, path);
                     if !legal {
                         summary.unknown += 1;
                         continue;
@@ -224,6 +244,78 @@ pub fn route_remaining(pcb: &mut Pcb, opts: VerdictOptions) -> VerdictSummary {
         }
     }
     summary
+}
+
+/// The copper layers a barrel from `start` to `end` occupies, in stackup
+/// order — endpoints *and* every interior layer.
+///
+/// A barrel is a hole through all of them: probing or committing only the two
+/// endpoint layers leaves the interior invisible to the oracle, and a later
+/// path is then routed straight through the barrel on an inner layer (measured
+/// on the CM5: two 0.000mm shorts, both a FCu..In2Cu barrel against an In1Cu
+/// trace).
+fn spanned_layers(pcb: &Pcb, start: PcbLayer, end: PcbLayer) -> Vec<PcbLayer> {
+    let mut out: Vec<PcbLayer> = pcb
+        .stackup
+        .layers
+        .iter()
+        .map(|l| l.layer)
+        .filter(|l| l.is_copper() && l.spanned_by(start, end))
+        .collect();
+    for endpoint in [start, end] {
+        if !out.contains(&endpoint) {
+            out.push(endpoint);
+        }
+    }
+    out
+}
+
+/// Fail-closed via legality for a candidate path, against the session as it
+/// stands (clustermates already committed).
+///
+/// Two rules the segment probe structurally cannot answer, and which
+/// `commit_path` used to commit blind:
+///
+/// * the barrel's annulus must clear foreign copper on **every** layer it
+///   spans, not just its endpoints;
+/// * the *drill* must keep `hole_to_hole` from every other hole on the board —
+///   layer- and net-agnostic, so two vias whose copper never meets still
+///   collide in the drill file. The window router spaces vias inside ONE
+///   window by a drill-aware grid pitch; nothing spaced them against the vias
+///   of earlier windows, earlier rounds, or the arriving board (measured on the
+///   CM5: four hole-to-hole violations, every one of them copper-legal and
+///   drill-illegal — the 0.29..0.37mm window between the two rules).
+fn vias_legal(
+    pcb: &Pcb,
+    session: &RouteSession,
+    net: &str,
+    path: &[(Vec2, Vec2, PcbLayer)],
+) -> bool {
+    let (via_d, via_drill) = via_geom_for(pcb, net);
+    let clearance = session.clearance_for(net);
+    let vias = path_vias(path);
+    vias.iter().all(|&(p, l0, l1)| {
+        if !session.probe_via_drill(p, net).legal {
+            return false;
+        }
+        // The path's own barrels must clear each other too — the session
+        // cannot judge them until they are committed.
+        let self_clear = vias.iter().all(|&(q, _, _)| {
+            let (dx, dy) = (q.x - p.x, q.y - p.y);
+            dx.abs() + dy.abs() < 1e-9
+                || (dx * dx + dy * dy).sqrt() - via_drill >= pcb.rules.hole_to_hole - 1e-6
+        });
+        if !self_clear {
+            return false;
+        }
+        let disc = CopperGeom::Disc {
+            center: p,
+            r: via_d / 2.0,
+        };
+        spanned_layers(pcb, l0, l1)
+            .into_iter()
+            .all(|l| session.probe(&disc, l, net, clearance).legal)
+    })
 }
 
 /// Commit one accepted path to both the legality oracle and the board.
@@ -255,32 +347,34 @@ fn commit_path(
             source: None,
         });
     }
-    // A layer change between consecutive segments that share an endpoint is a
-    // via at that point.
-    for pair in path.windows(2) {
-        let (_, b0, l0) = pair[0];
-        let (a1, _, l1) = pair[1];
-        if l0 != l1 && (b0.x - a1.x).abs() < 1e-9 && (b0.y - a1.y).abs() < 1e-9 {
-            let r = pcb.rules.default_rules.via_diameter / 2.0;
-            for layer in [l0, l1] {
-                session.commit(CopperElement {
-                    min: [b0.x - r, b0.y - r],
-                    max: [b0.x + r, b0.y + r],
-                    net: net.to_string(),
-                    layer,
-                    geom: CopperGeom::Disc { center: b0, r },
-                });
-            }
-            pcb.vias.push(Via {
-                position: b0,
-                diameter: pcb.rules.default_rules.via_diameter,
-                drill: pcb.rules.default_rules.via_drill,
-                start_layer: l0,
-                end_layer: l1,
+    // Layer changes are barrels. `path_vias` merges a multi-step transition at
+    // one point into a single barrel — two stacked vias at the same position
+    // are a hole-to-hole violation against each other.
+    let (via_d, via_drill) = via_geom_for(pcb, net);
+    let r = via_d / 2.0;
+    for (p, l0, l1) in path_vias(path) {
+        // Copper on every spanned layer, and the drill in the hole index, so
+        // the next path sees the whole barrel — both the annulus it must clear
+        // and the hole it must keep `hole_to_hole` from.
+        for layer in spanned_layers(pcb, l0, l1) {
+            session.commit(CopperElement {
+                min: [p.x - r, p.y - r],
+                max: [p.x + r, p.y + r],
                 net: net.to_string(),
-                source: None,
+                layer,
+                geom: CopperGeom::Disc { center: p, r },
             });
         }
+        session.commit_drill(p, via_drill);
+        pcb.vias.push(Via {
+            position: p,
+            diameter: via_d,
+            drill: via_drill,
+            start_layer: l0,
+            end_layer: l1,
+            net: net.to_string(),
+            source: None,
+        });
     }
 }
 
@@ -379,5 +473,157 @@ mod tests {
         });
         let nets = nets_with_copper(&pcb);
         assert!(nets.contains("A") && nets.contains("B"));
+    }
+
+    /// A four-layer board, so a FCu..In2Cu barrel has an interior layer that a
+    /// two-endpoint model cannot see.
+    fn four_layer_board() -> Pcb {
+        let mut pcb = test_board();
+        pcb.stackup.layers = [
+            PcbLayer::FCu,
+            PcbLayer::In1Cu,
+            PcbLayer::In2Cu,
+            PcbLayer::BCu,
+        ]
+        .into_iter()
+        .map(|layer| vcad_ir::ecad::StackupLayer {
+            layer,
+            copper_thickness: Some(0.035),
+            dielectric_thickness: Some(0.2),
+            dielectric_er: Some(4.5),
+            material: Some("FR4".into()),
+        })
+        .collect();
+        pcb
+    }
+
+    /// A two-step path FCu -> In2Cu through (5,5): one barrel, spanning In1Cu.
+    fn transition_path() -> Vec<(Vec2, Vec2, PcbLayer)> {
+        vec![
+            (Vec2::new(3.0, 5.0), Vec2::new(5.0, 5.0), PcbLayer::FCu),
+            (Vec2::new(5.0, 5.0), Vec2::new(7.0, 5.0), PcbLayer::In2Cu),
+        ]
+    }
+
+    #[test]
+    fn barrel_spans_interior_layers() {
+        let pcb = four_layer_board();
+        assert_eq!(
+            spanned_layers(&pcb, PcbLayer::FCu, PcbLayer::In2Cu),
+            vec![PcbLayer::FCu, PcbLayer::In1Cu, PcbLayer::In2Cu],
+        );
+        // Order-insensitive: the router emits (start, end) in path order.
+        assert_eq!(
+            spanned_layers(&pcb, PcbLayer::In2Cu, PcbLayer::FCu),
+            vec![PcbLayer::FCu, PcbLayer::In1Cu, PcbLayer::In2Cu],
+        );
+    }
+
+    /// A barrel overlapping foreign copper on an INTERIOR layer of its span
+    /// must be refused. Committing only the endpoint layers is how two 0.000mm
+    /// shorts reached the CM5 fab package: FCu..In2Cu barrels with an In1Cu
+    /// trace driven through them.
+    #[test]
+    fn via_over_interior_layer_copper_is_refused() {
+        let mut pcb = four_layer_board();
+        let clear = RouteSession::from_pcb(&pcb);
+        assert!(vias_legal(&pcb, &clear, "A", &transition_path()));
+
+        pcb.traces.push(Trace {
+            start: Vec2::new(5.0, 4.0),
+            end: Vec2::new(5.0, 6.0),
+            width: 0.2,
+            layer: PcbLayer::In1Cu,
+            net: "VICTIM".into(),
+            source: None,
+        });
+        let session = RouteSession::from_pcb(&pcb);
+        assert!(
+            !vias_legal(&pcb, &session, "A", &transition_path()),
+            "a barrel straight through an interior-layer foreign trace must be illegal"
+        );
+    }
+
+    /// Hole-to-hole is a drill rule: two vias whose copper never shares a layer
+    /// still collide in the drill file. The copper probe cannot see it, so the
+    /// commit gate has to probe the drill index — the four CM5 hole-to-hole
+    /// violations were all copper-legal.
+    #[test]
+    fn via_too_close_to_an_existing_hole_is_refused() {
+        let mut pcb = four_layer_board();
+        // Copper-legal by a mile (disjoint layers: In3Cu is not even in the
+        // stackup used here), drill-illegal: centres 0.5mm, drills 0.3 → 0.2mm
+        // hole-to-hole against a 0.25mm rule.
+        pcb.vias.push(Via {
+            position: Vec2::new(5.5, 5.0),
+            diameter: 0.6,
+            drill: 0.3,
+            start_layer: PcbLayer::In2Cu,
+            end_layer: PcbLayer::BCu,
+            net: "OTHER".into(),
+            source: None,
+        });
+        let session = RouteSession::from_pcb(&pcb);
+        assert!(session
+            .probe(
+                &CopperGeom::Disc {
+                    center: Vec2::new(5.0, 5.0),
+                    r: 0.3,
+                },
+                PcbLayer::FCu,
+                "A",
+                0.2,
+            )
+            .legal);
+        assert!(
+            !vias_legal(&pcb, &session, "A", &transition_path()),
+            "a barrel 0.20mm hole-to-hole from an existing via must be illegal"
+        );
+    }
+
+    /// Two barrels of ONE path have to clear each other, which the session
+    /// cannot judge until they are committed.
+    #[test]
+    fn two_barrels_of_one_path_must_clear_each_other() {
+        let pcb = four_layer_board();
+        let session = RouteSession::from_pcb(&pcb);
+        let path = vec![
+            (Vec2::new(3.0, 5.0), Vec2::new(5.0, 5.0), PcbLayer::FCu),
+            (Vec2::new(5.0, 5.0), Vec2::new(5.4, 5.0), PcbLayer::In2Cu),
+            (Vec2::new(5.4, 5.0), Vec2::new(7.0, 5.0), PcbLayer::FCu),
+        ];
+        assert!(
+            !vias_legal(&pcb, &session, "A", &path),
+            "two barrels 0.10mm hole-to-hole apart must be illegal"
+        );
+    }
+
+    /// The commit indexes the whole barrel — every spanned layer's copper AND
+    /// the drill — so the next path sees it.
+    #[test]
+    fn commit_indexes_barrel_copper_and_drill() {
+        let mut pcb = four_layer_board();
+        let mut session = RouteSession::from_pcb(&pcb);
+        commit_path(&mut pcb, &mut session, "A", 0.2, &transition_path());
+        assert_eq!(pcb.vias.len(), 1);
+        assert_eq!(pcb.vias[0].position, Vec2::new(5.0, 5.0));
+        // Interior layer now blocked for a foreign net...
+        assert!(!session
+            .probe(
+                &CopperGeom::Segment {
+                    a: Vec2::new(5.0, 4.0),
+                    b: Vec2::new(5.0, 6.0),
+                    half_w: 0.1,
+                },
+                PcbLayer::In1Cu,
+                "VICTIM",
+                0.2,
+            )
+            .legal);
+        // ...and the drill is in the hole index.
+        assert!(!session.probe_drill(Vec2::new(5.5, 5.0), 0.3).legal);
+        // A second path through the same spot is now refused rather than
+        // stacking a coincident drill.
+        assert!(!vias_legal(&pcb, &session, "B", &transition_path()));
     }
 }

--- a/crates/vcad-ecad-fabprep/src/verdict.rs
+++ b/crates/vcad-ecad-fabprep/src/verdict.rs
@@ -564,17 +564,19 @@ mod tests {
             source: None,
         });
         let session = RouteSession::from_pcb(&pcb);
-        assert!(session
-            .probe(
-                &CopperGeom::Disc {
-                    center: Vec2::new(5.0, 5.0),
-                    r: 0.3,
-                },
-                PcbLayer::FCu,
-                "A",
-                0.2,
-            )
-            .legal);
+        assert!(
+            session
+                .probe(
+                    &CopperGeom::Disc {
+                        center: Vec2::new(5.0, 5.0),
+                        r: 0.3,
+                    },
+                    PcbLayer::FCu,
+                    "A",
+                    0.2,
+                )
+                .legal
+        );
         assert!(
             !vias_legal(&pcb, &session, "A", &transition_path()),
             "a barrel 0.20mm hole-to-hole from an existing via must be illegal"
@@ -608,18 +610,20 @@ mod tests {
         assert_eq!(pcb.vias.len(), 1);
         assert_eq!(pcb.vias[0].position, Vec2::new(5.0, 5.0));
         // Interior layer now blocked for a foreign net...
-        assert!(!session
-            .probe(
-                &CopperGeom::Segment {
-                    a: Vec2::new(5.0, 4.0),
-                    b: Vec2::new(5.0, 6.0),
-                    half_w: 0.1,
-                },
-                PcbLayer::In1Cu,
-                "VICTIM",
-                0.2,
-            )
-            .legal);
+        assert!(
+            !session
+                .probe(
+                    &CopperGeom::Segment {
+                        a: Vec2::new(5.0, 4.0),
+                        b: Vec2::new(5.0, 6.0),
+                        half_w: 0.1,
+                    },
+                    PcbLayer::In1Cu,
+                    "VICTIM",
+                    0.2,
+                )
+                .legal
+        );
         // ...and the drill is in the hole index.
         assert!(!session.probe_drill(Vec2::new(5.5, 5.0), 0.3).legal);
         // A second path through the same spot is now refused rather than

--- a/crates/vcad-ecad-pcb/src/router/classes.rs
+++ b/crates/vcad-ecad-pcb/src/router/classes.rs
@@ -162,6 +162,28 @@ pub fn apply_classes(pcb: &mut Pcb, classifier: &NetClassifier) {
         .insert(DIFF_PAIR_CLASS.to_string(), members);
 }
 
+/// The `(pad_diameter, drill)` geometry a via on `net` gets from its net
+/// class, falling back to the board defaults.
+///
+/// One source of truth for every site that *writes* a via: the session's
+/// [`crate::session::RouteSession::via_drill_for`] sizes the drill it probes
+/// from the same class table, so a caller that probes with one and commits
+/// with the other would enforce hole-to-hole against a hole of the wrong size.
+pub fn via_geom_for(pcb: &Pcb, net: &str) -> (f64, f64) {
+    let rules = &pcb.rules;
+    for (class, nets) in &rules.net_class_assignments {
+        if nets.iter().any(|n| n == net) {
+            if let Some(c) = rules.class_rules.iter().find(|c| c.name == *class) {
+                return (c.via_diameter, c.via_drill);
+            }
+        }
+    }
+    (
+        rules.default_rules.via_diameter,
+        rules.default_rules.via_drill,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/vcad-ecad-pcb/src/router/legalize.rs
+++ b/crates/vcad-ecad-pcb/src/router/legalize.rs
@@ -214,22 +214,7 @@ fn pos_key(p: Vec2) -> (u64, u64) {
     )
 }
 
-/// Via pad/drill geometry for `net` from its net class, defaulting to the
-/// board's default rules (mirrors how the committed via is sized).
-fn via_geom_for(pcb: &Pcb, net: &str) -> (f64, f64) {
-    let rules = &pcb.rules;
-    for (class, nets) in &rules.net_class_assignments {
-        if nets.iter().any(|n| n == net) {
-            if let Some(c) = rules.class_rules.iter().find(|c| c.name == *class) {
-                return (c.via_diameter, c.via_drill);
-            }
-        }
-    }
-    (
-        rules.default_rules.via_diameter,
-        rules.default_rules.via_drill,
-    )
-}
+use super::classes::via_geom_for;
 
 fn d2(a: Vec2, b: Vec2) -> f64 {
     let (dx, dy) = (a.x - b.x, a.y - b.y);


### PR DESCRIPTION
The CM5 fab package failed closed with exactly 8 route-attributable violations. Both families come from one place: `vcad-ecad-fabprep`'s window-router committer, the only via emitter on the board whose barrels the legality oracle never saw. KiCad's independent DRC confirms all of them at the same coordinates (0 on the stripped baseline).

## What was wrong

**Barrel over a foreign trace — 2 defects, each raising a Short and a Clearance.** [`commit_path`](crates/vcad-ecad-fabprep/src/verdict.rs) committed the via annulus on the two *endpoint* layers only, and the probe-then-commit gate above it probed segments and never a via at all. So a barrel was committed blind, and its interior layers stayed invisible to the next path in the same round. Both defects are `FCu..In2Cu` barrels with the victim trace on `In1Cu` — the single interior layer, at 0.000mm.

**Via-to-via hole-to-hole — 4 defects.** The committer never called `commit_drill`, the gate never called `probe_via_drill`, and fab-prep called `route_window_complete` rather than `_pinned`, so `via: None` left the search's `drill_floor` at zero and `barrel_ok` a no-op. Hole-to-hole was enforced nowhere on this path. All four sit in the window *between* the two rules — centre spacing 0.29–0.36mm, i.e. copper-legal (≥ 0.21 + 0.08) and drill-illegal (< 0.12 + 0.25). Three of the four are two single-ended nets, so this is not specific to the pair router; `/PCIe.RX_P`/`_N` are twins only incidentally (different windows).

The router proper is clean here — every `route_all` commit goes through `validate_and_commit`, which does probe `span_slice` and `probe_via_drill`. `examples/cm5_verdict.rs`, which `verdict.rs`'s module docs claim it was lifted out of "so they don't drift", also already does all of this. It drifted.

## What changed

- `vias_legal`: drill probe, annulus on every spanned layer, and the path's own barrels against each other (the session cannot judge those until they are committed). Folded into the per-path gate, so a path with an illegal barrel downgrades itself to an honest unknown rather than being committed.
- `commit_path`: discs on **every** spanned layer, `commit_drill`, `path_vias` so a multi-step transition is one barrel instead of two stacked drills, and net-class via geometry instead of `default_rules`.
- The real `ViaClass` is handed to the search, so its grid pitch carries the hole-to-hole floor instead of proposing paths the gate must discard.
- `via_geom_for` promoted to `router::classes` as one source of truth (was private in `legalize`).

## Reviewer notes

- **Two fixture tests move to `max_rounds: 0`.** They set `route_remaining: false`, but that option gates only the *opening* verdict pass — the fix loop re-routes regardless. With the gate in place the loop now strips the crossing pair and honestly declines to re-route it into the same 0.3mm-drill congestion, which moves the blocker from geometry to connectivity. Giving the loop nothing to strip keeps the geometric offender under test, which is what those two assert.
- **This can make the connectivity number worse before it makes it better.** A path that used to commit illegally now stays unrouted, and the loop's objective is geometric only — a stripped net it cannot replace still scores as clean (the CM5 run reports 293 → 365 unconnected on arrival vs completion). Fail-closed is the right behaviour, but if convergence now blocks on connectivity rather than on the 8, the next lever is routability — terminal-layer pinning, which fab-prep also dropped versus `cm5_verdict` — not the gate.
- 5 new regression tests pin both bypasses (interior-layer span, drill vs existing hole, intra-path barrels, and that the commit indexes both). `cargo test -p vcad-ecad-fabprep` 36/36, `-p vcad-ecad-pcb` 297/297, clippy and fmt clean.
- **Full-board CM5 verification is still running** (a fresh `cm5_bench` for the arriving board, plus `fab-prep` over the packaged one). The mechanism above is established by code and by the measured geometry of all 6 offending vias; the before/after violation counts are not in yet, so this should not land on the strength of the CM5 numbers until they are posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)