### PR TITLE
fix(physics): stop the joint axis-alignment rotation leaking into child body frames

### DIFF
--- a/changelog/entries/2026-07-25-physics-joint-axis-frame-leak.json
+++ b/changelog/entries/2026-07-25-physics-joint-axis-frame-leak.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-physics-joint-axis-frame-leak",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "Fix compounding pose error on non-Z joint axes",
+  "summary": "Serial chains with X/Y revolute axes reported wrong link poses at zero angle; the axis-alignment rotation leaked into each child body frame and compounded with depth.",
+  "features": ["physics", "assembly", "simulation"],
+  "mcpTools": ["create_robot_env", "gym_reset", "gym_observe", "gym_step"]
+}

--- a/crates/vcad-kernel-physics/src/joints.rs
+++ b/crates/vcad-kernel-physics/src/joints.rs
@@ -65,27 +65,47 @@ impl MotorTarget {
 
 /// Create a phyz joint from a vcad joint definition.
 ///
-/// Returns the phyz Joint and the parent-to-joint spatial transform.
-pub(crate) fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, PhysicsError> {
-    // Convert parent anchor from mm to meters — this becomes the translation
-    // in the parent-to-joint transform.
-    let anchor = Vec3::new(
+/// `parent_frame` is the parent body's part→body map `(R_p, t_p)` with
+/// `p_body = R_p * p_part_m + t_p` (see [`PhysicsWorld::body_part_frames`]).
+/// It is **required**: phyz's `parent_to_joint` maps the *parent body* frame
+/// to the joint frame, and a jointed parent's body frame is itself rotated by
+/// its own axis-alignment rotation. Ignoring it leaks one axis-alignment
+/// rotation into every link past the first and compounds down the chain —
+/// invisible at depth 1 (ground is unrotated), fatal for any serial arm or
+/// leg with non-Z joint axes.
+///
+/// [`PhysicsWorld::body_part_frames`]: crate::world::PhysicsWorld
+pub(crate) fn vcad_joint_to_phyz(
+    joint: &VcadJoint,
+    parent_frame: (&Mat3, &Vec3),
+) -> Result<PhyzJoint, PhysicsError> {
+    let (r_parent, t_parent) = parent_frame;
+
+    // Joint origin: parent_anchor is in the parent *part*'s mm coordinates;
+    // phyz wants it in the parent *body* frame, in meters.
+    let anchor_part_m = Vec3::new(
         joint.parent_anchor.x / 1000.0,
         joint.parent_anchor.y / 1000.0,
         joint.parent_anchor.z / 1000.0,
     );
+    let anchor = r_parent.mul_vec(anchor_part_m) + *t_parent;
+
+    // Plücker parent→joint coordinate map. The joint frame's axes expressed
+    // in the parent *part* frame are the columns of `joint_frame_rotation`;
+    // in the parent *body* frame they are `R_p * R_j`. The coordinate map is
+    // the transpose of that.
+    let rot = r_parent
+        .mul_mat(&joint_frame_rotation(&joint.kind))
+        .transpose();
 
     match &joint.kind {
         JointKind::Fixed => {
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
+            let xform = SpatialTransform::new(rot, anchor);
             Ok(PhyzJoint::fixed(xform))
         }
         JointKind::Revolute { limits, .. } => {
-            // phyz revolute joints rotate about Z in joint frame.
-            // We need to orient the joint frame so that Z aligns with the desired axis.
-            // Plücker parent→joint coordinate map: E = Rᵀ where R carries
-            // the joint frame axes (Z = motion axis) in parent coordinates.
-            let rot = joint_frame_rotation(&joint.kind).transpose();
+            // phyz revolute joints rotate about Z in the joint frame, so
+            // `joint_frame_rotation` orients that frame's Z onto the axis.
             let xform = SpatialTransform::new(rot, anchor);
 
             let mut phyz_joint = PhyzJoint::revolute(xform);
@@ -97,8 +117,10 @@ pub(crate) fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, Physics
             Ok(phyz_joint)
         }
         JointKind::Slider { axis, limits } => {
+            // The slider's joint frame is part-aligned (identity
+            // `joint_frame_rotation`), so the axis needs no re-expression.
             let axis_vec = Vec3::new(axis.x, axis.y, axis.z).normalize();
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
+            let xform = SpatialTransform::new(rot, anchor);
 
             let mut phyz_joint = PhyzJoint::prismatic(xform, axis_vec);
 
@@ -111,12 +133,11 @@ pub(crate) fn vcad_joint_to_phyz(joint: &VcadJoint) -> Result<PhyzJoint, Physics
         }
         JointKind::Cylindrical { .. } => {
             // Approximate as revolute (primary DOF)
-            let rot = joint_frame_rotation(&joint.kind).transpose();
             let xform = SpatialTransform::new(rot, anchor);
             Ok(PhyzJoint::revolute(xform))
         }
         JointKind::Ball => {
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
+            let xform = SpatialTransform::new(rot, anchor);
             Ok(PhyzJoint::spherical(xform))
         }
     }
@@ -217,7 +238,7 @@ mod tests {
             state: 0.0,
         };
 
-        let phyz_joint = vcad_joint_to_phyz(&joint).unwrap();
+        let phyz_joint = vcad_joint_to_phyz(&joint, (&Mat3::identity(), &Vec3::zero())).unwrap();
 
         // Check that joint was created and has correct limits
         assert!(phyz_joint.limits.is_some());

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -279,8 +279,12 @@ impl PhysicsWorld {
                 body_part_frames.push((r_part_to_body, r_part_to_body.mul_vec(-anchor_m)));
                 let inertia = build_inertia(&mesh, mass, authored);
 
-                // Create phyz joint
-                let phyz_joint = vcad_joint_to_phyz(joint)?;
+                // Create phyz joint. `parent_to_joint` is measured from the
+                // parent *body* frame, which for a jointed parent is itself
+                // rotated by that joint's axis alignment — pass it in so the
+                // rotation does not accumulate down the chain.
+                let (r_parent, t_parent) = body_part_frames[parent_body_idx];
+                let phyz_joint = vcad_joint_to_phyz(joint, (&r_parent, &t_parent))?;
 
                 builder =
                     builder.add_body(&child_inst.id, parent_body_idx as i32, phyz_joint, inertia);
@@ -1216,5 +1220,259 @@ mod tests {
             "expected nonzero gravity torque at q=60° about Y axis, got {}",
             t
         );
+    }
+
+    /// Build the three-link hanging chain from the depth-compounding repro:
+    /// ground at world z=500, then three identical 20x20x100 segments each
+    /// hanging -Z from its own origin, joined tip-to-tip by revolute joints
+    /// about `axis`. At zero joint angle every link must sit exactly 100 mm
+    /// below the previous one with an identity orientation, for *any* axis.
+    fn hanging_chain(axis: VcadVec3) -> Document {
+        let mut doc = Document::new();
+
+        // seg geometry: 20x20x100 box translated so it hangs down -Z.
+        doc.nodes.insert(
+            1,
+            vcad_ir::Node {
+                id: 1,
+                name: None,
+                op: vcad_ir::CsgOp::Cube {
+                    size: VcadVec3::new(20.0, 20.0, 100.0),
+                },
+            },
+        );
+        doc.nodes.insert(
+            2,
+            vcad_ir::Node {
+                id: 2,
+                name: None,
+                op: vcad_ir::CsgOp::Translate {
+                    child: 1,
+                    offset: VcadVec3::new(-10.0, -10.0, -100.0),
+                },
+            },
+        );
+        // base geometry: a small block for the ground instance.
+        doc.nodes.insert(
+            3,
+            vcad_ir::Node {
+                id: 3,
+                name: None,
+                op: vcad_ir::CsgOp::Cube {
+                    size: VcadVec3::new(40.0, 40.0, 20.0),
+                },
+            },
+        );
+
+        let mut part_defs = HashMap::new();
+        part_defs.insert(
+            "seg".to_string(),
+            PartDef {
+                id: "seg".to_string(),
+                name: None,
+                root: 2,
+                default_material: None,
+                inertial: None,
+            },
+        );
+        part_defs.insert(
+            "base".to_string(),
+            PartDef {
+                id: "base".to_string(),
+                name: None,
+                root: 3,
+                default_material: None,
+                inertial: None,
+            },
+        );
+        doc.part_defs = Some(part_defs);
+
+        let inst = |id: &str, part: &str, z: f64| Instance {
+            id: id.to_string(),
+            part_def_id: part.to_string(),
+            name: None,
+            tags: Vec::new(),
+            transform: Some(vcad_ir::Transform3D {
+                translation: VcadVec3::new(0.0, 0.0, z),
+                ..Default::default()
+            }),
+            material: None,
+        };
+        doc.instances = Some(vec![
+            inst("i-base", "base", 500.0),
+            inst("i-1", "seg", 500.0),
+            inst("i-2", "seg", 400.0),
+            inst("i-3", "seg", 300.0),
+        ]);
+
+        let joint = |id: &str, parent: &str, child: &str, pz: f64| Joint {
+            id: id.to_string(),
+            name: None,
+            parent_instance_id: Some(parent.to_string()),
+            child_instance_id: child.to_string(),
+            parent_anchor: VcadVec3::new(0.0, 0.0, pz),
+            child_anchor: VcadVec3::new(0.0, 0.0, 0.0),
+            kind: JointKind::Revolute {
+                axis,
+                limits: Some((-90.0, 90.0)),
+            },
+            state: 0.0,
+        };
+        doc.joints = Some(vec![
+            joint("j1", "i-base", "i-1", 0.0),
+            joint("j2", "i-1", "i-2", -100.0),
+            joint("j3", "i-2", "i-3", -100.0),
+        ]);
+        doc.ground_instance_id = Some("i-base".to_string());
+
+        doc
+    }
+
+    /// Poses of the chain at zero joint angle must be axis-independent:
+    /// links at z = 0.5, 0.4, 0.3 m, all with identity orientation. The
+    /// axis-alignment rotation used to point phyz's Z-only revolute at an
+    /// arbitrary axis must not leak into the child body's world frame — it
+    /// used to, invisibly at depth 1 and compounding at every depth beyond.
+    fn assert_chain_poses(axis: VcadVec3) {
+        let doc = hanging_chain(axis);
+        let world = PhysicsWorld::from_document(&doc).unwrap();
+
+        for (inst, expect_z) in [("i-1", 0.5), ("i-2", 0.4), ("i-3", 0.3)] {
+            let (pos, quat) = world.get_instance_pose(inst).unwrap();
+            assert!(
+                (pos[0]).abs() < 1e-9 && (pos[1]).abs() < 1e-9 && (pos[2] - expect_z).abs() < 1e-9,
+                "axis {:?}: {} at {:?}, expected [0, 0, {}]",
+                (axis.x, axis.y, axis.z),
+                inst,
+                pos,
+                expect_z
+            );
+            // Identity quaternion, up to sign.
+            assert!(
+                (quat[0].abs() - 1.0).abs() < 1e-9
+                    && quat[1].abs() < 1e-9
+                    && quat[2].abs() < 1e-9
+                    && quat[3].abs() < 1e-9,
+                "axis {:?}: {} orientation {:?}, expected identity",
+                (axis.x, axis.y, axis.z),
+                inst,
+                quat
+            );
+        }
+    }
+
+    #[test]
+    fn test_chain_zero_pose_z_axis() {
+        assert_chain_poses(VcadVec3::new(0.0, 0.0, 1.0));
+    }
+
+    #[test]
+    fn test_chain_zero_pose_y_axis() {
+        assert_chain_poses(VcadVec3::new(0.0, 1.0, 0.0));
+    }
+
+    #[test]
+    fn test_chain_zero_pose_x_axis() {
+        assert_chain_poses(VcadVec3::new(1.0, 0.0, 0.0));
+    }
+
+    /// Mixed-axis chain, the humanoid-leg shape: yaw/roll/pitch alternating.
+    /// Same invariant — the chain hangs straight down at zero angle.
+    #[test]
+    fn test_chain_zero_pose_mixed_axes() {
+        let mut doc = hanging_chain(VcadVec3::new(0.0, 0.0, 1.0));
+        let axes = [
+            VcadVec3::new(0.0, 0.0, 1.0),
+            VcadVec3::new(0.0, 1.0, 0.0),
+            VcadVec3::new(1.0, 0.0, 0.0),
+        ];
+        for (joint, axis) in doc.joints.as_mut().unwrap().iter_mut().zip(axes) {
+            joint.kind = JointKind::Revolute {
+                axis,
+                limits: Some((-90.0, 90.0)),
+            };
+        }
+        let world = PhysicsWorld::from_document(&doc).unwrap();
+        for (inst, expect_z) in [("i-1", 0.5), ("i-2", 0.4), ("i-3", 0.3)] {
+            let (pos, quat) = world.get_instance_pose(inst).unwrap();
+            assert!(
+                pos[0].abs() < 1e-9 && pos[1].abs() < 1e-9 && (pos[2] - expect_z).abs() < 1e-9,
+                "mixed axes: {} at {:?}, expected [0, 0, {}]",
+                inst,
+                pos,
+                expect_z
+            );
+            assert!(
+                (quat[0].abs() - 1.0).abs() < 1e-9,
+                "mixed axes: {} orientation {:?}, expected identity",
+                inst,
+                quat
+            );
+        }
+    }
+
+    /// Physics FK must agree with the CAD-side assembly evaluator at every
+    /// joint configuration, not just zero — the shared-oracle check. The CAD
+    /// evaluator is the reference: it was correct while the physics
+    /// conversion was not.
+    #[test]
+    fn test_physics_fk_matches_cad_fk_mixed_axes() {
+        let mut doc = hanging_chain(VcadVec3::new(0.0, 1.0, 0.0));
+        let axes = [
+            VcadVec3::new(1.0, 0.0, 0.0),
+            VcadVec3::new(0.0, 1.0, 0.0),
+            VcadVec3::new(0.0, 0.0, 1.0),
+        ];
+        let angles = [17.0, -35.0, 48.0];
+        for ((joint, axis), state) in doc
+            .joints
+            .as_mut()
+            .unwrap()
+            .iter_mut()
+            .zip(axes)
+            .zip(angles)
+        {
+            joint.kind = JointKind::Revolute {
+                axis,
+                limits: Some((-90.0, 90.0)),
+            };
+            joint.state = state;
+        }
+
+        let mut world = PhysicsWorld::from_document(&doc).unwrap();
+        let poses = world.forward_kinematics_at(&angles).unwrap();
+
+        // CAD-side reference: walk the chain by hand with the same
+        // convention the assembly evaluator uses — each joint places its
+        // child at parent_anchor, rotated by `state` about `axis`.
+        let mut ref_rot = Mat3::identity();
+        let mut ref_pos = Vec3::new(0.0, 0.0, 0.5);
+        for (i, joint) in doc.joints.as_ref().unwrap().iter().enumerate() {
+            let JointKind::Revolute { axis, .. } = joint.kind else {
+                unreachable!()
+            };
+            let anchor = Vec3::new(
+                joint.parent_anchor.x / 1000.0,
+                joint.parent_anchor.y / 1000.0,
+                joint.parent_anchor.z / 1000.0,
+            );
+            ref_pos += ref_rot.mul_vec(anchor);
+            let a = Vec3::new(axis.x, axis.y, axis.z).normalize();
+            ref_rot = ref_rot.mul_mat(&phyz::math::Mat3::rotation_axis(a, angles[i].to_radians()));
+
+            let inst = format!("i-{}", i + 1);
+            let (pos, _) = poses[&inst];
+            for k in 0..3 {
+                let expect = [ref_pos.x, ref_pos.y, ref_pos.z][k];
+                assert!(
+                    (pos[k] - expect).abs() < 1e-9,
+                    "{} component {}: physics {} vs CAD {}",
+                    inst,
+                    k,
+                    pos[k],
+                    expect
+                );
+            }
+        }
     }
 }

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -141,6 +141,12 @@ impl BatchSimPipeline {
             .dt(1.0 / 240.0);
 
         let mut instance_to_body: HashMap<String, usize> = HashMap::new();
+        // Per-body part→body rotation `R_b` (`p_body = R_b * p_part`). phyz
+        // body frames coincide with the joint frame, so a child hung off a
+        // non-Z revolute has a rotated body frame — and its own children's
+        // `parent_to_joint` is measured from that rotated frame. Identity for
+        // ground and free bodies.
+        let mut body_rotations: Vec<Mat3> = Vec::new();
         let mut body_count = 0usize;
 
         // Compute box inertia from a primitive node
@@ -196,6 +202,7 @@ impl BatchSimPipeline {
             let xform = instance_transform(ground_inst);
             builder = builder.add_fixed_body(&ground_inst.id, -1, xform, inertia);
             instance_to_body.insert(ground_inst.id.clone(), body_count);
+            body_rotations.push(Mat3::identity());
             body_count += 1;
         }
 
@@ -223,14 +230,22 @@ impl BatchSimPipeline {
                 let part = part_defs
                     .get(&child_inst.part_def_id)
                     .ok_or(SimError::NoAssembly)?;
-                let (_, inertia) = compute_inertia(part.root);
+                let (_, mut inertia) = compute_inertia(part.root);
 
-                let phyz_joint = build_phyz_model_joint(joint)?;
+                // Body frame = joint frame, so the part-axis-aligned box
+                // inertia has to be rotated into it.
+                let r_part_to_body = joint_frame_rotation(&joint.kind).transpose();
+                inertia.inertia = r_part_to_body
+                    .mul_mat(&inertia.inertia)
+                    .mul_mat(&r_part_to_body.transpose());
+
+                let phyz_joint = build_phyz_model_joint(joint, &body_rotations[parent_body_idx])?;
 
                 builder =
                     builder.add_body(&child_inst.id, parent_body_idx as i32, phyz_joint, inertia);
 
                 instance_to_body.insert(child_inst.id.clone(), body_count);
+                body_rotations.push(r_part_to_body);
                 body_count += 1;
                 visited.insert(child_inst.id.clone());
                 queue.push(child_inst.id.clone());
@@ -246,29 +261,37 @@ impl BatchSimPipeline {
 /// Mirrors `vcad_kernel_physics::joints::vcad_joint_to_phyz`, but targets the
 /// `phyz_model` crate's `Joint` type (required by `phyz-gpu`'s `ModelBuilder`),
 /// which is a separate Rust type from `phyz::model::Joint`.
-fn build_phyz_model_joint(joint: &vcad_ir::Joint) -> Result<phyz_model::Joint, SimError> {
-    use phyz_math::{Mat3, SpatialTransform, Vec3};
+///
+/// `r_parent` is the parent body's part→body rotation: `parent_to_joint` is
+/// measured from the parent *body* frame, which is itself rotated whenever
+/// the parent hangs off a non-Z joint axis. Composing it out here is what
+/// keeps the axis-alignment rotation from compounding down a serial chain.
+fn build_phyz_model_joint(
+    joint: &vcad_ir::Joint,
+    r_parent: &phyz_math::Mat3,
+) -> Result<phyz_model::Joint, SimError> {
+    use phyz_math::{SpatialTransform, Vec3};
     use phyz_model::Joint as PhyzJoint;
     use vcad_ir::JointKind;
 
-    // Convert parent anchor from mm to meters — this becomes the translation
-    // in the parent-to-joint transform.
-    let anchor = Vec3::new(
+    // parent_anchor is in the parent *part*'s mm coordinates; phyz wants the
+    // joint origin in the parent *body* frame, in meters.
+    let anchor = r_parent.mul_vec(Vec3::new(
         joint.parent_anchor.x / 1000.0,
         joint.parent_anchor.y / 1000.0,
         joint.parent_anchor.z / 1000.0,
-    );
+    ));
+
+    // Plücker parent→joint coordinate map: the transpose of the joint frame's
+    // axes expressed in the parent body frame.
+    let rot = r_parent
+        .mul_mat(&joint_frame_rotation(&joint.kind))
+        .transpose();
+    let xform = SpatialTransform::new(rot, anchor);
 
     match &joint.kind {
-        JointKind::Fixed => {
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
-            Ok(PhyzJoint::fixed(xform))
-        }
-        JointKind::Revolute { axis, limits } => {
-            let axis_vec = Vec3::new(axis.x, axis.y, axis.z).normalize();
-            let rot = rotation_aligning_z_to(axis_vec);
-            let xform = SpatialTransform::new(rot, anchor);
-
+        JointKind::Fixed => Ok(PhyzJoint::fixed(xform)),
+        JointKind::Revolute { limits, .. } => {
             let mut phyz_joint = PhyzJoint::revolute(xform);
 
             if let Some((lower, upper)) = limits {
@@ -278,9 +301,9 @@ fn build_phyz_model_joint(joint: &vcad_ir::Joint) -> Result<phyz_model::Joint, S
             Ok(phyz_joint)
         }
         JointKind::Slider { axis, limits } => {
+            // Slider joint frames are part-aligned, so the axis carries over
+            // unchanged.
             let axis_vec = Vec3::new(axis.x, axis.y, axis.z).normalize();
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
-
             let mut phyz_joint = PhyzJoint::prismatic(xform, axis_vec);
 
             if let Some((lower, upper)) = limits {
@@ -289,15 +312,22 @@ fn build_phyz_model_joint(joint: &vcad_ir::Joint) -> Result<phyz_model::Joint, S
 
             Ok(phyz_joint)
         }
-        JointKind::Cylindrical { axis } => {
-            let axis_vec = Vec3::new(axis.x, axis.y, axis.z).normalize();
-            let rot = rotation_aligning_z_to(axis_vec);
-            let xform = SpatialTransform::new(rot, anchor);
-            Ok(PhyzJoint::revolute(xform))
+        JointKind::Cylindrical { .. } => Ok(PhyzJoint::revolute(xform)),
+        JointKind::Ball => Ok(PhyzJoint::spherical(xform)),
+    }
+}
+
+/// Rotation whose columns are the joint frame's axes in the part frame:
+/// phyz revolute joints spin about the joint frame's Z, so that frame is
+/// oriented to put Z on the declared axis.
+fn joint_frame_rotation(kind: &vcad_ir::JointKind) -> phyz_math::Mat3 {
+    use vcad_ir::JointKind;
+    match kind {
+        JointKind::Revolute { axis, .. } | JointKind::Cylindrical { axis } => {
+            rotation_aligning_z_to(phyz_math::Vec3::new(axis.x, axis.y, axis.z).normalize())
         }
-        JointKind::Ball => {
-            let xform = SpatialTransform::new(Mat3::identity(), anchor);
-            Ok(PhyzJoint::spherical(xform))
+        JointKind::Slider { .. } | JointKind::Fixed | JointKind::Ball => {
+            phyz_math::Mat3::identity()
         }
     }
 }


### PR DESCRIPTION
## The bug

Any serial chain with non-Z revolute axes reported wrong link poses at **zero joint angle**, before any simulation had stepped. The error is absent at depth 1, appears at depth 2, and compounds with every additional link.

Reproduced with two documents identical except for the joint axis vector — three 20×20×100 segments hanging tip-to-tip below a ground body at z=500:

| link | axis (0,1,0) — broken | axis (0,0,1) — correct |
|---|---|---|
| i-1 | `[0, 0, 0.5]` identity | `[0, 0, 0.5]` identity |
| i-2 | `[0, -0.1, 0.5]` **−90° about X** | `[0, 0, 0.4]` identity |
| i-3 | `[0, -0.1, 0.6]` **180° about X** | `[0, 0, 0.3]` identity |

Rotation at depth *n* is exactly −90°·(n−1) about X, and the anchor offsets get rotated along with it — by depth 3 the link travels **up** instead of down.

Found while building a 22-DOF humanoid: feet reported z=0.468 m (hip height) instead of z=0.040 m. The CAD-side FK was correct throughout — the same assembly evaluates to a correct 948 mm-tall scene with feet on the ground — so the defect was confined to the physics conversion.

## Root cause

phyz revolute joints spin about their joint frame's Z, so `vcad_joint_to_phyz` builds a rotation aligning that frame's Z onto the declared axis. Because phyz body frames coincide with the joint frame (Featherstone), that rotation lands on the child body frame — but it was never composed out of the *next* joint's `parent_to_joint`, which phyz measures from the parent **body** frame, not the parent **part** frame:

```rust
let rot = joint_frame_rotation(&joint.kind).transpose();  // R_j^T only
let xform = SpatialTransform::new(rot, anchor);           // anchor in part coords
```

Ground is unrotated, so depth 1 is clean; every link past it inherits an uncancelled `R_j` and they multiply. Aligning +Z to +Y *is* −90° about X — precisely the observed error. Z is the only axis needing no realignment, which is why Z-axis chains were the only ones that worked.

## The fix

Compose the parent's part→body map into both the rotation and the anchor. The map was already tracked in `body_part_frames`, but only used for reporting poses back out:

```rust
let anchor = r_parent.mul_vec(anchor_part_m) + *t_parent;
let rot = r_parent.mul_mat(&joint_frame_rotation(&joint.kind)).transpose();
```

Applied to `Fixed`/`Ball`/`Slider` too — they had the same unrotated-anchor problem, just without the rotation half.

`vcad-sim`'s GPU batch path mirrors this conversion and carried the same defect, plus a missing `.transpose()` on the Plücker map and a box inertia never rotated into the body frame. Fixed alongside.

## Tests

In `crates/vcad-kernel-physics/src/world.rs`, the reported repro verbatim as `hanging_chain(axis)`, asserting exact positions **and** identity quaternions at all three depths:

- `test_chain_zero_pose_{z,y,x}_axis` — Z is the working control, Y and X are the failing class
- `test_chain_zero_pose_mixed_axes` — the humanoid-leg shape, alternating yaw/roll/pitch
- `test_physics_fk_matches_cad_fk_mixed_axes` — shared-oracle check pinning physics FK to a hand-walked CAD chain at non-zero angles (17°/−35°/48° about X/Y/Z)

Verified non-vacuous: reverting the two lines fails Y, X, and mixed while Z still passes — the exact reported signature.

## Reviewer notes

- **Joint targets are unaffected.** `q` is rotation about the joint frame's own Z, which is the declared axis by construction; the corruption was purely in how that frame was anchored to its parent. The non-zero-angle oracle test confirms sign and axis mapping, so commanded `gym_step` position/velocity targets were always correct — only the reported observation was wrong.
- Ground and free bodies keep an identity part→body map, so the composition is a no-op there and pre-existing single-link behavior is untouched.
- `cargo test -p vcad-kernel-physics -p vcad-sim` and `cargo clippy --all-targets -- -D warnings` are clean; the Unitree G1/Go2 URDF integration tests still pass.
- The GPU batch path still places COM at the body origin and ignores `child_anchor` — a pre-existing approximation in that coarse model, left as-is rather than widened into this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)