### PR TITLE
feat(loon): ship the loon2vcad example the docs already assume

### DIFF
--- a/crates/vcad-loon/examples/loon2vcad.rs
+++ b/crates/vcad-loon/examples/loon2vcad.rs
@@ -1,0 +1,15 @@
+//! Evaluate a `.loon` source file to a `.vcad` document on stdout.
+//!
+//! Usage: cargo run -p vcad-loon --example loon2vcad -- input.loon > out.vcad
+
+use std::path::Path;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: loon2vcad <input.loon>");
+    let source = std::fs::read_to_string(&path).expect("read source");
+    let doc = vcad_loon::eval_vcad(&source, Path::new(&path).parent())
+        .unwrap_or_else(|e| panic!("loon eval failed: {e}"));
+    println!("{}", serde_json::to_string_pretty(&doc).expect("serialize"));
+}


### PR DESCRIPTION
## What

Adds `crates/vcad-loon/examples/loon2vcad.rs` — 12 lines that evaluate a `.loon` source file to a `.vcad` document on stdout.

```bash
cargo run -q -p vcad-loon --example loon2vcad -- part.loon > part.vcad
vcad-render part.vcad --format png --size 4096 -o part.png
```

## Why

CLAUDE.md's "Adding Functionality" section instructs, for every new kernel feature:

> Write the example in loon, evaluate it to IR with `vcad_loon::eval_vcad` (a ~10-line helper binary depending on `vcad-loon` + `serde_json` does it; `.loon` → `.vcad` JSON on stdout)

**That helper binary doesn't ship.** `crates/vcad-loon` has no `examples/` and no `src/bin/`, and the `vcad` CLI (export / import-step / info) doesn't cover it. So the documented docs-render workflow — the one every kernel feature is supposed to follow — can't be run without first hand-rolling the missing step. Everyone writes the same throwaway, and each one is a chance to get it wrong.

I hit this while rendering a humanoid assembly for docs and wrote it anyway; upstreaming so the next person doesn't.

## Verification

Round-tripped a 23-instance, 22-joint humanoid assembly: emits a 37663-byte `.vcad` with 13 partDefs / 23 instances / 22 joints and `version` as a string (satisfying the known "`.vcad` version must be a string" constraint). `vcad-render` consumes the output directly and produced correct 4096/8192 px renders from it.

`cargo fmt -p vcad-loon --check` clean; `cargo clippy -p vcad-loon --example loon2vcad -- -D warnings` clean (remaining warnings come from the sibling `loon` repo, untouched here).

## Reviewer notes

**An API trap worth a doc comment, which cost a build cycle here:** `eval_vcad_to_value` returns a **loon** `Value`, which is not `serde::Serialize` — the obvious `serde_json::to_string_pretty(&value)` fails to compile with `E0277`. `eval_vcad` is the one returning a serde-serializable `Document`. Renaming or documenting the pair would make that visible at the call site; I left it alone as out of scope.

`Cargo.lock` picked up an unrelated `phyz-rigid` entry from the sibling phyz repo's moving main tip during the build. Deliberately **not** committed, per the standing guidance about sibling-repo lock churn.

## Related

Overlaps with a queued task covering this same gap plus a test and a CLAUDE.md correction, and separately `vcad-render`'s square-only `--size`. This PR is the minimal proven piece; happy to fold the test and doc fix in here instead if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)