### PR TITLE
fix(mcp): make MCP session loss self-announcing, not silent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,44 @@ is behind `origin/main`, then execs the server. A raw `npm run build` doesn't
 write the stamp, so the next `serve` triggers one redundant rebuild and then
 stamps — self-correcting, not an error.
 
+## Preview-shaped complaint? Check `server_info` FIRST
+
+"Preview unavailable", a widget that stopped updating, an `Unknown
+document_id` — before debugging the renderer, call `server_info` and read
+`uptime_s` and `instance_id`. A low `uptime_s` (or an `instance_id` that
+changed since the last call) means **the server restarted**, not that the
+feature broke. This is the single fastest way to separate "the server
+restarted" from "the feature is broken", and it costs one call.
+
+Why it looks like a renderer bug: on a restart every live `document_id` dies
+at the same instant, so every mounted widget in the transcript — including
+ones that rendered fine minutes earlier — goes dark simultaneously. The
+inline `_meta` GLB can't rescue them (it only covers first paint on mount
+tools, capped at 1.5M base64 chars), so a dead session's widget never
+recovers. The viewer now says *"session lost (server restarted) — re-run the
+last authoring call"* instead of the old bare "preview unavailable".
+
+Session ids carry the minting process's boot token, so the server tells the
+two cases apart: an id from a dead process reports `SESSION LOST TO A SERVER
+RESTART`, a genuinely unknown id reports a typo. Every tool result also
+stamps `_meta['io.vcad/build']` with `boot_token` + `instance_id` +
+`session_durable`, so a client can detect a restart on the very next call
+without polling.
+
+**Durability.** Local runs persist sessions to `~/.vcad/mcp-sessions`
+(override with `VCAD_MCP_SESSION_DIR`, opt out with
+`VCAD_MCP_DISK_SESSIONS=0`), so a restart no longer destroys a long build.
+Hosted deploys need `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`; a
+serverless instance never uses the disk store (its filesystem is ephemeral
+and unshared, so it would report durability it can't provide). When
+`server_info` reports `durable:false`, session-minting tools say so in their
+result — keep the authoring source rather than treating the server as
+storage.
+
+**Artifacts are separate and shorter-lived.** `artifact_store:"in-memory"`
+means `render_view` PNG URLs die on the same restart. Treat any artifact link
+handed to a user as short-lived unless the artifact store is durable.
+
 ## Supabase
 
 Cloud sync uses Supabase (Postgres + Auth). Config and migrations live in `supabase/`.

--- a/changelog/entries/2026-07-25-mcp-session-restart-visibility.json
+++ b/changelog/entries/2026-07-25-mcp-session-restart-visibility.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-mcp-session-restart-visibility",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "MCP sessions survive restarts, and announce it when they can't",
+  "summary": "Local MCP sessions now persist to disk, a lost session says so instead of looking like a typo or a broken renderer, and every result carries a restart signal.",
+  "features": ["mcp", "sessions", "durability", "preview"],
+  "mcpTools": ["open_document", "server_info", "get_preview_glb", "checkpoint_document"]
+}

--- a/packages/mcp/src/__tests__/durability-smoke.test.ts
+++ b/packages/mcp/src/__tests__/durability-smoke.test.ts
@@ -97,6 +97,9 @@ const ENV_KEYS = [
   "SUPABASE_SERVICE_ROLE_KEY",
   "VERCEL_ENV",
   "NODE_ENV",
+  // Local runs now persist sessions to disk by default, so the tests that
+  // model the HOSTED "no durable store" hazard must opt out of it explicitly.
+  "VCAD_MCP_DISK_SESSIONS",
 ] as const;
 
 describe("session durability self-report", () => {
@@ -116,6 +119,10 @@ describe("session durability self-report", () => {
   });
 
   it("isSessionStoreDurable mirrors the createSessionStore env check", () => {
+    // A local run is durable via the disk store even with no Supabase env.
+    expect(isSessionStoreDurable()).toBe(true);
+    // Opted out of disk sessions → genuinely nothing survives a restart.
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
     expect(isSessionStoreDurable()).toBe(false);
     process.env.SUPABASE_URL = "https://supa.test";
     expect(isSessionStoreDurable()).toBe(false); // url alone isn't enough
@@ -136,6 +143,15 @@ describe("session durability self-report", () => {
   });
 
   it("sessionStoreInfo reports durable:false / in-memory without the key", () => {
+    // Local default: disk-backed, and it names the directory so an operator
+    // can find (or clear) the persisted sessions.
+    expect(sessionStoreInfo()).toEqual({
+      durable: true,
+      session_store: "file",
+      production: false,
+      session_dir: expect.any(String),
+    });
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
     expect(sessionStoreInfo()).toEqual({
       durable: false,
       session_store: "in-memory",
@@ -228,6 +244,9 @@ describe("deploy smoke: a session survives a redeploy", () => {
   it("NEGATIVE CONTROL: without the service-role key the doc is LOST on redeploy", async () => {
     delete process.env.SUPABASE_SERVICE_ROLE_KEY; // the prod-incident condition
     process.env.SUPABASE_URL = "https://supa.test";
+    // The hazard being modelled is a HOSTED instance with no durable backend;
+    // the local disk store would otherwise rescue the doc and mask it.
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
     installFake();
 
     const a = await connect(engine, USER);

--- a/packages/mcp/src/__tests__/health-observability.test.ts
+++ b/packages/mcp/src/__tests__/health-observability.test.ts
@@ -3,6 +3,7 @@ import { Engine } from "@vcad/engine";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer, getBuildInfo } from "../server.js";
+import { currentBootToken } from "../tools/session.js";
 import {
   computeStaleness,
   getExpectedBuildSha,
@@ -179,6 +180,26 @@ describe("tool results carry build identity in _meta (end-to-end)", () => {
     expect(meta.version_full).toBe(info.version_full);
     expect(typeof meta.uptime_s).toBe("number");
     expect(typeof meta.is_stale).toBe("boolean");
+
+    await client.close();
+    await server.close();
+  });
+
+  // Restart detection without polling: a client that remembers boot_token
+  // learns the server restarted (and whether that cost it its open documents)
+  // on the very next call — instead of when a dead document_id finally fails
+  // many turns later.
+  it("stamps the restart signal (boot_token + session_durable) on every result", async () => {
+    const { client, server } = await connect();
+    const res = await client.callTool({ name: "open_document", arguments: {} });
+
+    const meta = buildMetaOf(res);
+    expect(meta.boot_token).toBe(currentBootToken());
+    expect(typeof meta.session_durable).toBe("boolean");
+    // Stable within a process — a CHANGE is the signal, so it must not be
+    // re-randomized per call.
+    const again = await client.callTool({ name: "server_info", arguments: {} });
+    expect(buildMetaOf(again).boot_token).toBe(meta.boot_token);
 
     await client.close();
     await server.close();

--- a/packages/mcp/src/__tests__/session-restart.test.ts
+++ b/packages/mcp/src/__tests__/session-restart.test.ts
@@ -1,0 +1,343 @@
+/**
+ * Session loss must be SELF-ANNOUNCING.
+ *
+ * The failure this pins (observed 2026-07-25): a non-durable server restarted
+ * mid-session, every live document_id silently died, and the first symptom was
+ * an unrelated call failing many turns later with an error indistinguishable
+ * from a typo'd id — while every mounted preview widget went dark at once and
+ * looked like a broken renderer. Three defenses, tested here:
+ *
+ *  1. ids carry the minting process's boot token, so "lost to a restart" is
+ *     mechanically separable from "no such id";
+ *  2. local runs persist to disk, so the restart doesn't destroy the work;
+ *  3. a mint under a non-durable store says so, up front.
+ */
+import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { Document } from "@vcad/ir";
+import { createServer } from "../server.js";
+import { FileSessionStore, sessionDir, useFileSessionStore } from "../session-store.js";
+import {
+  documents,
+  nextSessionId,
+  getSession,
+  hydrateSession,
+  persistSession,
+  dropSession,
+  currentBootToken,
+  sessionIdBootToken,
+  isForeignSessionId,
+  unknownSessionMessage,
+  durabilityWarning,
+} from "../tools/session.js";
+
+function makeDoc(): Document {
+  return { nodes: {}, roots: [] } as unknown as Document;
+}
+
+/** A session id minted by a DIFFERENT process — i.e. one that survived a
+ *  restart in an agent's context while its contents did not. */
+function foreignId(): string {
+  const ours = currentBootToken();
+  const other = ours[0] === "z" ? `y${ours.slice(1)}` : `z${ours.slice(1)}`;
+  return `doc_7_${other}AAAAAAAAAAAA`;
+}
+
+const ENV_KEYS = ["VCAD_MCP_DISK_SESSIONS", "SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY"] as const;
+
+describe("boot-generation tagging", () => {
+  it("mints ids carrying THIS process's boot token", () => {
+    const id = nextSessionId();
+    expect(sessionIdBootToken(id)).toBe(currentBootToken());
+    expect(isForeignSessionId(id)).toBe(false);
+  });
+
+  it("recognizes an id minted by an earlier process as foreign", () => {
+    expect(isForeignSessionId(foreignId())).toBe(true);
+  });
+
+  it("treats an untagged / hand-written id as not-foreign (no false alarm)", () => {
+    // Better to fall back to the generic message than to tell someone their
+    // typo was a server restart.
+    expect(sessionIdBootToken("not-a-session-id")).toBeNull();
+    expect(isForeignSessionId("not-a-session-id")).toBe(false);
+  });
+
+  it("ids stay unguessable — the token is a prefix, not a replacement", () => {
+    const a = nextSessionId();
+    const b = nextSessionId();
+    expect(a).not.toBe(b);
+    // Boot token + at least the 12 base64url chars of the 9 random bytes.
+    expect(a.split("_")[2].length).toBeGreaterThanOrEqual(16);
+  });
+});
+
+describe("unknownSessionMessage distinguishes the two causes", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("names the RESTART (not a typo) for a foreign id on a non-durable store", () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const msg = unknownSessionMessage(foreignId());
+    expect(msg).toMatch(/SESSION LOST TO A SERVER RESTART/);
+    expect(msg).toMatch(/not a typo/i);
+    // The remediation must be actionable: re-author, and how to check.
+    expect(msg).toMatch(/re-run the authoring calls/i);
+    expect(msg).toMatch(/server_info/);
+    // The pinned prefix every caller greps for is preserved.
+    expect(msg).toMatch(/^Unknown document_id/);
+  });
+
+  it("does NOT cry restart-loss when the store is durable", () => {
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    const msg = unknownSessionMessage(foreignId());
+    expect(msg).not.toMatch(/SESSION LOST/);
+    expect(msg).toMatch(/durable session store/);
+  });
+
+  it("reads as a typo for an id this process could have minted", () => {
+    const msg = unknownSessionMessage(nextSessionId());
+    expect(msg).not.toMatch(/SESSION LOST/);
+    expect(msg).toMatch(/typo/);
+  });
+
+  it("getSession raises the specialized message", () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(() => getSession(foreignId())).toThrow(/SESSION LOST TO A SERVER RESTART/);
+  });
+});
+
+describe("FileSessionStore survives the restart", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "vcad-sessions-"));
+    documents.clear();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    documents.clear();
+  });
+
+  it("round-trips a document through disk", async () => {
+    const store = new FileSessionStore(dir);
+    const id = nextSessionId();
+    await store.save(id, makeDoc());
+    expect(await store.load(id)).toEqual(makeDoc());
+    await store.drop(id);
+    expect(await store.load(id)).toBeNull();
+  });
+
+  it("REGRESSION: a restart no longer loses the work", async () => {
+    const store = new FileSessionStore(dir);
+    const id = nextSessionId();
+    documents.set(id, makeDoc());
+    await persistSession(store, id);
+
+    // ── The restart: every warm cache is gone.
+    documents.clear();
+    expect(documents.has(id)).toBe(false);
+
+    // The dispatch layer's hydrate-on-miss brings it back instead of throwing.
+    expect(await hydrateSession(store, id)).toBe(true);
+    expect(() => getSession(id)).not.toThrow();
+  });
+
+  it("close_document forgets the file too (no orphaned snapshots)", async () => {
+    const store = new FileSessionStore(dir);
+    const id = nextSessionId();
+    documents.set(id, makeDoc());
+    await persistSession(store, id);
+    expect(existsSync(join(dir, `${id}.json`))).toBe(true);
+    await dropSession(store, id);
+    expect(existsSync(join(dir, `${id}.json`))).toBe(false);
+  });
+
+  it("refuses an id that could escape the session directory", async () => {
+    const store = new FileSessionStore(dir);
+    await store.save("../../etc/passwd", makeDoc());
+    expect(await store.load("../../etc/passwd")).toBeNull();
+    expect(existsSync(join(dir, "..", "..", "etc", "passwd"))).toBe(false);
+  });
+
+  it("a corrupt snapshot is a miss, not a crash", async () => {
+    const store = new FileSessionStore(dir);
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(join(dir, "doc_1_abcd.json"), "{ truncated", "utf8");
+    expect(await store.load("doc_1_abcd")).toBeNull();
+  });
+});
+
+describe("end-to-end: a local restart no longer loses the document", () => {
+  let engine: Engine;
+  let dir: string;
+  let saved: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    dir = mkdtempSync(join(tmpdir(), "vcad-sessions-e2e-"));
+    process.env.VCAD_MCP_SESSION_DIR = dir;
+    documents.clear();
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    delete process.env.VCAD_MCP_SESSION_DIR;
+    rmSync(dir, { recursive: true, force: true });
+    documents.clear();
+  });
+
+  async function connect() {
+    const server = await createServer(engine, { user: null });
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "t", version: "0.0.0" }, { capabilities: {} });
+    await Promise.all([client.connect(ct), server.connect(st)]);
+    return { client, server };
+  }
+
+  const text = (r: unknown): string =>
+    (r as { content: Array<{ text: string }> }).content[0].text;
+
+  const blocksOf = (r: unknown): Array<{ text?: string }> =>
+    (r as { content?: Array<{ text?: string }> }).content ?? [];
+
+  /** create_cad_loon leads with a VCode text block, so scan for the JSON one. */
+  const docIdOf = (r: unknown): string => {
+    for (const b of blocksOf(r)) {
+      try {
+        const parsed = JSON.parse(b.text ?? "") as { document_id?: string };
+        if (parsed.document_id) return parsed.document_id;
+      } catch {
+        /* not the JSON block */
+      }
+    }
+    throw new Error(`no document_id in result: ${JSON.stringify(blocksOf(r))}`);
+  };
+
+  // The 2026-07-25 incident, start to finish: author a part, restart the
+  // server under it, and use the SAME document_id afterwards.
+  it("a document authored on instance A still resolves after a restart", async () => {
+    const a = await connect();
+    const created = await a.client.callTool({
+      name: "create_cad_loon",
+      arguments: { source: "[root [cube 10 10 10] \"part\"]" },
+    });
+    expect((created as { isError?: boolean }).isError ?? false).toBe(false);
+    const id = docIdOf(created);
+    await a.client.close();
+    await a.server.close();
+
+    // ── The restart: a brand-new process's empty cache.
+    documents.clear();
+    const b = await connect();
+
+    const got = await b.client.callTool({
+      name: "inspect_cad",
+      arguments: { document_id: id },
+    });
+    expect((got as { isError?: boolean }).isError ?? false).toBe(false);
+    // The actual geometry came back, not just a live handle: 10³ mm.
+    expect(JSON.parse(text(got)).volume_mm3).toBeCloseTo(1000, 6);
+
+    await b.client.close();
+    await b.server.close();
+  });
+
+  it("with disk sessions off, the mint warns that the work is unrecoverable", async () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    const a = await connect();
+    const created = await a.client.callTool({
+      name: "create_cad_loon",
+      arguments: { source: "[root [cube 10 10 10] \"part\"]" },
+    });
+    // The agent is told AT MINT TIME to keep the authoring source — the only
+    // moment it can still act on it.
+    expect(
+      blocksOf(created).some((b) => /NON-DURABLE SESSION/.test(b.text ?? "")),
+    ).toBe(true);
+    await a.client.close();
+    await a.server.close();
+  });
+
+  // A true restart can't be simulated in-process (the boot token is per
+  // process), so drive the dispatch path with an id bearing a FOREIGN token —
+  // exactly what an agent holds after its server restarted underneath it.
+  it("dispatch surfaces the restart diagnosis for an id from a dead process", async () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    const b = await connect();
+    const got = (await b.client.callTool({
+      name: "inspect_cad",
+      arguments: { document_id: foreignId() },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(got.isError).toBe(true);
+    // Not a mystery, and not mistakable for a typo.
+    expect(got.content[0].text).toMatch(/SESSION LOST TO A SERVER RESTART/);
+    expect(got.content[0].text).toMatch(/re-run the authoring calls/i);
+
+    await b.client.close();
+    await b.server.close();
+  });
+});
+
+describe("non-durable storage announces itself at mint time", () => {
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV_KEYS) saved[k] = process.env[k];
+  });
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("warns, with the remedy, when sessions are memory-only", () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const w = durabilityWarning();
+    expect(w).toMatch(/NON-DURABLE SESSION/);
+    // Tell the agent to keep the source — the loss is otherwise unrecoverable.
+    expect(w).toMatch(/keep the authoring source/i);
+    expect(w).toMatch(/checkpoint_document/);
+  });
+
+  it("stays quiet when the store is durable", () => {
+    process.env.SUPABASE_URL = "https://supa.test";
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "svc";
+    expect(durabilityWarning()).toBeUndefined();
+  });
+
+  it("local runs are durable by default, under a real directory", () => {
+    delete process.env.VCAD_MCP_DISK_SESSIONS;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    expect(useFileSessionStore()).toBe(true);
+    expect(sessionDir()).toMatch(/mcp-sessions$/);
+    expect(durabilityWarning()).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/__tests__/session-store.test.ts
+++ b/packages/mcp/src/__tests__/session-store.test.ts
@@ -4,8 +4,10 @@ import {
   SupabaseSessionStore,
   AnonSupabaseSessionStore,
   InMemorySessionStore,
+  FileSessionStore,
   createSessionStore,
   setSessionFetch,
+  isSessionStoreDurable,
 } from "../session-store.js";
 import {
   documents,
@@ -329,18 +331,48 @@ describe("createSessionStore factory", () => {
     expect(createSessionStore(null)).toBeInstanceOf(AnonSupabaseSessionStore);
   });
 
-  it("returns in-memory without a user AND no keys (stdio/local)", () => {
+  // Local runs default to the DISK store, not pure memory: an agent can spend
+  // 30+ turns building an assembly, and a process restart used to vaporize it.
+  it("returns the file store without a user AND no keys (stdio/local)", () => {
     delete process.env.SUPABASE_URL;
     delete process.env.SUPABASE_SERVICE_ROLE_KEY;
-    expect(createSessionStore(null)).toBeInstanceOf(InMemorySessionStore);
+    expect(createSessionStore(null)).toBeInstanceOf(FileSessionStore);
   });
 
-  it("returns in-memory with a user but no service-role key", () => {
+  it("returns the file store with a user but no service-role key", () => {
     process.env.SUPABASE_URL = "https://supa.test";
     delete process.env.SUPABASE_SERVICE_ROLE_KEY;
     expect(
       createSessionStore({ sub: "user-me", email: "a@b.c" }),
-    ).toBeInstanceOf(InMemorySessionStore);
+    ).toBeInstanceOf(FileSessionStore);
+  });
+
+  it("falls back to in-memory when disk sessions are opted out", () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.VCAD_MCP_DISK_SESSIONS = "0";
+    try {
+      expect(createSessionStore(null)).toBeInstanceOf(InMemorySessionStore);
+    } finally {
+      delete process.env.VCAD_MCP_DISK_SESSIONS;
+    }
+  });
+
+  // A serverless instance's filesystem is ephemeral and unshared, so a file
+  // store there would report durable:true while providing none — strictly
+  // worse than the loud non-durable warning.
+  it("never uses the file store on a production deploy", () => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      expect(createSessionStore(null)).toBeInstanceOf(InMemorySessionStore);
+      expect(isSessionStoreDurable()).toBe(false);
+    } finally {
+      if (prevEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = prevEnv;
+    }
   });
 
   it("returns the Supabase store with a user + url + key", () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -29,6 +29,8 @@ import {
   dropSession,
   runInSessionScope,
   recordHistorySnapshot,
+  currentBootToken,
+  durabilityWarning,
 } from "./tools/session.js";
 import { createCadLoon } from "./tools/loon.js";
 import { previewVersion, previewGlbFor } from "./tools/preview.js";
@@ -39,6 +41,7 @@ import {
   createPackStore,
   sessionStoreInfo,
   warnIfSessionStoreNotDurable,
+  isSessionStoreDurable,
 } from "./session-store.js";
 // Re-exported so the Vercel entry (services/mcp/entry.ts) and standalone
 // /health (http.ts) report the same durability state as server_info.
@@ -586,6 +589,9 @@ function buildInstructions(kernelPrompt: string | null): string {
     "- Ship with `export_cad` (STL/GLB/STEP) or `open_in_browser` (vcad.io deep link).",
     "- Fix in place: when geometry is wrong, prefer `update` on the offending node over deleting parts and starting over.",
     "- Deliver the project bill of materials with `bom_create` → `bom_export` (markdown/CSV/JSON with landed-cost totals): link quote_manufacturing quotes on manufactured lines, and source COTS hardware (bearings, shafts, standoffs, screws, ferrite magnets) with `search_mechanical_parts`. All BOM prices are estimates and flagged as such.",
+    "",
+    "",
+    "Sessions and server restarts: a `document_id` is a handle to server-side state, NOT storage. If ANY preview goes dark, a widget stops updating, or a call fails with an unknown `document_id`, check `server_info` FIRST — a low `uptime_s` or a changed `instance_id` means the SERVER RESTARTED and the feature is fine. That is the fastest way to tell a restart from a bug, and it should be the first check for any preview-shaped complaint. On a restart every live document_id dies at once, so previously-working widgets all go dark together — that is not a renderer bug. When `server_info` reports `durable:false`, sessions are in-memory only and cannot be recovered: keep the authoring source (your `create_cad_loon` call or record of edits) so a document can be rebuilt, and snapshot long-lived work with `checkpoint_document` / `save_document`. Every tool result also carries `_meta['io.vcad/build']` with `boot_token` + `instance_id`, so a changed value flags a restart without polling.",
     "",
     "PCB workflow: `create_schematic` (declare connectivity as data via `nets`) → `place_components` → `route_nets` / `add_coil` / `add_coil_array` → `run_drc` → `validate_for_fab` → `export_gerber`. All take the `document_id` from create_schematic and mutate that session — never re-send the document. `validate_for_fab` is the single 'is this board ready?' gate (DRC + renderability + Gerber serialization + blockers, all fail-closed); `export_gerber` enforces a clean DRC by default and blocks a dirty board. `board_from_solid` turns a solid part (e.g. an enclosure or stator disc in a CAD session) into an outline polygon for `place_components`. For motors, plan the winding first with `winding_layout` (slots + poles → per-coil phase/polarity/winding-factor, as data — it touches no board), then realize it with `add_coil_array`. `run_drc` returns a summary by default (counts by rule + net-pair, worst clearance, a capped sample); pass `detail:'full'` for every violation. Surgical copper edits: `get_copper` lists existing traces/vias/zones (filtered by layer/net/bbox/kind) with the same indices `delete_trace`/`delete_via`/`delete_zone` accept — discover, then delete, without exporting the document. Where two nets must touch on purpose (wye neutral, split ground, shunt tap), declare it with `add_net_tie` — prefer a region-scoped tie (position+radius) so DRC stays honest away from the junction; `delete_net_tie` takes it back.",
   ].join("\n");
@@ -1302,6 +1308,13 @@ export async function createServer(
           uptime_s: info.uptime_s,
           expected_build_sha,
           is_stale,
+          // Restart detection without polling: boot_token changes iff the
+          // process serving these calls restarted, and session_durable says
+          // whether that restart cost the caller their open documents. A
+          // client that remembers the last pair learns about a restart on the
+          // very next call, instead of when a dead document_id finally fails.
+          boot_token: currentBootToken(),
+          session_durable: isSessionStoreDurable(),
         },
       };
     } catch {
@@ -1475,6 +1488,14 @@ export async function createServer(
       // (import_step / create_cad_loon) aren't double-registered.
       if (!result.isError && def?.behavior.writesDoc) {
         const writtenId = effectiveDocId(result, args);
+        // A tool that just MINTED a session (returned an id the caller didn't
+        // pass in) is the one moment an agent can still act on the storage
+        // contract — before 30 turns of work depend on a handle that a restart
+        // will silently invalidate. Say it once per session, in a
+        // model-visible text block; no-op when the store is durable.
+        if (writtenId && writtenId !== incomingId) {
+          noteSessionDurability(result, writtenId);
+        }
         if (writtenId) {
           try {
             await persistSession(sessionStore, writtenId);
@@ -1785,6 +1806,28 @@ function resolvePreviewDocumentId(
  * does NOT call resolvePreviewDocumentId, which registers a fresh session for
  * import_step / create_cad_loon and would double-mint here.
  */
+/** Sessions already warned about non-durability, so a long build gets the
+ *  notice once rather than on every mint. Capped so it can't grow unbounded on
+ *  a long-lived instance. */
+const durabilityWarned = new Set<string>();
+
+/**
+ * Append the non-durable-storage warning to a session-minting tool result.
+ * Model-visible by design (a text block, not `_meta`): the whole point is that
+ * the AGENT learns it must keep the authoring source. No-op when the store is
+ * durable, or when this session was already warned about.
+ */
+function noteSessionDurability(result: ToolResult, documentId: string): void {
+  const warning = durabilityWarning();
+  if (!warning || durabilityWarned.has(documentId)) return;
+  if (durabilityWarned.size > 1000) durabilityWarned.clear();
+  durabilityWarned.add(documentId);
+  result.content = [
+    ...(result.content ?? []),
+    { type: "text", text: JSON.stringify({ durability: warning }) },
+  ];
+}
+
 function effectiveDocId(
   result: {
     content: Array<{ type: string; text: string }>;

--- a/packages/mcp/src/session-store.ts
+++ b/packages/mcp/src/session-store.ts
@@ -17,6 +17,9 @@
  * in-memory impl reproduces today's behavior exactly.
  */
 import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+import os from "node:os";
 import type { Document } from "@vcad/ir";
 import type { AuthUser } from "./oauth.js";
 
@@ -54,6 +57,102 @@ export class InMemorySessionStore implements SessionStore {
   async drop(): Promise<void> {
     /* nothing durable to forget */
   }
+}
+
+/**
+ * Disk-backed store for LOCAL runs (stdio / `npx @vcad/mcp` / a dev server on a
+ * developer's machine). One JSON file per session under the session directory.
+ *
+ * WHY this is the local default: an agent can spend 30+ turns authoring an
+ * assembly, and a process restart under it used to vaporize the work with no
+ * signal. The Supabase store fixes that for hosted deploys, but local runs have
+ * no Supabase env and fell all the way back to in-memory. A file per session is
+ * the cheapest thing that survives a restart, needs no configuration, and keeps
+ * the same load/save/drop contract — so the existing hydrate-on-miss dispatch
+ * path rehydrates a local session exactly like a cloud one.
+ *
+ * Deliberately NOT used on a production/serverless deploy: a function instance's
+ * filesystem is ephemeral and unshared, so a file store there would report
+ * durable:true while providing none — strictly worse than the loud warning.
+ *
+ * Best-effort throughout, mirroring the Supabase stores: a read failure is a
+ * miss (the warm cache still serves), a write failure is logged and never turns
+ * a successful tool call into an error.
+ */
+export class FileSessionStore implements SessionStore {
+  readonly scope = "capability" as const;
+  constructor(private dir: string) {}
+
+  /** Session ids are `doc_<n>_<base64url>`; anything else can't have been
+   *  minted by us, and must never be able to escape the session directory. */
+  private pathFor(documentId: string): string | null {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(documentId)) return null;
+    return nodePath.join(this.dir, `${documentId}.json`);
+  }
+
+  async load(documentId: string): Promise<Document | null> {
+    const file = this.pathFor(documentId);
+    if (!file) return null;
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      return unwrapDocument(JSON.parse(raw) as unknown);
+    } catch (err) {
+      // ENOENT is the ordinary miss — only log something unexpected.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        console.error("[session-store] file load failed:", err);
+      }
+      return null;
+    }
+  }
+
+  async save(documentId: string, doc: Document): Promise<void> {
+    const file = this.pathFor(documentId);
+    if (!file) return;
+    try {
+      await fs.mkdir(this.dir, { recursive: true });
+      // Write-then-rename: a crash mid-write leaves the previous good snapshot
+      // rather than a truncated file that would fail to parse on rehydrate.
+      const tmp = `${file}.${process.pid}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(doc), "utf8");
+      await fs.rename(tmp, file);
+    } catch (err) {
+      console.error("[session-store] file save failed:", err);
+    }
+  }
+
+  async drop(documentId: string): Promise<void> {
+    const file = this.pathFor(documentId);
+    if (!file) return;
+    try {
+      await fs.rm(file, { force: true });
+    } catch (err) {
+      console.error("[session-store] file drop failed:", err);
+    }
+  }
+}
+
+/** Where local sessions persist: `VCAD_MCP_SESSION_DIR`, else
+ *  `~/.vcad/mcp-sessions`. */
+export function sessionDir(): string {
+  return (
+    process.env.VCAD_MCP_SESSION_DIR ||
+    nodePath.join(os.homedir(), ".vcad", "mcp-sessions")
+  );
+}
+
+/**
+ * True when local runs should persist sessions to disk: not a hosted
+ * production deploy, no Supabase env (which takes precedence), and not
+ * explicitly opted out with `VCAD_MCP_DISK_SESSIONS=0`.
+ */
+export function useFileSessionStore(): boolean {
+  if (/^(0|false|off)$/i.test(process.env.VCAD_MCP_DISK_SESSIONS || "")) {
+    return false;
+  }
+  if (isProductionDeploy()) return false;
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return !(url && key);
 }
 
 /**
@@ -361,7 +460,10 @@ function unwrapDocument(content: unknown): Document | null {
 export function isSessionStoreDurable(): boolean {
   const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
-  return !!(url && key);
+  if (url && key) return true;
+  // A local run persists to disk, which survives the restart this flag exists
+  // to warn about. (Never true on a serverless deploy — see useFileSessionStore.)
+  return useFileSessionStore();
 }
 
 /** True on a hosted production deploy: Vercel prod (`VERCEL_ENV=production`) or
@@ -379,14 +481,29 @@ export function isProductionDeploy(): boolean {
  *  condition is observable over the wire without reading logs. */
 export function sessionStoreInfo(): {
   durable: boolean;
-  session_store: "supabase" | "in-memory";
+  session_store: "supabase" | "file" | "in-memory";
   production: boolean;
+  /** Where file-backed sessions live — only set for the "file" store, so an
+   *  operator can find (or clear) them. */
+  session_dir?: string;
 } {
-  const durable = isSessionStoreDurable();
+  const supabase = !!(
+    (process.env.SUPABASE_URL || "").replace(/\/+$/, "") &&
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+  if (supabase) {
+    return {
+      durable: true,
+      session_store: "supabase",
+      production: isProductionDeploy(),
+    };
+  }
+  const file = useFileSessionStore();
   return {
-    durable,
-    session_store: durable ? "supabase" : "in-memory",
+    durable: file,
+    session_store: file ? "file" : "in-memory",
     production: isProductionDeploy(),
+    ...(file ? { session_dir: sessionDir() } : {}),
   };
 }
 
@@ -424,6 +541,9 @@ export function createSessionStore(user: AuthUser | null): SessionStore {
       ? new SupabaseSessionStore({ supabaseUrl: url, serviceRoleKey: key, userId: user.sub })
       : new AnonSupabaseSessionStore({ supabaseUrl: url, serviceRoleKey: key });
   }
+  // Local run: persist to disk so a restart doesn't vaporize an in-progress
+  // build. Opt out with VCAD_MCP_DISK_SESSIONS=0 for the old pure-memory mode.
+  if (useFileSessionStore()) return new FileSessionStore(sessionDir());
   return new InMemorySessionStore();
 }
 

--- a/packages/mcp/src/tools/session-core.ts
+++ b/packages/mcp/src/tools/session-core.ts
@@ -75,12 +75,61 @@ function randomSuffix(): string {
   return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
+// ─── Boot generation (restart detection) ─────────────────────────────────────
+//
+// A non-durable server keeps sessions in process memory, so a restart silently
+// invalidates every live document_id. The first symptom used to be an
+// indistinguishable "Unknown document_id" much later — identical to the error
+// for a typo'd id, even though the remediations are opposite (re-author the
+// work vs fix the argument). Stamping the minting process's boot token INTO the
+// id makes the two cases mechanically separable: an id whose token isn't ours
+// was minted by a process that is gone.
+
+/** Length of the boot-token prefix carried in a session id's suffix segment. */
+const BOOT_TOKEN_LEN = 4;
+
+/** This process's boot token — fresh at every cold start, stable for its life. */
+const BOOT_TOKEN: string = randomSuffix().slice(0, BOOT_TOKEN_LEN);
+
+/** The boot token of the process serving this call. Changes iff the server
+ *  restarted, so a client that remembers it can detect a restart without
+ *  polling anything. Surfaced on every tool result's `_meta`. */
+export function currentBootToken(): string {
+  return BOOT_TOKEN;
+}
+
+/** Extract the boot token from a session id, or null if the id doesn't carry
+ *  one (a hand-written id, or one minted before ids were generation-tagged). */
+export function sessionIdBootToken(documentId: string): string | null {
+  const m = /^doc_\d+_([A-Za-z0-9_-]{4,})$/.exec(documentId);
+  return m ? m[1].slice(0, BOOT_TOKEN_LEN) : null;
+}
+
+/** True when `documentId` was minted by a DIFFERENT process than the one
+ *  serving this call — i.e. the server restarted (or, on a multi-instance
+ *  deploy, another instance answered) since the id was handed out. */
+export function isForeignSessionId(documentId: string): boolean {
+  const token = sessionIdBootToken(documentId);
+  return token !== null && token !== BOOT_TOKEN;
+}
+
+/** Whether this deployment's session store survives a restart. Injected by the
+ *  Node layer (`session.ts`) because the probe reads process env; browser
+ *  bundles keep the conservative default. */
+let durabilityProbe: () => boolean = () => false;
+
+/** Install the durability probe (Node-only bridge to `isSessionStoreDurable`). */
+export function setDurabilityProbe(probe: () => boolean): void {
+  durabilityProbe = probe;
+}
+
 export function nextSessionId(): string {
   // The counter keeps intra-process uniqueness; the random suffix makes the id
   // unguessable. Once a session persists to a user's account the id is a
   // capability — sequential ids would let one caller enumerate another's
-  // warm-cache sessions.
-  return `doc_${nextId++}_${randomSuffix()}`;
+  // warm-cache sessions. The boot token rides in front of the random bytes, so
+  // it costs no extra id segment and can't be confused for one.
+  return `doc_${nextId++}_${BOOT_TOKEN}${randomSuffix()}`;
 }
 
 /** Register a freshly-built document as a session and return its id.
@@ -99,12 +148,45 @@ export function registerSession(doc: Document): string {
  *  it, and a genuine miss still throws the pinned error. */
 export function getSession(documentId: string): Document {
   const doc = documents.get(documentId);
-  if (!doc) {
-    throw new Error(
-      `Unknown document_id "${documentId}". Open one with open_document first, or list active sessions with the documents map.`,
-    );
-  }
+  if (!doc) throw new Error(unknownSessionMessage(documentId));
   return doc;
+}
+
+/**
+ * The "Unknown document_id" error text, specialized to WHY the id didn't
+ * resolve. The dispatch layer has already tried the durable store by the time
+ * this fires, so a miss is terminal — but the remediation differs sharply:
+ *
+ *  - foreign boot token → the minting process is gone. On a non-durable store
+ *    the session's contents went with it and the only fix is to re-run the
+ *    authoring calls. Saying so turns a mystifying late failure into a
+ *    self-announcing one.
+ *  - our boot token (or no token) → this process minted no such id: a typo, a
+ *    stale copy/paste, or an already-closed session.
+ */
+export function unknownSessionMessage(documentId: string): string {
+  const head = `Unknown document_id "${documentId}".`;
+  if (isForeignSessionId(documentId)) {
+    const durable = durabilityProbe();
+    return durable
+      ? `${head} It was minted by a different server process (this one booted ` +
+          `as "${BOOT_TOKEN}") and was not found in the durable session store — ` +
+          `it may have been closed or dropped. Re-open it, or re-run the ` +
+          `authoring calls that built it.`
+      : `${head} SESSION LOST TO A SERVER RESTART — this id was minted by an ` +
+          `earlier process (this one booted as "${BOOT_TOKEN}") and sessions on ` +
+          `this server are in-memory only, so its contents are gone. This is ` +
+          `not a typo: re-run the authoring calls that built the document (a ` +
+          `checkpoint_document / save_document snapshot, or the original ` +
+          `create_cad_loon source, restores it). Check server_info — a low ` +
+          `uptime_s confirms the restart. Configure a durable session store to ` +
+          `prevent this.`;
+  }
+  return (
+    `${head} This server has no such session — check for a typo, or it was ` +
+    `closed. Open one with open_document first, or list active sessions with ` +
+    `the documents map.`
+  );
 }
 
 // ─── Dual-mode document input (session id OR inline document) ─────────────────

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -16,7 +16,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveWithinRoot } from "./safe-path.js";
 import { storeArtifact } from "./artifact-store.js";
 import { maxInlineArtifactBytes } from "./remote.js";
-import type { SessionStore } from "../session-store.js";
+import {
+  isSessionStoreDurable,
+  sessionStoreInfo,
+  type SessionStore,
+} from "../session-store.js";
 import type { AuthUser } from "../oauth.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import {
@@ -26,6 +30,7 @@ import {
   getSession,
   clearHistory,
   setSessionScopeProvider,
+  setDurabilityProbe,
 } from "./session-core.js";
 
 // The browser-safe core of the session layer (document cache, ids, undo
@@ -47,8 +52,38 @@ export {
   getLastChanged,
   recordTriangles,
   getLastTriangles,
+  currentBootToken,
+  sessionIdBootToken,
+  isForeignSessionId,
+  unknownSessionMessage,
   type DocInputCtx,
 } from "./session-core.js";
+
+/**
+ * Warning attached to every result that MINTS a session, when this server's
+ * sessions won't survive a restart.
+ *
+ * WHY it goes on the mint result rather than only in `server_info`: an agent
+ * learns it needed `checkpoint_document` only when a later call fails with a
+ * dead id, by which point the work is already gone. Stating the storage
+ * contract at the moment the handle is issued is what lets an agent decide to
+ * keep the authoring source instead of treating the server as storage. Returns
+ * undefined (field omitted) when the store IS durable, so the happy path stays
+ * quiet.
+ */
+export function durabilityWarning(): string | undefined {
+  if (isSessionStoreDurable()) return undefined;
+  return (
+    "NON-DURABLE SESSION: this server keeps documents IN MEMORY ONLY — a " +
+    "restart destroys this document_id and everything built under it, with no " +
+    "other warning. Keep the authoring source (the create_cad_loon call, or " +
+    "your own record of the edits) so the document can be rebuilt, and " +
+    "snapshot long-lived work with checkpoint_document / save_document. To " +
+    "make sessions durable: unset VCAD_MCP_DISK_SESSIONS=0 for local runs " +
+    "(sessions then persist under ~/.vcad/mcp-sessions), or set SUPABASE_URL " +
+    "+ SUPABASE_SERVICE_ROLE_KEY on a hosted deploy."
+  );
+}
 
 // ─── Per-connection scoping (Node-only: AsyncLocalStorage) ────────────────────
 //
@@ -64,6 +99,12 @@ const sessionScope = new AsyncLocalStorage<{
 }>();
 
 setSessionScopeProvider(() => sessionScope.getStore()?.documents ?? null);
+
+// Teach the browser-safe core whether this deployment's sessions survive a
+// restart, so `getSession`'s miss message can tell "lost to a restart, re-author
+// it" from "not found in the durable store". Reads process env, hence the
+// Node-side injection.
+setDurabilityProbe(isSessionStoreDurable);
 
 /**
  * Run `fn` with an isolated per-connection session cache when `user` is signed
@@ -165,6 +206,7 @@ export function openDocument(args: Record<string, unknown>): {
             "For a live view that stays open while we work, offer the user " +
             "a shareable watch link (share_session) or a vcad.io deep link " +
             "(open_in_browser).",
+          ...(durabilityWarning() ? { durability: durabilityWarning() } : {}),
         }),
       },
     ],

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -994,6 +994,26 @@ function findPreviewMode(result: ToolResultLike): string | null {
  * current state and only re-fetches when it actually changes. Shared by the
  * tool-result handler (mount tools) and the poll loop (data-tool mutations).
  */
+/**
+ * Turn a failed `get_preview_glb` into a status line that explains WHY the
+ * viewport went dark. The server distinguishes "lost to a restart" from "no
+ * such id" in its error text, so key off that rather than guessing: a restart
+ * is unrecoverable for this widget (re-run the authoring call), while any other
+ * error is worth reporting verbatim-ish.
+ */
+function sessionLostStatus(result: ToolResultLike): string {
+  const text = (result?.content ?? [])
+    .map((b) => (b?.type === "text" ? b.text ?? "" : ""))
+    .join(" ");
+  if (/SESSION LOST TO A SERVER RESTART/i.test(text)) {
+    return "session lost (server restarted) — re-run the last authoring call";
+  }
+  if (/Unknown document_id/i.test(text)) {
+    return "session no longer on the server — re-run the last authoring call";
+  }
+  return "preview unavailable (server error)";
+}
+
 async function fetchAndRenderGlb(
   docId: string,
   changed: PartsChanged | null,
@@ -1013,8 +1033,18 @@ async function fetchAndRenderGlb(
     // An error result (e.g. the session isn't resident on the instance that
     // answered) is not the same as an empty document — say so instead of
     // masquerading as "no geometry".
+    //
+    // Name the CAUSE, not just the symptom. When a non-durable server restarts,
+    // every mounted widget in the transcript goes dark at the same moment —
+    // including ones that rendered fine minutes earlier — which reads exactly
+    // like a broken renderer. "preview unavailable" sent people to debug the
+    // viewer; the server tells us the session is gone, so say that and give
+    // the remedy. (The inline `_meta` GLB can't rescue this: it only covers
+    // first paint on mount tools.)
     setStatus(
-      previewResult?.isError ? "preview unavailable" : "no geometry to preview",
+      previewResult?.isError
+        ? sessionLostStatus(previewResult)
+        : "no geometry to preview",
       "idle",
     );
     return;


### PR DESCRIPTION
## Summary

A non-durable MCP server keeps `document_id` sessions in memory only. When it restarts mid-conversation, every live session dies silently: the first symptom is an unrelated call failing much later with `Unknown document_id` — indistinguishable from a typo — while every mounted preview widget goes permanently dark at once, which reads exactly like a broken renderer.

- **Restart vs typo, disambiguated.** Session ids now carry the minting process's boot token, so a lookup miss can tell "this id never existed" (typo/closed — fix the argument) from "this id was lost to a restart" (re-author it) — opposite remediations, same error shape before this change.
- **Local durability by default.** Local runs persist sessions to disk (`~/.vcad/mcp-sessions`, override with `VCAD_MCP_SESSION_DIR`) instead of pure in-memory, so a 30-turn build survives a server restart. Never used on a serverless deploy — its filesystem is ephemeral and unshared, so a file store there would report durability it can't provide. Opt out with `VCAD_MCP_DISK_SESSIONS=0`.
- **Warn at mint time, not failure time.** A session-minting call (`open_document`, `create_cad_loon`, ...) now warns in its result when the store is non-durable — the one moment an agent can still act on it, before 30 turns of work depend on a handle a restart will destroy.
- **Restart detection without polling.** Every tool result's `_meta['io.vcad/build']` now carries `boot_token` + `session_durable`, so a client that remembers the last pair learns about a restart on the very next call.
- **The viewer says why.** The mounted widget now reports *"session lost (server restarted) — re-run the last authoring call"* instead of the old bare "preview unavailable", which sent people to debug the renderer instead of the actual cause.
- **Documented the fast diagnostic.** `server_info`'s `uptime_s`/`instance_id` as the first check for any preview-shaped complaint, in both CLAUDE.md and the MCP server's `instructions` field.

Known related gap, deliberately not addressed here: `artifact_store:"in-memory"` means `render_view` PNG artifact URLs die the same way on a restart — flagged in CLAUDE.md as a separate decision.

## Test plan

- [x] New `packages/mcp/src/__tests__/session-restart.test.ts`: boot-token tagging/unguessability, the specialized `unknownSessionMessage`, `FileSessionStore` round-trip/drop/path-traversal/corrupt-file handling, and an end-to-end test through the real dispatch path (author a cube, wipe the cache, `inspect_cad` on the same id returns the correct volume; with disk sessions off, the same id reports `SESSION LOST TO A SERVER RESTART`).
- [x] Updated `durability-smoke.test.ts` / `health-observability.test.ts` / `session-store.test.ts` for the new local-disk default (added `VCAD_MCP_DISK_SESSIONS` opt-out coverage, a production-deploy negative test).
- [x] Full `packages/mcp` suite: 962 passed, 3 skipped.
- [x] `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)