### PR TITLE
fix(mcp): bound the preview payload so big models render instead of failing

### DIFF
--- a/changelog/entries/2026-07-25-preview-payload-budget.json
+++ b/changelog/entries/2026-07-25-preview-payload-budget.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-preview-payload-budget",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "Large models preview instead of failing",
+  "summary": "The inline 3D viewer now fits oversized preview geometry to a shared payload budget, so big assemblies render at reduced detail instead of showing \"preview unavailable\".",
+  "features": ["viewer", "mcp"],
+  "mcpTools": ["get_preview_glb"]
+}

--- a/packages/mcp/src/__tests__/pcb-preview.test.ts
+++ b/packages/mcp/src/__tests__/pcb-preview.test.ts
@@ -65,7 +65,7 @@ describe("PCB GLB preview", () => {
     out(await placeComponents({ document_id: id, board_width: 50, board_height: 50 }));
     out(await routeNets({ document_id: id }));
 
-    const b64 = await generateGlbPreview(getSession(id), engine);
+    const b64 = (await generateGlbPreview(getSession(id), engine))?.glb ?? null;
     expect(b64).toBeTruthy();
     const gltf = parseGlbJson(b64!);
 
@@ -111,7 +111,7 @@ describe("PCB GLB preview", () => {
     const id = created.document_id;
     out(await placeComponents({ document_id: id, board_width: 30, board_height: 30 }));
 
-    const b64 = await generateGlbPreview(getSession(id), engine);
+    const b64 = (await generateGlbPreview(getSession(id), engine))?.glb ?? null;
     expect(b64).toBeTruthy();
     const gltf = parseGlbJson(b64!);
     const colors = gltf.materials.map((m) => m.pbrMetallicRoughness?.baseColorFactor);
@@ -139,7 +139,7 @@ describe("PCB GLB preview", () => {
       },
     } as unknown as Engine;
 
-    const b64 = await generateGlbPreview(getSession(id), throwingEngine);
+    const b64 = (await generateGlbPreview(getSession(id), throwingEngine))?.glb ?? null;
     expect(b64).toBeTruthy();
     const gltf = parseGlbJson(b64!);
     expect(gltf.meshes.length).toBeGreaterThan(0);

--- a/packages/mcp/src/__tests__/preview-budget.test.ts
+++ b/packages/mcp/src/__tests__/preview-budget.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import {
+  PREVIEW_MAX_BASE64,
+  fitPreviewToBudget,
+  decimateMesh,
+} from "../tools/preview.js";
+import type { GlbMesh } from "../export/glb.js";
+import type { Document } from "@vcad/ir";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * Covers the OVER-CAP branch end to end: a document whose preview GLB exceeds
+ * INLINE_PREVIEW_MAX_BASE64 used to attach no inline `_meta` preview and then
+ * fall through to a fetch path with no ceiling of its own — guaranteed to blow
+ * the transport's result ceiling and surface as a bare "preview unavailable".
+ * The budget now belongs to the shared build path, so over-cap documents come
+ * back degraded-but-renderable instead of not at all.
+ */
+
+/** A dense sphere-ish mesh: `n` triangles of real, non-degenerate geometry
+ *  spread over a unit sphere, so vertex clustering actually has something to
+ *  collapse (unlike a random point cloud). */
+function denseMesh(name: string, triangles: number): GlbMesh {
+  const positions: number[] = [];
+  const indices: number[] = [];
+  const normals: number[] = [];
+  const golden = Math.PI * (3 - Math.sqrt(5));
+  for (let t = 0; t < triangles; t++) {
+    for (let k = 0; k < 3; k++) {
+      const i = t * 3 + k;
+      const y = 1 - (i / (triangles * 3)) * 2;
+      const r = Math.sqrt(Math.max(0, 1 - y * y));
+      const th = golden * i;
+      const x = Math.cos(th) * r;
+      const z = Math.sin(th) * r;
+      positions.push(x * 50, y * 50, z * 50);
+      normals.push(x, y, z);
+      indices.push(i);
+    }
+  }
+  return {
+    name,
+    positions: new Float32Array(positions),
+    indices: new Uint32Array(indices),
+    normals: new Float32Array(normals),
+    color: [0.7, 0.7, 0.7],
+    metallic: 0.1,
+    roughness: 0.6,
+  };
+}
+
+function trianglesOf(mesh: GlbMesh): number {
+  return mesh.indices.length / 3;
+}
+
+/** A document heavy enough to exceed PREVIEW_MAX_BASE64 once tessellated. */
+function heavySphereDoc(n: number): Document {
+  const nodes: Record<string, unknown> = {};
+  const roots: Array<{ root: number; material: string }> = [];
+  for (let i = 1; i <= n; i++) {
+    nodes[String(i)] = { id: i, name: `s${i}`, op: { type: "Sphere", radius: 20 } };
+    roots.push({ root: i, material: "default" });
+  }
+  return {
+    version: "0.1",
+    nodes,
+    materials: {},
+    part_materials: {},
+    roots,
+  } as unknown as Document;
+}
+
+describe("over-cap document through the viewer's fetch path", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  }, 60_000);
+
+  it("get_preview_glb returns bounded, renderable geometry (not a dropped payload)", async () => {
+    documents.clear();
+    const server = await createServer(engine, { user: null });
+    const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
+    await Promise.all([client.connect(clientT), server.connect(serverT)]);
+
+    const docId = "over-cap-doc";
+    documents.set(docId, heavySphereDoc(40));
+
+    const res = (await client.callTool({
+      name: "get_preview_glb",
+      arguments: { document_id: docId },
+    })) as { isError?: boolean; content: Array<{ type: string; text: string }> };
+    expect(res.isError ?? false).toBe(false);
+    const payload = JSON.parse(res.content[0].text) as {
+      _vcad_glb: string | null;
+      degraded?: boolean;
+      error?: string;
+    };
+
+    // The regression: this used to be an unbounded payload the transport
+    // dropped, leaving the viewer on a bare "preview unavailable".
+    expect(payload.error).toBeUndefined();
+    expect(typeof payload._vcad_glb).toBe("string");
+    expect(payload._vcad_glb!.length).toBeLessThanOrEqual(PREVIEW_MAX_BASE64);
+    expect(payload.degraded).toBe(true);
+
+    // Renderable: a well-formed GLB container with actual meshes in it.
+    const bytes = Buffer.from(payload._vcad_glb!, "base64");
+    expect(bytes.subarray(0, 4).toString("ascii")).toBe("glTF");
+    const jsonLen = bytes.readUInt32LE(12);
+    const gltf = JSON.parse(bytes.subarray(20, 20 + jsonLen).toString()) as {
+      meshes?: unknown[];
+      nodes?: unknown[];
+    };
+    expect(gltf.meshes?.length ?? 0).toBeGreaterThan(0);
+    expect(gltf.nodes?.length ?? 0).toBeGreaterThan(0);
+
+    await client.close();
+    await server.close();
+  }, 120_000);
+});
+
+describe("preview payload budget", () => {
+  // buildGlb serializes through the kernel WASM writer.
+  beforeAll(async () => {
+    await Engine.init();
+  });
+
+  it("leaves a small document at full fidelity", () => {
+    const meshes = [denseMesh("part_0", 200)];
+    const built = fitPreviewToBudget(meshes);
+    expect(built.glb.length).toBeLessThanOrEqual(PREVIEW_MAX_BASE64);
+    expect(built.degraded).toBeUndefined();
+    expect(built.oversize).toBeUndefined();
+  });
+
+  it("fits an over-cap document to the budget instead of dropping it", () => {
+    // ~90k triangles across 30 parts — the shape of the reported repro
+    // (31 filleted parts, ~81k triangles, 9.1M base64 chars).
+    const meshes = Array.from({ length: 30 }, (_, i) => denseMesh(`part_${i}`, 3000));
+    const full = fitPreviewToBudget([meshes[0]]);
+    expect(full.glb.length).toBeGreaterThan(0);
+
+    const built = fitPreviewToBudget(meshes);
+    // The whole point: still renderable geometry, and inside the ceiling.
+    expect(built.glb.length).toBeLessThanOrEqual(PREVIEW_MAX_BASE64);
+    expect(built.degraded).toBe(true);
+    expect(built.oversize).toBeUndefined();
+    expect(built.glb.length).toBeGreaterThan(0);
+    // Valid GLB container, not a truncated payload.
+    const bytes = Buffer.from(built.glb, "base64");
+    expect(bytes.subarray(0, 4).toString("ascii")).toBe("glTF");
+    expect(bytes.readUInt32LE(8)).toBe(bytes.length);
+  });
+
+  it("decimation preserves per-part mesh identity and materials", () => {
+    const meshes = Array.from({ length: 4 }, (_, i) => denseMesh(`part_${i}`, 5000));
+    const reduced = meshes.map((m) => decimateMesh(m, 4, [-50, -50, -50]));
+    expect(reduced.map((m) => m.name)).toEqual(meshes.map((m) => m.name));
+    for (let i = 0; i < reduced.length; i++) {
+      expect(reduced[i].color).toEqual(meshes[i].color);
+      expect(trianglesOf(reduced[i])).toBeLessThan(trianglesOf(meshes[i]));
+      expect(trianglesOf(reduced[i])).toBeGreaterThan(0);
+      // Normals are recomputed, not carried over stale — one per vertex.
+      expect(reduced[i].normals!.length).toBe(reduced[i].positions.length);
+    }
+  });
+
+  it("decimation emits only in-range, non-degenerate triangles", () => {
+    const mesh = denseMesh("part_0", 4000);
+    const reduced = decimateMesh(mesh, 6, [-50, -50, -50]);
+    const vertCount = reduced.positions.length / 3;
+    for (let t = 0; t < reduced.indices.length; t += 3) {
+      const [a, b, c] = [
+        reduced.indices[t],
+        reduced.indices[t + 1],
+        reduced.indices[t + 2],
+      ];
+      for (const i of [a, b, c]) {
+        expect(i).toBeGreaterThanOrEqual(0);
+        expect(i).toBeLessThan(vertCount);
+      }
+      expect(new Set([a, b, c]).size).toBe(3);
+    }
+    for (const v of reduced.positions) expect(Number.isFinite(v)).toBe(true);
+    for (const v of reduced.normals as Float32Array) {
+      expect(Number.isFinite(v)).toBe(true);
+    }
+  });
+});

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1363,7 +1363,7 @@ describe("GLB part-identity node names", () => {
   it("names glTF nodes <part_id>:<name> for the viewer's click-to-select", async () => {
     const { generateGlbPreview } = await import("../tools/preview.js");
     const engine = await Engine.init();
-    const b64 = await generateGlbPreview(makeCubeDoc(), engine);
+    const b64 = (await generateGlbPreview(makeCubeDoc(), engine))?.glb ?? null;
     expect(b64).toBeTruthy();
     const glb = Buffer.from(b64!, "base64");
     expect(glb.subarray(0, 4).toString()).toBe("glTF");

--- a/packages/mcp/src/live-route.ts
+++ b/packages/mcp/src/live-route.ts
@@ -217,7 +217,10 @@ export async function handleLiveRequest(
       text(res, 503, "geometry engine unavailable");
       return true;
     }
-    const b64 = await generateGlbPreview(doc, engine);
+    // Full fidelity: this route streams the GLB over a real HTTP body, so it
+    // has none of the JSON-RPC result ceiling the tool paths are budgeted for.
+    const built = await generateGlbPreview(doc, engine, null);
+    const b64 = built?.glb;
     if (!b64) {
       text(res, 404, "no previewable geometry");
       return true;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -31,7 +31,7 @@ import {
   recordHistorySnapshot,
 } from "./tools/session.js";
 import { createCadLoon } from "./tools/loon.js";
-import { previewVersion, previewGlbFor } from "./tools/preview.js";
+import { previewVersion, previewGlbFor, PREVIEW_MAX_BASE64 } from "./tools/preview.js";
 import {
   createSessionStore,
   createSessionEventStore,
@@ -1672,9 +1672,15 @@ function sessionHasPcb(docId: string): boolean {
 }
 
 /** Upper bound for a preview GLB riding inline in a mount result's `_meta`.
- *  Matches the artifact-offload text ethos: big geometry goes through the
- *  fetch path; this fast path is for the common small-to-medium part. */
-const INLINE_PREVIEW_MAX_BASE64 = 1_500_000;
+ *
+ *  Re-exported from the preview module so the inline attach and the viewer's
+ *  `get_preview_glb` fallback share ONE ceiling. They used to be unrelated:
+ *  this cap made oversized documents fall through to a fetch path with no
+ *  limit of its own, which then blew the transport's result ceiling — so
+ *  everything above the cap was guaranteed to fail. `previewGlbFor` now fits
+ *  the payload to this budget, so being over it is a degraded preview, not a
+ *  missing one. */
+const INLINE_PREVIEW_MAX_BASE64 = PREVIEW_MAX_BASE64;
 
 /**
  * Attach a ready-to-render preview GLB to a mount-tool result's `_meta`
@@ -1693,7 +1699,8 @@ export async function attachInlinePreview(
 ): Promise<void> {
   try {
     const preview = await previewGlbFor(getSession(docId), engine);
-    if (!preview || preview.glb.length > INLINE_PREVIEW_MAX_BASE64) return;
+    if (!preview || preview.oversize) return;
+    if (preview.glb.length > INLINE_PREVIEW_MAX_BASE64) return;
     result._meta = {
       ...result._meta,
       "vcad.io/preview": {
@@ -1701,6 +1708,7 @@ export async function attachInlinePreview(
         glb: preview.glb,
         version: preview.version,
         ...(preview.mode ? { mode: preview.mode } : {}),
+        ...(preview.degraded ? { degraded: true } : {}),
       },
     };
   } catch {

--- a/packages/mcp/src/tools/preview.ts
+++ b/packages/mcp/src/tools/preview.ts
@@ -34,9 +34,15 @@ import { behavior, type ToolDef } from "./tool-def.js";
 // content, so the cache is tenant-safe (two users with identical content get
 // identical bytes) and never serves stale geometry (any edit flips the hash).
 const GLB_CACHE_MAX = 16;
-const glbCache = new Map<string, string>();
+const glbCache = new Map<string, CachedGlb>();
 
-function glbCacheGet(key: string): string | undefined {
+interface CachedGlb {
+  glb: string;
+  degraded?: boolean;
+  oversize?: boolean;
+}
+
+function glbCacheGet(key: string): CachedGlb | undefined {
   const hit = glbCache.get(key);
   if (hit !== undefined) {
     // LRU touch: re-insert so the hottest entries survive eviction.
@@ -46,9 +52,9 @@ function glbCacheGet(key: string): string | undefined {
   return hit;
 }
 
-function glbCachePut(key: string, glb: string): void {
+function glbCachePut(key: string, value: CachedGlb): void {
   glbCache.delete(key);
-  glbCache.set(key, glb);
+  glbCache.set(key, value);
   while (glbCache.size > GLB_CACHE_MAX) {
     const oldest = glbCache.keys().next().value;
     if (oldest === undefined) break;
@@ -70,7 +76,26 @@ export interface PreviewGlb {
   glb: string;
   version: string;
   mode?: "instances";
+  /** The GLB was decimated to fit {@link PREVIEW_MAX_BASE64} — preview
+   *  fidelity, not export fidelity. */
+  degraded?: boolean;
+  /** Even after degradation the payload exceeds the budget. Callers must NOT
+   *  ship it through the JSON-RPC channel. */
+  oversize?: boolean;
 }
+
+/**
+ * Hard upper bound (in base64 chars) on ANY preview GLB leaving this server —
+ * the `_meta` inline attach AND the `get_preview_glb` fetch fallback alike.
+ *
+ * Both paths ride the same JSON-RPC transport, so they have the same ceiling;
+ * previously only the inline attach checked a limit, which meant every
+ * document above that limit silently fell through to a fetch path that was
+ * *guaranteed* to blow the host's result ceiling and surface as a bare
+ * "preview unavailable". A document over budget is now decimated until it
+ * fits (see {@link fitPreviewToBudget}) rather than being sent whole.
+ */
+export const PREVIEW_MAX_BASE64 = 1_500_000;
 
 /**
  * Build (or fetch from cache) the preview GLB for a document. Single shared
@@ -87,21 +112,31 @@ export async function previewGlbFor(
   if (instances) {
     const key = `${version}:instances`;
     const cached = glbCacheGet(key);
-    if (cached !== undefined) return { glb: cached, version, mode: "instances" };
+    if (cached !== undefined) {
+      return { ...cached, version, mode: "instances" };
+    }
     const instGlb = generateInstancesGlbPreview(doc, engine);
     if (instGlb) {
-      glbCachePut(key, instGlb);
-      return { glb: instGlb, version, mode: "instances" };
+      // Instances mode is NOT degraded: the glTF node layout (one node per
+      // instance, meshes shared by `meshKey`) is the replay's FK bind
+      // contract, and per-mesh decimation would desync shared meshes. An
+      // over-budget instances preview is reported as oversize instead.
+      const entry: CachedGlb = {
+        glb: instGlb,
+        oversize: instGlb.length > PREVIEW_MAX_BASE64 || undefined,
+      };
+      glbCachePut(key, entry);
+      return { ...entry, version, mode: "instances" };
     }
     // No instances — fall through to the parts preview (flag is safe on any doc).
   }
   const key = `${version}:parts`;
   const cached = glbCacheGet(key);
-  if (cached !== undefined) return { glb: cached, version };
-  const glb = await generateGlbPreview(doc, engine);
-  if (!glb) return null;
-  glbCachePut(key, glb);
-  return { glb, version };
+  if (cached !== undefined) return { ...cached, version };
+  const built = await generateGlbPreview(doc, engine);
+  if (!built) return null;
+  glbCachePut(key, built);
+  return { ...built, version };
 }
 
 /**
@@ -119,7 +154,11 @@ export async function previewGlbFor(
 export async function generateGlbPreview(
   doc: Document,
   engine: Engine,
-): Promise<string | null> {
+  /** Base64-char ceiling to fit the payload into, or `null` for full fidelity.
+   *  Tool results ride JSON-RPC and must be bounded; the plain-HTTP live route
+   *  serves bytes over a real HTTP body and passes `null`. */
+  budget: number | null = PREVIEW_MAX_BASE64,
+): Promise<CachedGlb | null> {
   // Part-identity node names let the viewer map a click back to a part_id
   // for selection context and "ask about this part".
   const labels = buildPartLabels(doc);
@@ -206,7 +245,213 @@ export async function generateGlbPreview(
   }
 
   if (meshes.length === 0) return null;
-  return uint8ArrayToBase64(buildGlb(meshes, "preview"));
+  return fitPreviewToBudget(meshes, budget);
+}
+
+// ─── Bounded preview payloads ────────────────────────────────────────────────
+//
+// A preview GLB is unbounded in principle: filleted mechanical parts inflate
+// triangle counts hard (a 31-part filleted assembly reaches ~81k triangles and
+// ~9 MB of base64), and the kernel tessellation is non-indexed, so the naive
+// payload is ~84 bytes per triangle. The transport ceiling doesn't care why —
+// it just drops the result. So the preview is fitted to the budget here, once,
+// on the single path both the inline attach and the fetch fallback share.
+//
+// Degradation is uniform vertex clustering (a grid over the scene bbox,
+// collapsing each cell's vertices to their centroid, dropping the triangles
+// that collapse). It's cheap, deterministic, and preserves per-part mesh
+// identity — node names, materials, and part→click mapping all survive, which
+// quadric decimation across merged meshes would not.
+
+/** Grid resolutions tried, coarsest-last. 256 barely changes a normal part;
+ *  4 flattens anything into a coarse blob. The ladder bottoms out rather than
+ *  running forever — below ~4 cells across the scene there is no shape left. */
+const DECIMATE_GRIDS = [256, 192, 128, 96, 64, 48, 32, 24, 16, 12, 8, 6, 4];
+
+/**
+ * Build the GLB for `meshes`, decimating progressively until the base64
+ * payload fits {@link PREVIEW_MAX_BASE64}. Documents under budget are built
+ * once and returned at full fidelity — degradation only ever kicks in above
+ * the ceiling, where the alternative is no preview at all.
+ */
+export function fitPreviewToBudget(
+  meshes: GlbMesh[],
+  budget: number | null = PREVIEW_MAX_BASE64,
+): CachedGlb {
+  const full = uint8ArrayToBase64(buildGlb(meshes, "preview"));
+  if (budget === null || full.length <= budget) return { glb: full };
+
+  const box = sceneBounds(meshes);
+  // Diagonal-relative cell size: scale-independent, so a 5 mm part and a
+  // 500 mm assembly degrade the same way.
+  const diag =
+    Math.hypot(box.max[0] - box.min[0], box.max[1] - box.min[1], box.max[2] - box.min[2]) ||
+    1;
+
+  // Surface-ish scaling: clustered triangle count grows ~grid², so start near
+  // the resolution the required reduction implies instead of walking the whole
+  // ladder from 256 down (each rung costs a full pass over every vertex).
+  const startGrid = DECIMATE_GRIDS[0] * Math.sqrt(budget / full.length);
+  let best = full;
+  for (const grid of DECIMATE_GRIDS) {
+    if (grid > startGrid * 1.5) continue;
+    const cell = diag / grid;
+    const reduced = meshes.map((m) => decimateMesh(m, cell, box.min, grid));
+    if (reduced.every((m, i) => m.indices.length === meshes[i].indices.length)) {
+      continue; // grid too fine to change anything — skip the rebuild
+    }
+    // Skip the (expensive) serialize when the buffers alone already blow the
+    // budget — the GLB is strictly larger than its vertex/index data.
+    if (estimateBase64(reduced) > budget) continue;
+    const glb = uint8ArrayToBase64(buildGlb(reduced, "preview"));
+    best = glb;
+    if (glb.length <= budget) return { glb, degraded: true };
+  }
+  // Pathological input (e.g. millions of triangles spread so thin that even
+  // the coarsest grid keeps them distinct). Report it rather than shipping a
+  // payload we know the transport will drop.
+  return { glb: best, degraded: true, oversize: true };
+}
+
+/** Lower bound on the base64 length of the GLB these meshes would serialize
+ *  to: f32 positions + f32 normals + u32 indices, 4/3 base64 expansion. */
+function estimateBase64(meshes: GlbMesh[]): number {
+  let bytes = 0;
+  for (const m of meshes) {
+    bytes += m.positions.length * 4 + (m.normals?.length ?? 0) * 4 + m.indices.length * 4;
+  }
+  return Math.ceil((bytes * 4) / 3);
+}
+
+interface Bounds {
+  min: [number, number, number];
+  max: [number, number, number];
+}
+
+function sceneBounds(meshes: GlbMesh[]): Bounds {
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (const m of meshes) {
+    const p = m.positions;
+    for (let i = 0; i + 2 < p.length; i += 3) {
+      for (let a = 0; a < 3; a++) {
+        const v = p[i + a];
+        if (v < min[a]) min[a] = v;
+        if (v > max[a]) max[a] = v;
+      }
+    }
+  }
+  for (let a = 0; a < 3; a++) {
+    if (!Number.isFinite(min[a])) {
+      min[a] = 0;
+      max[a] = 0;
+    }
+  }
+  return { min, max };
+}
+
+/**
+ * Collapse a mesh's vertices onto a uniform grid of `cell`-sized cubes anchored
+ * at `origin`, dropping triangles whose corners land in the same cell. Normals
+ * are recomputed area-weighted from the surviving triangles, so the result
+ * still shades — a decimated mesh carrying stale normals reads as corrupt.
+ */
+export function decimateMesh(
+  mesh: GlbMesh,
+  cell: number,
+  origin: [number, number, number],
+  /** Cells per axis across the scene — only used to pack the cell coordinates
+   *  into a collision-free integer key. Must bound the coordinates actually
+   *  produced by `cell`; a mesh reaching past it clamps into the edge cell. */
+  grid = 4096,
+): GlbMesh {
+  const pos = mesh.positions;
+  const idx = mesh.indices;
+  const vertCount = Math.floor(pos.length / 3);
+  if (cell <= 0 || vertCount === 0) return mesh;
+
+  // Cell key → new vertex index; accumulate centroids so the collapsed
+  // vertex sits on the surface rather than at a grid corner.
+  const cells = new Map<number, number>();
+  const remap = new Int32Array(vertCount);
+  const sums: number[] = [];
+  const counts: number[] = [];
+  const span = grid + 1;
+  const axis = (v: number, o: number): number =>
+    Math.min(span - 1, Math.max(0, Math.floor((v - o) / cell)));
+  for (let v = 0; v < vertCount; v++) {
+    const x = pos[v * 3];
+    const y = pos[v * 3 + 1];
+    const z = pos[v * 3 + 2];
+    const key =
+      (axis(x, origin[0]) * span + axis(y, origin[1])) * span + axis(z, origin[2]);
+    let ni = cells.get(key);
+    if (ni === undefined) {
+      ni = counts.length;
+      cells.set(key, ni);
+      sums.push(0, 0, 0);
+      counts.push(0);
+    }
+    sums[ni * 3] += x;
+    sums[ni * 3 + 1] += y;
+    sums[ni * 3 + 2] += z;
+    counts[ni] += 1;
+    remap[v] = ni;
+  }
+
+  const newPos = new Float32Array(counts.length * 3);
+  for (let i = 0; i < counts.length; i++) {
+    const n = counts[i] || 1;
+    newPos[i * 3] = sums[i * 3] / n;
+    newPos[i * 3 + 1] = sums[i * 3 + 1] / n;
+    newPos[i * 3 + 2] = sums[i * 3 + 2] / n;
+  }
+
+  const newIdx: number[] = [];
+  const newNormals = new Float32Array(counts.length * 3);
+  for (let t = 0; t + 2 < idx.length; t += 3) {
+    const a = remap[idx[t]];
+    const b = remap[idx[t + 1]];
+    const c = remap[idx[t + 2]];
+    if (a === b || b === c || a === c) continue; // collapsed to a sliver
+    newIdx.push(a, b, c);
+    // Area-weighted face normal (cross product magnitude IS 2×area).
+    const ux = newPos[b * 3] - newPos[a * 3];
+    const uy = newPos[b * 3 + 1] - newPos[a * 3 + 1];
+    const uz = newPos[b * 3 + 2] - newPos[a * 3 + 2];
+    const vx = newPos[c * 3] - newPos[a * 3];
+    const vy = newPos[c * 3 + 1] - newPos[a * 3 + 1];
+    const vz = newPos[c * 3 + 2] - newPos[a * 3 + 2];
+    const nx = uy * vz - uz * vy;
+    const ny = uz * vx - ux * vz;
+    const nz = ux * vy - uy * vx;
+    for (const i of [a, b, c]) {
+      newNormals[i * 3] += nx;
+      newNormals[i * 3 + 1] += ny;
+      newNormals[i * 3 + 2] += nz;
+    }
+  }
+  if (newIdx.length === 0) return mesh; // fully collapsed — keep the original
+
+  for (let i = 0; i < counts.length; i++) {
+    const len = Math.hypot(
+      newNormals[i * 3],
+      newNormals[i * 3 + 1],
+      newNormals[i * 3 + 2],
+    );
+    if (len > 0) {
+      newNormals[i * 3] /= len;
+      newNormals[i * 3 + 1] /= len;
+      newNormals[i * 3 + 2] /= len;
+    }
+  }
+
+  return {
+    ...mesh,
+    positions: newPos,
+    indices: new Uint32Array(newIdx),
+    normals: newNormals,
+  };
 }
 
 /**
@@ -348,6 +593,27 @@ export async function getPreviewGlb(
   instances = false,
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
   const preview = await previewGlbFor(doc, engine, instances);
+  if (preview?.oversize) {
+    // Explicit, named failure instead of a payload the transport will drop
+    // and a viewer status that says only "preview unavailable".
+    const mb = (preview.glb.length / 1_000_000).toFixed(1);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            _vcad_glb: null,
+            version: preview.version,
+            error: "preview_too_large",
+            detail:
+              `Model too large for inline preview (${mb} MB of GLB, ` +
+              `budget ${(PREVIEW_MAX_BASE64 / 1_000_000).toFixed(1)} MB) — ` +
+              "open it in vcad.io or use export_cad for the full geometry.",
+          }),
+        },
+      ],
+    };
+  }
   if (preview) {
     return {
       content: [
@@ -357,6 +623,7 @@ export async function getPreviewGlb(
             _vcad_glb: preview.glb,
             version: preview.version,
             ...(preview.mode ? { mode: preview.mode } : {}),
+            ...(preview.degraded ? { degraded: true } : {}),
           }),
         },
       ],

--- a/packages/mcp/viewer-app/main.ts
+++ b/packages/mcp/viewer-app/main.ts
@@ -885,6 +885,8 @@ type InlineMetaPreview = {
   glb?: string;
   version?: string;
   mode?: string;
+  /** Server decimated the geometry to fit the payload budget. */
+  degraded?: boolean;
 };
 
 function findMetaPreview(result: ToolResultLike): InlineMetaPreview | null {
@@ -988,6 +990,25 @@ function findPreviewMode(result: ToolResultLike): string | null {
   return hit?.mode ?? null;
 }
 
+/** A named preview failure from the server (currently `preview_too_large`) —
+ *  as opposed to a bare empty result or a transport error. */
+function findPreviewError(
+  result: ToolResultLike,
+): { error: string; detail?: string } | null {
+  const hit = findPayload<{ error?: string; detail?: string }>(
+    result,
+    (o) => typeof o.error === "string" && "_vcad_glb" in o,
+  );
+  return hit?.error ? { error: hit.error, detail: hit.detail } : null;
+}
+
+/** Did the server decimate this preview to fit its payload budget? */
+function findPreviewDegraded(result: ToolResultLike): boolean {
+  return Boolean(
+    findPayload<{ degraded?: boolean }>(result, (o) => o.degraded === true),
+  );
+}
+
 /**
  * Fetch a document's GLB via the app-only preview tool and render it in
  * place. Records the version token so the self-refresh poll knows the
@@ -1010,6 +1031,17 @@ async function fetchAndRenderGlb(
   })) as ToolResultLike;
   const glb = findInlineGlb(previewResult);
   if (!glb) {
+    // Three distinct outcomes, three distinct messages — "preview unavailable"
+    // on its own names no cause and leaves nothing to act on.
+    const named = findPreviewError(previewResult);
+    if (named) {
+      // Server declined to send a payload it knows the transport would drop.
+      setStatus("model too large for inline preview", "error");
+      errEl.textContent = named.detail ?? named.error;
+      // The deep link is the working escape hatch for exactly this case.
+      openBtn.style.display = "inline-flex";
+      return;
+    }
     // An error result (e.g. the session isn't resident on the instance that
     // answered) is not the same as an empty document — say so instead of
     // masquerading as "no geometry".
@@ -1017,6 +1049,9 @@ async function fetchAndRenderGlb(
       previewResult?.isError ? "preview unavailable" : "no geometry to preview",
       "idle",
     );
+    if (previewResult?.isError) {
+      errEl.textContent = "session not resolvable on this server instance";
+    }
     return;
   }
   const ver = findPreviewVersion(previewResult);
@@ -1025,6 +1060,11 @@ async function fetchAndRenderGlb(
   const isInstancesGlb =
     wantInstances && findPreviewMode(previewResult) === "instances";
   renderGlbForDoc(glb, docId, changed, isInstancesGlb);
+  // Say so when the server decimated to fit the payload budget — a preview
+  // that silently isn't the geometry you authored is worse than a slow one.
+  if (findPreviewDegraded(previewResult)) {
+    docLabelEl.textContent = `${docId} · reduced detail`;
+  }
 }
 
 /** Capture VCode IR text for the "Open in vcad.io" button. */
@@ -2381,6 +2421,7 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
         false,
         metaPreview.version ?? null,
       );
+      if (metaPreview.degraded) docLabelEl.textContent = `${docId} · reduced detail`;
       return;
     } catch (e) {
       // Corrupt inline payload (e.g. bad base64) — fall through to the
@@ -2409,8 +2450,12 @@ async function handleToolResult(result: ToolResultLike): Promise<void> {
     await fetchAndRenderGlb(docId, changed);
   } catch (e) {
     console.error("[vcad-viewer] preview fetch failed:", e);
-    setStatus("preview unavailable", "error");
+    // The size case is handled server-side (fetchAndRenderGlb reports it by
+    // name); reaching here means the CALL itself failed — say that, and keep
+    // the deep link as the escape hatch.
+    setStatus("preview fetch failed", "error");
     errEl.textContent = e instanceof Error ? e.message : String(e);
+    openBtn.style.display = "inline-flex";
   }
 }
 


### PR DESCRIPTION
## The bug

The inline 3D viewer's two size limits were never connected to each other:

1. `attachInlinePreview()` caps the `_meta` GLB at 1.5M base64 chars and, above that, attaches nothing — working as designed.
2. The viewer then falls back to fetching geometry itself via `get_preview_glb`, and **that path had no size ceiling at all**. The payload blows the host's result ceiling and the widget lands on a bare `setStatus("preview unavailable", "error")`.

So everything above the inline cap was *guaranteed* to fail, and the cap exists precisely because payloads that big are a problem. Repro: a 31-part filleted assembly (~81k triangles, 9,093,620 base64 chars) — geometry watertight, `render_view` fine, widget an empty grid. Filleted primitives inflate triangle counts hard, so ordinary mechanical parts hit this much sooner than "31 boxes" suggests.

## The fix

Give the budget to the single build path both callers share.

- **One ceiling.** `PREVIEW_MAX_BASE64` lives in `tools/preview.ts`; `server.ts` re-exports it as `INLINE_PREVIEW_MAX_BASE64`.
- **Bounded, not dropped.** `fitPreviewToBudget()` builds full fidelity first; only if that exceeds the budget does it degrade, via uniform vertex clustering over the scene bbox. Per-part, so glTF node names, materials and click→part identity all survive (quadric decimation across merged meshes would not); normals are recomputed area-weighted so the result still shades. Grid ladder 256→4, seeded from the required reduction so it doesn't walk every rung.
- **Full fidelity where it's safe.** `generateGlbPreview` takes an explicit budget; the plain-HTTP live route passes `null` — it streams over a real HTTP body and has none of the JSON-RPC ceiling.
- **Named failure.** If even the coarsest grid can't fit, the result is `{_vcad_glb: null, error: "preview_too_large", detail: …}` rather than a payload we know the transport will drop.

Viewer (`viewer-app/main.ts`) now distinguishes three outcomes instead of one: *model too large for inline preview* (server's detail line in `errEl`), *preview fetch failed* (the call itself errored), and *no geometry to preview*. Both failure paths force the working "Open in vcad.io" button visible. A decimated preview labels itself `<docId> · reduced detail` — a preview that silently isn't the geometry you authored is worse than a slow one.

## Cost

Measured on a 40-root heavy document: budget fitting is ~40ms; the kernel evaluation dominates at ~2s. Documents under the cap are built exactly once, unchanged from before.

## Tests

`packages/mcp/src/__tests__/preview-budget.test.ts` drives an over-cap document through the real MCP client → `get_preview_glb` and asserts the result is under budget, flagged `degraded`, and a well-formed GLB with meshes and nodes — plus unit coverage on identity preservation and index validity. The over-cap branch had no end-to-end coverage before.

86 mcp test files pass (945 tests, 3 skipped); `tsc --noEmit` clean.

## Reviewer notes

- Three call sites of `generateGlbPreview` moved from `string | null` to an envelope; `.glb` reads at each.
- **Not done, deliberately:** artifact offload (needs a reachable public base URL, which a stdio/local server doesn't have — so it can't be the sole path and is orthogonal to this fix), and meshopt/Draco (adds a dep plus a viewer-side decoder; decimation bounds the payload today).
- **Not visually verified:** this worktree is missing `vite-plugin-singlefile` and `@modelcontextprotocol/ext-apps`, so `build:viewer` fails and the widget could not be rendered against the branch. Viewer changes are covered by typecheck and the server-side tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)