### PR TITLE
fix(mcp): structuredContent is a superset of content, never a lossy stub

### DIFF
--- a/changelog/entries/2026-07-25-structured-content-superset.json
+++ b/changelog/entries/2026-07-25-structured-content-superset.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-structured-content-superset",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "MCP results no longer drop a tool's deliverable",
+  "summary": "structuredContent was only the {document_id, document_version} preview handle, so hosts that render it hid real payloads — sheet_metal_unfold's flat pattern and DXF among them.",
+  "features": ["mcp", "sheet-metal"],
+  "mcpTools": ["sheet_metal_unfold", "sheet_metal_create"]
+}

--- a/packages/mcp/src/__tests__/sheet-metal-deliverable.test.ts
+++ b/packages/mcp/src/__tests__/sheet-metal-deliverable.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { documents } from "../tools/session.js";
+
+/**
+ * `sheet_metal_unfold`'s deliverable — the flat pattern and the fab-ready DXF
+ * — must survive the FULL server dispatch path, in BOTH renderings a host can
+ * choose: the text `content` blocks and `structuredContent`.
+ *
+ * Field report (2026-07-25): the handler returned everything, but the only
+ * structured payload was the `{document_id, document_version}` preview handle,
+ * and a host that renders structuredContent in preference to the text blocks
+ * showed the caller exactly that stub — no flat pattern, no DXF, no bbox. A
+ * handler-level test would have passed while that shipped, so this drives the
+ * real ListTools/CallTool handlers end to end and asserts both fields.
+ */
+
+interface ToolCallResult {
+  content: Array<{ type: string; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+async function connect(engine: Engine) {
+  const server = await createServer(engine, { user: null });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0.0.0" }, { capabilities: {} });
+  await Promise.all([client.connect(clientT), server.connect(serverT)]);
+  return { client, server };
+}
+
+/** The JSON object a text-only host would parse out of the result. */
+function bodyOf(result: ToolCallResult): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  for (const block of result.content) {
+    if (block.type !== "text") continue;
+    try {
+      const parsed = JSON.parse(block.text) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        Object.assign(merged, parsed);
+      }
+    } catch {
+      // prose block
+    }
+  }
+  return merged;
+}
+
+// 2mm Al-soft on the sendcutsend profile: fixed inside radius 0.97, K 0.48.
+// Bend allowance = (pi/2) * (R + K*t) = (pi/2) * (0.97 + 0.96).
+const ALLOWANCE = (Math.PI / 2) * (0.97 + 0.48 * 2);
+const BASE_WIDTH = 76;
+const FLANGE = 55;
+// Developed width: base + two flanges, each joined by one bend allowance.
+const DEVELOPED_WIDTH = BASE_WIDTH + 2 * (FLANGE + ALLOWANCE);
+
+describe("sheet_metal_unfold returns its deliverable through full dispatch", () => {
+  let engine: Engine;
+  beforeAll(async () => {
+    engine = await Engine.init();
+  });
+
+  it("returns flat pattern + layered DXF in content AND structuredContent", async () => {
+    documents.clear();
+    const { client, server } = await connect(engine);
+
+    const created = (await client.callTool({
+      name: "sheet_metal_create",
+      arguments: {
+        width: BASE_WIDTH,
+        depth: 200,
+        thickness: 2,
+        material: "Al-soft",
+        shop_profile: "sendcutsend",
+        bend_relief: true,
+        flanges: [
+          { edge_index: 1, length: FLANGE, direction: "Up" },
+          { edge_index: 3, length: FLANGE, direction: "Up" },
+        ],
+      },
+    })) as ToolCallResult;
+    expect(created.isError).toBeFalsy();
+
+    // sheet_metal_create's own promised summary must survive too — same
+    // behavior flags, same hazard.
+    const createBody = bodyOf(created);
+    expect(createBody.model).toBeDefined();
+    expect(createBody.violations).toBeDefined();
+    expect(created.structuredContent?.model).toBeDefined();
+
+    const docId = created.structuredContent?.document_id as string;
+    expect(typeof docId).toBe("string");
+
+    const unfolded = (await client.callTool({
+      name: "sheet_metal_unfold",
+      arguments: { document_id: docId, include_dxf: true },
+    })) as ToolCallResult;
+    expect(unfolded.isError).toBeFalsy();
+
+    // Both renderings carry the deliverable — neither may be a bare handle.
+    for (const [label, view] of [
+      ["content", bodyOf(unfolded)],
+      ["structuredContent", unfolded.structuredContent ?? {}],
+    ] as Array<[string, Record<string, unknown>]>) {
+      const flat = view.flat_pattern as Record<string, unknown> | undefined;
+      expect(flat, `${label}: flat_pattern missing`).toBeDefined();
+
+      const dxf = view.dxf;
+      expect(typeof dxf, `${label}: dxf missing`).toBe("string");
+      const text = dxf as string;
+      expect(text.length).toBeGreaterThan(0);
+      // The documented layers, all four declared in the LAYER table.
+      for (const layer of ["CUT", "BEND_UP", "BEND_DOWN", "ENGRAVE"]) {
+        expect(text, `${label}: DXF missing ${layer}`).toContain(layer);
+      }
+      // Bend centerlines are DASHED, and real cut geometry was emitted.
+      expect(text).toContain("DASHED");
+      expect(text).toContain("LWPOLYLINE");
+
+      // Flat bbox matches the developed length for this flange/K-factor case.
+      const bbox = flat!.bbox as number[];
+      expect(bbox).toHaveLength(4);
+      expect(bbox[2] - bbox[0]).toBeCloseTo(DEVELOPED_WIDTH, 6);
+      expect(bbox[3] - bbox[1]).toBeCloseTo(200, 6);
+
+      // Two 90-degree Up creases, one per flange, on the allowance midline.
+      const creases = flat!.creases as Array<Record<string, unknown>>;
+      expect(creases).toHaveLength(2);
+      for (const crease of creases) {
+        expect(crease.direction).toBe("Up");
+        expect(crease.k_factor).toBeCloseTo(0.48, 6);
+      }
+      expect(flat!.area_mm2 as number).toBeGreaterThan(0);
+    }
+
+    await client.close();
+    await server.close();
+  });
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1544,7 +1544,10 @@ export async function createServer(
  * loses the entire payload — it must keep the full text result.
  */
 export function slimPreviewForInlineUi(
-  result: { content: Array<{ type: string; text: string }> },
+  result: {
+    content: Array<{ type: string; text: string }>;
+    structuredContent?: Record<string, unknown>;
+  },
   docId: string,
   toolName: string,
   clientHasInlineUi: boolean,
@@ -1595,6 +1598,19 @@ export function slimPreviewForInlineUi(
     { type: "text", text: summary },
     { type: "text", text: JSON.stringify({ document_id: docId, ...keep }) },
   ];
+  // attachPreviewHandle folded the FULL body into structuredContent (so a
+  // host that renders structured data can't miss a deliverable). When we
+  // slim the text, the structured payload has to shed the same bulk or the
+  // spill this function exists to prevent just moves to the other field.
+  // The two renderings stay equivalent — both are now the slim stub.
+  if (result.structuredContent) {
+    const { document_id, document_version } = result.structuredContent;
+    result.structuredContent = {
+      ...keep,
+      document_id: document_id ?? docId,
+      ...(document_version !== undefined ? { document_version } : {}),
+    };
+  }
 }
 
 /** Fields that must never be slimmed away: success/fault verdicts the caller
@@ -1617,6 +1633,18 @@ const SLIM_PRESERVED_FIELDS = [
  * id, as a small JSON text block too. Cursor has known gaps forwarding
  * structuredContent to widgets, and the id is useful to agents anyway
  * (it opens the result up for follow-up mutations).
+ *
+ * `structuredContent` MUST stay a SUPERSET of the text payload, never a
+ * lossy stub. Field report (2026-07-25): `sheet_metal_unfold` returned the
+ * full flat pattern + DXF in `content`, but the only structured payload was
+ * `{document_id, document_version}` — and a host that renders
+ * structuredContent when present (in preference to the text blocks) showed
+ * the caller exactly that stub. The tool's entire deliverable, the only
+ * route from a vcad sheet-metal part to a cuttable flat file, silently
+ * vanished on the way out. Every geometry tool carried the same hazard.
+ * So: fold the handler's own JSON body into the structured payload, with
+ * the preview handle merged ON TOP (the ids are ours to define). The two
+ * renderings are then equivalent and the failure mode is "kept too much".
  */
 function attachPreviewHandle(
   result: {
@@ -1627,6 +1655,7 @@ function attachPreviewHandle(
   toolName?: string,
 ): void {
   const structured: Record<string, unknown> = {
+    ...jsonBodyOf(result.content),
     ...result.structuredContent,
     document_id: docId,
   };
@@ -1650,6 +1679,33 @@ function attachPreviewHandle(
       text: JSON.stringify({ document_id: docId }),
     });
   }
+}
+
+/**
+ * Merge every text block that parses as a JSON *object* into one record —
+ * the handler's own return body, as structured data. Non-JSON prose blocks
+ * and JSON arrays/scalars have no field names to merge and are skipped;
+ * they still ride in `content` untouched. First writer wins, so a handler's
+ * primary body isn't overwritten by a trailing annotation block.
+ */
+function jsonBodyOf(
+  content: Array<{ type: string; text: string }>,
+): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  for (const block of content) {
+    if (block.type !== "text") continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(block.text);
+    } catch {
+      continue; // prose block — nothing to merge
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (body[k] === undefined) body[k] = v;
+    }
+  }
+  return body;
 }
 
 /**


### PR DESCRIPTION
## The bug

`sheet_metal_unfold` returned exactly `{"document_id":"…","document_version":"…"}` — no `flat_pattern`, no `dxf`, no `area`, no `bbox`. Its own description promises all of it. There was no route from a vcad sheet-metal part to a cuttable flat file; DXF is what laser shops actually consume, and a 2D-only shop can't take the STEP export that happened to work.

## Root cause — not the slimmer

`slimPreviewForInlineUi` was the obvious suspect and is innocent on two counts: it already exempts `sheet_metal_unfold` by name (landed in `f418b60c`), and the whole function no-ops unless `clientHasInlineUi`, which Claude Code never declares.

Reproduced through the real `createServer` + `InMemoryTransport` dispatch: the handler's payload arrives fully intact in `content` — all three panel outlines, `silhouette_2d`, both creases, and a complete DXF with the CUT/BEND_UP/BEND_DOWN/ENGRAVE layer table.

The culprit is `attachPreviewHandle`, which set `structuredContent` to precisely the reported id pair. A host that renders `structuredContent` in preference to the text blocks shows the caller the preview handle and nothing else — silently, with no error. The handle was designed as a private viewer channel (document id + a change token for the poll loop), but `structuredContent` is a protocol-level rendering of the whole result. **All 39 `geometry: true` tools carried the same hazard**, `sheet_metal_create` included.

## The fix

Fixed at the chokepoint rather than by allowlist, so tool #40 can't regress: `attachPreviewHandle` folds the handler's own JSON body into the structured payload with the ids merged on top. The two renderings are now equivalent and the failure mode is "kept too much" rather than "silently returned nothing."

`slimPreviewForInlineUi` slims both fields in lockstep — otherwise the spill it exists to prevent would just relocate to `structuredContent`.

No artifact offload was needed: the DXF for this part is ~4KB and nothing was ever size-gated.

## Test

`packages/mcp/src/__tests__/sheet-metal-deliverable.test.ts` drives the full dispatch and asserts **both** renderings carry the deliverable — a handler-only test passes while this ships. It checks all four documented DXF layers, `DASHED` bend centerlines, real `LWPOLYLINE` geometry, and the flat bbox against the closed-form developed width `76 + 2·(55 + (π/2)(0.97 + 0.48·2))` = 192.0633mm, plus `sheet_metal_create`'s `model`/`violations`. Verified red without the fix (`expected undefined to be defined`).

## Audit of other large-payload tools

`export_gerber`, `bom_export`, `get_copper` — all `behavior({})`, so no `structuredContent` is ever attached and the slimmer never runs. Clean. The only other post-handler mutation is `stampResultMeta`, which touches `_meta` only.

## Verification

- Full MCP suite: **941 passed, 3 skipped across 86 files**
- `tsc --noEmit` clean
- Changelog entry added

## Reviewer note

Unrelated to this change, spotted while reproducing: the preview GLB for a two-flange part is a single node named `"3:Bend relief"` — the base flange and both flanges may not be reaching the preview mesh. The geometry itself is fine (`sheet_metal_check` and the STEP export both agree), so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)