### PR TITLE
fix(mcp): export_cad exports assembly documents

### DIFF
--- a/changelog/entries/2026-07-25-export-assemblies.json
+++ b/changelog/entries/2026-07-25-export-assemblies.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-export-assemblies",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "export_cad exports assemblies",
+  "summary": "Assembly documents (partDefs + instances) now export to STL and GLB — STL bakes world transforms, GLB keeps one named node per instance.",
+  "features": ["assembly", "export"],
+  "mcpTools": ["export_cad", "quote_manufacturing"]
+}

--- a/packages/mcp/src/__tests__/assembly-export.test.ts
+++ b/packages/mcp/src/__tests__/assembly-export.test.ts
@@ -1,0 +1,153 @@
+/**
+ * export_cad must export ASSEMBLY documents (partDefs + instances, no scene
+ * roots) — regression for "Document has no parts to export", which fired on
+ * every assembly because the exporter walked `doc.roots` only.
+ *
+ * STL bakes instance transforms into world space; GLB keeps geometry
+ * part-local and carries the world pose on one named node per instance.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { exportCad } from "../tools/export.js";
+import { computeInspection } from "../tools/inspect.js";
+import { measureDocument } from "../fabricate/geometry.js";
+
+let engine: Engine;
+let dir: string;
+beforeAll(async () => {
+  engine = await Engine.init();
+  dir = mkdtempSync(join(tmpdir(), "vcad-asm-export-"));
+  process.env.VCAD_MCP_EXPORT_DIR = dir;
+});
+
+/** Two parts, one revolute joint — the smallest real assembly. */
+const ASSEMBLY_LOON = `
+[assembly
+  #[[part "base" [cylinder 40.0 30.0] "steel"]
+    [part "arm" [cube 80.0 20.0 20.0] "aluminum"]]
+  #[[instance "base-inst" "base" 0.0 0.0 0.0]
+    [instance "arm-inst" "arm" 0.0 0.0 30.0]]
+  #[[revolute-joint "shoulder" 0.0 1.0 0.0 -90.0 90.0
+      "base-inst" 0.0 0.0 25.0
+      "arm-inst" 0.0 0.0 0.0]]
+  "base-inst"]
+`;
+
+function assemblyDoc(): Document {
+  const doc = engine.evalVcadSource(ASSEMBLY_LOON);
+  if (!doc) throw new Error("loon eval failed");
+  return doc;
+}
+
+function runExport(doc: Document, filename: string): Record<string, unknown> {
+  const res = exportCad({ document: doc, filename }, engine);
+  return JSON.parse(res.content[0].text) as Record<string, unknown>;
+}
+
+/** Bounding box of a binary STL's triangle soup. */
+function stlBbox(bytes: Uint8Array): {
+  min: [number, number, number];
+  max: [number, number, number];
+  triangles: number;
+} {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const triangles = view.getUint32(80, true);
+  const min: [number, number, number] = [Infinity, Infinity, Infinity];
+  const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  for (let t = 0; t < triangles; t++) {
+    const base = 84 + t * 50 + 12; // skip the per-facet normal
+    for (let v = 0; v < 3; v++) {
+      for (let c = 0; c < 3; c++) {
+        const x = view.getFloat32(base + v * 12 + c * 4, true);
+        min[c] = Math.min(min[c], x);
+        max[c] = Math.max(max[c], x);
+      }
+    }
+  }
+  return { min, max, triangles };
+}
+
+/** glTF JSON chunk of a GLB. */
+function glbJson(bytes: Uint8Array): Record<string, any> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  expect(new TextDecoder().decode(bytes.slice(0, 4))).toBe("glTF");
+  const jsonLen = view.getUint32(12, true);
+  return JSON.parse(new TextDecoder().decode(bytes.slice(20, 20 + jsonLen)));
+}
+
+describe("export_cad on assembly documents", () => {
+  it("exports STL with instance transforms baked, matching inspect_cad's bbox", () => {
+    const doc = assemblyDoc();
+    expect(doc.roots?.length ?? 0).toBe(0);
+    expect(doc.instances?.length).toBe(2);
+
+    const payload = runExport(doc, "asm.stl");
+    expect(payload.parts).toBe(2);
+    expect(payload.instances).toBe(2);
+
+    const bytes = readFileSync(String(payload.path));
+    expect(bytes.length).toBeGreaterThan(84);
+    const stl = stlBbox(new Uint8Array(bytes));
+    expect(stl.triangles).toBeGreaterThan(0);
+
+    // World-space bbox must agree with what inspect_cad reports for the same
+    // document — i.e. the arm instance's z=30 offset is really baked in.
+    const inspected = computeInspection(doc, engine).bounding_box;
+    const tol = 1e-3;
+    expect(stl.min[0]).toBeCloseTo(inspected.min.x, 2);
+    expect(stl.min[1]).toBeCloseTo(inspected.min.y, 2);
+    expect(stl.min[2]).toBeCloseTo(inspected.min.z, 2);
+    expect(stl.max[0]).toBeCloseTo(inspected.max.x, 2);
+    expect(stl.max[1]).toBeCloseTo(inspected.max.y, 2);
+    expect(stl.max[2]).toBeCloseTo(inspected.max.z, 2);
+    expect(stl.max[2]).toBeGreaterThan(30 - tol);
+  });
+
+  it("exports GLB with one named node per instance", () => {
+    const doc = assemblyDoc();
+    const payload = runExport(doc, "asm.glb");
+    const bytes = new Uint8Array(readFileSync(String(payload.path)));
+    expect(bytes.length).toBeGreaterThan(0);
+
+    const json = glbJson(bytes);
+    expect(json.nodes).toHaveLength(doc.instances!.length);
+    const names = json.nodes.map((n: { name: string }) => n.name);
+    expect(names).toContain("base-inst:base-inst");
+    expect(names.some((n: string) => n.startsWith("arm-inst:"))).toBe(true);
+
+    // Structure preserved, not flattened: the arm's world pose rides on the
+    // node TRS rather than being welded into the vertices.
+    const arm = json.nodes.find((n: { name: string }) =>
+      n.name.startsWith("arm-inst:"),
+    );
+    // FK-solved: the joint anchor, not the authored instance origin.
+    const fk = engine
+      .evaluate(doc)
+      .instances!.find((i) => i.instanceId === "arm-inst")!;
+    expect(arm.translation?.[2]).toBeCloseTo(fk.transform!.translation.z, 3);
+    expect(fk.transform!.translation.z).toBeGreaterThan(0);
+  });
+
+  it("quote_manufacturing's geometry measurement sees assemblies", () => {
+    const metrics = measureDocument(assemblyDoc(), engine);
+    expect(metrics.ok).toBe(true);
+    expect(metrics.parts).toBe(2);
+    expect(metrics.volume_mm3).toBeGreaterThan(0);
+    expect(metrics.bbox!.max[2]).toBeGreaterThan(30);
+  });
+
+  it("names the real reason when there is genuinely nothing to export", () => {
+    const empty = {
+      version: "1",
+      nodes: {},
+      roots: [],
+      materials: {},
+      part_materials: {},
+    } as unknown as Document;
+    expect(() => runExport(empty, "empty.stl")).toThrow(/no scene roots/);
+  });
+});

--- a/packages/mcp/src/export/glb.ts
+++ b/packages/mcp/src/export/glb.ts
@@ -14,6 +14,7 @@
 import { getKernelWasmSync } from "@vcad/engine";
 import type { EvaluatedScene } from "@vcad/engine";
 import type { Document, Vec3 } from "@vcad/ir";
+import { sceneExportUnits } from "./scene-units.js";
 
 interface ExportWasm {
   buildGlbBytes(
@@ -251,20 +252,41 @@ export function buildGlb(
  * {@link buildPartLabels}. Omitted entries fall back to `part_<idx>`.
  *
  * Parts keep the neutral default material; for colored PCB previews the
- * caller builds {@link GlbMesh}es directly and calls {@link buildGlb}. */
+ * caller builds {@link GlbMesh}es directly and calls {@link buildGlb}.
+ *
+ * Assembly instances become one node each, named `"<instanceId>:<name>"`,
+ * with the FK-solved world pose on the node TRS and geometry left part-local
+ * — so the structure round-trips into other tools instead of flattening, and
+ * repeated instances of one partDef share a single glTF mesh. */
 export function toGlbBytes(
   scene: EvaluatedScene,
   name: string,
   partLabels?: string[],
 ): Uint8Array {
-  const meshes: GlbMesh[] = scene.parts.map((part, i) => ({
-    name: partLabels?.[i] ?? `part_${i}`,
-    positions: part.mesh.positions,
-    indices: part.mesh.indices,
-    normals: part.mesh.normals,
+  const meshes: GlbMesh[] = sceneExportUnits(scene, partLabels).map((unit) => ({
+    name: unit.name,
+    positions: unit.mesh.positions,
+    indices: unit.mesh.indices,
+    normals: unit.mesh.normals,
     color: DEFAULT_MATERIAL.color,
     metallic: DEFAULT_MATERIAL.metallic,
     roughness: DEFAULT_MATERIAL.roughness,
+    meshKey: unit.meshKey,
+    transform: unit.transform
+      ? {
+          translation: [
+            unit.transform.translation.x,
+            unit.transform.translation.y,
+            unit.transform.translation.z,
+          ],
+          rotationQuat: eulerXyzDegToQuat(unit.transform.rotation),
+          scale: [
+            unit.transform.scale.x,
+            unit.transform.scale.y,
+            unit.transform.scale.z,
+          ],
+        }
+      : undefined,
   }));
   return buildGlb(meshes, name);
 }

--- a/packages/mcp/src/export/scene-units.ts
+++ b/packages/mcp/src/export/scene-units.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared "what is there to export?" view of an evaluated scene.
+ *
+ * A document authored as an ASSEMBLY has `roots: []` — all geometry lives in
+ * `partDefs` + `instances`, placed by the joint tree — so anything that walks
+ * `scene.parts` alone sees an empty document. This module folds both shapes
+ * into one list of export units, mirroring the traversal `render_view` /
+ * `get_preview_glb` / `inspect_cad` already use (a part-local mesh plus the
+ * FK-solved world transform).
+ */
+
+import { transformMesh } from "@vcad/engine";
+import type { EvaluatedScene, TriangleMesh } from "@vcad/engine";
+
+/** World placement of an instance's part-local mesh (Euler XYZ degrees). */
+export interface UnitTransform {
+  translation: { x: number; y: number; z: number };
+  rotation: { x: number; y: number; z: number };
+  scale: { x: number; y: number; z: number };
+}
+
+/** One exportable piece of geometry: a scene root part, or an assembly
+ *  instance (part-local `mesh` + world `transform`). */
+export interface ExportUnit {
+  /** glTF node name — `"<part_id>:<name>"` for roots,
+   *  `"<instanceId>:<name>"` for assembly instances. */
+  name: string;
+  /** Part-LOCAL geometry. Apply `transform` (or {@link worldMesh}) for world space. */
+  mesh: TriangleMesh;
+  /** World placement; absent for root parts (geometry is already world-space). */
+  transform?: UnitTransform;
+  /** Geometry-dedup key (partDefId) so repeated instances share one glTF mesh. */
+  meshKey?: string;
+}
+
+/**
+ * Flatten an evaluated scene into export units: root parts first (index-aligned
+ * with `partLabels`), then assembly instances.
+ */
+export function sceneExportUnits(
+  scene: EvaluatedScene,
+  partLabels?: string[],
+): ExportUnit[] {
+  const units: ExportUnit[] = scene.parts.map((part, i) => ({
+    name: partLabels?.[i] ?? `part_${i}`,
+    mesh: part.mesh,
+  }));
+
+  for (const inst of scene.instances ?? []) {
+    units.push({
+      name: `${inst.instanceId}:${inst.name ?? ""}`,
+      mesh: inst.mesh,
+      transform: inst.transform,
+      meshKey: inst.partDefId,
+    });
+  }
+
+  return units;
+}
+
+/** The unit's geometry in world space (transform baked into the vertices). */
+export function worldMesh(unit: ExportUnit): TriangleMesh {
+  if (!unit.transform) return unit.mesh;
+  return transformMesh(unit.mesh, {
+    translate: unit.transform.translation,
+    rotate: unit.transform.rotation,
+    scale: unit.transform.scale,
+  });
+}

--- a/packages/mcp/src/export/stl.ts
+++ b/packages/mcp/src/export/stl.ts
@@ -5,31 +5,37 @@
  * `buildStlBytes`) — the single source of truth for STL serialization.
  */
 
-import type { EvaluatedScene } from "@vcad/engine";
+import type { EvaluatedScene, TriangleMesh } from "@vcad/engine";
 import { exportKernel } from "./glb.js";
+import { sceneExportUnits, worldMesh } from "./scene-units.js";
 
-/** Convert evaluated scene to binary STL bytes (merged triangle soup). */
+/** Convert evaluated scene to binary STL bytes (merged triangle soup).
+ *
+ * STL has no scene graph, so assembly instances are baked into world space —
+ * the merged soup matches what `inspect_cad` measures for the same document. */
 export function toStlBytes(scene: EvaluatedScene, name: string): Uint8Array {
+  const bodies: TriangleMesh[] = sceneExportUnits(scene).map(worldMesh);
+
   let f32Len = 0;
   let u32Len = 0;
-  for (const part of scene.parts) {
-    f32Len += part.mesh.positions.length;
-    u32Len += part.mesh.indices.length;
+  for (const mesh of bodies) {
+    f32Len += mesh.positions.length;
+    u32Len += mesh.indices.length;
   }
 
   const f32Data = new Float32Array(f32Len);
   const u32Data = new Uint32Array(u32Len);
   let f32Off = 0;
   let u32Off = 0;
-  const meshes = scene.parts.map((part) => {
-    f32Data.set(part.mesh.positions, f32Off);
-    u32Data.set(part.mesh.indices, u32Off);
+  const meshes = bodies.map((mesh) => {
+    f32Data.set(mesh.positions, f32Off);
+    u32Data.set(mesh.indices, u32Off);
     const spec = {
-      positions: [f32Off, part.mesh.positions.length],
-      indices: [u32Off, part.mesh.indices.length],
+      positions: [f32Off, mesh.positions.length],
+      indices: [u32Off, mesh.indices.length],
     };
-    f32Off += part.mesh.positions.length;
-    u32Off += part.mesh.indices.length;
+    f32Off += mesh.positions.length;
+    u32Off += mesh.indices.length;
     return spec;
   });
 

--- a/packages/mcp/src/fabricate/geometry.ts
+++ b/packages/mcp/src/fabricate/geometry.ts
@@ -14,8 +14,9 @@
  */
 
 import type { Document } from "@vcad/ir";
-import type { Engine, TriangleMesh } from "@vcad/engine";
+import type { Engine, EvaluatedScene, TriangleMesh } from "@vcad/engine";
 import { computeMeshProperties } from "../tools/inspect.js";
+import { sceneExportUnits, worldMesh } from "../export/scene-units.js";
 import type { GeometryMetrics } from "./types.js";
 
 const EMPTY: GeometryMetrics = {
@@ -28,23 +29,28 @@ const EMPTY: GeometryMetrics = {
   bbox: null,
 };
 
-/** Evaluate `ir` and aggregate geometry metrics across all parts. */
+/** Evaluate `ir` and aggregate geometry metrics across all parts.
+ *
+ * Assembly-authored documents have no scene roots — their geometry is
+ * instances placed by the joint tree — so instances are folded in world-space
+ * alongside root parts, matching what `inspect_cad` reports. */
 export function measureDocument(ir: Document, engine: Engine): GeometryMetrics {
-  let scene: { parts: Array<{ mesh: TriangleMesh }> };
+  let scene: EvaluatedScene;
   try {
-    scene = engine.evaluate(ir) as { parts: Array<{ mesh: TriangleMesh }> };
+    scene = engine.evaluate(ir);
   } catch {
     return { ...EMPTY };
   }
-  if (!scene.parts || scene.parts.length === 0) return { ...EMPTY };
+  const bodies: TriangleMesh[] = sceneExportUnits(scene).map(worldMesh);
+  if (bodies.length === 0) return { ...EMPTY };
 
   let volume = 0;
   let area = 0;
   const min: [number, number, number] = [Infinity, Infinity, Infinity];
   const max: [number, number, number] = [-Infinity, -Infinity, -Infinity];
 
-  for (const part of scene.parts) {
-    const props = computeMeshProperties(part.mesh);
+  for (const mesh of bodies) {
+    const props = computeMeshProperties(mesh);
     volume += props.volume;
     area += props.area;
     min[0] = Math.min(min[0], props.bbox.min.x);
@@ -63,7 +69,7 @@ export function measureDocument(ir: Document, engine: Engine): GeometryMetrics {
 
   return {
     ok: true,
-    parts: scene.parts.length,
+    parts: bodies.length,
     volume_mm3: volume,
     surface_area_mm2: area,
     footprint_mm2: dx * dy,

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -6,6 +6,7 @@ import type { Engine } from "@vcad/engine";
 import { writeFileSync } from "node:fs";
 import { toStlBytes } from "../export/stl.js";
 import { toGlbBytes } from "../export/glb.js";
+import { sceneExportUnits } from "../export/scene-units.js";
 import { resolveWithinRoot } from "./safe-path.js";
 import { isRemoteDeployment, maxInlineExportBytes } from "./remote.js";
 import { storeArtifact } from "./artifact-store.js";
@@ -131,11 +132,36 @@ export function exportCad(
     });
   }
 
-  // Evaluate the document to get meshes
+  // Evaluate the document to get meshes. Both document shapes export: scene
+  // roots (`doc.roots`) AND assembly instances (`partDefs` + `instances`,
+  // placed by the joint tree) — an assembly-authored document has no roots at
+  // all, which is normal, not an error.
   const scene = engine.evaluate(ir);
+  const units = sceneExportUnits(scene);
 
-  if (scene.parts.length === 0) {
-    throw new Error("Document has no parts to export");
+  if (units.length === 0) {
+    const failures = scene.failures ?? [];
+    if (failures.length > 0) {
+      throw new Error(
+        "Nothing to export: every feature failed to evaluate — " +
+          failures.map((f) => `${f.scope}: ${f.error}`).join("; ") +
+          ". Fix the failing feature with `update`, then re-export.",
+      );
+    }
+    throw new Error(
+      "Nothing to export: the document defines no geometry — it has no scene " +
+        "roots (doc.roots) and no assembly instances. Add a part with " +
+        "`create_cad_loon` / `create`, then re-export.",
+    );
+  }
+
+  const triangles = units.reduce((n, u) => n + u.mesh.indices.length / 3, 0);
+  if (triangles === 0) {
+    throw new Error(
+      `Nothing to export: ${units.length} part(s) evaluated but produced zero ` +
+        "triangles (empty geometry — e.g. a boolean that removed everything). " +
+        "Check the shape with `render_view`, then fix it with `update`.",
+    );
   }
 
   // Determine format from extension
@@ -155,7 +181,10 @@ export function exportCad(
 
   return deliver(filename, bytes, {
     format: ext,
-    parts: scene.parts.length,
+    parts: units.length,
+    ...(scene.instances && scene.instances.length > 0
+      ? { instances: scene.instances.length }
+      : {}),
   });
 }
 


### PR DESCRIPTION
## The bug

`export_cad` could not export an assembly. It walked `doc.roots` only, and an assembly-authored document has `roots: []` — all geometry lives in `partDefs` + `instances`, placed by the joint tree. So a perfectly valid 23-instance humanoid (volume 4.66e6 mm³, 17k triangles, renders fine) hit:

```
Error: Document has no parts to export
```

…with `next_actions` suggesting `read`, a dead end. The message was actively misleading: the document had 13 partDefs and 23 instances. It had no *roots*, which is not the same thing and is not a user error.

Inconsistent with the rest of the surface, which all handle assemblies: `render_view` renders them, `get_preview_glb` has an explicit `instances: true` mode, `inspect_cad` / `describe_scene` report per-instance geometry. The assembly evaluation path already existed and was proven — the exporter just wasn't using it.

## What changed

- **`packages/mcp/src/export/scene-units.ts` (new)** — one shared flattening of an evaluated scene into export units (root parts + assembly instances), mirroring the traversal `render_view` / `get_preview_glb` / `inspect_cad` already use. No second traversal.
- **STL** — bakes each instance's FK-solved world transform into the merged triangle soup (STL has no scene graph).
- **GLB** — one node per instance, named `"<instanceId>:<name>"`, geometry left part-local with the world pose on the node TRS, and `meshKey: partDefId` so repeated instances of one partDef share a single glTF mesh. Structure round-trips into other tools instead of flattening.
- **Errors name the real reason** — three distinct cases instead of one wrong message: every feature failed to evaluate (the failures are listed), the document has no roots *and* no instances, or parts evaluated to zero triangles. Each says what to do next.
- **Sibling path, same bug** — `quote_manufacturing` → `measureDocument` returned `ok:false` with zeroed volume/bbox for any assembly, so quotes silently fell back to non-geometric pricing. It now folds instances in world-space, matching `inspect_cad`.

The result payload now reports `instances` alongside `parts`.

## Other `doc.roots` consumers

Grepped them. `clearance`, `measure`, `inspect`, `preview`, and `integrity` already handle instances. `enclosure` and `topopt` operate on explicitly-selected root parts by design, so they are not silently wrong.

## Tests

`packages/mcp/src/__tests__/assembly-export.test.ts` — 2 parts, 1 revolute joint:

- STL bbox parsed back out of the exported bytes matches `inspect_cad`'s bbox for the same document (proves the transform is really baked, not dropped)
- GLB node count equals the instance count; the arm node's translation equals its FK-solved pose (proves structure preserved, not flattened)
- `measureDocument` sees the assembly
- the empty-document error names its reason

Full `@vcad/mcp` suite: 944 passed, 3 skipped. `tsc --noEmit` clean.

## Reviewer note

I left GLB **root-part** node names as `part_<i>` rather than switching them to the `"<part_id>:<name>"` convention `buildPartLabels` provides. That would be an improvement (it is what the viewer parses for click-to-select) but it changes the output of every existing non-assembly export, which is beyond this bug. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)