### PR TITLE
fix(em): simulate_em can solve a strongly saturating magnetostatics problem

### DIFF
--- a/changelog/entries/2026-07-25-em-saturated-picard.json
+++ b/changelog/entries/2026-07-25-em-saturated-picard.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-em-saturated-picard",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "fix",
+  "title": "simulate_em solves strongly saturating magnetostatics",
+  "summary": "Saturated motor cross-sections no longer fail with an unfixable 'Picard not converged': the nonlinear loop's cap, tolerance and relaxation are now caller-settable, and the default cap was raised.",
+  "features": ["em", "magnetostatics", "motors"],
+  "mcpTools": ["simulate_em"]
+}

--- a/crates/vcad-kernel-em/src/axisym.rs
+++ b/crates/vcad-kernel-em/src/axisym.rs
@@ -114,23 +114,150 @@ impl Material {
 }
 
 /// Options for the Picard (successive-substitution) nonlinear loop.
+///
+/// These govern the **outer** nonlinear loop only. The inner SOR sweep
+/// has its own [`SolveOptions::tol`] / `max_sweeps`; loosening those does
+/// nothing for a device whose materials refuse to settle.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PicardOptions {
     /// Hard cap on outer iterations.
     pub max_iters: usize,
     /// Convergence: largest relative change of any cell's reluctivity.
     pub tol: f64,
-    /// Under-relaxation on the reluctivity update, in (0, 1].
+    /// Under-relaxation on the reluctivity update, in (0, 1]. With
+    /// `adaptive` set this is the *starting* (and maximum) value.
     pub relax: f64,
+    /// Back `relax` off when the residual makes no net progress over a
+    /// 10-iteration window, and give it back when contraction resumes.
+    ///
+    /// **Off by default, and that is a measured choice, not caution.** On
+    /// the saturating motor section in this crate's tests it cost ~1.7x
+    /// the iterations (236 vs 140) by reacting to the residual jitter of
+    /// a healthy solve, and on the same device started from `relax = 0.3`
+    /// it ratcheted to the floor and turned a slow-but-converging run
+    /// into a failure. Damping is the right lever for a genuine limit
+    /// cycle; on this solver's B–H fixed point, slow contraction is the
+    /// far more common failure and wants `max_iters` instead. Turn this
+    /// on when a device is demonstrably oscillating — the failure message
+    /// says which mode you are in.
+    pub adaptive: bool,
 }
 
 impl Default for PicardOptions {
     fn default() -> Self {
         Self {
-            max_iters: 80,
+            // 80 was too tight to be a default: a saturating motor
+            // cross-section contracts steadily at this relaxation and
+            // simply needs ~140 iterations, so the old cap turned an
+            // ordinary machine into a hard failure with no caller-side
+            // recourse. Raising a cap can only convert failures into
+            // answers — it never changes a solve that already converged.
+            max_iters: 300,
             tol: 1e-4,
             relax: 0.7,
+            adaptive: false,
         }
+    }
+}
+
+/// Floor for adaptive under-relaxation — below this the loop is crawling
+/// and more iterations, not more damping, is the answer.
+pub(crate) const MIN_PICARD_RELAX: f64 = 0.02;
+
+/// Window (iterations) over which the residual's contraction rate is
+/// measured, for both the give-up diagnosis and nothing else.
+const PICARD_WINDOW: usize = 10;
+
+/// Adaptive under-relaxation and convergence-rate tracking, shared by the
+/// axisym and planar nonlinear drivers.
+///
+/// Two distinct failure modes hide behind "Picard not converged", and
+/// they want opposite fixes:
+///
+/// - **Oscillation.** Past the B–H knee the fixed-point map can stop
+///   contracting; the residual bounces instead of falling. More
+///   iterations never help — the relaxation has to come down.
+/// - **Slow contraction.** The residual falls steadily but geometrically
+///   at a rate near 1, and the iteration cap arrives first. Here
+///   *lowering* the relaxation makes things strictly worse; the cap is
+///   the only thing wrong.
+///
+/// So this tracks the residual history and (a) halves the relaxation only
+/// on a sustained *increase*, never merely on slow progress, and (b)
+/// exposes the observed per-iteration contraction rate so a failure can
+/// name which of the two modes it hit.
+pub(crate) struct PicardDamping {
+    relax: f64,
+    max_relax: f64,
+    adaptive: bool,
+    /// Iterations since the relaxation was last changed — an adjustment
+    /// is only made on a window that does not straddle a previous one.
+    since_adjust: usize,
+    /// Residuals of the last `PICARD_WINDOW` iterations, oldest first.
+    hist: std::collections::VecDeque<f64>,
+}
+
+impl PicardDamping {
+    pub(crate) fn new(popts: &PicardOptions) -> Self {
+        Self {
+            relax: popts.relax,
+            max_relax: popts.relax,
+            adaptive: popts.adaptive,
+            since_adjust: 0,
+            hist: std::collections::VecDeque::with_capacity(PICARD_WINDOW),
+        }
+    }
+
+    /// Relaxation to apply on the iteration about to run.
+    pub(crate) fn relax(&self) -> f64 {
+        self.relax
+    }
+
+    /// Feed the relative residual of the iteration just finished.
+    ///
+    /// Judged over the trailing window, never iteration to iteration: a
+    /// healthy solve's residual jitters upward regularly (the inner SOR
+    /// solve is only converged to a loosened tolerance while the
+    /// materials move), and reacting to those upticks costs real
+    /// iterations — measured at ~2x on a saturating motor section. Ten
+    /// iterations of no net progress is oscillation; a single bad step is
+    /// not.
+    pub(crate) fn observe(&mut self, rel: f64) {
+        if self.hist.len() == PICARD_WINDOW {
+            self.hist.pop_front();
+        }
+        self.hist.push_back(rel);
+        self.since_adjust += 1;
+        if !self.adaptive || self.since_adjust < PICARD_WINDOW {
+            return;
+        }
+        let Some(rate) = self.decay_rate() else {
+            return;
+        };
+        if rate >= 0.999 {
+            self.relax = (self.relax * 0.5).max(MIN_PICARD_RELAX);
+            self.since_adjust = 0;
+        } else if rate < 0.8 && self.relax < self.max_relax {
+            // Contracting briskly again — give back the damping that a
+            // now-passed rough patch cost.
+            self.relax = (self.relax * 1.5).min(self.max_relax);
+            self.since_adjust = 0;
+        }
+    }
+
+    /// Observed per-iteration contraction factor over the trailing
+    /// window, or `None` before the window fills. `< 1` means the loop is
+    /// converging (just perhaps slowly); `>= 1` means it is not.
+    pub(crate) fn decay_rate(&self) -> Option<f64> {
+        if self.hist.len() < PICARD_WINDOW {
+            return None;
+        }
+        let first = *self.hist.front()?;
+        let last = *self.hist.back()?;
+        if first <= 0.0 || last <= 0.0 {
+            return None;
+        }
+        Some((last / first).powf(1.0 / (PICARD_WINDOW - 1) as f64))
     }
 }
 
@@ -462,6 +589,7 @@ impl AxisymMagnetostatics {
             ));
         }
         let mut nu = self.initial_nu_cells(nr, nz);
+        let mut damp = PicardDamping::new(popts);
         let mut h_est = vec![0.0_f64; (nr - 1) * (nz - 1)];
         let mut warm: Option<Vec<f64>> = None;
         let mut report = PicardReport {
@@ -490,6 +618,7 @@ impl AxisymMagnetostatics {
             let g = &solution.system.grid;
             let mut max_db: f64 = 0.0;
             let mut b_scale: f64 = 1e-12;
+            let relax = damp.relax();
             for ci in 0..nr - 1 {
                 for cj in 0..nz - 1 {
                     let id = ci * (nz - 1) + cj;
@@ -502,17 +631,21 @@ impl AxisymMagnetostatics {
                     let b = (br * br + bz * bz).sqrt();
                     let h_solved = nu[id] * b;
                     let delta = h_solved - h_est[id];
-                    h_est[id] += popts.relax * delta;
+                    h_est[id] += relax * delta;
                     nu[id] = if h_est[id] > 1e-9 {
                         h_est[id] / b_of_h(mu_ri, s, h_est[id])
                     } else {
                         1.0 / (MU_0 * mu_ri)
                     };
-                    max_db = max_db.max((popts.relax * delta).abs());
+                    // Measured on the UNDAMPED update: this is the
+                    // fixed-point residual, so it does not shrink just
+                    // because the adaptive damping backed `relax` off.
+                    max_db = max_db.max(delta.abs());
                     b_scale = b_scale.max(h_est[id].abs());
                 }
             }
             let rel = max_db / b_scale;
+            damp.observe(rel);
             report = PicardReport {
                 iterations: it,
                 max_rel_delta: rel,
@@ -532,7 +665,33 @@ impl AxisymMagnetostatics {
         Err(SolveError::NonlinearNotConverged {
             max_rel_delta: report.max_rel_delta,
             iterations: report.iterations,
+            relax: damp.relax(),
+            tol: popts.tol,
+            decay_rate: damp.decay_rate(),
         })
+    }
+}
+
+impl SolveError {
+    /// The nonlinear convergence report carried by a failed Picard solve
+    /// — how many outer iterations ran and how far off the fixed point
+    /// they left the materials. `None` for the other failure modes.
+    ///
+    /// A caller that wants to accept a looser answer deliberately can
+    /// read this, judge the gap, and re-solve with a raised
+    /// [`PicardOptions::tol`].
+    pub fn picard_report(&self) -> Option<PicardReport> {
+        match self {
+            SolveError::NonlinearNotConverged {
+                iterations,
+                max_rel_delta,
+                ..
+            } => Some(PicardReport {
+                iterations: *iterations,
+                max_rel_delta: *max_rel_delta,
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -696,6 +855,48 @@ pub fn inductance_matrix(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn adaptive_damping_reacts_to_stagnation_not_to_jitter() {
+        let base = PicardOptions {
+            adaptive: true,
+            ..PicardOptions::default()
+        };
+        // A healthy solve: contracting overall, with the upward jitter a
+        // loosened inner solve produces. The relaxation must not move —
+        // reacting to these upticks is what made adaptive damping cost
+        // 1.7x on the motor section.
+        let mut d = PicardDamping::new(&base);
+        let mut rel = 1.0;
+        for i in 0..40 {
+            rel *= if i % 4 == 3 { 1.05 } else { 0.85 };
+            d.observe(rel);
+        }
+        assert_eq!(d.relax(), base.relax, "jitter must not trigger damping");
+        assert!(d.decay_rate().is_some_and(|r| r < 1.0));
+
+        // A limit cycle: no net progress. Now it must back off.
+        let mut d = PicardDamping::new(&base);
+        for i in 0..40 {
+            d.observe(if i % 2 == 0 { 1.0e-2 } else { 1.1e-2 });
+        }
+        assert!(
+            d.relax() < base.relax,
+            "stagnation must lower the relaxation: {}",
+            d.relax()
+        );
+        assert!(d.relax() >= MIN_PICARD_RELAX);
+
+        // And with `adaptive` off (the default) the same stagnation must
+        // leave the relaxation exactly where the caller put it.
+        let fixed = PicardOptions::default();
+        assert!(!fixed.adaptive, "adaptive damping must be opt-in");
+        let mut d = PicardDamping::new(&fixed);
+        for i in 0..40 {
+            d.observe(if i % 2 == 0 { 1.0e-2 } else { 1.1e-2 });
+        }
+        assert_eq!(d.relax(), fixed.relax);
+    }
     use crate::constants::MU_0;
 
     /// Infinite solenoid via Neumann boundaries: winding r ∈ [R1, R2]

--- a/crates/vcad-kernel-em/src/grid.rs
+++ b/crates/vcad-kernel-em/src/grid.rs
@@ -222,6 +222,16 @@ pub enum SolveError {
         max_rel_delta: f64,
         /// Outer iterations performed.
         iterations: usize,
+        /// Relaxation in force when the loop gave up (below the starting
+        /// `picard_relax` if adaptive damping backed it off).
+        relax: f64,
+        /// Tolerance the loop was aiming for.
+        tol: f64,
+        /// Observed per-iteration contraction of the residual over the
+        /// trailing window. `< 1` = converging, just not fast enough for
+        /// the iteration cap; `>= 1` = not converging at all. `None` when
+        /// the loop gave up before the window filled.
+        decay_rate: Option<f64>,
     },
 }
 
@@ -236,11 +246,66 @@ impl std::fmt::Display for SolveError {
             SolveError::NonlinearNotConverged {
                 max_rel_delta,
                 iterations,
-            } => write!(
-                f,
-                "Picard not converged after {iterations} iterations \
-                 (largest reluctivity update {max_rel_delta:.3e})"
-            ),
+                relax,
+                tol,
+                decay_rate,
+            } => {
+                write!(
+                    f,
+                    "Picard not converged after {iterations} iterations \
+                     (largest reluctivity update {max_rel_delta:.3e}, target \
+                     {tol:.1e}, relaxation {relax:.3}). This is the NONLINEAR \
+                     outer loop over the B-H law, NOT the SOR inner solve — \
+                     `tol` and `max_sweeps` have no effect on it. "
+                )?;
+                // Two failure modes, opposite fixes. Read the measured
+                // contraction rate rather than guessing: a residual still
+                // falling geometrically wants a higher iteration cap, and
+                // under-relaxing it further would only slow it down.
+                match decay_rate {
+                    // Too few iterations to have measured a trend — say
+                    // that, rather than diagnosing a mode from nothing.
+                    None => write!(
+                        f,
+                        "The loop stopped before its contraction rate could be \
+                         measured, so which mode this is (slow convergence vs \
+                         oscillation) is not yet known. Raise \
+                         `picard_max_iters` and retry; the next failure will \
+                         name the mode."
+                    ),
+                    Some(rate) if *rate < 0.999 => {
+                        let need = (max_rel_delta / tol).ln() / (1.0 / rate).ln();
+                        let suggested =
+                            iterations + ((need * 1.5).ceil().max(50.0) as usize).max(50);
+                        write!(
+                            f,
+                            "The residual IS still falling, at {rate:.4} per \
+                             iteration — the iteration cap arrived first. \
+                             Retry with `picard_max_iters: {suggested}`. Do \
+                             not lower `picard_relax` here; it would only \
+                             slow the contraction further."
+                        )
+                    }
+                    _ => {
+                        let suggested_relax = (relax * 0.4).max(0.05);
+                        write!(
+                            f,
+                            "The residual has stopped falling, so more \
+                             iterations alone will not close it. Try \
+                             `picard_relax: {suggested_relax:.2}` (deeper \
+                             under-relaxation, the lever for a limit cycle) — \
+                             but check the device too: a flux path driven \
+                             past what it can carry stalls the same way, and \
+                             no solver setting fixes that."
+                        )
+                    }
+                }?;
+                write!(
+                    f,
+                    " Raising `picard_tol` accepts a looser material state \
+                     deliberately."
+                )
+            }
         }
     }
 }

--- a/crates/vcad-kernel-em/src/planar.rs
+++ b/crates/vcad-kernel-em/src/planar.rs
@@ -29,7 +29,7 @@
 //! depth**; multiply by the stack length. Not modeled at M0: curvature of
 //! the unrolled annulus, radial end effects, saturation, eddy currents.
 
-use crate::axisym::{PicardOptions, PicardReport};
+use crate::axisym::{PicardDamping, PicardOptions, PicardReport};
 use crate::constants::MU_0;
 use crate::grid::{Bc, EnergyBalance, FvSystem, Grid2D, SolveError, SolveOptions};
 use crate::material::{b_of_h, Saturation};
@@ -576,6 +576,7 @@ impl PlanarMagnetostatics {
         let mut nu = self.initial_nu_cells(nx, ny);
         // Damped on the solved H — see the axisym driver for why both
         // ν-damping and B-damping diverge.
+        let mut damp = PicardDamping::new(popts);
         let mut h_est = vec![0.0_f64; x_cells * y_cells];
         let mut warm: Option<Vec<f64>> = None;
         let mut report = PicardReport {
@@ -603,6 +604,7 @@ impl PlanarMagnetostatics {
             let solution = self.wrap_solution(sys, unit, mag, sol);
             let mut max_db: f64 = 0.0;
             let mut b_scale: f64 = 1e-12;
+            let relax = damp.relax();
             for ci in 0..x_cells {
                 for cj in 0..y_cells {
                     let id = ci * y_cells + cj;
@@ -615,17 +617,19 @@ impl PlanarMagnetostatics {
                     let b = (bx * bx + by * by).sqrt();
                     let h_solved = nu[id] * b;
                     let delta = h_solved - h_est[id];
-                    h_est[id] += popts.relax * delta;
+                    h_est[id] += relax * delta;
                     nu[id] = if h_est[id] > 1e-9 {
                         h_est[id] / b_of_h(mu_ri, s, h_est[id])
                     } else {
                         1.0 / (MU_0 * mu_ri)
                     };
-                    max_db = max_db.max((popts.relax * delta).abs());
+                    // Undamped — see the axisym driver.
+                    max_db = max_db.max(delta.abs());
                     b_scale = b_scale.max(h_est[id].abs());
                 }
             }
             let rel = max_db / b_scale;
+            damp.observe(rel);
             report = PicardReport {
                 iterations: it,
                 max_rel_delta: rel,
@@ -645,6 +649,9 @@ impl PlanarMagnetostatics {
         Err(SolveError::NonlinearNotConverged {
             max_rel_delta: report.max_rel_delta,
             iterations: report.iterations,
+            relax: damp.relax(),
+            tol: popts.tol,
+            decay_rate: damp.decay_rate(),
         })
     }
 }
@@ -992,5 +999,185 @@ mod tests {
         assert!(asym < 1e-3, "action–reaction mismatch: {asym:.3e}");
         assert!(fx0.abs() < 0.02 * fy0.abs());
         assert!(fx1.abs() < 0.02 * fy0.abs());
+    }
+
+    /// An unrolled axial-flux machine cross-section at mean radius 49 mm:
+    /// rotor back-iron, four alternating NdFeB poles on a 15.395 mm
+    /// pitch, a 1 mm air gap, five stator teeth on a 12.316 mm pitch, and
+    /// a stator yoke — all iron saturable (μ_ri 4000, J_s 2.0 T).
+    ///
+    /// `tooth_w_mm` sets the flux concentration: the tooth carries a pole
+    /// pitch of gap flux through its own width, so a narrow tooth runs
+    /// past the B–H knee and a wide one stays under it. That is the whole
+    /// point of the fixture — the same geometry on both sides of the
+    /// knee.
+    pub(super) fn axial_flux_section(tooth_w_mm: f64) -> PlanarMagnetostatics {
+        let pole_pitch = 15.395;
+        let x_max = 4.0 * pole_pitch; // 61.58 mm, four poles
+        let tooth_pitch = x_max / 5.0; // five teeth, fractional-slot
+        let mut dev = PlanarMagnetostatics::new(0.0, x_max, 0.0, 29.0);
+        let iron = |x0: f64, x1: f64, y0: f64, y1: f64| {
+            PlanarMaterial::saturable(
+                Rect {
+                    x_min_mm: x0,
+                    x_max_mm: x1,
+                    y_min_mm: y0,
+                    y_max_mm: y1,
+                },
+                4000.0,
+                2.0,
+            )
+        };
+        // Rotor back-iron, then magnets, gap, teeth, stator yoke.
+        dev.materials.push(iron(0.0, x_max, 0.0, 5.0));
+        for k in 0..4 {
+            let x0 = k as f64 * pole_pitch;
+            dev.magnets.push(MagnetBlock {
+                region: Rect {
+                    x_min_mm: x0,
+                    x_max_mm: x0 + pole_pitch,
+                    y_min_mm: 5.0,
+                    y_max_mm: 9.0,
+                },
+                br_x_t: 0.0,
+                br_y_t: if k % 2 == 0 { 1.3 } else { -1.3 },
+                mu_r: 1.05,
+            });
+        }
+        for k in 0..5 {
+            let cx = (k as f64 + 0.5) * tooth_pitch;
+            dev.materials.push(iron(
+                cx - tooth_w_mm / 2.0,
+                cx + tooth_w_mm / 2.0,
+                10.0,
+                22.0,
+            ));
+        }
+        dev.materials.push(iron(0.0, x_max, 22.0, 28.0));
+        dev
+    }
+
+    /// Peak |B| over the tooth column at mid-height — the number that
+    /// says which side of the knee the fixture is on.
+    pub(super) fn peak_tooth_b(sol: &PlanarMagSolution, tooth_w_mm: f64) -> f64 {
+        let tooth_pitch = 4.0 * 15.395 / 5.0;
+        let mut peak: f64 = 0.0;
+        for k in 0..5 {
+            let cx = (k as f64 + 0.5) * tooth_pitch;
+            for s in 0..9 {
+                let x = cx + (s as f64 / 8.0 - 0.5) * tooth_w_mm * 0.8;
+                let (bx, by) = sol.b_at(x * 1e-3, 16.0e-3);
+                peak = peak.max((bx * bx + by * by).sqrt());
+            }
+        }
+        peak
+    }
+
+    #[test]
+    fn unsaturated_motor_section_converges_on_the_defaults() {
+        // 8 mm teeth: the tooth stays under the knee, and the stock
+        // Picard settings must keep handling it. This is the control for
+        // the saturated case below — it makes the failure boundary
+        // explicit rather than implicit.
+        let dev = axial_flux_section(8.0);
+        let (sol, report) = dev
+            .solve_nonlinear(95, 45, &SolveOptions::default(), &PicardOptions::default())
+            .expect("below-knee section must converge on the defaults");
+        let b = peak_tooth_b(&sol, 8.0);
+        assert!(
+            (0.8..1.7).contains(&b),
+            "control fixture drifted off the knee: peak tooth B = {b:.3} T"
+        );
+        assert!(
+            report.iterations <= PicardOptions::default().max_iters,
+            "iterations {}",
+            report.iterations
+        );
+    }
+
+    #[test]
+    fn saturating_motor_section_converges_with_adjusted_picard_options() {
+        // 6.4 mm teeth push the tooth well past the knee. This is the
+        // case that used to be unreachable: it contracts steadily at the
+        // stock relaxation but needs ~140 outer iterations, and the old
+        // 80-iteration cap was not caller-settable, so `tol` and
+        // `max_sweeps` (which govern the inner SOR solve) left the
+        // reported residual bit-identical.
+        let dev = axial_flux_section(6.4);
+        let popts = PicardOptions {
+            max_iters: 400,
+            ..PicardOptions::default()
+        };
+        let (sol, report) = dev
+            .solve_nonlinear(95, 45, &SolveOptions::default(), &popts)
+            .expect("saturated section must converge with a raised cap");
+        assert!(report.max_rel_delta < popts.tol);
+        assert!(
+            report.iterations > 80,
+            "fixture no longer exercises the old cap: {} iterations",
+            report.iterations
+        );
+        let b = peak_tooth_b(&sol, 6.4);
+        assert!(
+            b > 1.6,
+            "fixture is supposed to be saturated: peak tooth B = {b:.3} T"
+        );
+    }
+
+    #[test]
+    fn saturating_motor_section_converges_on_the_defaults() {
+        // And with the raised default cap it needs no options at all —
+        // the repro from the bug report, verbatim in spirit.
+        let dev = axial_flux_section(6.4);
+        let (_, report) = dev
+            .solve_nonlinear(95, 45, &SolveOptions::default(), &PicardOptions::default())
+            .expect("saturated section must converge on the defaults");
+        assert!(report.max_rel_delta < PicardOptions::default().tol);
+    }
+
+    #[test]
+    fn nonconvergence_names_the_knob_and_carries_the_report() {
+        // Fail-closed contract: the error must carry the report as DATA
+        // (so a caller can judge how far off the material state was, or
+        // accept a looser answer deliberately) and must point at the
+        // nonlinear knobs, not the SOR ones a caller would otherwise
+        // reach for.
+        let dev = axial_flux_section(6.4);
+        let popts = PicardOptions {
+            max_iters: 1,
+            ..PicardOptions::default()
+        };
+        let err = dev
+            .solve_nonlinear(95, 45, &SolveOptions::default(), &popts)
+            .expect_err("one iteration must not converge");
+        let report = err.picard_report().expect("report must survive failure");
+        assert_eq!(report.iterations, 1);
+        assert!(report.max_rel_delta > popts.tol);
+        let msg = err.to_string();
+        assert!(msg.contains("picard_max_iters"), "{msg}");
+        assert!(msg.contains("max_sweeps"), "{msg}");
+    }
+
+    #[test]
+    fn slow_convergence_is_diagnosed_as_the_iteration_cap() {
+        // The exact shape of the reported bug: a device that contracts
+        // steadily, stopped by the cap. The error must say so and point
+        // at `picard_max_iters` — advising deeper under-relaxation here
+        // would have made it strictly slower.
+        let dev = axial_flux_section(6.4);
+        let popts = PicardOptions {
+            max_iters: 40,
+            ..PicardOptions::default()
+        };
+        let err = dev
+            .solve_nonlinear(95, 45, &SolveOptions::default(), &popts)
+            .expect_err("40 iterations is short of this device's ~140");
+        let msg = err.to_string();
+        assert!(msg.contains("still falling"), "{msg}");
+        assert!(msg.contains("picard_max_iters"), "{msg}");
+        assert!(
+            !msg.contains("under-relax harder"),
+            "must not advise under-relaxing a converging loop: {msg}"
+        );
     }
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -8977,6 +8977,18 @@ struct EmSimOptions {
     ny: usize,
     tol: f64,
     max_sweeps: usize,
+    /// Nonlinear (saturable-iron) outer loop: iteration cap. Independent
+    /// of `max_sweeps`, which caps the inner SOR solve.
+    picard_max_iters: usize,
+    /// Nonlinear outer loop: convergence tolerance on the largest
+    /// relative reluctivity update. Independent of `tol`.
+    picard_tol: f64,
+    /// Nonlinear outer loop: starting (and maximum) under-relaxation, in
+    /// (0, 1]. Lower it for strongly saturated devices.
+    picard_relax: f64,
+    /// Nonlinear outer loop: back the relaxation off when the residual
+    /// stops falling. Default true.
+    picard_adaptive: bool,
     /// Axisym: which coil the inductance claim is priced for.
     drive_coil: usize,
     /// Axisym: also emit force claims for this coil.
@@ -8991,11 +9003,16 @@ struct EmSimOptions {
 
 impl Default for EmSimOptions {
     fn default() -> Self {
+        let p = vcad_kernel::vcad_kernel_em::axisym::PicardOptions::default();
         Self {
             nx: 81,
             ny: 81,
             tol: 1e-8,
             max_sweeps: 200_000,
+            picard_max_iters: p.max_iters,
+            picard_tol: p.tol,
+            picard_relax: p.relax,
+            picard_adaptive: p.adaptive,
             drive_coil: 0,
             force_coil: None,
             stress_probe: None,
@@ -9020,6 +9037,48 @@ struct WasmEmSim {
     qois: serde_json::Value,
     claim_sets: Vec<vcad_kernel::vcad_kernel_em::receipt::ClaimSet>,
     receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
+}
+
+/// Map a nonlinear-solve failure to an error that carries the Picard
+/// report as data alongside the prose, so a caller can judge how far off
+/// the material state was rather than only reading that it failed.
+fn em_nonlinear_err(e: vcad_kernel::vcad_kernel_em::grid::SolveError) -> JsError {
+    match e.picard_report() {
+        Some(r) => JsError::new(&format!(
+            "{e} | picard_report: {{\"iterations\": {}, \"max_rel_delta\": {:e}, \
+             \"converged\": false}}",
+            r.iterations, r.max_rel_delta
+        )),
+        None => JsError::new(&e.to_string()),
+    }
+}
+
+/// Nonlinear outer-loop options, validated. The knobs are independent of
+/// the SOR ones — a caller fighting a saturating device needs these.
+fn em_picard_options(
+    opts: &EmSimOptions,
+) -> Result<vcad_kernel::vcad_kernel_em::axisym::PicardOptions, JsError> {
+    if !(opts.picard_relax > 0.0 && opts.picard_relax <= 1.0) {
+        return Err(JsError::new(&format!(
+            "picard_relax must be in (0, 1] (got {})",
+            opts.picard_relax
+        )));
+    }
+    if opts.picard_max_iters == 0 {
+        return Err(JsError::new("picard_max_iters must be at least 1"));
+    }
+    if opts.picard_tol <= 0.0 {
+        return Err(JsError::new(&format!(
+            "picard_tol must be positive (got {})",
+            opts.picard_tol
+        )));
+    }
+    Ok(vcad_kernel::vcad_kernel_em::axisym::PicardOptions {
+        max_iters: opts.picard_max_iters,
+        tol: opts.picard_tol,
+        relax: opts.picard_relax,
+        adaptive: opts.picard_adaptive,
+    })
 }
 
 fn em_solve_options(opts: &EmSimOptions) -> vcad_kernel::vcad_kernel_em::grid::SolveOptions {
@@ -9086,10 +9145,10 @@ pub fn em_simulate(
             }
             let nonlinear = dev.materials.iter().any(|m| m.sat.is_some());
             let (sol, picard) = if nonlinear {
-                let popts = em::axisym::PicardOptions::default();
+                let popts = em_picard_options(&opts)?;
                 let (sol, report) = dev
                     .solve_nonlinear(opts.nx, opts.ny, &sopts, &popts)
-                    .map_err(|e| JsError::new(&e.to_string()))?;
+                    .map_err(em_nonlinear_err)?;
                 (
                     sol,
                     Some(WasmEmPicard {
@@ -9164,10 +9223,10 @@ pub fn em_simulate(
             })?;
             let nonlinear = dev.materials.iter().any(|m| m.sat.is_some());
             let (sol, picard) = if nonlinear {
-                let popts = em::axisym::PicardOptions::default();
+                let popts = em_picard_options(&opts)?;
                 let (sol, report) = dev
                     .solve_nonlinear(opts.nx, opts.ny, &sopts, &popts)
-                    .map_err(|e| JsError::new(&e.to_string()))?;
+                    .map_err(em_nonlinear_err)?;
                 (
                     sol,
                     Some(WasmEmPicard {

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -2996,6 +2996,22 @@
               "type": "number",
               "description": "SOR sweep cap. Default 200000."
             },
+            "picard_max_iters": {
+              "type": "number",
+              "description": "Saturable iron only: cap on the NONLINEAR outer loop over the B-H law. Default 300. Separate from max_sweeps, which caps the inner SOR solve and does nothing for a non-converging material state. A deeply saturated motor section contracts steadily but needs 150-250 iterations; raise this when the error says the residual is still falling."
+            },
+            "picard_tol": {
+              "type": "number",
+              "description": "Saturable iron only: nonlinear convergence tolerance on the largest relative reluctivity update. Default 1e-4. Raise it to accept a looser material state deliberately."
+            },
+            "picard_relax": {
+              "type": "number",
+              "description": "Saturable iron only: under-relaxation of the nonlinear loop, in (0, 1]. Default 0.7. Lower it ONLY when the error reports the residual has stopped falling (a limit cycle); when the residual is still falling, lowering this makes convergence strictly slower — raise picard_max_iters instead."
+            },
+            "picard_adaptive": {
+              "type": "boolean",
+              "description": "Saturable iron only: back the relaxation off automatically when the nonlinear residual makes no progress over a 10-iteration window. Default FALSE — on a healthy saturated solve it reacts to ordinary residual jitter and costs ~1.7x the iterations. Turn it on for a device that is demonstrably oscillating."
+            },
             "drive_coil": {
               "type": "number",
               "description": "Axisym: coil index the inductance claim is priced for. Default 0."

--- a/packages/mcp/src/tools/em.ts
+++ b/packages/mcp/src/tools/em.ts
@@ -246,6 +246,44 @@ export const toolDefs: ToolDef[] = [
               type: "number" as const,
               description: "SOR sweep cap. Default 200000.",
             },
+            picard_max_iters: {
+              type: "number" as const,
+              description:
+                "Saturable iron only: cap on the NONLINEAR outer loop over " +
+                "the B-H law. Default 300. Separate from max_sweeps, which " +
+                "caps the inner SOR solve and does nothing for a " +
+                "non-converging material state. A deeply saturated motor " +
+                "section contracts steadily but needs 150-250 iterations; " +
+                "raise this when the error says the residual is still " +
+                "falling.",
+            },
+            picard_tol: {
+              type: "number" as const,
+              description:
+                "Saturable iron only: nonlinear convergence tolerance on the " +
+                "largest relative reluctivity update. Default 1e-4. Raise it " +
+                "to accept a looser material state deliberately.",
+            },
+            picard_relax: {
+              type: "number" as const,
+              description:
+                "Saturable iron only: under-relaxation of the nonlinear " +
+                "loop, in (0, 1]. Default 0.7. Lower it ONLY when the error " +
+                "reports the residual has stopped falling (a limit cycle); " +
+                "when the residual is still falling, lowering this makes " +
+                "convergence strictly slower — raise picard_max_iters " +
+                "instead.",
+            },
+            picard_adaptive: {
+              type: "boolean" as const,
+              description:
+                "Saturable iron only: back the relaxation off automatically " +
+                "when the nonlinear residual makes no progress over a " +
+                "10-iteration window. Default FALSE — on a healthy saturated " +
+                "solve it reacts to ordinary residual jitter and costs ~1.7x " +
+                "the iterations. Turn it on for a device that is " +
+                "demonstrably oscillating.",
+            },
             drive_coil: {
               type: "number" as const,
               description:


### PR DESCRIPTION
## The problem

`simulate_em` with `problem: "planar_magnetostatics"` and `js_t` on iron regions failed on any device saturated hard enough to need more than 80 Picard iterations:

```
Error: Picard not converged after 80 iterations (largest reluctivity update 1.346e-3)
```

Passing `tol: 1e-6` and `max_sweeps: 400000` changed **nothing** — the residual came back bit-identical. Those govern the inner SOR sweep; the outer nonlinear loop's options were always `PicardOptions::default()` and were exposed nowhere. Strongly saturated machines are a primary use case for this solver, so the tool was simply unusable for them.

## What the measurement showed

The reported diagnosis was oscillation wanting deeper under-relaxation. It isn't. On the repro (unrolled axial-flux section, saturable teeth past the knee) the loop **contracts steadily** at the stock relaxation — 0.92 per iteration — and just needs ~140 iterations against a cap of 80.

Lowering `relax`, the intuitive fix, is strictly worse:

| `relax` | iterations to converge |
|---|---|
| 0.7 | 137 |
| 0.5 | 189 |
| 0.3 | 309 |
| 0.15 | no convergence in 400 |

That reframed the fix: the cap was the bug, and any error message advising under-relaxation would have sent callers the wrong way.

## Changes

- **Knobs plumbed through** — `picard_max_iters`, `picard_tol`, `picard_relax`, `picard_adaptive` on `EmSimOptions` and the `simulate_em` schema, validated fail-closed (`picard_relax: 1.5` errors rather than silently clamping).
- **Default cap 80 → 300.** Raising a cap can only convert failures into answers; it never changes a solve that already converged. The repro now converges **on the defaults, no options**, in 140 iterations.
- **The error names the knob, measured not guessed.** The loop tracks its residual's contraction rate over a trailing window and branches on it:
  - still falling → *"The residual IS still falling, at 0.9234 per iteration — the iteration cap arrived first. Retry with `picard_max_iters: 128`. Do not lower `picard_relax` here."* (the suggested value is extrapolated from the observed decay)
  - stalled → name `picard_relax`, and note the device itself may be over-driven
  - too few iterations to tell → say exactly that, rather than diagnosing from nothing

  Every branch states up front that `tol`/`max_sweeps` are the SOR knobs and do nothing here.
- **`PicardReport` survives failure** — `SolveError::picard_report()`, carried as JSON alongside the message, so a caller can judge how far off the material state was instead of parsing prose.
- **Latent correctness fix:** the residual was measured on the *damped* update, so lowering `relax` would have shrunk the reported residual and faked convergence. It is now the undamped fixed-point delta.

## On adaptive under-relaxation

Implemented, but **ships off by default**, with the evidence in the doc comment. On this device it cost 1.7× the iterations (236 vs 140) by reacting to the ordinary residual jitter of a healthy solve, and starting from `relax=0.3` it ratcheted to the floor and turned a slow-but-converging run into a failure. It's the right lever for a genuine limit cycle — which this fixture is not — so it's an opt-in knob rather than a default-on heuristic I can't demonstrate a win for.

Aitken/Anderson acceleration and a Newton step on the B–H law are **not** in this PR. They're worth doing, but they should be justified against a device that genuinely limit-cycles.

## Testing

New regression tests in `planar.rs`: the saturating section (6.4 mm teeth, ~1.8 T) on defaults and with a raised cap; an 8 mm control below the knee, so the failure boundary is explicit rather than implicit; the slow-contraction diagnosis; the fail-closed report contract; and a deterministic `PicardDamping` unit test separating jitter from stagnation.

52 `vcad-kernel-em` tests + 9 validation tests + 980 MCP tests pass. Clippy and fmt clean. Tool-surface fixture regenerated.

Verified end to end through a locally rebuilt kernel WASM against the actual `simulate_em` path; the generated artifacts were reverted per CLAUDE.md and will be refreshed by `wasm-refresh.yml` on merge.

## Reviewer notes

- The `adaptive` default and the raised `max_iters` default are the two judgement calls here — both are argued from numbers in the code comments, and both are easy to flip if you read the tradeoff differently.
- Does not touch `calc_motor`'s missing saturation (task_fdde42af). `simulate_em` can now serve as its oracle, which it couldn't before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
