### PR TITLE
fix(mcp): unbreak two session-restart tests failing on Linux CI

### DIFF
--- a/packages/mcp/src/__tests__/session-restart.test.ts
+++ b/packages/mcp/src/__tests__/session-restart.test.ts
@@ -77,7 +77,7 @@ describe("boot-generation tagging", () => {
     // splitting on "_" and taking [2] truncates it ~22% of the time.
     const suffix = (id: string) => id.replace(/^doc_\d+_/, "");
     expect(suffix(a)).not.toBe(a);
-    expect(suffix(a).length).toBeGreaterThanOrEqual(16);
+    for (const id of [a, b]) expect(suffix(id).length).toBeGreaterThanOrEqual(16);
   });
 });
 

--- a/packages/mcp/src/__tests__/session-restart.test.ts
+++ b/packages/mcp/src/__tests__/session-restart.test.ts
@@ -13,7 +13,7 @@
  *  3. a mint under a non-durable store says so, up front.
  */
 import { describe, it, expect, beforeEach, afterEach, beforeAll } from "vitest";
-import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Engine } from "@vcad/engine";
@@ -73,7 +73,11 @@ describe("boot-generation tagging", () => {
     const b = nextSessionId();
     expect(a).not.toBe(b);
     // Boot token + at least the 12 base64url chars of the 9 random bytes.
-    expect(a.split("_")[2].length).toBeGreaterThanOrEqual(16);
+    // NB: base64url uses "_", so the suffix can itself contain underscores —
+    // splitting on "_" and taking [2] truncates it ~22% of the time.
+    const suffix = (id: string) => id.replace(/^doc_\d+_/, "");
+    expect(suffix(a)).not.toBe(a);
+    expect(suffix(a).length).toBeGreaterThanOrEqual(16);
   });
 });
 
@@ -125,13 +129,21 @@ describe("unknownSessionMessage distinguishes the two causes", () => {
 });
 
 describe("FileSessionStore survives the restart", () => {
+  // The session dir is NESTED inside a sandbox so the traversal test can assert
+  // on the sandbox's contents. Probing an absolute host path (e.g.
+  // join(dir, "..", "..", "etc", "passwd")) is not a test of this code: on a
+  // shallow tmpdir like Linux CI's /tmp it resolves to the REAL /etc/passwd and
+  // fails no matter how airtight the guard is.
+  let sandbox: string;
   let dir: string;
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "vcad-sessions-"));
+    sandbox = mkdtempSync(join(tmpdir(), "vcad-sessions-"));
+    dir = join(sandbox, "sessions");
+    mkdirSync(dir);
     documents.clear();
   });
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    rmSync(sandbox, { recursive: true, force: true });
     documents.clear();
   });
 
@@ -171,9 +183,15 @@ describe("FileSessionStore survives the restart", () => {
 
   it("refuses an id that could escape the session directory", async () => {
     const store = new FileSessionStore(dir);
-    await store.save("../../etc/passwd", makeDoc());
-    expect(await store.load("../../etc/passwd")).toBeNull();
-    expect(existsSync(join(dir, "..", "..", "etc", "passwd"))).toBe(false);
+    for (const id of ["../../etc/passwd", "../escaped", "..", "/abs/path"]) {
+      await store.save(id, makeDoc());
+      expect(await store.load(id)).toBeNull();
+    }
+    // Nothing escaped: the sandbox still holds only the session dir, and the
+    // session dir itself is untouched. "../escaped" would have landed right
+    // here if the guard let it through.
+    expect(readdirSync(sandbox)).toEqual(["sessions"]);
+    expect(readdirSync(dir)).toEqual([]);
   });
 
   it("a corrupt snapshot is a miss, not a crash", async () => {


### PR DESCRIPTION
The `TypeScript` CI job is red on `main`, and therefore on every PR branch. Two tests in `packages/mcp/src/__tests__/session-restart.test.ts` fail on Linux but pass on macOS. Neither is a bug in the code under test — both assertions were checking something other than the invariant they meant to pin.

Test-only change. No production behavior is modified.

## 1. `refuses an id that could escape the session directory`

The test probed an absolute host path:

```ts
expect(existsSync(join(dir, "..", "..", "etc", "passwd"))).toBe(false);
```

`dir` is `mkdtempSync(join(tmpdir(), "vcad-sessions-"))`. On Linux CI that's `/tmp/vcad-sessions-XXXX`, so the expression resolves to the **real `/etc/passwd`**, which exists — the assertion failed regardless of whether `FileSessionStore` was secure. macOS passed only incidentally: its tmpdir (`/var/folders/rs/.../T/...`) is deep enough that the same expression lands on a nonexistent path.

Fix: nest the session dir inside an outer sandbox and assert on the *sandbox's* contents. Nothing escaped iff the sandbox still holds only `sessions/` and `sessions/` is empty. The input set is also widened to `["../../etc/passwd", "../escaped", "..", "/abs/path"]` — `"../escaped"` is the one that would land *inside* the sandbox, so the assertion now observes an actual escape rather than the host filesystem.

**Teeth verified:** deleting the `/^[A-Za-z0-9_-]{1,128}$/` guard from `FileSessionStore.pathFor` makes the test fail (`expected { nodes: {}, roots: [] } to be null`). Restored afterward.

## 2. `ids stay unguessable — the token is a prefix, not a replacement`

This one was reported as possibly flaky. It is deterministic, and it's a real assertion bug:

```ts
expect(a.split("_")[2].length).toBeGreaterThanOrEqual(16);
```

Session ids are `doc_<n>_<boot><random>`, and the suffix is **base64URL — which uses `_` as a character**. When any of the 16 suffix chars is an underscore, `split("_")[2]` is truncated and the assertion fails. Measured failure rate: **22.4% per id**, and the test mints two, so ~1 CI run in 5. PR #712 was simply lucky.

Fix: strip the prefix with `id.replace(/^doc_\d+_/, "")` instead of splitting on a character that occurs in the payload.

## Verification

- `npm test -w @vcad/mcp` → **90 files, 980 passed / 3 skipped**
- Re-run under `TMPDIR=/tmp` to reproduce the shallow-tmpdir condition that breaks Linux CI → still green
- Traversal test confirmed to fail with the path guard removed

## Note for reviewers

A fresh worktree needs `npm ci` **and** `npm run build:live` before vitest can even collect this file — `src/live-html.generated.js` is generated and not checked in, and its absence surfaces as an unrelated-looking module-resolution error in `live-route.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)