### PR TITLE
feat(loon): resolve [use ...] modules in the browser and over MCP

### DIFF
--- a/changelog/entries/2026-07-25-loon-modules-everywhere.json
+++ b/changelog/entries/2026-07-25-loon-modules-everywhere.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-25-loon-modules-everywhere",
+  "version": "0.9.4",
+  "date": "2026-07-25",
+  "category": "feat",
+  "title": "Multi-file loon projects, everywhere loon runs",
+  "summary": "[use ...] now resolves in the browser and over MCP, not just on disk: pass modules by value or point create_cad_loon at a base_dir, and pub, aliasing and selective imports all work.",
+  "features": ["loon", "mcp", "modules"],
+  "mcpTools": ["create_cad_loon"]
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -7043,11 +7043,31 @@ pub fn build_part(path: &str, params_json: &str) -> Result<String, JsError> {
 /// Evaluate a loon source string and return a JSON-serialized vcad Document.
 ///
 /// The vcad library (types, constructors) is automatically prepended.
-/// Module resolution (`[use ...]`) is not available in WASM — all code
-/// must be self-contained or use the bundled vcad library.
+/// There is no filesystem in WASM, so `[use ...]` resolves against nothing
+/// here — pass modules explicitly with [`eval_vcad_source_with_modules`].
 #[wasm_bindgen(js_name = evalVcadSource)]
 pub fn eval_vcad_source(source: &str) -> Result<JsValue, JsError> {
     let doc = vcad_loon::eval_vcad(source, None).map_err(|e| JsError::new(&e))?;
+    let json = serde_json::to_string(&doc)
+        .map_err(|e| JsError::new(&format!("Serialization error: {}", e)))?;
+    Ok(JsValue::from_str(&json))
+}
+
+/// Evaluate loon source whose `[use ...]` resolves against an in-memory
+/// module map, and return a JSON-serialized vcad Document.
+///
+/// `modules_json` is a JSON object of `{ "<module name>": "<loon source>" }`
+/// — the browser's stand-in for a filesystem. `[use foo]` finds the entry
+/// keyed `foo` (or `foo.loon`); the vcad library is available inside each
+/// module, and `pub` controls what a module exports. Multi-file CAD projects
+/// therefore behave identically here and on the native side, where the same
+/// modules would be files on disk.
+#[wasm_bindgen(js_name = evalVcadSourceWithModules)]
+pub fn eval_vcad_source_with_modules(source: &str, modules_json: &str) -> Result<JsValue, JsError> {
+    let modules: std::collections::HashMap<String, String> = serde_json::from_str(modules_json)
+        .map_err(|e| JsError::new(&format!("invalid modules JSON: {e}")))?;
+    let doc =
+        vcad_loon::eval_vcad_with_modules(source, None, &modules).map_err(|e| JsError::new(&e))?;
     let json = serde_json::to_string(&doc)
         .map_err(|e| JsError::new(&format!("Serialization error: {}", e)))?;
     Ok(JsValue::from_str(&json))

--- a/crates/vcad-loon/src/lib.rs
+++ b/crates/vcad-loon/src/lib.rs
@@ -3,9 +3,12 @@
 //! Evaluates `.vcad` loon source files and converts the resulting
 //! `Value::Adt` tree into a `vcad_ir::Document`.
 
+use std::collections::HashMap;
 use std::path::Path;
+use std::rc::Rc;
 
 use loon_lang::interp::Value;
+use loon_lang::module::{MapProvider, ModuleProvider};
 use vcad_ir::Document;
 
 mod convert;
@@ -24,6 +27,37 @@ pub fn eval_vcad(source: &str, base_dir: Option<&Path>) -> Result<Document, Stri
     value_to_document(&result)
 }
 
+/// Evaluate a `.vcad` loon source string whose `[use ...]` resolves against an
+/// in-memory `name -> source` map instead of (or before) the filesystem.
+///
+/// This is the resolver for hosts with no filesystem — the browser/WASM
+/// kernel and the MCP server, which reads the files itself and hands the
+/// kernel a map. A name absent from the map still falls through to
+/// `base_dir` when one is given, so the two mechanisms compose.
+///
+/// The vcad library is available inside imported modules exactly as it is in
+/// the root program, and a module's own definitions are what it exports.
+pub fn eval_vcad_with_modules(
+    source: &str,
+    base_dir: Option<&Path>,
+    modules: &HashMap<String, String>,
+) -> Result<Document, String> {
+    let result = eval_vcad_to_value_with_modules(source, base_dir, modules)?;
+    value_to_document(&result)
+}
+
+/// [`eval_vcad_with_modules`], returning the raw loon `Value`.
+///
+/// See [`eval_vcad_to_value`] for why that `Value` is not serializable.
+pub fn eval_vcad_to_value_with_modules(
+    source: &str,
+    base_dir: Option<&Path>,
+    modules: &HashMap<String, String>,
+) -> Result<Value, String> {
+    let provider: Rc<dyn ModuleProvider> = Rc::new(MapProvider::new(modules.clone()));
+    eval_with_provider(source, base_dir, Some(provider))
+}
+
 /// Evaluate a `.vcad` loon source string and return the raw loon Value.
 ///
 /// Useful for debugging or inspecting the AST before conversion.
@@ -33,6 +67,16 @@ pub fn eval_vcad(source: &str, base_dir: Option<&Path>) -> Result<Document, Stri
 /// compile (E0277). To write a `.vcad` document, use [`eval_vcad`], which
 /// returns a serializable [`Document`] — see `examples/loon2vcad.rs`.
 pub fn eval_vcad_to_value(source: &str, base_dir: Option<&Path>) -> Result<Value, String> {
+    eval_with_provider(source, base_dir, None)
+}
+
+/// Shared body of the eval entry points: rewrite multi-value programs,
+/// prepend the vcad library, and evaluate with the given module resolver.
+fn eval_with_provider(
+    source: &str,
+    base_dir: Option<&Path>,
+    provider: Option<Rc<dyn ModuleProvider>>,
+) -> Result<Value, String> {
     // A loon program's value is its *last* expression, so a source with
     // several top-level value forms (e.g. two `[root ...]` statements) would
     // silently keep only the final one. Rewrite such programs so every
@@ -44,7 +88,10 @@ pub fn eval_vcad_to_value(source: &str, base_dir: Option<&Path>) -> Result<Value
 
     let exprs = loon_lang::parser::parse(&full_source).map_err(|e| e.message.clone())?;
 
-    loon_lang::interp::eval_program_with_base_dir(&exprs, base_dir).map_err(|e| format!("{e}"))
+    // Imported modules get the vcad library too, so `[use ...]` code can
+    // speak the same vocabulary as the root program.
+    loon_lang::interp::eval_program_with_modules(&exprs, base_dir, provider, Some(VCAD_LIB_SOURCE))
+        .map_err(|e| format!("{e}"))
 }
 
 /// Top-level statement heads — forms that bind, define, mutate, or print
@@ -435,6 +482,177 @@ mod tests {
         let doc = eval_vcad(source, None).unwrap();
         assert_eq!(doc.roots.len(), 2);
         assert_eq!(doc.roots[0].material, "steel");
+    }
+
+    // ── module resolution ────────────────────────────────────────────
+    //
+    // The point of these is the *equivalence*: the same two-file project
+    // must produce the same Document whether the modules come off disk or
+    // out of an in-memory map.
+
+    const BRACKET_MODULE: &str = r#"
+[pub let plate [cube 40.0 20.0 4.0]]
+[pub let post [cylinder 3.0 12.0]]
+[let internal-scrap [sphere 1.0]]
+"#;
+
+    const MAIN_SOURCE: &str = r#"
+[use bracket]
+[root bracket.plate "aluminum"]
+[root [translate 20.0 10.0 4.0 bracket.post] "steel"]
+"#;
+
+    fn modules_map(entries: &[(&str, &str)]) -> HashMap<String, String> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn eval_modules_from_disk() {
+        let dir = std::env::temp_dir().join(format!("vcad-loon-mod-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bracket.loon"), BRACKET_MODULE).unwrap();
+        let doc = eval_vcad(MAIN_SOURCE, Some(&dir)).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+        assert_eq!(doc.roots.len(), 2);
+        assert_eq!(doc.roots[0].material, "aluminum");
+        assert_eq!(doc.roots[1].material, "steel");
+    }
+
+    #[test]
+    fn eval_modules_in_memory_matches_disk() {
+        let dir = std::env::temp_dir().join(format!("vcad-loon-eq-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bracket.loon"), BRACKET_MODULE).unwrap();
+        let from_disk = eval_vcad(MAIN_SOURCE, Some(&dir)).unwrap();
+        std::fs::remove_dir_all(&dir).ok();
+
+        let from_map = eval_vcad_with_modules(
+            MAIN_SOURCE,
+            None,
+            &modules_map(&[("bracket", BRACKET_MODULE)]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(&from_disk).unwrap(),
+            serde_json::to_value(&from_map).unwrap(),
+            "in-memory and filesystem module resolution must agree"
+        );
+    }
+
+    #[test]
+    fn eval_modules_in_memory_keyed_by_filename() {
+        let doc = eval_vcad_with_modules(
+            MAIN_SOURCE,
+            None,
+            &modules_map(&[("bracket.loon", BRACKET_MODULE)]),
+        )
+        .unwrap();
+        assert_eq!(doc.roots.len(), 2);
+    }
+
+    #[test]
+    fn eval_modules_aliased_and_selective() {
+        let aliased = eval_vcad_with_modules(
+            "[use bracket :as b]\n[root b.plate \"aluminum\"]",
+            None,
+            &modules_map(&[("bracket", BRACKET_MODULE)]),
+        )
+        .unwrap();
+        assert_eq!(aliased.roots.len(), 1);
+
+        let selective = eval_vcad_with_modules(
+            "[use bracket [plate]]\n[root plate \"aluminum\"]",
+            None,
+            &modules_map(&[("bracket", BRACKET_MODULE)]),
+        )
+        .unwrap();
+        assert_eq!(selective.roots.len(), 1);
+    }
+
+    #[test]
+    fn eval_modules_pub_hides_non_pub_names() {
+        // `internal-scrap` is not `pub`, so a selective import must fail.
+        let err = eval_vcad_with_modules(
+            "[use bracket [internal-scrap]]\n[root internal-scrap \"steel\"]",
+            None,
+            &modules_map(&[("bracket", BRACKET_MODULE)]),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("does not export"),
+            "expected an export error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn eval_modules_stdlib_visible_inside_module() {
+        // The module body calls `cube`, which lives in the vcad library —
+        // proof the host prelude reaches imported modules.
+        let doc = eval_vcad_with_modules(
+            "[use m]\n[root m.thing \"steel\"]",
+            None,
+            &modules_map(&[("m", "[pub let thing [cube 5.0 5.0 5.0]]")]),
+        )
+        .unwrap();
+        assert_eq!(doc.roots.len(), 1);
+    }
+
+    #[test]
+    fn eval_modules_nested_use() {
+        // b imports a; the root imports b. Nested `[use]` inside an
+        // in-memory module resolves against the same map.
+        let doc = eval_vcad_with_modules(
+            "[use b]\n[root b.stack \"steel\"]",
+            None,
+            &modules_map(&[
+                ("a", "[pub let base [cube 10.0 10.0 2.0]]"),
+                (
+                    "b",
+                    "[use a]\n[pub let stack [translate 0.0 0.0 2.0 a.base]]",
+                ),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(doc.roots.len(), 1);
+    }
+
+    #[test]
+    fn eval_modules_circular_import_errors() {
+        let err = eval_vcad_with_modules(
+            "[use a]\n[root a.x \"steel\"]",
+            None,
+            &modules_map(&[
+                ("a", "[use b]\n[pub let x [cube 1.0 1.0 1.0]]"),
+                ("b", "[use a]\n[pub let y [cube 1.0 1.0 1.0]]"),
+            ]),
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("circular dependency"),
+            "expected a cycle error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn eval_modules_missing_module_errors() {
+        let err = eval_vcad_with_modules(
+            "[use nope]\n[cube 1.0 1.0 1.0]",
+            None,
+            &modules_map(&[("bracket", BRACKET_MODULE)]),
+        )
+        .unwrap_err();
+        assert!(!err.is_empty());
+    }
+
+    #[test]
+    fn eval_empty_provider_is_a_no_op() {
+        // Nothing downstream breaks when no modules are supplied.
+        let doc = eval_vcad_with_modules("[cube 10.0 20.0 30.0]", None, &HashMap::new()).unwrap();
+        assert_eq!(doc.nodes.len(), 1);
     }
 
     #[test]

--- a/packages/docs/content/reference/mcp/create-cad-loon.mdx
+++ b/packages/docs/content/reference/mcp/create-cad-loon.mdx
@@ -12,9 +12,32 @@ order: 3
 Loon source code defining the geometry. See the [Loon Language Docs](https://loonlang.com/docs) for the complete language reference.
 </Param>
 
+<Param name="modules" type="object" required={false}>
+A `{ "<module name>": "<loon source>" }` map that `[use <name>]` in `source` resolves against -- multi-file projects passed by value. Macros passed via `loons` are importable by name too.
+</Param>
+
+<Param name="base_dir" type="string" required={false}>
+A server-side directory to resolve `[use <name>]` against: the server reads `<base_dir>/<name>.loon` (dots are path separators), follows nested imports, and hands the sources to the kernel. Reads are confined to this directory, and explicit `modules` entries win.
+</Param>
+
 <Param name="format" type="string" required={false}>
 Output format: `"compact"` (default) or `"json"`. Compact is recommended for MCP workflows.
 </Param>
+
+## Modules
+
+Loon's module system works here, so an interface shared between projects can have a single source of truth instead of being concatenated in by a build step:
+
+```json
+{
+  "source": "[use bracket]\n[root bracket.plate \"aluminum\"]",
+  "modules": {
+    "bracket": "[pub let plate [cube 40 20 4]]\n[let scrap [sphere 1]]"
+  }
+}
+```
+
+`pub` picks what a module exports (`scrap` above is private), `[use bracket :as b]` aliases, and `[use bracket [plate]]` imports selectively. Modules see the vcad library exactly as the root program does, and imports nest. A module read from `base_dir` and the same module passed in `modules` produce the same document -- and on the native side (the CLI, `vcad-render`), `[use ...]` resolves against the file's own directory with no extra wiring.
 
 ## Return Value
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -521,6 +521,8 @@ export interface KernelModule {
   evaluateDocument?: (docJson: string, skipClashDetection: boolean) => unknown;
   /** Evaluate loon source → JSON-serialized Document. */
   evalVcadSource?: (source: string) => string;
+  /** Evaluate loon source with an in-memory `[use ...]` module map. */
+  evalVcadSourceWithModules?: (source: string, modulesJson: string) => string;
   /** d(mass-property + bbox QoIs)/dθ for a named document parameter. */
   documentParameterGradient?: (
     docJson: string,
@@ -1036,6 +1038,7 @@ export class Engine {
       createDetailView: wasmModule.createDetailView,
       evaluateDocument: (wasmModule as Record<string, unknown>).evaluateDocument as KernelModule["evaluateDocument"],
       evalVcadSource: (wasmModule as Record<string, unknown>).evalVcadSource as KernelModule["evalVcadSource"],
+      evalVcadSourceWithModules: (wasmModule as Record<string, unknown>).evalVcadSourceWithModules as KernelModule["evalVcadSourceWithModules"],
       documentParameterGradient: (wasmModule as Record<string, unknown>).documentParameterGradient as KernelModule["documentParameterGradient"],
       getPartsManifest: (wasmModule as Record<string, unknown>).getPartsManifest as KernelModule["getPartsManifest"],
       buildPart: (wasmModule as Record<string, unknown>).buildPart as KernelModule["buildPart"],
@@ -1960,6 +1963,26 @@ export class Engine {
   evalVcadSource(source: string): Document | null {
     if (!this.kernel.evalVcadSource) return null;
     const json = this.kernel.evalVcadSource(source);
+    return JSON.parse(json) as Document;
+  }
+
+  /**
+   * Evaluate loon source whose `[use ...]` resolves against an in-memory
+   * `name -> source` map — the browser's stand-in for a filesystem.
+   *
+   * With an empty map this is exactly {@link evalVcadSource}. Returns null
+   * if the kernel doesn't support module-aware loon evaluation.
+   */
+  evalVcadSourceWithModules(
+    source: string,
+    modules: Record<string, string>,
+  ): Document | null {
+    if (!Object.keys(modules).length) return this.evalVcadSource(source);
+    if (!this.kernel.evalVcadSourceWithModules) return null;
+    const json = this.kernel.evalVcadSourceWithModules(
+      source,
+      JSON.stringify(modules),
+    );
     return JSON.parse(json) as Document;
   }
 

--- a/packages/mcp/src/__tests__/loon-modules.test.ts
+++ b/packages/mcp/src/__tests__/loon-modules.test.ts
@@ -1,0 +1,109 @@
+/**
+ * create_cad_loon module resolution: loon's `[use ...]` works over the MCP
+ * seam, so a multi-file CAD project no longer needs an external linker that
+ * concatenates the sources. Modules arrive either by value (`modules`, and
+ * inline `loons`) or read server-side from `base_dir` — and a module read
+ * off disk must produce the same document as the same module passed by
+ * value, which is the point of the abstraction.
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Engine } from "@vcad/engine";
+import { composeLoonModules, toolDefs } from "../tools/loon.js";
+import type { ToolContext } from "../tools/tool-def.js";
+import { getSession, registerSession } from "../tools/session-core.js";
+
+const BRACKET = `
+[pub let plate [cube 40 20 4]]
+[pub let post [cylinder 3 12]]
+[let scrap [sphere 1]]
+`;
+
+const MAIN = `
+[use bracket]
+[root bracket.plate "aluminum"]
+[root [translate 20 10 4 bracket.post] "steel"]
+`;
+
+let engine: Engine;
+let ctx: ToolContext;
+let dir: string;
+const createCadLoonDef = toolDefs.find((t) => t.name === "create_cad_loon")!;
+
+beforeAll(async () => {
+  engine = await Engine.init();
+  ctx = { engine, user: null } as unknown as ToolContext;
+  dir = mkdtempSync(join(tmpdir(), "vcad-loon-modules-"));
+  writeFileSync(join(dir, "bracket.loon"), BRACKET);
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("create_cad_loon module resolution", () => {
+  it("resolves [use] against an in-memory modules map", () => {
+    const doc = engine.evalVcadSourceWithModules(MAIN, { bracket: BRACKET });
+    expect(doc).not.toBeNull();
+    expect(doc!.roots.length).toBe(2);
+  });
+
+  it("agrees with the same module read from base_dir", () => {
+    const fromMap = engine.evalVcadSourceWithModules(MAIN, { bracket: BRACKET });
+    const fromDisk = engine.evalVcadSourceWithModules(
+      MAIN,
+      composeLoonModules({ source: MAIN, base_dir: dir }),
+    );
+    expect(fromDisk).toEqual(fromMap);
+  });
+
+  it("follows nested imports when reading from base_dir", () => {
+    mkdirSync(join(dir, "sub"), { recursive: true });
+    writeFileSync(join(dir, "sub", "base.loon"), "[pub let slab [cube 10 10 2]]");
+    writeFileSync(
+      join(dir, "stack.loon"),
+      '[use sub.base]\n[pub let tower [translate 0 0 2 sub.base.slab]]',
+    );
+    const src = '[use stack]\n[root stack.tower "steel"]';
+    const modules = composeLoonModules({ source: src, base_dir: dir });
+    expect(Object.keys(modules).sort()).toEqual(["stack", "sub.base"]);
+    const doc = engine.evalVcadSourceWithModules(src, modules);
+    expect(doc!.roots.length).toBe(1);
+  });
+
+  it("refuses to read outside base_dir", () => {
+    const modules = composeLoonModules({
+      source: "[use ..secrets]",
+      base_dir: dir,
+    });
+    expect(modules).toEqual({});
+  });
+
+  it("makes inline `loons` importable by name", () => {
+    const modules = composeLoonModules({
+      source: "[use widget [widget]]",
+      loons: [{ name: "widget", source: "[pub let widget [cube 3 3 3]]" }],
+    });
+    expect(modules.widget).toContain("cube");
+  });
+
+  it("authors a multi-module document into an open session", async () => {
+    const empty = engine.evalVcadSource("#[]");
+    const id = registerSession(empty!);
+    await createCadLoonDef.handler(
+      { document_id: id, source: MAIN, modules: { bracket: BRACKET } },
+      ctx,
+    );
+    const doc = getSession(id);
+    expect(doc.roots.length).toBe(2);
+  });
+
+  it("advertises modules and base_dir in the input schema", () => {
+    const props = createCadLoonDef.inputSchema.properties as Record<string, unknown>;
+    expect(props.modules).toBeDefined();
+    expect(props.base_dir).toBeDefined();
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1283,7 +1283,7 @@
   {
     "name": "create_cad_loon",
     "title": "Create CAD (Loon)",
-    "description": "The preferred authoring tool for whole parts and multi-feature models — one call, full vocabulary. Create a CAD document from loon source code. Loon is a Lisp-like language for parametric CAD — the FULL modeling vocabulary (patterns, sketches, extrude/revolve/sweep/loft, assemblies) is available here even where no dedicated MCP tool exists. For incremental single-node edits to an open session, use create/update/delete instead.\n\nPrimitives: [cube x y z], [cylinder r h], [sphere r], [cone r-bottom r-top h]\nBooleans (subject-last): [difference tool subject], [union other subject], [intersection other subject]\nTransforms (subject-last): [translate x y z s], [rotate rx ry rz s], [scale sx sy sz s]\nFeatures: [fillet r s], [chamfer d s], [shell t s]\nPatterns (subject-last): [linear-pattern dx dy dz count spacing s], [circular-pattern ox oy oz ax ay az count angle s] — e.g. a bolt circle is [circular-pattern 0 0 0 0 0 1 6 360 bolt-hole]\nSketches: [sketch ox oy oz xx xy xz yx yy yz #[segments]] with [line x1 y1 x2 y2] and [arc x1 y1 x2 y2 cx cy ccw]\nSketch ops (sketch-last): [extrude dx dy dz sk], [revolve aox aoy aoz adx ady adz angle sk], [sweep-line sx sy sz ex ey ez sk], [sweep-helix radius pitch height turns sk], [loft #[sk1 sk2 …]]\nAssemblies: [assembly #[parts] #[instances] #[joints] ground-id] with [part name solid \"material\"], [instance name part-name x y z], [revolute-joint …], [prismatic-joint …], [fixed-joint …], [ball-joint …]\nPipe: [pipe [cube 50 30 5] [difference [cylinder 3 10]] [fillet 1.0]]\nLet bindings: [let body [cube 50 30 5]]\nScene: [root solid \"material-name\"]",
+    "description": "The preferred authoring tool for whole parts and multi-feature models — one call, full vocabulary. Create a CAD document from loon source code. Loon is a Lisp-like language for parametric CAD — the FULL modeling vocabulary (patterns, sketches, extrude/revolve/sweep/loft, assemblies) is available here even where no dedicated MCP tool exists. For incremental single-node edits to an open session, use create/update/delete instead.\n\nPrimitives: [cube x y z], [cylinder r h], [sphere r], [cone r-bottom r-top h]\nBooleans (subject-last): [difference tool subject], [union other subject], [intersection other subject]\nTransforms (subject-last): [translate x y z s], [rotate rx ry rz s], [scale sx sy sz s]\nFeatures: [fillet r s], [chamfer d s], [shell t s]\nPatterns (subject-last): [linear-pattern dx dy dz count spacing s], [circular-pattern ox oy oz ax ay az count angle s] — e.g. a bolt circle is [circular-pattern 0 0 0 0 0 1 6 360 bolt-hole]\nSketches: [sketch ox oy oz xx xy xz yx yy yz #[segments]] with [line x1 y1 x2 y2] and [arc x1 y1 x2 y2 cx cy ccw]\nSketch ops (sketch-last): [extrude dx dy dz sk], [revolve aox aoy aoz adx ady adz angle sk], [sweep-line sx sy sz ex ey ez sk], [sweep-helix radius pitch height turns sk], [loft #[sk1 sk2 …]]\nAssemblies: [assembly #[parts] #[instances] #[joints] ground-id] with [part name solid \"material\"], [instance name part-name x y z], [revolute-joint …], [prismatic-joint …], [fixed-joint …], [ball-joint …]\nPipe: [pipe [cube 50 30 5] [difference [cylinder 3 10]] [fillet 1.0]]\nLet bindings: [let body [cube 50 30 5]]\nScene: [root solid \"material-name\"]\nModules: [use bracket] then [bracket.plate] — multi-file projects work here, with sources passed in `modules` (or read from `base_dir`); [use bracket :as b] aliases, [use bracket [plate]] imports selectively, and `pub` in a module picks what it exports",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1323,6 +1323,17 @@
               }
             }
           }
+        },
+        "modules": {
+          "type": "object",
+          "description": "Multi-file projects, by value: a { \"<module name>\": \"<loon source>\" } map that `[use <name>]` in `source` resolves against. `pub` controls what a module exports; `[use m :as alias]` and `[use m [a b]]` work as in the language. Entries passed via `loons` are importable by name too.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "base_dir": {
+          "type": "string",
+          "description": "Server-side directory that `[use <name>]` resolves against — the server reads <base_dir>/<name>.loon (dots are path separators) and hands the sources to the kernel, following nested imports. Reads are confined to this directory. Explicit `modules` entries win."
         },
         "format": {
           "type": "string",

--- a/packages/mcp/src/tools/loon.ts
+++ b/packages/mcp/src/tools/loon.ts
@@ -2,6 +2,8 @@
  * create_cad_loon tool — evaluate loon source to produce a CAD document.
  */
 
+import { readFileSync } from "node:fs";
+import { isAbsolute, join, resolve, sep } from "node:path";
 import type { Engine } from "@vcad/engine";
 import { toVCode } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
@@ -51,6 +53,24 @@ export const createCadLoonSchema = {
         },
       },
     },
+    modules: {
+      type: "object" as const,
+      description:
+        "Multi-file projects, by value: a { \"<module name>\": \"<loon " +
+        "source>\" } map that `[use <name>]` in `source` resolves against. " +
+        "`pub` controls what a module exports; `[use m :as alias]` and " +
+        "`[use m [a b]]` work as in the language. Entries passed via " +
+        "`loons` are importable by name too.",
+      additionalProperties: { type: "string" as const },
+    },
+    base_dir: {
+      type: "string" as const,
+      description:
+        "Server-side directory that `[use <name>]` resolves against — the " +
+        "server reads <base_dir>/<name>.loon (dots are path separators) and " +
+        "hands the sources to the kernel, following nested imports. Reads " +
+        "are confined to this directory. Explicit `modules` entries win.",
+    },
     format: {
       type: "string" as const,
       enum: ["vcode", "json"],
@@ -65,6 +85,8 @@ interface CreateLoonInput {
   source: string;
   use_loons?: string[];
   loons?: InlineLoon[];
+  modules?: Record<string, string>;
+  base_dir?: string;
   format?: "vcode" | "json";
 }
 
@@ -81,6 +103,65 @@ export function composeLoonProgram(input: unknown): string {
   return `${macroPrelude(names, loons)}\n\n${source}`;
 }
 
+/** Module names a program imports: every `[use <name> …]` head. */
+function importedNames(source: string): string[] {
+  const names: string[] = [];
+  const re = /\[\s*use\s+([A-Za-z_][\w.-]*)/g;
+  for (let m = re.exec(source); m; m = re.exec(source)) names.push(m[1]);
+  return names;
+}
+
+/** Read `<base>/<a>/<b>.loon` for a dotted module name, refusing to escape
+ *  `base`. Returns null when the module isn't there. */
+function readModule(base: string, name: string): string | null {
+  if (isAbsolute(name) || name.split(".").includes("..")) return null;
+  const root = resolve(base);
+  for (const ext of [".loon", ".oo"]) {
+    const file = resolve(join(root, ...name.split(".")) + ext);
+    if (file !== root && !file.startsWith(root + sep)) continue;
+    try {
+      return readFileSync(file, "utf8");
+    } catch {
+      // try the next extension
+    }
+  }
+  return null;
+}
+
+/**
+ * The in-memory module map `[use ...]` resolves against: explicit `modules`,
+ * plus inline `loons` (a macro passed by value is also an importable
+ * module), plus — when `base_dir` is given — files read from disk, following
+ * nested imports transitively.
+ *
+ * A name the server can't find is simply left out; the kernel then reports
+ * the missing module with loon's own error, rather than the server guessing.
+ */
+export function composeLoonModules(input: unknown): Record<string, string> {
+  const { source, loons, modules, base_dir } = input as CreateLoonInput;
+  const map: Record<string, string> = {};
+  for (const m of loons ?? []) map[m.name] = m.source;
+  Object.assign(map, modules ?? {});
+
+  if (base_dir) {
+    const pending = [
+      ...importedNames(source),
+      ...Object.values(map).flatMap(importedNames),
+    ];
+    const seen = new Set<string>();
+    while (pending.length) {
+      const name = pending.pop() as string;
+      if (seen.has(name) || map[name]) continue;
+      seen.add(name);
+      const src = readModule(base_dir, name);
+      if (src === null) continue;
+      map[name] = src;
+      pending.push(...importedNames(src));
+    }
+  }
+  return map;
+}
+
 /** Evaluate loon source and return a CAD document. */
 export function createCadLoon(
   input: unknown,
@@ -89,11 +170,16 @@ export function createCadLoon(
   const { format = "vcode" } = input as CreateLoonInput;
   const source = composeLoonProgram(input);
 
-  const doc = engine.evalVcadSource(source);
+  const modules = composeLoonModules(input);
+  const doc = engine.evalVcadSourceWithModules(source, modules);
   if (!doc) {
-    return {
-      content: [{ type: "text", text: "Error: Loon evaluation not supported by this engine build" }],
-    };
+    // Distinguish "no loon at all" from "loon, but a kernel too old to
+    // resolve modules" — otherwise a stale kernel reads as a broken program.
+    const text = Object.keys(modules).length
+      ? "Error: this kernel build cannot resolve loon modules ([use ...]) — " +
+        "update the kernel, or inline the modules into `source`"
+      : "Error: Loon evaluation not supported by this engine build";
+    return { content: [{ type: "text", text }] };
   }
 
   const text = format === "json" ? JSON.stringify(doc, null, 2) : toVCode(doc);
@@ -119,7 +205,8 @@ export const toolDefs: ToolDef[] = [
       "Assemblies: [assembly #[parts] #[instances] #[joints] ground-id] with [part name solid \"material\"], [instance name part-name x y z], [revolute-joint …], [prismatic-joint …], [fixed-joint …], [ball-joint …]\n" +
       "Pipe: [pipe [cube 50 30 5] [difference [cylinder 3 10]] [fillet 1.0]]\n" +
       "Let bindings: [let body [cube 50 30 5]]\n" +
-      "Scene: [root solid \"material-name\"]",
+      "Scene: [root solid \"material-name\"]\n" +
+      "Modules: [use bracket] then [bracket.plate] — multi-file projects work here, with sources passed in `modules` (or read from `base_dir`); [use bracket :as b] aliases, [use bracket [plate]] imports selectively, and `pub` in a module picks what it exports",
     inputSchema: createCadLoonSchema,
     handler: async (args, ctx) => {
       // Hydrate any by-name macros from the durable per-user store before
@@ -142,7 +229,10 @@ export const toolDefs: ToolDef[] = [
       // authoring a whole document. The loon evaluation is cheap relative to
       // the mesh evaluation computeIntegrity runs anyway.
       try {
-        const doc = ctx.engine.evalVcadSource(composeLoonProgram(args));
+        const doc = ctx.engine.evalVcadSourceWithModules(
+          composeLoonProgram(args),
+          composeLoonModules(args),
+        );
         if (doc) {
           if (targetId) documents.set(targetId, doc);
           const integrity = computeIntegrity(doc, ctx.engine);


### PR DESCRIPTION
## Why

loon has a complete, working module system (`[use foo]`, `:as` aliasing, selective import, `pub` exports, cycle detection) that vcad could not reach:

- `vcad-kernel-wasm` called `vcad_loon::eval_vcad(source, None)` — `base_dir` was always `None`, so resolution could never fire.
- MCP's `create_cad_loon` takes a `source` **string**, so there is no directory to resolve against even in principle.

Multi-file CAD projects therefore needed an external linker that concatenates sources before the call. That works, but it defeats `pub` (everything is global), cannot alias, and is a build step you must remember to re-run.

Plumbing `base_dir` through would fix only the native path. The browser has **no filesystem**, so the resolver — not the path — is the thing to abstract.

## What changed

**loon (`loon-lang`, separate repo — see Dependency below)**

- `trait ModuleProvider { fetch(module_path, from_dir) -> Result<Option<String>> }` and a `MapProvider` over an in-memory `name -> source` map. Returning `Ok(None)` declines, so a provider is purely additive: the existing filesystem/package/lockfile resolution is untouched.
- `ModuleCache::{with_provider, set_provider, set_prelude}`. `load_module` consults the provider first under a virtual cache key, so `Loading`/`Loaded` cycle detection carries over; the eval body is factored into `eval_module` and shared by both origins, so nested `[use]` inside a provider module resolves through the same provider.
- `set_prelude` evaluates a host stdlib into every module env. The "no `pub` declared" export fallback now excludes everything defined before the module body (previously it exported loon-prelude names too).
- `interp::eval_program_with_modules(...)`; `eval_program_with_base_dir` delegates to it.

**vcad**

- `vcad_loon::eval_vcad_with_modules(source, base_dir, modules)` (+ a `_to_value` variant). All entry points now pass `VCAD_LIB_SOURCE` as the module prelude — an imported module can say `cube`, which was broken on the native path too.
- WASM: `evalVcadSourceWithModules(source, modulesJson)`; `Engine.evalVcadSourceWithModules(source, modules)` delegates to the old call for an empty map.
- MCP `create_cad_loon`: new `modules` (by value) and `base_dir` (server reads `<base_dir>/<name>.loon`, follows nested imports, reads confined to the root). Inline `loons` macros are now importable by `[use <name>]` — the bespoke prepend mechanism and the language's own import become one concept.
- Docs, changelog entry, tool-surface fixture regenerated.

```json
{
  "source": "[use bracket]\n[root bracket.plate \"aluminum\"]",
  "modules": { "bracket": "[pub let plate [cube 40 20 4]]\n[let scrap [sphere 1]]" }
}
```

## Tests

10 in `vcad-loon` and 7 in `packages/mcp`. The one that justifies the abstraction is the equivalence: the same project must yield the same `Document` whether the module comes off disk or out of a map — asserted on both sides of the seam. Also covered: aliasing, selective import, `pub` hiding non-`pub` names, stdlib visible inside a module, nested imports, circular-import error, base_dir traversal refusal, empty map is a no-op.

`loon-lang`'s own 415-test suite and the vcad MCP suite (990) are green.

## For the reviewer

- **Dependency:** CI clones `ecto/loon` at its default branch, so this will not compile until the `ModuleProvider` change lands there. That change is committed locally but **not pushed** — it needs your call on branch/PR over in loon.
- Checked-in kernel WASM artifacts are deliberately **not** touched (single-writer rule). Against the artifacts on `main`, the three kernel-dependent MCP tests fail with `evalVcadSourceWithModules` missing; they pass after `npm run build -w @vcad/kernel-wasm`, and CI builds WASM from source.
- Behavior change worth a look: a module that declares no `pub` names no longer re-exports loon-prelude names (`Option`, `Result`, …) — only its own definitions.
- The app has no UI for supplying a module map yet; the WASM surface exists, nothing in `App.tsx` calls it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)