### PR TITLE
feat(mcp): pose assemblies with joint_state

### DIFF
--- a/changelog/entries/2026-07-26-joint-state-pose.json
+++ b/changelog/entries/2026-07-26-joint-state-pose.json
@@ -1,0 +1,17 @@
+{
+  "id": "2026-07-26-joint-state-pose",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "feat",
+  "title": "Pose assemblies with joint_state",
+  "summary": "render_view, inspect_cad, inspect_part, describe_scene, check_clearance and export_cad now take an optional joint_state map, so a jointed assembly is no longer stuck in its zero pose.",
+  "features": ["assembly", "kinematics", "render", "export"],
+  "mcpTools": [
+    "render_view",
+    "inspect_cad",
+    "inspect_part",
+    "describe_scene",
+    "check_clearance",
+    "export_cad"
+  ]
+}

--- a/packages/mcp/src/__tests__/pose.test.ts
+++ b/packages/mcp/src/__tests__/pose.test.ts
@@ -1,0 +1,169 @@
+/**
+ * `joint_state` — posing an assembly through the read/export tools.
+ *
+ * The contract this pins is the one that used to be done by hand: posing the
+ * kinematic master via `joint_state` must produce exactly the geometry of a
+ * hand-placed "stance snapshot" document, so the second document stops being
+ * necessary. Plus the fail-closed rules: unknown joint keys error, and
+ * out-of-limit states clamp with a warning instead of rendering a machine
+ * that cannot exist.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { exportCad } from "../tools/export.js";
+import { computeInspection, inspectCad } from "../tools/inspect.js";
+import { applyJointState, PoseError } from "../tools/pose.js";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+  process.env.VCAD_MCP_EXPORT_DIR = mkdtempSync(join(tmpdir(), "vcad-pose-"));
+});
+
+/** Two parts, one revolute joint about +Y with ±90° limits. */
+const ASSEMBLY_LOON = `
+[assembly
+  #[[part "base" [cylinder 40.0 30.0] "steel"]
+    [part "arm" [cube 80.0 20.0 20.0] "aluminum"]]
+  #[[instance "base-inst" "base" 0.0 0.0 0.0]
+    [instance "arm-inst" "arm" 0.0 0.0 30.0]]
+  #[[revolute-joint "shoulder" 0.0 1.0 0.0 -90.0 90.0
+      "base-inst" 0.0 0.0 25.0
+      "arm-inst" 0.0 0.0 0.0]]
+  "base-inst"]
+`;
+
+function assemblyDoc(): Document {
+  const doc = engine.evalVcadSource(ASSEMBLY_LOON);
+  if (!doc) throw new Error("loon eval failed");
+  return doc;
+}
+
+function jointId(doc: Document): string {
+  const j = doc.joints?.[0];
+  if (!j) throw new Error("fixture lost its joint");
+  return j.id;
+}
+
+const bboxOf = (doc: Document) => computeInspection(doc, engine).bounding_box;
+
+describe("joint_state", () => {
+  it("poses the assembly exactly like a hand-placed stance snapshot", () => {
+    const doc = assemblyDoc();
+    const id = jointId(doc);
+
+    // Posed via FK: the arm swings 40° about +Y at the shoulder anchor.
+    const { doc: posed, pose } = applyJointState(doc, { [id]: 40 });
+    expect(pose?.applied[id]).toBe(40);
+
+    // The hand-built equivalent: no joints at all, the arm pre-rotated and
+    // placed at the anchor by hand — exactly the duplicate model this
+    // feature removes. world = parent_anchor - R(40°,+Y) * child_anchor,
+    // and the child anchor is the origin, so the translation is the anchor.
+    const hand = structuredClone(doc);
+    delete hand.joints;
+    const arm = hand.instances?.find((i) => i.id === "arm-inst");
+    if (!arm) throw new Error("fixture lost its instance");
+    arm.transform = {
+      translation: { x: 0, y: 0, z: 25 },
+      rotation: { x: 0, y: 40, z: 0 },
+      scale: { x: 1, y: 1, z: 1 },
+    };
+
+    // The FK readout and the hand placement agree...
+    const fk = pose!.transforms["arm-inst"]!;
+    expect(fk.translation).toEqual({ x: 0, y: 0, z: 25 });
+    expect(fk.rotation.x).toBeCloseTo(0, 9);
+    expect(fk.rotation.y).toBeCloseTo(40, 9);
+    expect(fk.rotation.z).toBeCloseTo(0, 9);
+
+    // ...and so does the geometry both documents evaluate to.
+    const a = bboxOf(posed);
+    const b = bboxOf(hand);
+    for (const corner of ["min", "max"] as const) {
+      for (const axis of ["x", "y", "z"] as const) {
+        expect(a[corner][axis]).toBeCloseTo(b[corner][axis], 6);
+      }
+    }
+  });
+
+  it("changes the measured geometry (a pose is not a no-op)", () => {
+    const doc = assemblyDoc();
+    const zero = bboxOf(doc);
+    const { doc: posed } = applyJointState(doc, { [jointId(doc)]: 40 });
+    expect(bboxOf(posed)).not.toEqual(zero);
+  });
+
+  it("leaves the input document untouched", () => {
+    const doc = assemblyDoc();
+    const before = JSON.stringify(doc);
+    applyJointState(doc, { [jointId(doc)]: 40 });
+    expect(JSON.stringify(doc)).toBe(before);
+  });
+
+  it("is a no-op when omitted", () => {
+    const doc = assemblyDoc();
+    const { doc: same, pose } = applyJointState(doc, undefined);
+    expect(pose).toBeUndefined();
+    expect(same).toBe(doc);
+  });
+
+  it("resolves a joint by name as well as by id", () => {
+    const doc = assemblyDoc();
+    const name = doc.joints?.[0]?.name;
+    if (!name) return; // fixture carries no name — nothing to pin
+    const { pose } = applyJointState(doc, { [name]: 25 });
+    expect(pose?.applied[jointId(doc)]).toBe(25);
+  });
+
+  it("clamps an out-of-limits state and says so", () => {
+    const doc = assemblyDoc();
+    const id = jointId(doc);
+    const { pose } = applyJointState(doc, { [id]: 200 });
+    expect(pose?.applied[id]).toBe(90);
+    expect(pose?.warnings?.join(" ")).toMatch(/clamped to 90/);
+  });
+
+  it("errors on an unknown joint key instead of silently ignoring it", () => {
+    const doc = assemblyDoc();
+    expect(() => applyJointState(doc, { elbow: 10 })).toThrow(PoseError);
+    expect(() => applyJointState(doc, { elbow: 10 })).toThrow(/matches no joint/);
+  });
+
+  it("errors when the document has no joints to pose", () => {
+    const doc = assemblyDoc();
+    delete doc.joints;
+    expect(() => applyJointState(doc, { shoulder: 10 })).toThrow(/no joints/);
+  });
+
+  it("errors on a non-numeric state", () => {
+    const doc = assemblyDoc();
+    expect(() => applyJointState(doc, { [jointId(doc)]: "up" })).toThrow(
+      /not a finite number/,
+    );
+  });
+
+  it("flows through inspect_cad and export_cad", () => {
+    const doc = assemblyDoc();
+    const id = jointId(doc);
+
+    const inspected = JSON.parse(
+      inspectCad({ document: doc, joint_state: { [id]: 40 } }, engine).content[0]!
+        .text,
+    ) as Record<string, unknown>;
+    expect((inspected.pose as { applied: Record<string, number> }).applied[id]).toBe(40);
+    expect(inspected.bounding_box).not.toEqual(bboxOf(doc));
+
+    const exported = JSON.parse(
+      exportCad(
+        { document: doc, filename: "posed.stl", joint_state: { [id]: 40 } },
+        engine,
+      ).content[0]!.text,
+    ) as Record<string, unknown>;
+    expect((exported.pose as { applied: Record<string, number> }).applied[id]).toBe(40);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1081,6 +1081,13 @@
         "part_id": {
           "type": "string",
           "description": "The part ID to inspect."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       },
       "required": [
@@ -1113,6 +1120,13 @@
         "limit": {
           "type": "integer",
           "description": "Cap the number of parts returned when no part_ids are provided (default 100)."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       },
       "required": [
@@ -1502,7 +1516,7 @@
   {
     "name": "export_cad",
     "title": "Export CAD",
-    "description": "Export a CAD document to a file. Supports STL (3D printing), GLB (visualization), and — for sheet-metal documents — STEP AP214 of the FOLDED body with true cylindrical bend faces (fab 3D pipelines like SendCutSend auto-detect bends/angles/directions; zero data entry). Format is determined by file extension.",
+    "description": "Export a CAD document to a file. Supports STL (3D printing), GLB (visualization), and — for sheet-metal documents — STEP AP214 of the FOLDED body with true cylindrical bend faces (fab 3D pipelines like SendCutSend auto-detect bends/angles/directions; zero data entry). Format is determined by file extension. Pass `joint_state` to export a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) instead of its zero pose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1521,6 +1535,13 @@
         "filename": {
           "type": "string",
           "description": "Output filename with extension (.stl, .glb, or — for sheet-metal documents — .step/.stp), relative to the server working directory (or VCAD_MCP_EXPORT_DIR if set). STEP exports the FOLDED sheet-metal body (AP214) with true cylindrical bend faces sized by the document's shop profile, so fab services with a 3D pipeline (e.g. SendCutSend) auto-detect bends, angles, and directions with zero data entry."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       },
       "required": [
@@ -1534,7 +1555,7 @@
   {
     "name": "inspect_cad",
     "title": "Inspect CAD",
-    "description": "Inspect an open session document to get aggregate geometry properties: volume, surface area, bounding box, center of mass, triangle count, and mass (if material density is known). For per-part detail use `inspect_part` (one part) or `describe_scene` (every part at once); for the gap or overlap between two parts use `measure`.",
+    "description": "Inspect an open session document to get aggregate geometry properties: volume, surface area, bounding box, center of mass, triangle count, and mass (if material density is known). For per-part detail use `inspect_part` (one part) or `describe_scene` (every part at once); for the gap or overlap between two parts use `measure`. Pass `joint_state` to measure a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) rather than its zero pose.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1545,6 +1566,13 @@
         "document": {
           "type": "object",
           "description": "Inline Document IR to inspect instead of a session. Use this stateless path when no `document_id` is resident (e.g. a cold serverless instance)."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       }
     },
@@ -5712,7 +5740,7 @@
   {
     "name": "render_view",
     "title": "Render View",
-    "description": "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Call after mutations to visually confirm the part matches intent before declaring done.",
+    "description": "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Pass `joint_state` to render a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) instead of its zero pose — forward kinematics resolves the instance placements and the resolved transforms come back in `pose.transforms`. Call after mutations to visually confirm the part matches intent before declaring done.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -5785,6 +5813,13 @@
             "shaded"
           ],
           "description": "Shading style: 'drafting' (default) keeps part colors in the navy drafting tonal family; 'shaded' renders each part in its full assigned material color (same Lambertian shading). Any other value is an error."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       }
     },
@@ -8251,7 +8286,7 @@
   {
     "name": "check_clearance",
     "title": "Check Clearance",
-    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
+    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at a real pose (joint id or name → degrees, or mm for sliders) instead of the stored zero pose — that is how you check a mechanism clears through its travel. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -8284,6 +8319,13 @@
         "allow_contact": {
           "type": "boolean",
           "description": "Treat exact surface contact (measured distance within 0.001 mm of zero) as passing even though it is below `min_mm` — for parts designed to touch, e.g. a stage bolted flush to the chamber floor. Penetration beyond the tolerance still fails. Persisted with the spec when `label` is given."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
         }
       },
       "required": [

--- a/packages/mcp/src/tools/clearance.ts
+++ b/packages/mcp/src/tools/clearance.ts
@@ -26,6 +26,7 @@ import type {
 import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
 import { transformMesh } from "@vcad/engine";
 import { unverifiableClaim } from "../receipt-unified.js";
+import { applyJointState, jointStateSchemaProp, type PoseInfo } from "./pose.js";
 import { getSession } from "./session-core.js";
 import { asBool } from "./arg-coerce.js";
 
@@ -105,6 +106,7 @@ export const checkClearanceSchema = {
       description:
         "Treat exact surface contact (measured distance within 0.001 mm of zero) as passing even though it is below `min_mm` — for parts designed to touch, e.g. a stage bolted flush to the chamber floor. Penetration beyond the tolerance still fails. Persisted with the spec when `label` is given.",
     },
+    joint_state: jointStateSchemaProp,
   },
   required: ["document_id", "group_a", "group_b", "min_mm"],
 } as const;
@@ -288,7 +290,30 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
   const label = typeof args.label === "string" && args.label.trim() ? args.label.trim() : undefined;
   const allowContact = asBool(args.allow_contact);
 
-  const doc = getSession(documentId);
+  // A persisted spec is re-measured by build_receipt / verify_receipt against
+  // the document's *stored* joint states, so a spec captured at an ad-hoc pose
+  // would re-verify against different geometry and read Violated for no
+  // reason. Refuse the combination rather than persist an unre-verifiable
+  // assertion.
+  if (label && args.joint_state !== undefined && args.joint_state !== null) {
+    return err(
+      "`label` and `joint_state` cannot be combined: a persisted clearance spec is " +
+        "re-measured at the document's stored joint states, so an assertion captured at " +
+        "an ad-hoc pose could not be re-verified. Either drop `label` (one-off pose " +
+        "measurement), or set the joint states on the document and assert there.",
+    );
+  }
+
+  const stored = getSession(documentId);
+  // Measure the requested pose. The pose is a measurement condition applied to
+  // a clone — the session document is never mutated by it.
+  let doc: Document;
+  let pose: PoseInfo | undefined;
+  try {
+    ({ doc, pose } = applyJointState(stored, args.joint_state));
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
   const { result, error } = computeGroupClearance(doc, engine, groupA, groupB);
   if (error || !result) return err(error ?? "Clearance could not be computed.");
 
@@ -297,7 +322,7 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
   let specSaved = false;
   if (label) {
     // Persist by resolved part ids so the assertion survives renames.
-    upsertClearanceSpec(doc, {
+    upsertClearanceSpec(stored, {
       label,
       group_a: result.group_a.map((p) => p.id),
       group_b: result.group_b.map((p) => p.id),
@@ -316,6 +341,7 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
     pass,
     verdict,
     ...(allowContact ? { allow_contact: true } : {}),
+    ...(pose ? { pose } : {}),
     intersecting: result.intersecting,
     worst_pair: result.worst_pair,
     pairs_checked: result.pairs_checked,
@@ -527,7 +553,7 @@ export const toolDefs: ToolDef[] = [
     name: "check_clearance",
     pack: null,
     description:
-      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
+      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at a real pose (joint id or name → degrees, or mm for sliders) instead of the stored zero pose — that is how you check a mechanism clears through its travel. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes.",
     inputSchema: checkClearanceSchema,
     handler: (a, c) => checkClearance(a, c.engine),
     behavior: behavior({ writesDoc: true }),

--- a/packages/mcp/src/tools/export.ts
+++ b/packages/mcp/src/tools/export.ts
@@ -10,6 +10,7 @@ import { sceneExportUnits } from "../export/scene-units.js";
 import { resolveWithinRoot } from "./safe-path.js";
 import { isRemoteDeployment, maxInlineExportBytes } from "./remote.js";
 import { storeArtifact } from "./artifact-store.js";
+import { applyJointState, jointStateSchemaProp } from "./pose.js";
 import { resolveDocInput } from "./session.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
@@ -97,6 +98,7 @@ export const exportCadSchema = {
         "the document's shop profile, so fab services with a 3D pipeline (e.g. SendCutSend) " +
         "auto-detect bends, angles, and directions with zero data entry.",
     },
+    joint_state: jointStateSchemaProp,
   },
   required: ["filename"],
 };
@@ -106,7 +108,9 @@ export function exportCad(
   engine: Engine,
 ): { content: Array<{ type: "text"; text: string }> } {
   const args = (input ?? {}) as Record<string, unknown>;
-  const { doc: ir } = resolveDocInput(args, ["document", "ir"]);
+  const { doc: stored } = resolveDocInput(args, ["document", "ir"]);
+  // Export the posed assembly, not just the zero pose.
+  const { doc: ir, pose } = applyJointState(stored, args.joint_state);
   const filename = String(args.filename ?? "");
 
   // STEP: only the folded sheet-metal body is exportable (mesh-evaluated
@@ -182,6 +186,7 @@ export function exportCad(
   return deliver(filename, bytes, {
     format: ext,
     parts: units.length,
+    ...(pose ? { pose } : {}),
     ...(scene.instances && scene.instances.length > 0
       ? { instances: scene.instances.length }
       : {}),
@@ -193,7 +198,7 @@ export const toolDefs: ToolDef[] = [
     name: "export_cad",
     pack: null,
     description:
-      "Export a CAD document to a file. Supports STL (3D printing), GLB (visualization), and — for sheet-metal documents — STEP AP214 of the FOLDED body with true cylindrical bend faces (fab 3D pipelines like SendCutSend auto-detect bends/angles/directions; zero data entry). Format is determined by file extension.",
+      "Export a CAD document to a file. Supports STL (3D printing), GLB (visualization), and — for sheet-metal documents — STEP AP214 of the FOLDED body with true cylindrical bend faces (fab 3D pipelines like SendCutSend auto-detect bends/angles/directions; zero data entry). Format is determined by file extension. Pass `joint_state` to export a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) instead of its zero pose.",
     inputSchema: exportCadSchema,
     handler: (a, c) => exportCad(a, c.engine),
     behavior: behavior({}),

--- a/packages/mcp/src/tools/inspect.ts
+++ b/packages/mcp/src/tools/inspect.ts
@@ -16,6 +16,7 @@ import {
 } from "@vcad/engine";
 import type { Document } from "@vcad/ir";
 import { isoperimetricViolation } from "./integrity.js";
+import { applyJointState, jointStateSchemaProp, type PoseInfo } from "./pose.js";
 import { resolveDocInput } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 
@@ -32,6 +33,7 @@ export const inspectCadSchema = {
         "Inline Document IR to inspect instead of a session. Use this stateless " +
         "path when no `document_id` is resident (e.g. a cold serverless instance).",
     },
+    joint_state: jointStateSchemaProp,
   },
 };
 
@@ -65,6 +67,9 @@ export interface InspectResult {
    * Absent when the inspection is clean.
    */
   warnings?: string[];
+  /** Applied `joint_state` pose and the FK transforms it resolved to.
+   *  Absent when the document was measured in its stored pose. */
+  pose?: PoseInfo;
 }
 
 /** Compute properties for a single mesh. Exported so `measure`, the
@@ -300,9 +305,12 @@ export function inspectCad(
   engine: Engine,
 ): { content: Array<{ type: "text"; text: string }> } {
   const args = (input ?? {}) as Record<string, unknown>;
-  const { doc: ir } = resolveDocInput(args);
+  const { doc: stored } = resolveDocInput(args);
+  // Measure the pose the caller asked for, not just the zero pose.
+  const { doc: ir, pose } = applyJointState(stored, args.joint_state);
 
   const result = computeInspection(ir, engine);
+  if (pose) result.pose = pose;
 
   return {
     content: [
@@ -319,7 +327,7 @@ export const toolDefs: ToolDef[] = [
     name: "inspect_cad",
     pack: null,
     description:
-      "Inspect an open session document to get aggregate geometry properties: volume, surface area, bounding box, center of mass, triangle count, and mass (if material density is known). For per-part detail use `inspect_part` (one part) or `describe_scene` (every part at once); for the gap or overlap between two parts use `measure`.",
+      "Inspect an open session document to get aggregate geometry properties: volume, surface area, bounding box, center of mass, triangle count, and mass (if material density is known). For per-part detail use `inspect_part` (one part) or `describe_scene` (every part at once); for the gap or overlap between two parts use `measure`. Pass `joint_state` to measure a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) rather than its zero pose.",
     inputSchema: inspectCadSchema,
     handler: (a, c) => inspectCad(a, c.engine),
     behavior: behavior({}),

--- a/packages/mcp/src/tools/pose.ts
+++ b/packages/mcp/src/tools/pose.ts
@@ -1,0 +1,177 @@
+/**
+ * `joint_state` — pose an assembly before you look at it.
+ *
+ * Forward kinematics already exists in the kernel
+ * (`vcad_eval::solve_forward_kinematics`, reached through the WASM binding);
+ * without this shim it was only reachable at the *stored* joint states, so a
+ * jointed assembly could only ever be rendered, measured, or exported in its
+ * zero pose. Every read tool that evaluates a document therefore accepts an
+ * optional `joint_state` map — joint id (or name) → angle in degrees for
+ * revolute/ball joints, mm for sliders — which is applied to a **clone** of
+ * the document before evaluation. Unspecified joints keep their stored state,
+ * so omitting the argument is exactly today's behaviour.
+ *
+ * Two fail-closed rules:
+ *  - an unknown joint key is an error, not a silent no-op (a pose you thought
+ *    you set but didn't is a lie about the machine);
+ *  - a state outside the joint's declared limits is **clamped**, and the clamp
+ *    is reported as a warning on the result — an out-of-limits render would
+ *    show a machine that cannot exist.
+ */
+
+import { solveForwardKinematics } from "@vcad/engine";
+import type { Document, Joint, Transform3D } from "@vcad/ir";
+
+/** JSON-schema fragment for the `joint_state` argument, shared by every tool
+ *  that accepts a pose so the wording stays identical across the surface. */
+export const jointStateSchemaProp = {
+  type: "object" as const,
+  additionalProperties: { type: "number" as const },
+  description:
+    "Pose the assembly before evaluating: map of joint id (or joint name) → state — " +
+    "degrees for revolute/ball joints, mm for sliders. Joints not listed keep their " +
+    "stored state, so omitting this renders the document exactly as stored. States " +
+    "outside a joint's declared limits are clamped and reported in `pose.warnings`; " +
+    "an unknown joint key is an error.",
+};
+
+/** Resolved pose report, echoed on the tool result so a caller can read off
+ *  where the mechanism actually ended up instead of re-deriving it by hand. */
+export interface PoseInfo {
+  /** Joint id → state actually applied (post-clamp). */
+  applied: Record<string, number>;
+  /** Clamp notices, one per joint driven outside its limits. */
+  warnings?: string[];
+  /** Instance id → world transform resolved by forward kinematics. */
+  transforms: Record<string, Transform3D>;
+}
+
+/** Bad `joint_state` input — surfaced as a tool error, never swallowed. */
+export class PoseError extends Error {}
+
+function limitsOf(joint: Joint): [number, number] | undefined {
+  const kind = joint.kind as { type?: string; limits?: [number, number] };
+  if (kind.type === "Revolute" || kind.type === "Slider") return kind.limits;
+  return undefined;
+}
+
+function unitOf(joint: Joint): string {
+  return (joint.kind as { type?: string }).type === "Slider" ? "mm" : "deg";
+}
+
+const round = (v: number) => Math.round(v * 1e6) / 1e6;
+
+function roundTransform(t: Transform3D): Transform3D {
+  return {
+    translation: {
+      x: round(t.translation.x),
+      y: round(t.translation.y),
+      z: round(t.translation.z),
+    },
+    rotation: {
+      x: round(t.rotation.x),
+      y: round(t.rotation.y),
+      z: round(t.rotation.z),
+    },
+    scale: t.scale,
+  } as Transform3D;
+}
+
+/**
+ * Apply a `joint_state` map to a clone of `doc`.
+ *
+ * Returns the original document unchanged (and no pose report) when the
+ * argument is absent — the default path costs nothing. The input document is
+ * never mutated.
+ */
+export function applyJointState(
+  doc: Document,
+  raw: unknown,
+): { doc: Document; pose?: PoseInfo } {
+  if (raw === undefined || raw === null) return { doc };
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new PoseError(
+      "`joint_state` must be an object mapping joint id (or name) to a number " +
+        "(degrees for revolute/ball joints, mm for sliders).",
+    );
+  }
+  const entries = Object.entries(raw as Record<string, unknown>);
+  if (entries.length === 0) return { doc };
+
+  const joints = doc.joints ?? [];
+  if (joints.length === 0) {
+    throw new PoseError(
+      "`joint_state` was given but this document has no joints — nothing to pose. " +
+        "Author the assembly's joints first (they are what make a pose meaningful).",
+    );
+  }
+
+  // Resolve a key by joint id first, then by unique joint name.
+  const byId = new Map(joints.map((j) => [j.id, j]));
+  const byName = new Map<string, Joint | null>();
+  for (const j of joints) {
+    if (!j.name) continue;
+    byName.set(j.name, byName.has(j.name) ? null : j);
+  }
+
+  const posed = structuredClone(doc);
+  const posedById = new Map((posed.joints ?? []).map((j) => [j.id, j]));
+  const applied: Record<string, number> = {};
+  const warnings: string[] = [];
+
+  for (const [key, value] of entries) {
+    const joint = byId.get(key) ?? byName.get(key) ?? undefined;
+    if (joint === null) {
+      throw new PoseError(
+        `joint_state key "${key}" is ambiguous — more than one joint carries that name. ` +
+          "Use the joint id instead.",
+      );
+    }
+    if (!joint) {
+      const known = joints
+        .map((j) => (j.name ? `${j.id} ("${j.name}")` : j.id))
+        .join(", ");
+      throw new PoseError(
+        `joint_state key "${key}" matches no joint in this document. Known joints: ${known}.`,
+      );
+    }
+    const state = typeof value === "number" ? value : Number(value);
+    if (!Number.isFinite(state)) {
+      throw new PoseError(
+        `joint_state["${key}"] is not a finite number (got ${JSON.stringify(value)}).`,
+      );
+    }
+
+    let effective = state;
+    const limits = limitsOf(joint);
+    if (limits) {
+      const [lo, hi] = limits;
+      if (state < lo || state > hi) {
+        effective = Math.min(hi, Math.max(lo, state));
+        warnings.push(
+          `joint "${joint.id}"${joint.name ? ` ("${joint.name}")` : ""} was driven to ` +
+            `${state} ${unitOf(joint)}, outside its limits [${lo}, ${hi}] — clamped to ` +
+            `${effective}. The rendered pose is the clamped one, not the requested one.`,
+        );
+      }
+    }
+
+    const target = posedById.get(joint.id);
+    if (target) target.state = effective;
+    applied[joint.id] = effective;
+  }
+
+  const transforms: Record<string, Transform3D> = {};
+  for (const [id, t] of solveForwardKinematics(posed)) {
+    transforms[id] = roundTransform(t);
+  }
+
+  return {
+    doc: posed,
+    pose: {
+      applied,
+      ...(warnings.length > 0 ? { warnings } : {}),
+      transforms,
+    },
+  };
+}

--- a/packages/mcp/src/tools/registry-dispatch.ts
+++ b/packages/mcp/src/tools/registry-dispatch.ts
@@ -16,6 +16,7 @@ import {
   listPartsFromDocument,
 } from "@vcad/core";
 import { getSession, recordLastChanged, recordTriangles } from "./session.js";
+import { applyJointState, jointStateSchemaProp } from "./pose.js";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
 import {
   describeSceneResult,
@@ -248,6 +249,11 @@ function withDocumentId(tool: AnthropicTool): {
         "Parameters for the chosen `type` — see the Type Catalog in this server's instructions (e.g. cube: {size:{x,y,z}}, cylinder: {radius,height}).",
     };
   }
+  // Pose-aware reads: measuring a jointed assembly at a real pose is the
+  // point of `joint_state` (see tools/pose.ts).
+  if (tool.name === "inspect_part" || tool.name === "describe_scene") {
+    properties.joint_state = jointStateSchemaProp;
+  }
   const required = ["document_id", ...(original.required ?? [])];
   return {
     name: tool.name,
@@ -402,7 +408,11 @@ export function dispatchRegistryTool(
   // planner (they were app-only, reading the browser docstore + engine
   // scene). Answer them directly from the session document + engine.
   if (toolName === "inspect_part" || toolName === "describe_scene") {
-    return handleMeasureRead(toolName, doc, toolArgs, engine);
+    // These two read measured geometry, so they honour `joint_state` — the
+    // pose is applied to a clone, never to the session document.
+    const { joint_state: jointState, ...readArgs } = toolArgs;
+    const posed = applyJointState(doc, jointState);
+    return handleMeasureRead(toolName, posed.doc, readArgs, engine, posed.pose);
   }
 
   const before = snapshotParts(doc);
@@ -546,6 +556,7 @@ function handleMeasureRead(
   doc: import("@vcad/ir").Document,
   args: Record<string, unknown>,
   engine?: import("@vcad/engine").Engine,
+  pose?: import("./pose.js").PoseInfo,
 ): { content: Array<{ type: "text"; text: string }> } {
   if (!engine) {
     throw new Error(
@@ -569,6 +580,7 @@ function handleMeasureRead(
     if (e instanceof MeasureError) throw new Error(e.message);
     throw e;
   }
+  if (pose) payload.pose = pose;
   return {
     content: [{ type: "text", text: JSON.stringify(payload) }],
   };

--- a/packages/mcp/src/tools/render.ts
+++ b/packages/mcp/src/tools/render.ts
@@ -31,6 +31,7 @@ import {
   withRenderAssets,
 } from "./render-assets.js";
 import { asBool } from "./arg-coerce.js";
+import { applyJointState, jointStateSchemaProp, type PoseInfo } from "./pose.js";
 
 export const renderViewSchema = {
   type: "object" as const,
@@ -108,6 +109,7 @@ export const renderViewSchema = {
       description:
         "Shading style: 'drafting' (default) keeps part colors in the navy drafting tonal family; 'shaded' renders each part in its full assigned material color (same Lambertian shading). Any other value is an error.",
     },
+    joint_state: jointStateSchemaProp,
   },
 };
 
@@ -226,9 +228,30 @@ export async function rasterize(
 export async function renderView(
   args: Record<string, unknown>,
 ): Promise<RenderViewResult> {
-  const { doc, documentId: resolvedId } = resolveDocInput(args);
+  const { doc: storedDoc, documentId: resolvedId } = resolveDocInput(args);
   // Echoed back in result/error payloads; the empty string marks the inline path.
   const documentId = resolvedId ?? "";
+
+  // Optional pose: render the assembly at the requested joint states rather
+  // than the stored (usually zero) pose. Never mutates the session document.
+  let doc: Document;
+  let pose: PoseInfo | undefined;
+  try {
+    ({ doc, pose } = applyJointState(storedDoc, args.joint_state));
+  } catch (e) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            error: e instanceof Error ? e.message : String(e),
+            document_id: documentId,
+          }),
+        },
+      ],
+      isError: true,
+    };
+  }
 
   const widthRaw = Number(args.width_px ?? DEFAULT_WIDTH_PX);
   const widthPx = Math.min(
@@ -631,6 +654,7 @@ export async function renderView(
             ...(style !== "drafting" ? { style } : {}),
             width_px: widthPx,
             format: "png",
+            ...(pose ? { pose } : {}),
             ...(highlight.length > 0 ? { highlight } : {}),
             asset: renderAssetSummary(asset),
             suggested_final_markdown: asset.markdown,
@@ -681,6 +705,7 @@ export async function renderView(
           ...(sectionRaw ? { section: sectionRaw } : {}),
           format: "svg",
           ...(highlight.length > 0 ? { highlight } : {}),
+          ...(pose ? { pose } : {}),
           note,
           ...(svgBytes <= MAX_INLINE_SVG_BYTES
             ? { svg }
@@ -1300,7 +1325,7 @@ export const toolDefs: ToolDef[] = [
     name: "render_view",
     pack: null,
     description:
-      "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Call after mutations to visually confirm the part matches intent before declaring done.",
+      "Render an open session document to a PNG image so you can SEE the current geometry — silhouettes, holes, creases — not just numbers. Drafting-style line art, Z-up, same renderer as the vcad CLI. Defaults to isometric; pass azimuth/elevation for an arbitrary orbit view, and focus to frame a single part. Opt-in overlays add engineering context: `axes` (X/Y/Z origin gizmo), `labels` (part names), `dims` (overall W×D×H in mm). Pass style:'shaded' to render parts in their full assigned material colors instead of the navy drafting look. Pass `joint_state` to render a jointed assembly at a real pose (joint id or name → degrees, or mm for sliders) instead of its zero pose — forward kinematics resolves the instance placements and the resolved transforms come back in `pose.transforms`. Call after mutations to visually confirm the part matches intent before declaring done.",
     inputSchema: renderViewSchema,
     handler: async (a) => (await renderView(a)) as unknown as ToolResult,
     behavior: behavior({}),


### PR DESCRIPTION
## What

Adds an optional `joint_state` map — joint id (or name) → angle in degrees, mm for sliders — to the tools that evaluate a document:

- `render_view` — "render this at the stance pose"
- `inspect_cad`, `inspect_part`, `describe_scene` — bbox / COM / mass measured at a real pose
- `check_clearance` — clearance measured through the mechanism's travel
- `export_cad` — STL/GLB of the posed assembly

The states are applied to a **clone** of the document, forward kinematics resolves the instance placements, and the resolved world transforms come back in `pose.transforms`.

## Why

A jointed assembly could only ever be seen in its stored (zero) pose, so every posed view had to be built twice: the kinematic master (structurally true, renders as a starfish) and a separate hand-posed "stance snapshot" with the parts pre-rotated at hand-computed coordinates. The two then drift. FK already existed in the kernel (`vcad_eval::solve_forward_kinematics`, `crates/vcad-eval/src/kinematics.rs:218`, exposed through the WASM binding) — it just wasn't reachable from the MCP surface. `pose.transforms` also removes the other half of the hand work: reading off where the end effector actually ended up.

## Semantics

- Unspecified joints keep their stored state, and omitting the argument returns the document untouched — **today's behaviour is the default**, nothing changes for existing callers.
- The session document is never mutated by a pose.
- Keys resolve by joint id first, then by unique joint name (an ambiguous name errors).

## Fail-closed rules

- **Unknown joint key → error**, listing the known joints. A pose you thought you set but didn't is a lie about the machine.
- **Out-of-limit state → clamped**, with the clamp reported in `pose.warnings` ("the rendered pose is the clamped one, not the requested one").
- **`check_clearance` refuses `label` + `joint_state` together.** A persisted spec is re-measured by `build_receipt` / `verify_receipt` against the document's *stored* joint states, so an assertion captured at an ad-hoc pose could never re-verify — it would read Violated for no reason.

## Reviewer notes

- New shared shim: `packages/mcp/src/tools/pose.ts` (`applyJointState`, `jointStateSchemaProp`, `PoseInfo`, `PoseError`). One implementation, one wording, six tools.
- `inspect_part` / `describe_scene` are registry-dispatched, so the schema is injected in `withDocumentId` and the pose applied in `dispatchRegistryTool` before the scene measure.
- `tool-surface.fixture.json` regenerated (`UPDATE_TOOL_SURFACE=1`) for the schema additions.
- The validation the issue asked for is `packages/mcp/src/__tests__/pose.test.ts`: a 40° shoulder pose evaluates to the same world transform *and* the same geometry as a hand-built joint-free document with the arm pre-rotated and placed by hand — the exact duplication this removes. Plus clamp/unknown-key/no-mutation/no-op coverage.

## Not included

Flagged in the issue as "worth considering", left out as out of scope: static `joint_state` keyframes on `render_sequence` / `animate` (the timeline path already poses via `poseDocument`), and swept-range interference in `check_clearance`.

## Testing

- `npm test -w @vcad/mcp` — 1002 passed, 3 skipped, 92 files
- `npx tsc --noEmit -p packages/mcp` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)