### PR TITLE
feat(mcp): link a session document to the loon source that made it

### DIFF
--- a/changelog/entries/2026-07-26-document-source-provenance.json
+++ b/changelog/entries/2026-07-26-document-source-provenance.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-26-document-source-provenance",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "feat",
+  "title": "Documents remember the loon source that made them",
+  "summary": "create_cad_loon stores its source on the document, save_document writes the .loon alongside the .vcad, load_document opens a file path, and sessions report source_stale when they drift.",
+  "features": ["loon", "documents", "mcp"],
+  "mcpTools": ["create_cad_loon", "get_document", "save_document", "load_document"]
+}

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -1915,6 +1915,55 @@ pub struct Document {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "ts-rs", ts(optional))]
     pub timeline: Option<animation::Timeline>,
+
+    // Provenance (optional, zero-cost when absent)
+    /// The authored source this document was evaluated from, when it came
+    /// from one. Lets a document say what made it, so a session and the file
+    /// it came from can be compared instead of silently drifting apart.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub source: Option<DocumentSource>,
+}
+
+/// The authored source a [`Document`] was evaluated from.
+///
+/// A document evaluated from loon used to discard its source immediately, so
+/// the authored form was unrecoverable and a session could diverge from the
+/// `.loon` file that produced it with nothing detecting it. Carrying the
+/// source (and, when it came from disk, the path plus a content hash) makes
+/// that divergence observable: re-hash the file and compare, or check
+/// `diverged` for incremental IR mutations that can't round-trip back to
+/// source.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
+#[cfg_attr(feature = "ts-rs", ts(export, export_to = "bindings/"))]
+pub struct DocumentSource {
+    /// Source language — currently always `"loon"`.
+    pub language: String,
+    /// The source text, exactly as authored.
+    pub text: String,
+    /// Modules `[use ...]` resolved against, by value.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub modules: HashMap<String, String>,
+    /// Server-side directory modules were read from, when one was used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub base_dir: Option<String>,
+    /// Path the source was read from, when the document is *of* a file.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub path: Option<String>,
+    /// SHA-256 (hex) of `text`, for comparing against the file on disk.
+    pub hash: String,
+    /// True once the document has been mutated by an operation that cannot
+    /// round-trip back to `text` (incremental create/update/delete). The
+    /// source is then a record of the document's origin, not its current
+    /// state.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub diverged: bool,
+    /// Tool names that diverged the document, in order, capped at a handful.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diverged_by: Vec<String>,
 }
 
 /// A named minimum-clearance assertion between two groups of parts.
@@ -2127,6 +2176,7 @@ impl Default for Document {
             analysis_studies: Vec::new(),
             drawing: None,
             timeline: None,
+            source: None,
         }
     }
 }

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -1537,7 +1537,61 @@ drawing?: DrawingSettings,
  * Animation timeline: keyframed parameters/joints/visibility plus
  * camera shots. Absent for static models.
  */
-timeline?: Timeline, };
+timeline?: Timeline, 
+/**
+ * The authored source this document was evaluated from, when it came
+ * from one. Lets a document say what made it, so a session and the file
+ * it came from can be compared instead of silently drifting apart.
+ */
+source?: DocumentSource, };
+
+/**
+ * The authored source a [`Document`] was evaluated from.
+ *
+ * A document evaluated from loon used to discard its source immediately, so
+ * the authored form was unrecoverable and a session could diverge from the
+ * `.loon` file that produced it with nothing detecting it. Carrying the
+ * source (and, when it came from disk, the path plus a content hash) makes
+ * that divergence observable: re-hash the file and compare, or check
+ * `diverged` for incremental IR mutations that can't round-trip back to
+ * source.
+ */
+export type DocumentSource = { 
+/**
+ * Source language — currently always `"loon"`.
+ */
+language: string, 
+/**
+ * The source text, exactly as authored.
+ */
+text: string, 
+/**
+ * Modules `[use ...]` resolved against, by value.
+ */
+modules: Record<string, string>, 
+/**
+ * Server-side directory modules were read from, when one was used.
+ */
+base_dir?: string, 
+/**
+ * Path the source was read from, when the document is *of* a file.
+ */
+path?: string, 
+/**
+ * SHA-256 (hex) of `text`, for comparing against the file on disk.
+ */
+hash: string, 
+/**
+ * True once the document has been mutated by an operation that cannot
+ * round-trip back to `text` (incremental create/update/delete). The
+ * source is then a record of the document's origin, not its current
+ * state.
+ */
+diverged: boolean, 
+/**
+ * Tool names that diverged the document, in order, capped at a handful.
+ */
+diverged_by: Array<string>, };
 
 /**
  * A section cut line drawn on an orthographic drawing view. The polyline

--- a/packages/mcp/src/__tests__/document-source.test.ts
+++ b/packages/mcp/src/__tests__/document-source.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Document ⇄ source provenance: a document says what made it, a save writes
+ * both forms, a file path opens as a session that is *of* that file, and
+ * divergence in either direction is reported rather than silent.
+ *
+ * The failure this pins is a long design session where several revisions
+ * existed only as session documents: `get_document` returned IR, the authored
+ * loon was unrecoverable, and a `.loon` edited on disk went on driving nothing
+ * until someone remembered to re-evaluate it.
+ */
+
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Engine } from "@vcad/engine";
+import { toolDefs as loonToolDefs } from "../tools/loon.js";
+import {
+  getDocumentTool,
+  loadDocument,
+  saveDocument,
+  openDocument,
+} from "../tools/session.js";
+import { documents, getSession } from "../tools/session-core.js";
+import {
+  markSourceDiverged,
+  sourceHash,
+  sourceStatus,
+} from "../tools/source-provenance.js";
+import type { SessionStore } from "../session-store.js";
+import type { ToolContext } from "../tools/tool-def.js";
+
+const PLATE = `[root [cube 40 20 4] "aluminum"]`;
+
+let engine: Engine;
+let ctx: ToolContext;
+let dir: string;
+const createCadLoon = loonToolDefs.find((t) => t.name === "create_cad_loon")!;
+
+/** The local/stdio store: file-backed save/load under the state root. */
+const memoryStore = { scope: "memory" } as unknown as SessionStore;
+
+/** Mint a session and author `source` into it, returning its id. */
+async function author(source: string): Promise<string> {
+  const opened = JSON.parse(openDocument({}).content[0].text) as {
+    document_id: string;
+  };
+  await createCadLoon.handler(
+    { source, document_id: opened.document_id },
+    ctx,
+  );
+  return opened.document_id;
+}
+
+beforeAll(async () => {
+  engine = await Engine.init();
+  ctx = { engine, user: null } as unknown as ToolContext;
+  dir = mkdtempSync(join(tmpdir(), "vcad-doc-source-"));
+  process.env.VCAD_MCP_STATE_DIR = dir;
+});
+
+afterAll(() => {
+  delete process.env.VCAD_MCP_STATE_DIR;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("source on the document", () => {
+  it("create_cad_loon records the source it evaluated", async () => {
+    const id = await author(PLATE);
+    const src = getSession(id).source;
+    expect(src?.language).toBe("loon");
+    expect(src?.text).toContain("cube 40 20 4");
+    expect(src?.hash).toBe(sourceHash(src!.text));
+    expect(src?.diverged).toBe(false);
+  });
+
+  it("get_document returns the source, not only the IR", async () => {
+    const id = await author(PLATE);
+    const result = getDocumentTool({ document_id: id });
+    const doc = JSON.parse(result.content[0].text) as {
+      source?: { text: string };
+    };
+    expect(doc.source?.text).toContain("cube 40 20 4");
+    expect(result.structuredContent?.source_stale).toBe(false);
+  });
+});
+
+describe("staleness", () => {
+  it("an incremental mutation marks the document diverged from its source", async () => {
+    const id = await author(PLATE);
+    expect(markSourceDiverged(id, "update")).toBe(true);
+    // Only the first divergence is "new" — the note is said once.
+    expect(markSourceDiverged(id, "delete")).toBe(false);
+
+    const status = sourceStatus(documents.get(id));
+    expect(status.source_stale).toBe(true);
+    expect(status.reason).toMatch(/update, delete/);
+  });
+
+  it("a document with no source is never stale", () => {
+    expect(sourceStatus(undefined).source_stale).toBe(false);
+    const opened = JSON.parse(openDocument({}).content[0].text) as {
+      document_id: string;
+    };
+    expect(sourceStatus(getSession(opened.document_id)).source_stale).toBe(
+      false,
+    );
+  });
+
+  it("a file edited underneath the session reads as stale", async () => {
+    const path = join(dir, "bracket.loon");
+    writeFileSync(path, PLATE);
+    const loaded = JSON.parse(
+      (await loadDocument({ path }, memoryStore, engine)).content[0].text,
+    ) as { document_id: string; source_stale: boolean };
+    expect(loaded.source_stale).toBe(false);
+
+    writeFileSync(path, `[root [cube 60 20 4] "aluminum"]`);
+    const status = sourceStatus(getSession(loaded.document_id));
+    expect(status.source_stale).toBe(true);
+    expect(status.reason).toMatch(/changed on disk/);
+  });
+});
+
+describe("load_document from a path", () => {
+  it("evaluates a .loon file into a session bound to it", async () => {
+    const path = join(dir, "post.loon");
+    writeFileSync(path, `[root [cylinder 3 12] "steel"]`);
+    const loaded = JSON.parse(
+      (await loadDocument({ path }, memoryStore, engine)).content[0].text,
+    ) as { document_id: string; path: string };
+    const doc = getSession(loaded.document_id);
+    expect(doc.roots.length).toBe(1);
+    expect(doc.source?.path).toBe(path);
+  });
+
+  it("reports an unreadable path instead of minting an empty session", async () => {
+    const result = await loadDocument(
+      { path: join(dir, "nope.loon") },
+      memoryStore,
+      engine,
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/Cannot read/);
+  });
+});
+
+describe("save_document", () => {
+  it("writes the .loon alongside the .vcad", async () => {
+    const id = await author(PLATE);
+    const saved = JSON.parse(
+      (await saveDocument({ document_id: id, name: "plate" }, memoryStore))
+        .content[0].text,
+    ) as { path: string; source_path?: string };
+    expect(readFileSync(saved.path, "utf8")).toContain('"nodes"');
+    expect(saved.source_path).toBeDefined();
+    expect(readFileSync(saved.source_path!, "utf8")).toContain("cube 40 20 4");
+  });
+
+  it("refuses to write loon that would not reproduce a diverged document", async () => {
+    const id = await author(PLATE);
+    markSourceDiverged(id, "update");
+    const saved = JSON.parse(
+      (await saveDocument({ document_id: id, name: "diverged" }, memoryStore))
+        .content[0].text,
+    ) as { source_path?: string; source_not_written?: string };
+    expect(saved.source_path).toBeUndefined();
+    expect(saved.source_not_written).toMatch(/would not reproduce/);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -28,7 +28,7 @@
   {
     "name": "get_document",
     "title": "Get Document",
-    "description": "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`. Very large documents come back as a compact artifact handle instead ({document_id, artifact_url, manifest with sha256, …}) — download the full IR at `artifact_url`.",
+    "description": "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`. A document authored from loon carries that source under `source`, and the result reports `source_stale` when the session no longer matches it (the file changed, or incremental edits moved the session away from it). Very large documents come back as a compact artifact handle instead ({document_id, artifact_url, manifest with sha256, …}) — download the full IR at `artifact_url`.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -72,7 +72,7 @@
   {
     "name": "save_document",
     "title": "Save Document",
-    "description": "Persist a live session under a name so it can be reopened with load_document. On the hosted server the save is durable: a signed-in user's save goes to their vcad.io account under the (normalized) name; an anonymous save returns an unguessable `saved_…` key to reopen with. On a local/stdio server it writes `<name>.vcad` under VCAD_MCP_STATE_DIR (or the working directory).",
+    "description": "Persist a live session under a name so it can be reopened with load_document. On the hosted server the save is durable: a signed-in user's save goes to their vcad.io account under the (normalized) name; an anonymous save returns an unguessable `saved_…` key to reopen with. On a local/stdio server it writes `<name>.vcad` under VCAD_MCP_STATE_DIR (or the working directory) — plus `<name>.loon` when the document knows the source it was authored from, so the file and the session can't diverge without someone choosing it.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -97,18 +97,19 @@
   {
     "name": "load_document",
     "title": "Load Document",
-    "description": "Reopen a save_document save into a fresh session and return its new document_id. Pass the same name you saved under (or the `saved_…` key an anonymous save returned). The cheap way to resume a board/part across runs instead of rebuilding it.",
+    "description": "Reopen a save_document save into a fresh session and return its new document_id. Pass the same name you saved under (or the `saved_…` key an anonymous save returned). The cheap way to resume a board/part across runs instead of rebuilding it. Pass `path` instead to open a `.loon` source file (evaluated on load) or a `.vcad` document from disk — that session stays bound to the file and reports `source_stale` if the two drift apart.",
     "inputSchema": {
       "type": "object",
       "properties": {
         "name": {
           "type": "string",
-          "description": "The name passed to save_document (or the `saved_…` key an anonymous save returned). On a local/stdio server this reads <name>.vcad from the state directory."
+          "description": "The name passed to save_document (or the `saved_…` key an anonymous save returned). On a local/stdio server this reads <name>.vcad from the state directory. Provide this OR `path`."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to a `.loon` source file (evaluated on load) or a `.vcad` document to open as a session. The session records the path and a content hash, so it is explicitly *of* that file: later calls report `source_stale` when the file changes underneath it or the session is edited away from it. Local/stdio servers only — a hosted server's filesystem is ephemeral."
         }
-      },
-      "required": [
-        "name"
-      ]
+      }
     },
     "annotations": {
       "readOnlyHint": false

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -33,6 +33,10 @@ import {
   durabilityWarning,
 } from "./tools/session.js";
 import { createCadLoon } from "./tools/loon.js";
+import {
+  markSourceDiverged,
+  sourceStatus,
+} from "./tools/source-provenance.js";
 import { previewVersion, previewGlbFor, PREVIEW_MAX_BASE64 } from "./tools/preview.js";
 import {
   createSessionStore,
@@ -1498,6 +1502,24 @@ export async function createServer(
         if (writtenId && writtenId !== incomingId) {
           noteSessionDurability(result, writtenId);
         }
+        // ── Source divergence ──────────────────────────────────────────
+        // Incremental mutations edit the IR directly and cannot round-trip
+        // back to loon, so a document evaluated from source stops matching
+        // that source the moment one lands. Marking it here — the single
+        // site every writer passes through — is what keeps "the model I'm
+        // editing" and "the file I'll fabricate from" from diverging
+        // silently. `create_cad_loon` re-authors the whole document and
+        // re-attaches its own source; `undo` restores a snapshot along with
+        // whatever divergence state that snapshot had.
+        if (
+          incomingId &&
+          writtenId === incomingId &&
+          name !== "create_cad_loon" &&
+          name !== "undo" &&
+          markSourceDiverged(incomingId, name)
+        ) {
+          noteSourceDivergence(result, incomingId);
+        }
         if (writtenId) {
           try {
             await persistSession(sessionStore, writtenId);
@@ -1891,6 +1913,22 @@ function noteSessionDurability(result: ToolResult, documentId: string): void {
   result.content = [
     ...(result.content ?? []),
     { type: "text", text: JSON.stringify({ durability: warning }) },
+  ];
+}
+
+/**
+ * Say — once, at the moment it becomes true — that a session no longer matches
+ * the source it was evaluated from. Said once per session rather than on every
+ * mutation: the state is durable on the document (and readable any time via
+ * `get_document`), so repeating it would be noise, but never saying it is how
+ * the file and the model drift apart unnoticed.
+ */
+function noteSourceDivergence(result: ToolResult, documentId: string): void {
+  const status = sourceStatus(documents.get(documentId));
+  if (!status.source_stale) return;
+  result.content = [
+    ...(result.content ?? []),
+    { type: "text", text: JSON.stringify(status) },
   ];
 }
 

--- a/packages/mcp/src/tools/loon.ts
+++ b/packages/mcp/src/tools/loon.ts
@@ -9,6 +9,7 @@ import { toVCode } from "@vcad/ir";
 import { appendIntegrity, computeIntegrity } from "./integrity.js";
 import { hydrateMacros, macroPrelude, type InlineLoon } from "./loon-macros.js";
 import { documents, getSession, recordTriangles } from "./session-core.js";
+import { attachLoonSource } from "./source-provenance.js";
 import { behavior, type ToolDef } from "./tool-def.js";
 import type { ToolResult } from "./tool-result.js";
 
@@ -167,11 +168,16 @@ export function createCadLoon(
   input: unknown,
   engine: Engine,
 ): { content: Array<{ type: "text"; text: string }> } {
-  const { format = "vcode" } = input as CreateLoonInput;
+  const { format = "vcode", base_dir } = input as CreateLoonInput;
   const source = composeLoonProgram(input);
 
   const modules = composeLoonModules(input);
   const doc = engine.evalVcadSourceWithModules(source, modules);
+  // Record what made this document. The COMPOSED program is stored rather
+  // than the bare `source` argument: it inlines the macro prelude, so the
+  // stored text re-evaluates to the same geometry with no dependency on a
+  // macro registry that a restart may have emptied.
+  if (doc) attachLoonSource(doc, { text: source, modules, base_dir });
   if (!doc) {
     // Distinguish "no loon at all" from "loon, but a kernel too old to
     // resolve modules" — otherwise a stale kernel reads as a broken program.
@@ -229,11 +235,16 @@ export const toolDefs: ToolDef[] = [
       // authoring a whole document. The loon evaluation is cheap relative to
       // the mesh evaluation computeIntegrity runs anyway.
       try {
-        const doc = ctx.engine.evalVcadSourceWithModules(
-          composeLoonProgram(args),
-          composeLoonModules(args),
-        );
+        const composed = composeLoonProgram(args);
+        const modules = composeLoonModules(args);
+        const doc = ctx.engine.evalVcadSourceWithModules(composed, modules);
         if (doc) {
+          attachLoonSource(doc, {
+            text: composed,
+            modules,
+            base_dir:
+              typeof args.base_dir === "string" ? args.base_dir : undefined,
+          });
           if (targetId) documents.set(targetId, doc);
           const integrity = computeIntegrity(doc, ctx.engine);
           if (integrity) {

--- a/packages/mcp/src/tools/session.ts
+++ b/packages/mcp/src/tools/session.ts
@@ -10,10 +10,13 @@
 
 import { createDocument } from "@vcad/ir";
 import type { Document } from "@vcad/ir";
+import type { Engine } from "@vcad/engine";
 import { writeFileSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { resolveWithinRoot } from "./safe-path.js";
+import { composeLoonModules } from "./loon.js";
 import { storeArtifact } from "./artifact-store.js";
 import { maxInlineArtifactBytes } from "./remote.js";
 import {
@@ -32,6 +35,7 @@ import {
   setSessionScopeProvider,
   setDurabilityProbe,
 } from "./session-core.js";
+import { attachLoonSource, sourceStatus } from "./source-provenance.js";
 
 // The browser-safe core of the session layer (document cache, ids, undo
 // snapshots, resolveDocInput) lives in session-core.ts so pure-compute tool
@@ -250,6 +254,7 @@ export function getDocumentTool(args: Record<string, unknown>): {
       artifact_url: handle.artifact_url,
       manifest: handle.manifest,
       expires_at: handle.expires_at,
+      ...sourceStatus(doc),
       note:
         `Document IR is ${handle.bytes} bytes — over the ${cap}-byte inline ` +
         "limit, so the full IR was written to the artifact store. Download " +
@@ -268,9 +273,17 @@ export function getDocumentTool(args: Record<string, unknown>): {
   // that stub and never the document the tool exists to return. Carrying
   // the IR in both places makes get_document return the document on every
   // client. (Large docs offload above, so this never duplicates megabytes.)
+  // `doc.source` rides inside the IR, so the authored loon comes back with the
+  // document — a document can say what made it. The status flags sit alongside
+  // it because staleness is a comparison against the world (the file on disk,
+  // the mutations since), not a field of the IR.
   return {
     content: [{ type: "text", text: inline }],
-    structuredContent: { document: doc, document_id: id },
+    structuredContent: {
+      document: doc,
+      document_id: id,
+      ...sourceStatus(doc),
+    },
   };
 }
 
@@ -400,11 +413,35 @@ export async function saveDocument(
   if (store.scope === "memory") {
     const path = resolveWithinRoot(`${name}.vcad`, stateRoot());
     writeFileSync(path, JSON.stringify(doc));
+    // A document that knows its source saves BOTH forms, so the file and the
+    // session cannot diverge without someone choosing it: the `.vcad` is the
+    // evaluated IR, the `.loon` is the authored form `load_document({path})`
+    // re-evaluates. Skipped once the session has diverged — writing loon that
+    // no longer produces this geometry would be worse than writing none.
+    const status = sourceStatus(doc);
+    let sourcePath: string | undefined;
+    if (doc.source && !status.source_stale) {
+      sourcePath = resolveWithinRoot(`${name}.loon`, stateRoot());
+      writeFileSync(sourcePath, doc.source.text);
+      doc.source.path = sourcePath;
+    }
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify({ saved: true, name, path }),
+          text: JSON.stringify({
+            saved: true,
+            name,
+            path,
+            ...(sourcePath ? { source_path: sourcePath } : {}),
+            ...(doc.source && status.source_stale
+              ? {
+                  source_not_written:
+                    `${status.reason} The .loon was NOT written — it would not ` +
+                    `reproduce this document. The .vcad IR is the source of truth.`,
+                }
+              : {}),
+          }),
         },
       ],
     };
@@ -481,20 +518,38 @@ export const loadDocumentSchema = {
       description:
         "The name passed to save_document (or the `saved_…` key an anonymous " +
         "save returned). On a local/stdio server this reads <name>.vcad from " +
-        "the state directory.",
+        "the state directory. Provide this OR `path`.",
+    },
+    path: {
+      type: "string" as const,
+      description:
+        "Path to a `.loon` source file (evaluated on load) or a `.vcad` " +
+        "document to open as a session. The session records the path and a " +
+        "content hash, so it is explicitly *of* that file: later calls report " +
+        "`source_stale` when the file changes underneath it or the session is " +
+        "edited away from it. Local/stdio servers only — a hosted server's " +
+        "filesystem is ephemeral.",
     },
   },
-  required: ["name"],
 };
 
 export async function loadDocument(
   args: Record<string, unknown>,
   store: SessionStore,
+  engine?: Engine,
 ): Promise<{
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 }> {
+  const path = typeof args.path === "string" ? args.path.trim() : "";
+  if (path) return loadDocumentFromPath(path, store, engine);
+
   const name = String(args.name ?? "");
+  if (!name.trim()) {
+    throw new Error(
+      "Pass `name` (a save_document save) or `path` (a .loon or .vcad file).",
+    );
+  }
 
   // Local/stdio: file-backed, exactly as before.
   if (store.scope === "memory") {
@@ -562,6 +617,115 @@ export async function loadDocument(
   };
 }
 
+/**
+ * Open a `.loon` (evaluated) or `.vcad` (parsed) file as a session that knows
+ * which file it came from.
+ *
+ * This is the half of the source⇄document link that runs in the file's
+ * direction: without it a `.loon` edited on disk only reached the server by
+ * someone remembering to re-paste it through `create_cad_loon`, and nothing
+ * marked the session as no longer matching the file.
+ */
+async function loadDocumentFromPath(
+  path: string,
+  store: SessionStore,
+  engine?: Engine,
+): Promise<{
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+}> {
+  const fail = (text: string) => ({
+    isError: true,
+    content: [{ type: "text" as const, text }],
+  });
+
+  // Hosted instances have an ephemeral, unshared filesystem: a path load would
+  // succeed once and then resolve to nothing after an instance flip. Refusing
+  // is the honest answer.
+  if (store.scope !== "memory") {
+    return fail(
+      "`path` loads are local/stdio only — this server's filesystem is " +
+        "ephemeral. Pass the source inline to create_cad_loon, or save with " +
+        "save_document and reopen by `name`.",
+    );
+  }
+
+  const abs = resolve(path);
+  let raw: string;
+  try {
+    raw = readFileSync(abs, "utf8");
+  } catch {
+    return fail(`Cannot read ${abs} — no such file, or it is not readable.`);
+  }
+
+  if (abs.endsWith(".vcad") || abs.endsWith(".json")) {
+    let doc: Document;
+    try {
+      doc = JSON.parse(raw) as Document;
+    } catch (e) {
+      return fail(`${abs} is not valid .vcad JSON: ${(e as Error).message}`);
+    }
+    const id = registerSession(doc);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            document_id: id,
+            path: abs,
+            parts: doc.roots?.length ?? 0,
+            ...sourceStatus(doc),
+          }),
+        },
+      ],
+    };
+  }
+
+  if (!engine) {
+    return fail(
+      "Loon evaluation is unavailable in this server build — load a .vcad " +
+        "document instead.",
+    );
+  }
+  // `[use ...]` resolves against the file's own directory, so a multi-file
+  // project loads the way it reads on disk.
+  const baseDir = dirname(abs);
+  const modules = composeLoonModules({ source: raw, base_dir: baseDir });
+  let doc: Document | null;
+  try {
+    doc = engine.evalVcadSourceWithModules(raw, modules) ?? null;
+  } catch (e) {
+    return fail(`Loon evaluation of ${abs} failed: ${(e as Error).message}`);
+  }
+  if (!doc) return fail(`Loon evaluation of ${abs} produced no document.`);
+
+  attachLoonSource(doc, {
+    text: raw,
+    modules,
+    base_dir: baseDir,
+    path: abs,
+  });
+  const id = registerSession(doc);
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          document_id: id,
+          path: abs,
+          parts: doc.roots?.length ?? 0,
+          source_stale: false,
+          hint:
+            "This session is bound to the file: mutating tools report " +
+            "`source_stale` once it diverges, and save_document rewrites the " +
+            "loon alongside the .vcad.",
+          ...(durabilityWarning() ? { durability: durabilityWarning() } : {}),
+        }),
+      },
+    ],
+  };
+}
+
 /** Open a saved snapshot as a fresh, independent session. The deep copy keeps
  *  the saved row frozen — editing the loaded session never mutates the save. */
 function openSavedSnapshot(
@@ -591,7 +755,7 @@ export const toolDefs: ToolDef[] = [
     name: "get_document",
     pack: null,
     description:
-      "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`. Very large documents come back as a compact artifact handle instead ({document_id, artifact_url, manifest with sha256, …}) — download the full IR at `artifact_url`.",
+      "Return the full IR Document JSON for an open session. Use after a series of mutations to capture the result, or to feed into `export_cad` / `open_in_browser`. A document authored from loon carries that source under `source`, and the result reports `source_stale` when the session no longer matches it (the file changed, or incremental edits moved the session away from it). Very large documents come back as a compact artifact handle instead ({document_id, artifact_url, manifest with sha256, …}) — download the full IR at `artifact_url`.",
     inputSchema: getDocumentSchema,
     handler: (a) => getDocumentTool(a),
     behavior: behavior({ geometry: true, widgetCallable: true, pureJson: true }),
@@ -614,7 +778,9 @@ export const toolDefs: ToolDef[] = [
       "user's save goes to their vcad.io account under the (normalized) name; " +
       "an anonymous save returns an unguessable `saved_…` key to reopen with. " +
       "On a local/stdio server it writes `<name>.vcad` under VCAD_MCP_STATE_DIR " +
-      "(or the working directory).",
+      "(or the working directory) — plus `<name>.loon` when the document knows " +
+      "the source it was authored from, so the file and the session can't " +
+      "diverge without someone choosing it.",
     inputSchema: saveDocumentSchema,
     handler: (a, c) => saveDocument(a, c.sessionStore),
     behavior: behavior({}),
@@ -626,9 +792,12 @@ export const toolDefs: ToolDef[] = [
       "Reopen a save_document save into a fresh session and return its new " +
       "document_id. Pass the same name you saved under (or the `saved_…` key " +
       "an anonymous save returned). The cheap way to resume a board/part " +
-      "across runs instead of rebuilding it.",
+      "across runs instead of rebuilding it. Pass `path` instead to open a " +
+      "`.loon` source file (evaluated on load) or a `.vcad` document from " +
+      "disk — that session stays bound to the file and reports " +
+      "`source_stale` if the two drift apart.",
     inputSchema: loadDocumentSchema,
-    handler: (a, c) => loadDocument(a, c.sessionStore),
+    handler: (a, c) => loadDocument(a, c.sessionStore, c.engine),
     behavior: behavior({ writesDoc: true, geometry: true, mount: true }),
   },
 ];

--- a/packages/mcp/src/tools/source-provenance.ts
+++ b/packages/mcp/src/tools/source-provenance.ts
@@ -1,0 +1,143 @@
+/**
+ * Document ⇄ source provenance.
+ *
+ * `create_cad_loon` used to evaluate loon source into a session document and
+ * then throw the source away: `get_document` returned IR, the authored form
+ * was unrecoverable, and a session and the `.loon` file that produced it could
+ * drift apart with nothing detecting it. This module keeps the two linked.
+ *
+ * The link lives on the document itself (`Document.source`, see the Rust
+ * `vcad-ir` crate) rather than in a side map, so it survives the durable
+ * session store, `save_document`, and a `.vcad` round-trip — exactly the
+ * places a side map would silently lose it.
+ *
+ * Two ways a document goes stale, both reported by `sourceStatus`:
+ *  - the FILE changed underneath a session loaded from a path (hash mismatch);
+ *  - the SESSION was mutated by an incremental create/update/delete, which
+ *    edits IR directly and cannot round-trip back to loon (`diverged`).
+ *
+ * We don't try to reconcile the second case — the honest move is to mark the
+ * document as diverged from its source and say so.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import type { Document, DocumentSource } from "@vcad/ir";
+import { documents } from "./session-core.js";
+
+/** SHA-256 (hex) of a source text — the same digest stored in `source.hash`. */
+export function sourceHash(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+/** How many diverging tool names to remember; enough to explain, not a log. */
+const MAX_DIVERGED_BY = 8;
+
+/** Inputs `create_cad_loon` (or a file load) evaluated. */
+export interface LoonProvenance {
+  text: string;
+  modules?: Record<string, string>;
+  base_dir?: string;
+  path?: string;
+}
+
+/**
+ * Record on `doc` the loon source it was evaluated from. Called at every
+ * authoring entry point, so a document can always say what made it.
+ */
+export function attachLoonSource(
+  doc: Document,
+  { text, modules, base_dir, path }: LoonProvenance,
+): void {
+  const source: DocumentSource = {
+    language: "loon",
+    text,
+    modules: modules && Object.keys(modules).length ? { ...modules } : {},
+    hash: sourceHash(text),
+    diverged: false,
+    diverged_by: [],
+  };
+  if (base_dir) source.base_dir = base_dir;
+  if (path) source.path = path;
+  doc.source = source;
+}
+
+/**
+ * Mark a session's document as diverged from its stored source, naming the
+ * tool that did it. No-op when the document has no source (nothing to diverge
+ * from) or is already diverged by the same tool most recently.
+ */
+export function markSourceDiverged(documentId: string, tool: string): boolean {
+  const src = documents.get(documentId)?.source;
+  if (!src) return false;
+  const firstTime = !src.diverged;
+  src.diverged = true;
+  const by = (src.diverged_by ??= []);
+  if (by[by.length - 1] !== tool) by.push(tool);
+  if (by.length > MAX_DIVERGED_BY) by.splice(0, by.length - MAX_DIVERGED_BY);
+  return firstTime;
+}
+
+/** Whether the document's source is still an accurate account of it. */
+export interface SourceStatus {
+  /** True when the session's geometry no longer corresponds to its source. */
+  source_stale: boolean;
+  /** Human-readable reason, present only when stale. */
+  reason?: string;
+  /** Path the source came from, when the document is *of* a file. */
+  source_path?: string;
+}
+
+/**
+ * Compare a document against its stored source. Checks the on-disk file first
+ * (a file that changed underneath the session is the case the agent can't see
+ * at all), then in-session divergence.
+ */
+export function sourceStatus(doc: Document | undefined): SourceStatus {
+  const src = doc?.source;
+  if (!src) return { source_stale: false };
+  const path = src.path;
+
+  if (path) {
+    let onDisk: string | null = null;
+    try {
+      onDisk = readFileSync(path, "utf8");
+    } catch {
+      return {
+        source_stale: true,
+        source_path: path,
+        reason:
+          `The source file ${path} can no longer be read — this session is ` +
+          `no longer backed by the file it was loaded from.`,
+      };
+    }
+    if (sourceHash(onDisk) !== src.hash) {
+      return {
+        source_stale: true,
+        source_path: path,
+        reason:
+          `${path} changed on disk since this session was evaluated from it — ` +
+          `the session's geometry is from the OLD source. Re-load the file to ` +
+          `pick up the edits.`,
+      };
+    }
+  }
+
+  if (src.diverged) {
+    const by = src.diverged_by ?? [];
+    return {
+      source_stale: true,
+      ...(path ? { source_path: path } : {}),
+      reason:
+        `This session has been edited directly (${by.join(", ") || "mutation"})` +
+        `, and those edits cannot round-trip back to loon. The stored source ` +
+        `describes the document's ORIGIN, not its current state` +
+        (path
+          ? ` — saving would not reproduce ${path}, and re-evaluating ${path} ` +
+            `would discard the edits.`
+          : `.`),
+    };
+  }
+
+  return { source_stale: false, ...(path ? { source_path: path } : {}) };
+}


### PR DESCRIPTION
## Why

A document evaluated from loon threw its source away. From that point `get_document` returned IR and the authored form was unrecoverable, so several revisions of a long design session existed only as live session documents and had to be reconstructed by re-sending source from conversation history. The reverse drifted too: editing a `.loon` on disk did nothing until someone remembered to re-evaluate it, and nothing flagged that a session's geometry no longer matched the file it came from.

This is the same problem `packages/mcp/scripts/serve.mjs` already solves for the server's own dist (fingerprint + stamp). Documents get the same treatment.

## What changed

**`Document.source`** — a new `DocumentSource` in `vcad-ir` (`language`, `text`, `modules`, `base_dir`, `path`, `hash`, `diverged`, `diverged_by`), regenerated into `packages/ir/src/generated.ts` via `ir:gen`. It lives on the IR rather than a side map so it survives the durable session store, `save_document`, checkpoints, and a `.vcad` round-trip — exactly where a side map would silently lose it.

- **`create_cad_loon`** attaches it at both eval sites. It stores the *composed* program (macro prelude inlined) rather than the bare `source` argument: that text is self-contained and re-evaluates without depending on a macro registry a restart may have emptied.
- **`get_document`** returns the source inline with the IR and adds `source_stale` to `structuredContent`.
- **`save_document`** writes `<name>.loon` alongside `<name>.vcad` on a local/stdio server and returns `source_path`, binding the session to that file. A diverged document gets **no** `.loon` — writing loon that doesn't reproduce the geometry is worse than writing none — and says so via `source_not_written`.
- **`load_document({path})`** opens a `.loon` (evaluated, with `[use ...]` resolving against the file's own directory) or a `.vcad` (parsed), recording path + hash. Refused on hosted scope, where the filesystem is ephemeral and a path load would resolve to nothing after an instance flip.
- **Staleness** — `sourceStatus()` checks the on-disk hash first, then in-session divergence. The dispatch layer marks the document diverged on any successful `writesDoc` tool against a resident session and emits the warning **once, at the transition** (the state stays readable via `get_document` afterward).

## Notes for a reviewer

- Incremental `create`/`update`/`delete` edit IR directly and cannot round-trip back to loon. This doesn't try to solve that — it marks the document diverged and names the tools that did it, so the message is specific ("edited directly (update, delete)") rather than a bare flag.
- `create_cad_loon` and `undo` are excluded from the divergence hook: the former re-authors the whole document and re-attaches its own source, the latter restores whatever divergence state its snapshot carried.
- Only `Document::default()` constructs the struct exhaustively, so the new Rust field breaks no call sites (`cargo check -p vcad-loon -p vcad-cli` clean).
- `tool-surface.fixture.json` regenerated for the new `load_document` `path` param and the description updates.

## Verification

- New `packages/mcp/src/__tests__/document-source.test.ts` (9 tests) covers source capture, `get_document` round-trip, divergence-once semantics, a file edited underneath a session, path loads (incl. unreadable path), and both save paths.
- `npm test --workspaces` — 1001 MCP tests + 3 skipped, all workspaces green.
- `cargo test -p vcad-ir`, `cargo clippy -p vcad-ir --all-targets -D warnings`, `cargo fmt --check`, `npm run ir:check`, `npm run build -w @vcad/app` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)