### PR TITLE
fix(kernel): stop extrude/loft silently building inside-out solids

### DIFF
--- a/changelog/entries/2026-07-26-backwards-extrude-inverted-winding.json
+++ b/changelog/entries/2026-07-26-backwards-extrude-inverted-winding.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-26-backwards-extrude-inverted-winding",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "fix",
+  "title": "Extruding against the sketch normal no longer inverts the solid",
+  "summary": "Extrude and loft silently built inside-out solids (negative volume, renders normally, corrupts every downstream boolean) when the direction opposed the sketch normal; integrity warnings now name the offending root.",
+  "features": ["kernel", "sketch", "mcp"],
+  "mcpTools": ["create_cad_loon", "create", "update"]
+}

--- a/crates/vcad-kernel-sketch/src/extrude.rs
+++ b/crates/vcad-kernel-sketch/src/extrude.rs
@@ -31,7 +31,119 @@ impl Default for ExtrudeOptions {
     }
 }
 
+/// True when the extrusion runs against the profile's plane normal.
+///
+/// The builders below all assume the material lies on the +normal side of
+/// the sketch plane: cap normals are taken as ±`profile.normal` and the
+/// lateral winding is derived from a CCW-in-frame loop seen from +normal.
+/// Extruding along −normal silently inverted every one of those decisions,
+/// producing a watertight but inside-out solid (negative volume) that
+/// renders identically to a correct one and corrupts every downstream
+/// boolean. See [`canonicalize_extrusion`].
+fn opposes_normal(profile: &SketchProfile, direction: Vec3) -> bool {
+    direction.dot(profile.normal.as_ref()) < 0.0
+}
+
+/// Reverse a segment loop in place-ish: reverse traversal order and swap
+/// each segment's endpoints. Arc handedness flips with the traversal.
+fn reversed_loop(segments: &[SketchSegment]) -> Vec<SketchSegment> {
+    segments
+        .iter()
+        .rev()
+        .map(|seg| match seg {
+            SketchSegment::Line { start, end } => SketchSegment::Line {
+                start: *end,
+                end: *start,
+            },
+            SketchSegment::Arc {
+                start,
+                end,
+                center,
+                ccw,
+            } => SketchSegment::Arc {
+                start: *end,
+                end: *start,
+                center: *center,
+                ccw: !*ccw,
+            },
+        })
+        .collect()
+}
+
+/// Swap the 2D coordinates of a segment loop (u,v) → (v,u). Paired with a
+/// frame whose x/y axes are swapped, this leaves every 3D point untouched;
+/// the reflection flips arc handedness.
+fn swapped_axes_loop(segments: &[SketchSegment]) -> Vec<SketchSegment> {
+    let swap = |p: Point2| Point2::new(p.y, p.x);
+    segments
+        .iter()
+        .map(|seg| match seg {
+            SketchSegment::Line { start, end } => SketchSegment::Line {
+                start: swap(*start),
+                end: swap(*end),
+            },
+            SketchSegment::Arc {
+                start,
+                end,
+                center,
+                ccw,
+            } => SketchSegment::Arc {
+                start: swap(*start),
+                end: swap(*end),
+                center: swap(*center),
+                ccw: !*ccw,
+            },
+        })
+        .collect()
+}
+
+/// Re-express a profile on a frame whose normal points the other way,
+/// without moving a single 3D point.
+///
+/// The x and y axes are swapped (so `normal = x × y` flips sign) and the 2D
+/// coordinates swap with them; the loop is then reversed so it stays CCW
+/// when viewed from the *new* +normal. The result describes exactly the
+/// same 3D curve — only the frame's handedness changed — so an extrusion
+/// that opposed the old normal runs *along* the new one and the builders'
+/// winding assumptions hold.
+///
+/// This is why extruding "backwards" is not an error: a prism on the −normal
+/// side of a sketch is perfectly well defined, and the caller gets the solid
+/// they asked for, correctly wound, at the position they asked for.
+fn flip_profile_frame(profile: &SketchProfile) -> SketchProfile {
+    let segments = reversed_loop(&swapped_axes_loop(&profile.segments));
+    SketchProfile::new(
+        profile.origin,
+        *profile.y_dir.as_ref(),
+        *profile.x_dir.as_ref(),
+        segments,
+    )
+    .expect("flipping a valid profile's frame preserves closure and non-degeneracy")
+}
+
+/// Canonicalize `(profile, holes)` so the extrusion direction always has a
+/// positive dot product with the profile normal. Returns `None` when the
+/// input is already canonical (the common case — no allocation).
+fn canonicalize_extrusion(
+    profile: &SketchProfile,
+    holes: &[Vec<SketchSegment>],
+    direction: Vec3,
+) -> Option<(SketchProfile, Vec<Vec<SketchSegment>>)> {
+    if !opposes_normal(profile, direction) {
+        return None;
+    }
+    let flipped_holes = holes
+        .iter()
+        .map(|h| reversed_loop(&swapped_axes_loop(h)))
+        .collect();
+    Some((flip_profile_frame(profile), flipped_holes))
+}
+
 /// Extrude a closed profile along a direction to create a B-rep solid.
+///
+/// The direction need not point along the profile's normal: extruding along
+/// −normal builds the prism on the other side of the sketch plane, correctly
+/// wound (positive volume) either way.
 ///
 /// # Arguments
 ///
@@ -67,6 +179,11 @@ pub fn extrude(profile: &SketchProfile, direction: Vec3) -> Result<BRepSolid, Sk
     let dir_len = direction.norm();
     if dir_len < 1e-12 {
         return Err(SketchError::ZeroExtrusion);
+    }
+
+    // Re-frame a backwards extrusion before any winding decision is made.
+    if let Some((flipped, _)) = canonicalize_extrusion(profile, &[], direction) {
+        return extrude(&flipped, direction);
     }
 
     // Analytic fast path: a profile that is a full circle extruded along
@@ -659,6 +776,10 @@ pub fn extrude_with_holes(
         return Err(SketchError::ZeroExtrusion);
     }
 
+    if let Some((flipped, flipped_holes)) = canonicalize_extrusion(profile, holes, direction) {
+        return extrude_with_holes(&flipped, &flipped_holes, direction);
+    }
+
     let arc_segs = ExtrudeOptions::default().arc_segments as usize;
 
     // Validate each hole loop (closure, degeneracy) by round-tripping it
@@ -956,6 +1077,20 @@ pub fn extrude_with_options(
 
     if profile.segments.is_empty() {
         return Err(SketchError::EmptyProfile);
+    }
+
+    // Re-frame a backwards extrusion. Swapping the frame's x/y axes reverses
+    // the sense of the twist rotation (it runs x → y), so the requested
+    // twist is negated to describe the same physical twist.
+    if let Some((flipped, _)) = canonicalize_extrusion(profile, &[], direction) {
+        return extrude_with_options(
+            &flipped,
+            direction,
+            ExtrudeOptions {
+                twist_angle: -options.twist_angle,
+                ..options
+            },
+        );
     }
 
     // Calculate number of segments based on twist angle
@@ -1540,6 +1675,110 @@ mod tests {
             (vol - 1000.0).abs() < 5.0,
             "expected volume ~1000, got {vol}"
         );
+    }
+
+    /// Signed mesh volume — the discriminator the abs()-taking helper below
+    /// throws away, and the only signal that separates an inside-out solid
+    /// from a correct one (they render identically).
+    fn signed_mesh_volume(mesh: &vcad_kernel_tessellate::TriangleMesh) -> f64 {
+        let verts = &mesh.vertices;
+        let mut vol = 0.0;
+        for tri in mesh.indices.chunks(3) {
+            let (i0, i1, i2) = (
+                tri[0] as usize * 3,
+                tri[1] as usize * 3,
+                tri[2] as usize * 3,
+            );
+            let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
+            let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
+            let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
+            vol += v0[0] * (v1[1] * v2[2] - v2[1] * v1[2])
+                - v1[0] * (v0[1] * v2[2] - v2[1] * v0[2])
+                + v2[0] * (v0[1] * v1[2] - v1[1] * v0[2]);
+        }
+        vol / 6.0
+    }
+
+    fn signed_volume_of(solid: &BRepSolid) -> f64 {
+        signed_mesh_volume(&vcad_kernel_tessellate::tessellate_brep(solid, 32))
+    }
+
+    /// Field report 2026-07-26: a sketch frame whose axes give a −Y normal,
+    /// extruded along +Y (the natural thing to write), produced a
+    /// watertight but inside-out plate. Renders normally; poisons every
+    /// downstream boolean. All four (frame handedness × direction sign)
+    /// combinations must now yield the same positive volume.
+    #[test]
+    fn extrude_is_positive_volume_for_either_direction_sign() {
+        let w = 10.0;
+        let h = 5.0;
+        let t = 3.0;
+        let expected = w * h * t;
+
+        // Two frames spanning the same plane with opposite normals:
+        // (X, Z) → normal −Y, and (Z, X) → normal +Y.
+        let frames = [(Vec3::x(), Vec3::z()), (Vec3::z(), Vec3::x())];
+        let dirs = [
+            Vec3::new(0.0, t, 0.0),  // +Y
+            Vec3::new(0.0, -t, 0.0), // −Y
+        ];
+
+        for (x_dir, y_dir) in frames {
+            for dir in dirs {
+                let profile = SketchProfile::rectangle(Point3::origin(), x_dir, y_dir, w, h);
+                let solid = extrude(&profile, dir).unwrap();
+                let vol = signed_volume_of(&solid);
+                assert!(
+                    (vol - expected).abs() < 0.05,
+                    "frame ({x_dir:?},{y_dir:?}) dir {dir:?}: expected +{expected}, got {vol}"
+                );
+
+                // Watertight regardless of which way it was built.
+                let unpaired = solid
+                    .topology
+                    .half_edges
+                    .iter()
+                    .filter(|(_, he)| he.twin.is_none())
+                    .count();
+                assert_eq!(unpaired, 0, "frame ({x_dir:?},{y_dir:?}) dir {dir:?}");
+            }
+        }
+    }
+
+    /// Same invariant for the arc-bearing (analytic cylinder) path and the
+    /// holed path — both make the identical +normal assumption.
+    #[test]
+    fn backwards_extrude_positive_volume_for_circle_and_holes() {
+        let r = 4.0;
+        let t = 3.0;
+        // Full-circle profile on the XZ plane (normal −Y).
+        let circle = SketchProfile::circle(Point3::origin(), -Vec3::y(), r, 4);
+        for dir in [Vec3::new(0.0, t, 0.0), Vec3::new(0.0, -t, 0.0)] {
+            let vol = signed_volume_of(&extrude(&circle, dir).unwrap());
+            let expected = PI * r * r * t;
+            assert!(
+                (vol - expected).abs() / expected < 0.02,
+                "circle dir {dir:?}: expected ~+{expected}, got {vol}"
+            );
+        }
+
+        // Plate with a square hole, frame (X, Z) → normal −Y.
+        let outer = SketchProfile::new(
+            Point3::origin(),
+            Vec3::x(),
+            Vec3::z(),
+            rect_loop(0.0, 0.0, 10.0, 10.0),
+        )
+        .unwrap();
+        let hole = vec![rect_loop(3.0, 3.0, 6.0, 6.0)];
+        let expected = (100.0 - 9.0) * t;
+        for dir in [Vec3::new(0.0, t, 0.0), Vec3::new(0.0, -t, 0.0)] {
+            let vol = signed_volume_of(&extrude_with_holes(&outer, &hole, dir).unwrap());
+            assert!(
+                (vol - expected).abs() < 0.05,
+                "holed dir {dir:?}: expected +{expected}, got {vol}"
+            );
+        }
     }
 
     fn compute_mesh_volume(mesh: &vcad_kernel_tessellate::TriangleMesh) -> f64 {

--- a/crates/vcad-kernel-sketch/src/profile.rs
+++ b/crates/vcad-kernel-sketch/src/profile.rs
@@ -252,6 +252,60 @@ impl SketchProfile {
         self.segments.iter().map(|s| s.start()).collect()
     }
 
+    /// The same closed loop walked the other way round: segment order
+    /// reversed, each segment's endpoints swapped, arc handedness flipped.
+    ///
+    /// The 3D curve is untouched — only the traversal direction (and hence
+    /// the loop's winding, which is what every solid builder reads to decide
+    /// which side is "out") changes.
+    pub fn reversed(&self) -> Self {
+        let segments = self
+            .segments
+            .iter()
+            .rev()
+            .map(|seg| match seg {
+                SketchSegment::Line { start, end } => SketchSegment::Line {
+                    start: *end,
+                    end: *start,
+                },
+                SketchSegment::Arc {
+                    start,
+                    end,
+                    center,
+                    ccw,
+                } => SketchSegment::Arc {
+                    start: *end,
+                    end: *start,
+                    center: *center,
+                    ccw: !*ccw,
+                },
+            })
+            .collect();
+        Self {
+            origin: self.origin,
+            x_dir: self.x_dir,
+            y_dir: self.y_dir,
+            normal: self.normal,
+            segments,
+        }
+    }
+
+    /// Newell area-weighted normal of the loop in 3D. Its direction encodes
+    /// the loop's winding independently of the sketch frame's handedness —
+    /// the quantity a builder needs when deciding which side of the loop the
+    /// material is on. Zero-length for a degenerate loop.
+    pub fn loop_area_normal(&self) -> Vec3 {
+        let pts = self.vertices_3d();
+        let n = pts.len();
+        let mut acc = Vec3::zeros();
+        for i in 0..n {
+            let a = pts[i];
+            let b = pts[(i + 1) % n];
+            acc += (a - Point3::origin()).cross(b - Point3::origin());
+        }
+        acc / 2.0
+    }
+
     /// Get all segment endpoints mapped to 3D.
     pub fn vertices_3d(&self) -> Vec<Point3> {
         self.vertices_2d().iter().map(|p| self.to_3d(*p)).collect()

--- a/crates/vcad-kernel-sketch/src/revolve.rs
+++ b/crates/vcad-kernel-sketch/src/revolve.rs
@@ -802,6 +802,46 @@ mod tests {
         }
     }
 
+    /// Revolve's sibling of the extrude orientation trap: the same 3D
+    /// profile described on frames of opposite handedness must produce the
+    /// same *positively* wound solid, whichever way the frame normal points
+    /// relative to the axis. (Revolve derives its outward sense from the
+    /// profile's own shoelace, so this holds — the test pins it.)
+    #[test]
+    fn revolve_is_positive_volume_for_either_frame_handedness() {
+        let expected = PI * (8.0 * 8.0 - 5.0 * 5.0) * 10.0 / 4.0;
+        // Same 3D rectangle (r ∈ [5,8], z ∈ [0,10]) described on frames of
+        // opposite handedness: (X,Z) → normal −Y, (Z,X) → normal +Y.
+        for (x_dir, y_dir, w, h) in [
+            (Vec3::x(), Vec3::z(), 3.0, 10.0),
+            (Vec3::z(), Vec3::x(), 10.0, 3.0),
+        ] {
+            let profile = SketchProfile::rectangle(Point3::new(5.0, 0.0, 0.0), x_dir, y_dir, w, h);
+            let solid = revolve(&profile, Point3::origin(), Vec3::z(), PI / 2.0).unwrap();
+            let mesh = vcad_kernel_tessellate::tessellate_brep(&solid, 64);
+            let verts = &mesh.vertices;
+            let mut vol = 0.0;
+            for tri in mesh.indices.chunks(3) {
+                let (i0, i1, i2) = (
+                    tri[0] as usize * 3,
+                    tri[1] as usize * 3,
+                    tri[2] as usize * 3,
+                );
+                let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
+                let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
+                let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
+                vol += v0[0] * (v1[1] * v2[2] - v2[1] * v1[2])
+                    - v1[0] * (v0[1] * v2[2] - v2[1] * v0[2])
+                    + v2[0] * (v0[1] * v1[2] - v1[1] * v0[2]);
+            }
+            vol /= 6.0;
+            assert!(
+                vol > expected * 0.5 && vol < expected * 1.2,
+                "frame ({x_dir:?},{y_dir:?}): expected ~+{expected:.1}, got {vol:.1}"
+            );
+        }
+    }
+
     fn compute_mesh_volume(mesh: &vcad_kernel_tessellate::TriangleMesh) -> f64 {
         let verts = &mesh.vertices;
         let indices = &mesh.indices;

--- a/crates/vcad-kernel-sweep/src/loft.rs
+++ b/crates/vcad-kernel-sweep/src/loft.rs
@@ -92,6 +92,30 @@ pub fn loft(profiles: &[SketchProfile], options: LoftOptions) -> Result<BRepSoli
         }
     }
 
+    // Canonicalize the section winding before any face is built. The ruled
+    // builder below assumes each section is wound CCW as seen from the
+    // *previous* section — i.e. the loop's area normal points along the
+    // stacking direction. Sections described on a frame of the opposite
+    // handedness violate that and produced a watertight, correctly shaped,
+    // inside-out solid: negative volume, renders identically to a good one,
+    // and silently corrupts every downstream boolean and mass property.
+    // Reversing the traversal moves no geometry, so the caller still gets
+    // exactly the solid they asked for.
+    let centroid = |p: &SketchProfile| {
+        let pts = p.vertices_3d();
+        let n = pts.len() as f64;
+        pts.iter()
+            .fold(Vec3::zeros(), |acc, q| acc + (q - Point3::origin()))
+            / n
+    };
+    let stack = centroid(&profiles[1]) - centroid(&profiles[0]);
+    if profiles[0].loop_area_normal().dot(stack) < 0.0 {
+        let flipped: Vec<SketchProfile> = profiles.iter().map(|p| p.reversed()).collect();
+        return match options.mode {
+            LoftMode::Ruled | LoftMode::Smooth => loft_ruled(&flipped, options.closed),
+        };
+    }
+
     match options.mode {
         LoftMode::Ruled => loft_ruled(profiles, options.closed),
         LoftMode::Smooth => {
@@ -323,6 +347,44 @@ mod tests {
 
     fn create_circle_profile(origin: Point3, radius: f64, n_arcs: u32) -> SketchProfile {
         SketchProfile::circle(origin, Vec3::z(), radius, n_arcs)
+    }
+
+    fn signed_volume(solid: &BRepSolid) -> f64 {
+        let mesh = vcad_kernel_tessellate::tessellate_brep(solid, 32);
+        let v = &mesh.vertices;
+        let mut vol = 0.0;
+        for tri in mesh.indices.chunks(3) {
+            let (a, b, c) = (
+                tri[0] as usize * 3,
+                tri[1] as usize * 3,
+                tri[2] as usize * 3,
+            );
+            let p0 = [v[a] as f64, v[a + 1] as f64, v[a + 2] as f64];
+            let p1 = [v[b] as f64, v[b + 1] as f64, v[b + 2] as f64];
+            let p2 = [v[c] as f64, v[c + 1] as f64, v[c + 2] as f64];
+            vol += p0[0] * (p1[1] * p2[2] - p2[1] * p1[2])
+                - p1[0] * (p0[1] * p2[2] - p2[1] * p0[2])
+                + p2[0] * (p0[1] * p1[2] - p1[1] * p0[2]);
+        }
+        vol / 6.0
+    }
+
+    /// Loft's flavour of the silent-inversion trap: the section profiles
+    /// described on frames of opposite handedness. The result must be
+    /// positively wound either way (an inverted solid renders identically
+    /// and only shows up downstream, in a boolean or a mass property).
+    #[test]
+    fn loft_is_positive_volume_for_either_frame_handedness() {
+        for (x_dir, y_dir) in [(Vec3::x(), Vec3::y()), (Vec3::y(), Vec3::x())] {
+            let p1 = SketchProfile::rectangle(Point3::origin(), x_dir, y_dir, 10.0, 10.0);
+            let p2 =
+                SketchProfile::rectangle(Point3::new(0.0, 0.0, 20.0), x_dir, y_dir, 10.0, 10.0);
+            let vol = signed_volume(&loft(&[p1, p2], LoftOptions::default()).unwrap());
+            assert!(
+                (vol - 2000.0).abs() < 1.0,
+                "frame ({x_dir:?},{y_dir:?}): expected +2000, got {vol}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vcad-kernel-sweep/src/sweep.rs
+++ b/crates/vcad-kernel-sweep/src/sweep.rs
@@ -498,6 +498,45 @@ mod tests {
         SketchProfile::circle(Point3::origin(), Vec3::z(), radius, n_arcs)
     }
 
+    fn signed_volume(solid: &BRepSolid) -> f64 {
+        let mesh = vcad_kernel_tessellate::tessellate_brep(solid, 32);
+        let v = &mesh.vertices;
+        let mut vol = 0.0;
+        for tri in mesh.indices.chunks(3) {
+            let (a, b, c) = (
+                tri[0] as usize * 3,
+                tri[1] as usize * 3,
+                tri[2] as usize * 3,
+            );
+            let p0 = [v[a] as f64, v[a + 1] as f64, v[a + 2] as f64];
+            let p1 = [v[b] as f64, v[b + 1] as f64, v[b + 2] as f64];
+            let p2 = [v[c] as f64, v[c + 1] as f64, v[c + 2] as f64];
+            vol += p0[0] * (p1[1] * p2[2] - p2[1] * p1[2])
+                - p1[0] * (p0[1] * p2[2] - p2[1] * p0[2])
+                + p2[0] * (p0[1] * p1[2] - p1[1] * p0[2]);
+        }
+        vol / 6.0
+    }
+
+    /// Sweep places the profile on rotation-minimizing frames, so its
+    /// winding depends on the profile's 2D handedness and the path
+    /// direction rather than on the sketch normal (the extrude trap). Pin
+    /// both signs: a sweep must never come back inside-out.
+    #[test]
+    fn sweep_is_positive_volume_for_either_frame_handedness() {
+        for (x_dir, y_dir) in [(Vec3::x(), Vec3::y()), (Vec3::y(), Vec3::x())] {
+            for end in [Point3::new(0.0, 0.0, 10.0), Point3::new(0.0, 0.0, -10.0)] {
+                let profile = SketchProfile::rectangle(Point3::origin(), x_dir, y_dir, 4.0, 2.0);
+                let path = Line3d::from_points(Point3::origin(), end);
+                let vol = signed_volume(&sweep(&profile, &path, SweepOptions::default()).unwrap());
+                assert!(
+                    (vol - 80.0).abs() < 0.5,
+                    "frame ({x_dir:?},{y_dir:?}) to {end:?}: expected +80, got {vol}"
+                );
+            }
+        }
+    }
+
     #[test]
     fn test_sweep_straight_line() {
         // Sweep along a straight line should be equivalent to extrude

--- a/packages/mcp/src/__tests__/integrity.test.ts
+++ b/packages/mcp/src/__tests__/integrity.test.ts
@@ -12,6 +12,7 @@ import { commandRegistry } from "@vcad/core";
 import {
   computeIntegrity,
   isoperimetricViolation,
+  partLabels,
 } from "../tools/integrity.js";
 import { dispatchRegistryTool } from "../tools/registry-dispatch.js";
 import { registerSession } from "../tools/session.js";
@@ -185,5 +186,40 @@ describe("mutation responses", () => {
     expect(payload.integrity!.volume_mm3).toBeGreaterThan(2500);
     expect(payload.integrity!.volume_mm3).toBeLessThan(2600);
     expect(payload.integrity!.watertight).toBe(true);
+  });
+});
+
+/**
+ * Field report 2026-07-26: four identical `inverted winding` warnings in a
+ * 44-root document named nothing, and the reporter had to bisect the model
+ * by hand to find the bad plates. Every per-part warning now carries the
+ * root id (plus the node's name when the document has one).
+ */
+describe("partLabels", () => {
+  const doc = {
+    roots: [
+      { root: 7, material: "steel" },
+      { root: 12, material: "steel", visible: false },
+      { root: 19, material: "steel" },
+    ],
+    nodes: {
+      "7": { id: 7, name: null, op: { type: "Cube" } },
+      "12": { id: 12, name: "hidden-jig", op: { type: "Cube" } },
+      "19": { id: 19, name: "femur-plate", op: { type: "Extrude" } },
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+
+  it("names the root node, and its name when the document has one", () => {
+    // Hidden roots are skipped by the evaluator, so scene part 2 is root 19
+    // — indexing doc.roots directly would blame the wrong feature.
+    expect(partLabels(doc, 2)).toEqual([
+      'part 1 (root 7)',
+      'part 2 "femur-plate" (root 19)',
+    ]);
+  });
+
+  it("falls back to an index when the document has fewer roots than parts", () => {
+    expect(partLabels({ roots: [], nodes: {} } as never, 1)).toEqual(["part 1"]);
   });
 });

--- a/packages/mcp/src/tools/integrity.ts
+++ b/packages/mcp/src/tools/integrity.ts
@@ -152,6 +152,34 @@ function countOpenEdges(mesh: TriangleMesh): number {
   return open;
 }
 
+/**
+ * A label per scene part, in evaluation order.
+ *
+ * Scene parts correspond 1:1 to `doc.roots` *filtered by visibility* — the
+ * evaluator skips hidden roots, so indexing `doc.roots` directly would skew
+ * every label after the first hidden part. Each label names the root node
+ * (and its human name when the document carries one), which is what a
+ * caller needs to go fix the thing.
+ */
+export function partLabels(doc: Document, partCount: number): string[] {
+  const visibleRoots = (doc.roots ?? []).filter((r) => r.visible !== false);
+  const labels: string[] = [];
+  for (let i = 0; i < partCount; i++) {
+    const entry = visibleRoots[i];
+    if (!entry) {
+      labels.push(`part ${i + 1}`);
+      continue;
+    }
+    const name = doc.nodes?.[String(entry.root)]?.name;
+    labels.push(
+      name
+        ? `part ${i + 1} "${name}" (root ${entry.root})`
+        : `part ${i + 1} (root ${entry.root})`,
+    );
+  }
+  return labels;
+}
+
 /** Distinct circular-pattern axes in the document (deduped by line). */
 function circularPatternAxes(
   doc: Document,
@@ -230,6 +258,7 @@ export function computeIntegrity(
   // same way check_clearance's candidate set bakes FK transforms. Without
   // this, an assembly-only document reported parts: 0, volume: 0.
   const instanceMeshes: TriangleMesh[] = [];
+  const instanceLabels: string[] = [];
   for (const inst of scene.instances ?? []) {
     const mesh = inst.transform
       ? transformMesh(inst.mesh, {
@@ -240,6 +269,10 @@ export function computeIntegrity(
       : inst.mesh;
     if (!mesh || mesh.positions.length === 0) continue;
     instanceMeshes.push(mesh);
+    // Labelled here rather than by index later: empty meshes are skipped, so
+    // an index into doc.instances would drift.
+    const who = inst.name ?? inst.instanceId;
+    instanceLabels.push(who ? `instance "${who}"` : "instance");
   }
 
   let volume = 0;
@@ -259,6 +292,14 @@ export function computeIntegrity(
     ...scene.parts.map((p) => p.mesh),
     ...instanceMeshes,
   ];
+
+  // Labels for every mesh in the aggregate. Field report 2026-07-26: four
+  // identical `inverted winding` warnings in a 44-root document identified
+  // nothing, and the reporter had to bisect the model by hand to find the
+  // bad plates. A warning that can't be traced back to a root is not
+  // actionable, so every per-part warning below carries this label.
+  const labels = [...partLabels(doc, scene.parts.length), ...instanceLabels];
+  const openEdgesByLabel: Array<{ label: string; open: number }> = [];
   for (let partIndex = 0; partIndex < meshes.length; partIndex++) {
     const mesh = meshes[partIndex];
     const tris = mesh.indices.length / 3;
@@ -290,22 +331,25 @@ export function computeIntegrity(
         bbox.max.z = Math.max(bbox.max.z, q[2]);
       }
     }
+    const label = labels[partIndex] ?? `part ${partIndex + 1}`;
     if (partVolume < 0) {
       warnings.push(
-        `part mesh has net negative volume (${round3(partVolume)} mm³) — inverted winding`,
+        `${label} has net negative volume (${round3(partVolume)} mm³) — inverted winding`,
       );
     }
     const impossible = isoperimetricViolation(partVolume, partArea);
     if (impossible) {
       warnings.push(
-        `part ${partIndex + 1} volume ${round3(Math.abs(partVolume))} mm³ is isoperimetrically impossible for its ` +
+        `${label} volume ${round3(Math.abs(partVolume))} mm³ is isoperimetrically impossible for its ` +
           `${round3(partArea)} mm² of surface (A³ ≥ 36πV² for any real solid; this area can enclose at most ` +
           `≈${round3(impossible.max_volume_mm3)} mm³) — the volume integral is corrupt, do not trust this geometry`,
       );
     }
     volume += partVolume;
     area += partArea;
-    openEdges += countOpenEdges(mesh);
+    const partOpen = countOpenEdges(mesh);
+    if (partOpen > 0) openEdgesByLabel.push({ label, open: partOpen });
+    openEdges += partOpen;
   }
 
   const hasBbox = Number.isFinite(bbox.min.x);
@@ -320,7 +364,20 @@ export function computeIntegrity(
     );
   }
   if (openEdges > 0) {
-    warnings.push(`mesh is not watertight (${openEdges} unpaired edges)`);
+    // Per-part breakdown: one bad part and open edges spread across the
+    // document are very different bugs, and the aggregate count can't tell
+    // them apart. Long documents get the worst offenders plus a tail count.
+    const ranked = [...openEdgesByLabel].sort((a, b) => b.open - a.open);
+    const shown = ranked.slice(0, 5);
+    const rest = ranked.length - shown.length;
+    const breakdown =
+      shown.map((e) => `${e.label}: ${e.open}`).join("; ") +
+      (rest > 0 ? `; +${rest} more part${rest === 1 ? "" : "s"}` : "");
+    warnings.push(
+      `mesh is not watertight (${openEdges} unpaired edges across ${ranked.length} part${
+        ranked.length === 1 ? "" : "s"
+      } — ${breakdown})`,
+    );
   }
   if (com && hasBbox) {
     const eps =


### PR DESCRIPTION
Field report from a detailed robot-assembly build (2026-07-26). Two silent-corruption failure modes, plus a third found while auditing the neighbours.

## The bug

A sketch frame like `[sketch 0 0 0  1 0 0  0 0 1 ...]` (x = world X, y = world Z) has normal x̂ × ŷ = **−Y**. Extruding it along **+Y** — the natural thing to write — produced an inside-out solid: negative volume, inverted winding, and every subsequent boolean compounded it. Four of five plates in the reporter's first pass were built this way.

The lethal part is that **it renders completely normally**. Nothing in a render, a bbox, or a screenshot distinguishes an inverted solid from a correct one. It's the only modelling error in that session that didn't announce itself.

## The fix

Not an error, and not a warning — a correction. Extruding along −normal is a well-defined request (the prism on the other side of the sketch plane); only the *winding* was wrong. Before any face is built, a backwards extrude is re-expressed on a frame whose x/y axes are swapped: the normal flips, the 2D coordinates swap with it, and the loop is reversed so it stays CCW as seen from the new +normal. **No 3D point moves**, so the caller gets exactly the solid they asked for, where they asked for it, positively wound. There's nothing left to warn about.

Applies to all three entry points (`extrude`, `extrude_with_holes`, `extrude_with_options`). The twist angle is negated under the flip, since the twist runs x → y and the swap reverses its sense.

## The other three ops

The report asked whether `revolve`, `sweep-line` and `loft` share the trap. Audited all three:

- **`revolve`** — clean. Derives outwardness from the profile's own shoelace in the (r,z) half-plane, which is frame-independent.
- **`sweep`** — clean. Rotation-minimizing frames never consult the sketch normal.
- **`loft`** — **had it.** Sections on an opposite-handedness frame gave exactly −2000 mm³ for a 2000 mm³ box. Fixed the same way, canonicalizing section winding against the stacking direction.

The two clean ones get regression tests anyway so they stay clean.

## Warnings that name the part

The second half of the report: a `create_cad_loon` call returned four *identical* warnings —

> `part mesh has net negative volume (-30385.052 mm³) — inverted winding` ×4

In a 44-root document that identifies nothing, and the reporter bisected the model by hand to find the bad plates. Warnings now read:

> `part 12 "femur-plate" (root 19) has net negative volume (-30385.052 mm³) — inverted winding`

Unpaired edges get a per-root breakdown instead of one aggregate number (`3059 unpaired edges across 2 parts — part 12 "femur-plate" (root 19): 3051; part 3 (root 7): 8`), so "one bad part" and "damage spread across the document" are distinguishable. Labels index *visibility-filtered* roots — the evaluator skips hidden ones, and a naive `doc.roots[i]` would blame the wrong feature.

## Tests

The validation procedure from the report, verbatim: `extrude_is_positive_volume_for_either_frame_handedness` builds the same plate on both frame handednesses × both direction signs and asserts equal positive volume and zero unpaired edges in all four. Siblings cover the arc/analytic-cylinder path, the holed path, revolve, sweep and loft. Each new test was verified to fail against the unfixed code.

`cargo test` green for the affected crates, clippy/fmt clean, MCP integrity tests pass.

## Reviewer notes

- The kernel fix reaches the app and MCP only once the WASM artifacts are rebuilt. Per CLAUDE.md's single-writer rule I did **not** touch `packages/kernel-wasm/vcad_kernel_wasm*` — `wasm-refresh.yml` picks it up on merge to main. Until then a local `create_cad_loon` will keep inverting.
- `SketchProfile` gains two public helpers used by the fix: `reversed()` and `loop_area_normal()` (Newell normal — encodes loop winding independently of frame handedness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)