### PR TITLE
Anisotropic roughness driven by the BRep surface parameterisation

### DIFF
--- a/changelog/entries/2026-07-26-anisotropic-roughness.json
+++ b/changelog/entries/2026-07-26-anisotropic-roughness.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-26-anisotropic-roughness",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "feat",
+  "title": "Brushed and turned finishes render correctly",
+  "summary": "Materials gain an anisotropy value, and the photoreal path tracer orients the stretched highlight by the BRep's own surface parameterisation, so turned shafts and bored holes get the circumferential grain they have in life.",
+  "features": ["rendering", "raytracing", "materials"]
+}

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -1405,6 +1405,18 @@ pub struct MaterialDef {
     )]
     #[cfg_attr(feature = "ts-rs", ts(rename = "clearcoatRoughness", optional))]
     pub clearcoat_roughness: Option<f64>,
+    /// Directional bias of the specular highlight, in -1.0..1.0.
+    ///
+    /// `0` (the default when absent) is an ordinary round highlight.
+    /// Positive values stretch it along the surface's own `dP/du` — the
+    /// circumferential direction on a cylinder, i.e. the grain a lathe or a
+    /// boring bar leaves. Negative values stretch it across. This is what
+    /// distinguishes brushed and turned finishes from a uniformly polished
+    /// one; it is honoured by the photoreal path tracer, which shades the
+    /// analytic BRep and therefore has the exact parameterisation to hand.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "ts-rs", ts(optional))]
+    pub anisotropy: Option<f64>,
 }
 
 /// An entry in the scene — a root node with an assigned material.

--- a/crates/vcad-kernel-raytrace/src/bvh.rs
+++ b/crates/vcad-kernel-raytrace/src/bvh.rs
@@ -9,7 +9,7 @@ use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::TriangleMesh;
 use vcad_kernel_topo::FaceId;
 
-use crate::intersect::{intersect_surface, intersect_triangle};
+use crate::intersect::{intersect_surface, intersect_triangle, surface_tangent};
 use crate::trim::{face_normal, point_in_face};
 use crate::{Ray, RayHit};
 
@@ -362,7 +362,11 @@ impl Bvh {
                     if point_in_face(brep, face_id, hit.uv) {
                         let point = ray.at(hit.t);
                         let normal = face_normal(brep, face_id, hit.uv);
-                        hits.push(RayHit::new(hit.t, point, normal, hit.uv, face_id));
+                        let tangent = surface_tangent(surface.as_ref(), hit.uv);
+                        hits.push(
+                            RayHit::new(hit.t, point, normal, hit.uv, face_id)
+                                .with_tangent(tangent),
+                        );
                     }
                 }
             }
@@ -392,7 +396,11 @@ impl Bvh {
                     {
                         let point = ray.at(hit.t);
                         let normal = face_normal(brep, face_id, hit.uv);
-                        closest = Some(RayHit::new(hit.t, point, normal, hit.uv, face_id));
+                        let tangent = surface_tangent(surface.as_ref(), hit.uv);
+                        closest = Some(
+                            RayHit::new(hit.t, point, normal, hit.uv, face_id)
+                                .with_tangent(tangent),
+                        );
                     }
                 }
 
@@ -684,6 +692,59 @@ mod tests {
     use super::*;
     use vcad_kernel_math::{Point3, Vec3};
     use vcad_kernel_primitives::make_cube;
+
+    /// A hit on a cylinder wall must report the *circumferential* tangent —
+    /// the direction a lathe tool travels. Anisotropic shading orients its
+    /// specular lobe with this, so if it ever came back axial or radial,
+    /// turned parts would get their grain rotated 90°.
+    #[test]
+    fn cylinder_hit_reports_circumferential_tangent() {
+        use vcad_kernel_primitives::make_cylinder;
+
+        let cyl = make_cylinder(5.0, 20.0, 32);
+        let bvh = Bvh::build(&cyl);
+
+        // Fire at the wall from +X, off-axis in Y so the tangent is not
+        // trivially an axis vector.
+        let ray = Ray::new(Point3::new(20.0, 2.0, 10.0), Vec3::new(-1.0, 0.0, 0.0));
+        let hit = bvh.trace_closest(&ray).expect("ray should hit the wall");
+        let t = hit
+            .dpdu
+            .expect("cylinder wall must carry a tangent")
+            .normalize();
+
+        // Circumferential means: perpendicular to the axis (Z) and
+        // perpendicular to the outward radial direction.
+        assert!(
+            t.z.abs() < 1e-9,
+            "tangent should not run along the axis: {t:?}"
+        );
+        let radial = Vec3::new(hit.point.x, hit.point.y, 0.0).normalize();
+        assert!(
+            t.dot(radial).abs() < 1e-9,
+            "tangent should be perpendicular to the radial direction: {t:?}"
+        );
+        // And it must be a real direction, not a degenerate zero.
+        assert!((t.norm() - 1.0).abs() < 1e-9);
+    }
+
+    /// The flat cap of the same cylinder is a plane: it still has a
+    /// parameterisation, so it reports a tangent lying in the cap.
+    #[test]
+    fn planar_cap_tangent_lies_in_the_face() {
+        use vcad_kernel_primitives::make_cylinder;
+
+        let cyl = make_cylinder(5.0, 20.0, 32);
+        let bvh = Bvh::build(&cyl);
+        let ray = Ray::new(Point3::new(1.0, 1.0, 40.0), Vec3::new(0.0, 0.0, -1.0));
+        let hit = bvh.trace_closest(&ray).expect("ray should hit the top cap");
+        let t = hit.dpdu.expect("plane must carry a tangent");
+        let n = hit.normal.into_inner();
+        assert!(
+            t.normalize().dot(n).abs() < 1e-9,
+            "planar tangent must lie in the face"
+        );
+    }
 
     #[test]
     fn test_bvh_build() {

--- a/crates/vcad-kernel-raytrace/src/intersect/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/intersect/mod.rs
@@ -23,7 +23,7 @@ pub use triangle::{intersect_triangle, TriangleHit};
 
 use crate::Ray;
 use vcad_kernel_geom::{Surface, SurfaceKind};
-use vcad_kernel_math::Point2;
+use vcad_kernel_math::{Point2, Vec3};
 
 /// Result of a ray-surface intersection (before trim testing).
 #[derive(Debug, Clone, Copy)]
@@ -32,6 +32,42 @@ pub struct SurfaceHit {
     pub t: f64,
     /// Surface parameter coordinates (u, v).
     pub uv: Point2,
+}
+
+/// The surface tangent `dP/du` at `uv`, when the parameterisation carries a
+/// physically meaningful direction.
+///
+/// Analytic surfaces are parameterised the way the geometry actually runs, so
+/// `dP/du` is the surface's grain rather than an arbitrary basis:
+///
+/// - **Plane** — the plane's own x-axis.
+/// - **Cylinder / cone / sphere / torus** — the circumferential (around-the-
+///   axis) direction. On a turned or bored feature that is the direction the
+///   tool travelled, which is what makes anisotropic highlights read as
+///   machined rather than rendered.
+///
+/// Returns `None` for surfaces whose parameterisation is an artefact of
+/// fitting rather than of the geometry (B-spline, bilinear), and at
+/// parametric degeneracies where `dP/du` vanishes — sphere poles, the cone
+/// apex — so that shading falls back to an arbitrary tangent frame instead of
+/// snapping to a garbage direction.
+pub fn surface_tangent(surface: &dyn Surface, uv: Point2) -> Option<Vec3> {
+    match surface.surface_type() {
+        SurfaceKind::Plane
+        | SurfaceKind::Cylinder
+        | SurfaceKind::Cone
+        | SurfaceKind::Sphere
+        | SurfaceKind::Torus => {
+            let d = surface.d_du(uv);
+            // Degenerate at poles/apex: length collapses to zero there.
+            if d.norm() > 1e-9 {
+                Some(d)
+            } else {
+                None
+            }
+        }
+        SurfaceKind::Bilinear | SurfaceKind::BSpline => None,
+    }
 }
 
 /// Intersect a ray with a surface, returning all intersections sorted by t.

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -47,6 +47,16 @@ pub struct Pbr {
     pub metallic: f32,
     /// Perceptual roughness in 0..1. Squared internally to get the GGX alpha.
     pub roughness: f32,
+    /// Directional bias of the specular lobe, in -1..1.
+    ///
+    /// `0` is isotropic and reduces exactly to a round GGX highlight.
+    /// Positive values stretch the highlight *along* the surface tangent
+    /// (`dP/du`), negative values stretch it across. Because vcad shades the
+    /// analytic BRep, that tangent is the real parameterisation of the
+    /// surface — the circumferential direction on a cylinder — so a turned
+    /// shaft or a bored hole gets the smeared highlight it has in life
+    /// without any generated tangents or texture.
+    pub anisotropy: f32,
     /// Strength of the clearcoat layer (0 = none, 1 = full).
     pub clearcoat: f32,
     /// Perceptual roughness of the clearcoat layer.
@@ -63,6 +73,7 @@ impl Default for Pbr {
             base_color: [0.62, 0.64, 0.67],
             metallic: 0.0,
             roughness: 0.4,
+            anisotropy: 0.0,
             clearcoat: 0.0,
             clearcoat_roughness: 0.1,
             ior: 1.5,
@@ -93,10 +104,54 @@ impl Pbr {
         }
     }
 
-    /// GGX alpha for the base specular lobe.
+    /// A brushed or turned metal: the specular lobe is stretched along the
+    /// surface's own tangent direction.
+    ///
+    /// `anisotropy` is signed — positive smears the highlight along `dP/du`
+    /// (circumferentially on a cylinder, which is a turned finish), negative
+    /// smears it across (an axially-brushed one).
+    pub fn brushed_metal(base_color: [f32; 3], roughness: f32, anisotropy: f32) -> Self {
+        Self {
+            base_color,
+            metallic: 1.0,
+            roughness,
+            anisotropy: anisotropy.clamp(-1.0, 1.0),
+            ..Default::default()
+        }
+    }
+
+    /// GGX alpha for the base specular lobe, ignoring anisotropy.
     #[inline]
     fn alpha(&self) -> f32 {
         (self.roughness * self.roughness).max(1e-4)
+    }
+
+    /// GGX alphas along the tangent and bitangent for the base specular
+    /// lobe.
+    ///
+    /// Uses the standard Disney/glTF construction: an aspect ratio of
+    /// `sqrt(1 - 0.9·|anisotropy|)` splits the isotropic alpha into a
+    /// stretched and a squeezed axis while keeping their product — and hence
+    /// the overall highlight area — roughly fixed. `0.9` bounds the extreme
+    /// case away from a zero-width lobe.
+    ///
+    /// At `anisotropy == 0` the aspect is exactly `1`, so both alphas are
+    /// bit-identical to [`Self::alpha`] and every anisotropic code path
+    /// reduces to the isotropic one.
+    #[inline]
+    fn alpha_tb(&self) -> (f32, f32) {
+        let a = self.alpha();
+        let aniso = self.anisotropy.clamp(-1.0, 1.0);
+        if aniso == 0.0 {
+            return (a, a);
+        }
+        let aspect = (1.0 - 0.9 * aniso.abs()).sqrt();
+        let (wide, narrow) = ((a / aspect).min(1.0), a * aspect);
+        if aniso > 0.0 {
+            (wide, narrow)
+        } else {
+            (narrow, wide)
+        }
     }
 
     /// GGX alpha for the clearcoat lobe.
@@ -793,6 +848,44 @@ fn onb(n: Vec3) -> (Vec3, Vec3) {
     )
 }
 
+/// An orthonormal shading frame: tangent, bitangent, normal.
+///
+/// The tangent is meaningful, not arbitrary, whenever the hit surface has a
+/// real parameterisation — that is what anisotropic shading orients itself
+/// by — so the three vectors travel together rather than as loose arguments.
+#[derive(Debug, Clone, Copy)]
+struct Frame {
+    t: Vec3,
+    b: Vec3,
+    n: Vec3,
+}
+
+/// Shading tangent frame around a unit normal.
+///
+/// When the hit carried a surface tangent `dP/du`, it is Gram-Schmidt
+/// orthogonalised against the (possibly face-forwarded) shading normal and
+/// used as the frame's x axis, so the anisotropic lobe lines up with the
+/// surface's own parameterisation. Otherwise this is the arbitrary [`onb`]
+/// basis the isotropic path has always used — which is exactly what an
+/// isotropic material wants, since its BSDF is invariant to the choice.
+fn shading_frame(n: Vec3, dpdu: Option<Vec3>) -> Frame {
+    if let Some(d) = dpdu {
+        let t = d - n * d.dot(n);
+        // A tangent that is (numerically) parallel to the normal carries no
+        // direction; fall back rather than normalising noise.
+        if t.norm() > 1e-9 {
+            let t = t.normalize();
+            return Frame {
+                t,
+                b: n.cross(t),
+                n,
+            };
+        }
+    }
+    let (t, b) = onb(n);
+    Frame { t, b, n }
+}
+
 #[inline]
 fn to_local(t: Vec3, b: Vec3, n: Vec3, w: Vec3) -> Vec3 {
     Vec3::new(w.dot(t), w.dot(b), w.dot(n))
@@ -838,6 +931,22 @@ fn d_ggx(n_dot_h: f32, alpha: f32) -> f32 {
     a2 / (std::f32::consts::PI * d * d).max(1e-9)
 }
 
+/// Anisotropic GGX normal distribution.
+///
+/// `wh` is the half-vector in the local shading frame, whose x axis is the
+/// surface tangent. When `at == ab` this is algebraically identical to
+/// [`d_ggx`]; the equality is made exact (not merely near-exact in floating
+/// point) by dispatching to it.
+#[inline]
+fn d_ggx_aniso(wh: Vec3, at: f32, ab: f32) -> f32 {
+    if at == ab {
+        return d_ggx(wh.z.max(0.0) as f32, at);
+    }
+    let (hx, hy, hz) = (wh.x as f32, wh.y as f32, wh.z as f32);
+    let d = (hx / at) * (hx / at) + (hy / ab) * (hy / ab) + hz * hz;
+    1.0 / (std::f32::consts::PI * at * ab * d * d).max(1e-9)
+}
+
 /// Smith height-correlated visibility term (already divided by 4·NoL·NoV).
 #[inline]
 fn v_smith(n_dot_v: f32, n_dot_l: f32, alpha: f32) -> f32 {
@@ -845,6 +954,40 @@ fn v_smith(n_dot_v: f32, n_dot_l: f32, alpha: f32) -> f32 {
     let gv = n_dot_l * (n_dot_v * n_dot_v * (1.0 - a2) + a2).sqrt();
     let gl = n_dot_v * (n_dot_l * n_dot_l * (1.0 - a2) + a2).sqrt();
     0.5 / (gv + gl).max(1e-9)
+}
+
+/// Anisotropic Smith height-correlated visibility term (already divided by
+/// 4·NoL·NoV). Reduces exactly to [`v_smith`] when `at == ab`.
+#[inline]
+fn v_smith_aniso(wo: Vec3, wi: Vec3, at: f32, ab: f32) -> f32 {
+    if at == ab {
+        return v_smith(wo.z as f32, wi.z as f32, at);
+    }
+    // Λ-style stretched lengths: sqrt((at·x)² + (ab·y)² + z²).
+    let stretched = |w: Vec3| -> f32 {
+        let (x, y, z) = (w.x as f32, w.y as f32, w.z as f32);
+        ((at * x) * (at * x) + (ab * y) * (ab * y) + z * z).sqrt()
+    };
+    let gv = (wi.z as f32) * stretched(wo);
+    let gl = (wo.z as f32) * stretched(wi);
+    0.5 / (gv + gl).max(1e-9)
+}
+
+/// Smith G1 masking term for the anisotropic GGX distribution.
+///
+/// The `at == ab` branch is the isotropic expression evaluated exactly as it
+/// was before anisotropy existed, so isotropic renders are bit-unchanged.
+#[inline]
+fn g1_smith_aniso(w: Vec3, at: f32, ab: f32) -> f32 {
+    let z = w.z.max(1e-6) as f32;
+    let lambda = if at == ab {
+        let a2 = at * at;
+        ((1.0 + a2 * (1.0 - z * z) / (z * z)).sqrt() - 1.0) * 0.5
+    } else {
+        let (x, y) = (w.x as f32, w.y as f32);
+        (((at * x) * (at * x) + (ab * y) * (ab * y) + z * z).sqrt() / z - 1.0) * 0.5
+    };
+    1.0 / (1.0 + lambda)
 }
 
 /// Schlick Fresnel.
@@ -859,11 +1002,16 @@ fn fresnel(f0: [f32; 3], cos_theta: f32) -> [f32; 3] {
 }
 
 /// Sample the GGX visible-normal distribution (Heitz 2018). `wo` is in local
-/// space with +Z the shading normal; returns the sampled half-vector.
-fn sample_vndf(wo: Vec3, alpha: f32, r1: f64, r2: f64) -> Vec3 {
-    let a = alpha as f64;
+/// space with +Z the shading normal and +X the surface tangent; returns the
+/// sampled half-vector.
+///
+/// The method is anisotropic by construction: the stretch step that maps to
+/// the hemisphere-configured space takes each axis' alpha separately, so
+/// passing `at != ab` needs no other change.
+fn sample_vndf(wo: Vec3, at: f32, ab: f32, r1: f64, r2: f64) -> Vec3 {
+    let (a, b) = (at as f64, ab as f64);
     // Stretch the view direction into the hemisphere-configured space.
-    let vh = Vec3::new(a * wo.x, a * wo.y, wo.z).normalize();
+    let vh = Vec3::new(a * wo.x, b * wo.y, wo.z).normalize();
     let lensq = vh.x * vh.x + vh.y * vh.y;
     let t1 = if lensq > 0.0 {
         Vec3::new(-vh.y, vh.x, 0.0) / lensq.sqrt()
@@ -880,19 +1028,15 @@ fn sample_vndf(wo: Vec3, alpha: f32, r1: f64, r2: f64) -> Vec3 {
     let p2 = (1.0 - s) * (1.0 - p1 * p1).max(0.0).sqrt() + s * p2r;
 
     let nh = t1 * p1 + t2 * p2 + vh * (1.0 - p1 * p1 - p2 * p2).max(0.0).sqrt();
-    Vec3::new(a * nh.x, a * nh.y, nh.z.max(1e-9)).normalize()
+    Vec3::new(a * nh.x, b * nh.y, nh.z.max(1e-9)).normalize()
 }
 
 /// PDF of the VNDF sampling strategy, in solid angle around `wi`.
 #[inline]
-fn vndf_pdf(wo: Vec3, wh: Vec3, alpha: f32) -> f32 {
-    let n_dot_h = wh.z.max(0.0) as f32;
+fn vndf_pdf(wo: Vec3, wh: Vec3, at: f32, ab: f32) -> f32 {
     let n_dot_v = wo.z.max(1e-6) as f32;
-    let d = d_ggx(n_dot_h, alpha);
-    // G1 for the Smith masking function.
-    let a2 = alpha * alpha;
-    let lambda = ((1.0 + a2 * (1.0 - n_dot_v * n_dot_v) / (n_dot_v * n_dot_v)).sqrt() - 1.0) * 0.5;
-    let g1 = 1.0 / (1.0 + lambda);
+    let d = d_ggx_aniso(wh, at, ab);
+    let g1 = g1_smith_aniso(wo, at, ab);
     let o_dot_h = wo.dot(wh).max(1e-9) as f32;
     d * g1 * o_dot_h / n_dot_v / (4.0 * o_dot_h)
 }
@@ -926,15 +1070,18 @@ fn bsdf_eval(m: &Pbr, wo: Vec3, wi: Vec3) -> ([f32; 3], f32) {
     let diffuse = scale3(m.diffuse_albedo(), std::f32::consts::FRAC_1_PI * n_dot_l);
     let pdf_d = n_dot_l * std::f32::consts::FRAC_1_PI;
 
-    // Base specular.
-    let alpha = m.alpha();
-    let d = d_ggx(n_dot_h, alpha);
-    let vis = v_smith(n_dot_v, n_dot_l, alpha);
+    // Base specular. Anisotropy stretches the lobe along the local x axis,
+    // which the integrator has aligned with the surface tangent dP/du.
+    let (at, ab) = m.alpha_tb();
+    let d = d_ggx_aniso(wh, at, ab);
+    let vis = v_smith_aniso(wo, wi, at, ab);
     let f = fresnel(m.f0(), o_dot_h);
     let spec = scale3(f, d * vis * n_dot_l);
-    let pdf_s = vndf_pdf(wo, wh, alpha);
+    let pdf_s = vndf_pdf(wo, wh, at, ab);
 
-    // Clearcoat: a thin dielectric layer over everything else.
+    // Clearcoat: a thin dielectric layer over everything else. It is a
+    // separate isotropic film — the grain lives in the substrate beneath it,
+    // not in the lacquer — so it never takes the anisotropy.
     let (coat, pdf_c, coat_atten) = if m.clearcoat > 0.0 {
         let ca = m.coat_alpha();
         let cd = d_ggx(n_dot_h, ca);
@@ -943,7 +1090,7 @@ fn bsdf_eval(m: &Pbr, wo: Vec3, wi: Vec3) -> ([f32; 3], f32) {
         let c = cd * cv * n_dot_l * cf;
         (
             [c, c, c],
-            vndf_pdf(wo, wh, ca),
+            vndf_pdf(wo, wh, ca, ca),
             // Energy removed from the layers beneath.
             1.0 - cf,
         )
@@ -970,14 +1117,16 @@ fn bsdf_sample(m: &Pbr, wo: Vec3, rng: &mut Rng) -> Option<(Vec3, [f32; 3], f32)
     let wi = if u < pd {
         cosine_hemisphere(r1, r2)
     } else if u < pd + ps {
-        let wh = sample_vndf(wo, m.alpha(), r1, r2);
+        let (at, ab) = m.alpha_tb();
+        let wh = sample_vndf(wo, at, ab, r1, r2);
         let wi = reflect(-wo, wh);
         if wi.z <= 0.0 {
             return None;
         }
         wi
     } else {
-        let wh = sample_vndf(wo, m.coat_alpha(), r1, r2);
+        let ca = m.coat_alpha();
+        let wh = sample_vndf(wo, ca, ca, r1, r2);
         let wi = reflect(-wo, wh);
         if wi.z <= 0.0 {
             return None;
@@ -1016,6 +1165,8 @@ enum Landing {
     Surface {
         point: Point3,
         normal: Vec3,
+        /// Surface tangent dP/du, when the parameterisation has one.
+        tangent: Option<Vec3>,
         material: Pbr,
     },
     Light {
@@ -1040,6 +1191,7 @@ impl Scene {
                     landing = Landing::Surface {
                         point: hit.point,
                         normal: hit.normal.into_inner(),
+                        tangent: hit.dpdu,
                         material: obj.material,
                     };
                 }
@@ -1055,6 +1207,9 @@ impl Scene {
                     landing = Landing::Surface {
                         point: ray.at(t),
                         normal: Vec3::new(0.0, 0.0, 1.0),
+                        // The studio sweep is a backdrop, not a machined
+                        // face; it has no grain to align to.
+                        tangent: None,
                         material: g.material,
                     };
                 }
@@ -1109,13 +1264,12 @@ impl Scene {
     fn sample_lights(
         &self,
         p: Point3,
-        t: Vec3,
-        b: Vec3,
-        n: Vec3,
+        frame: &Frame,
         wo_local: Vec3,
         m: &Pbr,
         rng: &mut Rng,
     ) -> [f32; 3] {
+        let Frame { t, b, n } = *frame;
         let mut sum = [0.0f32; 3];
         for light in &self.lights {
             let lp = light.sample(rng.f64(), rng.f64());
@@ -1163,19 +1317,15 @@ impl Scene {
     /// Only runs for an importance-sampled environment ([`EnvMap`]). The
     /// analytic gradient stays BSDF-only, exactly as before — it is
     /// low-frequency enough that a second strategy buys nothing.
-    // Same hot-loop shading-frame arguments as `sample_lights`, and the same
-    // reasoning for keeping them positional.
-    #[allow(clippy::too_many_arguments)]
     fn sample_environment(
         &self,
         p: Point3,
-        t: Vec3,
-        b: Vec3,
-        n: Vec3,
+        frame: &Frame,
         wo_local: Vec3,
         m: &Pbr,
         rng: &mut Rng,
     ) -> [f32; 3] {
+        let Frame { t, b, n } = *frame;
         let Some((wi_world, li, env_pdf)) = self.env.sample(rng.f64(), rng.f64()) else {
             return [0.0; 3];
         };
@@ -1261,6 +1411,7 @@ fn radiance(scene: &Scene, opts: &PathTraceOptions, ray: Ray, rng: &mut Rng) -> 
             Landing::Surface {
                 point,
                 normal,
+                tangent,
                 material,
             } => {
                 if depth == 0 {
@@ -1273,8 +1424,8 @@ fn radiance(scene: &Scene, opts: &PathTraceOptions, ray: Ray, rng: &mut Rng) -> 
                 } else {
                     normal
                 };
-                let (t, b) = onb(n);
-                let wo_local = to_local(t, b, n, wo_world);
+                let frame = shading_frame(n, tangent);
+                let wo_local = to_local(frame.t, frame.b, n, wo_world);
                 if wo_local.z <= 0.0 {
                     break;
                 }
@@ -1284,8 +1435,8 @@ fn radiance(scene: &Scene, opts: &PathTraceOptions, ray: Ray, rng: &mut Rng) -> 
                 // Next-event estimation: explicit lights, plus the
                 // environment when it is importance-sampled.
                 let direct = add3(
-                    scene.sample_lights(point, t, b, n, wo_local, &material, rng),
-                    scene.sample_environment(point, t, b, n, wo_local, &material, rng),
+                    scene.sample_lights(point, &frame, wo_local, &material, rng),
+                    scene.sample_environment(point, &frame, wo_local, &material, rng),
                 );
                 let direct = match opts.firefly_clamp {
                     Some(c) if depth > 0 => [direct[0].min(c), direct[1].min(c), direct[2].min(c)],
@@ -1301,7 +1452,7 @@ fn radiance(scene: &Scene, opts: &PathTraceOptions, ray: Ray, rng: &mut Rng) -> 
                 prev_bsdf_pdf = pdf;
                 specular_chain = false;
 
-                let wi_world = to_world(t, b, n, wi_local);
+                let wi_world = to_world(frame.t, frame.b, n, wi_local);
                 ray = Ray::new(point + n * 1e-5, wi_world);
 
                 // Russian roulette.
@@ -1595,51 +1746,160 @@ mod tests {
     /// energy-wrong in a way that is hard to see by eye.
     #[test]
     fn bsdf_sample_pdf_matches_eval_pdf() {
-        let m = Pbr {
-            base_color: [0.8, 0.8, 0.8],
-            metallic: 0.3,
-            roughness: 0.4,
-            clearcoat: 0.5,
-            ..Default::default()
-        };
-        let wo = Vec3::new(0.3, 0.15, 0.94).normalize();
-        let mut rng = Rng::new(7);
-        for _ in 0..256 {
-            if let Some((wi, _f, pdf)) = bsdf_sample(&m, wo, &mut rng) {
-                let (_f2, pdf2) = bsdf_eval(&m, wo, wi);
-                assert!(
-                    (pdf - pdf2).abs() <= 1e-4 * pdf.max(1.0),
-                    "pdf mismatch: sampled {pdf}, evaluated {pdf2}"
-                );
+        // Isotropic, plus anisotropy swept across both signs and both
+        // extremes — the sampling and evaluation paths must agree for all of
+        // them or MIS is silently energy-wrong.
+        let anisos = [0.0, 0.4, 0.8, 1.0, -0.4, -0.8, -1.0];
+        for aniso in anisos {
+            for roughness in [0.1, 0.4, 0.8] {
+                let m = Pbr {
+                    base_color: [0.8, 0.8, 0.8],
+                    metallic: 0.3,
+                    roughness,
+                    anisotropy: aniso,
+                    clearcoat: 0.5,
+                    ..Default::default()
+                };
+                // Several view directions: a grazing wo is where an
+                // anisotropic G1 and a mismatched PDF diverge fastest.
+                for wo in [
+                    Vec3::new(0.3, 0.15, 0.94).normalize(),
+                    Vec3::new(0.85, 0.1, 0.52).normalize(),
+                    Vec3::new(0.1, 0.85, 0.52).normalize(),
+                    Vec3::new(0.0, 0.0, 1.0),
+                ] {
+                    let mut rng = Rng::new(7);
+                    for _ in 0..256 {
+                        if let Some((wi, _f, pdf)) = bsdf_sample(&m, wo, &mut rng) {
+                            let (_f2, pdf2) = bsdf_eval(&m, wo, wi);
+                            assert!(
+                                (pdf - pdf2).abs() <= 1e-4 * pdf.max(1.0),
+                                "pdf mismatch at aniso={aniso} rough={roughness}: \
+                                 sampled {pdf}, evaluated {pdf2}"
+                            );
+                        }
+                    }
+                }
             }
         }
+    }
+
+    /// Anisotropy 0 must be the isotropic model exactly — not merely close.
+    /// If this drifts, every existing render changes silently.
+    #[test]
+    fn zero_anisotropy_is_exactly_isotropic() {
+        let m = Pbr {
+            base_color: [0.8, 0.7, 0.6],
+            metallic: 0.6,
+            roughness: 0.35,
+            anisotropy: 0.0,
+            clearcoat: 0.3,
+            ..Default::default()
+        };
+        let (at, ab) = m.alpha_tb();
+        assert_eq!(at, m.alpha(), "tangent alpha diverged from the base alpha");
+        assert_eq!(
+            ab,
+            m.alpha(),
+            "bitangent alpha diverged from the base alpha"
+        );
+
+        // And the lobe terms must take their isotropic branches bit-exactly.
+        let wo = Vec3::new(0.3, 0.15, 0.94).normalize();
+        let wi = Vec3::new(-0.2, 0.35, 0.91).normalize();
+        let wh = (wo + wi).normalize();
+        assert_eq!(d_ggx_aniso(wh, at, ab), d_ggx(wh.z.max(0.0) as f32, at));
+        assert_eq!(
+            v_smith_aniso(wo, wi, at, ab),
+            v_smith(wo.z as f32, wi.z as f32, at)
+        );
+    }
+
+    /// The whole point of the feature: an anisotropic lobe must actually
+    /// prefer one tangent direction over the other, and swapping the sign of
+    /// the anisotropy must swap which one.
+    #[test]
+    fn anisotropy_stretches_the_lobe_along_the_tangent() {
+        let rough = |anisotropy| Pbr {
+            base_color: [1.0, 1.0, 1.0],
+            metallic: 1.0,
+            roughness: 0.3,
+            anisotropy,
+            clearcoat: 0.0,
+            ..Default::default()
+        };
+        // Straight-on view, so the mirror direction is +Z and any asymmetry
+        // is the lobe's own, not the geometry's.
+        let wo = Vec3::new(0.0, 0.0, 1.0);
+        // Two directions tilted off the mirror by the same angle: one along
+        // the tangent (x), one along the bitangent (y).
+        let along = Vec3::new(0.25, 0.0, 1.0).normalize();
+        let across = Vec3::new(0.0, 0.25, 1.0).normalize();
+
+        let (f_iso_a, _) = bsdf_eval(&rough(0.0), wo, along);
+        let (f_iso_b, _) = bsdf_eval(&rough(0.0), wo, across);
+        assert!(
+            (f_iso_a[0] - f_iso_b[0]).abs() < 1e-6,
+            "isotropic lobe must be rotationally symmetric"
+        );
+
+        let (f_pos_a, _) = bsdf_eval(&rough(0.8), wo, along);
+        let (f_pos_b, _) = bsdf_eval(&rough(0.8), wo, across);
+        assert!(
+            f_pos_a[0] > f_pos_b[0] * 1.5,
+            "positive anisotropy should spread energy along the tangent: \
+             along {} vs across {}",
+            f_pos_a[0],
+            f_pos_b[0]
+        );
+
+        let (f_neg_a, _) = bsdf_eval(&rough(-0.8), wo, along);
+        let (f_neg_b, _) = bsdf_eval(&rough(-0.8), wo, across);
+        assert!(
+            f_neg_b[0] > f_neg_a[0] * 1.5,
+            "negative anisotropy should spread energy across the tangent: \
+             along {} vs across {}",
+            f_neg_a[0],
+            f_neg_b[0]
+        );
     }
 
     /// A white furnace test: with no lights and a uniform environment, a
     /// pure-white rough dielectric must not create or destroy much energy.
     #[test]
     fn furnace_conserves_energy_roughly() {
-        let m = Pbr {
-            base_color: [1.0, 1.0, 1.0],
-            metallic: 0.0,
-            roughness: 0.5,
-            clearcoat: 0.0,
-            ..Default::default()
-        };
-        let wo = Vec3::new(0.0, 0.0, 1.0);
-        let mut rng = Rng::new(11);
-        let n = 20000;
-        let mut sum = 0.0f32;
-        for _ in 0..n {
-            if let Some((_wi, f, pdf)) = bsdf_sample(&m, wo, &mut rng) {
-                sum += f[0] / pdf;
+        // Anisotropy redistributes energy within the lobe; it must not
+        // create or destroy any. Grazing views are included because that is
+        // where a wrong anisotropic masking term shows up as gain.
+        for aniso in [0.0, 0.5, 0.9, -0.5, -0.9] {
+            for wo in [
+                Vec3::new(0.0, 0.0, 1.0),
+                Vec3::new(0.6, 0.2, 0.77).normalize(),
+            ] {
+                let m = Pbr {
+                    base_color: [1.0, 1.0, 1.0],
+                    metallic: 0.0,
+                    roughness: 0.5,
+                    anisotropy: aniso,
+                    clearcoat: 0.0,
+                    ..Default::default()
+                };
+                let mut rng = Rng::new(11);
+                let n = 20000;
+                let mut sum = 0.0f32;
+                for _ in 0..n {
+                    if let Some((_wi, f, pdf)) = bsdf_sample(&m, wo, &mut rng) {
+                        sum += f[0] / pdf;
+                    }
+                }
+                let albedo = sum / n as f32;
+                assert!(
+                    (0.75..=1.05).contains(&albedo),
+                    "directional albedo {albedo} outside plausible range \
+                     (anisotropy {aniso}, wo {wo:?})"
+                );
             }
         }
-        let albedo = sum / n as f32;
-        assert!(
-            (0.75..=1.05).contains(&albedo),
-            "directional albedo {albedo} outside plausible range"
-        );
     }
 
     // ── environment maps ──────────────────────────────────────────────────

--- a/crates/vcad-kernel-raytrace/src/ray.rs
+++ b/crates/vcad-kernel-raytrace/src/ray.rs
@@ -100,10 +100,26 @@ pub struct RayHit {
     /// Index of the triangle that was hit, when this hit came from a
     /// mesh-backed BVH. `None` for analytic BRep-face hits.
     pub tri: Option<u32>,
+    /// Surface tangent `dP/du` at the intersection, when the surface's
+    /// parameterisation carries a meaningful direction.
+    ///
+    /// This is the *grain* of the surface: on a cylinder it is the
+    /// circumferential direction, which is exactly the axis a lathe or a
+    /// belt sander leaves its marks along. Anisotropic shading uses it to
+    /// orient the specular lobe. It is `None` for surfaces whose
+    /// parameterisation is arbitrary (fitted B-splines, bilinear patches),
+    /// at parametric degeneracies (sphere poles, the cone apex), and for
+    /// triangle hits, where shading must fall back to an arbitrary tangent
+    /// frame.
+    ///
+    /// Not normalised, and not guaranteed orthogonal to [`Self::normal`] —
+    /// consumers should orthogonalise against the normal they shade with.
+    pub dpdu: Option<Vec3>,
 }
 
 impl RayHit {
-    /// Create a new ray hit on an analytic BRep face.
+    /// Create a new ray hit on an analytic BRep face, with no surface
+    /// tangent.
     pub fn new(t: f64, point: Point3, normal: Dir3, uv: Point2, face_id: FaceId) -> Self {
         Self {
             t,
@@ -112,6 +128,7 @@ impl RayHit {
             uv,
             face_id,
             tri: None,
+            dpdu: None,
         }
     }
 
@@ -119,6 +136,10 @@ impl RayHit {
     ///
     /// `uv` carries the barycentric weights `(u, v)` of the hit and
     /// [`face_id`](Self::face_id) is left null — a mesh has no BRep faces.
+    ///
+    /// Triangle hits carry no tangent: a mesh has no parameterisation to
+    /// read a grain from, so anisotropic shading falls back to an arbitrary
+    /// frame exactly as it does for fitted surfaces.
     pub fn triangle(t: f64, point: Point3, normal: Dir3, uv: Point2, tri: u32) -> Self {
         Self {
             t,
@@ -127,7 +148,14 @@ impl RayHit {
             uv,
             face_id: FaceId::default(),
             tri: Some(tri),
+            dpdu: None,
         }
+    }
+
+    /// Attach a surface tangent `dP/du` to this hit.
+    pub fn with_tangent(mut self, dpdu: Option<Vec3>) -> Self {
+        self.dpdu = dpdu;
+        self
     }
 }
 

--- a/crates/vcad-kernel-raytrace/tests/fillet_corner_trim.rs
+++ b/crates/vcad-kernel-raytrace/tests/fillet_corner_trim.rs
@@ -90,7 +90,7 @@ fn corner_blends_are_eight_spherical_octants() {
         for a in 0..3 {
             let b = (a + 1) % 3;
             assert!(
-                dirs[a].dot(&dirs[b]).abs() < 1e-9,
+                dirs[a].dot(dirs[b]).abs() < 1e-9,
                 "{face_id:?} corner directions must be orthogonal"
             );
         }

--- a/crates/vcad-render/src/photoreal.rs
+++ b/crates/vcad-render/src/photoreal.rs
@@ -114,6 +114,26 @@ pub fn render_photoreal_png_str(
 /// machined and moulded parts almost always have some surface layer —
 /// anodising, paint, moulding skin — and adding it is the single biggest
 /// step from "CAD shaded" to "photographed".
+/// Fallback anisotropy for materials that name a directional finish but do
+/// not carry an explicit `anisotropy` value.
+///
+/// Deliberately conservative — only finishes that are unambiguously
+/// directional, and at moderate strength. Anything else stays isotropic, so
+/// this can never change how an existing material renders unless its name
+/// says it is brushed or turned.
+fn anisotropy_from_name(name: &str) -> f32 {
+    let n = name.to_ascii_lowercase();
+    // Turning and boring cut circumferentially, which is the +u direction on
+    // a cylinder — the same direction the tangent frame is built from.
+    if n.contains("turned") || n.contains("machined") || n.contains("bored") {
+        0.6
+    } else if n.contains("brushed") {
+        0.7
+    } else {
+        0.0
+    }
+}
+
 fn to_pbr(mat: Option<&vcad_ir::MaterialDef>, tint: Option<[f64; 3]>) -> Pbr {
     let base = mat.map(|m| m.color).or(tint).unwrap_or([0.62, 0.64, 0.67]);
     let base_color = [base[0] as f32, base[1] as f32, base[2] as f32];
@@ -141,10 +161,25 @@ fn to_pbr(mat: Option<&vcad_ir::MaterialDef>, tint: Option<[f64; 3]>) -> Pbr {
         0.0
     };
 
+    // Anisotropy is a real IR field (`MaterialDef::anisotropy`) rather than
+    // a rendering-time guess: Rust is the source of truth for IR types, the
+    // value is a genuine property of the surface finish, and it round-trips
+    // in `.vcad`. The name heuristic below only fills in when the document
+    // says nothing — a document that names its material "brushed_aluminum"
+    // or "turned_shaft" has told us the finish, and rendering that as a
+    // uniform polish is the CG tell this feature exists to remove. Anything
+    // explicit always wins.
+    let anisotropy = mat
+        .and_then(|m| m.anisotropy)
+        .map(|v| v as f32)
+        .unwrap_or_else(|| mat.map(|m| anisotropy_from_name(&m.name)).unwrap_or(0.0))
+        .clamp(-1.0, 1.0);
+
     Pbr {
         base_color,
         metallic,
         roughness,
+        anisotropy,
         clearcoat,
         clearcoat_roughness: 0.08,
         ior,

--- a/packages/ir/src/generated.ts
+++ b/packages/ir/src/generated.ts
@@ -2589,7 +2589,19 @@ clearcoat?: number,
 /**
  * Clearcoat layer roughness (0.0..1.0).
  */
-clearcoatRoughness?: number, };
+clearcoatRoughness?: number, 
+/**
+ * Directional bias of the specular highlight, in -1.0..1.0.
+ *
+ * `0` (the default when absent) is an ordinary round highlight.
+ * Positive values stretch it along the surface's own `dP/du` — the
+ * circumferential direction on a cylinder, i.e. the grain a lathe or a
+ * boring bar leaves. Negative values stretch it across. This is what
+ * distinguishes brushed and turned finishes from a uniformly polished
+ * one; it is honoured by the photoreal path tracer, which shades the
+ * analytic BRep and therefore has the exact parameterisation to hand.
+ */
+anisotropy?: number, };
 
 /**
  * A molecular / atomic system: the optional `molecule` domain on a `Document`.


### PR DESCRIPTION
Brushed aluminium and turned shafts are everywhere in mechanical CAD, and they currently render with the same round isotropic highlight as a polished ball. That is a large part of what makes CAD renders read as CG.

Because vcad ray traces analytic surfaces rather than tessellating, every hit already knows where it sits in the surface's own parameter space. The tangent frame is therefore exact and semantically meaningful: on a cylinder `dP/du` **is** the circumferential direction — the path a lathe tool or boring bar actually travelled. A mesh renderer has to fake this with generated tangents or a texture; here it is physically correct and free.

## What changed

- **`RayHit.dpdu`** — populated for the surfaces whose parameterisation is unambiguous (plane, cylinder, cone, sphere, torus) via a new `intersect::surface_tangent`. Fitted surfaces (B-spline, bilinear) and parametric degeneracies (sphere poles, cone apex) report `None` and fall back to the existing arbitrary `onb()` basis, so nothing regresses.
- **`Pbr::anisotropy` (-1..1)** — splits the base roughness into `alpha_t` / `alpha_b` by the standard Disney/glTF aspect construction. Positive smears the highlight along the tangent (turned), negative across it (axially brushed).
- **Anisotropic GGX** — `d_ggx`, `v_smith`, `sample_vndf` and `vndf_pdf` generalised. Heitz 2018's VNDF sampling handles this natively: the stretch step just takes the two alphas separately. The clearcoat lobe stays isotropic — the grain lives in the substrate, not the lacquer.
- **`MaterialDef::anisotropy`** — a real IR field (Rust is the source of truth; `packages/ir/src/generated.ts` regenerated via `npm run ir:gen`), because the finish is a genuine property of the material and should round-trip in `.vcad`. A deliberately conservative name heuristic ("brushed", "turned", "machined", "bored") fills in only when the document says nothing.

## Invariants

- **Anisotropy 0 reduces to the isotropic model exactly**, not merely closely — each generalised term dispatches to the original expression when the alphas are equal, so existing renders are bit-unchanged. Pinned by a new `zero_anisotropy_is_exactly_isotropic`.
- **`bsdf_sample`'s PDF still equals `bsdf_eval`'s** for the same direction pair. `bsdf_sample_pdf_matches_eval_pdf` now sweeps both signs, three roughnesses and four view directions including grazing — that is where a mismatched anisotropic masking term diverges fastest. If these drift, MIS goes silently energy-wrong.
- **`furnace_conserves_energy_roughly`** extended across anisotropy and grazing views.
- New geometry tests assert a cylinder-wall hit reports a tangent perpendicular to both the axis and the radial direction (i.e. genuinely circumferential), and that a planar cap's tangent lies in the face.

## Verified visually

Turned shaft, front view, identical seed and lighting:

| anisotropy | result |
|---|---|
| `0.0` | tight vertical softbox streak — the current look |
| `+0.8` | streak breaks up circumferentially, as a turned part does |
| `-0.8` | streak draws out along the axis — an axially brushed finish |

The two signs producing opposite, axis-aligned effects is the confirmation that the frame really is the surface's own parameterisation and not an arbitrary basis.

## Checks

`cargo test -p vcad-kernel-raytrace -p vcad-render`, `cargo clippy -p vcad-kernel-raytrace --all-targets -- -D warnings`, `cargo fmt --all --check`, `npm run ir:check` — all clean. Workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
