### PR TITLE
fix(raytrace): close the corner holes on ray-traced fillets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7642,6 +7642,7 @@ dependencies = [
  "tang",
  "thiserror 2.0.18",
  "vcad-kernel-booleans",
+ "vcad-kernel-fillet",
  "vcad-kernel-geom",
  "vcad-kernel-gpu",
  "vcad-kernel-math",

--- a/changelog/entries/2026-07-26-fillet-corner-raytrace-hole.json
+++ b/changelog/entries/2026-07-26-fillet-corner-raytrace-hole.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-26-fillet-corner-raytrace-hole",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "fix",
+  "title": "Fix holes at fillet corners in ray-traced renders",
+  "summary": "Ray-traced filleted parts showed a crescent-shaped hole at every rounded corner; the spherical corner blend's trim boundary collapsed at the sphere's pole and cut away half the patch.",
+  "features": ["fillet", "rendering", "raytrace"]
+}

--- a/crates/vcad-kernel-fillet/tests/cube_watertight.rs
+++ b/crates/vcad-kernel-fillet/tests/cube_watertight.rs
@@ -1,0 +1,104 @@
+//! Standing invariant: `fillet_all_edges` on a box produces a closed manifold
+//! solid whose volume matches the analytic rounded box.
+//!
+//! These assertions passed before the ray-tracer corner-trim fix and still
+//! pass after it — the corner hole lived in the ray tracer's trim test, not in
+//! the B-rep — so they are an invariant, not that fix's regression test (see
+//! `vcad-kernel-raytrace/tests/fillet_corner_trim.rs`). They are worth pinning
+//! anyway: this pipeline rebuilds the whole shell from scratch, and a cracked
+//! shell is exactly the failure mode that a trim-level test cannot see.
+
+use vcad_kernel_fillet::fillet_all_edges;
+use vcad_kernel_primitives::make_cube;
+use vcad_kernel_tessellate::{tessellate_solid, TessellationParams};
+
+const DIMS: (f64, f64, f64) = (40.0, 30.0, 6.0);
+const RADIUS: f64 = 2.0;
+
+/// Volume of a box of `dims` with all edges rounded at radius `r`: the inner
+/// box, plus a slab over each of the 6 faces, plus a quarter-cylinder along
+/// each of the 12 edges, plus 8 sphere octants (one whole sphere).
+fn analytic_rounded_box_volume(dims: (f64, f64, f64), r: f64) -> f64 {
+    let (a, b, c) = (dims.0 - 2.0 * r, dims.1 - 2.0 * r, dims.2 - 2.0 * r);
+    let core = a * b * c;
+    let slabs = 2.0 * r * (a * b + b * c + a * c);
+    let edges = std::f64::consts::PI * r * r * (a + b + c);
+    let corners = 4.0 / 3.0 * std::f64::consts::PI * r * r * r;
+    core + slabs + edges + corners
+}
+
+#[test]
+fn filleted_cube_brep_is_a_closed_manifold() {
+    let filleted = fillet_all_edges(&make_cube(DIMS.0, DIMS.1, DIMS.2), RADIUS);
+
+    // The fillet must actually have happened — a refused fillet returns the
+    // input unchanged, and a 6-face box would trivially pass the checks below.
+    assert_eq!(
+        filleted.topology.faces.len(),
+        26,
+        "6 trimmed faces + 12 edge cylinders + 8 corner blends"
+    );
+
+    let boundary: Vec<_> = filleted
+        .topology
+        .half_edges
+        .iter()
+        .filter(|(_, he)| he.twin.is_none())
+        .map(|(id, _)| id)
+        .collect();
+    assert!(
+        boundary.is_empty(),
+        "{} half-edges have no twin — the rebuilt shell is cracked: {boundary:?}",
+        boundary.len()
+    );
+}
+
+#[test]
+fn filleted_cube_mesh_is_watertight() {
+    let filleted = fillet_all_edges(&make_cube(DIMS.0, DIMS.1, DIMS.2), RADIUS);
+    let mesh = tessellate_solid(&filleted, &TessellationParams::default());
+
+    // Weld by position, then require every undirected edge to carry one
+    // triangle in each direction. A hole shows up as a non-zero imbalance.
+    let quantized = |i: usize| -> [i64; 3] {
+        [0, 1, 2].map(|k| ((mesh.vertices[i * 3 + k] as f64) * 1e4).round() as i64)
+    };
+    let mut balance: std::collections::HashMap<([i64; 3], [i64; 3]), i32> = Default::default();
+    for tri in mesh.indices.chunks(3) {
+        let p = [
+            quantized(tri[0] as usize),
+            quantized(tri[1] as usize),
+            quantized(tri[2] as usize),
+        ];
+        for i in 0..3 {
+            let (a, b) = (p[i], p[(i + 1) % 3]);
+            let (key, dir) = if a < b { ((a, b), 1) } else { ((b, a), -1) };
+            *balance.entry(key).or_insert(0) += dir;
+        }
+    }
+    let unpaired = balance.values().filter(|v| **v != 0).count();
+    assert_eq!(
+        unpaired, 0,
+        "{unpaired} mesh edges are not shared by two oppositely-wound triangles"
+    );
+}
+
+#[test]
+fn filleted_cube_volume_matches_the_analytic_rounded_box() {
+    let filleted = fillet_all_edges(&make_cube(DIMS.0, DIMS.1, DIMS.2), RADIUS);
+    let mesh = tessellate_solid(&filleted, &TessellationParams::default());
+    let props =
+        vcad_kernel_tessellate::mesh_props::compute_mesh_properties(&mesh.vertices, &mesh.indices);
+
+    let expected = analytic_rounded_box_volume(DIMS, RADIUS);
+    // The mesh is a chordal approximation, so it under-reports slightly;
+    // 0.5% covers the default tessellation density.
+    let rel_err = (props.volume - expected).abs() / expected;
+    assert!(
+        rel_err < 5e-3,
+        "filleted volume {} differs from the analytic rounded box {expected} \
+         by {:.3}%",
+        props.volume,
+        rel_err * 100.0
+    );
+}

--- a/crates/vcad-kernel-raytrace/Cargo.toml
+++ b/crates/vcad-kernel-raytrace/Cargo.toml
@@ -30,5 +30,8 @@ web-sys = { version = "0.3", features = ["console"] }
 default = []
 gpu = ["dep:vcad-kernel-gpu", "dep:wgpu"]
 
+[dev-dependencies]
+vcad-kernel-fillet = { workspace = true }
+
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 pollster = { workspace = true }

--- a/crates/vcad-kernel-raytrace/src/trim.rs
+++ b/crates/vcad-kernel-raytrace/src/trim.rs
@@ -18,15 +18,23 @@ pub fn point_in_face(brep: &BRepSolid, face_id: FaceId, uv: Point2) -> bool {
     let surface = &brep.geometry.surfaces[face.surface_index];
 
     // Get UV coordinates of the outer loop vertices
-    let outer_uvs = loop_uv_coords(brep, face.outer_loop, surface.as_ref());
+    let raw_uvs = loop_uv_coords(brep, face.outer_loop, surface.as_ref());
 
     // A closed surface covering the whole primitive (a full sphere or
     // torus) is bounded only by its seam: the outer loop projects to a
     // zero-area polygon in UV, which would reject every hit. Treat a
     // degenerate outer loop as "untrimmed" — the face spans the entire
     // surface — and still honour inner loops (holes) below.
-    let mut outer_uvs = outer_uvs;
-    let mut untrimmed = polygon_area(&outer_uvs).abs() < 1e-9;
+    //
+    // The degeneracy verdict is taken on the *raw* projection, before any
+    // pole repair: a full sphere's seam loop passes through both poles, and
+    // repairing those would hand it a non-zero area and reject every hit.
+    let mut untrimmed = polygon_area(&raw_uvs).abs() < 1e-9;
+    let mut outer_uvs = if untrimmed {
+        raw_uvs
+    } else {
+        repair_pole_vertices(surface.as_ref(), &raw_uvs)
+    };
 
     // A planar cap bounded by a single closed circle edge (cylinder/cone
     // caps) projects to a degenerate UV polygon too — but "untrimmed" on a
@@ -50,7 +58,7 @@ pub fn point_in_face(brep: &BRepSolid, face_id: FaceId, uv: Point2) -> bool {
                 return false;
             }
         }
-    } else if !point_in_polygon(&uv, &outer_uvs) {
+    } else if !point_in_polygon(&wrap_u_into_polygon(uv, &outer_uvs), &outer_uvs) {
         return false;
     }
 
@@ -63,6 +71,118 @@ pub fn point_in_face(brep: &BRepSolid, face_id: FaceId, uv: Point2) -> bool {
     }
 
     true
+}
+
+/// Latitude magnitude above which a spherical loop vertex counts as sitting
+/// on a pole, where longitude is indeterminate.
+const POLE_V_EPS: f64 = 1e-7;
+
+/// Repair a spherical face's UV trim polygon around pole vertices and the
+/// longitude seam.
+///
+/// On a sphere, `u` (longitude) is meaningless at a pole: every meridian
+/// meets there, and `project_to_sphere` reports `u = 0` for want of anything
+/// better. Straight-line point-in-polygon then draws the boundary to
+/// `u = 0` instead of up the two meridians that actually bound the patch.
+///
+/// The fillet corner blend is exactly this case. Each convex corner of a
+/// filleted box gets a spherical octant whose three vertices are the
+/// tangency points with the three faces; the first of those lands on the
+/// pole (the surface's `axis` is that face's normal), so the loop projects
+/// to the right triangle `(0, π/2), (0, 0), (π/2, 0)` when the true patch is
+/// the *square* `[0, π/2] × [0, π/2]`. The hypotenuse cuts away half the
+/// octant, and rays through the missing half pass into the solid — the
+/// crescent-shaped hole visible at every corner of a ray-traced filleted
+/// part, right where the three fillet cylinders meet.
+///
+/// The repair replaces each pole vertex with two vertices carrying the
+/// longitudes of its neighbours, so the boundary runs up one meridian,
+/// across the pole, and back down the other. Longitudes are also unwrapped
+/// onto one continuous branch first, so a patch straddling the `u = 0` seam
+/// stays a single polygon instead of folding across the whole domain.
+///
+/// Non-spherical surfaces are returned unchanged.
+fn repair_pole_vertices(surface: &dyn Surface, uvs: &[Point2]) -> Vec<Point2> {
+    use vcad_kernel_geom::SurfaceKind;
+    if surface.surface_type() != SurfaceKind::Sphere || uvs.len() < 3 {
+        return uvs.to_vec();
+    }
+    let half_pi = std::f64::consts::FRAC_PI_2;
+    let is_pole = |uv: &Point2| (uv.y.abs() - half_pi).abs() < POLE_V_EPS;
+
+    // Nothing to do when the loop avoids both poles — but still unwrap, so a
+    // seam-straddling patch tests as one contiguous polygon.
+    let n = uvs.len();
+    let anchor = (0..n).find(|&i| !is_pole(&uvs[i]));
+    let Some(anchor) = anchor else {
+        return uvs.to_vec();
+    };
+
+    // Unwrap longitudes of the non-pole vertices onto a continuous branch,
+    // walking the loop from the anchor so each step takes the shortest turn.
+    let tau = std::f64::consts::TAU;
+    let mut unwrapped: Vec<Option<f64>> = vec![None; n];
+    unwrapped[anchor] = Some(uvs[anchor].x);
+    let mut last = uvs[anchor].x;
+    for step in 1..n {
+        let i = (anchor + step) % n;
+        if is_pole(&uvs[i]) {
+            continue;
+        }
+        let mut u = uvs[i].x;
+        while u - last > std::f64::consts::PI {
+            u -= tau;
+        }
+        while last - u > std::f64::consts::PI {
+            u += tau;
+        }
+        unwrapped[i] = Some(u);
+        last = u;
+    }
+
+    // Emit, expanding each pole vertex into the two meridian endpoints that
+    // bracket it in loop order.
+    let prev_nonpole = |i: usize| -> f64 {
+        (1..=n)
+            .find_map(|k| unwrapped[(i + n - k) % n])
+            .unwrap_or(0.0)
+    };
+    let next_nonpole =
+        |i: usize| -> f64 { (1..=n).find_map(|k| unwrapped[(i + k) % n]).unwrap_or(0.0) };
+
+    let mut out = Vec::with_capacity(n + 2);
+    for i in 0..n {
+        if let Some(u) = unwrapped[i] {
+            out.push(Point2::new(u, uvs[i].y));
+            continue;
+        }
+        let v = if uvs[i].y > 0.0 { half_pi } else { -half_pi };
+        out.push(Point2::new(prev_nonpole(i), v));
+        out.push(Point2::new(next_nonpole(i), v));
+    }
+    out
+}
+
+/// Shift a query longitude onto the branch spanned by a repaired polygon.
+///
+/// [`repair_pole_vertices`] unwraps longitudes, so a polygon may live on
+/// `[-π/2, π/2]` while `project_to_sphere` reports the hit at `3π/2`. The
+/// polygon's `u` extent is always under a full turn, so at most one whole-turn
+/// shift can land inside.
+fn wrap_u_into_polygon(uv: Point2, polygon: &[Point2]) -> Point2 {
+    let tau = std::f64::consts::TAU;
+    let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+    for p in polygon {
+        lo = lo.min(p.x);
+        hi = hi.max(p.x);
+    }
+    if !lo.is_finite() || hi - lo >= tau {
+        return uv;
+    }
+    // Map u into [lo, lo + τ). Since the polygon spans under a full turn,
+    // that interval contains [lo, hi] and any u inside the patch lands there.
+    let u = uv.x - ((uv.x - lo) / tau).floor() * tau;
+    Point2::new(u, uv.y)
 }
 
 /// Signed area of a UV polygon (shoelace). Near-zero means the loop is
@@ -197,6 +317,21 @@ pub(crate) fn synthesize_planar_cap_polygon(
     }
 
     None
+}
+
+/// Project a 3D point onto the parameter space of a face's surface.
+///
+/// The inverse of evaluating the face's surface — the coordinates
+/// [`point_in_face`] expects. Exposed so callers can ask whether a specific
+/// surface point falls inside a face's trim boundary.
+pub fn project_face_uv(
+    brep: &BRepSolid,
+    face_id: FaceId,
+    point: &vcad_kernel_math::Point3,
+) -> Point2 {
+    let face = &brep.topology.faces[face_id];
+    let surface = &brep.geometry.surfaces[face.surface_index];
+    project_to_surface_uv(surface.as_ref(), point)
 }
 
 /// Get the UV coordinates of vertices in a loop by projecting 3D positions onto the surface.
@@ -485,7 +620,15 @@ pub fn extract_face_uv_loop(brep: &BRepSolid, face_id: FaceId) -> Vec<Point2> {
     let face = &topo.faces[face_id];
     let surface = &brep.geometry.surfaces[face.surface_index];
 
-    loop_uv_coords(brep, face.outer_loop, surface.as_ref())
+    let raw = loop_uv_coords(brep, face.outer_loop, surface.as_ref());
+    // Mirror `point_in_face`: repair pole longitudes on a real trim loop, but
+    // leave a degenerate (seam-only) loop alone so callers can still detect
+    // it and fall back to "untrimmed".
+    if polygon_area(&raw).abs() < 1e-9 {
+        raw
+    } else {
+        repair_pole_vertices(surface.as_ref(), &raw)
+    }
 }
 
 /// Extract UV coordinates for all inner loops (holes) of a face.

--- a/crates/vcad-kernel-raytrace/tests/fillet_corner_trim.rs
+++ b/crates/vcad-kernel-raytrace/tests/fillet_corner_trim.rs
@@ -1,0 +1,170 @@
+//! Regression: the spherical corner blends of a filleted box must trim as
+//! whole spherical triangles, with no hole where the three fillet cylinders
+//! meet.
+//!
+//! `try_sphere_blend` builds each corner patch with `axis` set to one of the
+//! three face normals, so one of the patch's three loop vertices lands
+//! exactly on the sphere's pole — where longitude is indeterminate and
+//! `project_to_sphere` reports `u = 0` for want of anything better. The
+//! straight-line point-in-polygon trim test then saw the right triangle
+//! `(0, π/2), (0, 0), (π/2, 0)` instead of the true square
+//! `[0, π/2] × [0, π/2]`, and its hypotenuse sliced away half of every
+//! octant. Rays through the missing half passed into the solid: the
+//! crescent-shaped hole visible at each corner of a ray-traced filleted part.
+//!
+//! Note this defect is invisible to a watertightness check. The B-rep and its
+//! tessellation are both closed manifolds before and after the fix — the hole
+//! lived purely in the ray tracer's trim test — so the oracle has to probe
+//! trimming directly.
+
+use vcad_kernel_geom::SurfaceKind;
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_raytrace::trim::{extract_face_uv_loop, point_in_face, project_face_uv};
+use vcad_kernel_raytrace::{Bvh, Ray};
+use vcad_kernel_topo::FaceId;
+
+/// Sample directions strictly inside the spherical triangle spanned by three
+/// unit corner directions, as normalized positive barycentric combinations.
+fn interior_directions(corners: [Vec3; 3], steps: usize) -> Vec<Vec3> {
+    let mut out = Vec::new();
+    for i in 1..steps {
+        for j in 1..(steps - i) {
+            let k = steps - i - j;
+            let w = [i as f64, j as f64, k as f64];
+            let d = corners[0] * w[0] + corners[1] * w[1] + corners[2] * w[2];
+            if d.norm() > 1e-12 {
+                out.push(d.normalize());
+            }
+        }
+    }
+    out
+}
+
+/// Every spherical corner patch of the filleted plate, with its sphere and
+/// the three unit directions of its loop vertices.
+fn corner_patches(brep: &BRepSolid) -> Vec<(FaceId, vcad_kernel_geom::SphereSurface, [Vec3; 3])> {
+    let mut out = Vec::new();
+    for (face_id, face) in &brep.topology.faces {
+        let surface = &brep.geometry.surfaces[face.surface_index];
+        if surface.surface_type() != SurfaceKind::Sphere {
+            continue;
+        }
+        let sph = surface
+            .as_any()
+            .downcast_ref::<vcad_kernel_geom::SphereSurface>()
+            .expect("sphere kind must downcast");
+        let verts = brep.topology.loop_vertices(face.outer_loop);
+        assert_eq!(
+            verts.len(),
+            3,
+            "a convex corner blend is a spherical triangle"
+        );
+        let dirs: Vec<Vec3> = verts
+            .iter()
+            .map(|&v| (brep.topology.vertices[v].point - sph.center).normalize())
+            .collect();
+        out.push((face_id, sph.clone(), [dirs[0], dirs[1], dirs[2]]));
+    }
+    out
+}
+
+fn filleted_plate() -> BRepSolid {
+    let cube = vcad_kernel_primitives::make_cube(40.0, 30.0, 6.0);
+    vcad_kernel_fillet::fillet_all_edges(&cube, 2.0)
+}
+
+#[test]
+fn corner_blends_are_eight_spherical_octants() {
+    let brep = filleted_plate();
+    let patches = corner_patches(&brep);
+    assert_eq!(patches.len(), 8, "one corner blend per box vertex");
+
+    // Each patch is a true octant: its three loop directions are mutually
+    // orthogonal, and each vertex sits exactly on the blend sphere.
+    for (face_id, sph, dirs) in &patches {
+        assert!(
+            (sph.radius.abs() - 2.0).abs() < 1e-9,
+            "{face_id:?} blend radius must equal the fillet radius"
+        );
+        for a in 0..3 {
+            let b = (a + 1) % 3;
+            assert!(
+                dirs[a].dot(&dirs[b]).abs() < 1e-9,
+                "{face_id:?} corner directions must be orthogonal"
+            );
+        }
+    }
+}
+
+#[test]
+fn corner_blend_trim_polygon_covers_the_whole_octant() {
+    let brep = filleted_plate();
+    for (face_id, _sph, dirs) in corner_patches(&brep) {
+        // An octant's boundary is three 90° great arcs, so in the sphere's
+        // own (longitude, latitude) space the patch is a π/2 × π/2 square of
+        // area (π/2)². The pole-collapsed polygon was the right triangle
+        // with half that area.
+        let uvs = extract_face_uv_loop(&brep, face_id);
+        let area = {
+            let mut a = 0.0;
+            for i in 0..uvs.len() {
+                let p = uvs[i];
+                let q = uvs[(i + 1) % uvs.len()];
+                a += p.x * q.y - q.x * p.y;
+            }
+            (a / 2.0).abs()
+        };
+        let expected = std::f64::consts::FRAC_PI_2 * std::f64::consts::FRAC_PI_2;
+        assert!(
+            (area - expected).abs() < 1e-9,
+            "{face_id:?} trim polygon covers {area} of the octant's {expected} \
+             in UV — the pole vertex collapsed its longitude"
+        );
+        let _ = dirs;
+    }
+}
+
+#[test]
+fn corner_blend_interior_is_never_trimmed_away() {
+    let brep = filleted_plate();
+    for (face_id, sph, dirs) in corner_patches(&brep) {
+        for d in interior_directions(dirs, 12) {
+            let p = Point3::from(sph.center.to_vec() + d * sph.radius.abs());
+            let uv = project_face_uv(&brep, face_id, &p);
+            assert!(
+                point_in_face(&brep, face_id, uv),
+                "{face_id:?} rejects its own surface point {p:?} at uv \
+                 ({}, {}) — the corner blend has a hole",
+                uv.x,
+                uv.y
+            );
+        }
+    }
+}
+
+#[test]
+fn rays_into_every_corner_hit_the_blend() {
+    let brep = filleted_plate();
+    let patches = corner_patches(&brep);
+    let bvh = Bvh::build(&brep);
+
+    for (face_id, sph, dirs) in patches {
+        for d in interior_directions(dirs, 8) {
+            let surf = Point3::from(sph.center.to_vec() + d * sph.radius.abs());
+            // Fire inward along the surface normal from well outside.
+            let origin = Point3::from(surf.to_vec() + d * 100.0);
+            let ray = Ray::new(origin, -d);
+            let hit = bvh.trace_closest(&ray).unwrap_or_else(|| {
+                panic!("{face_id:?}: ray into the corner blend missed entirely")
+            });
+            assert!(
+                (hit.t - 100.0).abs() < 1e-6,
+                "{face_id:?}: ray into the corner blend landed at t={} \
+                 instead of the blend surface at t=100 — it passed through a \
+                 hole and hit something behind it",
+                hit.t
+            );
+        }
+    }
+}


### PR DESCRIPTION
## The symptom

Ray-traced filleted parts show a crescent-shaped hole at every rounded corner — right where the three fillet cylinders meet — and you can see straight into the solid. Reproduces on a plain filleted cube, no booleans involved.

| before | after |
|---|---|
| crescent hole at each corner | clean, tangent-continuous |

Repro:

```bash
cargo build --release -p vcad-render && ./target/release/vcad-render /tmp/fillet_cube.vcad --raytrace --size 700 -o /tmp/out.png
```

## It is not a B-rep defect

Worth stating up front, because the obvious diagnosis (fillet cylinders overshooting the corner and leaving uncapped tube ends) is wrong. `fillet_all_edges` already trims each blend cylinder back to its tangent setback and caps the junction with a spherical octant. Measured on the repro solid:

- **26 faces** — 6 trimmed planes, 12 edge cylinders, 8 `SphereSurface` corner blends
- **0 untwinned half-edges**; the tessellation is watertight too (3084 tris, 0 unpaired edges)
- the **drafting path renders the same solid cleanly** — the defect is raytrace-only

The 3-vertex corner loop is also fine: for an ideal octant all three boundary arcs (one equator segment, two meridians) are straight lines in the sphere's own UV space, so three vertices are sufficient.

## The actual bug

`point_in_face` runs a straight-line point-in-polygon over the loop vertices projected into the surface's UV space. On a sphere, longitude is indeterminate at a pole, and `project_to_sphere` reports `u = 0` for want of anything better.

`try_sphere_blend` sets each corner patch's `axis` to one of the three face normals — so **one of its three vertices always lands exactly on the pole**. Every octant projected to the right triangle `(0, π/2), (0, 0), (π/2, 0)` instead of the true square `[0, π/2] × [0, π/2]`. The hypotenuse sliced away half the patch, and rays through the missing half passed into the solid.

## The fix

`repair_pole_vertices` replaces each pole vertex with two vertices carrying its neighbours' longitudes, so the boundary runs up one meridian, across the pole, and back down the other. Supporting details:

- Longitudes are unwrapped onto one continuous branch first, and query longitudes shifted onto it (`wrap_u_into_polygon`), so a patch straddling the `u = 0` seam stays a single polygon.
- The repair is **gated on the raw loop's area**, so a full primitive sphere's seam-only loop still reads as "untrimmed" — this is what keeps the existing `full_sphere_traces` test honest.
- `extract_face_uv_loop` applies the same rule, so the **GPU trim buffers get the fix too** (variable-length, no cap to worry about).

## Tests

`crates/vcad-kernel-raytrace/tests/fillet_corner_trim.rs` is the real oracle — it measures each octant's UV trim area, probes patch interiors via barycentric sampling, and fires rays into all 8 corners. **3 of its 4 tests fail without the fix**, with the trim area coming in at exactly half (1.2337 vs 2.4674).

Reviewer note: **a watertightness assertion does not catch this.** The B-rep and its mesh are closed manifolds both before and after — the hole lived purely in the trim test. `crates/vcad-kernel-fillet/tests/cube_watertight.rs` pins the closed-manifold and analytic-rounded-box-volume invariant separately, as a standing check on the shell rebuild rather than as this fix's regression test.

Also adds `vcad-kernel-fillet` as a **dev-dependency** of `vcad-kernel-raytrace` (no cycle; one-line `Cargo.lock` change).

## Verification

- Visually confirmed at corner crops in both the `--raytrace` and drafting paths
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean
- `cargo fmt --all` — clean
- `cargo test --workspace` — 99 test binaries green, 0 failures at the time of writing; the tail of the suite (slow physics/flow crates) was still running. Directly affected crates (`vcad-kernel-raytrace`, `vcad-kernel-fillet`, `vcad-kernel`, `vcad-render`) are fully green.

Pre-existing and untouched: `cargo clippy --all-targets` fails in `termview` and `vcad-kernel-gpu` test targets. CI does not pass `--all-targets`, and neither crate is touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
