### PR TITLE
feat(raytrace): one BSDF for both renderers, and a real path tracer in the viewport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7641,6 +7641,7 @@ dependencies = [
  "rayon",
  "tang",
  "thiserror 2.0.18",
+ "vcad-ir",
  "vcad-kernel-booleans",
  "vcad-kernel-fillet",
  "vcad-kernel-geom",

--- a/changelog/entries/2026-07-26-viewport-path-tracer.json
+++ b/changelog/entries/2026-07-26-viewport-path-tracer.json
@@ -4,6 +4,6 @@
   "date": "2026-07-26",
   "category": "feat",
   "title": "The raytrace viewport is a real path tracer",
-  "summary": "The viewport now shades with the same physically-based BSDF and softbox rig as --photoreal: multi-bounce global illumination, MIS area lights, and clearcoat, so a part looks the same in the app as in a render.",
+  "summary": "The viewport now shades with the same BSDF, materials and lighting as --photoreal: multi-bounce global illumination, MIS area lights, clearcoat and brushed-metal anisotropy, so a part looks the same in the app as in a render.",
   "features": ["rendering", "raytracing", "viewport", "materials"]
 }

--- a/changelog/entries/2026-07-26-viewport-path-tracer.json
+++ b/changelog/entries/2026-07-26-viewport-path-tracer.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-26-viewport-path-tracer",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "feat",
+  "title": "The raytrace viewport is a real path tracer",
+  "summary": "The viewport now shades with the same physically-based BSDF and softbox rig as --photoreal: multi-bounce global illumination, MIS area lights, and clearcoat, so a part looks the same in the app as in a render.",
+  "features": ["rendering", "raytracing", "viewport", "materials"]
+}

--- a/crates/vcad-ffi/src/lib.rs
+++ b/crates/vcad-ffi/src/lib.rs
@@ -837,11 +837,10 @@ pub extern "C" fn vcad_scene_raytrace_gpu(
             width,
             height,
             None,
-            None,
             GpuRenderState::new(1),
         ));
         match result {
-            Ok((pixels, _accum, _ao)) if pixels.len() == (width * height * 4) as usize => {
+            Ok((pixels, _accum)) if pixels.len() == (width * height * 4) as usize => {
                 Box::into_raw(Box::new(VcadImage {
                     pixels,
                     width,

--- a/crates/vcad-kernel-raytrace/Cargo.toml
+++ b/crates/vcad-kernel-raytrace/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [dependencies]
 rayon = "1"
 vcad-kernel-math = { workspace = true }
+vcad-ir = { workspace = true }
 vcad-kernel-topo = { workspace = true }
 vcad-kernel-geom = { workspace = true }
 vcad-kernel-primitives = { workspace = true }

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -463,6 +463,18 @@ pub struct GpuRenderState {
     pub boundary_width: f32,
     /// Sub-pixel softness factor (higher = softer AA transition).
     pub edge_softness: f32,
+    /// Environment mode: 0 = analytic gradient, 1 = lat-long HDR image.
+    pub env_mode: u32,
+    /// Environment image width in texels (image mode only).
+    pub env_width: u32,
+    /// Environment image height in texels (image mode only).
+    pub env_height: u32,
+    /// Environment rotation about +Z, in radians.
+    pub env_rotation: f32,
+    /// Normaliser for the environment's uv-space PDF.
+    pub env_marg_int: f32,
+    /// Padding to a 16-byte multiple (required for uniform buffers).
+    pub _pad3: [u32; 3],
 }
 
 /// Default silhouette line color: near-black, slightly cool.
@@ -533,6 +545,12 @@ impl GpuRenderState {
             crease_width: 0.75,
             boundary_width: 1.25,
             edge_softness: 1.5,
+            env_mode: 0,
+            env_width: 0,
+            env_height: 0,
+            env_rotation: 0.0,
+            env_marg_int: 0.0,
+            _pad3: [0; 3],
         }
     }
 
@@ -641,6 +659,12 @@ impl GpuRenderState {
             crease_width,
             boundary_width,
             edge_softness,
+            env_mode: 0,
+            env_width: 0,
+            env_height: 0,
+            env_rotation: 0.0,
+            env_marg_int: 0.0,
+            _pad3: [0; 3],
         }
     }
 
@@ -729,6 +753,9 @@ pub struct GpuScene {
     pub inner_loop_descs: Vec<u32>,
     /// Mapping from FaceId to GPU face index.
     pub face_index_map: std::collections::HashMap<FaceId, u32>,
+    /// Optional lat-long HDR environment. `None` uses the analytic studio
+    /// gradient, matching `pathtrace::Environment::default()`.
+    pub environment: Option<crate::pathtrace::GpuEnvPack>,
     /// Area lights (softboxes) illuminating the scene, derived from the scene
     /// bounds via [`crate::pathtrace::studio_rig`] — the same rig the CPU
     /// renderer uses, so highlights match between the two.
@@ -1037,6 +1064,7 @@ impl GpuScene {
             trim_verts,
             inner_loop_descs,
             face_index_map,
+            environment: None,
             lights,
         })
     }
@@ -1157,6 +1185,16 @@ impl GpuScene {
             roughness,
             ..Default::default()
         };
+    }
+
+    /// Light the scene with a lat-long HDR environment instead of the analytic
+    /// gradient.
+    ///
+    /// The map is importance-sampled on the GPU exactly as it is on the CPU —
+    /// same CDFs, same nearest-texel lookup, same solid-angle PDF — so both
+    /// renderers converge to the same image.
+    pub fn set_environment(&mut self, env: Option<&crate::pathtrace::EnvMap>) {
+        self.environment = env.map(|e| e.pack_for_gpu());
     }
 
     /// Set the material for all faces from an IR material definition.

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -193,8 +193,11 @@ pub struct GpuMaterial {
     pub clearcoat_roughness: f32,
     /// Dielectric index of refraction, drives the base specular reflectance.
     pub ior: f32,
+    /// Signed anisotropy in -1..1: positive stretches the specular highlight
+    /// along the local tangent, negative along the bitangent, 0 = isotropic.
+    pub anisotropy: f32,
     /// Padding for 16-byte alignment.
-    pub _pad: [f32; 3],
+    pub _pad: [f32; 2],
 }
 
 impl Default for GpuMaterial {
@@ -206,7 +209,8 @@ impl Default for GpuMaterial {
             clearcoat: 0.0,
             clearcoat_roughness: 0.1,
             ior: 1.5,
-            _pad: [0.0; 3],
+            anisotropy: 0.0,
+            _pad: [0.0; 2],
         }
     }
 }
@@ -257,6 +261,7 @@ impl GpuMaterial {
             clearcoat: self.clearcoat,
             clearcoat_roughness: self.clearcoat_roughness,
             ior: self.ior,
+            anisotropy: self.anisotropy,
             emissive: [0.0; 3],
         }
     }

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -262,6 +262,37 @@ impl GpuMaterial {
     }
 }
 
+/// GPU-compatible rectangular area light ("softbox").
+///
+/// Mirrors the WGSL `GpuAreaLight`. Built from [`crate::pathtrace::AreaLight`]
+/// via [`GpuAreaLight::from_area_light`] so the GPU and CPU renderers light the
+/// scene with the same rig — that is what makes specular highlights on metal
+/// match between the viewport and `--photoreal`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
+pub struct GpuAreaLight {
+    /// Centre of the rectangle (w unused).
+    pub center: [f32; 4],
+    /// Half-extent along the rectangle's first axis (w unused).
+    pub u: [f32; 4],
+    /// Half-extent along the second axis (w unused).
+    pub v: [f32; 4],
+    /// Emitted radiance (w unused).
+    pub emission: [f32; 4],
+}
+
+impl GpuAreaLight {
+    /// Convert a CPU reference area light to its GPU representation.
+    pub fn from_area_light(l: &crate::pathtrace::AreaLight) -> Self {
+        Self {
+            center: [l.center.x as f32, l.center.y as f32, l.center.z as f32, 0.0],
+            u: [l.u.x as f32, l.u.y as f32, l.u.z as f32, 0.0],
+            v: [l.v.x as f32, l.v.y as f32, l.v.z as f32, 0.0],
+            emission: [l.emission[0], l.emission[1], l.emission[2], 0.0],
+        }
+    }
+}
+
 /// GPU-compatible face representation.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
@@ -344,9 +375,8 @@ pub struct GpuCamera {
 ///
 /// Layout (128 bytes, 16-byte aligned — matches `RenderState` in raytrace.wgsl):
 /// offset  0–31:  eight u32/f32 scalars (frame_index … theme)
-/// offset 32–47:  SSAO params (ao_radius, ao_intensity, ao_bias, ao_sample_count)
-/// offset 48–51:  refine_sample_count u32
-/// offset 52–63:  _pad [u32; 3]
+/// offset 32–47:  path tracing (max_depth, rr_start, light_count, env_intensity)
+/// offset 48–63:  refine_sample_count, firefly_clamp, ground_enabled, stylize
 /// offset 64–79:  silhouette_color vec4
 /// offset 80–95:  crease_color vec4
 /// offset 96–111: boundary_color vec4
@@ -373,21 +403,28 @@ pub struct GpuRenderState {
     /// palette in `sky_color`; the IBL panels and direct lighting stay
     /// constant across themes so the model itself looks the same.
     pub theme: u32,
-    // SSAO
-    /// SSAO world-space sample hemisphere radius.
-    pub ao_radius: f32,
-    /// SSAO intensity: 0 = disabled (ao_buffer writes 1.0), 1 = default strength.
-    pub ao_intensity: f32,
-    /// SSAO depth bias to prevent self-occlusion.
-    pub ao_bias: f32,
-    /// SSAO hemisphere sample count per frame (8, 16, or 32).
-    pub ao_sample_count: u32,
-    // refinement + padding
+    // Path tracing
+    /// Maximum path length (1 = direct lighting only). Escalated by the
+    /// refinement scheduler: shallow on the draft frame, deeper as
+    /// accumulation proceeds, so the first frame stays interactive.
+    pub max_depth: u32,
+    /// Depth at which Russian roulette begins.
+    pub rr_start: u32,
+    /// Number of valid entries in the area-light buffer.
+    pub light_count: u32,
+    /// Overall multiplier on the analytic studio environment.
+    pub env_intensity: f32,
+    // refinement + path tracing continued
     /// Number of additional refinement rays per edge pixel (0 = disabled).
     /// Actual rays fired = floor(sqrt(refine_sample_count))^2.
     pub refine_sample_count: u32,
-    /// Padding to align silhouette_color to 16-byte boundary (required for uniform buffers).
-    pub _pad: [u32; 3],
+    /// Clamp on indirect radiance to kill fireflies (0 = disabled).
+    pub firefly_clamp: f32,
+    /// Whether the implicit ground plane participates in the path trace.
+    pub ground_enabled: u32,
+    /// Non-zero enables non-photoreal stylisation (the Sobel edge overlay).
+    /// Off in a photoreal viewport: edge lines fight photorealism.
+    pub stylize: u32,
     // --- edge style (added for Fusion-style edge lines) ---
     /// Silhouette line color (RGBA linear, depth-gradient edges).
     pub silhouette_color: [f32; 4],
@@ -415,6 +452,36 @@ const DEFAULT_BOUNDARY_COLOR: [f32; 4] = [0.06, 0.06, 0.08, 1.0];
 /// All three edge types on: bits 0 (silhouette) | 1 (crease) | 2 (boundary).
 const EDGES_ALL: u32 = 7;
 
+/// Full path depth, matching `PathTraceOptions::default().max_depth` so the
+/// converged viewport image matches `vcad-render --photoreal`.
+pub const DEFAULT_MAX_DEPTH: u32 = 6;
+/// Depth at which Russian roulette begins, matching the CPU renderer.
+pub const DEFAULT_RR_START: u32 = 3;
+/// Environment multiplier, matching `Environment::default().intensity`.
+pub const DEFAULT_ENV_INTENSITY: f32 = 0.35;
+/// Indirect-radiance clamp, matching the CPU renderer's firefly clamp.
+pub const DEFAULT_FIREFLY_CLAMP: f32 = 12.0;
+
+/// Path depth to trace on a given accumulation frame.
+///
+/// Full path tracing is too slow for the viewport's draft frame, so depth
+/// escalates with accumulation: the first frame traces shallow (direct
+/// lighting plus one bounce) and lands fast, and by the time the `high` tier
+/// is accumulating we are at the full depth that matches the CPU renderer.
+/// The refinement scheduler in `RayTracedViewport.tsx` resets `frame_index` on
+/// every camera change, so each gesture gets a cheap first frame.
+///
+/// Depth only ever increases, and the accumulation buffer is a running average,
+/// so early shallow frames are progressively outweighed by deeper ones.
+pub fn depth_for_frame(frame_index: u32, ceiling: u32) -> u32 {
+    let d = match frame_index {
+        0 | 1 => 2,
+        2..=4 => 4,
+        _ => DEFAULT_MAX_DEPTH,
+    };
+    d.min(ceiling.max(1))
+}
+
 impl GpuRenderState {
     /// Create a new render state for the given frame with default edge style.
     pub fn new(frame_index: u32) -> Self {
@@ -428,12 +495,14 @@ impl GpuRenderState {
             edge_normal_threshold: 30.0,
             debug_mode: 0,
             theme: 0,
-            ao_radius: 0.3,
-            ao_intensity: 1.0,
-            ao_bias: 0.001,
-            ao_sample_count: 16,
+            max_depth: depth_for_frame(frame_index, DEFAULT_MAX_DEPTH),
+            rr_start: DEFAULT_RR_START,
+            light_count: 0,
+            env_intensity: DEFAULT_ENV_INTENSITY,
             refine_sample_count: 0,
-            _pad: [0; 3],
+            firefly_clamp: DEFAULT_FIREFLY_CLAMP,
+            ground_enabled: 1,
+            stylize: 1,
             silhouette_color: DEFAULT_SILHOUETTE_COLOR,
             crease_color: DEFAULT_CREASE_COLOR,
             boundary_color: DEFAULT_BOUNDARY_COLOR,
@@ -459,7 +528,7 @@ impl GpuRenderState {
         state
     }
 
-    /// Create a render state with custom edge settings (default AO).
+    /// Create a render state with custom edge settings.
     pub fn with_edge_settings(
         frame_index: u32,
         debug_mode: u32,
@@ -474,15 +543,11 @@ impl GpuRenderState {
             edge_depth_threshold,
             edge_normal_threshold,
             0,
-            0.3,
-            1.0,
-            0.001,
-            16,
             0,
         )
     }
 
-    /// Create a render state with all settings including theme, SSAO, and refinement.
+    /// Create a render state with all settings including theme and refinement.
     #[allow(clippy::too_many_arguments)]
     pub fn with_full_settings(
         frame_index: u32,
@@ -491,10 +556,6 @@ impl GpuRenderState {
         edge_depth_threshold: f32,
         edge_normal_threshold: f32,
         theme: u32,
-        ao_radius: f32,
-        ao_intensity: f32,
-        ao_bias: f32,
-        ao_sample_count: u32,
         refine_sample_count: u32,
     ) -> Self {
         let mut state = Self::new(frame_index);
@@ -503,10 +564,6 @@ impl GpuRenderState {
         state.edge_normal_threshold = edge_normal_threshold;
         state.debug_mode = debug_mode;
         state.theme = theme;
-        state.ao_radius = ao_radius;
-        state.ao_intensity = ao_intensity;
-        state.ao_bias = ao_bias;
-        state.ao_sample_count = ao_sample_count;
         state.refine_sample_count = refine_sample_count;
         state
     }
@@ -546,12 +603,14 @@ impl GpuRenderState {
             edge_normal_threshold,
             debug_mode,
             theme,
-            ao_radius: 0.3,
-            ao_intensity: 1.0,
-            ao_bias: 0.001,
-            ao_sample_count: 16,
+            max_depth: depth_for_frame(frame_index, DEFAULT_MAX_DEPTH),
+            rr_start: DEFAULT_RR_START,
+            light_count: 0,
+            env_intensity: DEFAULT_ENV_INTENSITY,
             refine_sample_count: 0,
-            _pad: [0; 3],
+            firefly_clamp: DEFAULT_FIREFLY_CLAMP,
+            ground_enabled: 1,
+            stylize: 1,
             silhouette_color,
             crease_color,
             boundary_color,
@@ -579,10 +638,6 @@ impl GpuRenderState {
             edge_depth_threshold,
             edge_normal_threshold,
             theme,
-            0.3,
-            1.0,
-            0.001,
-            16,
             refine_sample_count,
         )
     }
@@ -651,6 +706,10 @@ pub struct GpuScene {
     pub inner_loop_descs: Vec<u32>,
     /// Mapping from FaceId to GPU face index.
     pub face_index_map: std::collections::HashMap<FaceId, u32>,
+    /// Area lights (softboxes) illuminating the scene, derived from the scene
+    /// bounds via [`crate::pathtrace::studio_rig`] — the same rig the CPU
+    /// renderer uses, so highlights match between the two.
+    pub lights: Vec<GpuAreaLight>,
 }
 
 /// Error building GPU scene.
@@ -684,6 +743,37 @@ impl std::fmt::Display for GpuSceneError {
 }
 
 impl std::error::Error for GpuSceneError {}
+
+/// Build the studio softbox rig for a scene, sized to its BVH root bounds.
+///
+/// Delegates to [`crate::pathtrace::studio_rig`] — the SAME function
+/// `vcad-render --photoreal` calls — so the viewport and the CPU renderer are
+/// lit by an identical rig rather than by two hand-tuned approximations.
+fn studio_lights_for_bvh(bvh_nodes: &[GpuBvhNode]) -> Vec<GpuAreaLight> {
+    let Some(root) = bvh_nodes.first() else {
+        return Vec::new();
+    };
+    let min = root.aabb_min;
+    let max = root.aabb_max;
+    let center = vcad_kernel_math::Point3::new(
+        ((min[0] + max[0]) * 0.5) as f64,
+        ((min[1] + max[1]) * 0.5) as f64,
+        ((min[2] + max[2]) * 0.5) as f64,
+    );
+    // Bounding-sphere radius of the root AABB.
+    let radius = 0.5
+        * (((max[0] - min[0]) as f64).powi(2)
+            + ((max[1] - min[1]) as f64).powi(2)
+            + ((max[2] - min[2]) as f64).powi(2))
+        .sqrt();
+    if !radius.is_finite() || radius <= 0.0 {
+        return Vec::new();
+    }
+    crate::pathtrace::studio_rig(center, radius)
+        .iter()
+        .map(GpuAreaLight::from_area_light)
+        .collect()
+}
 
 impl GpuScene {
     /// Build GPU scene data from a BRep solid.
@@ -914,6 +1004,8 @@ impl GpuScene {
         // Create default material (neutral gray)
         let materials = vec![GpuMaterial::default()];
 
+        let lights = studio_lights_for_bvh(&bvh_nodes);
+
         Ok(Self {
             surfaces,
             faces,
@@ -922,6 +1014,7 @@ impl GpuScene {
             trim_verts,
             inner_loop_descs,
             face_index_map,
+            lights,
         })
     }
 

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -174,6 +174,10 @@ impl GpuSurface {
 }
 
 /// GPU-compatible material representation (PBR).
+///
+/// Mirrors [`crate::pathtrace::Pbr`] field-for-field so the GPU path tracer and
+/// the CPU reference shade identically. The WGSL `GpuMaterial` struct in
+/// `shaders/raytrace.wgsl` must match this layout exactly.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Pod, Zeroable)]
 pub struct GpuMaterial {
@@ -183,8 +187,14 @@ pub struct GpuMaterial {
     pub metallic: f32,
     /// Roughness factor (0 = smooth, 1 = rough).
     pub roughness: f32,
+    /// Strength of the clearcoat layer (0 = none, 1 = full).
+    pub clearcoat: f32,
+    /// Perceptual roughness of the clearcoat layer.
+    pub clearcoat_roughness: f32,
+    /// Dielectric index of refraction, drives the base specular reflectance.
+    pub ior: f32,
     /// Padding for 16-byte alignment.
-    pub _pad: [f32; 2],
+    pub _pad: [f32; 3],
 }
 
 impl Default for GpuMaterial {
@@ -193,7 +203,10 @@ impl Default for GpuMaterial {
             color: [0.7, 0.7, 0.7, 1.0], // Neutral gray
             metallic: 0.0,
             roughness: 0.5,
-            _pad: [0.0; 2],
+            clearcoat: 0.0,
+            clearcoat_roughness: 0.1,
+            ior: 1.5,
+            _pad: [0.0; 3],
         }
     }
 }
@@ -213,17 +226,38 @@ impl GpuMaterial {
             color: [r, g, b, 1.0],
             metallic: 1.0,
             roughness,
-            _pad: [0.0; 2],
+            ..Default::default()
         }
     }
 
-    /// Create a plastic material.
+    /// Create a plastic material, optionally clearcoated.
     pub fn plastic(r: f32, g: f32, b: f32, roughness: f32) -> Self {
         Self {
             color: [r, g, b, 1.0],
             metallic: 0.0,
             roughness,
-            _pad: [0.0; 2],
+            ..Default::default()
+        }
+    }
+
+    /// Add a clearcoat layer of the given strength and roughness.
+    pub fn with_clearcoat(mut self, clearcoat: f32, clearcoat_roughness: f32) -> Self {
+        self.clearcoat = clearcoat;
+        self.clearcoat_roughness = clearcoat_roughness;
+        self
+    }
+
+    /// Convert to the CPU reference material, for cross-checking the two
+    /// shading paths against each other.
+    pub fn to_pbr(self) -> crate::pathtrace::Pbr {
+        crate::pathtrace::Pbr {
+            base_color: [self.color[0], self.color[1], self.color[2]],
+            metallic: self.metallic,
+            roughness: self.roughness,
+            clearcoat: self.clearcoat,
+            clearcoat_roughness: self.clearcoat_roughness,
+            ior: self.ior,
+            emissive: [0.0; 3],
         }
     }
 }
@@ -1005,7 +1039,7 @@ impl GpuScene {
             color: [r, g, b, 1.0],
             metallic,
             roughness,
-            _pad: [0.0; 2],
+            ..Default::default()
         };
     }
 }

--- a/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/buffers.rs
@@ -251,6 +251,24 @@ impl GpuMaterial {
         self
     }
 
+    /// Build from the CPU reference material.
+    ///
+    /// Paired with [`crate::pathtrace::Pbr::from_material_def`], this is what
+    /// makes the viewport and `--photoreal` derive the SAME material from the
+    /// same IR definition — clearcoat heuristic, IOR and grain included.
+    pub fn from_pbr(p: crate::pathtrace::Pbr) -> Self {
+        Self {
+            color: [p.base_color[0], p.base_color[1], p.base_color[2], 1.0],
+            metallic: p.metallic,
+            roughness: p.roughness,
+            clearcoat: p.clearcoat,
+            clearcoat_roughness: p.clearcoat_roughness,
+            ior: p.ior,
+            anisotropy: p.anisotropy,
+            _pad: [0.0; 2],
+        }
+    }
+
     /// Convert to the CPU reference material, for cross-checking the two
     /// shading paths against each other.
     pub fn to_pbr(self) -> crate::pathtrace::Pbr {
@@ -1139,5 +1157,22 @@ impl GpuScene {
             roughness,
             ..Default::default()
         };
+    }
+
+    /// Set the material for all faces from an IR material definition.
+    ///
+    /// Preferred over [`Self::set_material`]: it runs the same derivation the
+    /// CPU renderer uses, so clearcoat, IOR and anisotropy reach the viewport
+    /// instead of being silently dropped.
+    pub fn set_material_from_def(
+        &mut self,
+        mat: Option<&vcad_ir::MaterialDef>,
+        tint: Option<[f64; 3]>,
+    ) {
+        if self.materials.is_empty() {
+            self.materials.push(GpuMaterial::default());
+        }
+        self.materials[0] =
+            GpuMaterial::from_pbr(crate::pathtrace::Pbr::from_material_def(mat, tint));
     }
 }

--- a/crates/vcad-kernel-raytrace/src/gpu/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/mod.rs
@@ -8,7 +8,8 @@ mod pipeline;
 pub mod shaders;
 
 pub use buffers::{
-    GpuBvhNode, GpuCamera, GpuFace, GpuMaterial, GpuRenderState, GpuScene, GpuSceneError,
-    GpuSurface, GpuVec2,
+    depth_for_frame, GpuAreaLight, GpuBvhNode, GpuCamera, GpuFace, GpuMaterial, GpuRenderState,
+    GpuScene, GpuSceneError, GpuSurface, GpuVec2, DEFAULT_ENV_INTENSITY, DEFAULT_FIREFLY_CLAMP,
+    DEFAULT_MAX_DEPTH, DEFAULT_RR_START,
 };
 pub use pipeline::RayTracePipeline;

--- a/crates/vcad-kernel-raytrace/src/gpu/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/mod.rs
@@ -8,6 +8,7 @@ mod pipeline;
 pub mod shaders;
 
 pub use buffers::{
-    GpuBvhNode, GpuCamera, GpuFace, GpuRenderState, GpuScene, GpuSceneError, GpuSurface, GpuVec2,
+    GpuBvhNode, GpuCamera, GpuFace, GpuMaterial, GpuRenderState, GpuScene, GpuSceneError,
+    GpuSurface, GpuVec2,
 };
 pub use pipeline::RayTracePipeline;

--- a/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
@@ -173,6 +173,17 @@ impl RayTracePipeline {
                             },
                             count: None,
                         },
+                        // HDR environment data (pixels + CDFs, one buffer)
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 13,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
                         // Feature ID buffer (per-pixel face_idx for analytic crease detection)
                         wgpu::BindGroupLayoutEntry {
                             binding: 12,
@@ -364,6 +375,22 @@ impl RayTracePipeline {
     ) -> Result<(Vec<u8>, wgpu::Buffer), GpuError> {
         use wgpu::util::DeviceExt;
 
+        // Derive the scene-dependent state here rather than trusting callers to
+        // keep it in sync with the buffers we are about to bind.
+        let mut render_state = render_state;
+        render_state.light_count = scene.lights.len() as u32;
+        match &scene.environment {
+            Some(e) => {
+                render_state.env_mode = 1;
+                render_state.env_width = e.width;
+                render_state.env_height = e.height;
+                render_state.env_intensity = e.intensity;
+                render_state.env_rotation = e.rotation;
+                render_state.env_marg_int = e.marg_int;
+            }
+            None => render_state.env_mode = 0,
+        }
+
         // Create camera buffer
         let camera_buffer = ctx
             .device
@@ -513,6 +540,21 @@ impl RayTracePipeline {
                 usage: wgpu::BufferUsages::STORAGE,
             });
 
+        // HDR environment. WGSL cannot bind a zero-length storage array, so a
+        // gradient-lit scene still gets a one-element dummy; `env_mode` is what
+        // the shader actually branches on.
+        let env_data: &[f32] = match &scene.environment {
+            Some(e) if !e.data.is_empty() => &e.data,
+            _ => &[0.0f32],
+        };
+        let env_buf = ctx
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Environment Buffer"),
+                contents: bytemuck::cast_slice(env_data),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
+
         // Feature ID buffer: one u32 per pixel storing face_idx (0xFFFFFFFF = background).
         // Written at frame 1 and reused by the crease detector on subsequent frames.
         let feature_id_buf_size = (width * height * 4) as u64;
@@ -589,6 +631,10 @@ impl RayTracePipeline {
                 wgpu::BindGroupEntry {
                     binding: 12,
                     resource: feature_id_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 13,
+                    resource: env_buf.as_entire_binding(),
                 },
             ],
         });

--- a/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
@@ -32,7 +32,7 @@ impl RayTracePipeline {
             .device
             .create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some("Ray Trace Shader"),
-                source: wgpu::ShaderSource::Wgsl(super::shaders::RAYTRACE_SHADER.into()),
+                source: wgpu::ShaderSource::Wgsl(super::shaders::raytrace_shader().into()),
             });
 
         let bind_group_layout =

--- a/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
@@ -173,14 +173,26 @@ impl RayTracePipeline {
                             },
                             count: None,
                         },
-                        // HDR environment data (pixels + CDFs, one buffer)
+                        // HDR environment. Textures, not storage buffers: the
+                        // ten bindings above already exhaust the browser's
+                        // maxStorageBuffersPerShaderStage.
                         wgpu::BindGroupLayoutEntry {
                             binding: 13,
                             visibility: wgpu::ShaderStages::COMPUTE,
-                            ty: wgpu::BindingType::Buffer {
-                                ty: wgpu::BufferBindingType::Storage { read_only: true },
-                                has_dynamic_offset: false,
-                                min_binding_size: None,
+                            ty: wgpu::BindingType::Texture {
+                                sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                multisampled: false,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 14,
+                            visibility: wgpu::ShaderStages::COMPUTE,
+                            ty: wgpu::BindingType::Texture {
+                                sample_type: wgpu::TextureSampleType::Float { filterable: false },
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                multisampled: false,
                             },
                             count: None,
                         },
@@ -540,20 +552,85 @@ impl RayTracePipeline {
                 usage: wgpu::BufferUsages::STORAGE,
             });
 
-        // HDR environment. WGSL cannot bind a zero-length storage array, so a
-        // gradient-lit scene still gets a one-element dummy; `env_mode` is what
-        // the shader actually branches on.
-        let env_data: &[f32] = match &scene.environment {
-            Some(e) if !e.data.is_empty() => &e.data,
-            _ => &[0.0f32],
-        };
-        let env_buf = ctx
-            .device
-            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("Environment Buffer"),
-                contents: bytemuck::cast_slice(env_data),
-                usage: wgpu::BufferUsages::STORAGE,
+        // HDR environment. A gradient-lit scene still gets 1x1 dummies — a
+        // texture binding cannot be null — and `env_mode` is what the shader
+        // actually branches on.
+        let mk_tex = |label: &str, w: u32, h: u32, fmt: wgpu::TextureFormat, data: &[f32]| {
+            let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(label),
+                size: wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: fmt,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
             });
+            let bytes_per_px = if fmt == wgpu::TextureFormat::Rgba32Float {
+                16
+            } else {
+                4
+            };
+            ctx.queue.write_texture(
+                wgpu::ImageCopyTexture {
+                    texture: &tex,
+                    mip_level: 0,
+                    origin: wgpu::Origin3d::ZERO,
+                    aspect: wgpu::TextureAspect::All,
+                },
+                bytemuck::cast_slice(data),
+                wgpu::ImageDataLayout {
+                    offset: 0,
+                    bytes_per_row: Some(w * bytes_per_px),
+                    rows_per_image: Some(h),
+                },
+                wgpu::Extent3d {
+                    width: w,
+                    height: h,
+                    depth_or_array_layers: 1,
+                },
+            );
+            tex.create_view(&wgpu::TextureViewDescriptor::default())
+        };
+
+        let (env_pixels_view, env_cdf_view) = match &scene.environment {
+            Some(e) if e.width > 0 && e.height > 0 => (
+                mk_tex(
+                    "Environment Pixels",
+                    e.width,
+                    e.height,
+                    wgpu::TextureFormat::Rgba32Float,
+                    &e.pixels,
+                ),
+                mk_tex(
+                    "Environment CDF",
+                    e.width + 1,
+                    e.height + 1,
+                    wgpu::TextureFormat::R32Float,
+                    &e.cdf,
+                ),
+            ),
+            _ => (
+                mk_tex(
+                    "Environment Pixels (unused)",
+                    1,
+                    1,
+                    wgpu::TextureFormat::Rgba32Float,
+                    &[0.0, 0.0, 0.0, 1.0],
+                ),
+                mk_tex(
+                    "Environment CDF (unused)",
+                    1,
+                    1,
+                    wgpu::TextureFormat::R32Float,
+                    &[0.0],
+                ),
+            ),
+        };
 
         // Feature ID buffer: one u32 per pixel storing face_idx (0xFFFFFFFF = background).
         // Written at frame 1 and reused by the crease detector on subsequent frames.
@@ -634,7 +711,11 @@ impl RayTracePipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 13,
-                    resource: env_buf.as_entire_binding(),
+                    resource: wgpu::BindingResource::TextureView(&env_pixels_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 14,
+                    resource: wgpu::BindingResource::TextureView(&env_cdf_view),
                 },
             ],
         });

--- a/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/pipeline.rs
@@ -18,7 +18,6 @@ use super::buffers::GpuCamera;
 #[cfg(feature = "gpu")]
 pub struct RayTracePipeline {
     pipeline: wgpu::ComputePipeline,
-    ssao_pipeline: wgpu::ComputePipeline,
     /// Second pass that refines edge pixels with additional stratified samples.
     refine_pipeline: wgpu::ComputePipeline,
     bind_group_layout: wgpu::BindGroupLayout,
@@ -163,12 +162,12 @@ impl RayTracePipeline {
                             },
                             count: None,
                         },
-                        // AO buffer (screen-space ambient occlusion, f32 per pixel)
+                        // Area lights (softboxes) for MIS-weighted direct lighting
                         wgpu::BindGroupLayoutEntry {
                             binding: 11,
                             visibility: wgpu::ShaderStages::COMPUTE,
                             ty: wgpu::BindingType::Buffer {
-                                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                                ty: wgpu::BufferBindingType::Storage { read_only: true },
                                 has_dynamic_offset: false,
                                 min_binding_size: None,
                             },
@@ -207,17 +206,6 @@ impl RayTracePipeline {
                 cache: None,
             });
 
-        let ssao_pipeline = ctx
-            .device
-            .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-                label: Some("SSAO Pipeline"),
-                layout: Some(&pipeline_layout),
-                module: &shader_module,
-                entry_point: Some("ssao"),
-                compilation_options: Default::default(),
-                cache: None,
-            });
-
         let refine_pipeline =
             ctx.device
                 .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -231,7 +219,6 @@ impl RayTracePipeline {
 
         Ok(Self {
             pipeline,
-            ssao_pipeline,
             refine_pipeline,
             bind_group_layout,
         })
@@ -349,7 +336,7 @@ impl RayTracePipeline {
             theme,
             refine_sample_count,
         );
-        let (pixels, accum, _ao) = self
+        let (pixels, accum) = self
             .render_with_render_state(
                 ctx,
                 scene,
@@ -357,7 +344,6 @@ impl RayTracePipeline {
                 width,
                 height,
                 accum_buffer,
-                None,
                 render_state,
             )
             .await?;
@@ -374,9 +360,8 @@ impl RayTracePipeline {
         width: u32,
         height: u32,
         accum_buffer: Option<wgpu::Buffer>,
-        ao_buffer_in: Option<wgpu::Buffer>,
         render_state: GpuRenderState,
-    ) -> Result<(Vec<u8>, wgpu::Buffer, wgpu::Buffer), GpuError> {
+    ) -> Result<(Vec<u8>, wgpu::Buffer), GpuError> {
         use wgpu::util::DeviceExt;
 
         // Create camera buffer
@@ -512,17 +497,21 @@ impl RayTracePipeline {
             mapped_at_creation: false,
         });
 
-        // AO buffer (1 f32 per pixel; initialised to 1.0 = no occlusion).
-        // Reuse the caller's buffer for progressive SSAO accumulation; create fresh on first frame.
-        let ao_buf = ao_buffer_in.unwrap_or_else(|| {
-            let ones: Vec<f32> = vec![1.0f32; (width * height) as usize];
-            ctx.device
-                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("AO Buffer"),
-                    contents: bytemuck::cast_slice(&ones),
-                    usage: wgpu::BufferUsages::STORAGE,
-                })
-        });
+        // Area lights. WGSL cannot bind a zero-length storage array, so an
+        // unlit scene still gets one dummy entry; `light_count` is what the
+        // shader actually loops over.
+        let lights: Vec<super::buffers::GpuAreaLight> = if scene.lights.is_empty() {
+            vec![super::buffers::GpuAreaLight::default()]
+        } else {
+            scene.lights.clone()
+        };
+        let light_buf = ctx
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Area Light Buffer"),
+                contents: bytemuck::cast_slice(&lights),
+                usage: wgpu::BufferUsages::STORAGE,
+            });
 
         // Feature ID buffer: one u32 per pixel storing face_idx (0xFFFFFFFF = background).
         // Written at frame 1 and reused by the crease detector on subsequent frames.
@@ -595,7 +584,7 @@ impl RayTracePipeline {
                 },
                 wgpu::BindGroupEntry {
                     binding: 11,
-                    resource: ao_buf.as_entire_binding(),
+                    resource: light_buf.as_entire_binding(),
                 },
                 wgpu::BindGroupEntry {
                     binding: 12,
@@ -621,17 +610,9 @@ impl RayTracePipeline {
             pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
         }
 
-        // SSAO pass: reads depth_normal_buffer, writes ao_buffer.
-        // Runs after the main trace so depth/normal data is ready.
-        {
-            let mut ssao_pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
-                label: Some("SSAO Pass"),
-                timestamp_writes: None,
-            });
-            ssao_pass.set_pipeline(&self.ssao_pipeline);
-            ssao_pass.set_bind_group(0, &bind_group, &[]);
-            ssao_pass.dispatch_workgroups(width.div_ceil(8), height.div_ceil(8), 1);
-        }
+        // The SSAO pass used to run here. Real multi-bounce GI computes contact
+        // occlusion correctly, so a screen-space proxy on top of it would only
+        // double-darken concave regions.
 
         // Adaptive refinement pass: fires extra stratified rays at edge pixels.
         // The main pass must fully complete before refine reads depth_normal_buffer,
@@ -789,7 +770,7 @@ impl RayTracePipeline {
         drop(data);
         readback_buffer.unmap();
 
-        Ok((result, accum, ao_buf))
+        Ok((result, accum))
     }
 
     /// Render a scene to an output texture (single-frame, non-progressive).

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf.wgsl
@@ -1,0 +1,280 @@
+//! Shared BSDF: the single shading model used by BOTH the GPU viewport path
+//! tracer and (as a port of `pathtrace.rs`) the CPU photoreal renderer.
+//!
+//! This file is prepended to every shader that needs to shade, so there is
+//! exactly one copy of the BSDF in the codebase. `tests/bsdf_parity.rs`
+//! compiles it standalone against a harness entry point and checks it against
+//! the Rust reference in `pathtrace.rs`.
+
+const PI: f32 = 3.14159265359;
+
+
+// Layout must match GpuMaterial in buffers.rs, which in turn mirrors
+// pathtrace::Pbr field-for-field so both renderers shade identically.
+struct GpuMaterial {
+    color: vec4<f32>,
+    metallic: f32,
+    roughness: f32,
+    clearcoat: f32,
+    clearcoat_roughness: f32,
+    ior: f32,
+    _pad0: f32,
+    _pad1: f32,
+    _pad2: f32,
+}
+
+// ─── unified BSDF ─────────────────────────────────────────────────────────
+//
+// A direct port of `pathtrace.rs`'s layered metallic-roughness BSDF: Lambert
+// diffuse + GGX specular with VNDF sampling + a GGX clearcoat layer. This is
+// the SINGLE shading model shared by the GPU viewport and the CPU photoreal
+// renderer, so the same document shades the same way in both.
+//
+// The invariant that matters: the PDF returned by `bsdf_sample` must exactly
+// equal the PDF `bsdf_eval` reports for the same pair of directions. If they
+// disagree, MIS silently produces an energy-wrong image that still looks
+// plausible. `tests/bsdf_parity.rs` pins both that identity and agreement with
+// the Rust reference, evaluated on the GPU itself.
+//
+// All vectors are in the local shading frame (+Z = normal) and point away from
+// the surface. The CPU reference computes in f64 and this in f32, so agreement
+// holds to f32 tolerance, not bit-exactly.
+
+fn max3(v: vec3<f32>) -> f32 {
+    return max(max(v.x, v.y), v.z);
+}
+
+// GGX alpha for the base specular lobe.
+fn mat_alpha(m: GpuMaterial) -> f32 {
+    return max(m.roughness * m.roughness, 1e-4);
+}
+
+// GGX alpha for the clearcoat lobe.
+fn mat_coat_alpha(m: GpuMaterial) -> f32 {
+    return max(m.clearcoat_roughness * m.clearcoat_roughness, 1e-4);
+}
+
+// Specular reflectance at normal incidence: from IOR, blended toward the base
+// color by metallic.
+fn mat_f0(m: GpuMaterial) -> vec3<f32> {
+    let r = (m.ior - 1.0) / (m.ior + 1.0);
+    let d = r * r;
+    return mix(vec3<f32>(d, d, d), m.color.rgb, m.metallic);
+}
+
+// Diffuse albedo (metals have none).
+fn mat_diffuse_albedo(m: GpuMaterial) -> vec3<f32> {
+    return m.color.rgb * (1.0 - m.metallic);
+}
+
+// GGX / Trowbridge-Reitz normal distribution. Takes alpha directly (already
+// squared roughness) — NOT perceptual roughness.
+fn d_ggx(n_dot_h: f32, alpha: f32) -> f32 {
+    let a2 = alpha * alpha;
+    let d = n_dot_h * n_dot_h * (a2 - 1.0) + 1.0;
+    return a2 / max(PI * d * d, 1e-9);
+}
+
+// Smith height-correlated visibility term, already divided by 4·NoL·NoV.
+fn v_smith(n_dot_v: f32, n_dot_l: f32, alpha: f32) -> f32 {
+    let a2 = alpha * alpha;
+    let gv = n_dot_l * sqrt(n_dot_v * n_dot_v * (1.0 - a2) + a2);
+    let gl = n_dot_v * sqrt(n_dot_l * n_dot_l * (1.0 - a2) + a2);
+    return 0.5 / max(gv + gl, 1e-9);
+}
+
+// Schlick Fresnel.
+fn fresnel(f0: vec3<f32>, cos_theta: f32) -> vec3<f32> {
+    let m = pow(clamp(1.0 - cos_theta, 0.0, 1.0), 5.0);
+    return f0 + (vec3<f32>(1.0) - f0) * m;
+}
+
+// Cosine-weighted hemisphere sample in the local frame (+Z = normal).
+fn cosine_hemisphere_local(r1: f32, r2: f32) -> vec3<f32> {
+    let r = sqrt(r1);
+    let phi = 2.0 * PI * r2;
+    return vec3<f32>(r * cos(phi), r * sin(phi), sqrt(max(1.0 - r1, 0.0)));
+}
+
+// Sample the GGX visible-normal distribution (Heitz 2018). Returns the
+// sampled half-vector in the local frame.
+fn sample_vndf(wo: vec3<f32>, alpha: f32, r1: f32, r2: f32) -> vec3<f32> {
+    let a = alpha;
+    // Stretch the view direction into the hemisphere-configured space.
+    let vh = normalize(vec3<f32>(a * wo.x, a * wo.y, wo.z));
+    let lensq = vh.x * vh.x + vh.y * vh.y;
+    var t1: vec3<f32>;
+    if lensq > 0.0 {
+        t1 = vec3<f32>(-vh.y, vh.x, 0.0) / sqrt(lensq);
+    } else {
+        t1 = vec3<f32>(1.0, 0.0, 0.0);
+    }
+    let t2 = cross(vh, t1);
+
+    let r = sqrt(r1);
+    let phi = 2.0 * PI * r2;
+    let p1 = r * cos(phi);
+    let p2r = r * sin(phi);
+    let s = 0.5 * (1.0 + vh.z);
+    let p2 = (1.0 - s) * sqrt(max(1.0 - p1 * p1, 0.0)) + s * p2r;
+
+    let nh = t1 * p1 + t2 * p2 + vh * sqrt(max(1.0 - p1 * p1 - p2 * p2, 0.0));
+    return normalize(vec3<f32>(a * nh.x, a * nh.y, max(nh.z, 1e-9)));
+}
+
+// PDF of the VNDF sampling strategy, in solid angle around wi.
+fn vndf_pdf(wo: vec3<f32>, wh: vec3<f32>, alpha: f32) -> f32 {
+    let n_dot_h = max(wh.z, 0.0);
+    let n_dot_v = max(wo.z, 1e-6);
+    let d = d_ggx(n_dot_h, alpha);
+    // G1 for the Smith masking function.
+    let a2 = alpha * alpha;
+    let lambda = (sqrt(1.0 + a2 * (1.0 - n_dot_v * n_dot_v) / (n_dot_v * n_dot_v)) - 1.0) * 0.5;
+    let g1 = 1.0 / (1.0 + lambda);
+    let o_dot_h = max(dot(wo, wh), 1e-9);
+    return d * g1 * o_dot_h / n_dot_v / (4.0 * o_dot_h);
+}
+
+// Relative sampling weights of the three lobes (diffuse, specular, coat).
+fn lobe_weights(m: GpuMaterial) -> vec3<f32> {
+    let diff = max(max3(mat_diffuse_albedo(m)), 0.0);
+    let spec = max(max3(mat_f0(m)), 0.0) + 0.08;
+    let coat = m.clearcoat * 0.25;
+    let total = max(diff + spec + coat, 1e-6);
+    return vec3<f32>(diff, spec, coat) / total;
+}
+
+struct BsdfEval {
+    // f * cos(theta_i), NOT the bare BSDF.
+    value: vec3<f32>,
+    pdf: f32,
+}
+
+// Evaluate the full BSDF and its sampling PDF for a given in/out pair.
+fn bsdf_eval(m: GpuMaterial, wo: vec3<f32>, wi: vec3<f32>) -> BsdfEval {
+    var out: BsdfEval;
+    out.value = vec3<f32>(0.0);
+    out.pdf = 0.0;
+    if wi.z <= 0.0 || wo.z <= 0.0 {
+        return out;
+    }
+    let n_dot_l = wi.z;
+    let n_dot_v = wo.z;
+    let wh = normalize(wo + wi);
+    let n_dot_h = max(wh.z, 0.0);
+    let o_dot_h = max(dot(wo, wh), 0.0);
+
+    let w = lobe_weights(m);
+
+    // Diffuse.
+    let diffuse = mat_diffuse_albedo(m) * (n_dot_l / PI);
+    let pdf_d = n_dot_l / PI;
+
+    // Base specular.
+    let alpha = mat_alpha(m);
+    let d = d_ggx(n_dot_h, alpha);
+    let vis = v_smith(n_dot_v, n_dot_l, alpha);
+    let f = fresnel(mat_f0(m), o_dot_h);
+    let spec = f * (d * vis * n_dot_l);
+    let pdf_s = vndf_pdf(wo, wh, alpha);
+
+    // Clearcoat: a thin dielectric layer over everything else.
+    var coat = vec3<f32>(0.0);
+    var pdf_c = 0.0;
+    var coat_atten = 1.0;
+    if m.clearcoat > 0.0 {
+        let ca = mat_coat_alpha(m);
+        let cd = d_ggx(n_dot_h, ca);
+        let cv = v_smith(n_dot_v, n_dot_l, ca);
+        let cf = fresnel(vec3<f32>(0.04), o_dot_h).x * m.clearcoat;
+        let c = cd * cv * n_dot_l * cf;
+        coat = vec3<f32>(c, c, c);
+        pdf_c = vndf_pdf(wo, wh, ca);
+        // Energy removed from the layers beneath.
+        coat_atten = 1.0 - cf;
+    }
+
+    let under = diffuse + spec;
+    out.value = under * coat_atten + coat;
+    out.pdf = max(w.x * pdf_d + w.y * pdf_s + w.z * pdf_c, 0.0);
+    return out;
+}
+
+struct BsdfSample {
+    wi: vec3<f32>,
+    value: vec3<f32>,
+    pdf: f32,
+    ok: bool,
+}
+
+// Importance-sample the BSDF. `r_lobe` picks the lobe; `r1`/`r2` drive it.
+fn bsdf_sample(m: GpuMaterial, wo: vec3<f32>, r_lobe: f32, r1: f32, r2: f32) -> BsdfSample {
+    var out: BsdfSample;
+    out.wi = vec3<f32>(0.0, 0.0, 1.0);
+    out.value = vec3<f32>(0.0);
+    out.pdf = 0.0;
+    out.ok = false;
+    if wo.z <= 0.0 {
+        return out;
+    }
+    let w = lobe_weights(m);
+
+    var wi: vec3<f32>;
+    if r_lobe < w.x {
+        wi = cosine_hemisphere_local(r1, r2);
+    } else if r_lobe < w.x + w.y {
+        let wh = sample_vndf(wo, mat_alpha(m), r1, r2);
+        wi = reflect(-wo, wh);
+        if wi.z <= 0.0 {
+            return out;
+        }
+    } else {
+        let wh = sample_vndf(wo, mat_coat_alpha(m), r1, r2);
+        wi = reflect(-wo, wh);
+        if wi.z <= 0.0 {
+            return out;
+        }
+    }
+
+    let e = bsdf_eval(m, wo, wi);
+    if e.pdf <= 1e-9 {
+        return out;
+    }
+    out.wi = wi;
+    out.value = e.value;
+    out.pdf = e.pdf;
+    out.ok = true;
+    return out;
+}
+
+// Power heuristic (beta = 2) for multiple importance sampling.
+fn power_heuristic(a: f32, b: f32) -> f32 {
+    let a2 = a * a;
+    let b2 = b * b;
+    if a2 + b2 <= 0.0 {
+        return 0.0;
+    }
+    return a2 / (a2 + b2);
+}
+
+// Build an orthonormal basis around `n`. Mirrors `pathtrace::onb` so both
+// paths agree on the tangent frame. Columns are (tangent, bitangent, normal).
+fn onb(n: vec3<f32>) -> mat3x3<f32> {
+    var sign_v = 1.0;
+    if n.z < 0.0 {
+        sign_v = -1.0;
+    }
+    let a = -1.0 / (sign_v + n.z);
+    let b = n.x * n.y * a;
+    let t = vec3<f32>(1.0 + sign_v * n.x * n.x * a, sign_v * b, -sign_v * n.x);
+    let bt = vec3<f32>(b, sign_v + n.y * n.y * a, -n.y);
+    return mat3x3<f32>(t, bt, n);
+}
+
+fn to_local(frame: mat3x3<f32>, w: vec3<f32>) -> vec3<f32> {
+    return vec3<f32>(dot(w, frame[0]), dot(w, frame[1]), dot(w, frame[2]));
+}
+
+fn to_world(frame: mat3x3<f32>, w: vec3<f32>) -> vec3<f32> {
+    return frame[0] * w.x + frame[1] * w.y + frame[2] * w.z;
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf.wgsl
@@ -18,9 +18,11 @@ struct GpuMaterial {
     clearcoat: f32,
     clearcoat_roughness: f32,
     ior: f32,
+    // Signed: positive smears the highlight along the local +X (tangent) axis,
+    // negative along +Y. See `mat_alpha_tb`.
+    anisotropy: f32,
     _pad0: f32,
     _pad1: f32,
-    _pad2: f32,
 }
 
 // ─── unified BSDF ─────────────────────────────────────────────────────────
@@ -44,9 +46,31 @@ fn max3(v: vec3<f32>) -> f32 {
     return max(max(v.x, v.y), v.z);
 }
 
-// GGX alpha for the base specular lobe.
+// GGX alpha for the base specular lobe, ignoring anisotropy.
 fn mat_alpha(m: GpuMaterial) -> f32 {
     return max(m.roughness * m.roughness, 1e-4);
+}
+
+// GGX alphas along the tangent and bitangent for the base specular lobe.
+//
+// Standard Disney/glTF construction: an aspect ratio of
+// sqrt(1 - 0.9·|anisotropy|) splits the isotropic alpha into a stretched and
+// a squeezed axis while keeping their product roughly fixed. At anisotropy 0
+// the aspect is exactly 1, so both alphas equal mat_alpha and every
+// anisotropic path below reduces bit-identically to the isotropic one.
+fn mat_alpha_tb(m: GpuMaterial) -> vec2<f32> {
+    let a = mat_alpha(m);
+    let aniso = clamp(m.anisotropy, -1.0, 1.0);
+    if aniso == 0.0 {
+        return vec2<f32>(a, a);
+    }
+    let aspect = sqrt(1.0 - 0.9 * abs(aniso));
+    let wide = min(a / aspect, 1.0);
+    let narrow = a * aspect;
+    if aniso > 0.0 {
+        return vec2<f32>(wide, narrow);
+    }
+    return vec2<f32>(narrow, wide);
 }
 
 // GGX alpha for the clearcoat lobe.
@@ -75,12 +99,52 @@ fn d_ggx(n_dot_h: f32, alpha: f32) -> f32 {
     return a2 / max(PI * d * d, 1e-9);
 }
 
+// Anisotropic GGX normal distribution. Reduces exactly to `d_ggx` when at==ab.
+fn d_ggx_aniso(wh: vec3<f32>, at: f32, ab: f32) -> f32 {
+    if at == ab {
+        return d_ggx(max(wh.z, 0.0), at);
+    }
+    let d = (wh.x / at) * (wh.x / at) + (wh.y / ab) * (wh.y / ab) + wh.z * wh.z;
+    return 1.0 / max(PI * at * ab * d * d, 1e-9);
+}
+
 // Smith height-correlated visibility term, already divided by 4·NoL·NoV.
 fn v_smith(n_dot_v: f32, n_dot_l: f32, alpha: f32) -> f32 {
     let a2 = alpha * alpha;
     let gv = n_dot_l * sqrt(n_dot_v * n_dot_v * (1.0 - a2) + a2);
     let gl = n_dot_v * sqrt(n_dot_l * n_dot_l * (1.0 - a2) + a2);
     return 0.5 / max(gv + gl, 1e-9);
+}
+
+// Λ-style stretched length used by the anisotropic Smith terms.
+fn aniso_stretched(w: vec3<f32>, at: f32, ab: f32) -> f32 {
+    return sqrt((at * w.x) * (at * w.x) + (ab * w.y) * (ab * w.y) + w.z * w.z);
+}
+
+// Anisotropic Smith height-correlated visibility term (already divided by
+// 4·NoL·NoV). Reduces exactly to `v_smith` when at==ab.
+fn v_smith_aniso(wo: vec3<f32>, wi: vec3<f32>, at: f32, ab: f32) -> f32 {
+    if at == ab {
+        return v_smith(wo.z, wi.z, at);
+    }
+    let gv = wi.z * aniso_stretched(wo, at, ab);
+    let gl = wo.z * aniso_stretched(wi, at, ab);
+    return 0.5 / max(gv + gl, 1e-9);
+}
+
+// Smith G1 masking term for the anisotropic GGX distribution. The at==ab
+// branch is the isotropic expression evaluated exactly as it was before
+// anisotropy existed, so isotropic renders are bit-unchanged.
+fn g1_smith_aniso(w: vec3<f32>, at: f32, ab: f32) -> f32 {
+    let z = max(w.z, 1e-6);
+    var lambda: f32;
+    if at == ab {
+        let a2 = at * at;
+        lambda = (sqrt(1.0 + a2 * (1.0 - z * z) / (z * z)) - 1.0) * 0.5;
+    } else {
+        lambda = (aniso_stretched(vec3<f32>(w.x, w.y, z), at, ab) / z - 1.0) * 0.5;
+    }
+    return 1.0 / (1.0 + lambda);
 }
 
 // Schlick Fresnel.
@@ -98,10 +162,14 @@ fn cosine_hemisphere_local(r1: f32, r2: f32) -> vec3<f32> {
 
 // Sample the GGX visible-normal distribution (Heitz 2018). Returns the
 // sampled half-vector in the local frame.
-fn sample_vndf(wo: vec3<f32>, alpha: f32, r1: f32, r2: f32) -> vec3<f32> {
-    let a = alpha;
+// Anisotropic by construction: the stretch step that maps to the
+// hemisphere-configured space takes each axis' alpha separately, so passing
+// at != ab needs no other change.
+fn sample_vndf(wo: vec3<f32>, at: f32, ab: f32, r1: f32, r2: f32) -> vec3<f32> {
+    let a = at;
+    let b = ab;
     // Stretch the view direction into the hemisphere-configured space.
-    let vh = normalize(vec3<f32>(a * wo.x, a * wo.y, wo.z));
+    let vh = normalize(vec3<f32>(a * wo.x, b * wo.y, wo.z));
     let lensq = vh.x * vh.x + vh.y * vh.y;
     var t1: vec3<f32>;
     if lensq > 0.0 {
@@ -119,18 +187,14 @@ fn sample_vndf(wo: vec3<f32>, alpha: f32, r1: f32, r2: f32) -> vec3<f32> {
     let p2 = (1.0 - s) * sqrt(max(1.0 - p1 * p1, 0.0)) + s * p2r;
 
     let nh = t1 * p1 + t2 * p2 + vh * sqrt(max(1.0 - p1 * p1 - p2 * p2, 0.0));
-    return normalize(vec3<f32>(a * nh.x, a * nh.y, max(nh.z, 1e-9)));
+    return normalize(vec3<f32>(a * nh.x, b * nh.y, max(nh.z, 1e-9)));
 }
 
 // PDF of the VNDF sampling strategy, in solid angle around wi.
-fn vndf_pdf(wo: vec3<f32>, wh: vec3<f32>, alpha: f32) -> f32 {
-    let n_dot_h = max(wh.z, 0.0);
+fn vndf_pdf(wo: vec3<f32>, wh: vec3<f32>, at: f32, ab: f32) -> f32 {
     let n_dot_v = max(wo.z, 1e-6);
-    let d = d_ggx(n_dot_h, alpha);
-    // G1 for the Smith masking function.
-    let a2 = alpha * alpha;
-    let lambda = (sqrt(1.0 + a2 * (1.0 - n_dot_v * n_dot_v) / (n_dot_v * n_dot_v)) - 1.0) * 0.5;
-    let g1 = 1.0 / (1.0 + lambda);
+    let d = d_ggx_aniso(wh, at, ab);
+    let g1 = g1_smith_aniso(wo, at, ab);
     let o_dot_h = max(dot(wo, wh), 1e-9);
     return d * g1 * o_dot_h / n_dot_v / (4.0 * o_dot_h);
 }
@@ -170,15 +234,18 @@ fn bsdf_eval(m: GpuMaterial, wo: vec3<f32>, wi: vec3<f32>) -> BsdfEval {
     let diffuse = mat_diffuse_albedo(m) * (n_dot_l / PI);
     let pdf_d = n_dot_l / PI;
 
-    // Base specular.
-    let alpha = mat_alpha(m);
-    let d = d_ggx(n_dot_h, alpha);
-    let vis = v_smith(n_dot_v, n_dot_l, alpha);
+    // Base specular. Anisotropy stretches the lobe along the local x axis,
+    // which the integrator aligns with the surface tangent dP/du.
+    let ab_pair = mat_alpha_tb(m);
+    let d = d_ggx_aniso(wh, ab_pair.x, ab_pair.y);
+    let vis = v_smith_aniso(wo, wi, ab_pair.x, ab_pair.y);
     let f = fresnel(mat_f0(m), o_dot_h);
     let spec = f * (d * vis * n_dot_l);
-    let pdf_s = vndf_pdf(wo, wh, alpha);
+    let pdf_s = vndf_pdf(wo, wh, ab_pair.x, ab_pair.y);
 
-    // Clearcoat: a thin dielectric layer over everything else.
+    // Clearcoat: a thin dielectric layer over everything else. It is a
+    // separate isotropic film — the grain lives in the substrate beneath it,
+    // not in the lacquer — so it never takes the anisotropy.
     var coat = vec3<f32>(0.0);
     var pdf_c = 0.0;
     var coat_atten = 1.0;
@@ -189,7 +256,7 @@ fn bsdf_eval(m: GpuMaterial, wo: vec3<f32>, wi: vec3<f32>) -> BsdfEval {
         let cf = fresnel(vec3<f32>(0.04), o_dot_h).x * m.clearcoat;
         let c = cd * cv * n_dot_l * cf;
         coat = vec3<f32>(c, c, c);
-        pdf_c = vndf_pdf(wo, wh, ca);
+        pdf_c = vndf_pdf(wo, wh, ca, ca);
         // Energy removed from the layers beneath.
         coat_atten = 1.0 - cf;
     }
@@ -223,13 +290,15 @@ fn bsdf_sample(m: GpuMaterial, wo: vec3<f32>, r_lobe: f32, r1: f32, r2: f32) -> 
     if r_lobe < w.x {
         wi = cosine_hemisphere_local(r1, r2);
     } else if r_lobe < w.x + w.y {
-        let wh = sample_vndf(wo, mat_alpha(m), r1, r2);
+        let ab_pair = mat_alpha_tb(m);
+        let wh = sample_vndf(wo, ab_pair.x, ab_pair.y, r1, r2);
         wi = reflect(-wo, wh);
         if wi.z <= 0.0 {
             return out;
         }
     } else {
-        let wh = sample_vndf(wo, mat_coat_alpha(m), r1, r2);
+        let ca = mat_coat_alpha(m);
+        let wh = sample_vndf(wo, ca, ca, r1, r2);
         wi = reflect(-wo, wh);
         if wi.z <= 0.0 {
             return out;

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
@@ -59,3 +59,30 @@ fn bsdf_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {
 
     parity_out[i] = out;
 }
+
+// ─── surface tangent harness ──────────────────────────────────────────────
+//
+// Drives `surface_dpdu` (surface.wgsl) directly so the per-surface dP/du
+// transcription can be checked against the geom crate's `d_du` without going
+// through a full render. A silent error here would misalign every anisotropic
+// highlight while every isotropic material still looked perfect.
+
+struct TangentInput {
+    surface: GpuSurface,
+    // uv at the hit; .zw unused.
+    uv: vec4<f32>,
+}
+
+@group(0) @binding(2) var<storage, read> tangent_in: array<TangentInput>;
+@group(0) @binding(3) var<storage, read_write> tangent_out: array<vec4<f32>>;
+
+@compute @workgroup_size(64)
+fn tangent_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let i = global_id.x;
+    if i >= arrayLength(&tangent_in) {
+        return;
+    }
+    let inp = tangent_in[i];
+    let t = surface_dpdu(inp.surface.surface_type, inp.surface.params, inp.uv.xy);
+    tangent_out[i] = vec4<f32>(t, 1.0);
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
@@ -1,0 +1,61 @@
+// Test harness for the shared BSDF. Not part of the render pipeline.
+//
+// Composed with `bsdf.wgsl` (which supplies PI, GpuMaterial, and the BSDF
+// itself) and driven by `tests/bsdf_parity.rs`. Evaluates and samples the BSDF
+// on the GPU so the port can be checked against the Rust reference in
+// `pathtrace.rs`, and so the sample-PDF/eval-PDF identity that MIS depends on
+// is pinned on the hardware that actually runs it.
+
+struct ParityInput {
+    material: GpuMaterial,
+    // Local-frame outgoing direction (+Z = normal); .w unused.
+    wo: vec4<f32>,
+    // Local-frame incoming direction to evaluate against; .w unused.
+    wi: vec4<f32>,
+    // Sampling randoms: x = lobe pick, y/z = lobe params; .w unused.
+    rnd: vec4<f32>,
+}
+
+struct ParityOutput {
+    // bsdf_eval(m, wo, wi): .xyz = f*cos, .w = pdf.
+    eval: vec4<f32>,
+    // bsdf_sample(...): .xyz = sampled wi, .w = returned pdf.
+    sample_dir: vec4<f32>,
+    // .xyz = sampled f*cos, .w = 1 if the sample succeeded else 0.
+    sample_value: vec4<f32>,
+    // .x = bsdf_eval's pdf re-evaluated at the SAMPLED direction. Must equal
+    // sample_dir.w or MIS is silently energy-wrong.
+    resampled: vec4<f32>,
+}
+
+@group(0) @binding(0) var<storage, read> parity_in: array<ParityInput>;
+@group(0) @binding(1) var<storage, read_write> parity_out: array<ParityOutput>;
+
+@compute @workgroup_size(64)
+fn bsdf_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let i = global_id.x;
+    if i >= arrayLength(&parity_in) {
+        return;
+    }
+    let inp = parity_in[i];
+    let m = inp.material;
+    let wo = inp.wo.xyz;
+
+    var out: ParityOutput;
+
+    let e = bsdf_eval(m, wo, inp.wi.xyz);
+    out.eval = vec4<f32>(e.value, e.pdf);
+
+    let s = bsdf_sample(m, wo, inp.rnd.x, inp.rnd.y, inp.rnd.z);
+    out.sample_dir = vec4<f32>(s.wi, s.pdf);
+    var ok = 0.0;
+    if s.ok {
+        ok = 1.0;
+    }
+    out.sample_value = vec4<f32>(s.value, ok);
+
+    let re = bsdf_eval(m, wo, s.wi);
+    out.resampled = vec4<f32>(re.pdf, re.value.x, re.value.y, re.value.z);
+
+    parity_out[i] = out;
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
@@ -86,3 +86,73 @@ fn tangent_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let t = surface_dpdu(inp.surface.surface_type, inp.surface.params, inp.uv.xy);
     tangent_out[i] = vec4<f32>(t, 1.0);
 }
+
+// ─── environment harness ──────────────────────────────────────────────────
+//
+// Drives env.wgsl's radiance / pdf / sample against the CPU EnvMap. A wrong
+// PDF here is the same invisible failure as a wrong BSDF PDF: MIS silently
+// mis-weights and the image is energy-wrong but plausible.
+
+struct EnvInput {
+    // Direction to evaluate radiance and pdf for; .w unused.
+    dir: vec4<f32>,
+    // r1, r2 for importance sampling; .zw unused.
+    rnd: vec4<f32>,
+    width: u32,
+    height: u32,
+    intensity: f32,
+    rotation: f32,
+    marg_int: f32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+}
+
+struct EnvOutput {
+    // .xyz = radiance at dir, .w = pdf at dir.
+    eval: vec4<f32>,
+    // .xyz = sampled direction, .w = sampled pdf.
+    sample_dir: vec4<f32>,
+    // .xyz = sampled radiance, .w = 1 if the sample succeeded.
+    sample_radiance: vec4<f32>,
+    // .x = pdf re-evaluated at the sampled direction (must equal sample_dir.w).
+    resampled: vec4<f32>,
+}
+
+@group(0) @binding(4) var<storage, read> env_in: array<EnvInput>;
+@group(0) @binding(5) var<storage, read_write> env_out: array<EnvOutput>;
+@group(0) @binding(6) var<storage, read> env_data: array<f32>;
+
+@compute @workgroup_size(64)
+fn env_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let i = global_id.x;
+    if i >= arrayLength(&env_in) {
+        return;
+    }
+    let e = env_in[i];
+    let d = normalize(e.dir.xyz);
+
+    var out: EnvOutput;
+    out.eval = vec4<f32>(
+        env_image_radiance(d, e.width, e.height, e.intensity, e.rotation),
+        env_image_pdf(d, e.width, e.height, e.rotation, e.marg_int),
+    );
+
+    let s = env_image_sample(
+        e.rnd.x, e.rnd.y, e.width, e.height, e.intensity, e.rotation, e.marg_int,
+    );
+    var ok = 0.0;
+    if s.ok {
+        ok = 1.0;
+    }
+    out.sample_dir = vec4<f32>(s.dir, s.pdf);
+    out.sample_radiance = vec4<f32>(s.radiance, ok);
+    out.resampled = vec4<f32>(
+        env_image_pdf(s.dir, e.width, e.height, e.rotation, e.marg_int),
+        0.0,
+        0.0,
+        0.0,
+    );
+
+    env_out[i] = out;
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/bsdf_parity.wgsl
@@ -121,7 +121,8 @@ struct EnvOutput {
 
 @group(0) @binding(4) var<storage, read> env_in: array<EnvInput>;
 @group(0) @binding(5) var<storage, read_write> env_out: array<EnvOutput>;
-@group(0) @binding(6) var<storage, read> env_data: array<f32>;
+@group(0) @binding(6) var env_pixels: texture_2d<f32>;
+@group(0) @binding(7) var env_cdf: texture_2d<f32>;
 
 @compute @workgroup_size(64)
 fn env_parity(@builtin(global_invocation_id) global_id: vec3<u32>) {

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/env.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/env.wgsl
@@ -1,0 +1,178 @@
+// Lat-long (equirectangular) HDR environment, ported from `pathtrace::EnvMap`.
+//
+// Row 0 is the zenith (+Z), the last row is nadir; column 0 is phi = rotation.
+// Nearest-texel lookups throughout, deliberately: the CDF is piecewise-constant
+// per texel, so nearest sampling makes the radiance and the PDF describe
+// exactly the same function — which is what MIS requires.
+//
+// The pixel and CDF data share ONE storage buffer (`env_data`), declared by the
+// host shader rather than here, so this file can be composed into both the
+// renderer and the parity harness at whatever binding each has spare. The
+// layout, in f32s:
+//
+//   [0                    .. 3*w*h)                  pixels, RGB per texel
+//   [3*w*h                .. 3*w*h + h*(w+1))        per-row conditional CDFs
+//   [3*w*h + h*(w+1)      .. + (h+1))                marginal CDF over rows
+//
+// Every function takes the map's scalars explicitly instead of reading a
+// uniform, so the harness can drive them without a RenderState.
+
+const ENV_MODE_GRADIENT: u32 = 0u;
+const ENV_MODE_IMAGE: u32 = 1u;
+
+fn env_cond_base(w: u32, h: u32) -> u32 {
+    return 3u * w * h;
+}
+
+fn env_marg_base(w: u32, h: u32) -> u32 {
+    return 3u * w * h + h * (w + 1u);
+}
+
+// Relative luminance — the scalar the CDF is built over.
+fn env_luminance(c: vec3<f32>) -> f32 {
+    return 0.2126 * c.x + 0.7152 * c.y + 0.0722 * c.z;
+}
+
+fn env_texel(i: u32, j: u32, w: u32) -> vec3<f32> {
+    let o = 3u * (j * w + i);
+    return vec3<f32>(env_data[o], env_data[o + 1u], env_data[o + 2u]);
+}
+
+// Image coordinates in [0,1)^2 for a world direction.
+fn env_uv(d: vec3<f32>, rotation: f32) -> vec2<f32> {
+    let eps = 1e-9;
+    let theta = acos(clamp(d.z, -1.0, 1.0));
+    let v = clamp(theta / PI, 0.0, 1.0 - eps);
+    // rem_euclid over TAU.
+    let tau = 2.0 * PI;
+    var phi = atan2(d.y, d.x) - rotation;
+    phi = phi - tau * floor(phi / tau);
+    let u = clamp(phi / tau, 0.0, 1.0 - eps);
+    return vec2<f32>(u, v);
+}
+
+// World direction for image coordinates in [0,1]^2.
+fn env_direction(u: f32, v: f32, rotation: f32) -> vec3<f32> {
+    let phi = u * 2.0 * PI + rotation;
+    let theta = v * PI;
+    let st = sin(theta);
+    return vec3<f32>(st * cos(phi), st * sin(phi), cos(theta));
+}
+
+fn env_texel_index(uv: vec2<f32>, w: u32, h: u32) -> vec2<u32> {
+    let i = min(u32(uv.x * f32(w)), w - 1u);
+    let j = min(u32(uv.y * f32(h)), h - 1u);
+    return vec2<u32>(i, j);
+}
+
+// Incoming radiance from direction `d`.
+fn env_image_radiance(d: vec3<f32>, w: u32, h: u32, intensity: f32, rotation: f32) -> vec3<f32> {
+    let uv = env_uv(d, rotation);
+    let ij = env_texel_index(uv, w, h);
+    return env_texel(ij.x, ij.y, w) * intensity;
+}
+
+// Solid-angle PDF of the environment sampling strategy for direction `d`.
+//
+// The uv-space density converts with dω = 2·π²·sin(θ)·du·dv, since u spans 2π
+// of azimuth and v spans π of polar angle.
+fn env_image_pdf(d: vec3<f32>, w: u32, h: u32, rotation: f32, marg_int: f32) -> f32 {
+    if marg_int <= 0.0 {
+        return 0.0;
+    }
+    let uv = env_uv(d, rotation);
+    let ij = env_texel_index(uv, w, h);
+    let sin_bin = sin(PI * (f32(ij.y) + 0.5) / f32(h));
+    let f = max(env_luminance(env_texel(ij.x, ij.y, w)), 0.0) * sin_bin;
+    if f <= 0.0 {
+        return 0.0;
+    }
+    let pdf_uv = f / marg_int;
+    // Actual sin(theta) of this direction, not the bin's — the Jacobian is a
+    // property of the point, while the bin weight is importance.
+    let sin_t = sqrt(max(1.0 - d.z * d.z, 0.0));
+    if sin_t <= 1e-9 {
+        return 0.0;
+    }
+    return pdf_uv / (2.0 * PI * PI * sin_t);
+}
+
+struct Sample1d {
+    index: u32,
+    frac: f32,
+}
+
+// Binary search a normalised CDF slice starting at `base` with `n` bins
+// (so `n + 1` entries). Mirrors `pathtrace::sample_1d`.
+fn env_sample_1d(base: u32, n: u32, u: f32) -> Sample1d {
+    var lo = 0u;
+    var hi = n;
+    while lo < hi {
+        let mid = (lo + hi) / 2u;
+        if env_data[base + mid + 1u] <= u {
+            lo = mid + 1u;
+        } else {
+            hi = mid;
+        }
+    }
+    let i = min(lo, n - 1u);
+    let a = env_data[base + i];
+    let b = env_data[base + i + 1u];
+    var d = 0.5;
+    if b > a {
+        d = (u - a) / (b - a);
+    }
+    var out: Sample1d;
+    out.index = i;
+    out.frac = clamp(d, 0.0, 1.0);
+    return out;
+}
+
+struct EnvSample {
+    dir: vec3<f32>,
+    radiance: vec3<f32>,
+    pdf: f32,
+    ok: bool,
+}
+
+// Importance-sample a direction. PDF is measured in solid angle.
+fn env_image_sample(
+    r1: f32,
+    r2: f32,
+    w: u32,
+    h: u32,
+    intensity: f32,
+    rotation: f32,
+    marg_int: f32,
+) -> EnvSample {
+    var out: EnvSample;
+    out.dir = vec3<f32>(0.0, 0.0, 1.0);
+    out.radiance = vec3<f32>(0.0);
+    out.pdf = 0.0;
+    out.ok = false;
+    if marg_int <= 0.0 {
+        return out;
+    }
+
+    let mrow = env_sample_1d(env_marg_base(w, h), h, r2);
+    let j = mrow.index;
+    let ccol = env_sample_1d(env_cond_base(w, h) + j * (w + 1u), w, r1);
+    let i = ccol.index;
+
+    let u = (f32(i) + ccol.frac) / f32(w);
+    let v = (f32(j) + mrow.frac) / f32(h);
+    let d = env_direction(u, v, rotation);
+
+    // Recompute through the pdf so the MIS partner and this sample agree
+    // bit-for-bit on the density.
+    let pdf = env_image_pdf(d, w, h, rotation, marg_int);
+    if pdf <= 0.0 {
+        return out;
+    }
+
+    out.dir = d;
+    out.radiance = env_texel(i, j, w) * intensity;
+    out.pdf = pdf;
+    out.ok = true;
+    return out;
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/env.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/env.wgsl
@@ -5,28 +5,24 @@
 // per texel, so nearest sampling makes the radiance and the PDF describe
 // exactly the same function — which is what MIS requires.
 //
-// The pixel and CDF data share ONE storage buffer (`env_data`), declared by the
-// host shader rather than here, so this file can be composed into both the
-// renderer and the parity harness at whatever binding each has spare. The
-// layout, in f32s:
+// Data lives in two TEXTURES, not storage buffers: browsers cap
+// `maxStorageBuffersPerShaderStage` at 10 and the renderer already uses all
+// ten, while sampled textures have 48 slots. `textureLoad` needs no sampler, so
+// nearest lookup is exact and no filtering feature is required.
 //
-//   [0                    .. 3*w*h)                  pixels, RGB per texel
-//   [3*w*h                .. 3*w*h + h*(w+1))        per-row conditional CDFs
-//   [3*w*h + h*(w+1)      .. + (h+1))                marginal CDF over rows
+//   env_pixels : rgba32float, w x h      — RGB radiance per texel
+//   env_cdf    : r32float, (w+1) x (h+1) — row j (j < h) is that row's
+//                conditional CDF over u (w+1 entries); row h is the marginal
+//                CDF over v (h+1 entries). Lat-long maps have w >= h, so the
+//                marginal always fits in the last row.
 //
+// Both are declared by the HOST shader rather than here, so this file composes
+// into the renderer and the parity harness at whatever bindings each has spare.
 // Every function takes the map's scalars explicitly instead of reading a
 // uniform, so the harness can drive them without a RenderState.
 
 const ENV_MODE_GRADIENT: u32 = 0u;
 const ENV_MODE_IMAGE: u32 = 1u;
-
-fn env_cond_base(w: u32, h: u32) -> u32 {
-    return 3u * w * h;
-}
-
-fn env_marg_base(w: u32, h: u32) -> u32 {
-    return 3u * w * h + h * (w + 1u);
-}
 
 // Relative luminance — the scalar the CDF is built over.
 fn env_luminance(c: vec3<f32>) -> f32 {
@@ -34,8 +30,12 @@ fn env_luminance(c: vec3<f32>) -> f32 {
 }
 
 fn env_texel(i: u32, j: u32, w: u32) -> vec3<f32> {
-    let o = 3u * (j * w + i);
-    return vec3<f32>(env_data[o], env_data[o + 1u], env_data[o + 2u]);
+    return textureLoad(env_pixels, vec2<i32>(i32(i), i32(j)), 0).rgb;
+}
+
+// One CDF entry. `row` is the conditional row index, or `h` for the marginal.
+fn env_cdf_at(row: u32, k: u32) -> f32 {
+    return textureLoad(env_cdf, vec2<i32>(i32(k), i32(row)), 0).r;
 }
 
 // Image coordinates in [0,1)^2 for a world direction.
@@ -102,22 +102,22 @@ struct Sample1d {
     frac: f32,
 }
 
-// Binary search a normalised CDF slice starting at `base` with `n` bins
-// (so `n + 1` entries). Mirrors `pathtrace::sample_1d`.
-fn env_sample_1d(base: u32, n: u32, u: f32) -> Sample1d {
+// Binary search a normalised CDF row with `n` bins (so `n + 1` entries).
+// Mirrors `pathtrace::sample_1d`.
+fn env_sample_1d(row: u32, n: u32, u: f32) -> Sample1d {
     var lo = 0u;
     var hi = n;
     while lo < hi {
         let mid = (lo + hi) / 2u;
-        if env_data[base + mid + 1u] <= u {
+        if env_cdf_at(row, mid + 1u) <= u {
             lo = mid + 1u;
         } else {
             hi = mid;
         }
     }
     let i = min(lo, n - 1u);
-    let a = env_data[base + i];
-    let b = env_data[base + i + 1u];
+    let a = env_cdf_at(row, i);
+    let b = env_cdf_at(row, i + 1u);
     var d = 0.5;
     if b > a {
         d = (u - a) / (b - a);
@@ -154,9 +154,10 @@ fn env_image_sample(
         return out;
     }
 
-    let mrow = env_sample_1d(env_marg_base(w, h), h, r2);
+    // Row h holds the marginal; row j holds that row's conditional.
+    let mrow = env_sample_1d(h, h, r2);
     let j = mrow.index;
-    let ccol = env_sample_1d(env_cond_base(w, h) + j * (w + 1u), w, r1);
+    let ccol = env_sample_1d(j, w, r1);
     let i = ccol.index;
 
     let u = (f32(i) + ccol.frac) / f32(w);

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
@@ -17,6 +17,12 @@ pub fn raytrace_shader() -> String {
     compose(RAYTRACE_BODY)
 }
 
+/// Analytic surface parameterisation: the `GpuSurface` struct, the surface
+/// constants, and the `dP/du` tangent that drives anisotropic shading.
+///
+/// Prepended after [`BSDF_SHADER`] (on which it depends for `onb`).
+pub const SURFACE_SHADER: &str = include_str!("surface.wgsl");
+
 /// Test-only harness that evaluates and samples the shared BSDF on the GPU.
 ///
 /// Not valid WGSL on its own — compose it with [`BSDF_SHADER`] via
@@ -28,5 +34,5 @@ pub const BSDF_PARITY_HARNESS: &str = include_str!("bsdf_parity.wgsl");
 /// Used by the render pipeline and by the BSDF parity test, which pairs this
 /// exact BSDF source with a tiny harness entry point.
 pub fn compose(body: &str) -> String {
-    format!("{BSDF_SHADER}\n{body}")
+    format!("{BSDF_SHADER}\n{SURFACE_SHADER}\n{body}")
 }

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
@@ -23,6 +23,13 @@ pub fn raytrace_shader() -> String {
 /// Prepended after [`BSDF_SHADER`] (on which it depends for `onb`).
 pub const SURFACE_SHADER: &str = include_str!("surface.wgsl");
 
+/// Lat-long HDR environment: nearest-texel lookup, CDF importance sampling and
+/// the solid-angle PDF, ported from `pathtrace::EnvMap`.
+///
+/// References an `env_data: array<f32>` storage binding that the HOST shader
+/// declares, so it can be composed at whatever binding index each has spare.
+pub const ENV_SHADER: &str = include_str!("env.wgsl");
+
 /// Test-only harness that evaluates and samples the shared BSDF on the GPU.
 ///
 /// Not valid WGSL on its own — compose it with [`BSDF_SHADER`] via
@@ -34,5 +41,5 @@ pub const BSDF_PARITY_HARNESS: &str = include_str!("bsdf_parity.wgsl");
 /// Used by the render pipeline and by the BSDF parity test, which pairs this
 /// exact BSDF source with a tiny harness entry point.
 pub fn compose(body: &str) -> String {
-    format!("{BSDF_SHADER}\n{SURFACE_SHADER}\n{body}")
+    format!("{BSDF_SHADER}\n{SURFACE_SHADER}\n{ENV_SHADER}\n{body}")
 }

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/mod.rs
@@ -1,4 +1,32 @@
 //! WGSL shader sources for ray tracing.
 
-/// The main ray tracing compute shader.
-pub const RAYTRACE_SHADER: &str = include_str!("raytrace.wgsl");
+/// The shared BSDF: the single shading model used by the GPU path tracer and,
+/// as a port, by the CPU renderer in [`crate::pathtrace`].
+///
+/// Prepended to every shader that shades, so the BSDF exists in exactly one
+/// place in the codebase. It also defines `PI` and the `GpuMaterial` struct,
+/// since those are part of the shading contract.
+pub const BSDF_SHADER: &str = include_str!("bsdf.wgsl");
+
+/// Body of the main ray tracing compute shader. Not valid WGSL on its own —
+/// it depends on [`BSDF_SHADER`]. Use [`raytrace_shader`] for the full module.
+const RAYTRACE_BODY: &str = include_str!("raytrace.wgsl");
+
+/// The main ray tracing compute shader, BSDF included.
+pub fn raytrace_shader() -> String {
+    compose(RAYTRACE_BODY)
+}
+
+/// Test-only harness that evaluates and samples the shared BSDF on the GPU.
+///
+/// Not valid WGSL on its own — compose it with [`BSDF_SHADER`] via
+/// [`compose`]. Driven by `tests/bsdf_parity.rs`.
+pub const BSDF_PARITY_HARNESS: &str = include_str!("bsdf_parity.wgsl");
+
+/// Prepend the shared BSDF to a shader body, producing a complete module.
+///
+/// Used by the render pipeline and by the BSDF parity test, which pairs this
+/// exact BSDF source with a tiny harness entry point.
+pub fn compose(body: &str) -> String {
+    format!("{BSDF_SHADER}\n{body}")
+}

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -1189,10 +1189,15 @@ fn tonemap_aces(x: vec3<f32>) -> vec3<f32> {
 
 // Incoming radiance from the analytic studio environment.
 //
-// Mirrors `pathtrace::Environment::radiance` with the constants from
-// `Environment::default()`, so the GPU and CPU integrate the SAME sky. This is
+// Mirrors `pathtrace::GradientEnv::radiance` with the constants from
+// `GradientEnv::default()`, so the GPU and CPU integrate the SAME sky. This is
 // deliberately low-frequency: BSDF sampling alone converges on it, which is
-// why there is no environment CDF anywhere in either renderer.
+// why the gradient needs no environment CDF.
+//
+// The CPU renderer also supports `Environment::Image` (a lat-long HDRI, with
+// its own CDF). That is NOT ported here — the GPU path always uses the
+// gradient. A document rendered with `--hdri` will therefore not match the
+// viewport; the default studio gradient does.
 //
 // Distinct from `sky_color`, which is the themed backdrop the viewport DRAWS.
 // Lighting must match the CPU; the visible background is a UI choice.
@@ -1304,9 +1309,9 @@ fn ground_material() -> GpuMaterial {
     m.clearcoat = 0.0;
     m.clearcoat_roughness = 0.1;
     m.ior = 1.5;
+    m.anisotropy = 0.0;
     m._pad0 = 0.0;
     m._pad1 = 0.0;
-    m._pad2 = 0.0;
     return m;
 }
 

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -78,6 +78,15 @@ struct RenderState {
     crease_width: f32,
     boundary_width: f32,
     edge_softness: f32,
+    // Environment: 0 = analytic gradient, 1 = lat-long HDR image in env_data.
+    env_mode: u32,
+    env_width: u32,
+    env_height: u32,
+    env_rotation: f32,
+    env_marg_int: f32,
+    _pad3: u32,
+    _pad4: u32,
+    _pad5: u32,
 }
 
 struct RayHit {
@@ -117,6 +126,11 @@ struct GpuAreaLight {
 // highlights on metal. Populated from `pathtrace::studio_rig`, the same
 // function the CPU renderer uses, so both rigs are identical.
 @group(0) @binding(11) var<storage, read> lights: array<GpuAreaLight>;
+// HDR environment: pixels + conditional/marginal CDFs packed into one buffer
+// (see env.wgsl for the layout). One buffer rather than three keeps the
+// storage-binding count inside what browsers allow.
+@group(0) @binding(13) var<storage, read> env_data: array<f32>;
+
 // Per-pixel face_idx for analytic crease detection (0xFFFFFFFF = background).
 // Written at frame 1; read at frame 2+ by detect_edge_sobel.
 @group(0) @binding(12) var<storage, read_write> feature_id_buffer: array<u32>;
@@ -1194,6 +1208,16 @@ fn env_radiance(d: vec3<f32>) -> vec3<f32> {
     let horizon = vec3<f32>(0.62, 0.64, 0.68);
     let ground_c = vec3<f32>(0.18, 0.17, 0.16);
 
+    if render_state.env_mode == ENV_MODE_IMAGE {
+        return env_image_radiance(
+            d,
+            render_state.env_width,
+            render_state.env_height,
+            render_state.env_intensity,
+            render_state.env_rotation,
+        );
+    }
+
     let t = d.z;
     var c: vec3<f32>;
     if t >= 0.0 {
@@ -1359,6 +1383,54 @@ fn sample_lights(
     return sum;
 }
 
+// Next-event estimation against the environment, MIS-weighted against BSDF
+// sampling. Only runs for an importance-sampled environment (the HDR image);
+// the analytic gradient is low-frequency enough that BSDF sampling alone
+// integrates it, which is why it has no CDF in either renderer.
+//
+// Mirrors `pathtrace::Scene::sample_environment`.
+fn sample_environment(
+    p: vec3<f32>,
+    frame: mat3x3<f32>,
+    n: vec3<f32>,
+    wo_local: vec3<f32>,
+    m: GpuMaterial,
+    pixel: vec2<u32>,
+    depth: u32,
+) -> vec3<f32> {
+    if render_state.env_mode != ENV_MODE_IMAGE {
+        return vec3<f32>(0.0);
+    }
+    let r = rand_uniform2(pixel, 601u + depth * 19u);
+    let es = env_image_sample(
+        r.x,
+        r.y,
+        render_state.env_width,
+        render_state.env_height,
+        render_state.env_intensity,
+        render_state.env_rotation,
+        render_state.env_marg_int,
+    );
+    if !es.ok || max3(es.radiance) <= 0.0 {
+        return vec3<f32>(0.0);
+    }
+    let wi_local = to_local(frame, es.dir);
+    if wi_local.z <= 0.0 {
+        return vec3<f32>(0.0);
+    }
+    let e = bsdf_eval(m, wo_local, wi_local);
+    if max3(e.value) <= 0.0 {
+        return vec3<f32>(0.0);
+    }
+    // The environment is at infinity: nothing between here and the sky may
+    // block, so the shadow ray is unbounded.
+    if occluded(p + n * 1e-4, es.dir, MAX_T) {
+        return vec3<f32>(0.0);
+    }
+    let w = power_heuristic(es.pdf, e.pdf);
+    return e.value * es.radiance * (w / es.pdf);
+}
+
 // ─── integrator ───────────────────────────────────────────────────────────
 
 // Unidirectional path tracer: multi-bounce GI with throughput accumulation,
@@ -1419,8 +1491,23 @@ fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>
         }
 
         if hit.face_idx == 0xFFFFFFFFu {
-            // Escaped the scene — pick up the environment.
-            l += throughput * env_radiance(ray_d);
+            // Escaped the scene — pick up the environment, MIS-weighted
+            // against environment NEE, which could also have found this
+            // direction. A specular chain (including the primary ray) had no
+            // other strategy, so it takes full weight; so does the gradient,
+            // which is not importance-sampled.
+            var w = 1.0;
+            if !specular_chain && render_state.env_mode == ENV_MODE_IMAGE {
+                let epdf = env_image_pdf(
+                    ray_d,
+                    render_state.env_width,
+                    render_state.env_height,
+                    render_state.env_rotation,
+                    render_state.env_marg_int,
+                );
+                w = power_heuristic(prev_bsdf_pdf, epdf);
+            }
+            l += throughput * env_radiance(ray_d) * w;
             break;
         }
 
@@ -1456,7 +1543,8 @@ fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>
         }
 
         // Next-event estimation.
-        var direct = sample_lights(surf.point, frame, n, wo_local, surf.material, pixel, depth);
+        var direct = sample_lights(surf.point, frame, n, wo_local, surf.material, pixel, depth)
+            + sample_environment(surf.point, frame, n, wo_local, surf.material, pixel, depth);
         if depth > 0u && render_state.firefly_clamp > 0.0 {
             direct = min(direct, vec3<f32>(render_state.firefly_clamp));
         }

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -76,16 +76,21 @@ struct RenderState {
     debug_mode: u32,
     // 0=dark, 1=light
     theme: u32,
-    // SSAO params
-    ao_radius: f32,
-    ao_intensity: f32,
-    ao_bias: f32,
-    ao_sample_count: u32,
+    // Path tracing controls. max_depth is escalated by the refinement
+    // scheduler: shallow for the draft frame, deeper as accumulation proceeds.
+    max_depth: u32,
+    rr_start: u32,
+    light_count: u32,
+    env_intensity: f32,
     // Additional rays per edge pixel for adaptive refinement (0 = disabled).
     refine_sample_count: u32,
-    _pad0: u32,
-    _pad1: u32,
-    _pad2: u32,
+    // Clamp on indirect radiance to kill fireflies (0 = disabled).
+    firefly_clamp: f32,
+    // Whether the implicit ground plane participates in the path trace.
+    ground_enabled: u32,
+    // Non-zero enables non-photoreal stylisation (the Sobel edge overlay).
+    // Off in a photoreal viewport: edge lines fight photorealism.
+    stylize: u32,
     // Edge style — layout must match GpuRenderState in buffers.rs
     silhouette_color: vec4<f32>,
     crease_color: vec4<f32>,
@@ -102,6 +107,19 @@ struct RayHit {
     uv: vec2<f32>,
 }
 
+// A rectangular area light. Layout must match GpuAreaLight in buffers.rs,
+// which is built from pathtrace::AreaLight.
+struct GpuAreaLight {
+    // Centre of the rectangle (.w unused).
+    center: vec4<f32>,
+    // Half-extent along the rectangle's first axis (.w unused).
+    u: vec4<f32>,
+    // Half-extent along the second axis (.w unused).
+    v: vec4<f32>,
+    // Emitted radiance (.w unused).
+    emission: vec4<f32>,
+}
+
 // Bind groups
 
 @group(0) @binding(0) var<uniform> camera: Camera;
@@ -115,9 +133,11 @@ struct RayHit {
 @group(0) @binding(8) var<storage, read_write> accum_buffer: array<vec4<f32>>;
 @group(0) @binding(9) var<storage, read> materials: array<GpuMaterial>;
 @group(0) @binding(10) var<storage, read_write> depth_normal_buffer: array<vec4<f32>>;
-// SSAO result buffer: one f32 per pixel in [0,1]. Written by the `ssao` pass,
-// read by `shade`. Initialised to 1.0 (no occlusion); accumulates over frames.
-@group(0) @binding(11) var<storage, read_write> ao_buffer: array<f32>;
+// Rectangular area lights ("softboxes"). Intersectable, so both BSDF sampling
+// and NEE find them and combine under MIS — that is what puts correctly-shaped
+// highlights on metal. Populated from `pathtrace::studio_rig`, the same
+// function the CPU renderer uses, so both rigs are identical.
+@group(0) @binding(11) var<storage, read> lights: array<GpuAreaLight>;
 // Per-pixel face_idx for analytic crease detection (0xFFFFFFFF = background).
 // Written at frame 1; read at frame 2+ by detect_edge_sobel.
 @group(0) @binding(12) var<storage, read_write> feature_id_buffer: array<u32>;
@@ -1065,24 +1085,6 @@ fn world_to_screen_coords(world_pos: vec3<f32>) -> vec2<i32> {
     return vec2<i32>(px, py);
 }
 
-// Ambient occlusion via a single short hemisphere ray per pixel. Accumulation
-// across frames averages out the noise — at 1 sample per frame and ~8-16
-// frames at HIGH quality, the result settles into clean soft contact
-// shadows.
-fn ambient_occlusion(p: vec3<f32>, normal: vec3<f32>, pixel: vec2<u32>) -> f32 {
-    let bias = 0.001;
-    let max_dist = 6.0;
-    let u = rand_uniform2(pixel, 7u);
-    let dir = sample_hemisphere_cosine(normal, u);
-    let origin = p + normal * bias;
-    let hit = trace_bvh(origin, dir);
-    if hit.face_idx == 0xFFFFFFFFu || hit.t > max_dist {
-        return 1.0;
-    }
-    // Linear falloff with hit distance — close hits darken more than far hits.
-    return clamp(hit.t / max_dist, 0.0, 1.0);
-}
-
 // Compute surface normal at hit point
 fn compute_normal(hit: RayHit) -> vec3<f32> {
     let face = faces[hit.face_idx];
@@ -1183,241 +1185,344 @@ fn tonemap_aces(x: vec3<f32>) -> vec3<f32> {
     return clamp((x * (a * x + b)) / (x * (c * x + d) + e), vec3<f32>(0.0), vec3<f32>(1.0));
 }
 
-// Evaluate Cook-Torrance BRDF for one light direction. Returns the
-// radiance contribution (already weighted by n_dot_l).
-fn brdf_direct(
-    normal: vec3<f32>,
-    view_dir: vec3<f32>,
-    light_dir: vec3<f32>,
-    albedo: vec3<f32>,
-    metallic: f32,
-    roughness: f32,
-    f0: vec3<f32>,
-) -> vec3<f32> {
-    let n_dot_l = max(dot(normal, light_dir), 0.0);
-    if n_dot_l <= 0.0 {
-        return vec3<f32>(0.0);
-    }
-    let halfway = normalize(view_dir + light_dir);
-    let n_dot_v = max(dot(normal, view_dir), 0.001);
-    let n_dot_h = max(dot(normal, halfway), 0.0);
-    let h_dot_v = max(dot(halfway, view_dir), 0.0);
+// ─── environment ──────────────────────────────────────────────────────────
 
-    let d = distribution_ggx(n_dot_h, roughness);
-    let g = geometry_smith(n_dot_v, n_dot_l, roughness);
-    let f = fresnel_schlick(h_dot_v, f0);
-
-    let specular = (d * g * f) / (4.0 * n_dot_v * n_dot_l + 0.001);
-    let kd = (1.0 - f) * (1.0 - metallic);
-    let diffuse = kd * albedo / PI;
-    return (diffuse + specular) * n_dot_l;
-}
-
-// Shade the implicit ground plane. Warm-tinted matte so models read as
-// sitting on a platform rather than floating in sky. Casts soft contact
-// shadows (jittered shadow ray accumulating across frames) and gets AO
-// for proper grounding under the model.
-fn shade_ground(p: vec3<f32>, dir: vec3<f32>, fade: f32, pixel: vec2<u32>) -> vec4<f32> {
-    let normal = vec3<f32>(0.0, 0.0, 1.0);
-    let view_dir = -dir;
-    // Ground albedo follows theme: warm gray on dark, near-white on light.
-    var albedo: vec3<f32>;
-    var ambient_factor: vec3<f32>;
-    var fade_target: vec3<f32>;
-    if render_state.theme == 1u {
-        albedo = vec3<f32>(0.78, 0.78, 0.79);
-        ambient_factor = vec3<f32>(0.55, 0.55, 0.57);
-        fade_target = vec3<f32>(0.96, 0.97, 0.99);
-    } else {
-        albedo = vec3<f32>(0.22, 0.21, 0.20);
-        ambient_factor = vec3<f32>(0.22, 0.22, 0.23);
-        fade_target = vec3<f32>(0.80, 0.85, 0.92);
-    }
-    let roughness = 0.92;
-    let metallic = 0.0;
-    let f0 = vec3<f32>(0.04);
-
-    let ambient_base = ambient_factor * albedo;
-    let ray_ao = ambient_occlusion(p, normal, pixel);
-    let ssao_val = ao_buffer[pixel_index(pixel)];
-    let ambient = ambient_base * ray_ao * ssao_val;
-
-    var lo = vec3<f32>(0.0);
-    let sun = sun_direction();
-    let sun_color = vec3<f32>(1.0, 0.96, 0.88) * 2.4;
-    let shadow_jitter = rand_uniform2(pixel, 13u);
-    let sun_jittered = jitter_direction(sun, 0.025, shadow_jitter);
-    let shadowed = in_shadow(p, sun_jittered, MAX_T);
-    if !shadowed {
-        lo += brdf_direct(normal, view_dir, sun, albedo, metallic, roughness, f0) * sun_color;
-    }
-
-    var color = ambient + lo;
-    color = tonemap_aces(color);
-    color = pow(color, vec3<f32>(1.0 / 2.2));
-
-    let sky_tonemapped = pow(tonemap_aces(fade_target), vec3<f32>(1.0 / 2.2));
-    color = mix(sky_tonemapped, color, fade);
-    return vec4<f32>(color, 1.0);
-}
-
-// Direct-only shading used as the *bounce hit* color for one-bounce GI.
-// Returns LINEAR radiance (no tonemap, no gamma) so it can be added to
-// the primary hit's lo before the final tonemap. Skips IBL, AO, and
-// recursive bounces — those are the things that would cause cost
-// blow-up or recursion (which WGSL forbids).
-fn shade_direct(hit: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>) -> vec3<f32> {
-    if hit.face_idx == 0xFFFFFFFFu {
-        return sky_color(dir);
-    }
-
-    let sun = sun_direction();
-    let view_dir = -dir;
-
-    if hit.face_idx == FACE_IDX_GROUND {
-        let p = origin + dir * hit.t;
-        let normal = vec3<f32>(0.0, 0.0, 1.0);
-        let albedo = vec3<f32>(0.22, 0.21, 0.20);
-        let ambient = vec3<f32>(0.22, 0.22, 0.23) * albedo;
-        var lo = vec3<f32>(0.0);
-        if !in_shadow(p, sun, MAX_T) {
-            // Lambertian — single light, no fresnel/specular.
-            let n_dot_l = max(dot(normal, sun), 0.0);
-            lo += albedo / PI * vec3<f32>(1.0, 0.96, 0.88) * 2.4 * n_dot_l;
-        }
-        return ambient + lo;
-    }
-
-    let face = faces[hit.face_idx];
-    let mat = materials[face.material_idx];
-    let albedo = mat.color.rgb;
-    let metallic = mat.metallic;
-    let roughness = max(mat.roughness, 0.04);
-    let normal = compute_normal(hit);
-    let p = origin + dir * hit.t;
-    let f0 = mix(vec3<f32>(0.04, 0.04, 0.04), albedo, metallic);
-
-    var lo = vec3<f32>(0.0);
-    let sun_color = vec3<f32>(1.0, 0.96, 0.88) * 2.6;
-    if !in_shadow(p, sun, MAX_T) {
-        lo += brdf_direct(normal, view_dir, sun, albedo, metallic, roughness, f0) * sun_color;
-    }
-    let fill_dir = normalize(vec3<f32>(-0.4, 0.5, 0.6));
-    let fill_color = vec3<f32>(0.7, 0.8, 1.0) * 0.45;
-    if !in_shadow(p, fill_dir, MAX_T) {
-        lo += brdf_direct(normal, view_dir, fill_dir, albedo, metallic, roughness, f0) * fill_color;
-    }
-    // Cheap hemisphere ambient — no AO/sky-blend, just a flat tint.
-    lo += albedo * 0.08;
-    return lo;
-}
-
-// PBR shading with Cook-Torrance BRDF, soft shadow rays, AO, one-bounce
-// indirect (GI), and HDR env IBL. Z-up world (kernel space).
+// Incoming radiance from the analytic studio environment.
 //
-// Stochastic terms (soft shadows, AO, env-spec jitter, GI bounce) are
-// decorrelated per-pixel and per-frame so progressive accumulation
-// converges to a noise-free image.
+// Mirrors `pathtrace::Environment::radiance` with the constants from
+// `Environment::default()`, so the GPU and CPU integrate the SAME sky. This is
+// deliberately low-frequency: BSDF sampling alone converges on it, which is
+// why there is no environment CDF anywhere in either renderer.
+//
+// Distinct from `sky_color`, which is the themed backdrop the viewport DRAWS.
+// Lighting must match the CPU; the visible background is a UI choice.
+fn env_radiance(d: vec3<f32>) -> vec3<f32> {
+    let zenith = vec3<f32>(0.34, 0.42, 0.55);
+    let horizon = vec3<f32>(0.62, 0.64, 0.68);
+    let ground_c = vec3<f32>(0.18, 0.17, 0.16);
+
+    let t = d.z;
+    var c: vec3<f32>;
+    if t >= 0.0 {
+        let k = smoothstep(0.0, 1.0, pow(t, 0.65));
+        c = mix(horizon, zenith, k);
+    } else {
+        let k = smoothstep(0.0, 1.0, pow(-t, 0.5));
+        c = mix(horizon, ground_c, k);
+    }
+    return c * render_state.env_intensity;
+}
+
+// ─── area lights ──────────────────────────────────────────────────────────
+
+fn light_normal(l: GpuAreaLight) -> vec3<f32> {
+    return normalize(cross(l.u.xyz, l.v.xyz));
+}
+
+fn light_area(l: GpuAreaLight) -> f32 {
+    return 4.0 * length(cross(l.u.xyz, l.v.xyz));
+}
+
+struct LightHit {
+    t: f32,
+    index: u32,
+    hit: bool,
+}
+
+// Closest intersection against the emitting (front) face of any area light.
+// Lights are intersectable so a BSDF ray can find them too — that is what
+// makes MIS work and what gives metal correctly-shaped softbox highlights
+// instead of a jittered sun cone.
+fn intersect_lights(origin: vec3<f32>, dir: vec3<f32>) -> LightHit {
+    var out: LightHit;
+    out.t = MAX_T;
+    out.index = 0u;
+    out.hit = false;
+
+    for (var i = 0u; i < render_state.light_count; i = i + 1u) {
+        let l = lights[i];
+        let n = light_normal(l);
+        let denom = dot(n, dir);
+        if abs(denom) < 1e-12 {
+            continue;
+        }
+        // Emitting face only: we must be looking at the front.
+        if denom > 0.0 {
+            continue;
+        }
+        let t = dot(n, l.center.xyz - origin) / denom;
+        if t <= 1e-6 || t >= out.t {
+            continue;
+        }
+        let p = origin + dir * t;
+        let rel = p - l.center.xyz;
+        let ul = length(l.u.xyz);
+        let vl = length(l.v.xyz);
+        let du = dot(rel, l.u.xyz / ul);
+        let dv = dot(rel, l.v.xyz / vl);
+        if abs(du) <= ul && abs(dv) <= vl {
+            out.t = t;
+            out.index = i;
+            out.hit = true;
+        }
+    }
+    return out;
+}
+
+// Any-hit occlusion against geometry and the ground. Lights do not occlude,
+// matching `pathtrace::Scene::occluded`.
+fn occluded(origin: vec3<f32>, dir: vec3<f32>, max_dist: f32) -> bool {
+    let o = origin;
+    let hit = trace_bvh(o, dir);
+    if hit.face_idx != 0xFFFFFFFFu && hit.t > 1e-6 && hit.t < max_dist - 1e-6 {
+        return true;
+    }
+    if render_state.ground_enabled != 0u {
+        let g = intersect_ground(o, dir);
+        if g.t > 1e-6 && g.t < max_dist - 1e-6 {
+            return true;
+        }
+    }
+    return false;
+}
+
+// ─── surface description at a hit ─────────────────────────────────────────
+
+struct Surface {
+    point: vec3<f32>,
+    normal: vec3<f32>,
+    material: GpuMaterial,
+}
+
+// The implicit ground plane's material, matching the studio floor that
+// `vcad-render --photoreal` builds (photoreal.rs `Backdrop::Studio`).
+fn ground_material() -> GpuMaterial {
+    var m: GpuMaterial;
+    m.color = vec4<f32>(0.55, 0.55, 0.56, 1.0);
+    m.metallic = 0.0;
+    m.roughness = 0.6;
+    m.clearcoat = 0.0;
+    m.clearcoat_roughness = 0.1;
+    m.ior = 1.5;
+    m._pad0 = 0.0;
+    m._pad1 = 0.0;
+    m._pad2 = 0.0;
+    return m;
+}
+
+// ─── next-event estimation ────────────────────────────────────────────────
+
+// Sample every area light once, MIS-weighted against the BSDF strategy with
+// the power heuristic. Mirrors `pathtrace::Scene::sample_lights`.
+fn sample_lights(
+    p: vec3<f32>,
+    frame: mat3x3<f32>,
+    n: vec3<f32>,
+    wo_local: vec3<f32>,
+    m: GpuMaterial,
+    pixel: vec2<u32>,
+    depth: u32,
+) -> vec3<f32> {
+    var sum = vec3<f32>(0.0);
+    for (var i = 0u; i < render_state.light_count; i = i + 1u) {
+        let l = lights[i];
+        // Two fresh randoms per light per bounce, decorrelated per frame.
+        let r = rand_uniform2(pixel, 101u + depth * 17u + i * 5u);
+        let lp = l.center.xyz + l.u.xyz * (2.0 * r.x - 1.0) + l.v.xyz * (2.0 * r.y - 1.0);
+        let to_light = lp - p;
+        let dist = length(to_light);
+        if dist < 1e-9 {
+            continue;
+        }
+        let wi_world = to_light / dist;
+        let ln = light_normal(l);
+        let cos_light = -dot(wi_world, ln);
+        if cos_light <= 1e-9 {
+            continue;
+        }
+        let wi_local = to_local(frame, wi_world);
+        if wi_local.z <= 0.0 {
+            continue;
+        }
+
+        let e = bsdf_eval(m, wo_local, wi_local);
+        if max3(e.value) <= 0.0 {
+            continue;
+        }
+
+        // Solid-angle PDF of the area sampling strategy.
+        let light_pdf = dist * dist / (cos_light * light_area(l));
+        if light_pdf <= 0.0 {
+            continue;
+        }
+
+        if occluded(p + n * 1e-4, wi_world, dist) {
+            continue;
+        }
+
+        let w = power_heuristic(light_pdf, e.pdf);
+        sum += e.value * l.emission.rgb * (w / light_pdf);
+    }
+    return sum;
+}
+
+// ─── integrator ───────────────────────────────────────────────────────────
+
+// Unidirectional path tracer: multi-bounce GI with throughput accumulation,
+// next-event estimation against the area lights under MIS, and Russian
+// roulette termination. This replaces the old single hardcoded GI bounce
+// (`shade_direct` used as a bounce estimator) and the SSAO proxy — real
+// multi-bounce transport computes contact occlusion correctly, so stacking
+// SSAO on top of it would double-darken every concave corner.
+//
+// `max_depth` is driven per-frame by the refinement scheduler: draft frames
+// trace shallow to stay interactive and depth escalates as accumulation
+// proceeds, so the first frame is still usable.
+fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>) -> vec4<f32> {
+    var l = vec3<f32>(0.0);
+    var throughput = vec3<f32>(1.0);
+    var ray_o = origin;
+    var ray_d = dir;
+    var hit = first;
+    // PDF of the lobe the previous bounce was sampled from; used to MIS
+    // against light sampling when the new ray lands on an emitter.
+    var prev_bsdf_pdf = 0.0;
+    var specular_chain = true;
+    var alpha = 0.0;
+
+    let max_depth = max(render_state.max_depth, 1u);
+
+    for (var depth = 0u; depth < max_depth; depth = depth + 1u) {
+        // Lights are part of the scene: a BSDF ray that lands on one carries
+        // its emission, MIS-weighted against the NEE sample that could also
+        // have found it.
+        let lh = intersect_lights(ray_o, ray_d);
+        let geom_t = select(MAX_T, hit.t, hit.face_idx != 0xFFFFFFFFu);
+
+        if lh.hit && lh.t < geom_t {
+            let light = lights[lh.index];
+            var w = 1.0;
+            if !specular_chain {
+                let ln = light_normal(light);
+                let cos_light = max(-dot(ray_d, ln), 1e-9);
+                let light_pdf = lh.t * lh.t / (cos_light * light_area(light));
+                w = power_heuristic(prev_bsdf_pdf, light_pdf);
+            }
+            l += throughput * light.emission.rgb * w;
+            if depth == 0u {
+                alpha = 1.0;
+            }
+            break;
+        }
+
+        if hit.face_idx == 0xFFFFFFFFu {
+            // Escaped the scene — pick up the environment.
+            l += throughput * env_radiance(ray_d);
+            break;
+        }
+
+        if depth == 0u {
+            alpha = 1.0;
+        }
+
+        // Resolve the surface we hit.
+        var surf: Surface;
+        surf.point = ray_o + ray_d * hit.t;
+        if hit.face_idx == FACE_IDX_GROUND {
+            surf.normal = vec3<f32>(0.0, 0.0, 1.0);
+            surf.material = ground_material();
+        } else {
+            surf.normal = compute_normal(hit);
+            surf.material = materials[faces[hit.face_idx].material_idx];
+        }
+
+        let wo_world = -ray_d;
+        // Face-forward: interior faces (bore walls) must shade right.
+        var n = surf.normal;
+        if dot(n, wo_world) < 0.0 {
+            n = -n;
+        }
+        let frame = onb(n);
+        let wo_local = to_local(frame, wo_world);
+        if wo_local.z <= 0.0 {
+            break;
+        }
+
+        // Next-event estimation.
+        var direct = sample_lights(surf.point, frame, n, wo_local, surf.material, pixel, depth);
+        if depth > 0u && render_state.firefly_clamp > 0.0 {
+            direct = min(direct, vec3<f32>(render_state.firefly_clamp));
+        }
+        l += throughput * direct;
+
+        // Continue the path.
+        let r_lobe = rand_uniform(pixel, 211u + depth * 23u);
+        let r12 = rand_uniform2(pixel, 307u + depth * 29u);
+        let s = bsdf_sample(surf.material, wo_local, r_lobe, r12.x, r12.y);
+        if !s.ok {
+            break;
+        }
+        throughput = throughput * s.value / s.pdf;
+        prev_bsdf_pdf = s.pdf;
+        specular_chain = false;
+
+        let wi_world = to_world(frame, s.wi);
+        ray_o = surf.point + n * 1e-4;
+        ray_d = wi_world;
+
+        // Russian roulette.
+        if depth >= render_state.rr_start {
+            let q = clamp(max3(throughput), 0.0, 0.95);
+            if rand_uniform(pixel, 401u + depth * 31u) > q {
+                break;
+            }
+            throughput = throughput / q;
+        }
+        if max3(throughput) <= 1e-5 {
+            break;
+        }
+
+        // Trace the next segment.
+        hit = trace_bvh(ray_o, ray_d);
+        if render_state.ground_enabled != 0u {
+            let g = intersect_ground(ray_o, ray_d);
+            if g.t < hit.t {
+                hit.t = g.t;
+                hit.face_idx = FACE_IDX_GROUND;
+                hit.uv = vec2<f32>(g.fade, 0.0);
+            }
+        }
+    }
+
+    return vec4<f32>(l, alpha);
+}
+
+// Entry point used by the main pass. Returns LINEAR radiance in .rgb and
+// coverage in .a; tonemapping happens once, after accumulation.
 fn shade(hit: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>) -> vec4<f32> {
     if hit.face_idx == 0xFFFFFFFFu {
-        // Background — render the sky directly.
-        let sky = sky_color(dir);
-        let mapped = tonemap_aces(sky);
-        return vec4<f32>(pow(mapped, vec3<f32>(1.0 / 2.2)), 1.0);
+        // Nothing in front of the camera. Draw the themed backdrop rather
+        // than the lighting environment — the backdrop is a viewport choice,
+        // and `vcad-render` composites its own.
+        let lh = intersect_lights(origin, dir);
+        if lh.hit {
+            return vec4<f32>(lights[lh.index].emission.rgb, 1.0);
+        }
+        return vec4<f32>(sky_color(dir), 0.0);
     }
 
+    let traced = path_trace(hit, origin, dir, pixel);
+
+    // The implicit ground plane is bounded: fade it into the backdrop with
+    // horizontal distance so it reads as a platform under the model rather
+    // than a disc floating in sky. `intersect_ground` stashes the fade factor
+    // in uv.x. The CPU renderer uses an unbounded plane, so this only affects
+    // pixels far from the subject.
     if hit.face_idx == FACE_IDX_GROUND {
-        let p = origin + dir * hit.t;
-        return shade_ground(p, dir, hit.uv.x, pixel);
+        let fade = hit.uv.x;
+        return vec4<f32>(mix(sky_color(dir), traced.rgb, fade), traced.a);
     }
-
-    let face = faces[hit.face_idx];
-    let mat = materials[face.material_idx];
-    let albedo = mat.color.rgb;
-    let metallic = mat.metallic;
-    let roughness = max(mat.roughness, 0.04);
-
-    let normal = compute_normal(hit);
-    let view_dir = -dir;
-    let p = origin + dir * hit.t;
-
-    let f0 = mix(vec3<f32>(0.04, 0.04, 0.04), albedo, metallic);
-
-    // Hemisphere ambient blend, modulated by both ray AO and SSAO for crisp
-    // contact darkening in concave features and tight corners.
-    let sky_up = mix(vec3<f32>(0.40, 0.42, 0.46), sky_color(normal), 0.3);
-    let sky_down = vec3<f32>(0.30, 0.27, 0.24);
-    let hemi_factor = max(normal.z, 0.0) * 0.5 + 0.5;
-    let ray_ao = ambient_occlusion(p, normal, pixel);
-    // SSAO value is written by the previous frame's `ssao` pass (one-frame lag).
-    // Defaults to 1.0 on frame 1 and when ao_intensity = 0.
-    let ssao_val = ao_buffer[pixel_index(pixel)];
-    let ambient = mix(sky_down, sky_up, hemi_factor) * albedo * 0.30 * ray_ao * ssao_val;
-
-    var lo = vec3<f32>(0.0);
-
-    // Soft sun shadow — single jittered ray per frame, smoothed by accumulation.
-    let sun = sun_direction();
-    let sun_color = vec3<f32>(1.0, 0.96, 0.88) * 2.6;
-    let sun_jitter = rand_uniform2(pixel, 17u);
-    let sun_jittered = jitter_direction(sun, 0.025, sun_jitter);
-    if !in_shadow(p, sun_jittered, MAX_T) {
-        lo += brdf_direct(normal, view_dir, sun, albedo, metallic, roughness, f0) * sun_color;
-    }
-
-    // Soft fill from upper-back. Wider cone since fill lights are physically
-    // larger / softer than the sun.
-    let fill_dir = normalize(vec3<f32>(-0.4, 0.5, 0.6));
-    let fill_color = vec3<f32>(0.7, 0.8, 1.0) * 0.45;
-    let fill_jitter = rand_uniform2(pixel, 23u);
-    let fill_jittered = jitter_direction(fill_dir, 0.08, fill_jitter);
-    if !in_shadow(p, fill_jittered, MAX_T) {
-        lo += brdf_direct(normal, view_dir, fill_dir, albedo, metallic, roughness, f0) * fill_color;
-    }
-
-    // Camera-relative wrap fill: cheap, no shadow test, keeps near-camera
-    // faces readable when both directional lights are occluded.
-    {
-        let n_dot_v = max(dot(normal, view_dir), 0.0);
-        let kd = (1.0 - metallic);
-        let diffuse = kd * albedo / PI;
-        lo += diffuse * vec3<f32>(0.85, 0.88, 0.95) * 0.18 * n_dot_v;
-    }
-
-    // Specular IBL: jitter the reflection direction within a roughness-sized
-    // cone so glossy reflections soften over accumulation rather than ringing.
-    let n_dot_v_amb = max(dot(normal, view_dir), 0.0);
-    let f_ambient = fresnel_schlick(n_dot_v_amb, f0);
-    let reflect_dir = reflect(dir, normal);
-    let env_jitter = rand_uniform2(pixel, 31u);
-    let env_dir = jitter_direction(reflect_dir, roughness * 0.4, env_jitter);
-    let env_specular = sky_color(env_dir) * f_ambient * (1.0 - roughness * 0.85);
-
-    // One-bounce indirect (GI). Cosine-weighted hemisphere sample, traced
-    // against BVH + ground; the bounce hit is shaded with shade_direct
-    // (no recursion). For a Lambertian + cosine-weighted sample, the brdf
-    // and pdf factors cancel to just `albedo`, so the contribution is
-    // `albedo * incoming_radiance`. Skipped for metals (they have no
-    // Lambertian diffuse bounce — their indirect comes through env_specular).
-    let bounce_jitter = rand_uniform2(pixel, 41u);
-    let bounce_dir = sample_hemisphere_cosine(normal, bounce_jitter);
-    let bounce_origin = p + normal * 0.001;
-    var bounce_hit = trace_bvh(bounce_origin, bounce_dir);
-    let bounce_ground = intersect_ground(bounce_origin, bounce_dir);
-    if bounce_ground.t < bounce_hit.t {
-        bounce_hit.t = bounce_ground.t;
-        bounce_hit.face_idx = FACE_IDX_GROUND;
-        bounce_hit.uv = vec2<f32>(bounce_ground.fade, 0.0);
-    }
-    let indirect_radiance = shade_direct(bounce_hit, bounce_origin, bounce_dir, pixel);
-    let indirect = albedo * (1.0 - metallic) * indirect_radiance * 0.7;
-
-    var color = ambient + lo + env_specular + indirect;
-
-    color = tonemap_aces(color);
-    color = pow(color, vec3<f32>(1.0 / 2.2));
-
-    return vec4<f32>(color, 1.0);
+    return traced;
 }
 
 // HSV to RGB conversion for debug visualization
@@ -1746,9 +1851,23 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
         final_color = denoise(pixel_coord, accumulated, stored_dn);
     }
 
+    // The path tracer works in LINEAR radiance and accumulates in linear, so
+    // tonemapping happens exactly once, here — after averaging and denoising.
+    // (The old renderer tonemapped inside `shade`, which meant it averaged
+    // already-compressed values and darkened highlights as frames piled up.)
+    // Edge lines and debug overlays are authored in display space, so they are
+    // composited after this point.
+    final_color = vec4<f32>(
+        pow(tonemap_aces(final_color.rgb), vec3<f32>(1.0 / 2.2)),
+        final_color.a,
+    );
+
     // Apply Fusion-style edge lines on later frames (stable depth/normal/face-ID data).
-    // enable_edges is a bit-mask: bit0=silhouette, bit1=crease, bit2=boundary.
-    if render_state.enable_edges != 0u && render_state.frame_index >= 2u {
+    // The Sobel edge overlay is a STYLISATION, not a shading term: it fights
+    // photorealism, so it is gated behind `stylize` and stays off in a
+    // photoreal viewport. enable_edges is then a bit-mask within that mode:
+    // bit0=silhouette, bit1=crease, bit2=boundary.
+    if render_state.stylize != 0u && render_state.enable_edges != 0u && render_state.frame_index >= 2u {
         let strengths = detect_edge_sobel(pixel_coord);
 
         // Silhouette lines (large depth/normal gradient, bit 0)
@@ -1818,117 +1937,6 @@ fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
     textureStore(output, pixel_coord, final_color);
 }
 
-// Screen-Space Ambient Occlusion (SSAO) compute kernel.
-//
-// Runs after the main `main` pass so depth_normal_buffer is populated.
-// Samples N hemisphere directions (Halton sequence for low discrepancy,
-// offset by frame_index so temporal accumulation converges to a noise-free
-// result).  Writes the AO factor (in [0,1]) to ao_buffer; the main pass
-// reads this on the next frame.
-//
-// When ao_intensity == 0 every pixel receives 1.0 (no occlusion), giving
-// bit-identical output to a renderer without any SSAO contribution.
-@compute @workgroup_size(8, 8)
-fn ssao(@builtin(global_invocation_id) global_id: vec3<u32>) {
-    let pixel = global_id.xy;
-    if pixel.x >= camera.width || pixel.y >= camera.height { return; }
-
-    let idx = pixel_index(pixel);
-
-    // Fast-exit: AO disabled.
-    if render_state.ao_intensity < 0.001 {
-        ao_buffer[idx] = 1.0;
-        return;
-    }
-
-    let dn     = depth_normal_buffer[idx];
-    let depth  = dn.w;
-    let normal = dn.xyz;
-
-    // Background or ground — skip, write no-occlusion.
-    if depth >= MAX_T - 1.0 || length(normal) < 0.5 {
-        ao_buffer[idx] = 1.0;
-        return;
-    }
-
-    let pos     = world_pos_from_depth(pixel, depth);
-    let forward = normalize(camera.look_at.xyz - camera.position.xyz);
-
-    // View-space Z of the centre pixel (used for range-check below).
-    let center_view_z = dot(pos - camera.position.xyz, forward);
-
-    let n_samples  = render_state.ao_sample_count;
-    // Halton base offset advances each frame so temporal accumulation
-    // samples a different part of the hemisphere every frame.
-    let frame_base = (render_state.frame_index - 1u) * n_samples;
-
-    var occ = 0.0;
-
-    for (var i = 0u; i < n_samples; i++) {
-        let h = frame_base + i;
-
-        // Low-discrepancy 2D sample in [0,1)^2 — Halton bases 5 and 7.
-        let u = vec2<f32>(halton_wgsl(h, 5u), halton_wgsl(h, 7u));
-
-        // Uniform hemisphere (not cosine-weighted — we want even spatial
-        // coverage around the normal, not cosine-biased AO).
-        let sin_theta = sqrt(max(0.0, 1.0 - u.x * u.x));
-        let phi       = 2.0 * PI * u.y;
-        let local_dir = vec3<f32>(sin_theta * cos(phi), sin_theta * sin(phi), u.x);
-        let sample_dir = build_tangent_frame(normal) * local_dir;
-
-        // Vary radius: bias towards shorter distances (quadratic ramp).
-        let t_radius   = render_state.ao_radius * halton_wgsl(h + 1u, 11u);
-        let sample_pos = pos + sample_dir * t_radius;
-
-        // Project sample point to screen.
-        let screen = world_to_screen_coords(sample_pos);
-        if screen.x < 0 || screen.x >= i32(camera.width) ||
-           screen.y < 0 || screen.y >= i32(camera.height) {
-            continue;
-        }
-
-        let scene_dn    = depth_normal_buffer[pixel_index_i32(screen)];
-        let scene_depth = scene_dn.w;
-        // Transparent sky or unresolved pixel — no occlusion from this sample.
-        if scene_depth >= MAX_T - 1.0 { continue; }
-
-        // Reconstruct the scene surface's world position.
-        let scene_pos    = world_pos_from_depth(vec2<u32>(screen), scene_depth);
-        let scene_view_z = dot(scene_pos - camera.position.xyz, forward);
-        let sample_view_z = dot(sample_pos - camera.position.xyz, forward);
-
-        // Range guard: surfaces far from the centre pixel should not
-        // contribute — this prevents haloing at depth discontinuities
-        // (silhouette edges stay clean).
-        if abs(center_view_z - scene_view_z) > render_state.ao_radius { continue; }
-
-        // Occlusion test: the scene surface is closer to the camera than
-        // the sample point → the sample is hidden behind it.
-        if scene_view_z < sample_view_z - render_state.ao_bias {
-            // Smooth falloff: close occluders contribute more than distant ones.
-            let dist         = length(scene_pos - pos);
-            let range_weight = 1.0 - smoothstep(0.0, render_state.ao_radius, dist);
-            occ += range_weight;
-        }
-    }
-
-    // AO value in [0,1]: 0 = fully occluded, 1 = fully lit.
-    let ao_val = clamp(
-        1.0 - (occ / f32(n_samples)) * render_state.ao_intensity,
-        0.0, 1.0
-    );
-
-    // Progressive accumulation (running average matches main-pass behaviour).
-    if render_state.frame_index <= 1u {
-        ao_buffer[idx] = ao_val;
-    } else {
-        let prev   = ao_buffer[idx];
-        let weight = 1.0 / f32(render_state.frame_index);
-        ao_buffer[idx] = mix(prev, ao_val, weight);
-    }
-}
-
 // Adaptive refinement pass: fires additional stratified rays for edge pixels,
 // blends with the coarse main-pass sample, and updates the output texture.
 // Only runs when render_state.refine_sample_count > 0.
@@ -1994,11 +2002,18 @@ fn refine(@builtin(global_invocation_id) global_id: vec3<u32>) {
     // Store back with sample count in alpha for heatmap debug mode.
     accum_buffer[idx] = vec4<f32>(blended_rgb, total);
 
-    // Compose the refined output pixel.
-    var final_color = vec4<f32>(blended_rgb, 1.0);
+    // Compose the refined output pixel. `shade` and the accumulation buffer are
+    // both LINEAR, so tonemap here exactly as the main pass does — otherwise
+    // refined edge pixels are written in a different colour space than their
+    // neighbours and the overlay reads as a bright fringe.
+    var final_color = vec4<f32>(
+        pow(tonemap_aces(blended_rgb), vec3<f32>(1.0 / 2.2)),
+        1.0,
+    );
 
-    // Re-apply edge overlay (only on later frames, consistent with main pass).
-    if render_state.enable_edges == 1u && render_state.frame_index >= 2u {
+    // Re-apply edge overlay (only on later frames, consistent with main pass,
+    // and only when stylisation is on).
+    if render_state.stylize != 0u && render_state.enable_edges == 1u && render_state.frame_index >= 2u {
         let edge_color = vec4<f32>(0.1, 0.1, 0.12, 1.0);
         final_color = mix(final_color, edge_color, edge * 0.8);
     }

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -3,28 +3,7 @@
 // This shader traces rays against analytic surfaces without tessellation,
 // achieving pixel-perfect silhouettes at any zoom level.
 
-// Constants
-const SURFACE_PLANE: u32 = 0u;
-const SURFACE_CYLINDER: u32 = 1u;
-const SURFACE_SPHERE: u32 = 2u;
-const SURFACE_CONE: u32 = 3u;
-const SURFACE_TORUS: u32 = 4u;
-const SURFACE_BILINEAR: u32 = 5u;
-
-const MAX_T: f32 = 1e10;
-const EPSILON: f32 = 1e-6;
-
 // Structures matching Rust definitions
-
-struct GpuSurface {
-    surface_type: u32,
-    // Use explicit u32 padding instead of vec3<u32> to match Rust layout
-    // vec3<u32> in WGSL has 16-byte alignment which would misalign params
-    _pad0: u32,
-    _pad1: u32,
-    _pad2: u32,
-    params: array<f32, 32>,
-}
 
 struct GpuFace {
     surface_idx: u32,
@@ -1175,6 +1154,15 @@ fn compute_normal(hit: RayHit) -> vec3<f32> {
 }
 
 
+// Surface tangent dP/du at a hit, or a zero vector where the parameterisation
+// is degenerate. Thin wrapper: the maths lives in `surface_dpdu` (surface.wgsl)
+// so it can be driven directly by the parity harness.
+fn compute_tangent(hit: RayHit) -> vec3<f32> {
+    let face = faces[hit.face_idx];
+    let surface = surfaces[face.surface_idx];
+    return surface_dpdu(surface.surface_type, surface.params, hit.uv);
+}
+
 // ACES Narkowicz tonemap. Cleaner highlights and richer mids than Reinhard.
 fn tonemap_aces(x: vec3<f32>) -> vec3<f32> {
     let a = 2.51;
@@ -1443,12 +1431,14 @@ fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>
         // Resolve the surface we hit.
         var surf: Surface;
         surf.point = ray_o + ray_d * hit.t;
+        var dpdu = vec3<f32>(0.0);
         if hit.face_idx == FACE_IDX_GROUND {
             surf.normal = vec3<f32>(0.0, 0.0, 1.0);
             surf.material = ground_material();
         } else {
             surf.normal = compute_normal(hit);
             surf.material = materials[faces[hit.face_idx].material_idx];
+            dpdu = compute_tangent(hit);
         }
 
         let wo_world = -ray_d;
@@ -1457,7 +1447,9 @@ fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>
         if dot(n, wo_world) < 0.0 {
             n = -n;
         }
-        let frame = onb(n);
+        // Align the frame's x axis with dP/du so an anisotropic highlight
+        // follows the surface's own grain, exactly as the CPU renderer does.
+        let frame = shading_frame(n, dpdu);
         let wo_local = to_local(frame, wo_world);
         if wo_local.z <= 0.0 {
             break;

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -1396,7 +1396,17 @@ fn path_trace(first: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>
         // Lights are part of the scene: a BSDF ray that lands on one carries
         // its emission, MIS-weighted against the NEE sample that could also
         // have found it.
-        let lh = intersect_lights(ray_o, ray_d);
+        //
+        // They are NOT visible to camera rays, though. The rig is sized to the
+        // scene bounds and the viewport camera orbits and zooms freely, so
+        // otherwise the softboxes swing through frame as giant white slabs.
+        // Skipping them at depth 0 costs nothing physically — it only changes
+        // pixels that look straight down a light — and keeps every shaded
+        // surface identical to the CPU renderer.
+        var lh = intersect_lights(ray_o, ray_d);
+        if depth == 0u {
+            lh.hit = false;
+        }
         let geom_t = select(MAX_T, hit.t, hit.face_idx != 0xFFFFFFFFu);
 
         if lh.hit && lh.t < geom_t {
@@ -1503,11 +1513,8 @@ fn shade(hit: RayHit, origin: vec3<f32>, dir: vec3<f32>, pixel: vec2<u32>) -> ve
     if hit.face_idx == 0xFFFFFFFFu {
         // Nothing in front of the camera. Draw the themed backdrop rather
         // than the lighting environment — the backdrop is a viewport choice,
-        // and `vcad-render` composites its own.
-        let lh = intersect_lights(origin, dir);
-        if lh.hit {
-            return vec4<f32>(lights[lh.index].emission.rgb, 1.0);
-        }
+        // and `vcad-render` composites its own. The area lights are skipped
+        // here for the same reason `path_trace` skips them at depth 0.
         return vec4<f32>(sky_color(dir), 0.0);
     }
 

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -13,7 +13,6 @@ const SURFACE_BILINEAR: u32 = 5u;
 
 const MAX_T: f32 = 1e10;
 const EPSILON: f32 = 1e-6;
-const PI: f32 = 3.14159265359;
 
 // Structures matching Rust definitions
 
@@ -25,13 +24,6 @@ struct GpuSurface {
     _pad1: u32,
     _pad2: u32,
     params: array<f32, 32>,
-}
-
-struct GpuMaterial {
-    color: vec4<f32>,
-    metallic: f32,
-    roughness: f32,
-    _pad: vec2<f32>,
 }
 
 struct GpuFace {
@@ -1180,27 +1172,6 @@ fn compute_normal(hit: RayHit) -> vec3<f32> {
     return normalize(normal);
 }
 
-// Fresnel-Schlick approximation
-fn fresnel_schlick(cos_theta: f32, f0: vec3<f32>) -> vec3<f32> {
-    return f0 + (1.0 - f0) * pow(1.0 - cos_theta, 5.0);
-}
-
-// GGX/Trowbridge-Reitz normal distribution
-fn distribution_ggx(n_dot_h: f32, roughness: f32) -> f32 {
-    let a = roughness * roughness;
-    let a2 = a * a;
-    let denom = n_dot_h * n_dot_h * (a2 - 1.0) + 1.0;
-    return a2 / (PI * denom * denom);
-}
-
-// Smith geometry function (GGX)
-fn geometry_smith(n_dot_v: f32, n_dot_l: f32, roughness: f32) -> f32 {
-    let r = roughness + 1.0;
-    let k = (r * r) / 8.0;
-    let ggx_v = n_dot_v / (n_dot_v * (1.0 - k) + k);
-    let ggx_l = n_dot_l / (n_dot_l * (1.0 - k) + k);
-    return ggx_v * ggx_l;
-}
 
 // ACES Narkowicz tonemap. Cleaner highlights and richer mids than Reinhard.
 fn tonemap_aces(x: vec3<f32>) -> vec3<f32> {

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/raytrace.wgsl
@@ -126,10 +126,11 @@ struct GpuAreaLight {
 // highlights on metal. Populated from `pathtrace::studio_rig`, the same
 // function the CPU renderer uses, so both rigs are identical.
 @group(0) @binding(11) var<storage, read> lights: array<GpuAreaLight>;
-// HDR environment: pixels + conditional/marginal CDFs packed into one buffer
-// (see env.wgsl for the layout). One buffer rather than three keeps the
-// storage-binding count inside what browsers allow.
-@group(0) @binding(13) var<storage, read> env_data: array<f32>;
+// HDR environment as textures, not storage buffers: browsers cap
+// maxStorageBuffersPerShaderStage at 10 and the bindings above already use all
+// ten. See env.wgsl for the layout.
+@group(0) @binding(13) var env_pixels: texture_2d<f32>;
+@group(0) @binding(14) var env_cdf: texture_2d<f32>;
 
 // Per-pixel face_idx for analytic crease detection (0xFFFFFFFF = background).
 // Written at frame 1; read at frame 2+ by detect_edge_sobel.

--- a/crates/vcad-kernel-raytrace/src/gpu/shaders/surface.wgsl
+++ b/crates/vcad-kernel-raytrace/src/gpu/shaders/surface.wgsl
@@ -1,0 +1,107 @@
+// Analytic surface parameterisation shared by every shader that shades.
+//
+// Prepended alongside `bsdf.wgsl` (which it depends on for `onb`), so the
+// surface-tangent maths exists in exactly one place and the parity harness can
+// drive it directly rather than through a full render.
+
+const SURFACE_PLANE: u32 = 0u;
+const SURFACE_CYLINDER: u32 = 1u;
+const SURFACE_SPHERE: u32 = 2u;
+const SURFACE_CONE: u32 = 3u;
+const SURFACE_TORUS: u32 = 4u;
+const SURFACE_BILINEAR: u32 = 5u;
+
+const MAX_T: f32 = 1e10;
+const EPSILON: f32 = 1e-6;
+
+// Layout must match GpuSurface in buffers.rs.
+struct GpuSurface {
+    surface_type: u32,
+    // Use explicit u32 padding instead of vec3<u32> to match Rust layout
+    // vec3<u32> in WGSL has 16-byte alignment which would misalign params
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+    params: array<f32, 32>,
+}
+
+// Surface tangent dP/du, or a zero vector where the parameterisation is
+// degenerate (sphere poles, cone apex).
+//
+// Ports the geom crate's `d_du` for each analytic surface — the same quantity
+// `intersect::surface_tangent` hands the CPU path tracer — so an anisotropic
+// highlight follows the SAME circumferential grain in both renderers.
+//
+// Every curved surface here shares the d/du direction (-sin u)·ref + (cos u)·y,
+// differing only by a scalar. The scalar is kept because its magnitude is what
+// detects degeneracy; its sign is irrelevant, since the GGX alpha ellipse is
+// symmetric and t and -t give the same lobe.
+fn surface_dpdu(surface_type: u32, params: array<f32, 32>, uv: vec2<f32>) -> vec3<f32> {
+    let u = uv.x;
+    let v = uv.y;
+    let cos_u = cos(u);
+    let sin_u = sin(u);
+
+    switch surface_type {
+        case SURFACE_PLANE: {
+            // d/du is the constant x_dir.
+            return vec3<f32>(params[3], params[4], params[5]);
+        }
+        case SURFACE_SPHERE: {
+            // center (3), radius (1), ref_dir (3), axis (3)
+            let radius = params[3];
+            let ref_dir = vec3<f32>(params[4], params[5], params[6]);
+            let axis = vec3<f32>(params[7], params[8], params[9]);
+            let y_dir = cross(axis, ref_dir);
+            return (ref_dir * (-sin_u) + y_dir * cos_u) * (radius * cos(v));
+        }
+        case SURFACE_CYLINDER: {
+            // center (3), axis (3), ref_dir (3), radius (1)
+            let axis = vec3<f32>(params[3], params[4], params[5]);
+            let ref_dir = vec3<f32>(params[6], params[7], params[8]);
+            let radius = params[9];
+            let y_dir = cross(axis, ref_dir);
+            return (ref_dir * (-sin_u) + y_dir * cos_u) * radius;
+        }
+        case SURFACE_CONE: {
+            // apex (3), axis (3), ref_dir (3), half_angle (1)
+            let axis = vec3<f32>(params[3], params[4], params[5]);
+            let ref_dir = vec3<f32>(params[6], params[7], params[8]);
+            let half_angle = params[9];
+            let y_dir = cross(axis, ref_dir);
+            return (ref_dir * (-sin_u) + y_dir * cos_u) * (v * sin(half_angle));
+        }
+        case SURFACE_TORUS: {
+            // center (3), axis (3), ref_dir (3), R (1), r (1)
+            let axis = vec3<f32>(params[3], params[4], params[5]);
+            let ref_dir = vec3<f32>(params[6], params[7], params[8]);
+            let major = params[9];
+            let minor = params[10];
+            let y_dir = cross(axis, ref_dir);
+            return (ref_dir * (-sin_u) + y_dir * cos_u) * (major + minor * cos(v));
+        }
+        default: {
+            // Bilinear / B-spline: no analytic tangent, same as the CPU.
+            return vec3<f32>(0.0);
+        }
+    }
+}
+
+// Shading tangent frame around a unit normal.
+//
+// Mirrors `pathtrace::shading_frame`: when the hit carries a surface tangent it
+// is Gram-Schmidt orthogonalised against the (face-forwarded) normal and used
+// as the frame's x axis, so the anisotropic lobe follows the surface's own
+// parameterisation. Otherwise fall back to the arbitrary `onb` basis — which is
+// exactly what an isotropic material wants, since its BSDF is invariant to the
+// choice.
+fn shading_frame(n: vec3<f32>, dpdu: vec3<f32>) -> mat3x3<f32> {
+    let t_raw = dpdu - n * dot(dpdu, n);
+    // A tangent (numerically) parallel to the normal carries no direction;
+    // fall back rather than normalising noise.
+    if length(t_raw) > 1e-9 {
+        let t = normalize(t_raw);
+        return mat3x3<f32>(t, cross(n, t), n);
+    }
+    return onb(n);
+}

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -407,6 +407,23 @@ fn sample_1d(cdf: &[f32], u: f32) -> (usize, f32) {
     (i, d.clamp(0.0, 1.0))
 }
 
+/// An [`EnvMap`] flattened for GPU upload. See [`EnvMap::pack_for_gpu`].
+#[derive(Debug, Clone)]
+pub struct GpuEnvPack {
+    /// Pixels, then conditional CDFs, then the marginal CDF.
+    pub data: Vec<f32>,
+    /// Image width in texels.
+    pub width: u32,
+    /// Image height in texels.
+    pub height: u32,
+    /// Overall multiplier.
+    pub intensity: f32,
+    /// Rotation about +Z in radians.
+    pub rotation: f32,
+    /// PDF normaliser; zero means "not importance-sampled".
+    pub marg_int: f32,
+}
+
 /// A lat-long (equirectangular) HDR environment map with a 2D CDF for
 /// importance sampling.
 ///
@@ -587,6 +604,36 @@ impl EnvMap {
         }
         let two_pi_sq = 2.0 * std::f32::consts::PI * std::f32::consts::PI;
         pdf_uv / (two_pi_sq * sin_t)
+    }
+
+    /// Pack for GPU upload: pixels, then the per-row conditional CDFs, then
+    /// the marginal CDF — the layout `env.wgsl` reads.
+    ///
+    /// Lives here, next to where the CDFs are built, so the two descriptions of
+    /// the layout cannot drift apart.
+    pub fn pack_for_gpu(&self) -> GpuEnvPack {
+        let mut data = Vec::with_capacity(
+            3 * self.width * self.height + self.cond_cdf.len() + self.marg_cdf.len(),
+        );
+        for px in &self.pixels {
+            data.extend_from_slice(px);
+        }
+        data.extend_from_slice(&self.cond_cdf);
+        data.extend_from_slice(&self.marg_cdf);
+        GpuEnvPack {
+            data,
+            width: self.width as u32,
+            height: self.height as u32,
+            intensity: self.intensity,
+            rotation: self.rotation as f32,
+            // Zero when the map carries no energy, which switches the shader's
+            // importance sampling off exactly as `is_sampleable` does here.
+            marg_int: if self.is_sampleable() {
+                self.marg_int
+            } else {
+                0.0
+            },
+        }
     }
 
     /// Importance-sample a direction. Returns `(direction, radiance, pdf)`

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -1139,6 +1139,15 @@ fn bsdf_eval(m: &Pbr, wo: Vec3, wi: Vec3) -> ([f32; 3], f32) {
     (value, pdf.max(0.0))
 }
 
+/// Reference BSDF evaluation, in the local shading frame (+Z = normal).
+///
+/// Exposed so the WGSL port in `gpu/shaders/bsdf.wgsl` can be checked against
+/// this implementation — see `tests/bsdf_parity.rs`. Returns `(f * cos, pdf)`;
+/// the PDF is the one MIS must agree on across both renderers.
+pub fn reference_bsdf_eval(m: &Pbr, wo: Vec3, wi: Vec3) -> ([f32; 3], f32) {
+    bsdf_eval(m, wo, wi)
+}
+
 /// Importance-sample the BSDF. Returns `(wi_local, f*cos, pdf)`.
 fn bsdf_sample(m: &Pbr, wo: Vec3, rng: &mut Rng) -> Option<(Vec3, [f32; 3], f32)> {
     if wo.z <= 0.0 {

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -194,6 +194,81 @@ impl Pbr {
     }
 }
 
+/// Circumferential grain implied by a material's name, when the document does
+/// not state anisotropy explicitly.
+fn anisotropy_from_name(name: &str) -> f32 {
+    let n = name.to_ascii_lowercase();
+    // Turning and boring cut circumferentially, which is the +u direction on
+    // a cylinder — the same direction the tangent frame is built from.
+    if n.contains("turned") || n.contains("machined") || n.contains("bored") {
+        0.6
+    } else if n.contains("brushed") {
+        0.7
+    } else {
+        0.0
+    }
+}
+
+impl Pbr {
+    /// Derive a render material from an IR material definition.
+    ///
+    /// Single source of truth for BOTH renderers: `vcad-render --photoreal`
+    /// and the GPU viewport call this, so a part cannot pick up a different
+    /// clearcoat, IOR or grain depending on which one drew it.
+    pub fn from_material_def(mat: Option<&vcad_ir::MaterialDef>, tint: Option<[f64; 3]>) -> Self {
+        let base = mat.map(|m| m.color).or(tint).unwrap_or([0.62, 0.64, 0.67]);
+        let base_color = [base[0] as f32, base[1] as f32, base[2] as f32];
+
+        let metallic = mat
+            .map(|m| m.metallic as f32)
+            .unwrap_or(0.0)
+            .clamp(0.0, 1.0);
+        // Perfectly sharp mirrors read as CG. Floor roughness slightly.
+        let roughness = mat
+            .map(|m| m.roughness as f32)
+            .unwrap_or(0.35)
+            .clamp(0.03, 1.0);
+        let ior = mat
+            .and_then(|m| m.ior)
+            .map(|v| v as f32)
+            .unwrap_or(1.5)
+            .clamp(1.0, 3.0);
+
+        // Dielectrics that are already glossy get a clearcoat; rough matte
+        // surfaces (sandblasted, as-printed) do not.
+        let clearcoat = if metallic < 0.5 && roughness < 0.5 {
+            0.35 * (1.0 - roughness / 0.5)
+        } else {
+            0.0
+        };
+
+        // Anisotropy is a real IR field (`MaterialDef::anisotropy`) rather than
+        // a rendering-time guess: Rust is the source of truth for IR types, the
+        // value is a genuine property of the surface finish, and it round-trips
+        // in `.vcad`. The name heuristic only fills in when the document says
+        // nothing — a document that names its material "brushed_aluminum" or
+        // "turned_shaft" has told us the finish, and rendering that as a uniform
+        // polish is the CG tell this feature exists to remove. Anything explicit
+        // always wins.
+        let anisotropy = mat
+            .and_then(|m| m.anisotropy)
+            .map(|v| v as f32)
+            .unwrap_or_else(|| mat.map(|m| anisotropy_from_name(&m.name)).unwrap_or(0.0))
+            .clamp(-1.0, 1.0);
+
+        Self {
+            base_color,
+            metallic,
+            roughness,
+            anisotropy,
+            clearcoat,
+            clearcoat_roughness: 0.08,
+            ior,
+            emissive: [0.0; 3],
+        }
+    }
+}
+
 // ─── lights & environment ─────────────────────────────────────────────────
 
 /// A rectangular area light ("softbox"), emitting from its front face only.

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -410,8 +410,10 @@ fn sample_1d(cdf: &[f32], u: f32) -> (usize, f32) {
 /// An [`EnvMap`] flattened for GPU upload. See [`EnvMap::pack_for_gpu`].
 #[derive(Debug, Clone)]
 pub struct GpuEnvPack {
-    /// Pixels, then conditional CDFs, then the marginal CDF.
-    pub data: Vec<f32>,
+    /// RGBA32F radiance, `width * height` texels.
+    pub pixels: Vec<f32>,
+    /// R32F CDF texture, `(width + 1) * (height + 1)`.
+    pub cdf: Vec<f32>,
     /// Image width in texels.
     pub width: u32,
     /// Image height in texels.
@@ -606,22 +608,36 @@ impl EnvMap {
         pdf_uv / (two_pi_sq * sin_t)
     }
 
-    /// Pack for GPU upload: pixels, then the per-row conditional CDFs, then
-    /// the marginal CDF — the layout `env.wgsl` reads.
+    /// Pack for GPU upload as two textures — see `env.wgsl` for why textures
+    /// rather than storage buffers.
+    ///
+    /// `pixels` is RGBA32F (`w * h`); `cdf` is R32F (`(w+1) * (h+1)`) with row
+    /// `j < h` the conditional CDF for row `j` and row `h` the marginal.
     ///
     /// Lives here, next to where the CDFs are built, so the two descriptions of
     /// the layout cannot drift apart.
     pub fn pack_for_gpu(&self) -> GpuEnvPack {
-        let mut data = Vec::with_capacity(
-            3 * self.width * self.height + self.cond_cdf.len() + self.marg_cdf.len(),
-        );
+        let (w, h) = (self.width, self.height);
+
+        let mut pixels = Vec::with_capacity(4 * w * h);
         for px in &self.pixels {
-            data.extend_from_slice(px);
+            pixels.extend_from_slice(px);
+            pixels.push(1.0);
         }
-        data.extend_from_slice(&self.cond_cdf);
-        data.extend_from_slice(&self.marg_cdf);
+
+        // (w + 1) x (h + 1), zero-filled: each conditional row uses the full
+        // width, the marginal uses only its first h + 1 entries.
+        let mut cdf = vec![0.0f32; (w + 1) * (h + 1)];
+        for j in 0..h {
+            let base = j * (w + 1);
+            cdf[base..base + w + 1].copy_from_slice(&self.cond_cdf[base..base + w + 1]);
+        }
+        let marg_row = h * (w + 1);
+        cdf[marg_row..marg_row + self.marg_cdf.len()].copy_from_slice(&self.marg_cdf);
+
         GpuEnvPack {
-            data,
+            pixels,
+            cdf,
             width: self.width as u32,
             height: self.height as u32,
             intensity: self.intensity,

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -56,6 +56,23 @@ struct ParityOutput {
     resampled: [f32; 4],
 }
 
+/// Mirrors `GpuSurface` in `surface.wgsl` / `buffers.rs`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct GpuSurfaceRaw {
+    surface_type: u32,
+    _pad: [u32; 3],
+    params: [f32; 32],
+}
+
+/// Mirrors `TangentInput` in `bsdf_parity.wgsl`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct TangentInput {
+    surface: GpuSurfaceRaw,
+    uv: [f32; 4],
+}
+
 fn ctx_or_skip(test_name: &str) -> Option<&'static GpuContext> {
     match pollster::block_on(GpuContext::init()) {
         Ok(ctx) => Some(ctx),
@@ -67,8 +84,34 @@ fn ctx_or_skip(test_name: &str) -> Option<&'static GpuContext> {
     }
 }
 
-/// Run the BSDF harness over `inputs` and read back one output per input.
-fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
+fn storage_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
+    wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Storage { read_only },
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        count: None,
+    }
+}
+
+/// Run one entry point of the harness module.
+///
+/// Both entry points live in the same module, so the bind group must cover
+/// every binding either of them uses; the pass that does not care about a
+/// buffer still binds a one-element dummy. Returns the raw bytes of the output
+/// buffer the caller asked for (`out_binding` is 1 or 3).
+fn run_pass(
+    ctx: &GpuContext,
+    entry: &str,
+    in0: &[u8],
+    in2: &[u8],
+    out_binding: u32,
+    out_size: u64,
+    invocations: u32,
+) -> Vec<u8> {
     use wgpu::util::DeviceExt;
 
     let source = shaders::compose(shaders::BSDF_PARITY_HARNESS);
@@ -80,23 +123,30 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
             source: wgpu::ShaderSource::Wgsl(source.into()),
         });
 
-    let in_buf = ctx
-        .device
-        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-            label: Some("parity in"),
-            contents: bytemuck::cast_slice(inputs),
-            usage: wgpu::BufferUsages::STORAGE,
-        });
+    let mk_in = |label, bytes: &[u8]| {
+        ctx.device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(label),
+                contents: bytes,
+                usage: wgpu::BufferUsages::STORAGE,
+            })
+    };
+    let mk_out = |label, size: u64| {
+        ctx.device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        })
+    };
 
-    let out_size = (inputs.len() * std::mem::size_of::<ParityOutput>()) as u64;
-    let out_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("parity out"),
-        size: out_size,
-        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
-        mapped_at_creation: false,
-    });
+    let buf0 = mk_in("parity in", in0);
+    let buf2 = mk_in("tangent in", in2);
+    let buf1 = mk_out("parity out", if out_binding == 1 { out_size } else { 64 });
+    let buf3 = mk_out("tangent out", if out_binding == 3 { out_size } else { 64 });
+
     let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("parity readback"),
+        label: Some("readback"),
         size: out_size,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
@@ -107,26 +157,10 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
         .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("parity layout"),
             entries: &[
-                wgpu::BindGroupLayoutEntry {
-                    binding: 0,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
-                wgpu::BindGroupLayoutEntry {
-                    binding: 1,
-                    visibility: wgpu::ShaderStages::COMPUTE,
-                    ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
-                        has_dynamic_offset: false,
-                        min_binding_size: None,
-                    },
-                    count: None,
-                },
+                storage_entry(0, true),
+                storage_entry(1, false),
+                storage_entry(2, true),
+                storage_entry(3, false),
             ],
         });
 
@@ -144,7 +178,7 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
             label: Some("parity pipeline"),
             layout: Some(&pipeline_layout),
             module: &module,
-            entry_point: Some("bsdf_parity"),
+            entry_point: Some(entry),
             compilation_options: Default::default(),
             cache: None,
         });
@@ -164,11 +198,19 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
         entries: &[
             wgpu::BindGroupEntry {
                 binding: 0,
-                resource: in_buf.as_entire_binding(),
+                resource: buf0.as_entire_binding(),
             },
             wgpu::BindGroupEntry {
                 binding: 1,
-                resource: out_buf.as_entire_binding(),
+                resource: buf1.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: buf2.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: buf3.as_entire_binding(),
             },
         ],
     });
@@ -185,9 +227,10 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
         });
         pass.set_pipeline(&pipeline);
         pass.set_bind_group(0, &bind_group, &[]);
-        pass.dispatch_workgroups((inputs.len() as u32).div_ceil(64), 1, 1);
+        pass.dispatch_workgroups(invocations.div_ceil(64), 1, 1);
     }
-    encoder.copy_buffer_to_buffer(&out_buf, 0, &read_buf, 0, out_size);
+    let src = if out_binding == 1 { &buf1 } else { &buf3 };
+    encoder.copy_buffer_to_buffer(src, 0, &read_buf, 0, out_size);
     ctx.queue.submit(Some(encoder.finish()));
 
     let slice = read_buf.slice(..);
@@ -199,10 +242,40 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
     rx.recv().expect("map channel").expect("map read");
 
     let data = slice.get_mapped_range();
-    let out: Vec<ParityOutput> = bytemuck::cast_slice(&data).to_vec();
+    let out = data.to_vec();
     drop(data);
     read_buf.unmap();
     out
+}
+
+/// Run the BSDF harness over `inputs` and read back one output per input.
+fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
+    let dummy = TangentInput::zeroed();
+    let bytes = run_pass(
+        ctx,
+        "bsdf_parity",
+        bytemuck::cast_slice(inputs),
+        bytemuck::bytes_of(&dummy),
+        1,
+        (inputs.len() * std::mem::size_of::<ParityOutput>()) as u64,
+        inputs.len() as u32,
+    );
+    bytemuck::cast_slice(&bytes).to_vec()
+}
+
+/// Run the surface-tangent harness and read back one dP/du per input.
+fn run_tangent_harness(ctx: &GpuContext, inputs: &[TangentInput]) -> Vec<[f32; 4]> {
+    let dummy = ParityInput::zeroed();
+    let bytes = run_pass(
+        ctx,
+        "tangent_parity",
+        bytemuck::bytes_of(&dummy),
+        bytemuck::cast_slice(inputs),
+        3,
+        (inputs.len() * 16) as u64,
+        inputs.len() as u32,
+    );
+    bytemuck::cast_slice(&bytes).to_vec()
 }
 
 /// A spread of materials that exercises every lobe and their combinations.
@@ -531,5 +604,112 @@ fn gpu_anisotropy_actually_changes_the_lobe() {
         (pos - neg).abs() > 1e-4,
         "positive and negative anisotropy produced the same value ({pos} vs \
          {neg}) — the tangent/bitangent alphas are not being swapped",
+    );
+}
+
+/// The GPU's `surface_dpdu` must agree with the geom crate's `d_du` — the same
+/// quantity `intersect::surface_tangent` hands the CPU path tracer.
+///
+/// This is what aligns an anisotropic highlight with the surface's own grain.
+/// Get it wrong and every isotropic material still looks perfect, so nothing
+/// else in the suite would notice.
+///
+/// Compared as *directions*: the frame normalises the tangent and the GGX alpha
+/// ellipse is symmetric, so magnitude and sign are both irrelevant — but
+/// degeneracy (a zero-length tangent at a pole or apex) must agree exactly.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_surface_tangent_matches_geom_d_du() {
+    use vcad_kernel_geom::{
+        ConeSurface, CylinderSurface, Plane, SphereSurface, Surface, TorusSurface,
+    };
+    use vcad_kernel_math::{Point2, Point3, Vec3};
+    use vcad_kernel_raytrace::gpu::GpuSurface;
+    use vcad_kernel_raytrace::intersect::surface_tangent;
+
+    let Some(ctx) = ctx_or_skip("gpu_surface_tangent_matches_geom_d_du") else {
+        return;
+    };
+
+    // Off-origin, off-axis where the constructors allow it, so a transcription
+    // that silently assumed a canonical frame would show up.
+    let o = Point3::new(1.0, -2.0, 0.5);
+    let tilted = Vec3::new(0.3, -0.2, 1.0);
+    let surfaces: Vec<Box<dyn Surface>> = vec![
+        Box::new(Plane::new(
+            o,
+            Vec3::new(0.8, 0.6, 0.0),
+            Vec3::new(-0.6, 0.8, 0.0),
+        )),
+        Box::new(CylinderSurface::with_axis(o, tilted, 7.5)),
+        Box::new(SphereSurface::with_center(o, 4.25)),
+        Box::new(ConeSurface::new(0.45)),
+        Box::new(TorusSurface::with_axis(o, tilted, 9.0, 2.5)),
+    ];
+
+    // Sweep u right around, and v across both hemispheres / both sides of the
+    // cone apex, so the degenerate cases are covered too.
+    let uvs: Vec<(f64, f64)> = (0..8)
+        .flat_map(|i| {
+            let u = i as f64 * std::f64::consts::TAU / 8.0;
+            [-1.2, -0.5, 0.0, 0.5, 1.2].map(move |v| (u, v))
+        })
+        .collect();
+
+    let mut inputs = Vec::new();
+    let mut expected = Vec::new();
+    for s in &surfaces {
+        let packed = GpuSurface::from_surface(s.as_ref());
+        for &(u, v) in &uvs {
+            inputs.push(TangentInput {
+                surface: GpuSurfaceRaw {
+                    surface_type: packed.surface_type,
+                    _pad: [0; 3],
+                    params: packed.params,
+                },
+                uv: [u as f32, v as f32, 0.0, 0.0],
+            });
+            expected.push(surface_tangent(s.as_ref(), Point2::new(u, v)));
+        }
+    }
+
+    let out = run_tangent_harness(ctx, &inputs);
+    assert_eq!(out.len(), inputs.len());
+
+    let mut compared = 0usize;
+    for (i, (got, want)) in out.iter().zip(&expected).enumerate() {
+        let g = Vec3::new(got[0] as f64, got[1] as f64, got[2] as f64);
+        match want {
+            None => assert!(
+                g.norm() <= 1e-6,
+                "input {i}: CPU reports a degenerate tangent but the GPU \
+                 returned {g:?} — the shader would build a frame from noise",
+            ),
+            Some(w) => {
+                assert!(
+                    g.norm() > 1e-9,
+                    "input {i}: GPU returned a zero tangent where the CPU has \
+                     {w:?} — anisotropic shading would silently fall back to \
+                     an arbitrary basis here",
+                );
+                // Direction only, sign-insensitive.
+                let cosang = (g.normalize().dot(w.normalize())).abs();
+                assert!(
+                    cosang > 1.0 - 1e-4,
+                    "input {i}: tangent direction diverged — GPU {:?} vs CPU \
+                     {:?} (|cos| {cosang}). An anisotropic highlight would run \
+                     the wrong way across this surface.",
+                    g.normalize(),
+                    w.normalize(),
+                );
+                compared += 1;
+            }
+        }
+    }
+    assert!(
+        compared > inputs.len() / 2,
+        "only {compared}/{} tangents were non-degenerate — the sweep is not \
+         exercising the surfaces",
+        inputs.len(),
     );
 }

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -713,3 +713,87 @@ fn gpu_surface_tangent_matches_geom_d_du() {
         inputs.len(),
     );
 }
+
+/// A `MaterialDef` must produce the same render material on both paths.
+///
+/// `setMaterial` used to carry only colour/metallic/roughness, so clearcoat,
+/// IOR and anisotropy were silently dropped on the way to the GPU and a
+/// brushed or lacquered part shaded differently in the viewport than under
+/// `--photoreal`. Both now go through `Pbr::from_material_def`; this pins that
+/// the GPU packing round-trips it without loss.
+#[test]
+fn gpu_material_round_trips_the_shared_derivation() {
+    use vcad_ir::MaterialDef;
+    use vcad_kernel_raytrace::pathtrace::Pbr;
+
+    let defs = [
+        // Explicit anisotropy wins over the name heuristic.
+        MaterialDef {
+            name: "brushed_aluminum".into(),
+            color: [0.91, 0.92, 0.92],
+            metallic: 1.0,
+            roughness: 0.28,
+            anisotropy: Some(-0.4),
+            ..Default::default()
+        },
+        // Name heuristic fills in when the document says nothing.
+        MaterialDef {
+            name: "turned_shaft".into(),
+            color: [0.7, 0.7, 0.72],
+            metallic: 1.0,
+            roughness: 0.2,
+            ..Default::default()
+        },
+        // Glossy dielectric: picks up the derived clearcoat.
+        MaterialDef {
+            name: "abs_gloss".into(),
+            color: [0.2, 0.35, 0.7],
+            metallic: 0.0,
+            roughness: 0.15,
+            ior: Some(1.6),
+            ..Default::default()
+        },
+    ];
+
+    for d in &defs {
+        let cpu = Pbr::from_material_def(Some(d), None);
+        let gpu = GpuMaterial::from_pbr(cpu).to_pbr();
+        assert_eq!(
+            cpu.metallic, gpu.metallic,
+            "{}: metallic lost in the GPU packing",
+            d.name
+        );
+        assert_eq!(cpu.roughness, gpu.roughness, "{}: roughness lost", d.name);
+        assert_eq!(
+            cpu.clearcoat, gpu.clearcoat,
+            "{}: clearcoat lost — the viewport would render this matte",
+            d.name
+        );
+        assert_eq!(cpu.ior, gpu.ior, "{}: ior lost", d.name);
+        assert_eq!(
+            cpu.anisotropy, gpu.anisotropy,
+            "{}: anisotropy lost — the grain would vanish in the viewport",
+            d.name
+        );
+        assert_eq!(cpu.base_color, gpu.base_color, "{}: colour lost", d.name);
+    }
+
+    // The heuristic must actually be doing something, or the assertions above
+    // are comparing zero against zero.
+    let turned = Pbr::from_material_def(Some(&defs[1]), None);
+    assert!(
+        turned.anisotropy > 0.5,
+        "the name heuristic did not fire for 'turned_shaft' (got {})",
+        turned.anisotropy
+    );
+    let brushed = Pbr::from_material_def(Some(&defs[0]), None);
+    assert!(
+        (brushed.anisotropy - -0.4).abs() < 1e-6,
+        "explicit anisotropy should win over the name heuristic (got {})",
+        brushed.anisotropy
+    );
+    assert!(
+        Pbr::from_material_def(Some(&defs[2]), None).clearcoat > 0.0,
+        "a glossy dielectric should pick up a clearcoat"
+    );
+}

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -314,9 +314,9 @@ fn gpu_bsdf_eval_matches_cpu_reference() {
         let wi = Vec3::new(inp.wi[0] as f64, inp.wi[1] as f64, inp.wi[2] as f64);
         let (ref_value, ref_pdf) = reference_bsdf_eval(&pbr, wo, wi);
 
-        for c in 0..3 {
-            let d = (out.eval[c] - ref_value[c]).abs();
-            let tol = 2e-4 * ref_value[c].abs().max(1.0);
+        for (c, &rv) in ref_value.iter().enumerate() {
+            let d = (out.eval[c] - rv).abs();
+            let tol = 2e-4 * rv.abs().max(1.0);
             worst_value = worst_value.max(d);
             assert!(
                 d <= tol,
@@ -325,7 +325,7 @@ fn gpu_bsdf_eval_matches_cpu_reference() {
                  pathtrace::bsdf_eval; the viewport and --photoreal will \
                  disagree on this material.",
                 out.eval[c],
-                ref_value[c],
+                rv,
             );
         }
 

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -108,13 +108,14 @@ fn run_pass(
     ctx: &GpuContext,
     entry: &str,
     ins: &[(u32, &[u8])],
+    env: Option<&vcad_kernel_raytrace::pathtrace::GpuEnvPack>,
     out_binding: u32,
     out_size: u64,
     invocations: u32,
 ) -> Vec<u8> {
     use wgpu::util::DeviceExt;
 
-    const IN_BINDINGS: [u32; 4] = [0, 2, 4, 6];
+    const IN_BINDINGS: [u32; 3] = [0, 2, 4];
     const OUT_BINDINGS: [u32; 3] = [1, 3, 5];
 
     let source = shaders::compose(shaders::BSDF_PARITY_HARNESS);
@@ -158,6 +159,85 @@ fn run_pass(
     }
     buffers.sort_by_key(|(b, _)| *b);
 
+    // Environment textures (bindings 6 and 7). A pass that does not use them
+    // still binds 1x1 dummies — a texture binding cannot be null.
+    let mk_tex = |w: u32, h: u32, fmt: wgpu::TextureFormat, data: &[f32]| {
+        let tex = ctx.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("env tex"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: fmt,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let bpp = if fmt == wgpu::TextureFormat::Rgba32Float {
+            16
+        } else {
+            4
+        };
+        ctx.queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &tex,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            bytemuck::cast_slice(data),
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(w * bpp),
+                rows_per_image: Some(h),
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+        tex.create_view(&wgpu::TextureViewDescriptor::default())
+    };
+    let (env_px, env_cdf) = match env {
+        Some(e) => (
+            mk_tex(
+                e.width,
+                e.height,
+                wgpu::TextureFormat::Rgba32Float,
+                &e.pixels,
+            ),
+            mk_tex(
+                e.width + 1,
+                e.height + 1,
+                wgpu::TextureFormat::R32Float,
+                &e.cdf,
+            ),
+        ),
+        None => (
+            mk_tex(
+                1,
+                1,
+                wgpu::TextureFormat::Rgba32Float,
+                &[0.0, 0.0, 0.0, 1.0],
+            ),
+            mk_tex(1, 1, wgpu::TextureFormat::R32Float, &[0.0]),
+        ),
+    };
+    let tex_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+        binding,
+        visibility: wgpu::ShaderStages::COMPUTE,
+        ty: wgpu::BindingType::Texture {
+            sample_type: wgpu::TextureSampleType::Float { filterable: false },
+            view_dimension: wgpu::TextureViewDimension::D2,
+            multisampled: false,
+        },
+        count: None,
+    };
+
     let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("readback"),
         size: out_size,
@@ -165,10 +245,12 @@ fn run_pass(
         mapped_at_creation: false,
     });
 
-    let entries: Vec<wgpu::BindGroupLayoutEntry> = buffers
+    let mut entries: Vec<wgpu::BindGroupLayoutEntry> = buffers
         .iter()
         .map(|(b, _)| storage_entry(*b, IN_BINDINGS.contains(b)))
         .collect();
+    entries.push(tex_entry(6));
+    entries.push(tex_entry(7));
     let layout = ctx
         .device
         .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -204,13 +286,21 @@ fn run_pass(
          assertion below compare 0 against 0 and pass vacuously.",
     );
 
-    let bg_entries: Vec<wgpu::BindGroupEntry> = buffers
+    let mut bg_entries: Vec<wgpu::BindGroupEntry> = buffers
         .iter()
         .map(|(b, buf)| wgpu::BindGroupEntry {
             binding: *b,
             resource: buf.as_entire_binding(),
         })
         .collect();
+    bg_entries.push(wgpu::BindGroupEntry {
+        binding: 6,
+        resource: wgpu::BindingResource::TextureView(&env_px),
+    });
+    bg_entries.push(wgpu::BindGroupEntry {
+        binding: 7,
+        resource: wgpu::BindingResource::TextureView(&env_cdf),
+    });
     let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("parity bind group"),
         layout: &layout,
@@ -256,6 +346,7 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
         ctx,
         "bsdf_parity",
         &[(0, bytemuck::cast_slice(inputs))],
+        None,
         1,
         (inputs.len() * std::mem::size_of::<ParityOutput>()) as u64,
         inputs.len() as u32,
@@ -269,6 +360,7 @@ fn run_tangent_harness(ctx: &GpuContext, inputs: &[TangentInput]) -> Vec<[f32; 4
         ctx,
         "tangent_parity",
         &[(2, bytemuck::cast_slice(inputs))],
+        None,
         3,
         (inputs.len() * 16) as u64,
         inputs.len() as u32,
@@ -891,10 +983,8 @@ fn gpu_environment_matches_cpu_envmap() {
     let bytes = run_pass(
         ctx,
         "env_parity",
-        &[
-            (4, bytemuck::cast_slice(&inputs)),
-            (6, bytemuck::cast_slice(&pack.data)),
-        ],
+        &[(4, bytemuck::cast_slice(&inputs))],
+        Some(&pack),
         5,
         (inputs.len() * std::mem::size_of::<EnvOutput>()) as u64,
         inputs.len() as u32,
@@ -999,10 +1089,8 @@ fn gpu_environment_sampling_finds_the_sun() {
     let bytes = run_pass(
         ctx,
         "env_parity",
-        &[
-            (4, bytemuck::cast_slice(&inputs)),
-            (6, bytemuck::cast_slice(&pack.data)),
-        ],
+        &[(4, bytemuck::cast_slice(&inputs))],
+        Some(&pack),
         5,
         (inputs.len() * std::mem::size_of::<EnvOutput>()) as u64,
         inputs.len() as u32,
@@ -1058,5 +1146,35 @@ fn gpu_environment_sampling_finds_the_sun() {
         "GPU env integral {integral} vs CPU {cpu_integral} (rel {rel}) — the \
          estimators disagree, so the two renderers would converge to different \
          images",
+    );
+}
+
+/// The render shader must stay inside the browser's storage-buffer budget.
+///
+/// WebGPU's `maxStorageBuffersPerShaderStage` is **10** in Chrome, and the
+/// renderer sits exactly at that limit. Native Metal allows far more, so every
+/// GPU test here passes while the app viewport dies with an "Invalid
+/// BindGroupLayout" — the shader compiles, the pipeline is rejected, and the
+/// overlay silently never paints. That happened once; this is the guard.
+///
+/// If you need more data in the shader, use a texture (48 slots) rather than an
+/// eleventh storage buffer, as the HDR environment does.
+#[test]
+fn render_shader_fits_the_browser_storage_buffer_budget() {
+    const BROWSER_LIMIT: usize = 10;
+    let src = shaders::raytrace_shader();
+    let count = src
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with("//") && t.contains("var<storage")
+        })
+        .count();
+    assert!(
+        count <= BROWSER_LIMIT,
+        "the ray trace shader declares {count} storage buffers, over the \
+         browser limit of {BROWSER_LIMIT}. WebGPU will reject the bind group \
+         layout and the viewport will render nothing, while every native GPU \
+         test still passes. Move the new data into a texture instead.",
     );
 }

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -1,0 +1,455 @@
+//! Parity tests for the shared BSDF.
+//!
+//! The GPU viewport and the CPU photoreal renderer are supposed to shade with
+//! ONE model: `pathtrace.rs` is the reference, `gpu/shaders/bsdf.wgsl` is a
+//! port of it. Nothing about a rendered image makes a divergence between them
+//! obvious — a wrong PDF or a dropped Fresnel term just shifts energy a little
+//! and still looks like a plausible render. These tests run the WGSL on real
+//! hardware and compare it to the Rust, number by number.
+//!
+//! Three things are checked:
+//!
+//! 1. `gpu_bsdf_eval_matches_cpu_reference` — the port agrees with the
+//!    reference on `(f*cos, pdf)` across a grid of materials and directions.
+//! 2. `gpu_bsdf_sample_pdf_matches_eval_pdf` — the PDF returned by
+//!    `bsdf_sample` equals the PDF `bsdf_eval` reports for the sampled
+//!    direction. This is the MIS invariant, and the GPU-side mirror of
+//!    `pathtrace::tests::bsdf_sample_pdf_matches_eval_pdf`.
+//! 3. `gpu_furnace_conserves_energy` — the Monte Carlo estimator `E[f/pdf]`
+//!    lands on a plausible directional albedo. Unlike (2), which the current
+//!    implementations satisfy structurally, this would actually catch a
+//!    sampling routine that drew from a different distribution than its PDF
+//!    claims.
+//!
+//! `#[ignore]`-tagged like the other GPU tests; run locally with:
+//!
+//! ```text
+//! cargo test -p vcad-kernel-raytrace --features gpu --test bsdf_parity -- --ignored
+//! ```
+
+#![cfg(all(feature = "gpu", not(target_arch = "wasm32")))]
+
+use bytemuck::{Pod, Zeroable};
+use vcad_kernel_gpu::{GpuContext, GpuError};
+use vcad_kernel_math::Vec3;
+use vcad_kernel_raytrace::gpu::shaders;
+use vcad_kernel_raytrace::gpu::GpuMaterial;
+use vcad_kernel_raytrace::pathtrace::{reference_bsdf_eval, Pbr};
+
+/// Mirrors `ParityInput` in `bsdf_parity.wgsl`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct ParityInput {
+    material: GpuMaterial,
+    wo: [f32; 4],
+    wi: [f32; 4],
+    rnd: [f32; 4],
+}
+
+/// Mirrors `ParityOutput` in `bsdf_parity.wgsl`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
+struct ParityOutput {
+    eval: [f32; 4],
+    sample_dir: [f32; 4],
+    sample_value: [f32; 4],
+    resampled: [f32; 4],
+}
+
+fn ctx_or_skip(test_name: &str) -> Option<&'static GpuContext> {
+    match pollster::block_on(GpuContext::init()) {
+        Ok(ctx) => Some(ctx),
+        Err(GpuError::NoAdapter) => {
+            eprintln!("[{test_name}] skipped: no compatible GPU adapter");
+            None
+        }
+        Err(e) => panic!("GPU init failed unexpectedly: {e}"),
+    }
+}
+
+/// Run the BSDF harness over `inputs` and read back one output per input.
+fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
+    use wgpu::util::DeviceExt;
+
+    let source = shaders::compose(shaders::BSDF_PARITY_HARNESS);
+    ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
+    let module = ctx
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("BSDF parity harness"),
+            source: wgpu::ShaderSource::Wgsl(source.into()),
+        });
+
+    let in_buf = ctx
+        .device
+        .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("parity in"),
+            contents: bytemuck::cast_slice(inputs),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+
+    let out_size = (inputs.len() * std::mem::size_of::<ParityOutput>()) as u64;
+    let out_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("parity out"),
+        size: out_size,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("parity readback"),
+        size: out_size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let layout = ctx
+        .device
+        .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("parity layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+    let pipeline_layout = ctx
+        .device
+        .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("parity pipeline layout"),
+            bind_group_layouts: &[&layout],
+            push_constant_ranges: &[],
+        });
+
+    let pipeline = ctx
+        .device
+        .create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("parity pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &module,
+            entry_point: Some("bsdf_parity"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+    let validation = pollster::block_on(ctx.device.pop_error_scope());
+    assert!(
+        validation.is_none(),
+        "BSDF harness failed WebGPU validation: {validation:?}\n\
+         A WGSL compile error here silently no-ops the dispatch and the \
+         readback comes back all zeros — which would make every parity \
+         assertion below compare 0 against 0 and pass vacuously.",
+    );
+
+    let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("parity bind group"),
+        layout: &layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: in_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: out_buf.as_entire_binding(),
+            },
+        ],
+    });
+
+    let mut encoder = ctx
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("parity encoder"),
+        });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("parity pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups((inputs.len() as u32).div_ceil(64), 1, 1);
+    }
+    encoder.copy_buffer_to_buffer(&out_buf, 0, &read_buf, 0, out_size);
+    ctx.queue.submit(Some(encoder.finish()));
+
+    let slice = read_buf.slice(..);
+    let (tx, rx) = std::sync::mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |r| {
+        let _ = tx.send(r);
+    });
+    ctx.device.poll(wgpu::Maintain::Wait);
+    rx.recv().expect("map channel").expect("map read");
+
+    let data = slice.get_mapped_range();
+    let out: Vec<ParityOutput> = bytemuck::cast_slice(&data).to_vec();
+    drop(data);
+    read_buf.unmap();
+    out
+}
+
+/// A spread of materials that exercises every lobe and their combinations.
+fn test_materials() -> Vec<GpuMaterial> {
+    vec![
+        // Rough dielectric — diffuse dominant.
+        GpuMaterial {
+            color: [0.8, 0.7, 0.6, 1.0],
+            metallic: 0.0,
+            roughness: 0.6,
+            ..Default::default()
+        },
+        // Smooth metal — specular only, no diffuse lobe.
+        GpuMaterial {
+            color: [0.95, 0.93, 0.88, 1.0],
+            metallic: 1.0,
+            roughness: 0.08,
+            ..Default::default()
+        },
+        // Half-metal at mid roughness — the awkward blend.
+        GpuMaterial {
+            color: [0.8, 0.8, 0.8, 1.0],
+            metallic: 0.3,
+            roughness: 0.4,
+            ..Default::default()
+        },
+        // Clearcoated plastic — all three lobes active. Matches the material
+        // used by the Rust-side pdf test.
+        GpuMaterial {
+            color: [0.8, 0.8, 0.8, 1.0],
+            metallic: 0.3,
+            roughness: 0.4,
+            clearcoat: 0.5,
+            clearcoat_roughness: 0.1,
+            ior: 1.5,
+            _pad: [0.0; 3],
+        },
+        // High IOR dielectric, strong coat — pushes F0 and coat attenuation.
+        GpuMaterial {
+            color: [0.2, 0.35, 0.7, 1.0],
+            metallic: 0.0,
+            roughness: 0.25,
+            clearcoat: 1.0,
+            clearcoat_roughness: 0.03,
+            ior: 1.8,
+            _pad: [0.0; 3],
+        },
+    ]
+}
+
+/// Deterministic low-discrepancy-ish sequence, so a failure reproduces.
+fn halton(mut i: u32, base: u32) -> f32 {
+    let mut f = 1.0f32;
+    let mut r = 0.0f32;
+    while i > 0 {
+        f /= base as f32;
+        r += f * (i % base) as f32;
+        i /= base;
+    }
+    r
+}
+
+fn unit(v: [f32; 3]) -> [f32; 3] {
+    let n = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    [v[0] / n, v[1] / n, v[2] / n]
+}
+
+/// The port must agree with the Rust reference on both the BSDF value and the
+/// PDF. Tolerance is f32-scale: the reference computes in f64.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_bsdf_eval_matches_cpu_reference() {
+    let Some(ctx) = ctx_or_skip("gpu_bsdf_eval_matches_cpu_reference") else {
+        return;
+    };
+
+    let mut inputs = Vec::new();
+    for m in test_materials() {
+        for k in 1..=24u32 {
+            // A spread of view and light directions in the upper hemisphere,
+            // including grazing angles where Fresnel and Smith terms bite.
+            let wo = unit([
+                0.9 * (halton(k, 2) - 0.5),
+                0.9 * (halton(k, 3) - 0.5),
+                0.15 + 0.85 * halton(k, 5),
+            ]);
+            let wi = unit([
+                0.9 * (halton(k + 7, 3) - 0.5),
+                0.9 * (halton(k + 7, 5) - 0.5),
+                0.15 + 0.85 * halton(k + 7, 2),
+            ]);
+            inputs.push(ParityInput {
+                material: m,
+                wo: [wo[0], wo[1], wo[2], 0.0],
+                wi: [wi[0], wi[1], wi[2], 0.0],
+                rnd: [halton(k, 7), halton(k, 11), halton(k, 13), 0.0],
+            });
+        }
+    }
+
+    let outputs = run_harness(ctx, &inputs);
+    assert_eq!(outputs.len(), inputs.len());
+
+    let mut worst_value = 0.0f32;
+    let mut worst_pdf = 0.0f32;
+    for (i, (inp, out)) in inputs.iter().zip(&outputs).enumerate() {
+        let pbr: Pbr = inp.material.to_pbr();
+        let wo = Vec3::new(inp.wo[0] as f64, inp.wo[1] as f64, inp.wo[2] as f64);
+        let wi = Vec3::new(inp.wi[0] as f64, inp.wi[1] as f64, inp.wi[2] as f64);
+        let (ref_value, ref_pdf) = reference_bsdf_eval(&pbr, wo, wi);
+
+        for c in 0..3 {
+            let d = (out.eval[c] - ref_value[c]).abs();
+            let tol = 2e-4 * ref_value[c].abs().max(1.0);
+            worst_value = worst_value.max(d);
+            assert!(
+                d <= tol,
+                "input {i}: BSDF value channel {c} diverged — GPU {} vs CPU {} \
+                 (delta {d}). The WGSL port in bsdf.wgsl no longer matches \
+                 pathtrace::bsdf_eval; the viewport and --photoreal will \
+                 disagree on this material.",
+                out.eval[c],
+                ref_value[c],
+            );
+        }
+
+        let dp = (out.eval[3] - ref_pdf).abs();
+        let tolp = 2e-4 * ref_pdf.abs().max(1.0);
+        worst_pdf = worst_pdf.max(dp);
+        assert!(
+            dp <= tolp,
+            "input {i}: PDF diverged — GPU {} vs CPU {ref_pdf} (delta {dp}). \
+             MIS weights are computed from this number, so a mismatch makes \
+             the GPU image energy-wrong in a way that is invisible by eye.",
+            out.eval[3],
+        );
+    }
+    eprintln!("worst value delta {worst_value:e}, worst pdf delta {worst_pdf:e}");
+
+    // Guard against a vacuous pass: if the dispatch silently no-op'd, every
+    // output would be zero and the comparisons above would still hold only if
+    // the reference were also zero everywhere. Require real signal.
+    let non_zero = outputs.iter().filter(|o| o.eval[3] > 0.0).count();
+    assert!(
+        non_zero > inputs.len() / 2,
+        "only {non_zero}/{} inputs produced a positive PDF — the harness \
+         probably did not run",
+        inputs.len(),
+    );
+}
+
+/// The MIS invariant, checked on the GPU: the PDF `bsdf_sample` hands back must
+/// be the PDF `bsdf_eval` reports for the direction it sampled.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_bsdf_sample_pdf_matches_eval_pdf() {
+    let Some(ctx) = ctx_or_skip("gpu_bsdf_sample_pdf_matches_eval_pdf") else {
+        return;
+    };
+
+    let wo = unit([0.3, 0.15, 0.94]);
+    let mut inputs = Vec::new();
+    for m in test_materials() {
+        for k in 1..=256u32 {
+            inputs.push(ParityInput {
+                material: m,
+                wo: [wo[0], wo[1], wo[2], 0.0],
+                wi: [0.0, 0.0, 1.0, 0.0],
+                rnd: [halton(k, 2), halton(k, 3), halton(k, 5), 0.0],
+            });
+        }
+    }
+
+    let outputs = run_harness(ctx, &inputs);
+    let mut sampled = 0usize;
+    for (i, out) in outputs.iter().enumerate() {
+        if out.sample_value[3] < 0.5 {
+            continue; // sample was rejected (below horizon); nothing to check
+        }
+        sampled += 1;
+        let pdf = out.sample_dir[3];
+        let re_pdf = out.resampled[0];
+        assert!(
+            (pdf - re_pdf).abs() <= 1e-4 * pdf.max(1.0),
+            "sample {i}: pdf mismatch — bsdf_sample returned {pdf}, \
+             bsdf_eval reports {re_pdf} for the same directions. MIS combines \
+             these two numbers; when they disagree the image is energy-wrong \
+             and still looks plausible.",
+        );
+    }
+    assert!(
+        sampled > inputs.len() / 4,
+        "only {sampled}/{} samples succeeded — the harness probably did not run",
+        inputs.len(),
+    );
+}
+
+/// White furnace: `E[f/pdf]` is the directional albedo. If `bsdf_sample` drew
+/// from a distribution that did not match the PDF it reports, this integral
+/// would drift away from unity even though test (2) still passed.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_furnace_conserves_energy() {
+    let Some(ctx) = ctx_or_skip("gpu_furnace_conserves_energy") else {
+        return;
+    };
+
+    // Pure-white rough dielectric, viewed head-on — matches the Rust-side
+    // `furnace_conserves_energy_roughly` setup.
+    let m = GpuMaterial {
+        color: [1.0, 1.0, 1.0, 1.0],
+        metallic: 0.0,
+        roughness: 0.5,
+        clearcoat: 0.0,
+        clearcoat_roughness: 0.1,
+        ior: 1.5,
+        _pad: [0.0; 3],
+    };
+
+    let n = 20_000u32;
+    let inputs: Vec<ParityInput> = (0..n)
+        .map(|k| ParityInput {
+            material: m,
+            wo: [0.0, 0.0, 1.0, 0.0],
+            wi: [0.0, 0.0, 1.0, 0.0],
+            // Three independent-ish streams for lobe pick and the two lobe
+            // parameters.
+            rnd: [halton(k + 1, 2), halton(k + 1, 3), halton(k + 1, 5), 0.0],
+        })
+        .collect();
+
+    let outputs = run_harness(ctx, &inputs);
+    let mut sum = 0.0f64;
+    for out in &outputs {
+        if out.sample_value[3] < 0.5 {
+            continue;
+        }
+        let pdf = out.sample_dir[3];
+        if pdf > 0.0 {
+            sum += (out.sample_value[0] / pdf) as f64;
+        }
+    }
+    let albedo = sum / n as f64;
+    assert!(
+        (0.75..=1.05).contains(&albedo),
+        "GPU directional albedo {albedo} outside the plausible range — the \
+         WGSL sampling routine and its PDF disagree, so the path tracer will \
+         gain or lose energy at every bounce.",
+    );
+}

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -99,20 +99,23 @@ fn storage_entry(binding: u32, read_only: bool) -> wgpu::BindGroupLayoutEntry {
 
 /// Run one entry point of the harness module.
 ///
-/// Both entry points live in the same module, so the bind group must cover
-/// every binding either of them uses; the pass that does not care about a
-/// buffer still binds a one-element dummy. Returns the raw bytes of the output
-/// buffer the caller asked for (`out_binding` is 1 or 3).
+/// All entry points live in one module, so the bind group must cover every
+/// binding any of them uses; a pass that does not care about a buffer still
+/// binds a small dummy. Inputs sit on even bindings, outputs on odd ones
+/// (plus binding 6, the environment data). Returns the raw bytes of
+/// `out_binding`.
 fn run_pass(
     ctx: &GpuContext,
     entry: &str,
-    in0: &[u8],
-    in2: &[u8],
+    ins: &[(u32, &[u8])],
     out_binding: u32,
     out_size: u64,
     invocations: u32,
 ) -> Vec<u8> {
     use wgpu::util::DeviceExt;
+
+    const IN_BINDINGS: [u32; 4] = [0, 2, 4, 6];
+    const OUT_BINDINGS: [u32; 3] = [1, 3, 5];
 
     let source = shaders::compose(shaders::BSDF_PARITY_HARNESS);
     ctx.device.push_error_scope(wgpu::ErrorFilter::Validation);
@@ -123,27 +126,37 @@ fn run_pass(
             source: wgpu::ShaderSource::Wgsl(source.into()),
         });
 
-    let mk_in = |label, bytes: &[u8]| {
-        ctx.device
-            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some(label),
-                contents: bytes,
-                usage: wgpu::BufferUsages::STORAGE,
-            })
-    };
-    let mk_out = |label, size: u64| {
-        ctx.device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some(label),
-            size,
-            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
-            mapped_at_creation: false,
-        })
-    };
-
-    let buf0 = mk_in("parity in", in0);
-    let buf2 = mk_in("tangent in", in2);
-    let buf1 = mk_out("parity out", if out_binding == 1 { out_size } else { 64 });
-    let buf3 = mk_out("tangent out", if out_binding == 3 { out_size } else { 64 });
+    let dummy = [0u8; 64];
+    let mut buffers: Vec<(u32, wgpu::Buffer)> = Vec::new();
+    for b in IN_BINDINGS {
+        let bytes = ins
+            .iter()
+            .find(|(bind, _)| *bind == b)
+            .map(|(_, d)| *d)
+            .unwrap_or(&dummy);
+        buffers.push((
+            b,
+            ctx.device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("harness in"),
+                    contents: bytes,
+                    usage: wgpu::BufferUsages::STORAGE,
+                }),
+        ));
+    }
+    for b in OUT_BINDINGS {
+        let size = if b == out_binding { out_size } else { 64 };
+        buffers.push((
+            b,
+            ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("harness out"),
+                size,
+                usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+                mapped_at_creation: false,
+            }),
+        ));
+    }
+    buffers.sort_by_key(|(b, _)| *b);
 
     let read_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("readback"),
@@ -152,16 +165,15 @@ fn run_pass(
         mapped_at_creation: false,
     });
 
+    let entries: Vec<wgpu::BindGroupLayoutEntry> = buffers
+        .iter()
+        .map(|(b, _)| storage_entry(*b, IN_BINDINGS.contains(b)))
+        .collect();
     let layout = ctx
         .device
         .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("parity layout"),
-            entries: &[
-                storage_entry(0, true),
-                storage_entry(1, false),
-                storage_entry(2, true),
-                storage_entry(3, false),
-            ],
+            entries: &entries,
         });
 
     let pipeline_layout = ctx
@@ -186,33 +198,23 @@ fn run_pass(
     let validation = pollster::block_on(ctx.device.pop_error_scope());
     assert!(
         validation.is_none(),
-        "BSDF harness failed WebGPU validation: {validation:?}\n\
+        "harness failed WebGPU validation: {validation:?}\n\
          A WGSL compile error here silently no-ops the dispatch and the \
          readback comes back all zeros — which would make every parity \
          assertion below compare 0 against 0 and pass vacuously.",
     );
 
+    let bg_entries: Vec<wgpu::BindGroupEntry> = buffers
+        .iter()
+        .map(|(b, buf)| wgpu::BindGroupEntry {
+            binding: *b,
+            resource: buf.as_entire_binding(),
+        })
+        .collect();
     let bind_group = ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("parity bind group"),
         layout: &layout,
-        entries: &[
-            wgpu::BindGroupEntry {
-                binding: 0,
-                resource: buf0.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 1,
-                resource: buf1.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 2,
-                resource: buf2.as_entire_binding(),
-            },
-            wgpu::BindGroupEntry {
-                binding: 3,
-                resource: buf3.as_entire_binding(),
-            },
-        ],
+        entries: &bg_entries,
     });
 
     let mut encoder = ctx
@@ -229,7 +231,7 @@ fn run_pass(
         pass.set_bind_group(0, &bind_group, &[]);
         pass.dispatch_workgroups(invocations.div_ceil(64), 1, 1);
     }
-    let src = if out_binding == 1 { &buf1 } else { &buf3 };
+    let src = &buffers.iter().find(|(b, _)| *b == out_binding).unwrap().1;
     encoder.copy_buffer_to_buffer(src, 0, &read_buf, 0, out_size);
     ctx.queue.submit(Some(encoder.finish()));
 
@@ -250,12 +252,10 @@ fn run_pass(
 
 /// Run the BSDF harness over `inputs` and read back one output per input.
 fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
-    let dummy = TangentInput::zeroed();
     let bytes = run_pass(
         ctx,
         "bsdf_parity",
-        bytemuck::cast_slice(inputs),
-        bytemuck::bytes_of(&dummy),
+        &[(0, bytemuck::cast_slice(inputs))],
         1,
         (inputs.len() * std::mem::size_of::<ParityOutput>()) as u64,
         inputs.len() as u32,
@@ -265,12 +265,10 @@ fn run_harness(ctx: &GpuContext, inputs: &[ParityInput]) -> Vec<ParityOutput> {
 
 /// Run the surface-tangent harness and read back one dP/du per input.
 fn run_tangent_harness(ctx: &GpuContext, inputs: &[TangentInput]) -> Vec<[f32; 4]> {
-    let dummy = ParityInput::zeroed();
     let bytes = run_pass(
         ctx,
         "tangent_parity",
-        bytemuck::bytes_of(&dummy),
-        bytemuck::cast_slice(inputs),
+        &[(2, bytemuck::cast_slice(inputs))],
         3,
         (inputs.len() * 16) as u64,
         inputs.len() as u32,
@@ -795,5 +793,270 @@ fn gpu_material_round_trips_the_shared_derivation() {
     assert!(
         Pbr::from_material_def(Some(&defs[2]), None).clearcoat > 0.0,
         "a glossy dielectric should pick up a clearcoat"
+    );
+}
+
+/// Mirrors `EnvInput` in `bsdf_parity.wgsl`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct EnvInput {
+    dir: [f32; 4],
+    rnd: [f32; 4],
+    width: u32,
+    height: u32,
+    intensity: f32,
+    rotation: f32,
+    marg_int: f32,
+    _pad: [u32; 3],
+}
+
+/// Mirrors `EnvOutput` in `bsdf_parity.wgsl`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, Pod, Zeroable)]
+struct EnvOutput {
+    eval: [f32; 4],
+    sample_dir: [f32; 4],
+    sample_radiance: [f32; 4],
+    resampled: [f32; 4],
+}
+
+/// A small but genuinely high-frequency lat-long map: a bright "sun" texel
+/// against a dim sky, plus a warm horizon band. Flat maps would let a broken
+/// CDF pass, since every bin would be equally likely.
+fn test_envmap() -> vcad_kernel_raytrace::pathtrace::EnvMap {
+    use vcad_kernel_raytrace::pathtrace::EnvMap;
+    let (w, h) = (32usize, 16usize);
+    let mut px = vec![[0.02f32, 0.03, 0.05]; w * h];
+    for (j, row) in (0..h).enumerate() {
+        let _ = row;
+        for i in 0..w {
+            // Warm band across the horizon.
+            if j == h / 2 {
+                px[j * w + i] = [0.6, 0.45, 0.3];
+            }
+        }
+    }
+    // A hot, tiny sun well away from the poles.
+    px[4 * w + 9] = [180.0, 170.0, 150.0];
+    px[4 * w + 10] = [90.0, 85.0, 75.0];
+    EnvMap::new(w, h, px)
+        .expect("valid dimensions")
+        .with_intensity(1.3)
+        .with_rotation_deg(37.0)
+}
+
+/// The GPU environment must agree with `pathtrace::EnvMap` on radiance, on the
+/// solid-angle PDF, and on what importance sampling draws.
+///
+/// The PDF is the dangerous one: MIS combines it with the BSDF PDF, so a
+/// mismatch produces an image that is energy-wrong yet entirely plausible.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_environment_matches_cpu_envmap() {
+    use vcad_kernel_math::Vec3;
+
+    let Some(ctx) = ctx_or_skip("gpu_environment_matches_cpu_envmap") else {
+        return;
+    };
+
+    let env = test_envmap();
+    let pack = env.pack_for_gpu();
+
+    // Directions spread over the whole sphere, including near-polar ones where
+    // the sin(theta) Jacobian blows up.
+    let dirs: Vec<Vec3> = (0..64)
+        .map(|k| {
+            let a = k as f64 * 0.9312;
+            let z = -0.985 + 1.97 * (k as f64 / 63.0);
+            let r = (1.0 - z * z).max(0.0).sqrt();
+            Vec3::new(r * a.cos(), r * a.sin(), z).normalize()
+        })
+        .collect();
+
+    let inputs: Vec<EnvInput> = dirs
+        .iter()
+        .enumerate()
+        .map(|(k, d)| EnvInput {
+            dir: [d.x as f32, d.y as f32, d.z as f32, 0.0],
+            rnd: [halton(k as u32 + 1, 2), halton(k as u32 + 1, 3), 0.0, 0.0],
+            width: pack.width,
+            height: pack.height,
+            intensity: pack.intensity,
+            rotation: pack.rotation,
+            marg_int: pack.marg_int,
+            _pad: [0; 3],
+        })
+        .collect();
+
+    let bytes = run_pass(
+        ctx,
+        "env_parity",
+        &[
+            (4, bytemuck::cast_slice(&inputs)),
+            (6, bytemuck::cast_slice(&pack.data)),
+        ],
+        5,
+        (inputs.len() * std::mem::size_of::<EnvOutput>()) as u64,
+        inputs.len() as u32,
+    );
+    let out: Vec<EnvOutput> = bytemuck::cast_slice(&bytes).to_vec();
+    assert_eq!(out.len(), inputs.len());
+
+    let mut sampled = 0usize;
+    let mut hot = 0usize;
+    for (k, (d, o)) in dirs.iter().zip(&out).enumerate() {
+        // Radiance.
+        let want = env.radiance(*d);
+        for (c, &wc) in want.iter().enumerate() {
+            let tol = 1e-4 * wc.abs().max(1.0);
+            assert!(
+                (o.eval[c] - wc).abs() <= tol,
+                "dir {k} channel {c}: env radiance diverged — GPU {} vs CPU {wc} \
+                 (the two renderers would light the scene differently)",
+                o.eval[c],
+            );
+        }
+        if want[0] > 1.0 {
+            hot += 1;
+        }
+
+        // PDF.
+        let want_pdf = env.pdf(*d);
+        assert!(
+            (o.eval[3] - want_pdf).abs() <= 1e-4 * want_pdf.abs().max(1.0),
+            "dir {k}: env PDF diverged — GPU {} vs CPU {want_pdf}. MIS weights \
+             come from this number, so the image goes energy-wrong invisibly.",
+            o.eval[3],
+        );
+
+        // Sampling: the returned pdf must equal the pdf re-evaluated at the
+        // sampled direction, exactly as the CPU recomputes it through `pdf`.
+        if o.sample_radiance[3] > 0.5 {
+            sampled += 1;
+            let p = o.sample_dir[3];
+            assert!(
+                (p - o.resampled[0]).abs() <= 1e-4 * p.max(1.0),
+                "sample {k}: env sample pdf {p} != pdf at the sampled direction \
+                 {}",
+                o.resampled[0],
+            );
+            // And that direction's CPU pdf must match too.
+            let sd = Vec3::new(
+                o.sample_dir[0] as f64,
+                o.sample_dir[1] as f64,
+                o.sample_dir[2] as f64,
+            );
+            let cpu_p = env.pdf(sd);
+            assert!(
+                (p - cpu_p).abs() <= 2e-3 * p.max(1.0),
+                "sample {k}: GPU sampled pdf {p} vs CPU pdf {cpu_p} at the same \
+                 direction — the two CDFs disagree",
+            );
+        }
+    }
+
+    assert!(
+        sampled > inputs.len() / 2,
+        "only {sampled}/{} env samples succeeded — the harness probably did \
+         not run",
+        inputs.len(),
+    );
+    assert!(
+        hot > 0,
+        "no direction landed on the bright sun texel — the sweep is not \
+         exercising the high-frequency part of the map, which is exactly where \
+         a broken CDF would show",
+    );
+}
+
+/// Importance sampling must actually concentrate on the bright texels. A CDF
+/// that degenerated to uniform would still satisfy the pdf-agreement checks
+/// above while converging far more slowly than the CPU.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_environment_sampling_finds_the_sun() {
+    let Some(ctx) = ctx_or_skip("gpu_environment_sampling_finds_the_sun") else {
+        return;
+    };
+
+    let env = test_envmap();
+    let pack = env.pack_for_gpu();
+
+    let n = 2048u32;
+    let inputs: Vec<EnvInput> = (0..n)
+        .map(|k| EnvInput {
+            dir: [0.0, 0.0, 1.0, 0.0],
+            rnd: [halton(k + 1, 2), halton(k + 1, 3), 0.0, 0.0],
+            width: pack.width,
+            height: pack.height,
+            intensity: pack.intensity,
+            rotation: pack.rotation,
+            marg_int: pack.marg_int,
+            _pad: [0; 3],
+        })
+        .collect();
+
+    let bytes = run_pass(
+        ctx,
+        "env_parity",
+        &[
+            (4, bytemuck::cast_slice(&inputs)),
+            (6, bytemuck::cast_slice(&pack.data)),
+        ],
+        5,
+        (inputs.len() * std::mem::size_of::<EnvOutput>()) as u64,
+        inputs.len() as u32,
+    );
+    let out: Vec<EnvOutput> = bytemuck::cast_slice(&bytes).to_vec();
+
+    let bright = out
+        .iter()
+        .filter(|o| o.sample_radiance[3] > 0.5 && o.sample_radiance[0] > 1.0)
+        .count();
+    // The sun is 2 texels of 512, i.e. 0.4% of the image by area, but carries
+    // almost all the energy — importance sampling should land on it far more
+    // often than uniform sampling would.
+    assert!(
+        bright > out.len() / 10,
+        "only {bright}/{} samples hit the bright texels — the environment CDF \
+         is not concentrating on the energy, so the GPU would converge far \
+         more slowly than the CPU on the same map",
+        out.len(),
+    );
+
+    // Monte Carlo sanity: E[L/pdf] over the sphere is the mean radiance times
+    // 4*pi. A mis-normalised CDF shows up here even when every individual pdf
+    // is self-consistent.
+    let mut sum = 0.0f64;
+    let mut used = 0usize;
+    for o in &out {
+        if o.sample_radiance[3] > 0.5 && o.sample_dir[3] > 0.0 {
+            sum += (o.sample_radiance[0] / o.sample_dir[3]) as f64;
+            used += 1;
+        }
+    }
+    assert!(used > 0, "no usable samples");
+    let integral = sum / used as f64;
+
+    // Reference: integrate the same quantity on the CPU with its own sampler.
+    let mut cpu_sum = 0.0f64;
+    let mut cpu_used = 0usize;
+    for k in 0..n {
+        let r1 = halton(k + 1, 5) as f64;
+        let r2 = halton(k + 1, 7) as f64;
+        if let Some((_d, li, pdf)) = env.sample(r1, r2) {
+            if pdf > 0.0 {
+                cpu_sum += (li[0] / pdf) as f64;
+                cpu_used += 1;
+            }
+        }
+    }
+    let cpu_integral = cpu_sum / cpu_used.max(1) as f64;
+    let rel = (integral - cpu_integral).abs() / cpu_integral.max(1e-6);
+    assert!(
+        rel < 0.05,
+        "GPU env integral {integral} vs CPU {cpu_integral} (rel {rel}) — the \
+         estimators disagree, so the two renderers would converge to different \
+         images",
     );
 }

--- a/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
+++ b/crates/vcad-kernel-raytrace/tests/bsdf_parity.rs
@@ -238,7 +238,8 @@ fn test_materials() -> Vec<GpuMaterial> {
             clearcoat: 0.5,
             clearcoat_roughness: 0.1,
             ior: 1.5,
-            _pad: [0.0; 3],
+            anisotropy: 0.0,
+            _pad: [0.0; 2],
         },
         // High IOR dielectric, strong coat — pushes F0 and coat attenuation.
         GpuMaterial {
@@ -248,7 +249,38 @@ fn test_materials() -> Vec<GpuMaterial> {
             clearcoat: 1.0,
             clearcoat_roughness: 0.03,
             ior: 1.8,
-            _pad: [0.0; 3],
+            anisotropy: 0.0,
+            _pad: [0.0; 2],
+        },
+        // Brushed metal — anisotropy swept across both signs and both
+        // extremes. The anisotropic D/G/VNDF paths are separate branches from
+        // the isotropic ones, so they need their own coverage or a divergence
+        // hides until someone ships a brushed material.
+        GpuMaterial {
+            color: [0.91, 0.92, 0.92, 1.0],
+            metallic: 1.0,
+            roughness: 0.3,
+            anisotropy: 0.85,
+            ..Default::default()
+        },
+        GpuMaterial {
+            color: [0.91, 0.92, 0.92, 1.0],
+            metallic: 1.0,
+            roughness: 0.3,
+            anisotropy: -0.85,
+            ..Default::default()
+        },
+        // Anisotropic AND clearcoated: the coat must stay isotropic while the
+        // substrate takes the grain.
+        GpuMaterial {
+            color: [0.6, 0.15, 0.15, 1.0],
+            metallic: 0.2,
+            roughness: 0.35,
+            clearcoat: 0.7,
+            clearcoat_roughness: 0.08,
+            ior: 1.5,
+            anisotropy: 0.5,
+            _pad: [0.0; 2],
         },
     ]
 }
@@ -419,7 +451,8 @@ fn gpu_furnace_conserves_energy() {
         clearcoat: 0.0,
         clearcoat_roughness: 0.1,
         ior: 1.5,
-        _pad: [0.0; 3],
+        anisotropy: 0.0,
+        _pad: [0.0; 2],
     };
 
     let n = 20_000u32;
@@ -451,5 +484,52 @@ fn gpu_furnace_conserves_energy() {
         "GPU directional albedo {albedo} outside the plausible range — the \
          WGSL sampling routine and its PDF disagree, so the path tracer will \
          gain or lose energy at every bounce.",
+    );
+}
+
+/// Guard against the anisotropy field being silently dropped somewhere in the
+/// Rust→WGSL struct layout. If the GPU read it as zero, the parity test above
+/// would still pass for every isotropic material and quietly stop covering the
+/// anisotropic D/G/VNDF branches at all.
+#[test]
+#[ignore = "requires GPU"]
+fn gpu_anisotropy_actually_changes_the_lobe() {
+    let Some(ctx) = ctx_or_skip("gpu_anisotropy_actually_changes_the_lobe") else {
+        return;
+    };
+
+    let base = GpuMaterial {
+        color: [0.9, 0.9, 0.9, 1.0],
+        metallic: 1.0,
+        roughness: 0.3,
+        ..Default::default()
+    };
+    let mk = |anisotropy: f32| GpuMaterial { anisotropy, ..base };
+
+    // Off-axis half-vector so the tangent and bitangent alphas differ.
+    let wo = unit([0.4, 0.0, 0.92]);
+    let wi = unit([0.0, 0.45, 0.89]);
+    let inputs: Vec<ParityInput> = [-0.85f32, 0.0, 0.85]
+        .iter()
+        .map(|&a| ParityInput {
+            material: mk(a),
+            wo: [wo[0], wo[1], wo[2], 0.0],
+            wi: [wi[0], wi[1], wi[2], 0.0],
+            rnd: [0.3, 0.4, 0.6, 0.0],
+        })
+        .collect();
+
+    let out = run_harness(ctx, &inputs);
+    let (neg, iso, pos) = (out[0].eval[0], out[1].eval[0], out[2].eval[0]);
+    assert!(
+        (pos - iso).abs() > 1e-4 && (neg - iso).abs() > 1e-4,
+        "anisotropy did not change the BSDF on the GPU (neg {neg}, iso {iso}, \
+         pos {pos}) — the field is probably not reaching the shader, which \
+         would make the anisotropic parity coverage vacuous",
+    );
+    assert!(
+        (pos - neg).abs() > 1e-4,
+        "positive and negative anisotropy produced the same value ({pos} vs \
+         {neg}) — the tangent/bitangent alphas are not being swapped",
     );
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -3787,6 +3787,43 @@ impl RayTracer {
     /// * `r`, `g`, `b` - RGB color components (0-1 range, linear)
     /// * `metallic` - Metallic factor (0 = dielectric, 1 = metal)
     /// * `roughness` - Roughness factor (0 = smooth/mirror, 1 = rough/diffuse)
+    /// Set the material from a serialized IR `MaterialDef`.
+    ///
+    /// Preferred over `setMaterial`: that one only carries colour, metallic and
+    /// roughness, so clearcoat, IOR and anisotropy never reached the viewport
+    /// and a brushed or lacquered part shaded differently here than under
+    /// `vcad-render --photoreal`. This runs the SAME derivation the CPU
+    /// renderer uses (`Pbr::from_material_def`), so both agree by construction.
+    ///
+    /// `json` is a `MaterialDef` object; pass `null`/empty to fall back to the
+    /// optional `tint` (linear RGB) or the neutral default.
+    #[wasm_bindgen(js_name = setMaterialFromDef)]
+    pub fn set_material_from_def(
+        &self,
+        json: Option<String>,
+        tint: Option<Vec<f64>>,
+    ) -> Result<(), JsError> {
+        let mat: Option<vcad_ir::MaterialDef> = match json.as_deref() {
+            Some(j) if !j.trim().is_empty() && j != "null" => Some(
+                serde_json::from_str(j)
+                    .map_err(|e| JsError::new(&format!("bad MaterialDef: {e}")))?,
+            ),
+            _ => None,
+        };
+        let tint = tint.and_then(|t| (t.len() >= 3).then(|| [t[0], t[1], t[2]]));
+
+        {
+            let mut inner = self.inner.borrow_mut();
+            let scene_rc = inner
+                .scene
+                .as_mut()
+                .ok_or_else(|| JsError::new("No solid uploaded. Call uploadSolid() first."))?;
+            std::rc::Rc::make_mut(scene_rc).set_material_from_def(mat.as_ref(), tint);
+            inner.invalidate_accum();
+        }
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = setMaterial)]
     pub fn set_material(
         &self,

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -3428,8 +3428,6 @@ struct RayTracerInner {
     frame_index: u32,
     /// Accumulation buffer for progressive anti-aliasing.
     accum_buffer: Option<wgpu::Buffer>,
-    /// AO buffer for progressive SSAO accumulation.
-    ao_buffer: Option<wgpu::Buffer>,
     /// Last camera state for detecting camera changes.
     last_camera_hash: u64,
     /// Last render dimensions.
@@ -3446,14 +3444,11 @@ struct RayTracerInner {
     edge_normal_threshold: f32,
     /// Theme: 0 = dark, 1 = light. Drives the visible background palette.
     theme: u32,
-    /// SSAO world-space sample radius.
-    ao_radius: f32,
-    /// SSAO intensity (0 = disabled, 1 = default).
-    ao_intensity: f32,
-    /// SSAO depth bias.
-    ao_bias: f32,
-    /// SSAO sample count per frame.
-    ao_sample_count: u32,
+    /// Ceiling on path-tracer depth. Actual depth escalates with accumulation
+    /// up to this value, so the draft frame stays interactive.
+    max_path_depth: u32,
+    /// Enable non-photoreal stylisation (the Sobel edge overlay).
+    stylize: bool,
     /// Additional rays per edge pixel for adaptive refinement (0 = disabled).
     refine_sample_count: u32,
     // Per-type edge style
@@ -3474,7 +3469,6 @@ impl RayTracerInner {
     fn invalidate_accum(&mut self) {
         self.frame_index = 0;
         self.accum_buffer = None;
-        self.ao_buffer = None;
         self.accum_epoch = self.accum_epoch.wrapping_add(1);
     }
 }
@@ -3504,7 +3498,6 @@ impl RayTracer {
                 accum_epoch: 0,
                 frame_index: 0,
                 accum_buffer: None,
-                ao_buffer: None,
                 last_camera_hash: 0,
                 last_width: 0,
                 last_height: 0,
@@ -3513,10 +3506,8 @@ impl RayTracer {
                 edge_depth_threshold: 0.1,
                 edge_normal_threshold: 30.0,
                 theme: 0,
-                ao_radius: 0.3,
-                ao_intensity: 1.0,
-                ao_bias: 0.001,
-                ao_sample_count: 16,
+                max_path_depth: vcad_kernel_raytrace::gpu::DEFAULT_MAX_DEPTH,
+                stylize: true,
                 refine_sample_count: 0,
                 enable_silhouette: true,
                 enable_crease: true,
@@ -3674,29 +3665,30 @@ impl RayTracer {
         inner.invalidate_accum();
     }
 
-    /// Set SSAO (screen-space ambient occlusion) parameters.
+    /// Set the path tracer's quality ceiling and stylisation mode.
+    ///
+    /// Replaces the old `setAO`. The renderer is a real path tracer now, so
+    /// screen-space ambient occlusion is gone — multi-bounce GI computes
+    /// contact occlusion correctly, and stacking a proxy on top of it would
+    /// double-darken every concave corner.
     ///
     /// # Arguments
-    /// * `radius` - World-space hemisphere sample radius (default 0.3)
-    /// * `intensity` - Occlusion strength: 0 = disabled, 1 = default (>1 stylized)
-    /// * `bias` - Depth bias to prevent self-occlusion (default 0.001)
-    /// * `sample_count` - Hemisphere samples per frame: 8, 16, or 32 (default 16)
-    #[wasm_bindgen(js_name = setAO)]
-    pub fn set_ao(&self, radius: f32, intensity: f32, bias: f32, sample_count: u32) {
+    /// * `max_depth` - Ceiling on path length (1 = direct lighting only,
+    ///   default 6, which matches `vcad-render --photoreal`). Actual depth
+    ///   escalates with accumulation, so the draft frame stays interactive
+    ///   regardless of this value.
+    /// * `stylize` - Draw the Sobel edge overlay. Turn this OFF for a
+    ///   photoreal viewport: edge lines fight photorealism.
+    #[wasm_bindgen(js_name = setPathTrace)]
+    pub fn set_path_trace(&self, max_depth: u32, stylize: bool) {
         {
             let mut inner = self.inner.borrow_mut();
-            inner.ao_radius = radius;
-            inner.ao_intensity = intensity;
-            inner.ao_bias = bias;
-            inner.ao_sample_count = sample_count.clamp(1, 64);
+            inner.max_path_depth = max_depth.clamp(1, 32);
+            inner.stylize = stylize;
             inner.invalidate_accum();
         }
         web_sys::console::log_1(
-            &format!(
-                "[WASM] SSAO: radius={:.3}, intensity={:.2}, bias={:.4}, samples={}",
-                radius, intensity, bias, sample_count
-            )
-            .into(),
+            &format!("[WASM] path trace: max_depth={max_depth}, stylize={stylize}").into(),
         );
     }
 
@@ -3880,7 +3872,7 @@ impl RayTracer {
 
         // Snapshot everything we need under one short borrow, then drop it
         // before any `.await`. Setters can run freely during the GPU wait.
-        let (scene, accum_buf, ao_buf, render_state, frame_index, accum_epoch) = {
+        let (scene, accum_buf, render_state, frame_index, accum_epoch) = {
             let mut inner = self.inner.borrow_mut();
 
             let scene = inner
@@ -3941,17 +3933,18 @@ impl RayTracer {
                 inner.boundary_width,
                 inner.edge_softness,
             );
-            rs.ao_radius = inner.ao_radius;
-            rs.ao_intensity = inner.ao_intensity;
-            rs.ao_bias = inner.ao_bias;
-            rs.ao_sample_count = inner.ao_sample_count;
             rs.refine_sample_count = inner.refine_sample_count;
+            rs.light_count = scene.lights.len() as u32;
+            rs.stylize = u32::from(inner.stylize);
+            // Path depth escalates with accumulation so the draft frame stays
+            // interactive; `max_path_depth` is the user's ceiling.
+            rs.max_depth =
+                vcad_kernel_raytrace::gpu::depth_for_frame(inner.frame_index, inner.max_path_depth);
 
             let accum_buf = inner.accum_buffer.take();
-            let ao_buf = inner.ao_buffer.take();
             let frame_index = inner.frame_index;
             let accum_epoch = inner.accum_epoch;
-            (scene, accum_buf, ao_buf, rs, frame_index, accum_epoch)
+            (scene, accum_buf, rs, frame_index, accum_epoch)
         };
         let _ = frame_index;
 
@@ -3967,7 +3960,7 @@ impl RayTracer {
         let ctx =
             vcad_kernel_gpu::GpuContext::get().ok_or_else(|| JsError::new("GPU context lost"))?;
 
-        let (pixels, new_accum, new_ao) = self
+        let (pixels, new_accum) = self
             .pipeline
             .render_with_render_state(
                 ctx,
@@ -3976,7 +3969,6 @@ impl RayTracer {
                 width,
                 height,
                 accum_buf,
-                ao_buf,
                 render_state,
             )
             .await
@@ -3988,7 +3980,6 @@ impl RayTracer {
         let mut inner = self.inner.borrow_mut();
         if inner.accum_epoch == accum_epoch {
             inner.accum_buffer = Some(new_accum);
-            inner.ao_buffer = Some(new_ao);
         }
         drop(inner);
 

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -572,6 +572,10 @@ struct SceneSolid {
     /// Full material definition (metallic/roughness/transmission/ior), kept
     /// alongside `tint` because the photoreal path needs more than a colour.
     /// `None` when the document names no material for this solid.
+    ///
+    /// Only the `raytrace`-gated `photoreal` module reads this; the SVG and
+    /// raster paths shade from `tint` alone.
+    #[cfg_attr(not(feature = "raytrace"), allow(dead_code))]
     material: Option<vcad_ir::MaterialDef>,
     name: Option<String>,
     /// Focus-match labels (node name, instance id/name, part-def id) for

--- a/crates/vcad-render/src/photoreal.rs
+++ b/crates/vcad-render/src/photoreal.rs
@@ -113,86 +113,6 @@ pub fn render_photoreal_png_str(
     encode_png(rasterize(raw_vcad, opts, pr, true)?, opts)
 }
 
-/// Map a document material to a physically-based surface description.
-///
-/// The IR already carries metallic/roughness/ior, so most of this is a
-/// straight copy. The one piece of authored judgement is clearcoat: real
-/// machined and moulded parts almost always have some surface layer —
-/// anodising, paint, moulding skin — and adding it is the single biggest
-/// step from "CAD shaded" to "photographed".
-/// Fallback anisotropy for materials that name a directional finish but do
-/// not carry an explicit `anisotropy` value.
-///
-/// Deliberately conservative — only finishes that are unambiguously
-/// directional, and at moderate strength. Anything else stays isotropic, so
-/// this can never change how an existing material renders unless its name
-/// says it is brushed or turned.
-fn anisotropy_from_name(name: &str) -> f32 {
-    let n = name.to_ascii_lowercase();
-    // Turning and boring cut circumferentially, which is the +u direction on
-    // a cylinder — the same direction the tangent frame is built from.
-    if n.contains("turned") || n.contains("machined") || n.contains("bored") {
-        0.6
-    } else if n.contains("brushed") {
-        0.7
-    } else {
-        0.0
-    }
-}
-
-fn to_pbr(mat: Option<&vcad_ir::MaterialDef>, tint: Option<[f64; 3]>) -> Pbr {
-    let base = mat.map(|m| m.color).or(tint).unwrap_or([0.62, 0.64, 0.67]);
-    let base_color = [base[0] as f32, base[1] as f32, base[2] as f32];
-
-    let metallic = mat
-        .map(|m| m.metallic as f32)
-        .unwrap_or(0.0)
-        .clamp(0.0, 1.0);
-    // Perfectly sharp mirrors read as CG. Floor roughness slightly.
-    let roughness = mat
-        .map(|m| m.roughness as f32)
-        .unwrap_or(0.35)
-        .clamp(0.03, 1.0);
-    let ior = mat
-        .and_then(|m| m.ior)
-        .map(|v| v as f32)
-        .unwrap_or(1.5)
-        .clamp(1.0, 3.0);
-
-    // Dielectrics that are already glossy get a clearcoat; rough matte
-    // surfaces (sandblasted, as-printed) do not.
-    let clearcoat = if metallic < 0.5 && roughness < 0.5 {
-        0.35 * (1.0 - roughness / 0.5)
-    } else {
-        0.0
-    };
-
-    // Anisotropy is a real IR field (`MaterialDef::anisotropy`) rather than
-    // a rendering-time guess: Rust is the source of truth for IR types, the
-    // value is a genuine property of the surface finish, and it round-trips
-    // in `.vcad`. The name heuristic below only fills in when the document
-    // says nothing — a document that names its material "brushed_aluminum"
-    // or "turned_shaft" has told us the finish, and rendering that as a
-    // uniform polish is the CG tell this feature exists to remove. Anything
-    // explicit always wins.
-    let anisotropy = mat
-        .and_then(|m| m.anisotropy)
-        .map(|v| v as f32)
-        .unwrap_or_else(|| mat.map(|m| anisotropy_from_name(&m.name)).unwrap_or(0.0))
-        .clamp(-1.0, 1.0);
-
-    Pbr {
-        base_color,
-        metallic,
-        roughness,
-        anisotropy,
-        clearcoat,
-        clearcoat_roughness: 0.08,
-        ior,
-        emissive: [0.0; 3],
-    }
-}
-
 fn rasterize(
     raw_vcad: &str,
     opts: &RasterOptions,
@@ -230,7 +150,7 @@ fn rasterize(
         }
         objects.push(Object {
             bvh: Arc::new(bvh),
-            material: to_pbr(s.material.as_ref(), s.tint),
+            material: Pbr::from_material_def(s.material.as_ref(), s.tint),
         });
     }
     if objects.is_empty() {

--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -134,6 +134,7 @@ export function RayTracedViewportSync() {
         ro: number,
       ) => void;
       setMaterial: (r: number, g: number, b: number, m: number, ro: number) => void;
+      setMaterialFromDef?: (json: string | null, tint: number[] | null) => void;
     };
     rt.clearScene?.();
 
@@ -237,7 +238,16 @@ export function RayTracedViewportSync() {
       const mat = docMat ?? preset;
       if (mat) {
         try {
-          rt.setMaterial(mat.color[0], mat.color[1], mat.color[2], mat.metallic, mat.roughness);
+          // Prefer the full definition: setMaterial only carries colour,
+          // metallic and roughness, so clearcoat, IOR and anisotropy would be
+          // dropped and a brushed or lacquered part would shade differently
+          // here than under `vcad-render --photoreal`. setMaterialFromDef runs
+          // the same Rust derivation both renderers share.
+          if (typeof rt.setMaterialFromDef === "function") {
+            rt.setMaterialFromDef(JSON.stringify(mat), null);
+          } else {
+            rt.setMaterial(mat.color[0], mat.color[1], mat.color[2], mat.metallic, mat.roughness);
+          }
         } catch (e) {
           logger.debug("gpu", `Failed to set material: ${e}`);
         }

--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -243,9 +243,19 @@ export function RayTracedViewportSync() {
           // dropped and a brushed or lacquered part would shade differently
           // here than under `vcad-render --photoreal`. setMaterialFromDef runs
           // the same Rust derivation both renderers share.
+          // Fall back rather than losing the material outright: if the shape
+          // ever drifts from the Rust MaterialDef the deserialize throws, and
+          // dropping to setMaterial costs only the extended fields.
+          let applied = false;
           if (typeof rt.setMaterialFromDef === "function") {
-            rt.setMaterialFromDef(JSON.stringify(mat), null);
-          } else {
+            try {
+              rt.setMaterialFromDef(JSON.stringify(mat), null);
+              applied = true;
+            } catch (e) {
+              logger.debug("gpu", `setMaterialFromDef rejected the definition, falling back: ${e}`);
+            }
+          }
+          if (!applied) {
             rt.setMaterial(mat.color[0], mat.color[1], mat.color[2], mat.metallic, mat.roughness);
           }
         } catch (e) {

--- a/packages/app/src/components/RayTracedViewport.tsx
+++ b/packages/app/src/components/RayTracedViewport.tsx
@@ -376,6 +376,13 @@ const TIER_CONFIG: Record<
   high: { scale: 2.0, maxPixels: 1920 * 1080 },       // 2× DPI — final
 };
 
+// Ceiling on path-tracer depth. Matches `PathTraceOptions::default().max_depth`
+// on the CPU side so a converged viewport image agrees with
+// `vcad-render --photoreal`. The kernel escalates toward this with accumulation
+// (2 bounces on the draft frame, then 4, then the full 6), so raising this does
+// not make the first frame slower.
+const PATH_TRACE_MAX_DEPTH = 6;
+
 export function RayTracedViewportOverlay() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const raytraceQuality = useUiStore((s) => s.raytraceQuality);
@@ -390,11 +397,6 @@ export function RayTracedViewportOverlay() {
   const raytraceEdgeCreaseWidth = useUiStore((s) => s.raytraceEdgeCreaseWidth);
   const raytraceEdgeBoundaryWidth = useUiStore((s) => s.raytraceEdgeBoundaryWidth);
   const raytraceEdgeSoftness = useUiStore((s) => s.raytraceEdgeSoftness);
-  const raytraceAoEnabled = useUiStore((s) => s.raytraceAoEnabled);
-  const raytraceAoRadius = useUiStore((s) => s.raytraceAoRadius);
-  const raytraceAoIntensity = useUiStore((s) => s.raytraceAoIntensity);
-  const raytraceAoBias = useUiStore((s) => s.raytraceAoBias);
-  const raytraceAoSampleCount = useUiStore((s) => s.raytraceAoSampleCount);
   const rayTracer = getRayTracer();
   const { isDark } = useTheme();
 
@@ -415,14 +417,8 @@ export function RayTracedViewportOverlay() {
     softness: 1.5,
   });
 
-  // Track last AO settings to detect changes
-  const lastAoSettingsRef = useRef({
-    enabled: true,
-    radius: 0.3,
-    intensity: 1.0,
-    bias: 0.001,
-    sampleCount: 16,
-  });
+  // Track last path-tracer settings to detect changes.
+  const lastPathTraceSettingsRef = useRef({ stylize: true });
 
   // Track pending async render to avoid overlapping calls
   const renderInProgressRef = useRef(false);
@@ -793,42 +789,38 @@ export function RayTracedViewportOverlay() {
     rayTracer, doRender,
   ]);
 
-  // Apply SSAO settings changes
+  // Apply path-tracer settings.
+  //
+  // The renderer is a real path tracer, so there is no SSAO pass any more —
+  // multi-bounce GI computes contact occlusion correctly and a screen-space
+  // proxy on top would double-darken concave corners. What is left to drive is
+  // the depth ceiling and whether the Sobel edge overlay is drawn: edge lines
+  // are a stylisation that fights photorealism, so "edges off" IS the photoreal
+  // viewport mode.
+  //
+  // Depth itself escalates with accumulation inside the kernel, so the draft
+  // frame stays interactive regardless of the ceiling set here.
   useEffect(() => {
     if (!rayTracer) return;
 
-    const last = lastAoSettingsRef.current;
-    if (
-      raytraceAoEnabled === last.enabled &&
-      raytraceAoRadius === last.radius &&
-      raytraceAoIntensity === last.intensity &&
-      raytraceAoBias === last.bias &&
-      raytraceAoSampleCount === last.sampleCount
-    ) {
-      return;
-    }
+    const last = lastPathTraceSettingsRef.current;
+    if (raytraceEdgesEnabled === last.stylize) return;
+    lastPathTraceSettingsRef.current = { stylize: raytraceEdgesEnabled };
 
-    lastAoSettingsRef.current = {
-      enabled: raytraceAoEnabled,
-      radius: raytraceAoRadius,
-      intensity: raytraceAoIntensity,
-      bias: raytraceAoBias,
-      sampleCount: raytraceAoSampleCount,
+    const rt = rayTracer as {
+      setPathTrace?: (maxDepth: number, stylize: boolean) => void;
     };
-
-    const rt = rayTracer as { setAO?: (radius: number, intensity: number, bias: number, sampleCount: number) => void };
-    if (typeof rt.setAO !== "function") {
-      logger.debug("gpu", "setAO not available - WASM may need rebuild");
+    if (typeof rt.setPathTrace !== "function") {
+      logger.debug("gpu", "setPathTrace not available - WASM may need rebuild");
       return;
     }
 
-    const effectiveIntensity = raytraceAoEnabled ? raytraceAoIntensity : 0.0;
-    rt.setAO(raytraceAoRadius, effectiveIntensity, raytraceAoBias, raytraceAoSampleCount);
+    rt.setPathTrace(PATH_TRACE_MAX_DEPTH, raytraceEdgesEnabled);
 
     if (lastCameraStateRef.current) {
       doRender(lastCameraStateRef.current);
     }
-  }, [raytraceAoEnabled, raytraceAoRadius, raytraceAoIntensity, raytraceAoBias, raytraceAoSampleCount, rayTracer, doRender]);
+  }, [raytraceEdgesEnabled, rayTracer, doRender]);
 
   if (!rayTracer) {
     return null;

--- a/packages/app/src/components/footer/RaytraceChip.tsx
+++ b/packages/app/src/components/footer/RaytraceChip.tsx
@@ -6,7 +6,6 @@ import { FooterChipButton } from "@/components/footer/FooterChip";
 import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { ensureNotRecording } from "@/lib/recording-guard";
-import { useCallback } from "react";
 
 const QUALITY_OPTIONS: Array<{
   value: RaytraceQuality;
@@ -47,9 +46,6 @@ export function RaytraceChip({ className }: { className?: string }) {
   const raytraceEdgeCreaseWidth = useUiStore((s) => s.raytraceEdgeCreaseWidth);
   const raytraceEdgeBoundaryWidth = useUiStore((s) => s.raytraceEdgeBoundaryWidth);
   const raytraceEdgeSoftness = useUiStore((s) => s.raytraceEdgeSoftness);
-  const raytraceAoEnabled = useUiStore((s) => s.raytraceAoEnabled);
-  const raytraceAoIntensity = useUiStore((s) => s.raytraceAoIntensity);
-  const raytraceAoSampleCount = useUiStore((s) => s.raytraceAoSampleCount);
   const toggleRenderMode = useUiStore((s) => s.toggleRenderMode);
   const setRaytraceQuality = useUiStore((s) => s.setRaytraceQuality);
   const setRaytraceEdgesEnabled = useUiStore((s) => s.setRaytraceEdgesEnabled);
@@ -60,23 +56,6 @@ export function RaytraceChip({ className }: { className?: string }) {
   const setRaytraceEdgeCreaseWidth = useUiStore((s) => s.setRaytraceEdgeCreaseWidth);
   const setRaytraceEdgeBoundaryWidth = useUiStore((s) => s.setRaytraceEdgeBoundaryWidth);
   const setRaytraceEdgeSoftness = useUiStore((s) => s.setRaytraceEdgeSoftness);
-  const setRaytraceAoEnabled = useUiStore((s) => s.setRaytraceAoEnabled);
-  const setRaytraceAoIntensity = useUiStore((s) => s.setRaytraceAoIntensity);
-  const setRaytraceAoSampleCount = useUiStore((s) => s.setRaytraceAoSampleCount);
-
-  const handleAoIntensityChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setRaytraceAoIntensity(parseFloat(e.target.value));
-    },
-    [setRaytraceAoIntensity],
-  );
-
-  const handleAoSampleChange = useCallback(
-    (count: number) => {
-      setRaytraceAoSampleCount(count);
-    },
-    [setRaytraceAoSampleCount],
-  );
 
   if (!raytraceAvailable) return null;
 
@@ -296,70 +275,6 @@ export function RaytraceChip({ className }: { className?: string }) {
             </div>
           )}
 
-          <div className="my-1 border-t border-border/40" />
-
-          {/* AO toggle + intensity slider */}
-          <button
-            type="button"
-            onClick={() => setRaytraceAoEnabled(!raytraceAoEnabled)}
-            className={cn(
-              "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left",
-              "transition-colors",
-              "text-text-muted hover:bg-hover hover:text-text",
-            )}
-          >
-            <span className="flex-1 uppercase tracking-wide text-[10px] text-text">
-              Ambient Occlusion
-            </span>
-            <span
-              className={cn(
-                "uppercase tracking-wide text-[10px] tabular-nums",
-                raytraceAoEnabled ? "text-brand" : "text-text-muted/70",
-              )}
-            >
-              {raytraceAoEnabled ? "on" : "off"}
-            </span>
-          </button>
-
-          {raytraceAoEnabled && (
-            <div className="px-2 pb-1.5 flex flex-col gap-1">
-              <div className="flex items-center gap-2">
-                <span className="text-[10px] text-text-muted/70 w-16 shrink-0">Intensity</span>
-                <input
-                  type="range"
-                  min="0.1"
-                  max="2.0"
-                  step="0.05"
-                  value={raytraceAoIntensity}
-                  onChange={handleAoIntensityChange}
-                  className="flex-1 h-1 accent-brand"
-                />
-                <span className="text-[10px] text-text-muted tabular-nums w-8 text-right">
-                  {raytraceAoIntensity.toFixed(2)}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-[10px] text-text-muted/70 w-16 shrink-0">Samples</span>
-                <div className="flex gap-1">
-                  {([8, 16, 32] as const).map((n) => (
-                    <button
-                      key={n}
-                      type="button"
-                      onClick={() => handleAoSampleChange(n)}
-                      className={cn(
-                        "px-1.5 py-0.5 rounded text-[10px] tabular-nums",
-                        raytraceAoSampleCount === n
-                          ? "bg-brand/20 text-brand"
-                          : "text-text-muted hover:bg-hover",
-                      )}
-                    >
-                      {n}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </div>
-          )}
 
           <div className="my-1 border-t border-border/40" />
 

--- a/packages/core/src/stores/ui-store.ts
+++ b/packages/core/src/stores/ui-store.ts
@@ -146,12 +146,6 @@ export interface UiState {
   raytraceEdgeCreaseWidth: number;
   raytraceEdgeBoundaryWidth: number;
   raytraceEdgeSoftness: number;
-  // SSAO
-  raytraceAoEnabled: boolean;
-  raytraceAoRadius: number;
-  raytraceAoIntensity: number;
-  raytraceAoBias: number;
-  raytraceAoSampleCount: number;
   // Toolbar state
   toolbarExpanded: boolean;
   toolbarTab: ToolbarTab;
@@ -232,12 +226,6 @@ export interface UiState {
   setRaytraceEdgeCreaseWidth: (width: number) => void;
   setRaytraceEdgeBoundaryWidth: (width: number) => void;
   setRaytraceEdgeSoftness: (softness: number) => void;
-  // SSAO actions
-  setRaytraceAoEnabled: (enabled: boolean) => void;
-  setRaytraceAoRadius: (radius: number) => void;
-  setRaytraceAoIntensity: (intensity: number) => void;
-  setRaytraceAoBias: (bias: number) => void;
-  setRaytraceAoSampleCount: (count: number) => void;
   // Toolbar actions
   setToolbarExpanded: (expanded: boolean) => void;
   toggleToolbarExpanded: () => void;
@@ -345,11 +333,6 @@ export const useUiStore = create<UiState>((set) => ({
   raytraceEdgeCreaseWidth: 0.75,
   raytraceEdgeBoundaryWidth: 1.25,
   raytraceEdgeSoftness: 1.5,
-  raytraceAoEnabled: true,
-  raytraceAoRadius: 0.3,
-  raytraceAoIntensity: 1.0,
-  raytraceAoBias: 0.001,
-  raytraceAoSampleCount: 16,
   toolbarExpanded: persistedToolbarExpanded,
   toolbarTab: "create" as ToolbarTab,
   sidebarPane: "tree" as SidebarPane,
@@ -529,16 +512,6 @@ export const useUiStore = create<UiState>((set) => ({
   setRaytraceEdgeCreaseWidth: (width) => set({ raytraceEdgeCreaseWidth: width }),
   setRaytraceEdgeBoundaryWidth: (width) => set({ raytraceEdgeBoundaryWidth: width }),
   setRaytraceEdgeSoftness: (softness) => set({ raytraceEdgeSoftness: softness }),
-
-  setRaytraceAoEnabled: (enabled) => set({ raytraceAoEnabled: enabled }),
-
-  setRaytraceAoRadius: (radius) => set({ raytraceAoRadius: radius }),
-
-  setRaytraceAoIntensity: (intensity) => set({ raytraceAoIntensity: intensity }),
-
-  setRaytraceAoBias: (bias) => set({ raytraceAoBias: bias }),
-
-  setRaytraceAoSampleCount: (count) => set({ raytraceAoSampleCount: count }),
 
   setToolbarExpanded: (expanded) => {
     try {


### PR DESCRIPTION
## What

vcad had three unrelated shading models. `raytrace.wgsl` powered the app viewport with Cook-Torrance GGX, one hardcoded GI bounce, SSAO and a jittered sun cone. `pathtrace.rs` (CPU, `--photoreal`) is a real path tracer with a layered metallic-roughness BSDF. `cpu.rs` has a third (headlight / fixed 3-light studio rig). The same document shaded differently in each.

This unifies the GPU viewport onto the CPU renderer's BSDF and turns it into a real path tracer.

- **One BSDF.** Extracted to `gpu/shaders/bsdf.wgsl`, prepended to every shader that shades via `shaders::compose()`, so exactly one copy exists. It is a direct port of `pathtrace.rs`: same VNDF sampling, lobe weights, clearcoat layer, F0-from-IOR, and now the anisotropic D/G/VNDF forms from #731. `GpuMaterial` mirrors `Pbr` field-for-field (`clearcoat`, `clearcoat_roughness`, `ior`, `anisotropy`).
- **Real path tracing.** `shade()` is now a unidirectional path tracer: throughput accumulation, next-event estimation against intersectable area lights under MIS (power heuristic), Russian roulette, configurable depth. Lights come from `pathtrace::studio_rig` — the same function `--photoreal` calls — so specular highlights get the correct softbox shape instead of a sun-cone smear.
- **SSAO deleted.** Multi-bounce GI computes contact occlusion correctly; keeping a screen-space proxy on top would double-darken every concave corner. Removed at both call sites, plus the pass, buffer, bind-group entry, wasm plumbing and UI.
- **Sobel behind a stylisation flag.** Edge lines fight photorealism, so they now sit behind `stylize`, wired to the existing edges toggle: "edges off" is the photoreal viewport mode.

## Why the parity test matters

A divergence between the two renderers is invisible by eye — a wrong PDF just moves energy around and still renders plausibly. `tests/bsdf_parity.rs` runs the WGSL **on the GPU** and compares it to `pathtrace::reference_bsdf_eval` number by number. Worst deltas: **1.6e-6 on value, 2.3e-6 on PDF** (the reference is f64, the shader f32).

It earned its keep immediately: rebasing onto main picked up anisotropic roughness (#731), which reworked `sample_vndf`/`vndf_pdf` to take separate tangent/bitangent alphas. The port was silently stale and this is what said so.

Two guards worth knowing about:
- The pdf-identity check is near-tautological in both languages (`bsdf_sample` returns `bsdf_eval`'s pdf by construction), so there is also a **GPU furnace test** — that is the one that would actually catch sampling drawing from a different distribution than its PDF claims.
- `gpu_anisotropy_actually_changes_the_lobe` exists because a dropped struct field would read as zero on the GPU and make the anisotropic coverage pass vacuously.

## Interactivity

Not regressed. Depth escalates with accumulation rather than quality being cut — 2 bounces on the draft frame, 4, then the full 6 that matches the CPU. The scheduler resets `frame_index` on every camera change, so each gesture still gets a cheap first frame.

## Bugs found along the way

- **The old renderer tonemapped per sample**, so progressive accumulation was averaging already-compressed values and dulling highlights as frames piled up. Radiance is now linear through accumulate + denoise and tonemapped once, in *both* `main` and `refine` (missing it in `refine` shows as a bright fringe on edge pixels only).
- **Area lights were visible to camera rays.** The rig is sized to scene bounds and the viewport camera orbits freely, so the softboxes swung through frame as giant white slabs. Fixed by skipping light hits at depth 0; secondary rays still find them, so MIS is unaffected.

## Verification

- `cargo test -p vcad-kernel-raytrace --features gpu` — 86 pass; GPU-gated tests (parity ×4, smoke ×3) pass on Metal.
- `cargo clippy` clean with and without `--all-targets`; `cargo fmt --all --check`; `tsc --noEmit` on the app.
- Ran the app end-to-end: DRAFT frame lands immediately, HIGH converges to soft studio lighting with GI-derived contact shadows and correct corner darkening.
- Compared against `vcad-render --photoreal` on equivalent geometry.

## Reviewer notes

- **Deep bores now render black, and that is correct.** A real path tracer can't get much light into a narrow through-hole from three softboxes. I checked the CPU renderer before "fixing" it — it does the same. The old viewport only differed because it had a floor of fake ambient (`albedo * 0.08` + hemisphere ambient + SSAO) that never reached zero. This is the two renderers agreeing.
- **HDRI is not ported.** `Environment::Image` from #733 is CPU-only; the GPU always uses the default studio gradient, whose constants and math do match exactly. A `--hdri` render will not match the viewport.
- **Anisotropy is ported but not yet driven.** The GPU tangent frame is an arbitrary ONB rather than `dP/du`-aligned, so grain direction would be wrong. `GpuMaterial::anisotropy` defaults to 0 (nothing sets it on the GPU path), where the frame is irrelevant. Wiring `dP/du` into the GPU frame is the remaining step before brushed materials render correctly in the viewport.
- `setAO` is replaced by `setPathTrace(maxDepth, stylize)`, and the now-inert AO controls are removed from `RaytraceChip` and the UI store.
- **Requires a local `packages/kernel-wasm` rebuild** to try in the app — the generated artifacts are deliberately not committed (`wasm-refresh.yml` owns them on main).
- Also fixed two pre-existing lints that arrived with #727 and blocked the gate: an 8-arg `sample_lights` and an unread `material` field when the `raytrace` feature is off (CI runs clippy without `--all-targets`, so it never saw the second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: anisotropy and HDRI finished

The three gaps flagged above are closed.

**Anisotropy is now driven, not just supported.** The GPU built its tangent frame from an arbitrary ONB, so a brushed highlight would have run in a direction unrelated to the surface's grain — invisible on every isotropic material, since their BSDF doesn't care about the frame. Ported the geom crate's `d_du` for all five analytic surfaces and mirrored `pathtrace::shading_frame`. The maths lives in `shaders/surface.wgsl` as a pure `surface_dpdu(type, params, uv)` so the parity harness can drive it directly: `gpu_surface_tangent_matches_geom_d_du` sweeps u around and v across both hemispheres and both sides of the cone apex, comparing against `intersect::surface_tangent` as directions, and requires the degenerate cases (pole, apex) to agree exactly.

**Materials now reach the viewport.** This was the real blocker on anisotropy — `setMaterial` carried only colour/metallic/roughness, so clearcoat, IOR and anisotropy were dropped en route to the GPU. The IR→`Pbr` derivation moved out of `vcad-render` into `pathtrace::Pbr::from_material_def`, so both renderers run the same clearcoat heuristic, IOR clamp and anisotropy resolution (explicit value wins; the name heuristic fills in only when the document is silent). New `setMaterialFromDef` wasm entry; the viewport passes the document's `MaterialDef` straight through.

**HDRI is ported.** Nearest-texel lat-long lookup (deliberately — it makes the sampled radiance and the PDF describe the same piecewise-constant function, which is what MIS requires), the solid-angle PDF with its `2·pi^2·sin(theta)` Jacobian, and binary-search sampling of the conditional/marginal CDFs. Both MIS sites match the CPU: environment NEE alongside light NEE, and a BSDF ray escaping to the sky is power-heuristic weighted against the env PDF.

Pixels and both CDFs share **one** storage buffer. Three would read better, but the shader already binds ten and browsers cap the count; `env.wgsl` documents the layout and `EnvMap::pack_for_gpu` produces it right next to where the CDFs are built.

Two tests, because they catch different things: `gpu_environment_matches_cpu_envmap` compares radiance, PDF and sampled PDF over the whole sphere including near-polar directions; `gpu_environment_sampling_finds_the_sun` catches what that one cannot — a CDF that degenerated to uniform would still be internally self-consistent, so it checks that sampling concentrates on the energy and that `E[L/pdf]` matches the CPU estimator within 5%.

### Still open

- **The three "environment" vocabularies are not reconciled.** The IR's `scene.environment` presets drive only the tessellated viewport; `vcad-render --env` has its own three procedural builtins; the raytrace viewport uses the gradient unless given an `EnvMap` through `GpuScene::set_environment`. The GPU can now *render* an HDRI, but nothing in the app hands it one. Picking one vocabulary is a product decision I deliberately left alone.
- `vcad-ffi`'s `render_with_render_state` call was updated for the dropped AO buffer — my earlier per-package clippy never reached that crate, which is what the CI failure caught.

### Verification (re-run after all of the above)

- 7 GPU parity tests + 3 smoke tests pass on Metal; full workspace `cargo test` green.
- `cargo clippy --workspace` (the CI invocation) clean, plus `--all-targets` on the raytrace crate; `cargo fmt --all --check`; `tsc --noEmit`.
