### PR TITLE
fix(step): anchor exported solids in the AP214 product structure

### DIFF
--- a/changelog/entries/2026-07-26-step-export-product-anchor.json
+++ b/changelog/entries/2026-07-26-step-export-product-anchor.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-26-step-export-product-anchor",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "fix",
+  "title": "STEP exports now open in external CAD",
+  "summary": "Exported STEP files carry the AP214 product/representation anchor and mm units, so Shapr3D, SolidWorks, and Fusion no longer reject them as containing no 3D geometry.",
+  "features": ["step-export", "interop"],
+  "mcpTools": ["export_cad"]
+}

--- a/crates/vcad-kernel-step/src/assembly.rs
+++ b/crates/vcad-kernel-step/src/assembly.rs
@@ -725,7 +725,7 @@ END-ISO-10303-21;
         // One instance
         assert_eq!(asm.instances.len(), 1);
         let inst = &asm.instances[0];
-        assert_eq!(inst.parent_id.is_some(), true);
+        assert!(inst.parent_id.is_some());
         // Transform: placed 20 mm along X
         assert!((inst.transform.origin[0] - 20.0).abs() < 1e-6);
         assert!(inst.transform.origin[1].abs() < 1e-6);

--- a/crates/vcad-kernel-step/src/reader.rs
+++ b/crates/vcad-kernel-step/src/reader.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use crate::entities::{
     curves::{parse_curve, StepCurve},
     parse_advanced_face, parse_edge_curve, parse_edge_loop, parse_manifold_solid_brep,
-    parse_oriented_edge, parse_shell, parse_surface_oriented, parse_vertex_point,
+    parse_oriented_edge, parse_shell, parse_surface_oriented, parse_vertex_point, EntityArgs,
 };
 use crate::error::StepError;
 use stepperoni::{Parser, StepFile};
@@ -125,14 +125,69 @@ impl<'a> StepReader<'a> {
         }
     }
 
-    fn read_all_solids(&mut self) -> Result<Vec<BRepSolid>, StepError> {
-        let solid_entities = self.file.entities_of_type("MANIFOLD_SOLID_BREP");
-        if solid_entities.is_empty() {
-            return Err(StepError::NoSolids);
+    /// Collect `MANIFOLD_SOLID_BREP` ids reachable through the product anchor:
+    /// SHAPE_DEFINITION_REPRESENTATION -> representation -> items. Returns
+    /// `None` when the file has no SDR entities at all (anchor-less file).
+    ///
+    /// Conforming importers only see geometry through this chain; when it is
+    /// present we honor it, so a vcad-written file is read the same way
+    /// Shapr3D/SolidWorks/Fusion read it — an anchor that references nothing
+    /// becomes a loud error instead of a silent direct-scan pass.
+    fn anchored_solid_ids(&self) -> Option<Vec<u64>> {
+        let sdrs = self
+            .file
+            .entities_of_type("SHAPE_DEFINITION_REPRESENTATION");
+        if sdrs.is_empty() {
+            return None;
         }
+        let mut ids = Vec::new();
+        for sdr in sdrs {
+            let Ok(rep_id) = sdr.entity_ref(1) else {
+                continue;
+            };
+            let Some(rep) = self.file.get(rep_id) else {
+                continue;
+            };
+            if let Ok(items) = rep.entity_ref_list(1) {
+                for item_id in items {
+                    let is_solid = self
+                        .file
+                        .get(item_id)
+                        .map(|e| e.type_name == "MANIFOLD_SOLID_BREP")
+                        .unwrap_or(false);
+                    if is_solid && !ids.contains(&item_id) {
+                        ids.push(item_id);
+                    }
+                }
+            }
+        }
+        Some(ids)
+    }
+
+    fn read_all_solids(&mut self) -> Result<Vec<BRepSolid>, StepError> {
+        let solid_ids: Vec<u64> = match self.anchored_solid_ids() {
+            // Anchor present: read exactly what it references. Empty means the
+            // product structure points at no solids — fail rather than rescue
+            // unreachable geometry a conforming importer would never show.
+            Some(ids) => {
+                if ids.is_empty() {
+                    return Err(StepError::NoSolids);
+                }
+                ids
+            }
+            // Anchor-less file (legacy vcad exports, minimal foreign files):
+            // fall back to scanning for solids directly.
+            None => {
+                let solid_entities = self.file.entities_of_type("MANIFOLD_SOLID_BREP");
+                if solid_entities.is_empty() {
+                    return Err(StepError::NoSolids);
+                }
+                solid_entities.iter().map(|e| e.id).collect()
+            }
+        };
 
         let mut solids = Vec::new();
-        for entity in solid_entities {
+        for entity_id in solid_ids {
             // Reset maps for each solid
             self.vertex_map.clear();
             self.edge_map.clear();
@@ -140,7 +195,7 @@ impl<'a> StepReader<'a> {
             self.surface_map.clear();
             self.subdivided_edges.clear();
 
-            let solid = self.read_solid(entity.id)?;
+            let solid = self.read_solid(entity_id)?;
             solids.push(solid);
         }
 
@@ -546,6 +601,46 @@ impl<'a> StepReader<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An anchor (SDR -> representation) that references no solids must fail
+    /// loudly, even when unreachable MANIFOLD_SOLID_BREPs exist in the file —
+    /// that is exactly what a conforming importer sees as "no 3D geometry".
+    #[test]
+    fn test_broken_anchor_is_detected() {
+        let cube = vcad_kernel_primitives::make_cube(10.0, 10.0, 10.0);
+        let buffer = crate::writer::write_step_to_buffer(&cube).unwrap();
+        let content = String::from_utf8_lossy(&buffer);
+
+        // Empty the ABSR's item list, orphaning the solid.
+        let start = content
+            .find("ADVANCED_BREP_SHAPE_REPRESENTATION")
+            .expect("writer must emit an ABSR");
+        let open = content[start..].find(",(").unwrap() + start;
+        let close = content[open..].find(')').unwrap() + open;
+        let broken = format!("{},(){}", &content[..open], &content[close + 1..]);
+        assert!(
+            broken.contains("MANIFOLD_SOLID_BREP"),
+            "solid still present"
+        );
+
+        let err = read_step_from_buffer(broken.as_bytes()).unwrap_err();
+        assert!(matches!(err, StepError::NoSolids), "got {err:?}");
+    }
+
+    /// Writer-emitted files are read through the anchor, not the fallback scan.
+    #[test]
+    fn test_anchored_read_finds_solids() {
+        let cube = vcad_kernel_primitives::make_cube(10.0, 20.0, 30.0);
+        let buffer = crate::writer::write_step_to_buffer(&cube).unwrap();
+        let step_file = Parser::parse(&buffer).unwrap();
+        let reader = StepReader::new(&step_file);
+        let anchored = reader
+            .anchored_solid_ids()
+            .expect("writer output must contain an SDR anchor");
+        assert_eq!(anchored.len(), 1);
+        let solids = read_step_from_buffer(&buffer).unwrap();
+        assert_eq!(solids.len(), 1);
+    }
 
     #[test]
     fn test_read_simple_box() {

--- a/crates/vcad-kernel-step/src/writer.rs
+++ b/crates/vcad-kernel-step/src/writer.rs
@@ -68,12 +68,21 @@ pub fn write_step_solids_to_buffer(solids: &[(&BRepSolid, &str)]) -> Result<Vec<
     }
     let mut entities: Vec<String> = Vec::new();
     let mut next_id = 1;
+    let mut solid_ids: Vec<u64> = Vec::new();
     for (solid, name) in solids {
         let mut writer = StepWriter::with_start_id(solid, next_id);
-        writer.write_entities(name)?;
+        solid_ids.push(writer.write_entities(name)?);
         next_id = writer.next_id;
         entities.extend(writer.output);
     }
+    // Product/representation anchor: without this layer (context with UNITS,
+    // ADVANCED_BREP_SHAPE_REPRESENTATION, PRODUCT chain, and the
+    // SHAPE_DEFINITION_REPRESENTATION that ties them together) conforming
+    // importers traverse PRODUCT -> SDR -> representation, find nothing, and
+    // report "no 3D geometry" even though the MANIFOLD_SOLID_BREPs are in the
+    // file. vcad's own reader scans for solids directly, which is why a
+    // round-trip through vcad alone cannot catch the omission.
+    write_product_anchor(&mut entities, &mut next_id, &solid_ids);
     assemble_file(&entities)
 }
 
@@ -85,6 +94,81 @@ pub fn write_step_solids(
     let buffer = write_step_solids_to_buffer(solids)?;
     std::fs::write(path, buffer)?;
     Ok(())
+}
+
+/// Append the AP214 product structure + representation context that anchor
+/// the solids for conforming importers: SI units (mm), uncertainty, one
+/// PRODUCT, and an ADVANCED_BREP_SHAPE_REPRESENTATION holding every solid.
+fn write_product_anchor(entities: &mut Vec<String>, next_id: &mut u64, solid_ids: &[u64]) {
+    let mut id = || {
+        let v = *next_id;
+        *next_id += 1;
+        v
+    };
+    let app = id();
+    entities.push(format!(
+        "#{app} = APPLICATION_CONTEXT('automotive design');"
+    ));
+    let apd = id();
+    entities.push(format!(
+        "#{apd} = APPLICATION_PROTOCOL_DEFINITION('international standard','automotive_design',2010,#{app});"
+    ));
+    let pctx = id();
+    entities.push(format!(
+        "#{pctx} = PRODUCT_CONTEXT('',#{app},'mechanical');"
+    ));
+    let prod = id();
+    entities.push(format!(
+        "#{prod} = PRODUCT('vcad_part','vcad_part','',(#{pctx}));"
+    ));
+    let prpc = id();
+    entities.push(format!(
+        "#{prpc} = PRODUCT_RELATED_PRODUCT_CATEGORY('part','',(#{prod}));"
+    ));
+    let pdf = id();
+    entities.push(format!(
+        "#{pdf} = PRODUCT_DEFINITION_FORMATION('','',#{prod});"
+    ));
+    let pdctx = id();
+    entities.push(format!(
+        "#{pdctx} = PRODUCT_DEFINITION_CONTEXT('part definition',#{app},'design');"
+    ));
+    let pd = id();
+    entities.push(format!(
+        "#{pd} = PRODUCT_DEFINITION('design','',#{pdf},#{pdctx});"
+    ));
+    let pds = id();
+    entities.push(format!("#{pds} = PRODUCT_DEFINITION_SHAPE('','',#{pd});"));
+    let len_u = id();
+    entities.push(format!(
+        "#{len_u} = ( LENGTH_UNIT() NAMED_UNIT(*) SI_UNIT(.MILLI.,.METRE.) );"
+    ));
+    let ang_u = id();
+    entities.push(format!(
+        "#{ang_u} = ( NAMED_UNIT(*) PLANE_ANGLE_UNIT() SI_UNIT($,.RADIAN.) );"
+    ));
+    let sol_u = id();
+    entities.push(format!(
+        "#{sol_u} = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );"
+    ));
+    let unc = id();
+    entities.push(format!(
+        "#{unc} = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.0E-6),#{len_u},'distance_accuracy_value','');"
+    ));
+    let ctx = id();
+    entities.push(format!(
+        "#{ctx} = ( GEOMETRIC_REPRESENTATION_CONTEXT(3) GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT((#{unc})) GLOBAL_UNIT_ASSIGNED_CONTEXT((#{len_u},#{ang_u},#{sol_u})) REPRESENTATION_CONTEXT('','3D') );"
+    ));
+    let items: Vec<String> = solid_ids.iter().map(|s| format!("#{s}")).collect();
+    let absr = id();
+    entities.push(format!(
+        "#{absr} = ADVANCED_BREP_SHAPE_REPRESENTATION('',({}),#{ctx});",
+        items.join(",")
+    ));
+    let sdr = id();
+    entities.push(format!(
+        "#{sdr} = SHAPE_DEFINITION_REPRESENTATION(#{pds},#{absr});"
+    ));
 }
 
 /// Wrap entity lines in the ISO-10303-21 header/footer.
@@ -101,7 +185,10 @@ fn assemble_file(entities: &[String]) -> Result<Vec<u8>, StepError> {
         "FILE_NAME('model.step', '{}', ('vcad'), ('vcad'), 'vcad-kernel-step', 'vcad', '');",
         chrono_lite_date()
     )?;
-    writeln!(buffer, "FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));")?;
+    writeln!(
+        buffer,
+        "FILE_SCHEMA(('AUTOMOTIVE_DESIGN {{ 1 0 10303 214 3 1 1 }}'));"
+    )?;
     writeln!(buffer, "ENDSEC;")?;
     writeln!(buffer, "DATA;")?;
     for line in entities {
@@ -162,7 +249,7 @@ impl<'a> StepWriter<'a> {
         self.output.push(format!("#{} = {};", id, entity));
     }
 
-    fn write_entities(&mut self, name: &str) -> Result<(), StepError> {
+    fn write_entities(&mut self, name: &str) -> Result<u64, StepError> {
         // Write all geometry and topology
         self.write_points()?;
         self.write_surfaces()?;
@@ -171,8 +258,8 @@ impl<'a> StepWriter<'a> {
         self.write_loops()?;
         self.write_faces()?;
         let shell_id = self.write_shell()?;
-        let _solid_id = self.write_solid(shell_id, name)?;
-        Ok(())
+        let solid_id = self.write_solid(shell_id, name)?;
+        Ok(solid_id)
     }
 
     fn write_points(&mut self) -> Result<(), StepError> {
@@ -598,8 +685,157 @@ mod tests {
         assert!(content.contains("MANIFOLD_SOLID_BREP"));
         assert!(content.contains("CLOSED_SHELL"));
         assert!(content.contains("ADVANCED_FACE"));
-        assert!(content.contains("PLANE"));
+        assert!(content.contains("PLANE("));
         assert!(content.contains("CARTESIAN_POINT"));
+    }
+
+    /// Parse the DATA section into `id -> entity body` (text after `=`,
+    /// trailing `;` stripped). Deliberately independent of vcad's own STEP
+    /// parser: these conformance tests must not share an oracle with the
+    /// reader, or a layer both sides skip goes untested (the round-trip
+    /// tests passed for months on files every conforming importer rejected).
+    fn parse_entities(content: &str) -> HashMap<u64, String> {
+        let mut map = HashMap::new();
+        for line in content.lines() {
+            let Some(rest) = line.strip_prefix('#') else {
+                continue;
+            };
+            let Some((id, body)) = rest.split_once('=') else {
+                continue;
+            };
+            let Ok(id) = id.trim().parse::<u64>() else {
+                continue;
+            };
+            map.insert(id, body.trim().trim_end_matches(';').trim().to_string());
+        }
+        map
+    }
+
+    fn ids_of_type(map: &HashMap<u64, String>, ty: &str) -> Vec<u64> {
+        let mut ids: Vec<u64> = map
+            .iter()
+            .filter(|(_, body)| {
+                body.strip_prefix(ty)
+                    .map(|rest| rest.trim_start().starts_with('('))
+                    .unwrap_or(false)
+            })
+            .map(|(&id, _)| id)
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    /// Entity ids referenced (as `#N`) inside a body string.
+    fn refs_in(body: &str) -> Vec<u64> {
+        let mut refs = Vec::new();
+        let bytes = body.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'#' {
+                let start = i + 1;
+                let mut end = start;
+                while end < bytes.len() && bytes[end].is_ascii_digit() {
+                    end += 1;
+                }
+                if end > start {
+                    refs.push(body[start..end].parse().unwrap());
+                }
+                i = end;
+            } else {
+                i += 1;
+            }
+        }
+        refs
+    }
+
+    /// Assert the product/representation anchor a conforming importer
+    /// traverses: PRODUCT -> ... -> SDR -> ABSR(all solids, unit context).
+    fn assert_anchor_graph(content: &str) {
+        let map = parse_entities(content);
+
+        // Header: FILE_SCHEMA must carry the AP214 object identifier.
+        assert!(
+            content.contains("FILE_SCHEMA(('AUTOMOTIVE_DESIGN { 1 0 10303 214 3 1 1 }'));"),
+            "FILE_SCHEMA must include the AP214 object-identifier suffix"
+        );
+
+        // Exactly one SDR per file.
+        let sdrs = ids_of_type(&map, "SHAPE_DEFINITION_REPRESENTATION");
+        assert_eq!(sdrs.len(), 1, "expected exactly one SDR, got {sdrs:?}");
+        let sdr_refs = refs_in(&map[&sdrs[0]]);
+        assert_eq!(
+            sdr_refs.len(),
+            2,
+            "SDR must reference (PDS, representation)"
+        );
+
+        // SDR arg 0 chains PDS -> PD -> PDF -> PRODUCT.
+        let pds = &map[&sdr_refs[0]];
+        assert!(
+            pds.starts_with("PRODUCT_DEFINITION_SHAPE"),
+            "SDR arg0: {pds}"
+        );
+        let pd = &map[refs_in(pds).last().unwrap()];
+        assert!(pd.starts_with("PRODUCT_DEFINITION"), "PDS ref: {pd}");
+        let pdf = &map[&refs_in(pd)[0]];
+        assert!(
+            pdf.starts_with("PRODUCT_DEFINITION_FORMATION"),
+            "PD arg2: {pdf}"
+        );
+        let product = &map[refs_in(pdf).last().unwrap()];
+        assert!(product.starts_with("PRODUCT"), "PDF ref: {product}");
+
+        // SDR arg 1 is the ABSR; it must reference every MANIFOLD_SOLID_BREP.
+        let absr = &map[&sdr_refs[1]];
+        assert!(
+            absr.starts_with("ADVANCED_BREP_SHAPE_REPRESENTATION"),
+            "SDR arg1: {absr}"
+        );
+        let absr_refs = refs_in(absr);
+        let solids = ids_of_type(&map, "MANIFOLD_SOLID_BREP");
+        assert!(!solids.is_empty(), "no MANIFOLD_SOLID_BREP entities");
+        for solid in &solids {
+            assert!(
+                absr_refs.contains(solid),
+                "ABSR does not reference solid #{solid}: {absr}"
+            );
+        }
+
+        // The ABSR's last ref is the geometric context; it must be the
+        // complex instance carrying GLOBAL_UNIT_ASSIGNED_CONTEXT, and that
+        // context must reference a LENGTH_UNIT.
+        let ctx = &map[absr_refs.last().unwrap()];
+        assert!(
+            ctx.contains("GEOMETRIC_REPRESENTATION_CONTEXT")
+                && ctx.contains("GLOBAL_UNIT_ASSIGNED_CONTEXT")
+                && ctx.contains("GLOBAL_UNCERTAINTY_ASSIGNED_CONTEXT"),
+            "ABSR context is not a unit-assigned representation context: {ctx}"
+        );
+        let has_length_unit = refs_in(ctx)
+            .iter()
+            .any(|r| map[r].contains("LENGTH_UNIT()") && map[r].contains("SI_UNIT"));
+        assert!(
+            has_length_unit,
+            "context does not reference an SI LENGTH_UNIT: {ctx}"
+        );
+    }
+
+    #[test]
+    fn test_anchor_graph_single_body() {
+        let cube = make_cube(10.0, 10.0, 10.0);
+        let buffer = write_step_to_buffer(&cube).unwrap();
+        assert_anchor_graph(&String::from_utf8_lossy(&buffer));
+    }
+
+    #[test]
+    fn test_anchor_graph_multi_body() {
+        let a = make_cube(10.0, 10.0, 10.0);
+        let b = make_cube(5.0, 5.0, 20.0);
+        let buffer = write_step_solids_to_buffer(&[(&a, "A"), (&b, "B")]).unwrap();
+        let content = String::from_utf8_lossy(&buffer);
+        assert_anchor_graph(&content);
+        let map = parse_entities(&content);
+        assert_eq!(ids_of_type(&map, "MANIFOLD_SOLID_BREP").len(), 2);
     }
 
     #[test]
@@ -706,7 +942,7 @@ mod tests {
             content
         );
         assert!(
-            !content.contains("PLANE"),
+            !content.contains("PLANE("),
             "B-spline surface should NOT be written as PLANE"
         );
     }
@@ -734,7 +970,7 @@ mod tests {
         let content = String::from_utf8_lossy(&buffer);
 
         assert!(
-            content.contains("PLANE"),
+            content.contains("PLANE("),
             "Planar bilinear should be written as PLANE"
         );
         assert!(
@@ -770,7 +1006,7 @@ mod tests {
             "Non-planar bilinear should be written as B_SPLINE_SURFACE_WITH_KNOTS"
         );
         assert!(
-            !content.contains("PLANE"),
+            !content.contains("PLANE("),
             "Non-planar bilinear should NOT be written as PLANE"
         );
     }


### PR DESCRIPTION
## Problem

STEP files from the just-merged boolean export work (#725) are rejected by conforming importers ("this file is empty or doesn't contain 3D geometry" — reproduced in Shapr3D on all 9 files of a CNC order package). The writer emitted raw `MANIFOLD_SOLID_BREP` geometry with no product/representation anchor, no representation context, and **no units anywhere in the file**. Conforming importers traverse `PRODUCT → PRODUCT_DEFINITION → PRODUCT_DEFINITION_SHAPE → SHAPE_DEFINITION_REPRESENTATION → representation → items`; with nothing referencing the solids, the geometry is unreachable.

vcad's own reader scans for solids directly — the round-trip test was **circular**, so both ends silently skipped the missing layer.

## Fix

**Writer** — `write_product_anchor()` appends the canonical minimal AP214 skeleton after the geometry: `APPLICATION_CONTEXT`/APD, PRODUCT chain (incl. `PRODUCT_RELATED_PRODUCT_CATEGORY`), SI units (mm / radian / steradian), `UNCERTAINTY_MEASURE_WITH_UNIT` 1e-6, the complex-instance `GEOMETRIC_REPRESENTATION_CONTEXT`, one `ADVANCED_BREP_SHAPE_REPRESENTATION` holding every solid id, and the `SHAPE_DEFINITION_REPRESENTATION`. `FILE_SCHEMA` gains the AP214 object identifier `{ 1 0 10303 214 3 1 1 }`. All write paths (single- and multi-body) share the one file assembler, so everything gets the anchor.

**Reader** — when an SDR is present, solids are read through the anchor exactly as commercial CAD does; an anchor referencing no solids fails loudly with `NoSolids` instead of rescuing unreachable geometry. Anchor-less files (legacy exports, minimal foreign files) keep the direct-scan fallback.

**Tests (circularity broken)** — new conformance tests assert the entity graph with a string-level oracle deliberately independent of vcad's parser: exactly one SDR per file; the ABSR references every `MANIFOLD_SOLID_BREP`; the ABSR's context carries `GLOBAL_UNIT_ASSIGNED_CONTEXT` referencing an SI `LENGTH_UNIT`; schema identifier present. Plus reader-side broken-anchor detection and multi-body coverage.

## Validation

- `cargo test -p vcad-kernel-step` (60), plus vcad-kernel / vcad-kernel-tessellate / vcad dependents — all green; clippy `-D warnings` and fmt clean.
- Real CLI export (`vcad export examples/parametric-plate.vcad plate.step`) carries the full chain: `PRODUCT #1641 → SDR #1653 → ABSR #1652 → MSB`, mm units, uncertainty.
- Acceptance test: user re-import into Shapr3D.

Follow-ups (not in this PR): per-solid PRODUCTs for multi-body body-naming semantics; optional CI job validating against an external reader (steputils / FreeCAD-OCC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)