### PR TITLE
fix(step): analytic CIRCLE edge reconstruction at export — curved faces survive third-party import

### DIFF
--- a/changelog/entries/2026-07-26-step-analytic-circle-edges.json
+++ b/changelog/entries/2026-07-26-step-analytic-circle-edges.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-26-step-analytic-circle-edges",
+  "version": "0.9.4",
+  "date": "2026-07-26",
+  "category": "fix",
+  "title": "STEP export: curved faces survive third-party import",
+  "summary": "Circular edges now export as analytic CIRCLEs instead of chord polylines, so importers like Shapr3D keep cylinder walls and annular faces at the spec 1e-6 accuracy.",
+  "features": ["step", "export", "kernel"]
+}

--- a/crates/vcad-kernel-step/src/lib.rs
+++ b/crates/vcad-kernel-step/src/lib.rs
@@ -48,6 +48,7 @@ mod entities;
 mod error;
 mod pmi;
 mod reader;
+mod reconstruct;
 mod writer;
 
 pub use assembly::{

--- a/crates/vcad-kernel-step/src/reader.rs
+++ b/crates/vcad-kernel-step/src/reader.rs
@@ -18,6 +18,17 @@ use vcad_kernel_topo::{EdgeId, HalfEdgeId, LoopId, Orientation, ShellType, Topol
 /// Number of intermediate points to sample along a curved edge (arc or B-spline).
 const CURVE_SAMPLE_COUNT: usize = 8;
 
+/// Angular resolution for sampling circular arcs: aim for 64 segments per
+/// full turn (matching the kernel's usual tessellation density), so a
+/// semicircular arc doesn't collapse to a 9-gon.
+const ARC_SEGMENTS_PER_TURN: f64 = 64.0;
+
+/// Intermediate sample count for a circular arc of the given sweep (radians).
+fn arc_sample_count(sweep: f64) -> usize {
+    let segments = (sweep.abs() * ARC_SEGMENTS_PER_TURN / std::f64::consts::TAU).ceil() as usize;
+    segments.saturating_sub(1).clamp(CURVE_SAMPLE_COUNT, 128)
+}
+
 /// Hard ceilings on how much topology we will try to parse from a single
 /// STEP solid. They exist purely to keep a malicious file from pinning the
 /// reader in a multi-hour allocation loop; legitimate CAD models come
@@ -564,7 +575,7 @@ impl<'a> StepReader<'a> {
             -s
         };
 
-        let n = CURVE_SAMPLE_COUNT;
+        let n = arc_sample_count(sweep);
         let mut mid_vids = Vec::with_capacity(n);
         for i in 1..=n {
             let frac = i as f64 / (n + 1) as f64;

--- a/crates/vcad-kernel-step/src/reconstruct.rs
+++ b/crates/vcad-kernel-step/src/reconstruct.rs
@@ -1,0 +1,605 @@
+//! Analytic edge reconstruction for STEP export.
+//!
+//! The topology reaching the writer carries no curve references: a circular
+//! intersection edge (cylinder ∩ plane) arrives as a chain of chord edges
+//! between tessellation vertices, and a pristine primitive's circular
+//! boundary arrives as a single closed edge with one vertex. Emitting those
+//! as LINEs pairs exact analytic surfaces with polyline boundaries that
+//! deviate from the surfaces by the chord sagitta, so conforming importers
+//! (with the spec-conventional 1e-6 uncertainty) fail to sew edge to surface
+//! and drop the face.
+//!
+//! This module reconstructs the analytic edges before writing:
+//! - chains of consecutive edges between the same face pair whose interior
+//!   vertices have total degree 2 are merged into one LINE (collinear) or one
+//!   CIRCLE arc (concyclic, verified against every chain vertex);
+//! - closed chains (full circles) are split into two semicircular arcs, since
+//!   many importers reject a closed edge with a single vertex;
+//! - a single closed edge bounding a plane and a cylinder/cone (the pristine
+//!   primitive case) is rebuilt as a circle from the adjacent surfaces and
+//!   split at a synthesized antipodal vertex.
+//!
+//! Everything that fails verification falls back to the existing per-edge
+//! LINE path — the reconstruction is strictly opportunistic and fail-safe.
+
+use std::collections::HashMap;
+
+use vcad_kernel_geom::{ConeSurface, CylinderSurface, Plane, SurfaceKind};
+use vcad_kernel_math::{Dir3, Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_topo::{EdgeId, HalfEdgeId, Orientation, VertexId};
+
+/// Endpoint of a reconstructed segment: an existing topology vertex, or an
+/// index into [`ChainPlan::synth_points`] for a vertex synthesized to split a
+/// closed circle into two arcs.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum SegEnd {
+    /// An existing topology vertex.
+    Topo(VertexId),
+    /// Index into the owning chain's `synth_points`.
+    Synth(usize),
+}
+
+/// One STEP edge replacing a run of topology edges.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Segment {
+    /// Start endpoint (in chain-forward direction).
+    pub start: SegEnd,
+    /// End endpoint.
+    pub end: SegEnd,
+}
+
+/// The analytic curve a chain was verified to lie on.
+#[derive(Debug, Clone)]
+pub(crate) enum ChainGeom {
+    /// All chain vertices are collinear; the chain becomes one LINE edge.
+    Line,
+    /// All chain vertices lie on this circle. Chain-forward traversal is
+    /// counterclockwise about `normal`.
+    Arc {
+        /// Circle center.
+        center: Point3,
+        /// Circle radius.
+        radius: f64,
+        /// Circle plane normal; chain-forward is CCW about it.
+        normal: Dir3,
+    },
+}
+
+/// A verified run of topology edges to be replaced by analytic segments.
+#[derive(Debug)]
+pub(crate) struct ChainPlan {
+    /// Member edges (unordered; used for run-length accounting).
+    pub edges: Vec<EdgeId>,
+    /// Ordered vertices along the chain. Open: `edges.len() + 1` entries.
+    /// Closed: `edges.len()` entries with an implicit wrap to the first.
+    pub vertices: Vec<VertexId>,
+    /// Whether the chain closes on itself (a full circle).
+    pub closed: bool,
+    /// Verified analytic geometry.
+    pub geom: ChainGeom,
+    /// Replacement segments in chain-forward order.
+    pub segments: Vec<Segment>,
+    /// Points for synthesized split vertices referenced by `SegEnd::Synth`.
+    pub synth_points: Vec<Point3>,
+}
+
+/// The full merge plan for one solid.
+#[derive(Debug, Default)]
+pub(crate) struct EdgeMergePlan {
+    /// Verified chains.
+    pub chains: Vec<ChainPlan>,
+    /// Maps every member edge to its chain index.
+    pub edge_chain: HashMap<EdgeId, usize>,
+}
+
+/// Absolute + relative tolerance for on-curve verification.
+pub(crate) fn fit_tol(scale: f64) -> f64 {
+    1e-6 * (1.0 + scale.abs())
+}
+
+/// Build the edge merge plan for a solid.
+pub(crate) fn plan_edge_merges(solid: &BRepSolid) -> EdgeMergePlan {
+    let topo = &solid.topology;
+
+    // Per-edge endpoints and adjacent-face pair (sorted so (a,b) == (b,a)).
+    struct EdgeInfo {
+        v0: VertexId,
+        v1: VertexId,
+        faces: Option<(vcad_kernel_topo::FaceId, vcad_kernel_topo::FaceId)>,
+    }
+    let mut info: HashMap<EdgeId, EdgeInfo> = HashMap::new();
+    for (eid, edge) in &topo.edges {
+        let he = edge.half_edge;
+        let v0 = topo.half_edges[he].origin;
+        // half_edge_dest panics on a half-edge without `next`; guard.
+        if topo.half_edges[he].next.is_none() {
+            continue;
+        }
+        let v1 = topo.half_edge_dest(he);
+        let faces = match topo.edge_faces(eid) {
+            (Some(a), Some(b)) => {
+                let (a, b) = if a <= b { (a, b) } else { (b, a) };
+                Some((a, b))
+            }
+            _ => None,
+        };
+        info.insert(eid, EdgeInfo { v0, v1, faces });
+    }
+
+    // Global vertex degree: edges plus orphan half-edges (edge == None). A
+    // vertex is only merged through when nothing else in the model needs a
+    // break there.
+    let mut vertex_edges: HashMap<VertexId, Vec<EdgeId>> = HashMap::new();
+    let mut orphan_touch: HashMap<VertexId, usize> = HashMap::new();
+    for (eid, ei) in &info {
+        if ei.v0 != ei.v1 {
+            vertex_edges.entry(ei.v0).or_default().push(*eid);
+            vertex_edges.entry(ei.v1).or_default().push(*eid);
+        }
+    }
+    for (he_id, he) in &topo.half_edges {
+        if he.edge.is_none() {
+            *orphan_touch.entry(he.origin).or_default() += 1;
+            if topo.half_edges[he_id].next.is_some() {
+                *orphan_touch.entry(topo.half_edge_dest(he_id)).or_default() += 1;
+            }
+        }
+    }
+
+    // A vertex we may merge through: exactly two incident edges, no orphan
+    // half-edges, and both edges bound the same (fully paired) face pair.
+    let merge_through = |v: VertexId| -> Option<(EdgeId, EdgeId)> {
+        if orphan_touch.contains_key(&v) {
+            return None;
+        }
+        let es = vertex_edges.get(&v)?;
+        if es.len() != 2 {
+            return None;
+        }
+        let (a, b) = (es[0], es[1]);
+        let fa = info.get(&a)?.faces?;
+        let fb = info.get(&b)?.faces?;
+        (fa == fb).then_some((a, b))
+    };
+
+    // Walk maximal chains through merge-through vertices.
+    let mut visited: HashMap<EdgeId, bool> = HashMap::new();
+    let mut raw_chains: Vec<(Vec<EdgeId>, Vec<VertexId>, bool)> = Vec::new();
+    for (eid, ei) in &info {
+        if visited.contains_key(eid) || ei.v0 == ei.v1 || ei.faces.is_none() {
+            continue;
+        }
+        // Only start from an edge that can merge with a neighbor at all.
+        if merge_through(ei.v0).is_none() && merge_through(ei.v1).is_none() {
+            continue;
+        }
+        let mut chain_edges = vec![*eid];
+        let mut chain_verts = vec![ei.v0, ei.v1];
+        visited.insert(*eid, true);
+
+        // Extend forward from the tail, then backward from the head.
+        loop {
+            let tail = *chain_verts.last().unwrap();
+            if tail == chain_verts[0] {
+                break; // closed
+            }
+            let Some((a, b)) = merge_through(tail) else {
+                break;
+            };
+            let cur = *chain_edges.last().unwrap();
+            let next = if a == cur { b } else { a };
+            if visited.contains_key(&next) {
+                break;
+            }
+            let ni = &info[&next];
+            let nv = if ni.v0 == tail { ni.v1 } else { ni.v0 };
+            visited.insert(next, true);
+            chain_edges.push(next);
+            chain_verts.push(nv);
+        }
+        let closed = chain_verts.len() > 2 && chain_verts[0] == *chain_verts.last().unwrap();
+        if !closed {
+            loop {
+                let head = chain_verts[0];
+                let Some((a, b)) = merge_through(head) else {
+                    break;
+                };
+                let cur = chain_edges[0];
+                let next = if a == cur { b } else { a };
+                if visited.contains_key(&next) {
+                    break;
+                }
+                let ni = &info[&next];
+                let nv = if ni.v0 == head { ni.v1 } else { ni.v0 };
+                visited.insert(next, true);
+                chain_edges.insert(0, next);
+                chain_verts.insert(0, nv);
+            }
+        }
+        let closed = chain_verts.len() > 2 && chain_verts[0] == *chain_verts.last().unwrap();
+        if closed {
+            chain_verts.pop(); // implicit wrap
+        }
+        if chain_edges.len() >= 2 {
+            raw_chains.push((chain_edges, chain_verts, closed));
+        }
+    }
+
+    let mut plan = EdgeMergePlan::default();
+
+    for (edges, vertices, closed) in raw_chains {
+        let points: Vec<Point3> = vertices.iter().map(|v| topo.vertices[*v].point).collect();
+        let geom = classify_chain(&points, closed);
+        let Some(geom) = geom else { continue };
+        let segments = match (&geom, closed) {
+            (_, false) => vec![Segment {
+                start: SegEnd::Topo(vertices[0]),
+                end: SegEnd::Topo(*vertices.last().unwrap()),
+            }],
+            (ChainGeom::Arc { .. }, true) => {
+                let mid = vertices.len() / 2;
+                vec![
+                    Segment {
+                        start: SegEnd::Topo(vertices[0]),
+                        end: SegEnd::Topo(vertices[mid]),
+                    },
+                    Segment {
+                        start: SegEnd::Topo(vertices[mid]),
+                        end: SegEnd::Topo(vertices[0]),
+                    },
+                ]
+            }
+            (ChainGeom::Line, true) => continue, // impossible; be safe
+        };
+        let idx = plan.chains.len();
+        for e in &edges {
+            plan.edge_chain.insert(*e, idx);
+        }
+        plan.chains.push(ChainPlan {
+            edges,
+            vertices,
+            closed,
+            geom,
+            segments,
+            synth_points: Vec::new(),
+        });
+    }
+
+    // Pristine-primitive case: a single closed edge (start == end) bounding a
+    // plane and a cylinder/cone. Rebuild the circle from the surfaces.
+    for (eid, ei) in &info {
+        if ei.v0 != ei.v1 || plan.edge_chain.contains_key(eid) {
+            continue;
+        }
+        let Some(chain) = single_closed_circle(solid, *eid, ei.v0) else {
+            continue;
+        };
+        let idx = plan.chains.len();
+        plan.edge_chain.insert(*eid, idx);
+        plan.chains.push(chain);
+    }
+
+    validate_loop_consecutiveness(solid, &mut plan);
+    plan
+}
+
+/// Verify a candidate chain's points against a line or circle.
+///
+/// Also used for orphan half-edge runs (boolean sewing leaves the chord
+/// chains of curved intersections as orphan half-edges with no twins). The
+/// classification depends only on the point sequence, never on which side of
+/// the boundary is being walked, so the two loops sharing a boundary always
+/// reconstruct identically — a requirement for importers to sew them.
+pub(crate) fn classify_chain(points: &[Point3], closed: bool) -> Option<ChainGeom> {
+    let n = points.len();
+    if n < 3 {
+        return None; // only a 2-edge closed chain lands here; nothing to fit
+    }
+
+    if !closed {
+        // Collinear?
+        let p0 = points[0];
+        let pk = points[n - 1];
+        let d = pk - p0;
+        let len = d.norm();
+        if len > 1e-9 {
+            let dir = d / len;
+            let tol = fit_tol(len);
+            let collinear = points.iter().all(|p| {
+                let w = *p - p0;
+                (w - dir * w.dot(dir)).norm() < tol
+            });
+            if collinear {
+                return Some(ChainGeom::Line);
+            }
+        }
+    }
+
+    // Any 3 points are concyclic and 4-6 exactly-concyclic points can be a
+    // genuine regular polygon; demand enough samples that "these all lie on
+    // one circle to 1e-6" is real evidence of a tessellated circle.
+    let min_pts = if closed { 6 } else { 5 };
+    if n < min_pts {
+        return None;
+    }
+    circle_fit(points, closed)
+}
+
+/// Canonical split indices for a closed circular run: the lexicographically
+/// smallest point and the point farthest from it. Both loops sharing the
+/// boundary walk the same vertices (in opposite orders), so this yields the
+/// same two split vertices on both sides regardless of traversal direction.
+pub(crate) fn canonical_split(points: &[Point3]) -> (usize, usize) {
+    let lex = |p: &Point3, q: &Point3| {
+        p.x.partial_cmp(&q.x)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(p.y.partial_cmp(&q.y).unwrap_or(std::cmp::Ordering::Equal))
+            .then(p.z.partial_cmp(&q.z).unwrap_or(std::cmp::Ordering::Equal))
+    };
+    let mut a = 0;
+    for i in 1..points.len() {
+        if lex(&points[i], &points[a]) == std::cmp::Ordering::Less {
+            a = i;
+        }
+    }
+    let mut b = if a == 0 { 1 } else { 0 };
+    let mut best = (points[b] - points[a]).norm_squared();
+    for (i, p) in points.iter().enumerate() {
+        if i == a {
+            continue;
+        }
+        let d = (*p - points[a]).norm_squared();
+        if d > best + 1e-18
+            || ((d - best).abs() <= 1e-18 && lex(p, &points[b]) == std::cmp::Ordering::Less)
+        {
+            best = d;
+            b = i;
+        }
+    }
+    (a, b)
+}
+
+/// Fit a circle through the points and verify every point lies on it, with
+/// monotone CCW traversal. Returns the chain-forward-oriented circle.
+fn circle_fit(points: &[Point3], closed: bool) -> Option<ChainGeom> {
+    let n = points.len();
+    if n < 3 {
+        return None;
+    }
+    // Three well-spread sample points.
+    let (i0, i1, i2) = (0, n / 3, (2 * n) / 3);
+    if i0 == i1 || i1 == i2 {
+        return None;
+    }
+    let (a, b, c) = (points[i0], points[i1], points[i2]);
+    let u = b - a;
+    let v = c - a;
+    let w = u.cross(v);
+    let w2 = w.norm_squared();
+    if w2 < 1e-18 {
+        return None;
+    }
+    // Circumcenter of the triangle (a, b, c).
+    let center = a + (v.cross(w) * u.norm_squared() + w.cross(u) * v.norm_squared()) / (2.0 * w2);
+    let radius = (a - center).norm();
+    if radius < 1e-9 {
+        return None;
+    }
+    let mut normal = w / w2.sqrt();
+    let tol = fit_tol(radius);
+
+    // Every point on the circle: coplanar and equidistant.
+    for p in points {
+        let r = *p - center;
+        if (r.norm() - radius).abs() > tol || r.dot(normal).abs() > tol {
+            return None;
+        }
+    }
+
+    // Orient the normal so chain order is CCW, then require monotone angles
+    // (guards against zigzag point sets that happen to be concyclic).
+    let mut signed = Vec3::zeros();
+    let last = if closed { n } else { n - 1 };
+    for i in 0..last {
+        let p = points[i] - center;
+        let q = points[(i + 1) % n] - center;
+        signed += p.cross(q);
+    }
+    if signed.dot(normal) < 0.0 {
+        normal = -normal;
+    }
+    let x_dir = (points[0] - center) / radius;
+    let y_dir = normal.cross(x_dir);
+    let mut prev = 0.0_f64;
+    let mut total = 0.0_f64;
+    for i in 1..=last {
+        let p = points[i % n] - center;
+        let mut ang = p.dot(y_dir).atan2(p.dot(x_dir));
+        if i == n {
+            ang = 2.0 * std::f64::consts::PI; // wrap of a closed chain
+        } else if ang <= 0.0 {
+            ang += 2.0 * std::f64::consts::PI;
+        }
+        if ang <= prev + 1e-12 {
+            return None;
+        }
+        total = ang;
+        prev = ang;
+    }
+    if closed && (total - 2.0 * std::f64::consts::PI).abs() > 1e-6 {
+        return None;
+    }
+
+    Some(ChainGeom::Arc {
+        center,
+        radius,
+        normal: Dir3::new_normalize(normal),
+    })
+}
+
+/// Rebuild a single closed edge (one vertex, start == end) bounding a plane
+/// and a cylinder or cone as a full circle split at a synthesized antipode.
+fn single_closed_circle(solid: &BRepSolid, eid: EdgeId, v: VertexId) -> Option<ChainPlan> {
+    let topo = &solid.topology;
+    let geom = &solid.geometry;
+
+    let he1 = topo.edges[eid].half_edge;
+    let he2 = topo.half_edges[he1].twin?;
+    let face_of = |he: HalfEdgeId| topo.half_edges[he].loop_id.and_then(|l| topo.loops[l].face);
+    let f1 = face_of(he1)?;
+    let f2 = face_of(he2)?;
+
+    let surf = |f: vcad_kernel_topo::FaceId| &geom.surfaces[topo.faces[f].surface_index];
+    // Identify which side is the plane and which is the curved surface.
+    let (planar_he, planar_face, curved_face) =
+        match (surf(f1).surface_type(), surf(f2).surface_type()) {
+            (SurfaceKind::Plane, SurfaceKind::Cylinder | SurfaceKind::Cone) => (he1, f1, f2),
+            (SurfaceKind::Cylinder | SurfaceKind::Cone, SurfaceKind::Plane) => (he2, f2, f1),
+            _ => return None,
+        };
+    let plane = surf(planar_face).as_any().downcast_ref::<Plane>()?;
+    let p = topo.vertices[v].point;
+
+    // Circle from the curved surface's axis and the vertex point.
+    let (axis, center, radius) = match surf(curved_face).surface_type() {
+        SurfaceKind::Cylinder => {
+            let cyl = surf(curved_face)
+                .as_any()
+                .downcast_ref::<CylinderSurface>()?;
+            let axis = *cyl.axis.as_ref();
+            let center = cyl.center + axis * (p - cyl.center).dot(axis);
+            let radius = (p - center).norm();
+            if (radius - cyl.radius).abs() > fit_tol(cyl.radius) {
+                return None;
+            }
+            (axis, center, radius)
+        }
+        SurfaceKind::Cone => {
+            let cone = surf(curved_face).as_any().downcast_ref::<ConeSurface>()?;
+            let axis = *cone.axis.as_ref();
+            let h = (p - cone.apex).dot(axis);
+            let center = cone.apex + axis * h;
+            let radius = (p - center).norm();
+            let expected = h.abs() * cone.half_angle.tan();
+            if (radius - expected).abs() > fit_tol(radius) {
+                return None;
+            }
+            (axis, center, radius)
+        }
+        _ => return None,
+    };
+    if radius < 1e-9 {
+        return None;
+    }
+    // The plane must be perpendicular to the axis (else the intersection is
+    // an ellipse, not this circle).
+    if plane.normal_dir.as_ref().dot(axis).abs() < 1.0 - 1e-9 {
+        return None;
+    }
+
+    // Orientation. The planar face's loop winds CCW about the face's outward
+    // normal when it is the outer bound, CW when it is an inner bound (hole).
+    // Derive the canonical half-edge's direction from that convention, since
+    // the topology itself carries no curve direction.
+    let planar_loop = topo.half_edges[planar_he].loop_id?;
+    let face = &topo.faces[planar_face];
+    let sign = if face.orientation == Orientation::Forward {
+        1.0
+    } else {
+        -1.0
+    };
+    let n_out = *plane.normal_dir.as_ref() * sign;
+    let planar_dir = if face.outer_loop == planar_loop {
+        n_out
+    } else {
+        -n_out
+    };
+    // Chain-forward is the canonical half-edge's direction.
+    let canonical_normal = if planar_he == topo.edges[eid].half_edge {
+        planar_dir
+    } else {
+        -planar_dir
+    };
+    // Snap to the exact axis direction.
+    let normal = axis * canonical_normal.dot(axis).signum();
+
+    let antipode = center + (center - p);
+    Some(ChainPlan {
+        edges: vec![eid],
+        vertices: vec![v],
+        closed: true,
+        geom: ChainGeom::Arc {
+            center,
+            radius,
+            normal: Dir3::new_normalize(normal),
+        },
+        segments: vec![
+            Segment {
+                start: SegEnd::Topo(v),
+                end: SegEnd::Synth(0),
+            },
+            Segment {
+                start: SegEnd::Synth(0),
+                end: SegEnd::Topo(v),
+            },
+        ],
+        synth_points: vec![antipode],
+    })
+}
+
+/// Drop any chain whose edges do not appear as one consecutive (cyclic) run
+/// covering the whole chain in every loop that touches it. The writer replaces
+/// runs wholesale, so a fragmented appearance would corrupt that loop.
+fn validate_loop_consecutiveness(solid: &BRepSolid, plan: &mut EdgeMergePlan) {
+    let topo = &solid.topology;
+    let mut dead: Vec<bool> = vec![false; plan.chains.len()];
+
+    for (loop_id, _) in &topo.loops {
+        let membership: Vec<Option<usize>> = topo
+            .loop_half_edges(loop_id)
+            .map(|he| {
+                topo.half_edges[he]
+                    .edge
+                    .and_then(|e| plan.edge_chain.get(&e).copied())
+            })
+            .collect();
+        let n = membership.len();
+        let mut counts: HashMap<usize, (usize, usize)> = HashMap::new(); // idx -> (count, blocks)
+        for i in 0..n {
+            if let Some(ci) = membership[i] {
+                let entry = counts.entry(ci).or_default();
+                entry.0 += 1;
+                let prev = membership[(i + n - 1) % n];
+                if prev != Some(ci) {
+                    entry.1 += 1;
+                }
+            }
+        }
+        for (ci, (count, blocks)) in counts {
+            let whole_loop = count == n && blocks == 0; // loop is entirely this chain
+            if !(whole_loop || blocks == 1) || count != plan.chains[ci].edges.len() {
+                dead[ci] = true;
+            }
+        }
+    }
+
+    if dead.iter().any(|d| *d) {
+        let mut remap: Vec<Option<usize>> = Vec::with_capacity(plan.chains.len());
+        let mut kept = Vec::new();
+        for (i, chain) in plan.chains.drain(..).enumerate() {
+            if dead[i] {
+                remap.push(None);
+            } else {
+                remap.push(Some(kept.len()));
+                kept.push(chain);
+            }
+        }
+        plan.chains = kept;
+        plan.edge_chain = plan
+            .edge_chain
+            .iter()
+            .filter_map(|(e, ci)| remap[*ci].map(|ni| (*e, ni)))
+            .collect();
+    }
+}

--- a/crates/vcad-kernel-step/src/reconstruct.rs
+++ b/crates/vcad-kernel-step/src/reconstruct.rs
@@ -577,6 +577,14 @@ fn validate_loop_consecutiveness(solid: &BRepSolid, plan: &mut EdgeMergePlan) {
             }
         }
         for (ci, (count, blocks)) in counts {
+            // blocks == 0 can only happen when EVERY half-edge in the loop
+            // belongs to this chain (any non-member creates a transition), so
+            // it is exactly the whole-loop case. The count guard applies in
+            // both arms on purpose: a whole-loop occurrence with
+            // count != edges.len() is a loop traversing chain edges more than
+            // once (e.g. both half-edges of an edge in one slit-shaped loop),
+            // which write_loops' run consumption cannot represent — the chain
+            // must be dropped there, not kept.
             let whole_loop = count == n && blocks == 0; // loop is entirely this chain
             if !(whole_loop || blocks == 1) || count != plan.chains[ci].edges.len() {
                 dead[ci] = true;

--- a/crates/vcad-kernel-step/src/writer.rs
+++ b/crates/vcad-kernel-step/src/writer.rs
@@ -14,11 +14,15 @@ use crate::entities::{
     write_vertex_point, AxisPlacement,
 };
 use crate::error::StepError;
+use crate::reconstruct::{
+    canonical_split, classify_chain, fit_tol, plan_edge_merges, ChainGeom, ChainPlan,
+    EdgeMergePlan, SegEnd,
+};
 
 use vcad_kernel_geom::{
     BilinearSurface, ConeSurface, CylinderSurface, Plane, SphereSurface, SurfaceKind, TorusSurface,
 };
-use vcad_kernel_math::{Dir3, Vec3};
+use vcad_kernel_math::{Dir3, Point3, Vec3};
 use vcad_kernel_nurbs::BSplineSurface;
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_topo::{EdgeId, FaceId, HalfEdgeId, LoopId, Orientation, VertexId};
@@ -86,16 +90,6 @@ pub fn write_step_solids_to_buffer(solids: &[(&BRepSolid, &str)]) -> Result<Vec<
     assemble_file(&entities)
 }
 
-/// Write several named BRepSolids to a single STEP file on disk.
-pub fn write_step_solids(
-    solids: &[(&BRepSolid, &str)],
-    path: impl AsRef<Path>,
-) -> Result<(), StepError> {
-    let buffer = write_step_solids_to_buffer(solids)?;
-    std::fs::write(path, buffer)?;
-    Ok(())
-}
-
 /// Append the AP214 product structure + representation context that anchor
 /// the solids for conforming importers: SI units (mm), uncertainty, one
 /// PRODUCT, and an ADVANCED_BREP_SHAPE_REPRESENTATION holding every solid.
@@ -151,6 +145,10 @@ fn write_product_anchor(entities: &mut Vec<String>, next_id: &mut u64, solid_ids
     entities.push(format!(
         "#{sol_u} = ( NAMED_UNIT(*) SI_UNIT($,.STERADIAN.) SOLID_ANGLE_UNIT() );"
     ));
+    // 1e-6 is the spec-conventional distance accuracy, and it is honest again:
+    // circular boundaries are reconstructed as CIRCLE edges before writing
+    // (see reconstruct.rs), so edges lie on their faces' analytic surfaces
+    // exactly instead of deviating by the tessellation chord sagitta.
     let unc = id();
     entities.push(format!(
         "#{unc} = UNCERTAINTY_MEASURE_WITH_UNIT(LENGTH_MEASURE(1.0E-6),#{len_u},'distance_accuracy_value','');"
@@ -169,6 +167,16 @@ fn write_product_anchor(entities: &mut Vec<String>, next_id: &mut u64, solid_ids
     entities.push(format!(
         "#{sdr} = SHAPE_DEFINITION_REPRESENTATION(#{pds},#{absr});"
     ));
+}
+
+/// Write several named BRepSolids to a single STEP file on disk.
+pub fn write_step_solids(
+    solids: &[(&BRepSolid, &str)],
+    path: impl AsRef<Path>,
+) -> Result<(), StepError> {
+    let buffer = write_step_solids_to_buffer(solids)?;
+    std::fs::write(path, buffer)?;
+    Ok(())
 }
 
 /// Wrap entity lines in the ISO-10303-21 header/footer.
@@ -220,6 +228,10 @@ struct StepWriter<'a> {
     face_bound_map: HashMap<FaceId, u64>,
     /// Maps vcad FaceId to STEP face ID.
     face_map: HashMap<FaceId, u64>,
+    /// Analytic edge reconstruction plan (chord chains → LINE/CIRCLE edges).
+    plan: EdgeMergePlan,
+    /// STEP edge IDs for each chain's segments, in chain-forward order.
+    chain_step: Vec<Vec<u64>>,
 }
 
 impl<'a> StepWriter<'a> {
@@ -236,6 +248,8 @@ impl<'a> StepWriter<'a> {
             loop_map: HashMap::new(),
             face_bound_map: HashMap::new(),
             face_map: HashMap::new(),
+            plan: EdgeMergePlan::default(),
+            chain_step: Vec::new(),
         }
     }
 
@@ -250,6 +264,9 @@ impl<'a> StepWriter<'a> {
     }
 
     fn write_entities(&mut self, name: &str) -> Result<u64, StepError> {
+        // Reconstruct analytic edges (chord chains → LINE/CIRCLE) up front so
+        // write_edges/write_loops can consult the plan.
+        self.plan = plan_edge_merges(self.solid);
         // Write all geometry and topology
         self.write_points()?;
         self.write_surfaces()?;
@@ -490,34 +507,93 @@ impl<'a> StepWriter<'a> {
     fn write_edges(&mut self) -> Result<(), StepError> {
         let topo = &self.solid.topology;
 
-        for (edge_id, edge) in &topo.edges {
-            // Get the half-edge to determine vertices
-            let he = &topo.half_edges[edge.half_edge];
-            let start_vid = he.origin;
-            let end_vid = topo.half_edge_dest(edge.half_edge);
+        let edge_ids: Vec<EdgeId> = topo.edges.keys().collect();
+        for edge_id in edge_ids {
+            if self.plan.edge_chain.contains_key(&edge_id) {
+                continue; // replaced by a reconstructed chain segment
+            }
+            let he = self.solid.topology.edges[edge_id].half_edge;
+            let start_vid = self.solid.topology.half_edges[he].origin;
+            let end_vid = self.solid.topology.half_edge_dest(he);
             let step_edge_id = self.write_line_edge_curve(start_vid, end_vid);
             self.edge_map.insert(edge_id, step_edge_id);
         }
 
+        // Emit one LINE or CIRCLE edge per reconstructed chain segment.
+        let plan = std::mem::take(&mut self.plan);
+        for chain in &plan.chains {
+            let mut seg_ids = Vec::with_capacity(chain.segments.len());
+            // Synthesized split vertices (closed single-edge circles) are
+            // minted once per chain and shared between its segments.
+            let mut synth_vertex_ids: Vec<Option<u64>> = vec![None; chain.synth_points.len()];
+            for seg in &chain.segments {
+                let (start_vertex, start_pt) =
+                    self.resolve_seg_end(seg.start, chain, &mut synth_vertex_ids);
+                let (end_vertex, _end_pt) =
+                    self.resolve_seg_end(seg.end, chain, &mut synth_vertex_ids);
+                let id = match &chain.geom {
+                    ChainGeom::Line => {
+                        let end_pt = match seg.end {
+                            SegEnd::Topo(v) => self.solid.topology.vertices[v].point,
+                            SegEnd::Synth(i) => chain.synth_points[i],
+                        };
+                        self.write_line_edge_between(start_vertex, end_vertex, start_pt, end_pt)
+                    }
+                    ChainGeom::Arc {
+                        center,
+                        radius,
+                        normal,
+                    } => self.write_arc_edge_curve(
+                        start_vertex,
+                        end_vertex,
+                        start_pt,
+                        *center,
+                        *radius,
+                        *normal,
+                    ),
+                };
+                seg_ids.push(id);
+            }
+            self.chain_step.push(seg_ids);
+        }
+        self.plan = plan;
+
         Ok(())
     }
 
-    /// Emit a straight EDGE_CURVE between two vcad vertices and return its ID.
-    ///
-    /// Used by `write_edges` for proper edges and by `write_loops` to synthesize
-    /// edges for orphan half-edges (those whose `parent_edge` link was severed
-    /// by the boolean sewing pipeline — see crates/vcad-kernel-booleans/src/sew.rs).
-    /// The geometry is approximated as a line segment regardless of the
-    /// underlying surface's curvature; this matches `write_edges`'s existing
-    /// limitation and keeps the writer's contract simple.
-    fn write_line_edge_curve(&mut self, start_vid: VertexId, end_vid: VertexId) -> u64 {
-        let topo = &self.solid.topology;
-        let start_vertex = self.vertex_map[&start_vid];
-        let end_vertex = self.vertex_map[&end_vid];
+    /// Resolve a segment endpoint to a STEP vertex ID and its 3D point,
+    /// minting a VERTEX_POINT for synthesized split vertices on first use.
+    fn resolve_seg_end(
+        &mut self,
+        end: SegEnd,
+        chain: &ChainPlan,
+        synth_ids: &mut [Option<u64>],
+    ) -> (u64, Point3) {
+        match end {
+            SegEnd::Topo(v) => (self.vertex_map[&v], self.solid.topology.vertices[v].point),
+            SegEnd::Synth(i) => {
+                let p = chain.synth_points[i];
+                if let Some(id) = synth_ids[i] {
+                    return (id, p);
+                }
+                let point_id = self.alloc_id();
+                self.emit(point_id, &write_cartesian_point(&p, ""));
+                let vertex_id = self.alloc_id();
+                self.emit(vertex_id, &write_vertex_point("", point_id));
+                synth_ids[i] = Some(vertex_id);
+                (vertex_id, p)
+            }
+        }
+    }
 
-        let start_point = topo.vertices[start_vid].point;
-        let end_point = topo.vertices[end_vid].point;
-
+    /// Emit a straight EDGE_CURVE between two STEP vertices at given points.
+    fn write_line_edge_between(
+        &mut self,
+        start_vertex: u64,
+        end_vertex: u64,
+        start_point: Point3,
+        end_point: Point3,
+    ) -> u64 {
         let dir_vec = end_point - start_point;
         let magnitude = dir_vec.norm();
         let dir = if magnitude > 1e-15 {
@@ -550,36 +626,160 @@ impl<'a> StepWriter<'a> {
         step_edge_id
     }
 
+    /// Emit an EDGE_CURVE over a CIRCLE from `start` counterclockwise about
+    /// `normal` to the end vertex. The circle's ref direction is placed at the
+    /// start point, so the edge parameterization begins at the start vertex.
+    fn write_arc_edge_curve(
+        &mut self,
+        start_vertex: u64,
+        end_vertex: u64,
+        start_point: Point3,
+        center: Point3,
+        radius: f64,
+        normal: Dir3,
+    ) -> u64 {
+        let ref_dir = Dir3::new_normalize(start_point - center);
+        let placement = AxisPlacement {
+            location: center,
+            axis: Some(normal),
+            ref_direction: Some(ref_dir),
+        };
+        let placement_id = self
+            .write_axis_placement(&placement)
+            .expect("axis placement emission is infallible");
+
+        let circle_id = self.alloc_id();
+        self.emit(
+            circle_id,
+            &format!("CIRCLE('', #{}, {:.15E})", placement_id, radius),
+        );
+
+        let step_edge_id = self.alloc_id();
+        let entity = write_edge_curve("", start_vertex, end_vertex, circle_id, true);
+        self.emit(step_edge_id, &entity);
+        step_edge_id
+    }
+
+    /// Emit a straight EDGE_CURVE between two vcad vertices and return its ID.
+    ///
+    /// Used by `write_edges` for proper edges and by `write_loops` to synthesize
+    /// edges for orphan half-edges (those whose `parent_edge` link was severed
+    /// by the boolean sewing pipeline — see crates/vcad-kernel-booleans/src/sew.rs).
+    /// The geometry is approximated as a line segment regardless of the
+    /// underlying surface's curvature; this matches `write_edges`'s existing
+    /// limitation and keeps the writer's contract simple.
+    fn write_line_edge_curve(&mut self, start_vid: VertexId, end_vid: VertexId) -> u64 {
+        let start_vertex = self.vertex_map[&start_vid];
+        let end_vertex = self.vertex_map[&end_vid];
+        let start_point = self.solid.topology.vertices[start_vid].point;
+        let end_point = self.solid.topology.vertices[end_vid].point;
+        self.write_line_edge_between(start_vertex, end_vertex, start_point, end_point)
+    }
+
     fn write_loops(&mut self) -> Result<(), StepError> {
         // Collect loops first so we can borrow self mutably inside.
         let loop_ids: Vec<LoopId> = self.solid.topology.loops.keys().collect();
+        let plan = std::mem::take(&mut self.plan);
+
+        let chain_of = |he_id: HalfEdgeId, topo: &vcad_kernel_topo::Topology| -> Option<usize> {
+            topo.half_edges[he_id]
+                .edge
+                .and_then(|e| plan.edge_chain.get(&e).copied())
+        };
 
         for loop_id in loop_ids {
             let he_ids: Vec<HalfEdgeId> = self.solid.topology.loop_half_edges(loop_id).collect();
+            let n = he_ids.len();
+
+            // Degenerate "slit" loop on a cylindrical face: exactly two
+            // half-edges that are twins of one axis-parallel seam edge. The
+            // boolean sewing pipeline loses the circular boundaries of a full
+            // cylindrical band, leaving a zero-area loop; rebuild the two
+            // circles from the surface so the face is properly bounded.
+            if n == 2 {
+                if let Some(el_id) = self.try_write_slit_cylinder_loop(loop_id, &he_ids) {
+                    self.loop_map.insert(loop_id, el_id);
+                    continue;
+                }
+            }
+
+            // Rotate so the walk never starts in the middle of a chain run
+            // (a chain's edges appear as one cyclic block — validated during
+            // planning) or an orphan half-edge run. If the whole loop is one
+            // chain or all-orphan, 0 is fine (handled as a closed run).
+            let is_orphan = |he: HalfEdgeId, topo: &vcad_kernel_topo::Topology| {
+                topo.half_edges[he].edge.is_none()
+            };
+            let mut start = 0;
+            for i in 0..n {
+                let cur = chain_of(he_ids[i], &self.solid.topology);
+                let prev = chain_of(he_ids[(i + n - 1) % n], &self.solid.topology);
+                let mid_chain = cur.is_some() && cur == prev;
+                let mid_orphan = is_orphan(he_ids[i], &self.solid.topology)
+                    && is_orphan(he_ids[(i + n - 1) % n], &self.solid.topology);
+                if !(mid_chain || mid_orphan) {
+                    start = i;
+                    break;
+                }
+            }
+            let rotated: Vec<HalfEdgeId> = (0..n).map(|i| he_ids[(start + i) % n]).collect();
 
             let mut oriented_edge_ids = Vec::new();
+            let mut i = 0;
+            while i < n {
+                let he_id = rotated[i];
+                if let Some(ci) = chain_of(he_id, &self.solid.topology) {
+                    // Consume the whole chain run and emit its segments.
+                    let chain = &plan.chains[ci];
+                    let run_len = chain.edges.len();
+                    let forward = self.chain_run_is_forward(chain, &rotated[i..], run_len);
+                    let seg_ids = self.chain_step[ci].clone();
+                    if forward {
+                        for sid in seg_ids {
+                            let oe_id = self.alloc_id();
+                            self.emit(oe_id, &write_oriented_edge("", sid, true));
+                            oriented_edge_ids.push(oe_id);
+                        }
+                    } else {
+                        for sid in seg_ids.into_iter().rev() {
+                            let oe_id = self.alloc_id();
+                            self.emit(oe_id, &write_oriented_edge("", sid, false));
+                            oriented_edge_ids.push(oe_id);
+                        }
+                    }
+                    i += run_len;
+                    continue;
+                }
 
-            for he_id in he_ids {
+                if self.solid.topology.half_edges[he_id].edge.is_none() {
+                    // Orphan half-edge — boolean sewing leaves these when face
+                    // boundaries can't be paired (curved-vs-polygonal mismatch).
+                    // Gather the maximal consecutive orphan run and try to
+                    // reconstruct it as one LINE or CIRCLE; fall back to
+                    // per-half-edge line segments.
+                    let mut run_len = 1;
+                    while i + run_len < n
+                        && self.solid.topology.half_edges[rotated[i + run_len]]
+                            .edge
+                            .is_none()
+                    {
+                        run_len += 1;
+                    }
+                    let run = &rotated[i..i + run_len];
+                    let edge_ids = self.write_orphan_run(run, run_len == n);
+                    for sid in edge_ids {
+                        let oe_id = self.alloc_id();
+                        self.emit(oe_id, &write_oriented_edge("", sid, true));
+                        oriented_edge_ids.push(oe_id);
+                    }
+                    i += run_len;
+                    continue;
+                }
+
                 let he = &self.solid.topology.half_edges[he_id];
-                let (step_edge_id, orientation) = match he.edge {
-                    Some(edge_id) => {
-                        let step_edge_id = self.edge_map[&edge_id];
-                        let edge = &self.solid.topology.edges[edge_id];
-                        let orientation = edge.half_edge == he_id;
-                        (step_edge_id, orientation)
-                    }
-                    None => {
-                        // Orphan half-edge — boolean sewing leaves these when face
-                        // boundaries can't be paired (curved-vs-polygonal mismatch).
-                        // Synthesize a one-off line edge so the loop can still be
-                        // emitted; orientation is forward since this he is the
-                        // synthetic edge's only half-edge.
-                        let start_vid = he.origin;
-                        let end_vid = self.solid.topology.half_edge_dest(he_id);
-                        let step_edge_id = self.write_line_edge_curve(start_vid, end_vid);
-                        (step_edge_id, true)
-                    }
-                };
+                let edge_id = he.edge.expect("checked above");
+                let step_edge_id = self.edge_map[&edge_id];
+                let orientation = self.solid.topology.edges[edge_id].half_edge == he_id;
 
                 let oe_id = self.alloc_id();
                 let entity = write_oriented_edge("", step_edge_id, orientation);
@@ -587,6 +787,7 @@ impl<'a> StepWriter<'a> {
                 self.oriented_edge_map.insert(he_id, oe_id);
 
                 oriented_edge_ids.push(oe_id);
+                i += 1;
             }
 
             let el_id = self.alloc_id();
@@ -595,7 +796,273 @@ impl<'a> StepWriter<'a> {
             self.loop_map.insert(loop_id, el_id);
         }
 
+        self.plan = plan;
         Ok(())
+    }
+
+    /// Whether a loop's run of half-edges traverses the chain in its forward
+    /// (as-emitted) direction.
+    fn chain_run_is_forward(&self, chain: &ChainPlan, run: &[HalfEdgeId], run_len: usize) -> bool {
+        let topo = &self.solid.topology;
+        if chain.edges.len() == 1 {
+            // Single closed edge: direction is the canonical half-edge's, by
+            // the same convention the plan used to orient the circle.
+            return topo.edges[chain.edges[0]].half_edge == run[0];
+        }
+        let first_origin = topo.half_edges[run[0]].origin;
+        if !chain.closed {
+            return first_origin == chain.vertices[0];
+        }
+        // Closed multi-edge chain: compare consecutive origins to chain order.
+        let k = chain.vertices.len();
+        let j = chain
+            .vertices
+            .iter()
+            .position(|v| *v == first_origin)
+            .expect("run origin must be a chain vertex");
+        debug_assert!(run_len >= 2);
+        let second_origin = topo.half_edges[run[1]].origin;
+        second_origin == chain.vertices[(j + 1) % k]
+    }
+
+    /// Emit STEP edges for a maximal run of orphan half-edges, reconstructing
+    /// the run as one LINE or CIRCLE when the whole run verifies as such
+    /// (falling back to per-half-edge line segments otherwise). Returns the
+    /// STEP edge IDs in traversal order; all are traversal-forward.
+    ///
+    /// Orphan half-edges have no twins, so the two loops sharing a boundary
+    /// each emit their own edges (as they always have); classification is
+    /// purely point-based and the closed-circle split vertices are canonical,
+    /// so both sides reconstruct identical geometry for importers to sew.
+    fn write_orphan_run(&mut self, run: &[HalfEdgeId], closed: bool) -> Vec<u64> {
+        // Chords along a tessellated smooth curve turn by a small angle per
+        // step; corners (tangent discontinuities) turn sharply. Splitting at
+        // sharp turns is symmetric under traversal reversal, keeping the two
+        // sides of a boundary consistent. cos(40°): full circles tessellated
+        // with ≥ 9 segments survive as one piece.
+        const COS_SHARP: f64 = 0.766;
+
+        let vids: Vec<VertexId> = {
+            let topo = &self.solid.topology;
+            let mut v: Vec<VertexId> = run.iter().map(|he| topo.half_edges[*he].origin).collect();
+            if !closed {
+                v.push(topo.half_edge_dest(*run.last().unwrap()));
+            }
+            v
+        };
+        let points: Vec<Point3> = vids
+            .iter()
+            .map(|v| self.solid.topology.vertices[*v].point)
+            .collect();
+        let n_v = vids.len();
+
+        let sharp = |prev: Point3, cur: Point3, next: Point3| -> bool {
+            let a = cur - prev;
+            let b = next - cur;
+            let (na, nb) = (a.norm(), b.norm());
+            na < 1e-12 || nb < 1e-12 || a.dot(b) / (na * nb) < COS_SHARP
+        };
+
+        if closed {
+            // A closed run is the entire loop (maximality), so cyclic
+            // rotation of the emitted edges is harmless.
+            let corners: Vec<usize> = (0..n_v)
+                .filter(|&i| {
+                    sharp(
+                        points[(i + n_v - 1) % n_v],
+                        points[i],
+                        points[(i + 1) % n_v],
+                    )
+                })
+                .collect();
+            if corners.is_empty() {
+                if let Some(ChainGeom::Arc {
+                    center,
+                    radius,
+                    normal,
+                }) = classify_chain(&points, true)
+                {
+                    // Full circle: split at canonical (direction-independent)
+                    // vertices so both sides of the boundary agree.
+                    let (a, b) = canonical_split(&points);
+                    let arc = |w: &mut Self, s: usize, e: usize| {
+                        let sv = w.vertex_map[&vids[s]];
+                        let ev = w.vertex_map[&vids[e]];
+                        w.write_arc_edge_curve(sv, ev, points[s], center, radius, normal)
+                    };
+                    // Traversal order is a → b → a (a < b or not, the two
+                    // arcs form the same cycle).
+                    return vec![arc(self, a, b), arc(self, b, a)];
+                }
+                return self.write_orphan_fallback(run);
+            }
+            // Segment cyclically between corners, starting at the first one.
+            let mut out = Vec::new();
+            for (k, &c) in corners.iter().enumerate() {
+                let next_c = corners[(k + 1) % corners.len()];
+                let span = if next_c > c {
+                    next_c - c
+                } else {
+                    n_v - c + next_c
+                };
+                let piece_vids: Vec<VertexId> = (0..=span).map(|j| vids[(c + j) % n_v]).collect();
+                let piece_pts: Vec<Point3> = (0..=span).map(|j| points[(c + j) % n_v]).collect();
+                let piece_hes: Vec<HalfEdgeId> = (0..span).map(|j| run[(c + j) % n_v]).collect();
+                out.extend(self.write_orphan_piece(&piece_hes, &piece_vids, &piece_pts));
+            }
+            return out;
+        }
+
+        // Open run: pieces between the endpoints and any sharp corners.
+        let mut bounds = vec![0usize];
+        for i in 1..n_v - 1 {
+            if sharp(points[i - 1], points[i], points[i + 1]) {
+                bounds.push(i);
+            }
+        }
+        bounds.push(n_v - 1);
+        let mut out = Vec::new();
+        for w in bounds.windows(2) {
+            let (s, e) = (w[0], w[1]);
+            out.extend(self.write_orphan_piece(&run[s..e], &vids[s..=e], &points[s..=e]));
+        }
+        out
+    }
+
+    /// Rebuild a degenerate slit loop (a seam edge and its twin as the only
+    /// boundary of a full cylindrical band face) by inserting the band's two
+    /// boundary circles, each split at a synthesized antipodal vertex.
+    /// Returns the STEP EDGE_LOOP id on success.
+    fn try_write_slit_cylinder_loop(
+        &mut self,
+        loop_id: LoopId,
+        he_ids: &[HalfEdgeId],
+    ) -> Option<u64> {
+        let topo = &self.solid.topology;
+        let (a, b) = (he_ids[0], he_ids[1]);
+        if topo.half_edges[a].twin != Some(b) || topo.half_edges[a].edge.is_none() {
+            return None;
+        }
+        let face_id = topo.loops[loop_id].face?;
+        let face = &topo.faces[face_id];
+        let surface = &self.solid.geometry.surfaces[face.surface_index];
+        if surface.surface_type() != SurfaceKind::Cylinder {
+            return None;
+        }
+        let cyl = surface.as_any().downcast_ref::<CylinderSurface>()?;
+        let axis = *cyl.axis.as_ref();
+
+        let p_a0 = topo.vertices[topo.half_edges[a].origin].point;
+        let p_a1 = topo.vertices[topo.half_edge_dest(a)].point;
+        let seam = p_a1 - p_a0;
+        let seam_len = seam.norm();
+        if seam_len < 1e-9 || seam.cross(axis).norm() > fit_tol(seam_len) {
+            return None; // not an axis-parallel seam
+        }
+
+        // Sign conventions: the loop winds CCW about the face's outward
+        // normal. At the band end reached along +axis the boundary circle
+        // runs CCW about (-outward_radial x sign) — combined: the traversal
+        // normal is axis * (-s_n * s_d) where s_n = +1 for an outward-radial
+        // face normal and s_d = +1 at the +axis end.
+        let s_n: f64 = if face.orientation == Orientation::Forward {
+            1.0
+        } else {
+            -1.0
+        };
+
+        let edge_id = topo.half_edges[a].edge.expect("checked above");
+        let step_line_id = self.edge_map[&edge_id];
+        let canonical_is_a = self.solid.topology.edges[edge_id].half_edge == a;
+
+        let mut oriented: Vec<u64> = Vec::new();
+        // Emit: a, circle at dest(a), b, circle at dest(b).
+        for this_he in [a, b] {
+            let orientation = if this_he == a {
+                canonical_is_a
+            } else {
+                !canonical_is_a
+            };
+            let oe_id = self.alloc_id();
+            self.emit(oe_id, &write_oriented_edge("", step_line_id, orientation));
+            oriented.push(oe_id);
+
+            let v_end = self.solid.topology.half_edge_dest(this_he);
+            let p_end = self.solid.topology.vertices[v_end].point;
+            let p_other =
+                self.solid.topology.vertices[self.solid.topology.half_edges[this_he].origin].point;
+            let s_d = (p_end - p_other).dot(axis).signum();
+            let normal = Dir3::new_normalize(axis * (-s_n * s_d));
+
+            let center = cyl.center + axis * (p_end - cyl.center).dot(axis);
+            let radius = (p_end - center).norm();
+            if (radius - cyl.radius).abs() > fit_tol(cyl.radius) {
+                return None;
+            }
+            let antipode = center + (center - p_end);
+
+            let sv = self.vertex_map[&v_end];
+            let anti_point_id = self.alloc_id();
+            self.emit(anti_point_id, &write_cartesian_point(&antipode, ""));
+            let anti_vertex_id = self.alloc_id();
+            self.emit(anti_vertex_id, &write_vertex_point("", anti_point_id));
+
+            let arc1 = self.write_arc_edge_curve(sv, anti_vertex_id, p_end, center, radius, normal);
+            let arc2 =
+                self.write_arc_edge_curve(anti_vertex_id, sv, antipode, center, radius, normal);
+            for arc in [arc1, arc2] {
+                let oe_id = self.alloc_id();
+                self.emit(oe_id, &write_oriented_edge("", arc, true));
+                oriented.push(oe_id);
+            }
+        }
+
+        let el_id = self.alloc_id();
+        self.emit(el_id, &write_edge_loop("", &oriented));
+        Some(el_id)
+    }
+
+    /// Emit one smooth orphan piece: a single LINE or CIRCLE arc if the whole
+    /// piece verifies as one, else per-half-edge lines.
+    fn write_orphan_piece(
+        &mut self,
+        hes: &[HalfEdgeId],
+        vids: &[VertexId],
+        points: &[Point3],
+    ) -> Vec<u64> {
+        if hes.len() >= 2 {
+            match classify_chain(points, false) {
+                Some(ChainGeom::Line) => {
+                    return vec![
+                        self.write_line_edge_curve(*vids.first().unwrap(), *vids.last().unwrap())
+                    ];
+                }
+                Some(ChainGeom::Arc {
+                    center,
+                    radius,
+                    normal,
+                }) => {
+                    let sv = self.vertex_map[vids.first().unwrap()];
+                    let ev = self.vertex_map[vids.last().unwrap()];
+                    return vec![
+                        self.write_arc_edge_curve(sv, ev, points[0], center, radius, normal)
+                    ];
+                }
+                None => {}
+            }
+        }
+        self.write_orphan_fallback(hes)
+    }
+
+    /// One line edge per orphan half-edge (the pre-reconstruction behavior).
+    fn write_orphan_fallback(&mut self, hes: &[HalfEdgeId]) -> Vec<u64> {
+        hes.iter()
+            .map(|he_id| {
+                let start_vid = self.solid.topology.half_edges[*he_id].origin;
+                let end_vid = self.solid.topology.half_edge_dest(*he_id);
+                self.write_line_edge_curve(start_vid, end_vid)
+            })
+            .collect()
     }
 
     fn write_faces(&mut self) -> Result<(), StepError> {
@@ -942,7 +1409,7 @@ mod tests {
             content
         );
         assert!(
-            !content.contains("PLANE("),
+            !content.contains("PLANE('"),
             "B-spline surface should NOT be written as PLANE"
         );
     }
@@ -970,7 +1437,7 @@ mod tests {
         let content = String::from_utf8_lossy(&buffer);
 
         assert!(
-            content.contains("PLANE("),
+            content.contains("PLANE('"),
             "Planar bilinear should be written as PLANE"
         );
         assert!(
@@ -1006,7 +1473,7 @@ mod tests {
             "Non-planar bilinear should be written as B_SPLINE_SURFACE_WITH_KNOTS"
         );
         assert!(
-            !content.contains("PLANE("),
+            !content.contains("PLANE('"),
             "Non-planar bilinear should NOT be written as PLANE"
         );
     }

--- a/crates/vcad-kernel-step/tests/circle_reconstruction.rs
+++ b/crates/vcad-kernel-step/tests/circle_reconstruction.rs
@@ -1,0 +1,187 @@
+//! Conformance: curved boundaries must export as analytic CIRCLE edges.
+//!
+//! The regression this pins: every edge used to be written as a LINE, so a
+//! circular intersection edge (cylinder ∩ plane) exported as a chain of ~n
+//! chord edges deviating from the analytic surfaces by the chord sagitta
+//! (r·(1−cos(π/n)) ≈ 0.06 mm at r=50, n=66). With the spec-conventional
+//! 1e-6 uncertainty declared, conforming importers (Shapr3D, OCC) failed to
+//! sew those edges to the surfaces and DROPPED the curved faces — annular
+//! faces and cylinder walls were simply absent, while all-planar boxes
+//! rendered perfectly.
+//!
+//! The assertions here are entity-graph assertions on the STEP text; the
+//! real acceptance oracle is a third-party kernel (validated against
+//! FreeCAD/OpenCascade: all faces present, sews to a valid closed solid,
+//! analytic-exact volume). vcad's own reader is deliberately NOT the oracle
+//! — that circular-validation trap has bitten twice before.
+
+use std::collections::HashMap;
+
+use vcad_kernel_booleans::{boolean_op, BooleanOp};
+use vcad_kernel_math::Transform;
+use vcad_kernel_primitives::{make_cube, make_cylinder};
+use vcad_kernel_step::{read_step_from_buffer, write_step_to_buffer};
+
+/// Minimal STEP entity graph: id -> (keyword, referenced ids).
+fn parse_entities(step: &str) -> HashMap<u64, (String, Vec<u64>)> {
+    let mut out = HashMap::new();
+    for line in step.lines() {
+        let Some(rest) = line.strip_prefix('#') else {
+            continue;
+        };
+        let Some((id, body)) = rest.split_once(" = ") else {
+            continue;
+        };
+        let Ok(id) = id.parse::<u64>() else { continue };
+        let keyword: String = body
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+        let mut refs = Vec::new();
+        for (i, c) in body.char_indices() {
+            if c == '#' {
+                let num: String = body[i + 1..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect();
+                if let Ok(n) = num.parse() {
+                    refs.push(n);
+                }
+            }
+        }
+        out.insert(id, (keyword, refs));
+    }
+    out
+}
+
+/// For every ADVANCED_FACE on a CYLINDRICAL_SURFACE, count LINE-backed and
+/// CIRCLE-backed edges in its bounds.
+fn cylindrical_face_edge_stats(step: &str) -> Vec<(usize, usize)> {
+    let ent = parse_entities(step);
+    let curve_kind = |edge_curve: u64| -> Option<&str> {
+        // EDGE_CURVE('', #start, #end, #curve, sense)
+        let (kw, refs) = ent.get(&edge_curve)?;
+        if kw != "EDGE_CURVE" {
+            return None;
+        }
+        let (ck, _) = ent.get(refs.get(2)?)?;
+        Some(ck.as_str())
+    };
+    let mut stats = Vec::new();
+    for (kw, refs) in ent.values() {
+        if kw != "ADVANCED_FACE" {
+            continue;
+        }
+        let Some(surf) = refs.last() else { continue };
+        if ent.get(surf).map(|(k, _)| k.as_str()) != Some("CYLINDRICAL_SURFACE") {
+            continue;
+        }
+        let (mut lines, mut circles) = (0usize, 0usize);
+        for bound in &refs[..refs.len() - 1] {
+            let Some((_, loop_refs)) = ent.get(bound) else {
+                continue;
+            };
+            let Some((_, oe_refs)) = loop_refs.first().and_then(|l| ent.get(l)) else {
+                continue;
+            };
+            for oe in oe_refs {
+                let Some((_, ec_refs)) = ent.get(oe) else {
+                    continue;
+                };
+                if let Some(kind) = ec_refs.first().and_then(|e| curve_kind(*e)) {
+                    match kind {
+                        "LINE" => lines += 1,
+                        "CIRCLE" => circles += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+        stats.push((lines, circles));
+    }
+    stats
+}
+
+fn assert_conformant(step: &str, what: &str) {
+    assert!(
+        step.contains("CIRCLE("),
+        "{what}: no CIRCLE entities — circular edges were not reconstructed"
+    );
+    for (i, (lines, circles)) in cylindrical_face_edge_stats(step).iter().enumerate() {
+        assert!(
+            *lines <= 4,
+            "{what}: cylindrical face {i} is bounded by {lines} LINE edges \
+             (> 4) — a chord-chain polyline survived reconstruction"
+        );
+        assert!(
+            *circles >= 1,
+            "{what}: cylindrical face {i} has no CIRCLE boundary edges"
+        );
+    }
+    assert!(
+        step.contains("LENGTH_MEASURE(1.0E-6)"),
+        "{what}: declared uncertainty is not the spec-conventional 1e-6"
+    );
+    // The product anchor conforming importers traverse.
+    for kw in [
+        "PRODUCT(",
+        "SHAPE_DEFINITION_REPRESENTATION",
+        "ADVANCED_BREP_SHAPE_REPRESENTATION",
+    ] {
+        assert!(step.contains(kw), "{what}: missing product anchor {kw}");
+    }
+}
+
+#[test]
+fn pristine_cylinder_exports_circles() {
+    let buf = write_step_to_buffer(&make_cylinder(10.0, 20.0, 32)).unwrap();
+    let step = String::from_utf8_lossy(&buf);
+    assert_conformant(&step, "cylinder");
+    // Two boundary circles, each split into two semicircular arcs.
+    assert_eq!(
+        step.matches("CIRCLE(").count(),
+        4,
+        "expected 2 circles x 2 arcs"
+    );
+    // Readback sanity (not the acceptance oracle).
+    assert_eq!(read_step_from_buffer(&buf).unwrap().len(), 1);
+}
+
+#[test]
+fn boolean_difference_reconstructs_arcs() {
+    let cube = make_cube(20.0, 20.0, 20.0);
+    let cyl = make_cylinder(5.0, 30.0, 32);
+    let result = boolean_op(&cube, &cyl, BooleanOp::Difference, 32).unwrap();
+    let buf = write_step_to_buffer(result.as_brep().unwrap()).unwrap();
+    let step = String::from_utf8_lossy(&buf);
+    assert_conformant(&step, "cube minus cylinder");
+    assert_eq!(read_step_from_buffer(&buf).unwrap().len(), 1);
+}
+
+#[test]
+fn through_hole_reconstructs_full_circles() {
+    // The annulus-style case from the field report: a plate with a round
+    // through-hole. The plate faces carry the hole as full-circle inner
+    // loops; the hole wall is a cylindrical band.
+    let plate = make_cube(40.0, 40.0, 10.0);
+    let mut hole = make_cylinder(8.0, 30.0, 64);
+    let t = Transform::translation(20.0, 20.0, -5.0);
+    for (_, v) in &mut hole.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    for s in &mut hole.geometry.surfaces {
+        *s = s.transform(&t);
+    }
+    let result = boolean_op(&plate, &hole, BooleanOp::Difference, 64).unwrap();
+    let buf = write_step_to_buffer(result.as_brep().unwrap()).unwrap();
+    let step = String::from_utf8_lossy(&buf);
+    assert_conformant(&step, "plate with hole");
+    // Hole circles on both plate faces plus both wall boundaries: at least
+    // 4 full circles = 8 arcs.
+    assert!(
+        step.matches("CIRCLE(").count() >= 8,
+        "expected >= 8 arcs, got {}",
+        step.matches("CIRCLE(").count()
+    );
+    assert_eq!(read_step_from_buffer(&buf).unwrap().len(), 1);
+}


### PR DESCRIPTION
## Problem

Follow-up to #725 and the product-anchor fix: files opened in third-party CAD but **curved faces were missing**. Observed in Shapr3D 2026-07-26 on the rana QDD actuator part set.

Root cause, two layers deep:
1. `writer.rs` had exactly one edge path — every edge became a LINE.
2. It couldn't do better: topo `Edge` carries no curve reference, so a circular intersection edge reaches the writer as ~66 chord edges (or as boolean-sewn **orphan half-edges**, which is the dominant case in practice), while faces still carry exact analytic surfaces. Chord polylines deviate from those surfaces by the sagitta (~0.06 mm at r=50), so at the spec 1e-6 uncertainty conforming importers fail to sew and **drop the face**.

## Fix (option 1 from the analysis: reconstruct at export)

New `reconstruct.rs` pre-pass + writer emission:
- **Paired-edge chains** between one face pair with degree-2 interior vertices → one LINE (collinear) or CIRCLE arc (concyclic — every vertex verified, monotone-angle guarded, ≥5/6 points so exact regular polygons can't masquerade). Closed chains split into two semicircular arcs (importers reject one-vertex closed edges).
- **Pristine primitives**: the single closed circular edge (one vertex) is rebuilt from the adjacent cylinder/cone + plane surfaces, split at a synthesized antipode, winding derived from the planar face's outer/inner-bound convention.
- **Orphan half-edge runs** (boolean sewing leaves chord chains unpaired and twinless): segmented at sharp-turn corners, each smooth piece merged. Classification is purely point-based and closed-circle splits are canonical (lexicographic-min + farthest point), so both sides of a boundary — which walk the same points in opposite orders — always reconstruct identical geometry for the importer to sew.
- **Slit loops**: a cylindrical band face bounded only by a seam edge + its twin (booleans lose the band's circles entirely — this was the invisible hole-wall) gets both boundary circles rebuilt from the surface.

Everything that fails verification falls back to the previous per-edge LINE path — strictly opportunistic, fail-safe.

Also included:
- AP214 **product anchor** (PRODUCT/SDR/ABSR + SI mm units) ported from the interim worktree, with uncertainty at the honest spec-conventional **1e-6** (not the 1e-1 tourniquet).
- Reader arc sampling is now adaptive (64 seg/turn vs fixed 8 points) so round-trip volume holds.

## Validation

Third-party kernel as the oracle (FreeCAD/OpenCascade), per the circular-validation lesson:

| model | faces present | sewn solid | volume |
|---|---|---|---|
| cylinder | 3/3 | valid, closed | π-exact |
| cube − cylinder (corner) | 7/7 | valid, closed | analytic-exact |
| plate with through-hole | 7/7 (wall was area-0 before) | valid, closed | analytic-exact |
| rana QDD actuator (25 bodies, 426 faces, 49 cylindrical) | 0 invalid/zero-area | 54/55 shells closed | — |

`tests/circle_reconstruction.rs` pins the entity graph in CI: CIRCLEs present, no cylindrical face bounded by >4 LINEs, 1e-6 declared, anchor entities present.

`cargo test` green for vcad-kernel-step (56+13), vcad-kernel (100), vcad-cli (21), vcad-kernel-tessellate (43); clippy `-D warnings` and fmt clean.

The rana exports under `~/Developer/rana/exports/step` should be re-exported to pick this up (user-visible acceptance: all faces present + smooth circular edges in Shapr3D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)